### PR TITLE
Fix preprocessor output (not working after inital load)

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1506,6 +1506,8 @@ class OWPreprocess(widget.OWWidget):
             # will be triggered by LayoutRequest event on the `flow_view`)
             self.__update_size_constraint()
 
+        self.apply()
+
     def load(self, saved):
         """Load a preprocessor list from a dict."""
         name = saved.get("name", "")


### PR DESCRIPTION
Call apply and send outputs after _initialize().

Loaded settings were not applied if the widget had no inputs.
E.g. loading a saved schema did not send preprocessor outputs.