### PR TITLE
Use MultiUser.nsh and MUI2.nsh for the NSIS installer.

### DIFF
--- a/scripts/windows/install-standalone.nsi
+++ b/scripts/windows/install-standalone.nsi
@@ -27,40 +27,73 @@ Name Orange3
 Icon OrangeInstall.ico
 UninstallIcon OrangeInstall.ico
 
-# Default installation directory
-InstallDir $PROGRAMFILES\Orange3\
+# Registry key/values where the installation layout is saved
+!define INSTALL_SETTINGS_KEY Software\OrangeCanvas\Standalone\Current
+!define INSTALL_SETTINGS_INSTDIR InstallDir
+!define INSTALL_SETTINGS_INSTMODE InstallMode
 
-# Ask the user for a target install dir.
-Page directory
-DirText "Choose a folder in which to install Orange3"
-Page instfiles
+!define MUI_ICON OrangeInstall.ico
+!define MUI_UNICON OrangeInstall.ico
+
+# Support for both current or all users installation layout
+# (see MultiUser/Readme.html)
+!define MULTIUSER_EXECUTIONLEVEL Highest
+
+# Enable the Current/All Users selection page.
+!define MULTIUSER_MUI
+
+# Enable /AllUsers or /CurrentUser command line switch (see MultiUser/Readme.html)
+!define MULTIUSER_INSTALLMODE_COMMANDLINE
+
+# the default folder name where Orange will be installed
+!define MULTIUSER_INSTALLMODE_INSTDIR "Orange3"
+
+!define MULTIUSER_INSTALLMODE_INSTDIR_REGISTRY_KEY ${INSTALL_SETTINGS_KEY}
+!define MULTIUSER_INSTALLMODE_INSTDIR_REGISTRY_VALUENAME ${INSTALL_SETTINGS_INSTDIR}
+
+!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_KEY ${INSTALL_SETTINGS_KEY}
+!define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME ${INSTALL_SETTINGS_INSTMODE}
+
+!include MultiUser.nsh
+!include MUI2.nsh
+!include LogicLib.nsh
+
+!insertmacro MULTIUSER_PAGE_INSTALLMODE
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+
+!insertmacro MUI_LANGUAGE English
 
 
-AutoCloseWindow false
-
-# Temporary folder where temp data is extracted
+# Temporary folder where temp data will be extracted
 !define TEMPDIR $TEMP\orange-installer
-
-!include "LogicLib.nsh"
 
 !include "install-common.nsi"
 
 !define SHELLFOLDERS \
   "Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders"
 
+!define UNINSTALLER "$INSTDIR\uninstall.exe"
 
 Function .onInit
-	# Initialize AdminInstall and PythonDir global variables.
-	${InitAdminInstall}
+	# Initialize MultiUser
+	!insertmacro MULTIUSER_INIT
+	# Initialize SSE global variable
 	${InitSSE}
 FunctionEnd
 
-Function .onInstSuccess
-	MessageBox MB_OK "Orange3 has been successfully installed." /SD IDOK
+
+Function un.onInit
+	!insertmacro MULTIUSER_UNINIT
 FunctionEnd
 
 
-Section ""
+Section "Main"
 
 	DetailPrint "Extracting installers"
 	${ExtractTemp} "${BASEDIR}\core\python\python-${PYTHON_VERSION}.msi" "${TEMPDIR}\core\python"
@@ -145,14 +178,30 @@ Section ""
 					"$PythonDir\pythonw.exe" "-m Orange.canvas" \
 					"$PythonDir\share\Orange\canvas\icons\orange.ico" 0
 
-	CreateShortCut "$SMPROGRAMS\Orange3\Uninstall Orange.lnk" \
-					"$PythonDir\share\Orange\canvas\uninst.exe"
+	CreateShortCut "$SMPROGRAMS\Orange3\Uninstall Orange.lnk" ${UNINSTALLER}
 
 	# Desktop shortcut
 	CreateShortCut "$DESKTOP\Orange Canvas.lnk" \
 					"$PythonDir\pythonw.exe" "-m Orange.canvas" \
 					"$PythonDir\share\Orange\canvas\icons\orange.ico" 0
 
+	WriteRegStr SHELL_CONTEXT \
+				${INSTALL_SETTINGS_KEY} ${INSTALL_SETTINGS_INSTDIR} \
+				"$INSTDIR"
+
+	WriteRegStr SHELL_CONTEXT \
+				${INSTALL_SETTINGS_KEY} "PythonDir" \
+				"$PythonDir"
+
+	WriteRegStr SHELL_CONTEXT \
+				${INSTALL_SETTINGS_KEY} ${INSTALL_SETTINGS_INSTMODE} \
+				$MultiUser.Privileges
+
+	WriteRegStr SHELL_CONTEXT "Software\Classes\.ows" "" "OrangeCanvas"
+	WriteRegStr SHELL_CONTEXT "Software\Classes\OrangeCanvas\DefaultIcon" "" "$PythonDir\share\Orange\canvas\icons\OrangeOWS.ico"
+	WriteRegStr SHELL_CONTEXT "Software\Classes\OrangeCanvas\Shell\Open\Command\" "" '$PythonDir\python.exe -m Orange.canvas "%1"'
+
+	WriteUninstaller ${UNINSTALLER}
 
 	WriteRegStr SHELL_CONTEXT \
 				"Software\Microsoft\Windows\CurrentVersion\Uninstall\Orange3" \
@@ -160,54 +209,34 @@ Section ""
 
 	WriteRegStr SHELL_CONTEXT \
 				"Software\Microsoft\Windows\CurrentVersion\Uninstall\Orange3" \
-				"UninstallString" '$PythonDir\share\Orange\canvas\uninst.exe'
-
-	WriteRegStr SHELL_CONTEXT \
-				"Software\OrangeCanvas\Standalone\Current" "InstallDir" \
-				"$INSTDIR"
-
-	WriteRegStr SHELL_CONTEXT \
-				"Software\OrangeCanvas\Standalone\Current" "PythonDir" \
-				"$PythonDir"
-
-	WriteRegStr HKEY_CLASSES_ROOT ".ows" "" "OrangeCanvas"
-	WriteRegStr HKEY_CLASSES_ROOT "OrangeCanvas\DefaultIcon" "" "$PythonDir\share\Orange\canvas\icons\OrangeOWS.ico"
-	WriteRegStr HKEY_CLASSES_ROOT "OrangeCanvas\Shell\Open\Command\" "" '$PythonDir\python.exe -m Orange.canvas "%1"'
-
-	WriteUninstaller "$PythonDir\share\Orange\canvas\uninst.exe"
+				"UninstallString" ${UNINSTALLER}
 
 	DetailPrint "Cleanup"
 	RmDir /R ${TEMPDIR}
+
 SectionEnd
 
 
 Section Uninstall
 
-	${If} $AdminInstall = 0
-	    SetShellVarContext all
-	${Else}
-	    SetShellVarContext current
-	${EndIf}
-
-	MessageBox MB_YESNO "Are you sure you want to remove Orange?" /SD IDYES IDNO abort
-
-	ReadRegStr $PythonDir SHELL_CONTEXT Software\OrangeCanvas\Standalone\Current PythonDir
+	ReadRegStr $PythonDir SHELL_CONTEXT ${INSTALL_SETTINGS_KEY} PythonDir
 
 	${If} ${FileExists} "$PythonDir\python.exe"
 		RmDir /R $PythonDir
 	${EndIf}
 
-	ReadRegStr $0 SHELL_CONTEXT Software\OrangeCanvas\Standalone\Current InstallDir
+	ReadRegStr $0 SHELL_CONTEXT ${INSTALL_SETTINGS_KEY} ${INSTALL_SETTINGS_INSTDIR}
 
 	${If} ${FileExists} "$0"
 		Delete "$0\*.bat"
 		Delete "$0\Orange Canvas.lnk"
+		Delete "$0\uninstall.exe"
 		RmDir "$0"
 	${EndIf}
 
 	RmDir /R "$SMPROGRAMS\Orange3"
 
-	# Remove application settings folder
+	# Remove application settings folder (?)
 	ReadRegStr $0 HKCU "${SHELLFOLDERS}" AppData
 	${If} $0 != ""
 		ReadRegStr $0 HKLM "${SHELLFOLDERS}" "Common AppData"
@@ -218,22 +247,13 @@ Section Uninstall
 		RmDir /R "$0\Orange3"
 	${EndIf}
 
-	${If} $AdminInstall == 1
-		DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Orange3"
-	${Else}
-		DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Orange3"
-	${Endif}
+	DeleteRegKey SHELL_CONTEXT "Software\Microsoft\Windows\CurrentVersion\Uninstall\Orange3"
 
 	Delete "$DESKTOP\Orange Canvas.lnk"
 
-	DeleteRegKey HKEY_CLASSES_ROOT ".ows"
-	DeleteRegKey HKEY_CLASSES_ROOT "OrangeCanvas"
+	DeleteRegKey SHELL_CONTEXT "Software\Classes\.ows"
+	DeleteRegKey SHELL_CONTEXT "Software\Classes\OrangeCanvas"
 
-	DeleteRegKey SHELL_CONTEXT Software\OrangeCanvas\Standalone\Current
-
-	MessageBox MB_OK "Orange has been succesfully removed from your system." /SD IDOK
-
-  abort:
-
+	DeleteRegKey SHELL_CONTEXT ${INSTALL_SETTINGS_KEY}
 
 SectionEnd


### PR DESCRIPTION
This properly enables current user installation scheme
as well as makes the GUI more standard and much prettier.