### PR TITLE
Enable container-based builds on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
     apt: true
     directories:
         - $TRAVIS_BUILD_DIR/wheelhouse
+        - $TRAVIS_BUILD_DIR/postgres
         - $HOME/.cache/pip
         - $HOME/.ccache
 
@@ -29,6 +30,7 @@ before_install:
 
 install:
     - source $TRAVIS_BUILD_DIR/travis/install.sh
+    - source $TRAVIS_BUILD_DIR/travis/install_postgres.sh
     - if [ $TRAVIS_REPO_SLUG = biolab/orange3 ] && [ $TRAVIS_PULL_REQUEST = false ]; then
         source $TRAVIS_BUILD_DIR/travis/install_pyqt.sh;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,26 @@
 language: python
 
+sudo: false
+
 python:
     - '3.4'
+
+cache:
+    apt: true
+    directories:
+        - $TRAVIS_BUILD_DIR/wheelhouse
+        - $HOME/.cache/pip
+        - $HOME/.ccache
+
+before_cache:
+
+addons:
+    apt:
+        packages:
+            - libblas-dev
+            - liblapack-dev
+            - postgresql-server-dev-9.1
+            - libqt4-dev
 
 before_install:
     - if [ $TRAVIS_REPO_SLUG = biolab/orange3 ]; then

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -7,13 +7,13 @@ from Orange import preprocess
 from Orange.data.sql.table import SqlTable
 from Orange.data import Domain
 from Orange.data.variable import DiscreteVariable
-from Orange.tests.sql.base import sql_test
+from Orange.tests.sql.base import sql_test, connection_params
 
 
 @sql_test
 class NaiveBayesTest(unittest.TestCase):
     def test_NaiveBayes(self):
-        table = SqlTable(dict(host='localhost', database='test'), 'iris',
+        table = SqlTable(connection_params(), 'iris',
                          type_hints=Domain([], DiscreteVariable("iris",
                                 values=['Iris-setosa', 'Iris-virginica',
                                         'Iris-versicolor'])))

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,4 +1,4 @@
-pip install -U setuptools pip wheel pgxnclient
+pip install -U setuptools pip wheel
 if [ ! "$(ls wheelhouse)" ]; then
     git clone -b pyqt --depth=1 https://github.com/astaric/orange3-requirements wheelhouse
 else
@@ -9,15 +9,3 @@ pip install wheelhouse/*.whl
 pip install -r requirements.txt
 
 python setup.py build_ext -i
-
-# Sql requirements
-#~ pip install wheelhouse/sql/*.whl
-#~ psql -c 'create database test;' -U postgres
-#~ cd wheelhouse/sql/quantile-1.1.3
-#~ sudo make install
-#~ cd ../../..
-#~ cd wheelhouse/sql/binning
-#~ sudo make install
-#~ cd ../../..
-#~ psql test -c 'CREATE EXTENSION quantile;' -U postgres
-#~ psql test -c 'CREATE EXTENSION binning;' -U postgres

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,8 +1,9 @@
-sudo apt-get update
-sudo apt-get install -qq libblas-dev liblapack-dev postgresql-server-dev-9.1 libqt4-dev
-
 pip install -U setuptools pip wheel pgxnclient
-git clone -b pyqt --depth=1 https://github.com/astaric/orange3-requirements wheelhouse
+if [ ! "$(ls wheelhouse)" ]; then
+    git clone -b pyqt --depth=1 https://github.com/astaric/orange3-requirements wheelhouse
+else
+    echo 'Using cached wheelhouse.';
+fi
 
 pip install wheelhouse/*.whl
 pip install -r requirements.txt
@@ -10,13 +11,13 @@ pip install -r requirements.txt
 python setup.py build_ext -i
 
 # Sql requirements
-pip install wheelhouse/sql/*.whl
-psql -c 'create database test;' -U postgres
-cd wheelhouse/sql/quantile-1.1.3
-sudo make install
-cd ../../..
-cd wheelhouse/sql/binning
-sudo make install
-cd ../../..
-psql test -c 'CREATE EXTENSION quantile;' -U postgres
-psql test -c 'CREATE EXTENSION binning;' -U postgres
+#~ pip install wheelhouse/sql/*.whl
+#~ psql -c 'create database test;' -U postgres
+#~ cd wheelhouse/sql/quantile-1.1.3
+#~ sudo make install
+#~ cd ../../..
+#~ cd wheelhouse/sql/binning
+#~ sudo make install
+#~ cd ../../..
+#~ psql test -c 'CREATE EXTENSION quantile;' -U postgres
+#~ psql test -c 'CREATE EXTENSION binning;' -U postgres

--- a/travis/install_postgres.sh
+++ b/travis/install_postgres.sh
@@ -1,0 +1,46 @@
+VERSION=9.5alpha1
+POSTGRES=$TRAVIS_BUILD_DIR/postgres/$VERSION
+
+if [ ! "$(ls $POSTGRES)" ]; then
+    mkdir -p $POSTGRES
+    cd $POSTGRES
+
+    # Download PostgreSQL and extension sources
+    wget -O postgres.tar.bz2 https://ftp.postgresql.org/pub/source/v$VERSION/postgresql-$VERSION.tar.bz2
+    tar xjf postgres.tar.bz2 --strip-components=1
+
+    wget http://api.pgxn.org/dist/quantile/1.1.4/quantile-1.1.4.zip
+    unzip quantile-1.1.4.zip
+
+    wget https://dl.dropboxusercontent.com/u/3818654/binning.tar.gz
+    tar xzf binning.tar.gz
+
+    # Build and install PostgreSQL
+    cd $POSTGRES
+    ./configure --prefix $POSTGRES
+    make install
+
+    # Add our PostgreSQL to PATH, so extensions know where to install.
+    export PATH=$POSTGRES/bin:$PATH
+
+    # Install quantile extension
+    cd $POSTGRES/quantile-1.1.4
+    make install
+
+    # Install binning extension
+    cd $POSTGRES/binning
+    make install
+else
+    echo "Using cached PostgreSQL."
+fi
+
+# Create a new database dir, create database test and register extensions
+$POSTGRES/bin/initdb -D $TRAVIS_BUILD_DIR/db
+$POSTGRES/bin/postgres -D $TRAVIS_BUILD_DIR/db -p 12345 &
+sleep 1
+$POSTGRES/bin/createdb -p 12345 test
+$POSTGRES/bin/psql test -c 'CREATE EXTENSION quantile;' -p 12345
+$POSTGRES/bin/psql test -c 'CREATE EXTENSION binning;' -p 12345
+
+pip install psycopg2
+export ORANGE_TEST_DB_URI=postgres://localhost:12345/test


### PR DESCRIPTION
This travis configuration is based on #503. I have moved PostgreSQL related installation code to a separate script, which builds and installs PostgreSQL and both extensions we use.

First Travis run that builds Postgres takes about 8 minutes. Subsequent runs finish in about 2.5 minutes, which is much better than the current 4.5 minutes per run.

