### PR TITLE
No values

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -313,14 +313,21 @@ class Domain:
 
         if isinstance(inst, Instance):
             if inst.domain == self:
-                return inst._values, inst._metas
+                return inst._x, inst._y, inst._metas
             c = self.get_conversion(inst.domain)
-            values = [(inst._values[i] if i >= 0 else inst._metas[-i - 1])
-                      if isinstance(i, int) else
-                      (Unknown if not i else i(inst)) for i in c.variables]
-            metas = [(inst._values[i] if i >= 0 else inst._metas[-i - 1])
-                     if isinstance(i, int) else
-                     (Unknown if not i else i(inst)) for i in c.metas]
+            l = len(inst.domain.attributes)
+            values = [(inst._x[i] if 0 <= i < l
+                       else inst._y[i - l] if i >= l
+                       else inst._metas[-i - 1])
+                      if isinstance(i, int)
+                      else (Unknown if not i else i(inst))
+                      for i in c.variables]
+            metas = [(inst._x[i] if 0 <= i < l
+                      else inst._y[i - l] if i >= l
+                      else inst._metas[-i - 1])
+                     if isinstance(i, int)
+                     else (Unknown if not i else i(inst))
+                     for i in c.metas]
         else:
             nvars = len(self._variables)
             nmetas = len(self._metas)
@@ -333,8 +340,10 @@ class Domain:
                          for var, val in zip(self._metas, inst[nvars:])]
             else:
                 metas = [var.Unknown for var in self._metas]
-            # Let np.array decide dtype for values
-        return np.array(values), np.array(metas, dtype=object)
+        nattrs = len(self.attributes)
+        # Let np.array decide dtype for values
+        return np.array(values[:nattrs]), np.array(values[nattrs:]),\
+               np.array(metas, dtype=object)
 
     def select_columns(self, col_idx):
         attributes, col_indices = self._compute_col_indices(col_idx)

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -362,7 +362,7 @@ class Domain:
             return self
 
     def _compute_col_indices(self, col_idx):
-        if col_idx is Ellipsis:
+        if col_idx is ...:
             return None, None
         if isinstance(col_idx, np.ndarray) and col_idx.dtype == bool:
             return ([attr for attr, c in zip(self, col_idx) if c],

--- a/Orange/data/instance.py
+++ b/Orange/data/instance.py
@@ -20,7 +20,6 @@ class Instance:
             domain = data.domain
 
         self._domain = domain
-        self.sparse_x = self.sparse_y = self.sparse_metas = None
         if data is None:
             self._x = np.repeat(Unknown, len(domain.attributes))
             self._y = np.repeat(Unknown, len(domain.class_vars))

--- a/Orange/data/instance.py
+++ b/Orange/data/instance.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from numbers import Real, Integral
 from ..data.value import Value, Unknown
 from math import isnan
@@ -21,19 +22,19 @@ class Instance:
         self._domain = domain
         self.sparse_x = self.sparse_y = self.sparse_metas = None
         if data is None:
-            self._values = np.repeat(Unknown, len(domain.variables))
+            self._x = np.repeat(Unknown, len(domain.attributes))
+            self._y = np.repeat(Unknown, len(domain.class_vars))
             self._metas = np.array([var.Unknown for var in domain.metas],
                                    dtype=object)
             self._weight = 1
         elif isinstance(data, Instance) and data.domain == domain:
-            self._values = np.array(data._values)
+            self._x = np.array(data._x)
+            self._y = np.array(data._y)
             self._metas = np.array(data._metas)
             self._weight = data._weight
         else:
-            self._values, self._metas = domain.convert(data)
+            self._x, self._y, self._metas = domain.convert(data)
             self._weight = 1
-        self._x = self._values[:len(domain.attributes)]
-        self._y = self._values[len(domain.attributes):]
 
     @property
     def domain(self):
@@ -77,19 +78,24 @@ class Instance:
         if not isinstance(key, Integral):
             key = self._domain.index(key)
         value = self._domain[key].to_val(value)
-        if key >= 0:
-            if not isinstance(value, (int, float)):
-                raise TypeError("Expected primitive value, got '%s'" %
-                                type(value).__name__)
-            self._values[key] = value
+        if key >= 0 and not isinstance(value, (int, float)):
+            raise TypeError("Expected primitive value, got '%s'" %
+                            type(value).__name__)
+
+        if 0 <= key < len(self._domain.attributes):
+            self._x[key] = value
+        elif len(self._domain.attributes) <= key:
+            self._y[key - len(self.domain.attributes)] = value
         else:
             self._metas[-1 - key] = value
 
     def __getitem__(self, key):
         if not isinstance(key, Integral):
             key = self._domain.index(key)
-        if key >= 0:
-            value = self._values[key]
+        if 0 <= key < len(self._domain.attributes):
+            value = self._x[key]
+        elif key >= len(self._domain.attributes):
+            value = self._y[key - len(self.domain.attributes)]
         else:
             value = self._metas[-1 - key]
         return Value(self._domain[key], value)
@@ -134,27 +140,31 @@ class Instance:
     def __eq__(self, other):
         if not isinstance(other, Instance):
             other = Instance(self._domain, other)
-        nan1 = np.isnan(self._values)
-        nan2 = np.isnan(other._values)
-        return np.array_equal(nan1, nan2) and \
-            np.array_equal(self._values[~nan1], other._values[~nan2]) \
+
+        def same(x1, x2):
+            nan1 = np.isnan(x1)
+            nan2 = np.isnan(x2)
+            return np.array_equal(nan1, nan2) and \
+                np.array_equal(x1[~nan1], x2[~nan2])
+
+        return same(self._x, other._x) and same(self._y, other._y) \
             and all(m1 == m2 or
                     type(m1) == type(m2) == float and isnan(m1) and isnan(m2)
                     for m1, m2 in zip(self._metas, other._metas))
 
     def __iter__(self):
-        return iter(self._values)
+        return chain(iter(self._x), iter(self._y))
 
     def values(self):
         return (Value(var, val)
-                for var, val in zip(self.domain.variables, self._values))
+                for var, val in zip(self.domain.variables, self))
 
     def __len__(self):
-        return len(self._values)
+        return len(self._x) + len(self._y)
 
     def attributes(self):
         """Return iterator over the instance's attributes"""
-        return iter(self._values[:len(self._domain.attributes)])
+        return iter(self._x)
 
     def classes(self):
         """Return iterator over the instance's class attributes"""
@@ -193,4 +203,3 @@ class Instance:
             self._y[0] = self._domain.class_var.to_val(value)
         else:
             self._y[0] = value
-        self._values[len(self._domain.attributes)] = self._y[0]

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -59,7 +59,6 @@ class RowInstance(Instance):
             return 1
         return self.table.W[self.row_index]
 
-    #noinspection PyMethodOverriding
     @weight.setter
     def weight(self, weight):
         if not self.table.has_weights():
@@ -490,20 +489,14 @@ class Table(MutableSequence, Storage):
                     self.X[row] = example._x
                     self._Y[row] = example._y
                 else:
-                    self.X[row] = example._values[:len(domain.attributes)]
-                    self._Y[row] = example._values[len(domain.attributes):]
+                    self.X[row] = example._x
+                    self._Y[row] = example._y
                 self.metas[row] = example._metas
                 return
             c = self.domain.get_conversion(example.domain)
-            self.X[row] = [example._values[i] if isinstance(i, Integral) else
-                           (Unknown if not i else i(example))
-                           for i in c.attributes]
-            self._Y[row] = [example._values[i] if isinstance(i, Integral) else
-                           (Unknown if not i else i(example))
-                           for i in c.class_vars]
-            self.metas[row] = [example._values[i] if isinstance(i, Integral) else
-                               (var.Unknown if not i else i(example))
-                               for i, var in zip(c.metas, domain.metas)]
+
+            self.X[row], self._Y[row], self.metas[row] = \
+                self.domain.convert(example)
             try:
                 self.ids[row] = example.id
             except:

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -364,12 +364,14 @@ class TestDomainInit(unittest.TestCase):
         domain = Domain([age, income], [race],
                         [gender, education, ssn])
 
-        values, metas = domain.convert([42, 13, "White"])
-        assert_array_equal(values, np.array([42, 13, 0]))
+        x, y, metas = domain.convert([42, 13, "White"])
+        assert_array_equal(x, np.array([42, 13]))
+        assert_array_equal(y, np.array([0]))
         assert_array_equal(metas, np.array([Unknown, Unknown, None]))
 
-        values, metas = domain.convert([42, 13, "White", "M", "HS", "1234567"])
-        assert_array_equal(values, np.array([42, 13, 0]))
+        x, y, metas = domain.convert([42, 13, "White", "M", "HS", "1234567"])
+        assert_array_equal(x, np.array([42, 13]))
+        assert_array_equal(y, np.array([0]))
         assert_array_equal(metas, np.array([0, 1, "1234567"], dtype=object))
 
     def test_conversion_size(self):

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -45,11 +45,9 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain)
         self.assertIsInstance(inst, Instance)
         self.assertIs(inst.domain, domain)
-        self.assertEqual(inst._values.shape, (len(self.attributes), ))
         self.assertEqual(inst._x.shape, (len(self.attributes), ))
         self.assertEqual(inst._y.shape, (0, ))
         self.assertEqual(inst._metas.shape, (0, ))
-        self.assertTrue(all(isnan(x) for x in inst._values))
         self.assertTrue(all(isnan(x) for x in inst._x))
 
     def test_init_xy_no_data(self):
@@ -57,12 +55,9 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain)
         self.assertIsInstance(inst, Instance)
         self.assertIs(inst.domain, domain)
-        self.assertEqual(inst._values.shape,
-                         (len(self.attributes) + len(self.class_vars), ))
         self.assertEqual(inst._x.shape, (len(self.attributes), ))
         self.assertEqual(inst._y.shape, (len(self.class_vars), ))
         self.assertEqual(inst._metas.shape, (0, ))
-        self.assertTrue(all(isnan(x) for x in inst._values))
         self.assertTrue(all(isnan(x) for x in inst._x))
         self.assertTrue(all(isnan(x) for x in inst._y))
 
@@ -71,12 +66,9 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain)
         self.assertIsInstance(inst, Instance)
         self.assertIs(inst.domain, domain)
-        self.assertEqual(inst._values.shape,
-                         (len(self.attributes) + len(self.class_vars), ))
         self.assertEqual(inst._x.shape, (len(self.attributes), ))
         self.assertEqual(inst._y.shape, (len(self.class_vars), ))
         self.assertEqual(inst._metas.shape, (3, ))
-        self.assertTrue(all(isnan(x) for x in inst._values))
         self.assertTrue(all(isnan(x) for x in inst._x))
         self.assertTrue(all(isnan(x) for x in inst._y))
         with warnings.catch_warnings():
@@ -87,7 +79,6 @@ class TestInstance(unittest.TestCase):
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")])
         vals = np.array([42, 0])
         inst = Instance(domain, vals)
-        assert_array_equal(inst._values, vals)
         assert_array_equal(inst._x, vals)
         self.assertEqual(inst._y.shape, (0, ))
         self.assertEqual(inst._metas.shape, (0, ))
@@ -104,7 +95,6 @@ class TestInstance(unittest.TestCase):
         lst = [42, 0]
         vals = np.array(lst)
         inst = Instance(domain, vals)
-        assert_array_equal(inst._values, vals)
         assert_array_equal(inst._x, vals)
         self.assertEqual(inst._y.shape, (0, ))
         self.assertEqual(inst._metas.shape, (0, ))
@@ -120,7 +110,6 @@ class TestInstance(unittest.TestCase):
                                     [DiscreteVariable("y", values="ABC")])
         vals = np.array([42, 0, 1])
         inst = Instance(domain, vals)
-        assert_array_equal(inst._values, vals)
         assert_array_equal(inst._x, vals[:2])
         self.assertEqual(inst._y.shape, (1, ))
         self.assertEqual(inst._y[0], 1)
@@ -132,7 +121,6 @@ class TestInstance(unittest.TestCase):
         lst = [42, "M", "C"]
         vals = np.array([42, 0, 2])
         inst = Instance(domain, vals)
-        assert_array_equal(inst._values, vals)
         assert_array_equal(inst._x, vals[:2])
         self.assertEqual(inst._y.shape, (1, ))
         self.assertEqual(inst._y[0], 2)
@@ -146,11 +134,9 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain, vals)
         self.assertIsInstance(inst, Instance)
         self.assertIs(inst.domain, domain)
-        self.assertEqual(inst._values.shape, (3, ))
         self.assertEqual(inst._x.shape, (2, ))
         self.assertEqual(inst._y.shape, (1, ))
         self.assertEqual(inst._metas.shape, (3, ))
-        assert_array_equal(inst._values, np.array([42, 0, 1]))
         assert_array_equal(inst._x, np.array([42, 0]))
         self.assertEqual(inst._y[0], 1)
         assert_array_equal(inst._metas, np.array([0, 43, "Foo"], dtype=object))
@@ -163,11 +149,9 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain, vals)
         self.assertIsInstance(inst, Instance)
         self.assertIs(inst.domain, domain)
-        self.assertEqual(inst._values.shape, (3, ))
         self.assertEqual(inst._x.shape, (2, ))
         self.assertEqual(inst._y.shape, (1, ))
         self.assertEqual(inst._metas.shape, (3, ))
-        assert_array_equal(inst._values, np.array([42, 0, 1]))
         assert_array_equal(inst._x, np.array([42, 0]))
         self.assertEqual(inst._y[0], 1)
         assert_array_equal(inst._metas, np.array([0, 43, "Foo"], dtype=object))
@@ -180,7 +164,6 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain, vals)
 
         inst2 = Instance(domain, inst)
-        assert_array_equal(inst2._values, np.array([42, 0, 1]))
         assert_array_equal(inst2._x, np.array([42, 0]))
         self.assertEqual(inst2._y[0], 1)
         assert_array_equal(inst2._metas, np.array([0, 43, "Foo"], dtype=object))
@@ -191,7 +174,6 @@ class TestInstance(unittest.TestCase):
         inst2 = Instance(domain2, inst)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
-            assert_array_equal(inst2._values, np.array([Unknown, 0, 43, 1]))
             assert_array_equal(inst2._x, np.array([Unknown, 0, 43]))
             self.assertEqual(inst2._y[0], 1)
             assert_array_equal(inst2._metas, np.array([0, Unknown, 42],


### PR DESCRIPTION
Remove _values from Instance, skip Instance.__init__ call in RowInstance. This speeds up iteration over data.Table.