### PR TITLE
Add tests for supported column types.

### DIFF
--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -27,6 +27,14 @@ def get_dburi():
         return "postgres://localhost/test"
 
 
+def server_version():
+    if has_psycopg2:
+        with psycopg2.connect(**connection_params()) as conn:
+            return conn.server_version
+    else:
+        return 0
+
+
 def create_iris():
     iris = Orange.data.Table("iris")
     with psycopg2.connect(**connection_params()) as conn:

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -7,7 +7,7 @@ from Orange.data import filter, ContinuousVariable, DiscreteVariable, \
     StringVariable, Table, Domain
 from Orange.data.sql.parser import SqlParser
 from Orange.data.sql.table import SqlTable
-from Orange.tests.sql.base import PostgresTest, get_dburi, has_psycopg2
+from Orange.tests.sql.base import PostgresTest, get_dburi, has_psycopg2, server_version
 
 
 @unittest.skipIf(not has_psycopg2, "Psycopg2 is required for sql tests.")
@@ -477,6 +477,7 @@ class SqlTableTests(PostgresTest):
         sql_table = SqlTable(uri, guess_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @unittest.skipIf(server_version() < 90200, "Type not supported on this server version.")
     def test_smallserial(self):
         table = np.arange(25).reshape((-1, 1))
         uri = self.create_sql_table(table, ['smallserial'])
@@ -487,6 +488,7 @@ class SqlTableTests(PostgresTest):
         sql_table = SqlTable(uri, guess_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @unittest.skipIf(server_version() < 90200, "Type not supported on this server version.")
     def test_bigserial(self):
         table = np.arange(25).reshape((-1, 1))
         uri = self.create_sql_table(table, ['bigserial'])


### PR DESCRIPTION
Add tests for supported sql column types implemented in cf5c744, 983d49,  4c0431 and 2660e74.
