### PR TITLE
Make sure the settings dir exists before settings reset.

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1537,6 +1537,7 @@ class CanvasMainWindow(QMainWindow):
             # function and is deleted there.
             fname = os.path.join(config.widget_settings_dir(),
                                  "DELETE_ON_START")
+            os.makedirs(config.widget_settings_dir(), exist_ok=True)
             with open(fname, "a"):
                 pass
 


### PR DESCRIPTION
If the settings were already reset, the dir was deleted
and creating DELETE_ON_START file failed.