### PR TITLE
Add instance id to Instance.

### DIFF
--- a/Orange/data/instance.py
+++ b/Orange/data/instance.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 class Instance:
-    def __init__(self, domain, data=None):
+    def __init__(self, domain, data=None, id=None):
         """
         Construct a new data instance.
 
@@ -14,6 +14,8 @@ class Instance:
         :type domain: Orange.data.Domain
         :param data: instance's values
         :type data: Orange.data.Instance or a sequence of values
+        :param id: instance id
+        :type id: hashable value
         """
         if data is None and isinstance(domain, Instance):
             data = domain
@@ -34,6 +36,12 @@ class Instance:
         else:
             self._x, self._y, self._metas = domain.convert(data)
             self._weight = 1
+
+        if id is not None:
+            self.id = id
+        else:
+            from Orange.data import Table
+            self.id = Table.new_id()
 
     @property
     def domain(self):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -462,6 +462,13 @@ class Table(MutableSequence, Storage):
             obj.ids = np.array(range(cls._next_instance_id, cls._next_instance_id + obj.X.shape[0]))
             cls._next_instance_id += obj.X.shape[0]
 
+    @classmethod
+    def new_id(cls):
+        with cls._next_instance_lock:
+            id = cls._next_instance_id
+            cls._next_instance_id += 1
+            return id
+
     FILE_FORMATS = {
         ".tab": (io.TabDelimFormat, )
     }

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -348,3 +348,14 @@ class TestInstance(unittest.TestCase):
         inst2[-3] = "Bar"
         self.assertFalse(inst == inst2)
 
+    def test_instance_id(self):
+        domain = self.create_domain(["x"])
+        vals = [42]
+
+        inst = Instance(domain, vals, id=42)
+        self.assertEqual(inst.id, 42)
+
+        inst2 = Instance(domain, vals)
+        inst3 = Instance(domain, vals)
+
+        self.assertNotEqual(inst2.id, inst3.id)


### PR DESCRIPTION
Currently only RowInstance supports ids, but there is no reason that
Instance should not have it as well.