### PR TITLE
has_discrete_class always returns a boolean, discretize handles None class.

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -282,7 +282,7 @@ class Domain:
 
     @property
     def has_discrete_class(self):
-        return self.class_var and self.class_var.is_discrete
+        return bool(self.class_var and self.class_var.is_discrete)
 
     def get_conversion(self, source):
         """

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -412,7 +412,7 @@ class OWDiscretize(widget.OWWidget):
             return None
 
         def disc_var(source):
-            if source.is_continuous:
+            if source and source.is_continuous:
                 return self.discretized_var(source)
             else:
                 return source


### PR DESCRIPTION
The discretizer failed since has_discrete_class returned None, not False. disc_var should also work when source is None.