### PR TITLE
New style signals

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -478,19 +478,16 @@ class OWDataTable(widget.OWWidget):
 
         size = table.verticalHeader().sectionSizeHint(0)
         table.verticalHeader().setDefaultSectionSize(size)
-        self.connect(datamodel, QtCore.SIGNAL("layoutChanged()"),
-                     lambda *args: QtCore.QTimer.singleShot(50, p))
+        datamodel.layoutChanged.connect(
+            lambda *args: QtCore.QTimer.singleShot(50, p))
 
         # set the header (attribute names)
         self.draw_attribute_labels(table)
 
-        self.connect(table.horizontalHeader(),
-                     QtCore.SIGNAL("sectionClicked(int)"), self.sort_by_column)
-        self.connect(
-            table.selectionModel(),
-            QtCore.SIGNAL("selectionChanged(QItemSelection, QItemSelection)"),
-            self.update_selection)
-
+        table.horizontalHeader().sectionClicked[int].connect(
+            self.sort_by_column)
+        table.selectionModel().selectionChanged[QItemSelection, QItemSelection
+                                                ].connect(self.update_selection)
         QtGui.qApp.restoreOverrideCursor()
 
     #noinspection PyBroadException

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -638,7 +638,7 @@ def spin(widget, master, value, minv, maxv, step=1, box=None, label=None,
     cfront, sbox.cback, sbox.cfunc = connectControl(
         master, value, callback,
         not (callback and callbackOnReturn) and
-        sbox.valueChanged((int, float)[isDouble]),
+        sbox.valueChanged[(int, float)[isDouble]],
         (CallFrontSpin, CallFrontDoubleSpin)[isDouble](sbox))
     if checked:
         cbox.disables = [sbox]

--- a/Orange/widgets/utils/colorpalette.py
+++ b/Orange/widgets/utils/colorpalette.py
@@ -465,8 +465,7 @@ class PaletteEditor(QDialog):
         buttonDOWNAttr.setIcon(QIcon(os.path.join(environ.widget_install_dir, "icons/Dlg_down3.png")))
         buttonDOWNAttr.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding))
         buttonDOWNAttr.setMaximumWidth(30)
-        self.connect(self.discListbox, QtCore.SIGNAL("itemDoubleClicked ( QListWidgetItem *)"),
-                     self.changeDiscreteColor)
+        self.discListbox.itemDoubleClicked.connect(self.changeDiscreteColor)
 
         box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
                                accepted=self.accept, rejected=self.reject)

--- a/Orange/widgets/utils/colorpalette.py
+++ b/Orange/widgets/utils/colorpalette.py
@@ -348,7 +348,7 @@ class ColorPaletteDlg(QDialog):
     # this function is called if one of the color buttons was pressed or there was any other change of the color palette
     def colorSchemaChange(self):
         self.setCurrentState(self.getCurrentState())
-        self.emit(QtCore.SIGNAL("shemaChanged"))
+        self.shemaChanged.emit()
 
 
 class ColorPalleteListing(QDialog):

--- a/Orange/widgets/utils/plot/owplot.py
+++ b/Orange/widgets/utils/plot/owplot.py
@@ -838,7 +838,7 @@ class OWPlot(orangeqt.Plot, OWComponent):
         c.set_point_symbols(shape_data)
         if len(marked_data):
             c.set_points_marked(marked_data)
-            self.emit(SIGNAL('marked_points_changed()'))
+            self.marked_points_changed.emit()
         c.name = 'Main Curve'
 
         self.replot()
@@ -1255,7 +1255,7 @@ class OWPlot(orangeqt.Plot, OWComponent):
         point = self.mapToScene(event.pos())
         if not self._pressed_mouse_button:
             if self.receivers(SIGNAL('point_hovered(Point*)')) > 0:
-                self.emit(SIGNAL('point_hovered(Point*)'), self.nearest_point(point))
+                self.point_hovered.emit(self.nearest_point(point))
 
         ## We implement a workaround here, because sometimes mouseMoveEvents are not fast enough
         ## so the moving legend gets left behind while dragging, and it's left in a pressed state
@@ -1355,11 +1355,11 @@ class OWPlot(orangeqt.Plot, OWComponent):
 
             if point_item:
                 point_item.set_selected(b == self.AddSelection or (b == self.ToggleSelection and not point_item.is_selected()))
-            self.emit(SIGNAL('selection_changed()'))
+            self.selection_changed.emit()
         elif a == SELECT and b == Qt.RightButton:
             point_item = self.nearest_point(point)
             if point_item:
-                self.emit(SIGNAL('point_rightclicked(Point*)'), self.nearest_point(point))
+                self.point_rightclicked.emit(self.nearest_point(point))
             else:
                 self.unselect_all_points()
         else:

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -136,7 +136,7 @@ class StateButtonContainer(OrientedWidget):
         self._clicked_button = None
         for i in buttons:
             b = gui.tool_button(i, self)
-            QObject.connect(b, SIGNAL("triggered(QAction*)"), self.button_clicked)
+            b.triggered.connect(self.button_clicked)
             self.buttons[i] = b
             self.layout().addWidget(b)
 
@@ -165,14 +165,16 @@ class OWAction(QAction):
         if type(callback) == str:
             callback = getattr(plot, callback, None)
         if callback:
-            QObject.connect(self, SIGNAL("triggered(bool)"), callback)
+            self.triggered.connect(callback)
         if attr_name:
             self._plot = plot
             self.attr_name = attr_name
             self.attr_value = attr_value
-            QObject.connect(self, SIGNAL("triggered(bool)"), self.set_attribute)
+            self.triggered.connect(self.set_attribute)
         if icon_name:
-            self.setIcon(QIcon(os.path.dirname(__file__) + "/../../icons/" + icon_name + '.png'))
+            self.setIcon(
+                QIcon(os.path.join(os.path.dirname(__file__),
+                      "../../icons", icon_name + '.png')))
             self.setIconVisibleInMenu(True)
 
     def set_attribute(self, clicked):
@@ -468,11 +470,11 @@ class OWPlotGUI:
         b.setMenu(m)
         b._actions = {}
 
-        QObject.connect(m, SIGNAL("triggered(QAction*)"), b, SLOT("setDefaultAction(QAction*)"))
+        m.triggered.connect(b, SLOT("setDefaultAction(QAction*)"))
 
         if main_action_id:
             main_action = OWAction(self._plot, icon_name, attr_name, attr_value, callback, parent=b)
-            QObject.connect(m, SIGNAL("triggered(QAction*)"), main_action, SLOT("trigger()"))
+            m.triggered.connect(main_action, SLOT("trigger()"))
 
         for id in ids:
             id, name, attr_name, attr_value, callback, icon_name = self._expand_id(id)

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -31,7 +31,7 @@ from Orange.widgets import gui
 from .owconstants import *
 
 from PyQt4.QtGui import QWidget, QToolButton, QGroupBox, QVBoxLayout, QHBoxLayout, QIcon, QMenu, QAction
-from PyQt4.QtCore import Qt, pyqtSignal, QObject, SIGNAL, SLOT
+from PyQt4.QtCore import Qt, pyqtSignal, QObject, SLOT
 
 
 class OrientedWidget(QWidget):
@@ -193,8 +193,9 @@ class OWButton(QToolButton):
 
     def setDown(self, down):
         if self.isDown() != down:
-            self.emit(SIGNAL("downChanged(bool)"), down)
+            self.downChanged[bool].emit(down)
         QToolButton.setDown(self, down)
+
 
 class OWPlotGUI:
     '''

--- a/Orange/widgets/utils/toolbar.py
+++ b/Orange/widgets/utils/toolbar.py
@@ -131,7 +131,7 @@ class ZoomSelectToolbar(QGroupBox):
             self.layout().addWidget(btn)
         btn.setCheckable(button.selectable)
         if action:
-            self.connect(btn, SIGNAL("clicked()"), action)
+            btn.clicked.connect(action)
         if button.icon:
             btn.setIcon(button.icon)
         btn.setToolTip(button.text)

--- a/Orange/widgets/utils/toolbar.py
+++ b/Orange/widgets/utils/toolbar.py
@@ -1,6 +1,6 @@
 import os.path
 
-from PyQt4.QtCore import SIGNAL, Qt
+from PyQt4.QtCore import Qt
 from PyQt4.QtGui import QToolButton, QGroupBox, QIcon, QHBoxLayout
 
 from Orange.canvas.utils import environ

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -233,7 +233,7 @@ class OWMosaicDisplay(OWWidget):
         #self.box6.setSizePolicy(QSizePolicy(QSizePolicy.Minimum , QSizePolicy.Fixed ))
         self.controlArea.layout().addStretch(1)
 
-        # self.connect(self.graphButton, SIGNAL("clicked()"), self.saveToFileCanvas)
+        # self.graphButton.clicked.connect(saveToFileCanvas)
         self.icons = gui.attributeIconDict
         self.resize(830, 550)
 

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -82,7 +82,7 @@ class OWSieveDiagram(OWWidget):
         gui.rubber(self.controlArea)
 
         # self.wdChildDialogs = [self.optimizationDlg]        # used when running widget debugging
-        # self.connect(self.graphButton, SIGNAL("clicked()"), self.saveToFileCanvas)
+        # self.graphButton.clicked.connect(self.saveToFileCanvas)
         self.icons = gui.attributeIconDict
         self.resize(800, 550)
         random.seed()


### PR DESCRIPTION
I believe I correctly ported all signals to new style. The only place which I knowingly omitted is line 1257 in owplot.py, `if self.receivers(SIGNAL('point_hovered(Point*)')) > 0:`. I have not found any documentation whether new style signals have method `receivers` and the code belongs to a class derived from orangeqt, therefore it is obsolete, difficult to test and may even not be portable to Qt 5, so there is not much point in changing it to new style.
