### PR TITLE
Widget settings fix

### DIFF
--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -249,6 +249,10 @@ class WidgetManager(QObject):
             state.future.cancel()
             del self.__initstate_for_node[node]
         else:
+            # Update the node's stored settings/properties dict before
+            # removing the widget.
+            # TODO: Update/sync whenever the widget settings change.
+            node.properties = self._widget_settings(state.widget)
             self.__widgets.remove(state.widget)
             del self.__initstate_for_node[node]
             del self.__widget_for_node[node]
@@ -257,6 +261,9 @@ class WidgetManager(QObject):
 
             self.widget_for_node_removed.emit(node, state.widget)
             self._delete_widget(state.widget)
+
+    def _widget_settings(self, widget):
+        return widget.settingsHandler.pack_data(widget)
 
     def _delete_widget(self, widget):
         """

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -39,6 +39,9 @@ class Setting:
 
     __repr__ = __str__
 
+    def __getnewargs__(self):
+        return (self.default, )
+
 
 class SettingProvider:
     """A hierarchical structure keeping track of settings belonging to
@@ -66,9 +69,11 @@ class SettingProvider:
         for name in dir(provider_class):
             value = getattr(provider_class, name, None)
             if isinstance(value, Setting):
+                value = copy.deepcopy(value)
                 value.name = name
                 self.settings[name] = value
             if isinstance(value, SettingProvider):
+                value = copy.deepcopy(value)
                 value.name = name
                 self.providers[name] = value
 


### PR DESCRIPTION
* Fix erroneous initial widget geometry due to shared OWWidget.savedWidgetGeometry setting.
* Store/retrieve the settings from the widget when removing from the workflow (ensures that settings
  are restored between undo/redo operations.