### PR TITLE
Build and provide help for widgets from the markdown files.

### DIFF
--- a/Orange/widgets/__init__.py
+++ b/Orange/widgets/__init__.py
@@ -1,12 +1,16 @@
 """
 
 """
+import os
+import sysconfig
+
 import pkg_resources
+
+import Orange
 
 
 # Entry point for main Orange categories/widgets discovery
 def widget_discovery(discovery):
-    #from . import data
     dist = pkg_resources.get_distribution("Orange")
     pkgs = ["Orange.widgets.data",
             "Orange.widgets.visualize",
@@ -17,3 +21,11 @@ def widget_discovery(discovery):
             "Orange.widgets.prototypes"]
     for pkg in pkgs:
         discovery.process_category_package(pkg, distribution=dist)
+
+
+WIDGET_HELP_PATH = (
+    ("{DEVELOP_ROOT}/doc/build/htmlhelp/index.html", None),
+#     os.path.join(sysconfig.get_path("data"),
+#                  "share", "doc", "Orange-{}".format(Orange.__version__)),
+    ("http://docs.orange.biolab.si/3/", "")
+)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,8 @@ autodoc_member_order = "bysource"
 templates_path = ['templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = [".rst", ".md"]
+source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,6 +26,37 @@ Development
 
     development/widget
 
+Widgets
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   widgets/data/file
+   widgets/data/save
+   widgets/data/datainfo
+   widgets/data/datatable
+   widgets/data/selectcolumns
+   widgets/data/selectrows
+   widgets/data/datasampler
+   widgets/data/discretize
+   widgets/data/continuize
+   widgets/data/concatenate
+   widgets/data/paintdata
+   widgets/data/pythonscript
+   widgets/data/featureconstructor
+   widgets/data/editdomain
+
+   widgets/visualize/boxplot
+   widgets/visualize/distributions
+   widgets/visualize/heat-map
+   widgets/visualize/scatterplot
+   widgets/visualize/venn-diagram
+
+   widgets/classify/naivebayes
+   widgets/classify/logisticregression
+
+
 Indices and tables
 ==================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ bottlechest>=0.7.0
 scikit-learn>=0.16
 nose==1.2.1
 Jinja2==2.6
-Sphinx
+Sphinx>=1.3
+recommonmark>=0.1.1
 numpydoc
 openpyxl>=2.1.2

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,11 @@ if len({'develop', 'release', 'bdist_egg', 'bdist_rpm', 'bdist_wininst',
         zip_safe=False,  # the package can run out of an .egg file
         include_package_data=True,
         test_suite='Orange.tests.test_suite',
-        install_requires=INSTALL_REQUIRES
+        install_requires=INSTALL_REQUIRES,
+        entry_points={
+            "orange.canvas.help": (
+                "html-index = Orange.widgets:WIDGET_HELP_PATH",)
+        }
     )
 else:
     extra_setuptools_args = dict()


### PR DESCRIPTION
@markotoplak @BlazZupan

The most straightforward tool for building documentation from markdown `mkdocs` unfortunately does not build it in a way suitable for local viewing/browsing (i.e. it builds the htmldir style directory structure and all the links in it point to 'something/' directory listing instead of the actual html file, making navigation extremely frustrating).

I think the best solution would be to incorporate the .md documentation in the existing sphinx build, which is (will be) easy but requires ~~an unreleased development version of sphinx 1.4a~~  sphinx 1.3 and recommonmark

 