### PR TITLE
Remove dependency on custom SQL extension "binning"

### DIFF
--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -65,7 +65,8 @@ class BinSql:
         self.points = points
 
     def __call__(self):
-        return 'bin(%s, ARRAY%s)' % (self.var.to_sql(), str(self.points))
+        return 'width_bucket(%s, ARRAY%s::double precision[])' % (
+            self.var.to_sql(), str(self.points))
 
 
 class SingleValueSql:

--- a/travis/install_postgres.sh
+++ b/travis/install_postgres.sh
@@ -12,9 +12,6 @@ if [ ! "$(ls $POSTGRES)" ]; then
     wget http://api.pgxn.org/dist/quantile/1.1.4/quantile-1.1.4.zip
     unzip quantile-1.1.4.zip
 
-    wget https://dl.dropboxusercontent.com/u/3818654/binning.tar.gz
-    tar xzf binning.tar.gz
-
     # Build and install PostgreSQL
     cd $POSTGRES
     ./configure --prefix $POSTGRES
@@ -26,10 +23,6 @@ if [ ! "$(ls $POSTGRES)" ]; then
     # Install quantile extension
     cd $POSTGRES/quantile-1.1.4
     make install
-
-    # Install binning extension
-    cd $POSTGRES/binning
-    make install
 else
     echo "Using cached PostgreSQL."
 fi
@@ -40,7 +33,6 @@ $POSTGRES/bin/postgres -D $TRAVIS_BUILD_DIR/db -p 12345 &
 sleep 1
 $POSTGRES/bin/createdb -p 12345 test
 $POSTGRES/bin/psql test -c 'CREATE EXTENSION quantile;' -p 12345
-$POSTGRES/bin/psql test -c 'CREATE EXTENSION binning;' -p 12345
 
 pip install psycopg2
 export ORANGE_TEST_DB_URI=postgres://localhost:12345/test


### PR DESCRIPTION
The function it provided (bin) is now available in core PostgreSQL (as width_bucket).