### PR TITLE
Box plot fixes

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -242,6 +242,14 @@ class OWBoxPlot(widget.OWWidget):
         self.update_display_box()
         self.layout_changed()
 
+        if self.is_continuous:
+            heights = 90 if self.show_annotations else 60
+            self.box_view.centerOn(self.scene_min_x + self.scene_width / 2,
+                                  -30 - len(self.stats) * heights / 2 + 45)
+        else:
+            self.box_view.centerOn(self.scene_width / 2,
+                                  -30 - len(self.boxes) * 40 / 2 + 45)
+
     def compute_box_data(self):
         dataset = self.dataset
         if dataset is None:
@@ -349,8 +357,6 @@ class OWBoxPlot(widget.OWWidget):
         r = QtCore.QRectF(self.scene_min_x, -30 - len(self.stats) * heights,
                           self.scene_width, len(self.stats) * heights + 90)
         self.box_scene.setSceneRect(r)
-        self.box_view.centerOn(self.scene_min_x + self.scene_width / 2,
-                              -30 - len(self.stats) * heights / 2 + 45)
 
         self.compute_tests()
         self.show_posthoc()
@@ -378,8 +384,6 @@ class OWBoxPlot(widget.OWWidget):
         self.box_scene.setSceneRect(-self.label_width - 5,
                                    -30 - len(self.boxes) * 40,
                                    self.scene_width, len(self.boxes * 40) + 90)
-        self.box_view.centerOn(self.scene_width / 2,
-                              -30 - len(self.boxes) * 40 / 2 + 45)
         self.infot1.setText("")
 
     # noinspection PyPep8Naming

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -150,12 +150,14 @@ class OWBoxPlot(widget.OWWidget):
 
         self.attr_list_box = gui.listBox(
             self.controlArea, self, "attributes_select", "attributes",
-            box="Variable", callback=self.attr_changed)
+            box="Variable", callback=self.attr_changed,
+            sizeHint=QtCore.QSize(200, 250))
 
         box = gui.widgetBox(self.controlArea, "Grouping")
         self.group_list_box = gui.listBox(
             box, self, 'grouping_select', "grouping",
-            callback=self.attr_changed)
+            callback=self.attr_changed,
+            sizeHint=QtCore.QSize(200, 150))
 
         # TODO: move Compare median/mean to grouping box
         self.display_box = gui.widgetBox(self.controlArea, "Display")

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -67,7 +67,7 @@ class OWBoxPlot(widget.OWWidget):
     """
     Here's how the widget's functions call each other:
 
-    - `data` is a signal handler fills the list boxes and calls `attr_changed`.
+    - `set_data` is a signal handler fills the list boxes and calls `attr_changed`.
 
     - `attr_changed` handles changes of attribute or grouping (callbacks for
     list boxes). It recomputes box data by calling `compute_box_data`, shows
@@ -213,6 +213,7 @@ class OWBoxPlot(widget.OWWidget):
             dataset = None
         self.closeContext()
         self.dataset = dataset
+        self.dist = self.stats = self.conts = []
         self.grouping_select = []
         self.attributes_select = []
         self.attr_list_box.clear()
@@ -294,7 +295,7 @@ class OWBoxPlot(widget.OWWidget):
 
     def layout_changed(self):
         self.clear_scene()
-        if len(self.conts) == len(self.dist) == 0:
+        if self.dataset is None or len(self.conts) == len(self.dist) == 0:
             return
 
         if not self.is_continuous:
@@ -316,6 +317,9 @@ class OWBoxPlot(widget.OWWidget):
         self.display_changed()
 
     def display_changed(self):
+        if self.dataset is None:
+            return
+
         if not self.is_continuous:
             return self.display_changed_disc()
 

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -216,13 +216,15 @@ class OWBoxPlot(widget.OWWidget):
         self.attr_list_box.clear()
         self.group_list_box.clear()
         if dataset:
-            self.openContext(self.dataset)
             self.attributes = [(a.name, vartype(a)) for a in dataset.domain]
             self.grouping = ["None"] + [(a.name, vartype(a))
                                         for a in dataset.domain
                                         if a.is_discrete]
             self.grouping_select = [0]
             self.attributes_select = [0]
+
+            self.openContext(self.dataset)
+
             self.attr_changed()
         else:
             self.reset_all_data()

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -230,7 +230,8 @@ class OWBoxPlot(widget.OWWidget):
     def reset_all_data(self):
         self.attr_list_box.clear()
         self.group_list_box.clear()
-        self.box_scene.clear()
+        self.clear_scene()
+        self.infot1.setText("")
 
     def attr_changed(self):
         self.compute_box_data()
@@ -375,6 +376,7 @@ class OWBoxPlot(widget.OWWidget):
                                    self.scene_width, len(self.boxes * 40) + 90)
         self.box_view.centerOn(self.scene_width / 2,
                               -30 - len(self.boxes) * 40 / 2 + 45)
+        self.infot1.setText("")
 
     # noinspection PyPep8Naming
     def compute_tests(self):


### PR DESCRIPTION
Allow the box plot median/mean labels in 'Compare medians/means' mode.
General code cleanup.
Clear the test report text below the plot when none is available.
