### PR TITLE
Variable unpickler uses make; anonymous variables are no longer stored

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -1,5 +1,6 @@
 from math import isnan, floor
 import numpy as np
+from pickle import PickleError
 
 from ..data.value import Value, Unknown
 import collections
@@ -140,6 +141,8 @@ class Variable:
             tpe._clear_cache()
 
     def __reduce__(self):
+        if not self.name:
+            raise PickleError("Variables without names cannot be pickled")
         return make_variable, (self.__class__, self.name), self.__dict__
 
     def __copy__(self):
@@ -382,6 +385,8 @@ class DiscreteVariable(Variable):
     str_val = repr_val
 
     def __reduce__(self):
+        if not self.name:
+            raise PickleError("Variables without names cannot be pickled")
         return make_variable, (self.__class__, self.name,
                                self.values, self.ordered, self.base_value), \
             self.__dict__

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -13,7 +13,18 @@ def make_variable(cls, *args):
     return cls.make(*args)
 
 
-class Variable:
+class VariableMeta(type):
+    # noinspection PyMethodParameters
+    def __new__(mcs, name, *args):
+        cls = type.__new__(mcs, name, *args)
+        if not hasattr(cls, '_all_vars'):
+            cls._all_vars = {}
+        if name != "Variable":
+            Variable._variable_types.append(cls)
+        return cls
+
+
+class Variable(metaclass=VariableMeta):
     """
     The base class for variable descriptors contains the variable's
     name and some basic properties.
@@ -59,6 +70,36 @@ class Variable:
         self.unknown_str = set(Variable._DefaultUnknownStr)
         self.source_variable = None
         self.attributes = {}
+        if name:
+            if isinstance(self._all_vars, collections.defaultdict):
+                self._all_vars[name].append(self)
+            else:
+                self._all_vars[name] = self
+
+    @classmethod
+    def make(cls, name):
+        """
+        Return an existing continuous variable with the given name, or
+        construct and return a new one.
+        """
+        if not name:
+            raise ValueError("Variables without names cannot be stored or made")
+        return cls._all_vars.get(name) or cls(name)
+
+    @classmethod
+    def _clear_cache(cls):
+        """
+        Clear the list of variables for reuse by :obj:`make`.
+        """
+        cls._all_vars.clear()
+
+    @classmethod
+    def _clear_all_caches(cls):
+        """
+        Clears list of stored variables for all subclasses
+        """
+        for cls0 in cls._variable_types:
+            cls0._clear_cache()
 
     @staticmethod
     def is_primitive():
@@ -135,11 +176,6 @@ class Variable:
     def compute_value(_):
         return Unknown
 
-    @classmethod
-    def _clear_cache(cls):
-        for tpe in cls._variable_types:
-            tpe._clear_cache()
-
     def __reduce__(self):
         if not self.name:
             raise PickleError("Variables without names cannot be pickled")
@@ -152,11 +188,6 @@ class Variable:
         newvar = type(self)()
         newvar.__dict__.update(self.__dict__)
         return newvar
-
-    @classmethod
-    def _clear_all_caches(cls):
-        for cls0 in cls._variable_types:
-            cls0._clear_cache()
 
 
 class ContinuousVariable(Variable):
@@ -182,7 +213,6 @@ class ContinuousVariable(Variable):
     If the `number_of_decimals` is set manually, `adjust_decimals` is
     set to 0 to prevent changes by `to_val`.
     """
-    all_vars = {}
 
     def __init__(self, name="", number_of_decimals=None):
         """
@@ -195,7 +225,6 @@ class ContinuousVariable(Variable):
             self.adjust_decimals = 2
         else:
             self.number_of_decimals = number_of_decimals
-        ContinuousVariable.all_vars[name] = self
 
     @property
     def number_of_decimals(self):
@@ -207,22 +236,6 @@ class ContinuousVariable(Variable):
         self._number_of_decimals = x
         self.adjust_decimals = 0
         self._out_format = "%.{}f".format(self.number_of_decimals)
-
-    @staticmethod
-    def make(name):
-        """
-        Return an existing continuous variable with the given name, or
-        construct and return a new one.
-        """
-        existing_var = ContinuousVariable.all_vars.get(name)
-        return existing_var or ContinuousVariable(name)
-
-    @classmethod
-    def _clear_cache(cls):
-        """
-        Clears the list of variables for reuse by :obj:`make`.
-        """
-        cls.all_vars.clear()
 
     @staticmethod
     def is_primitive():
@@ -292,7 +305,7 @@ class DiscreteVariable(Variable):
         used in some methods like, for instance, when creating dummy variables
         for regression.
     """
-    all_vars = collections.defaultdict(set)
+    _all_vars = collections.defaultdict(list)
     presorted_values = []
 
     def __init__(self, name="", values=(), ordered=False, base_value=-1):
@@ -301,7 +314,6 @@ class DiscreteVariable(Variable):
         self.ordered = ordered
         self.values = list(values)
         self.base_value = base_value
-        DiscreteVariable.all_vars[name].add(self)
 
     def __repr__(self):
         """
@@ -391,8 +403,8 @@ class DiscreteVariable(Variable):
                                self.values, self.ordered, self.base_value), \
             self.__dict__
 
-    @staticmethod
-    def make(name, values=(), ordered=False, base_value=-1):
+    @classmethod
+    def make(cls, name, values=(), ordered=False, base_value=-1):
         """
         Return a variable with the given name and other properties. The method
         first looks for a compatible existing variable: the existing
@@ -417,19 +429,21 @@ class DiscreteVariable(Variable):
         :type base_value: int
         :returns: an existing compatible variable or `None`
         """
-        var = DiscreteVariable._find_compatible(
+        if not name:
+            raise ValueError("Variables without names cannot be stored or made")
+        var = cls._find_compatible(
             name, values, ordered, base_value)
         if var:
             return var
         if not ordered:
             base_value_rep = base_value != -1 and values[base_value]
-            values = DiscreteVariable.ordered_values(values)
+            values = cls.ordered_values(values)
             if base_value != -1:
                 base_value = values.index(base_value_rep)
-        return DiscreteVariable(name, values, ordered, base_value)
+        return cls(name, values, ordered, base_value)
 
-    @staticmethod
-    def _find_compatible(name, values=(), ordered=False, base_value=-1):
+    @classmethod
+    def _find_compatible(cls, name, values=(), ordered=False, base_value=-1):
         """
         Return a compatible existing value, or `None` if there is None.
         See :obj:`make` for details; this function differs by returning `None`
@@ -447,11 +461,11 @@ class DiscreteVariable(Variable):
         :returns: an existing compatible variable or `None`
         """
         base_rep = base_value != -1 and values[base_value]
-        existing = DiscreteVariable.all_vars.get(name)
+        existing = cls._all_vars.get(name)
         if existing is None:
             return None
         if not ordered:
-            values = DiscreteVariable.ordered_values(values)
+            values = cls.ordered_values(values)
         for var in existing:
             if (var.ordered != ordered or
                     var.base_value != -1
@@ -486,13 +500,6 @@ class DiscreteVariable(Variable):
             var.base_value = var.values.index(base_rep)
         return var
 
-    @classmethod
-    def _clear_cache(cls):
-        """
-        Clears the list of variables for reuse by :obj:`make`.
-        """
-        cls.all_vars.clear()
-
     @staticmethod
     def ordered_values(values):
         """
@@ -511,13 +518,7 @@ class StringVariable(Variable):
     Descriptor for string variables. String variables can only appear as
     meta attributes.
     """
-    all_vars = {}
     Unknown = None
-
-    def __init__(self, name="", default_col=-1):
-        """Construct a new descriptor."""
-        super().__init__(name)
-        StringVariable.all_vars[name] = self
 
     @staticmethod
     def is_primitive():
@@ -541,7 +542,8 @@ class StringVariable(Variable):
 
     val_from_str_add = to_val
 
-    def str_val(self, val):
+    @staticmethod
+    def str_val(val):
         """Return a string representation of the value."""
         if isinstance(val, Value):
             if val.value is None:
@@ -552,23 +554,3 @@ class StringVariable(Variable):
     def repr_val(self, val):
         """Return a string representation of the value."""
         return '"{}"'.format(self.str_val(val))
-
-    @staticmethod
-    def make(name):
-        """
-        Return an existing string variable with the given name, or construct
-        and return a new one.
-        """
-        existing_var = StringVariable.all_vars.get(name)
-        return existing_var or StringVariable(name)
-
-    @classmethod
-    def _clear_cache(cls):
-        """
-        Clears the list of variables for reuse by :obj:`make`.
-        """
-        cls.all_vars.clear()
-
-Variable._variable_types += [
-    DiscreteVariable, ContinuousVariable, StringVariable
-]

--- a/Orange/testing/__init__.py
+++ b/Orange/testing/__init__.py
@@ -7,18 +7,11 @@ from Orange import data
 class PickleTest(unittest.TestCase):
     def setUp(self):
         """ Override __eq__ for Orange objects that do not implement it"""
-
-        self.add_comparator(data.DiscreteVariable,
-                            compare_members=("name", "values",
-                                             "ordered", "base_value"))
-        self.add_comparator(data.ContinuousVariable,
-                            compare_members=("name",))
-        self.add_comparator(data.StringVariable,
-                            compare_members=("name",))
         self.add_comparator(data.Domain,
                             compare_members=("attributes", "class_vars",
                                              "class_var", "variables",
                                              "metas", "anonymous"))
+        data.Variable._clear_all_caches()
 
     old_comparators = {}
 

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -29,7 +29,6 @@ class SqlTableTests(PostgresTest):
 
             self.assertIsInstance(discrete_attr, DiscreteVariable)
             self.assertEqual(discrete_attr.name, "col1")
-            print(discrete_attr.to_sql())
             self.assertTrue('"col1"' in discrete_attr.to_sql())
             self.assertEqual(discrete_attr.values, ['f', 'm'])
 

--- a/Orange/tests/test_continuize.py
+++ b/Orange/tests/test_continuize.py
@@ -8,7 +8,7 @@ from Orange.preprocess import transformation
 
 class ContinuizerTest(unittest.TestCase):
     def setUp(self):
-        Variable._clear_cache()
+        Variable._clear_all_caches()
         self.data = Table("test4")
 
     def test_default(self):

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -8,31 +8,44 @@ from Orange.data import (ContinuousVariable, DiscreteVariable, Domain,
                          StringVariable, Unknown, Variable)
 from Orange.testing import create_pickling_tests
 
+def create_domain(*ss):
+    Variable._clear_all_caches()
+    vars=dict(
+        age=ContinuousVariable(name="AGE"),
+        gender=DiscreteVariable(name="Gender", values=["M", "F"]),
+        incomeA=ContinuousVariable(name="incomeA"),
+        income=ContinuousVariable(name="income"),
+        education=DiscreteVariable(name="education", values=["GS", "HS", "C"]),
+        ssn=StringVariable(name="SSN"),
+        race=DiscreteVariable(name="race",
+                              values=["White", "Hypsanic", "African", "Other"]))
 
-age = ContinuousVariable(name="AGE")
-gender = DiscreteVariable(name="Gender", values=["M", "F"])
-incomeA = ContinuousVariable(name="incomeA")
-income = ContinuousVariable(name="income")
-education = DiscreteVariable(name="education", values=["GS", "HS", "C"])
-ssn = StringVariable(name="SSN")
-race = DiscreteVariable(name="race",
-                        values=["White", "Hypsanic", "African", "Other"])
+    def map_vars(s):
+        return [vars[x] for x in s]
+    return Domain(*[map_vars(s) for s in ss])
+
 
 PickleDomain = create_pickling_tests(
     "PickleDomain",
-    ("empty_domain", lambda: Domain([])),
-    ("with_continuous_variable", lambda: Domain([age])),
-    ("with_discrete_variable", lambda: Domain([gender])),
-    ("with_mixed_variables", lambda: Domain([age, gender])),
-    ("with_continuous_class", lambda: Domain([age, gender], [incomeA])),
-    ("with_discrete_class", lambda: Domain([age, gender], [education])),
-    ("with_multiple_classes", lambda: Domain([age, gender],
-                                             [incomeA, education])),
-    ("with_metas", lambda: Domain([age, gender], metas=[ssn])),
-    ("with_class_and_metas", lambda: Domain([age, gender],
-                                            [incomeA, education],
-                                            [ssn])),
+    ("empty_domain", lambda: create_domain([])),
+    ("with_continuous_variable", lambda: create_domain(["age"])),
+    ("with_discrete_variable", lambda: create_domain(["gender"])),
+    ("with_mixed_variables", lambda: create_domain(["age", "gender"])),
+    ("with_continuous_class", lambda: create_domain(["age", "gender"], ["incomeA"])),
+    ("with_discrete_class", lambda: create_domain(["age", "gender"], ["education"])),
+    ("with_multiple_classes", lambda: create_domain(["age", "gender"],
+                                             ["incomeA", "education"])),
+    ("with_metas", lambda: create_domain(["age", "gender"], [], ["ssn"])),
+    ("with_class_and_metas", lambda: create_domain(["age", "gender"],
+                                            ["incomeA", "education"],
+                                            ["ssn"])),
 )
+
+
+age, gender, incomeA, income, education, ssn, race = \
+    create_domain([], [],
+                  ["age", "gender", "incomeA", "income", "education", "ssn",
+                   "race"]).metas
 
 
 class TestDomainInit(unittest.TestCase):
@@ -382,6 +395,7 @@ class TestDomainInit(unittest.TestCase):
         domain.convert([0] * 6)
 
     def test_unpickling_recreates_known_domains(self):
+        Variable._clear_all_caches()
         domain = Domain([])
         unpickled_domain = pickle.loads(pickle.dumps(domain))
         self.assertTrue(hasattr(unpickled_domain, '_known_domains'))
@@ -391,22 +405,23 @@ class TestDomainInit(unittest.TestCase):
         domain2 = Domain([])
         self.assertEqual(domain1, domain2)
 
-        domain1.attributes = (ContinuousVariable('var1'),)
+        var1 = ContinuousVariable('var1')
+        domain1.attributes = (var1,)
         self.assertNotEqual(domain1, domain2)
 
-        domain2.attributes = (ContinuousVariable('var1'),)
+        domain2.attributes = (var1,)
         self.assertEqual(domain1, domain2)
 
-        domain1.class_vars = (ContinuousVariable('var1'),)
+        domain1.class_vars = (var1,)
         self.assertNotEqual(domain1, domain2)
 
-        domain2.class_vars = (ContinuousVariable('var1'),)
+        domain2.class_vars = (var1,)
         self.assertEqual(domain1, domain2)
 
-        domain1._metas = (ContinuousVariable('var1'),)
+        domain1._metas = (var1,)
         self.assertNotEqual(domain1, domain2)
 
-        domain2._metas = (ContinuousVariable('var1'),)
+        domain2._metas = (var1,)
         self.assertEqual(domain1, domain2)
 
 

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -26,9 +26,9 @@ class SimpleTreeTest(unittest.TestCase):
         y_reg[np.random.random(self.N) < 0.1] = np.nan
 
         di = [Orange.data.domain.DiscreteVariable(
-            '', [0, 1]) for _ in range(self.Mi)]
+            'd{}'.format(i), [0, 1]) for i in range(self.Mi)]
         df = [Orange.data.domain.ContinuousVariable(
-            '') for _ in range(self.Mf)]
+            'c{}'.format(i)) for i in range(self.Mf)]
         dcls = Orange.data.domain.DiscreteVariable('', [0, 1, 2])
         dreg = Orange.data.domain.ContinuousVariable('')
         domain_cls = Orange.data.domain.Domain(di + df, dcls)
@@ -46,7 +46,6 @@ class SimpleTreeTest(unittest.TestCase):
         self.assertAlmostEqual(p.max(), 1)
         np.testing.assert_almost_equal(p.sum(axis=1), np.ones(self.N))
 
-    @unittest.skip("test pickles anonymous variables")
     def test_SimpleTree_classification_pickle(self):
         lrn = SimpleTreeLearner()
         clf = lrn(self.data_cls)

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -29,8 +29,8 @@ class SimpleTreeTest(unittest.TestCase):
             'd{}'.format(i), [0, 1]) for i in range(self.Mi)]
         df = [Orange.data.domain.ContinuousVariable(
             'c{}'.format(i)) for i in range(self.Mf)]
-        dcls = Orange.data.domain.DiscreteVariable('', [0, 1, 2])
-        dreg = Orange.data.domain.ContinuousVariable('')
+        dcls = Orange.data.domain.DiscreteVariable('yc', [0, 1, 2])
+        dreg = Orange.data.domain.ContinuousVariable('yr')
         domain_cls = Orange.data.domain.Domain(di + df, dcls)
         domain_reg = Orange.data.domain.Domain(di + df, dreg)
 
@@ -38,6 +38,7 @@ class SimpleTreeTest(unittest.TestCase):
         self.data_reg = Orange.data.Table.from_numpy(domain_reg, X, y_reg)
 
     def test_SimpleTree_classification(self):
+        Orange.data.Variable._clear_all_caches()
         lrn = SimpleTreeLearner()
         clf = lrn(self.data_cls)
         p = clf(self.data_cls, clf.Probs)

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -46,6 +46,7 @@ class SimpleTreeTest(unittest.TestCase):
         self.assertAlmostEqual(p.max(), 1)
         np.testing.assert_almost_equal(p.sum(axis=1), np.ones(self.N))
 
+    @unittest.skip("test pickles anonymous variables")
     def test_SimpleTree_classification_pickle(self):
         lrn = SimpleTreeLearner()
         clf = lrn(self.data_cls)

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -121,10 +121,6 @@ class ContinuousVariableTest(VariableTest):
         a.val_from_str_add("5.1234")
         self.assertEqual(a.str_val(4.654321), "4.6543")
 
-    def dont_pickle_anonymous_variables(self):
-        self.assertRaises(pickle.PickleError,
-                          pickle.dumps, ContinuousVariable())
-
 
 @variabletest(StringVariable)
 class StringVariableTest(VariableTest):

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -1,5 +1,6 @@
 import math
 import unittest
+import pickle
 
 from Orange.testing import create_pickling_tests
 from Orange.data import ContinuousVariable, DiscreteVariable, StringVariable
@@ -75,6 +76,10 @@ class DiscreteVariableTest(unittest.TestCase):
         self.assertEqual(var.name, "a")
         self.assertEqual(var.values, ["F", "M"])
 
+    def dont_pickle_anonymous_variables(self):
+        self.assertRaises(pickle.PickleError,
+                          pickle.dumps, DiscreteVariable())
+
 
 class ContinuousVariableTest(unittest.TestCase):
     def test_make(self):
@@ -99,16 +104,24 @@ class ContinuousVariableTest(unittest.TestCase):
         a.val_from_str_add("5.1234")
         self.assertEqual(a.str_val(4.654321), "4.6543")
 
+    def dont_pickle_anonymous_variables(self):
+        self.assertRaises(pickle.PickleError,
+                          pickle.dumps, ContinuousVariable())
+
+
+class StringVariableTest(unittest.TestCase):
+    def dont_pickle_anonymous_variables(self):
+        self.assertRaises(pickle.PickleError,
+                          pickle.dumps, StringVariable())
+
 
 PickleContinuousVariable = create_pickling_tests(
     "PickleContinuousVariable",
-    ("variable", lambda: ContinuousVariable()),
     ("with_name", lambda: ContinuousVariable(name="Feature 0")),
 )
 
 PickleDiscreteVariable = create_pickling_tests(
     "PickleDiscreteVariable",
-    ("variable", lambda: DiscreteVariable()),
     ("with_name", lambda: DiscreteVariable(name="Feature 0")),
     ("with_int_values", lambda: DiscreteVariable(name="Feature 0",
                                                  values=[1, 2, 3])),
@@ -119,14 +132,13 @@ PickleDiscreteVariable = create_pickling_tests(
                                          ordered=True)),
     ("with_base_value", lambda: DiscreteVariable(name="Feature 0",
                                                  values=["F", "M"],
-                                                 base_value=0)),
+                                                 base_value=0))
 )
 
 
 PickleStringVariable = create_pickling_tests(
     "PickleStringVariable",
-    ("variable", lambda: StringVariable()),
-    ("with_name", lambda: StringVariable(name="Feature 0")),
+    ("with_name", lambda: StringVariable(name="Feature 0"))
 )
 
 

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -122,11 +122,13 @@ PickleDiscreteVariable = create_pickling_tests(
                                                  base_value=0)),
 )
 
+
 PickleStringVariable = create_pickling_tests(
     "PickleStringVariable",
     ("variable", lambda: StringVariable()),
     ("with_name", lambda: StringVariable(name="Feature 0")),
 )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@astaric Almost there. The tests that fails is test_SimpleTree_classification_pickle, yet the problem is general. The test uses data with domain with variables that have no names (e.g. empty strings) and have values [0, 1]. Variable unpickler cannot distinguish between them and thus cannot unpickle them correctly. We can't solve this: this test will never pass.

Solutions:
- anonymous variables cannot be pickled (`Variable.__reduce__` raises an exception if `not self.name`),
- anonymous variables are not allowed at all (`Variable.__init__` raises an exception if the name is empty).

I vote for the former. Let us allows "quick variables", but they are temporary in nature, so they cannot be pickled.

Perhaps we should go further: anonymous variables should not be stored in `all_vars` and `Variable.make` should raise en exception if the name is empty. Anonymous variables are "unmakable".