### PR TITLE
Widgets size constraint

### DIFF
--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -19,6 +19,7 @@ class OWClassificationTree(widget.OWWidget):
         ("Classification Tree", TreeClassifier)
     ]
     want_main_area = False
+    resizing_enabled = False
 
     model_name = Setting("Classification Tree")
     attribute_score = Setting(0)
@@ -59,9 +60,6 @@ class OWClassificationTree(widget.OWWidget):
         self.btn_apply = gui.button(self.controlArea, self, "&Apply",
                                     callback=self.set_learner, disabled=0,
                                     default=True)
-
-        gui.rubber(self.controlArea)
-        self.resize(100, 100)
 
         self.set_learner()
 

--- a/Orange/widgets/classify/owknn.py
+++ b/Orange/widgets/classify/owknn.py
@@ -14,6 +14,8 @@ class OWKNNLearner(widget.OWWidget):
     outputs = [("Learner", KNNLearner), ("Classifier", SklModel)]
 
     want_main_area = False
+    resizing_enabled = False
+
     learner_name = Setting("kNN")
     n_neighbors = Setting(5)
     metric_index = Setting(0)
@@ -38,10 +40,6 @@ class OWKNNLearner(widget.OWWidget):
 
         gui.button(self.controlArea, self, "Apply",
                    callback=self.apply, default=True)
-
-        self.setMinimumWidth(250)
-        layout = self.layout()
-        self.layout().setSizeConstraint(layout.SetFixedSize)
 
         self.apply()
 

--- a/Orange/widgets/classify/owloadclassifier.py
+++ b/Orange/widgets/classify/owloadclassifier.py
@@ -24,6 +24,7 @@ class OWLoadClassifier(widget.OWWidget):
     FILTER = "Pickle files (*.pickle *.pck)\nAll files (*.*)"
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -36,6 +37,8 @@ class OWLoadClassifier(widget.OWWidget):
         self.filesCB = gui.comboBox(
             box, self, "selectedIndex", callback=self._on_recent)
         self.filesCB.setMinimumContentsLength(20)
+        self.filesCB.setSizeAdjustPolicy(
+            QtGui.QComboBox.AdjustToMinimumContentsLength)
 
         self.loadbutton = gui.button(box, self, "...", callback=self.browse)
         self.loadbutton.setIcon(

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -20,6 +20,7 @@ class OWLogisticRegression(widget.OWWidget):
                ("Classifier", lr.LogisticRegressionClassifier)]
 
     want_main_area = False
+    resizing_enabled = False
 
     learner_name = settings.Setting("Logistic Regression")
 
@@ -63,9 +64,6 @@ class OWLogisticRegression(widget.OWWidget):
         self.c_label = gui.widgetLabel(box2)
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.apply, default=True)
-        self.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                                             QtGui.QSizePolicy.Fixed))
-        self.setMinimumWidth(300)
         self.set_c()
         self.apply()
 

--- a/Orange/widgets/classify/owmajority.py
+++ b/Orange/widgets/classify/owmajority.py
@@ -19,6 +19,9 @@ class OWMajority(widget.OWWidget):
 
     learner_name = Setting("Majority")
 
+    want_main_area = False
+    resizing_enabled = False
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.data = None

--- a/Orange/widgets/classify/ownaivebayes.py
+++ b/Orange/widgets/classify/ownaivebayes.py
@@ -19,6 +19,7 @@ class OWNaiveBayes(widget.OWWidget):
                ("Classifier", NaiveBayesModel)]
 
     want_main_area = False
+    resizing_enabled = False
 
     learner_name = settings.Setting("Naive Bayes")
 

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -22,6 +22,7 @@ class OWRandomForest(widget.OWWidget):
                ("Classifier", RandomForestClassifier)]
 
     want_main_area = False
+    resizing_enabled = False
 
     learner_name = settings.Setting("Random Forest Learner")
     n_estimators = settings.Setting(10)
@@ -120,11 +121,6 @@ class OWRandomForest(widget.OWWidget):
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.apply, default=True)
 
-        self.setSizePolicy(
-            QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                              QtGui.QSizePolicy.Fixed)
-        )
-        self.layout().setSizeConstraint(QLayout.SetFixedSize)
         self.settingsChanged()
         self.apply()
 

--- a/Orange/widgets/classify/owsaveclassifier.py
+++ b/Orange/widgets/classify/owsaveclassifier.py
@@ -25,6 +25,7 @@ class OWSaveClassifier(widget.OWWidget):
     FILTER = "Pickle files (*.pickle *.pck)\nAll files (*.*)"
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -37,6 +38,8 @@ class OWSaveClassifier(widget.OWWidget):
         self.filesCB = gui.comboBox(box, self, "selectedIndex",
                                     callback=self._on_recent)
         self.filesCB.setMinimumContentsLength(20)
+        self.filesCB.setSizeAdjustPolicy(
+            QtGui.QComboBox.AdjustToMinimumContentsLength)
 
         button = gui.button(
             box, self, "...", callback=self.browse, default=True

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -22,6 +22,7 @@ class OWSVMClassification(widget.OWWidget):
                ("Support vectors", Table)]
 
     want_main_area = False
+    resizing_enabled = False
 
     learner_name = settings.Setting("SVM Learner")
 
@@ -114,13 +115,6 @@ class OWSVMClassification(widget.OWWidget):
 
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.apply, default=True)
-
-        self.setSizePolicy(
-            QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                              QtGui.QSizePolicy.Fixed)
-        )
-
-        self.setMinimumWidth(300)
 
         self._on_kernel_changed()
 

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -48,6 +48,7 @@ class OWConcatenate(widget.OWWidget):
     source_attr_name = settings.Setting("Source ID")
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -120,9 +121,6 @@ class OWConcatenate(widget.OWWidget):
             self.controlArea, self, self.tr("Apply Changes"),
             callback=self.apply, default=True
         )
-
-        gui.rubber(self.controlArea)
-        self.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
 
     def set_primary_data(self, data):
         self.primary_data = data

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -21,6 +21,7 @@ class OWContinuize(widget.OWWidget):
     outputs = [("Data", Orange.data.Table)]
 
     want_main_area = False
+    resizing_enabled = False
 
     multinomial_treatment = Setting(0)
     zero_based = Setting(1)
@@ -85,7 +86,6 @@ class OWContinuize(widget.OWWidget):
         gui.auto_commit(self.controlArea, self, "autosend", "Apply")
 
         self.data = None
-        self.resize(150, 300)
 
     def settings_changed(self):
         self.commit()

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1120,7 +1120,7 @@ class SequenceFlow(QWidget):
         if self.widgets():
             return super().sizeHint()
         else:
-            return QSize(150, 100)
+            return QSize(250, 350)
 
     def addWidget(self, widget, title):
         """Add `widget` with `title` to list of widgets (in the last position).
@@ -1614,6 +1614,10 @@ class OWPreprocess(widget.OWWidget):
         self.scroll_area.setMinimumWidth(
             min(max(sh.width() + scroll_width + 2, self.controlArea.width()),
                 520))
+
+    def sizeHint(self):
+        sh = super().sizeHint()
+        return sh.expandedTo(QSize(sh.width(), 500))
 
 
 def test_main(argv=sys.argv):

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -29,6 +29,7 @@ class OWPurgeDomain(widget.OWWidget):
     sortClasses = Setting(True)
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -20,6 +20,7 @@ class OWSave(widget.OWWidget):
     inputs = [("Data", Table, "dataset")]
 
     want_main_area = False
+    resizing_enabled = False
 
     format_index = Setting(0)
     last_dir = Setting("")

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -30,6 +30,7 @@ class OWSql(widget.OWWidget):
         doc="Attribute-valued data set read from the input file.")]
 
     want_main_area = False
+    resizing_enabled = False
 
     host = Setting(None)
     port = Setting(None)
@@ -40,10 +41,8 @@ class OWSql(widget.OWWidget):
     sql = Setting("")
     guess_values = Setting(True)
 
-    def __init__(self, parent=None, signalManager=None, stored_settings=None):
-        super(OWSql, self).__init__(parent=parent,
-                                    signalManager=signalManager,
-                                    stored_settings=stored_settings)
+    def __init__(self, parent=None):
+        super(OWSql, self).__init__(parent=parent)
 
         self._connection = None
 
@@ -73,8 +72,11 @@ class OWSql(widget.OWWidget):
         box.layout().addWidget(self.passwordtext)
 
         tables = gui.widgetBox(box, orientation='horizontal')
-        self.tablecombo = QtGui.QComboBox(tables)
-
+        self.tablecombo = QtGui.QComboBox(
+            tables,
+            minimumContentsLength=35,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLength
+        )
         tables.layout().addWidget(self.tablecombo)
         self.tablecombo.activated[int].connect(self.select_table)
         self.connectbutton = gui.button(

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -47,6 +47,9 @@ class OWPredictions(widget.OWWidget):
     show_predictions = Setting(True)
     show_probabilities = Setting(True)
 
+    want_main_area = False
+    resizing_enabled = False
+
     def __init__(self):
         super().__init__()
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1105,7 +1105,8 @@ def lineEdit(widget, master, value, label=None, labelWidth=None,
     """
     if box or label:
         b = widgetBox(widget, box, orientation, addToLayout=False)
-        widgetLabel(b, label, labelWidth)
+        if label is not None:
+            widgetLabel(b, label, labelWidth)
         hasHBox = orientation == 'horizontal' or not orientation
     else:
         b = widget

--- a/Orange/widgets/regression/owmean.py
+++ b/Orange/widgets/regression/owmean.py
@@ -16,6 +16,9 @@ class OWMean(widget.OWWidget):
 
     learner_name = settings.Setting("Mean Learner")
 
+    want_main_area = False
+    resizing_enabled = False
+
     def __init__(self, parent=None):
         super().__init__(parent)
 

--- a/Orange/widgets/regression/owsgdregression.py
+++ b/Orange/widgets/regression/owsgdregression.py
@@ -40,6 +40,7 @@ class OWSGDRegression(widget.OWWidget):
     learning_rate = settings.Setting(InvScaling)
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -123,13 +124,6 @@ class OWSGDRegression(widget.OWWidget):
 
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.apply, default=True)
-
-        self.setSizePolicy(
-            QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                              QtGui.QSizePolicy.Fixed)
-        )
-
-        self.setMinimumWidth(300)
 
         self._on_func_changed()
 

--- a/Orange/widgets/regression/owsvmregression.py
+++ b/Orange/widgets/regression/owsvmregression.py
@@ -50,6 +50,7 @@ class OWSVMRegression(widget.OWWidget):
     tol = settings.Setting(0.001)
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -136,13 +137,6 @@ class OWSVMRegression(widget.OWWidget):
 
         gui.button(self.controlArea, self, "&Apply",
                    callback=self.apply, default=True)
-
-        self.setSizePolicy(
-            QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed,
-                              QtGui.QSizePolicy.Fixed)
-        )
-
-        self.setMinimumWidth(300)
 
         self._on_kernel_changed()
 

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -223,6 +223,9 @@ class OWWidget(QDialog, metaclass=WidgetMetaClass):
                 self.statusBarIconArea,
                 gui.resource_filename("icons/triangle-red.png"))
 
+        if not self.resizing_enabled:
+            self.layout().setSizeConstraint(QVBoxLayout.SetFixedSize)
+
     def updateStatusBarState(self):
         if not hasattr(self, "widgetStatusArea"):
             return


### PR DESCRIPTION
Make widgets which do not have expanding GUI non-resizable.
This is done by using (existing) ``OWWidget.resizing_enabled`` widget class member flag.

Also improve Preprocess widget's size hints and fix a bug in ``gui.lineEdit``

