### PR TITLE
SklLearner: change default value of _params

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -200,7 +200,7 @@ class SklLearner(Learner, metaclass=WrapperMeta):
     """
     __wraps__ = None
     __returns__ = SklModel
-    _params = None
+    _params = {}
 
     name = 'skl learner'
     preprocessors = [Continuize(),


### PR DESCRIPTION
SklLearner.params are a dict when set, so the default value (when not set) should be an empty dict.
This enables them to always be used in constructors as (**learner.params)