### PR TITLE
Set a non empty window title on all dialogs.

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -403,6 +403,7 @@ class AddonManagerDialog(QDialog):
             minimum=0, maximum=0,
             labelText=self.tr("Retrieving package list"),
             sizeGripEnabled=False,
+            windowTitle="Progress"
         )
 
         self.__progress.rejected.connect(self.reject)

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -667,7 +667,7 @@ def edit_links(scheme, source_node, sink_node, initial_links=None,
     """
     log.info("Constructing a Link Editor dialog.")
 
-    dlg = EditLinksDialog(parent)
+    dlg = EditLinksDialog(parent, windowTitle="Edit Links")
 
     # all SchemeLinks between the two nodes.
     links = scheme.find_links(source_node=source_node, sink_node=sink_node)
@@ -949,7 +949,7 @@ class EditNodeLinksAction(UserInteraction):
         """
         log.info("Constructing a Link Editor dialog.")
 
-        dlg = EditLinksDialog(self.document)
+        dlg = EditLinksDialog(self.document, windowTitle="Edit Links")
 
         links = self.scheme.find_links(source_node=self.source_node,
                                        sink_node=self.sink_node)


### PR DESCRIPTION
On Windows and Linux all windows get a default window title (executable
name - in our case 'python') unless specified otherwise.