### PR TITLE
Removed Mahalanobis distance

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -34,7 +34,7 @@ class SklDistance():
         """
         self.metric = metric
 
-    def __call__(self, e1, e2=None, axis=1, **kwargs):
+    def __call__(self, e1, e2=None, axis=1):
         """
         Method for calculating distances.
 
@@ -46,7 +46,6 @@ class SklDistance():
         :param axis: if axis=1 we calculate distances between rows,
            if axis=0 we calculate distances between columns
         :type axis: int
-        :param kwargs: used just for Mahalanobis for passing inverse of covariance matrix
         :return: the matrix with distances between given examples
         :rtype: :class:`Orange.misc.DistMatrix`
         """
@@ -60,44 +59,17 @@ class SklDistance():
             x1 = np.atleast_2d(x1)
         if e2 is not None and not sparse.issparse(x2):
             x2 = np.atleast_2d(x2)
-        dist = metrics.pairwise.pairwise_distances(x1, x2, metric=self.metric, **kwargs)
+        dist = metrics.pairwise.pairwise_distances(x1, x2, metric=self.metric)
         if isinstance(e1, data.Table) or isinstance(e1, data.RowInstance):
             dist = DistMatrix(dist, e1, e2)
         else:
             dist = DistMatrix(dist)
         return dist
 
-
-class SklMahalanobis(SklDistance):
-    """Mahalanobis class."""
-    def __init__(self):
-        self.metric = 'mahalanobis'
-
-    def __call__(self, e1, e2=None, axis=1, VI=None):
-        """
-        Method for calculating distances.
-
-        :param e1: input data instances
-        :type e1: :class:`Orange.data.Table` or :class:`Orange.data.RowInstance` or :class:`numpy.ndarray`
-        :param e2: optional second argument for data instances
-           if provided, distances between each pair, where first item is from e1 and second is from e2, are calculated
-        :type e2: :class:`Orange.data.Table` or :class:`Orange.data.RowInstance` or :class:`numpy.ndarray`
-        :param axis: if axis=1 we calculate distances between rows,
-           if axis=0 we calculate distances between columns
-        :type axis: int
-        :param VI: the inverse of the covariance matrix
-        :type VI: nd.array
-        :return: the matrix with distances between given examples
-        :rtype: :class:`Orange.misc.DistMatrix`
-        """
-        return super().__call__(e1, e2, axis, VI=VI)
-
-
 Euclidean = SklDistance('euclidean')
 Manhattan = SklDistance('manhattan')
 Cosine = SklDistance('cosine')
 Jaccard = SklDistance('jaccard')
-Mahalanobis = SklMahalanobis()
 
 
 class SpearmanDistance():

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from Orange.data import Table
-from Orange.distance import Euclidean, Mahalanobis, SpearmanR, SpearmanRAbsolute, PearsonR, PearsonRAbsolute, Manhattan, Cosine, Jaccard
+from Orange.distance import Euclidean, SpearmanR, SpearmanRAbsolute, PearsonR, PearsonRAbsolute, Manhattan, Cosine, Jaccard
 from scipy.sparse import csr_matrix
 import numpy as np
 
@@ -253,61 +253,6 @@ class TestJaccard(TestCase):
                                                  [ 0. ,  0. ,  0.5]]))
 
 
-class TestMahalanobis(TestCase):
-    def setUp(self):
-        self.hilbert = Table(np.array([[ 1.        ,  0.5       ,  0.33333333],
-                                       [ 0.5       ,  0.33333333,  0.25      ],
-                                       [ 0.33333333,  0.25      ,  0.2       ]]))
-        # self.rand = Table(np.eye(5))
-        self.hilbert_cov_inv = np.linalg.inv(np.cov(self.hilbert))
-        self.dist = Mahalanobis
-
-    def test_mahalanobis_distance_one_example(self):
-        np.testing.assert_almost_equal(self.dist(self.hilbert[0], VI=self.hilbert_cov_inv).X, np.array([[0]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert[0], VI=self.hilbert_cov_inv, axis=0).X, np.array([[0]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert[0], self.hilbert[1], VI=self.hilbert_cov_inv).X,  np.array([[2.5819888768157]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert[0], self.hilbert[1], VI=self.hilbert_cov_inv, axis=0).X,  np.array([[2.5819888768157]]))
-
-    def test_mahalanobis_distance_many_examples(self):
-        np.testing.assert_almost_equal(self.dist(self.hilbert).X,
-                                       np.array([[ 0.        ,  2.82842712,  1.78885431],
-                                                 [ 2.82842712,  0.        ,  2.11344888],
-                                                 [ 1.78885431,  2.11344888,  0.        ]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert, axis=0).X,
-                                       np.array([[ 0.        ,  2.82842712,  1.78885431],
-                                                 [ 2.82842712,  0.        ,  2.11344888],
-                                                 [ 1.78885431,  2.11344888,  0.        ]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert[:2], self.hilbert[2]).X,
-                                       np.array([[ 1.78885431],
-                                                 [ 2.11344888]]))
-        # np.testing.assert_almost_equal(self.dist(self.hilbert[:2], self.hilbert[:3]).X,
-        #                                np.array([[ 0.        ,  2.34520793,  2.96647933],
-        # np.testing.assert_almost_equal(self.dist(self.rand, self.rand, axis=0).X,
-        #     np.array([[ 0.        ,  3.        ,  2.82842712,  3.        ,  3.        ],
-        #               [ 3.        ,  0.        ,  3.        ,  3.        ,  3.        ],
-        #               [ 2.82842712,  3.        ,  0.        ,  3.        ,  2.82842712],
-        #               [ 3.        ,  3.        ,  3.        ,  0.        ,  3.        ],
-        #               [ 3.        ,  3.        ,  2.82842712,  3.        ,  0.        ]]))
-
-    def test_mahalanobis_distance_inverse_given(self):
-        np.testing.assert_almost_equal(self.dist(self.hilbert, self.hilbert, VI=self.hilbert_cov_inv).X,
-                                       np.array([[ 0.        ,  2.58198888,      np.nan],
-                                                 [ 2.58198888,  0.        ,  2.26568596],
-                                                 [     np.nan,  2.26568596,  0.        ]]))
-
-    def test_mahalanobis_distance_numpy(self):
-        np.testing.assert_almost_equal(self.dist(self.hilbert[0].x, self.hilbert[1].x, VI=self.hilbert_cov_inv, axis=0).X,  np.array([[2.5819888768157]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert.X).X,
-                                       np.array([[ 0.        ,  2.82842712,  1.78885431],
-                                                 [ 2.82842712,  0.        ,  2.11344888],
-                                                 [ 1.78885431,  2.11344888,  0.        ]]))
-        np.testing.assert_almost_equal(self.dist(self.hilbert[:2].X, self.hilbert[2].x).X,
-                                       np.array([[ 1.78885431],
-                                                 [ 2.11344888]]))
-
-
-
-
 class TestSpearmanR(TestCase):
     def setUp(self):
         self.breast = Table("breast-cancer-wisconsin-cont")
@@ -383,6 +328,7 @@ class TestSpearmanR(TestCase):
                                                  [ 0.25,  0.  ,  0.25,  0.  ,  0.  ,  0.  ,  0.25,  0.  ,  0.75],
                                                  [ 0.25,  0.75,  0.25,  0.75,  0.75,  0.75,  1.  ,  0.75,  0.  ]]))
 
+
 class TestSpearmanRAbsolute(TestCase):
     def setUp(self):
         self.breast = Table("breast-cancer-wisconsin-cont")
@@ -454,6 +400,7 @@ class TestSpearmanRAbsolute(TestCase):
                                                  [ 0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.  ,  0.25,  0.  ],
                                                  [ 0.25,  0.  ,  0.25,  0.  ,  0.  ,  0.  ,  0.25,  0.  ,  0.25],
                                                  [ 0.25,  0.25,  0.25,  0.25,  0.25,  0.25,  0.  ,  0.25,  0.  ]]))
+
 
 class TestPearsonR(TestCase):
     def setUp(self):

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -9,7 +9,6 @@ _METRICS = [
     ("Manhattan", distance.Manhattan),
     ("Cosine", distance.Cosine),
     ("Jaccard", distance.Jaccard),
-    ("Mahalanobis", distance.Mahalanobis),
     ("Spearman", distance.SpearmanR),
     ("Spearman absolute", distance.SpearmanRAbsolute),
     ("Pearson", distance.PearsonR),


### PR DESCRIPTION
Mahalanbois was removed due to instability. Calculation of inverse of covariance matrix causes the results to vary between different machines. This causes the problems when running tests.