### PR TITLE
Parent the QStandardItemModel to the widget so it is destroyed with it.

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -80,7 +80,7 @@ class OWConfusionMatrix(widget.OWWidget):
         grid.addWidget(QLabel("Predicted"), 0, 1, Qt.AlignCenter)
         grid.addWidget(VerticalLabel("Actual Class"), 1, 0, Qt.AlignCenter)
 
-        self.tablemodel = QStandardItemModel()
+        self.tablemodel = QStandardItemModel(self)
         self.tableview = QTableView(editTriggers=QTableView.NoEditTriggers)
         self.tableview.setModel(self.tablemodel)
         self.tableview.selectionModel().selectionChanged.connect(

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -126,7 +126,7 @@ class OWTestLearners(widget.OWWidget):
         header.setDefaultAlignment(Qt.AlignCenter)
         header.setStretchLastSection(False)
 
-        self.result_model = QStandardItemModel()
+        self.result_model = QStandardItemModel(self)
         self.view.setModel(self.result_model)
         self.view.setItemDelegate(ItemDelegate())
         self._update_header()

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -127,7 +127,7 @@ class OWKMeans(widget.OWWidget):
                         orientation="horizontal")
         gui.rubber(self.controlArea)
 
-        self.table_model = QStandardItemModel()
+        self.table_model = QStandardItemModel(self)
         self.table_model.setHorizontalHeaderLabels(["k", "Score"])
         self.table_model.setColumnCount(2)
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -226,6 +226,7 @@ class OWHeatMap(widget.OWWidget):
                       {3: [(0, 255, 0), (0, 0, 0), (255, 0, 0)]})]
         palettes += self.user_palettes
         model = color_palette_model(palettes, self.color_cb.iconSize())
+        model.setParent(self)
         self.color_cb.setModel(model)
         self.color_cb.activated.connect(self.update_color_schema)
         self.color_cb.setCurrentIndex(self.palette_index)


### PR DESCRIPTION
Fix an 'QObject::startTimer: QTimer can only be used with threads
started with QThread' warning on program exit, and the model outlives the
QApplication instance.