### PR TITLE
Remove MeanModel autoclass from documentation.

### DIFF
--- a/doc/modules/regression.rst
+++ b/doc/modules/regression.rst
@@ -69,9 +69,6 @@ Example
 .. autoclass:: MeanLearner
    :members:
 
-.. autoclass:: MeanModel
-   :members:
-
 
 .. index:: random forest (simple)
    pair: regression; simple random forest


### PR DESCRIPTION
Models are not documented for other learners
and not accessible from top level modeules (Orange.regression).