### PR TITLE
Fix an error in from_numpy constructor when W has zero size.

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -175,27 +175,27 @@ class Table(MutableSequence, Storage):
         if 'filename' in kwargs:
             args = [kwargs.pop('filename')]
 
-        try:
-            if isinstance(args[0], str):
-                if args[0].startswith('https://') or args[0].startswith('http://'):
-                    return cls.from_url(args[0], **kwargs)
-                else:
-                    return cls.from_file(args[0], **kwargs)
-            elif isinstance(args[0], Table):
-                return cls.from_table(args[0].domain, args[0])
-            elif isinstance(args[0], orange_domain.Domain):
-                domain, args = args[0], args[1:]
-                if not args:
-                    return cls.from_domain(domain, **kwargs)
-                if isinstance(args[0], Table):
-                    return cls.from_table(domain, args[0])
-            else:
-                domain = None
+        if not args:
+            raise TypeError(
+                "Table takes at least 1 positional argument (0 given))")
 
-            return cls.from_numpy(domain, *args, **kwargs)
-        except IndexError:
-            pass
-        raise ValueError("Invalid arguments for Table.__new__")
+        if isinstance(args[0], str):
+            if args[0].startswith('https://') or args[0].startswith('http://'):
+                return cls.from_url(args[0], **kwargs)
+            else:
+                return cls.from_file(args[0], **kwargs)
+        elif isinstance(args[0], Table):
+            return cls.from_table(args[0].domain, args[0])
+        elif isinstance(args[0], orange_domain.Domain):
+            domain, args = args[0], args[1:]
+            if not args:
+                return cls.from_domain(domain, **kwargs)
+            if isinstance(args[0], Table):
+                return cls.from_table(domain, args[0])
+        else:
+            domain = None
+
+        return cls.from_numpy(domain, *args, **kwargs)
 
     @classmethod
     def from_domain(cls, domain, n_rows=0, weights=False):
@@ -388,7 +388,7 @@ class Table(MutableSequence, Storage):
                 X = X[:, :len(domain.attributes)]
         if metas is None:
             metas = np.empty((X.shape[0], 0), object)
-        if W is None:
+        if W is None or W.size == 0:
             W = np.empty((X.shape[0], 0))
         else:
             W = W.reshape(W.size, 1)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1351,6 +1351,35 @@ class CreateTableWithData(TableTests):
         new_from_numpy.assert_called_with(domain, self.data, self.class_data,
                                           self.meta_data, self.weight_data)
 
+    def test_from_numpy_reconstructable(self):
+        def assert_equal(T1, T2):
+            np.testing.assert_array_equal(T1.X, T2.X)
+            np.testing.assert_array_equal(T1.Y, T2.Y)
+            np.testing.assert_array_equal(T1.metas, T2.metas)
+            np.testing.assert_array_equal(T1.W, T2.W)
+
+        nullcol = np.empty((self.nrows, 0))
+        domain = self.create_domain(self.attributes)
+        table = data.Table(domain, self.data)
+
+        table_1 = data.Table.from_numpy(
+            domain, table.X, table.Y, table.metas, table.W)
+        assert_equal(table, table_1)
+
+        domain = self.create_domain(classes=self.class_vars)
+        table = data.Table(domain, nullcol, self.class_data)
+
+        table_1 = data.Table.from_numpy(
+            domain, table.X, table.Y, table.metas, table.W)
+        assert_equal(table, table_1)
+
+        domain = self.create_domain(metas=self.metas)
+        table = data.Table(domain, nullcol, nullcol, self.meta_data)
+
+        table_1 = data.Table.from_numpy(
+            domain, table.X, table.Y, table.metas, table.W)
+        assert_equal(table, table_1)
+
 
 class CreateTableWithDomainAndTable(TableTests):
     interesting_slices = [


### PR DESCRIPTION
Add tests to ensure a table can be reconstructed from X, Y, metas and W
even when some have zero size.

Also remove one overzealous and confounding try except block.