### PR TITLE
Clear variable cache when generating datasets.info.

### DIFF
--- a/Orange/datasets/datasets.info
+++ b/Orange/datasets/datasets.info
@@ -116,7 +116,7 @@
         "rows": 683,
         "target": {
             "type": "discrete",
-            "values": 6
+            "values": 2
         }
     },
     "breast-cancer-wisconsin-cont": {
@@ -341,7 +341,7 @@
         "rows": 214,
         "target": {
             "type": "discrete",
-            "values": 8
+            "values": 6
         }
     },
     "hair-eye-sex": {
@@ -371,7 +371,7 @@
         "rows": 132,
         "target": {
             "type": "discrete",
-            "values": 8
+            "values": 3
         }
     },
     "hayes-roth_test": {
@@ -386,7 +386,7 @@
         "rows": 28,
         "target": {
             "type": "discrete",
-            "values": 8
+            "values": 3
         }
     },
     "heart_disease": {
@@ -551,7 +551,7 @@
         "rows": 32,
         "target": {
             "type": "discrete",
-            "values": 8
+            "values": 3
         }
     },
     "lymphography": {
@@ -821,7 +821,7 @@
         "rows": 253,
         "target": {
             "type": "discrete",
-            "values": 8
+            "values": 2
         }
     },
     "smokers_ct": {

--- a/Orange/datasets/list_update.py
+++ b/Orange/datasets/list_update.py
@@ -10,6 +10,7 @@ external_datasets = [
 
 def data_info(name, location):
     print(location)
+    Orange.data.Variable._clear_all_caches()
     data = Orange.data.Table(location)
     attr = data.domain.attributes
     class_var = data.domain.class_var


### PR DESCRIPTION
Otherwise, features with same names that are present in different
datasets contain merged values, resulting in wrong count.