### PR TITLE
Fix Table/Domain/Instance indexing with numpy.int* scalars.

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -1,5 +1,7 @@
 from collections import Iterable
 from itertools import chain
+from numbers import Integral
+
 import weakref
 from .variable import *
 import numpy as np
@@ -76,7 +78,7 @@ class Domain:
 
         if class_vars is None:
             class_vars = []
-        elif isinstance(class_vars, (Variable, int, str)):
+        elif isinstance(class_vars, (Variable, Integral, str)):
             class_vars = [class_vars]
         elif isinstance(class_vars, Iterable):
             class_vars = list(class_vars)
@@ -370,7 +372,7 @@ class Domain:
                 return None, None
             return attributes, np.fromiter(
                 (self.index(attr) for attr in attributes), int)
-        elif isinstance(col_idx, int):
+        elif isinstance(col_idx, Integral):
             attr = self[col_idx]
         else:
             attr = self[col_idx]

--- a/Orange/data/instance.py
+++ b/Orange/data/instance.py
@@ -1,4 +1,4 @@
-from numbers import Real
+from numbers import Real, Integral
 from ..data.value import Value, Unknown
 from math import isnan
 import numpy as np
@@ -74,7 +74,7 @@ class Instance:
         self._weight = weight
 
     def __setitem__(self, key, value):
-        if not isinstance(key, int):
+        if not isinstance(key, Integral):
             key = self._domain.index(key)
         value = self._domain[key].to_val(value)
         if key >= 0:
@@ -86,7 +86,7 @@ class Instance:
             self._metas[-1 - key] = value
 
     def __getitem__(self, key):
-        if not isinstance(key, int):
+        if not isinstance(key, Integral):
             key = self._domain.index(key)
         if key >= 0:
             value = self._values[key]

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -75,7 +75,7 @@ class RowInstance(Instance):
             self.table._Y[self.row_index, 0] = value
 
     def __setitem__(self, key, value):
-        if not isinstance(key, int):
+        if not isinstance(key, Integral):
             key = self._domain.index(key)
         if isinstance(value, str):
             var = self._domain[key]
@@ -247,29 +247,31 @@ class Table(MutableSequence, Storage):
                 return np.zeros((n_rows, 0), dtype=source.X.dtype)
 
             n_src_attrs = len(source.domain.attributes)
-            if all(isinstance(x, int) and 0 <= x < n_src_attrs
+            if all(isinstance(x, Integral) and 0 <= x < n_src_attrs
                    for x in src_cols):
                 return source.X[row_indices, src_cols]
-            if all(isinstance(x, int) and x < 0 for x in src_cols):
+            if all(isinstance(x, Integral) and x < 0 for x in src_cols):
                 return source.metas[row_indices, [-1 - x for x in src_cols]]
-            if all(isinstance(x, int) and x >= n_src_attrs for x in src_cols):
+            if all(isinstance(x, Integral) and x >= n_src_attrs
+                   for x in src_cols):
                 return source._Y[row_indices, [x - n_src_attrs for x in
                                               src_cols]]
 
             types = []
-            if any(isinstance(x, int) and 0 <= x < n_src_attrs
+            if any(isinstance(x, Integral) and 0 <= x < n_src_attrs
                    for x in src_cols):
                 types.append(source.X.dtype)
-            if any(isinstance(x, int) and x < 0 for x in src_cols):
+            if any(isinstance(x, Integral) and x < 0 for x in src_cols):
                 types.append(source.metas.dtype)
-            if any(isinstance(x, int) and x >= n_src_attrs for x in src_cols):
+            if any(isinstance(x, Integral) and x >= n_src_attrs
+                   for x in src_cols):
                 types.append(source._Y.dtype)
             new_type = np.find_common_type(types, [])
             a = np.empty((n_rows, len(src_cols)), dtype=new_type)
             for i, col in enumerate(src_cols):
                 if col is None:
                     a[:, i] = Unknown
-                elif not isinstance(col, int):
+                elif not isinstance(col, Integral):
                     a[:, i] = col(source)
                 elif col < 0:
                     a[:, i] = source.metas[row_indices, -1 - col]
@@ -493,13 +495,13 @@ class Table(MutableSequence, Storage):
                 self.metas[row] = example._metas
                 return
             c = self.domain.get_conversion(example.domain)
-            self.X[row] = [example._values[i] if isinstance(i, int) else
+            self.X[row] = [example._values[i] if isinstance(i, Integral) else
                            (Unknown if not i else i(example))
                            for i in c.attributes]
-            self._Y[row] = [example._values[i] if isinstance(i, int) else
+            self._Y[row] = [example._values[i] if isinstance(i, Integral) else
                            (Unknown if not i else i(example))
                            for i in c.class_vars]
-            self.metas[row] = [example._values[i] if isinstance(i, int) else
+            self.metas[row] = [example._values[i] if isinstance(i, Integral) else
                                (var.Unknown if not i else i(example))
                                for i, var in zip(c.metas, domain.metas)]
             try:
@@ -542,7 +544,7 @@ class Table(MutableSequence, Storage):
                 return None, None
             return attributes, np.fromiter(
                 (self.domain.index(attr) for attr in attributes), int)
-        elif isinstance(col_idx, int):
+        elif isinstance(col_idx, Integral):
             attr = self.domain[col_idx]
         else:
             attr = self.domain[col_idx]
@@ -597,8 +599,8 @@ class Table(MutableSequence, Storage):
             raise IndexError("Table indices must be one- or two-dimensional")
 
         row_idx, col_idx = key
-        if isinstance(row_idx, int):
-            if isinstance(col_idx, (str, int, Variable)):
+        if isinstance(row_idx, Integral):
+            if isinstance(col_idx, (str, Integral, Variable)):
                 col_idx = self.domain.index(col_idx)
                 var = self.domain[col_idx]
                 if 0 <= col_idx < len(self.domain.attributes):
@@ -647,7 +649,7 @@ class Table(MutableSequence, Storage):
         row_idx, col_idx = key
 
         # single row
-        if isinstance(row_idx, int):
+        if isinstance(row_idx, Integral):
             if isinstance(col_idx, slice):
                 col_idx = range(*slice.indices(col_idx, self.X.shape[1]))
             if not isinstance(col_idx, str) and isinstance(col_idx, Iterable):
@@ -665,9 +667,9 @@ class Table(MutableSequence, Storage):
             else:
                 col_idx, values = [col_idx], [value]
             for value, col_idx in zip(values, col_idx):
-                if not isinstance(value, int):
+                if not isinstance(value, Integral):
                     value = self.domain[col_idx].to_val(value)
-                if not isinstance(col_idx, int):
+                if not isinstance(col_idx, Integral):
                     col_idx = self.domain.index(col_idx)
                 if col_idx >= 0:
                     if col_idx < self.X.shape[1]:
@@ -956,7 +958,7 @@ class Table(MutableSequence, Storage):
             else:
                 return M, False
 
-        if not isinstance(index, int):
+        if not isinstance(index, Integral):
             index = self.domain.index(index)
         if index >= 0:
             if index < self.X.shape[1]:

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -1,3 +1,4 @@
+from numbers import Real, Integral
 from math import isnan, floor
 import numpy as np
 from pickle import PickleError
@@ -349,9 +350,9 @@ class DiscreteVariable(Variable):
         if s is None:
             return ValueUnknown
 
-        if isinstance(s, int):
+        if isinstance(s, Integral):
             return s
-        if np.isreal(s):
+        if isinstance(s, Real):
             return s if isnan(s) else floor(s + 0.25)
         if s in self.unknown_str:
             return ValueUnknown

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -167,16 +167,20 @@ class TestDomainInit(unittest.TestCase):
         self.assertEqual(d.index(age), 0)
         self.assertEqual(d.index("AGE"), 0)
         self.assertEqual(d.index(0), 0)
+        self.assertEqual(d.index(np.int_(0)), 0)
 
         self.assertEqual(d.index(income), 2)
         self.assertEqual(d.index("income"), 2)
         self.assertEqual(d.index(2), 2)
+        self.assertEqual(d.index(np.int_(2)), 2)
 
         self.assertEqual(d.index(ssn), -1)
         self.assertEqual(d.index("SSN"), -1)
         self.assertEqual(d.index(-1), -1)
+        self.assertEqual(d.index(np.int_(-1)), -1)
 
         self.assertEqual(d.index(-2), -2)
+        self.assertEqual(d.index(np.int_(-2)), -2)
 
     def test_get_item_slices(self):
         d = Domain((age, gender, income, race), metas=(ssn, race))
@@ -202,7 +206,11 @@ class TestDomainInit(unittest.TestCase):
         with self.assertRaises(ValueError):
             d.index(3)
         with self.assertRaises(ValueError):
+            d.index(np.int_(3))
+        with self.assertRaises(ValueError):
             d.index(-3)
+        with self.assertRaises(ValueError):
+            d.index(np.int_(-3))
         with self.assertRaises(ValueError):
             d.index(incomeA)
         with self.assertRaises(ValueError):
@@ -215,17 +223,22 @@ class TestDomainInit(unittest.TestCase):
         self.assertTrue("AGE" in d)
         self.assertTrue(age in d)
         self.assertTrue(0 in d)
+        self.assertTrue(np.int_(0) in d)
         self.assertTrue("income" in d)
         self.assertTrue(income in d)
         self.assertTrue(2 in d)
+        self.assertTrue(np.int_(2) in d)
         self.assertTrue("SSN" in d)
         self.assertTrue(ssn in d)
         self.assertTrue(-1 in d)
+        self.assertTrue(np.int_(-1) in d)
 
         self.assertFalse("no_such_thing" in d)
         self.assertFalse(race in d)
         self.assertFalse(3 in d)
+        self.assertFalse(np.int_(3) in d)
         self.assertFalse(-2 in d)
+        self.assertFalse(np.int_(-2) in d)
 
         with self.assertRaises(TypeError):
             {} in d

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -48,6 +48,8 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(d[0][1], "0")
             self.assertEqual(d[0][varc], "0")
             self.assertEqual(d[0]["c"], "0")
+            self.assertEqual(d[np.int_(0), np.int_(1)], "0")
+            self.assertEqual(d[np.int_(0)][np.int_(1)], "0")
 
             # regular, continuous
             varb = d.domain["b"]
@@ -57,6 +59,8 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(d[0][0], 0)
             self.assertEqual(d[0][varb], 0)
             self.assertEqual(d[0]["b"], 0)
+            self.assertEqual(d[np.int_(0), np.int_(0)], 0)
+            self.assertEqual(d[np.int_(0)][np.int_(0)], 0)
 
             # negative
             varb = d.domain["b"]
@@ -66,6 +70,8 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(d[-2][0], 3.333)
             self.assertEqual(d[-2][varb], 3.333)
             self.assertEqual(d[-2]["b"], 3.333)
+            self.assertEqual(d[np.int_(-2), np.int_(0)], 3.333)
+            self.assertEqual(d[np.int_(-2)][np.int_(0)], 3.333)
 
             # meta, discrete
             vara = d.domain["a"]
@@ -76,6 +82,8 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(d[0][metaa], "A")
             self.assertEqual(d[0][vara], "A")
             self.assertEqual(d[0]["a"], "A")
+            self.assertEqual(d[np.int_(0), np.int_(metaa)], "A")
+            self.assertEqual(d[np.int_(0)][np.int_(metaa)], "A")
 
             # meta, string
             vare = d.domain["e"]
@@ -86,6 +94,8 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(d[0][metae], "i")
             self.assertEqual(d[0][vare], "i")
             self.assertEqual(d[0]["e"], "i")
+            self.assertEqual(d[np.int_(0), np.int_(metae)], "i")
+            self.assertEqual(d[np.int_(0)][np.int_(metae)], "i")
 
     def test_indexing_example(self):
         import warnings
@@ -100,12 +110,14 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(e[1], "0")
             self.assertEqual(e[varc], "0")
             self.assertEqual(e["c"], "0")
+            self.assertEqual(e[np.int_(1)], "0")
 
             # regular, continuous
             varb = d.domain["b"]
             self.assertEqual(e[0], 0)
             self.assertEqual(e[varb], 0)
             self.assertEqual(e["b"], 0)
+            self.assertEqual(e[np.int_(0)], 0)
 
             # meta, discrete
             vara = d.domain["a"]
@@ -113,6 +125,7 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(e[metaa], "A")
             self.assertEqual(e[vara], "A")
             self.assertEqual(e["a"], "A")
+            self.assertEqual(e[np.int_(metaa)], "A")
 
             # meta, string
             vare = d.domain["e"]
@@ -120,6 +133,7 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(e[metae], "i")
             self.assertEqual(e[vare], "i")
             self.assertEqual(e["e"], "i")
+            self.assertEqual(e[np.int_(metae)], "i")
 
     def test_indexing_assign_value(self):
         import warnings
@@ -148,6 +162,11 @@ class TableTestCase(unittest.TestCase):
             d[0][metaa] = "A"
             self.assertEqual(d[0, "a"], "A")
 
+            d[0, np.int_(metaa)] = "B"
+            self.assertEqual(d[0, "a"], "B")
+            d[0][np.int_(metaa)] = "A"
+            self.assertEqual(d[0, "a"], "A")
+
             # regular
             varb = d.domain["b"]
 
@@ -165,6 +184,11 @@ class TableTestCase(unittest.TestCase):
             d[0, 0] = 42
             self.assertEqual(d[0, "b"], 42)
             d[0][0] = 0
+            self.assertEqual(d[0, "b"], 0)
+
+            d[0, np.int_(0)] = 42
+            self.assertEqual(d[0, "b"], 42)
+            d[0][np.int_(0)] = 0
             self.assertEqual(d[0, "b"], 0)
 
     def test_indexing_del_example(self):
@@ -206,13 +230,18 @@ class TableTestCase(unittest.TestCase):
             self.assertEqual(d[2, "e"], "4ex")
             self.assertEqual(d[-1, "e"], "was last")
 
+            d[np.int_(2), "e"] = "2ex"
+            del d[np.int_(2)]
+            self.assertEqual(len(d), initlen - 6)
+            self.assertNotEqual(d[2, "e"], "2ex")
+
             with self.assertRaises(IndexError):
                 del d[100]
-            self.assertEqual(len(d), initlen - 5)
+            self.assertEqual(len(d), initlen - 6)
 
             with self.assertRaises(IndexError):
                 del d[-100]
-            self.assertEqual(len(d), initlen - 5)
+            self.assertEqual(len(d), initlen - 6)
 
     def test_indexing_assign_example(self):
         def almost_equal_list(s, t):
@@ -234,13 +263,22 @@ class TableTestCase(unittest.TestCase):
             self.assertTrue(isnan(d[0, "a"]))
             d[0] = [3.15, 1, "t"]
             almost_equal_list(d[0].values(), [3.15, "0", "t"])
+            d[np.int_(0)] = [3.15, 2, "f"]
+            almost_equal_list(d[0].values(), [3.15, 2, "f"])
 
             with self.assertRaises(ValueError):
                 d[0] = ["3.14", "1"]
 
+            with self.assertRaises(ValueError):
+                d[np.int_(0)] = ["3.14", "1"]
+
             ex = data.Instance(d.domain, ["3.16", "1", "f"])
             d[0] = ex
             almost_equal_list(d[0].values(), [3.16, "1", "f"])
+
+            ex = data.Instance(d.domain, ["3.16", 2, "t"])
+            d[np.int_(0)] = ex
+            almost_equal_list(d[0].values(), [3.16, 2, "t"])
 
             ex = data.Instance(d.domain, ["3.16", "1", "f"])
             ex["e"] = "mmmapp"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.8.2
+numpy>=1.9.0
 scipy>=0.11.0
 bottlechest>=0.7.0
 scikit-learn>=0.13

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CLASSIFIERS = (
 
 INSTALL_REQUIRES = (
     'setuptools',
-    'numpy',
+    'numpy>=1.9.0',
     'scipy',
     'bottlechest',
     "sqlparse"


### PR DESCRIPTION
This is done by changing isinstance(_, int) to
isinstance(_, numbers.Integral) where appropriate.

Also increase the required numpy version to 1.9.0 (numpy scalars are
registered with python's ABC system since v1.9.0)