### PR TITLE
Simplified the distributions widget

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -300,12 +300,14 @@ class OWDistributions(widget.OWWidget):
             curves = [(X, Y * w) for (X, Y), w in zip(curves, weights)]
 
             for (X, Y), color in reversed(list(zip(curves, colors))):
+                X = X + (X[1] - X[0])/2
+                X = X[:-1]
                 item = pg.PlotCurveItem()
-                pen = QtGui.QPen(QtGui.QBrush(color), 5)
+                pen = QtGui.QPen(QtGui.QBrush(color), 3)
                 pen.setCosmetic(True)
                 color = QtGui.QColor(color)
-                color.setAlphaF(0.1)
-                item.setData(X, Y, antialias=True, stepMode=True,
+                color.setAlphaF(0.2)
+                item.setData(X, Y, antialias=True, stepMode=False,
                              fillLevel=0, brush=QtGui.QBrush(color),
                              pen=pen)
                 self.plot.addItem(item)

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -294,34 +294,17 @@ class OWDistributions(widget.OWWidget):
             colors = cols
             curves = [(X, Y * w) for (X, Y), w in zip(curves, weights)]
 
-            cum_curves = [curves[0]]
-            for X, Y in curves[1:]:
-                cum_curves.append(sum_rect_curve(X, Y, *cum_curves[-1]))
-
-            for (X, Y), color in reversed(list(zip(cum_curves, colors))):
+            for (X, Y), color in reversed(list(zip(curves, colors))):
                 item = pg.PlotCurveItem()
-                pen = QtGui.QPen(QtGui.QBrush(Qt.white), 0.5)
+                pen = QtGui.QPen(QtGui.QBrush(color), 5)
                 pen.setCosmetic(True)
+                color = QtGui.QColor(color)
+                color.setAlphaF(0.1)
                 item.setData(X, Y, antialias=True, stepMode=True,
                              fillLevel=0, brush=QtGui.QBrush(color),
                              pen=pen)
                 self.plot.addItem(item)
 
-#             # XXX: sum the individual curves and not the distributions.
-#             # The conditional distributions might be 'smoother' than
-#             # the cumulative one
-#             cum_dist = [cont[0]]
-#             for dist in cont[1:]:
-#                 cum_dist.append(dist_sum(dist, cum_dist[-1]))
-#
-#             curves = [rect_kernel_curve(dist) for dist in cum_dist]
-#             colors = [Qt.blue, Qt.red, Qt.magenta]
-#             for (X, Y), color in reversed(list(zip(curves, colors))):
-#                 item = pg.PlotCurveItem()
-#                 item.setData(X, Y, antialias=True, stepMode=True,
-#                              fillLevel=0, brush=QtGui.QBrush(color))
-#                 item.setPen(QtGui.QPen(color))
-#                 self.plot.addItem(item)
         elif var and var.is_discrete:
             bottomaxis.setTicks([list(enumerate(var.values))])
 

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -64,12 +64,11 @@ class DistributionBarItem(pg.GraphicsObject):
         geom = self.geometry
         x, y = geom.x(), geom.y()
         w, h = geom.width(), geom.height()
+        wsingle = w / len(self.dist)
         for d, c in zip(self.dist, self.colors):
-            if d == 0:
-                continue
             painter.setBrush(QtGui.QBrush(c.lighter()))
-            painter.drawRect(QtCore.QRectF(x, y, w, d * h))
-            y += d * h
+            painter.drawRect(QtCore.QRectF(x, y, wsingle, d * h))
+            x += wsingle
         painter.end()
 
         self.__picture = picture

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -265,6 +265,7 @@ class OWDistributions(widget.OWWidget):
             self.display_contingency()
         else:
             self.display_distribution()
+        self.plot.autoRange()
 
     def display_contingency(self):
         """
@@ -315,11 +316,20 @@ class OWDistributions(widget.OWWidget):
             bottomaxis.setTicks([list(enumerate(var.values))])
 
             cont = numpy.array(cont)
+
+            maxh = 0 #maximal column height
+            maxrh = 0 #maximal relative column height
+            for i, (value, dist) in enumerate(zip(var.values, cont.T)):
+                maxh = max(maxh, max(dist))
+                maxrh = max(maxrh, max(dist/sum(dist)))
+
             for i, (value, dist) in enumerate(zip(var.values, cont.T)):
                 dsum = sum(dist)
-                geom = QtCore.QRectF(i - 0.333, 0, 0.666, 100
-                                     if self.relative_freq else dsum)
-                item = DistributionBarItem(geom, dist / dsum, colors)
+                geom = QtCore.QRectF(i - 0.333, 0, 0.666, maxrh
+                                     if self.relative_freq else maxh)
+                item = DistributionBarItem(geom, dist/dsum/maxrh
+                                           if self.relative_freq
+                                           else dist/maxh, colors)
                 self.plot.addItem(item)
 
         for color, name in zip(colors, cvar_values):

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -66,7 +66,7 @@ class DistributionBarItem(pg.GraphicsObject):
         w, h = geom.width(), geom.height()
         wsingle = w / len(self.dist)
         for d, c in zip(self.dist, self.colors):
-            painter.setBrush(QtGui.QBrush(c.lighter()))
+            painter.setBrush(QtGui.QBrush(c))
             painter.drawRect(QtCore.QRectF(x, y, wsingle, d * h))
             x += wsingle
         painter.end()
@@ -275,7 +275,7 @@ class OWDistributions(widget.OWWidget):
 
         cvar_values = cvar.values
         palette = colorpalette.ColorPaletteGenerator(len(cvar_values))
-        colors = [palette[i] for i in range(len(cvar_values))]
+        colors = [palette[i].lighter() for i in range(len(cvar_values))]
 
         if var and var.is_continuous:
             bottomaxis.setTicks(None)
@@ -303,7 +303,7 @@ class OWDistributions(widget.OWWidget):
                 pen = QtGui.QPen(QtGui.QBrush(Qt.white), 0.5)
                 pen.setCosmetic(True)
                 item.setData(X, Y, antialias=True, stepMode=True,
-                             fillLevel=0, brush=QtGui.QBrush(color.lighter()),
+                             fillLevel=0, brush=QtGui.QBrush(color),
                              pen=pen)
                 self.plot.addItem(item)
 

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -217,10 +217,14 @@ class OWDistributions(widget.OWWidget):
         if var and var.is_continuous:
             bottomaxis.setTicks(None)
             edges, curve = ash_curve(dist, None, m=OWDistributions.ASH_HIST)
+            edges = edges + (edges[1] - edges[0])/2
+            edges = edges[:-1]
             item = pg.PlotCurveItem()
-            item.setData(edges, curve, antialias=True, stepMode=True,
+            pen = QtGui.QPen(QtGui.QBrush(Qt.white), 3)
+            pen.setCosmetic(True)
+            item.setData(edges, curve, antialias=True, stepMode=False,
                          fillLevel=0, brush=QtGui.QBrush(Qt.gray),
-                         pen=QtGui.QColor(Qt.white))
+                         pen=pen)
             self.plot.addItem(item)
         else:
             bottomaxis.setTicks([list(enumerate(var.values))])

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -468,31 +468,6 @@ def rect_kernel_curve(dist, cont=None, bandwidth=None):
     return edges, curve
 
 
-def sum_rect_curve(Xa, Ya, Xb, Yb):
-    """
-    Sum two curves (i.e. stack one over the other).
-    """
-    X = numpy.r_[Xa, Xb]
-    Y = numpy.r_[Ya, 0, Yb, 0]
-    assert X.shape == Y.shape
-
-    dY = numpy.r_[Y[0], numpy.diff(Y)]
-    sort_ind = numpy.argsort(X)
-    X = X[sort_ind]
-    dY = dY[sort_ind]
-
-    unique, uniq_index = numpy.unique(X, return_index=True)
-    spans = numpy.diff(numpy.r_[uniq_index, len(X)])
-    dY = [numpy.sum(dY[start:start + span])
-          for start, span in zip(uniq_index, spans)]
-    dY = numpy.array(dY)
-    assert dY.shape[0] == unique.shape[0]
-    # NOTE: The final cumulative sum element is 0
-    Y = numpy.cumsum(dY)[:-1]
-
-    return unique, Y
-
-
 def ash_curve(dist, cont=None, bandwidth=None, m=3):
     dist = numpy.asarray(dist)
     X, W = dist

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -147,8 +147,9 @@ class OWDistributions(widget.OWWidget):
         self.mainArea.layout().addWidget(w, Qt.AlignCenter)
 
         self.plot = pg.PlotItem()
-#         self.plot.getViewBox().setMouseEnabled(False, False)
+        self.plot.getViewBox().setMouseEnabled(False, False)
         self.plot.getViewBox().setMenuEnabled(False)
+        self.plot.hideButtons() 
         plotview.setCentralItem(self.plot)
 
         pen = QtGui.QPen(self.palette().color(QtGui.QPalette.Text))
@@ -214,6 +215,8 @@ class OWDistributions(widget.OWWidget):
             self.distributions = \
                 distribution.get_distribution(self.data, self.var)
             self.display_distribution()
+        self.plot.autoRange()
+
 
     def _density_estimator(self):
         if self.cont_est_type == OWDistributions.Hist:

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -275,18 +275,19 @@ class OWDistributions(widget.OWWidget):
             colors = cols
             curves = [(X, Y * w) for (X, Y), w in zip(curves, weights)]
 
-            for (X, Y), color in reversed(list(zip(curves, colors))):
-                X = X + (X[1] - X[0])/2
-                X = X[:-1]
-                item = pg.PlotCurveItem()
-                pen = QtGui.QPen(QtGui.QBrush(color), 3)
-                pen.setCosmetic(True)
-                color = QtGui.QColor(color)
-                color.setAlphaF(0.2)
-                item.setData(X, Y, antialias=True, stepMode=False,
-                             fillLevel=0, brush=QtGui.QBrush(color),
-                             pen=pen)
-                self.plot.addItem(item)
+            for t in [ "fill", "line" ]:
+                for (X, Y), color in reversed(list(zip(curves, colors))):
+                    X = X + (X[1] - X[0])/2
+                    X = X[:-1]
+                    item = pg.PlotCurveItem()
+                    pen = QtGui.QPen(QtGui.QBrush(color), 3)
+                    pen.setCosmetic(True)
+                    color = QtGui.QColor(color)
+                    color.setAlphaF(0.2)
+                    item.setData(X, Y, antialias=True, stepMode=False,
+                         fillLevel=0 if t == "fill" else None,
+                         brush=QtGui.QBrush(color), pen=pen)
+                    self.plot.addItem(item)
 
         elif var and var.is_discrete:
             bottomaxis.setTicks([list(enumerate(var.values))])


### PR DESCRIPTION
I have chosen average shifted histograms (with a gaussian kernel) as the only visualization for continuous attributes, because it returns similar results as gaussian KDE estimation from scikits but it was much (more that 10x) faster.

All visualizations are changed.

I have not implemented class probabilities yet.