### PR TITLE
Returning fig redundant for IP Notebook.

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -411,7 +411,5 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, w
         line([(begin, cline + bigtick / 2), (begin, cline - bigtick / 2)], linewidth=2.5)
         line([(end, cline + bigtick / 2), (end, cline - bigtick / 2)], linewidth=2.5)
 
-    if filename is None:
-        return fig
-    else:
+    if filename:
         print_figure(fig, filename, **kwargs)


### PR DESCRIPTION
Seems that IP notebook can display a graph that was created within the function withouth returning the graph object. If this later is returned, the notebook displays two figures instead of one.