### PR TITLE
Fixed error when removing data for TestLeaners.

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -148,9 +148,10 @@ class OWTestLearners(widget.OWWidget):
         self.train_data = data
         self.closeContext()
         self.class_selection = "(None)"
-        self.openContext(data.domain.class_var)
+        if data is not None:
+            self.openContext(data.domain.class_var)
+            self._update_header()
         self._update_class_selection()
-        self._update_header()
         self._invalidate()
 
     def set_test_data(self, data):
@@ -287,10 +288,12 @@ class OWTestLearners(widget.OWWidget):
             model.appendRow(row)
 
     def _update_class_selection(self):
+        self.class_selection_combo.clear()
+        if not self.train_data:
+            return
         if self.train_data.domain.class_var.is_discrete:
             self.cbox.setVisible(True)
             values = self.train_data.domain.class_var.values
-            self.class_selection_combo.clear()
             self.class_selection_combo.addItem("(None)")
             self.class_selection_combo.addItems(values)
 

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -147,7 +147,6 @@ class OWTestLearners(widget.OWWidget):
 
         self.train_data = data
         self.closeContext()
-        self.class_selection = "(None)"
         if data is not None:
             self.openContext(data.domain.class_var)
             self._update_header()
@@ -298,8 +297,10 @@ class OWTestLearners(widget.OWWidget):
             self.class_selection_combo.addItems(values)
 
             class_index = 0
-            if self.class_selection != '(None)' and self.class_selection != 0:
-                class_index = self.train_data.domain.class_var.values.index(self.class_selection)+1
+            if self.class_selection in self.train_data.domain.class_var.values:
+                    class_index = self.train_data.domain.class_var.values.index(self.class_selection)+1
+            else:
+                self.class_selection = '(None)'
 
             self.class_selection_combo.setCurrentIndex(class_index)
             self.previous_class_selection = "(None)"


### PR DESCRIPTION
When deleting input to TestLearnes widget the following error was triggered:
`AttributeError: 'NoneType' object has no attribute 'domain'` in line 156 since there is a call to `self.openContext(data.domain.class_var)`. I added the check so this is only done when we set the data and not also when we remove it.