### PR TITLE
Heatmap selections

### DIFF
--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -229,11 +229,6 @@ class DistanceMapItem(pg.ImageItem):
             self.setToolTip("")
 
 
-class DendrogramWidget(DendrogramWidget):
-    def sceneEventFilter(self, recv, event):
-        return QGraphicsWidget.sceneEventFilter(self, recv, event)
-
-
 class OWDistanceMap(widget.OWWidget):
     name = "Distance Map"
     description = "Visualize a distance matrix."
@@ -331,12 +326,18 @@ class OWDistanceMap(widget.OWWidget):
         self.grid.addItem(self.viewbox, 1, 1)
 
         self.left_dendrogram = DendrogramWidget(
-            self.grid_widget, orientation=DendrogramWidget.Left)
+            self.grid_widget, orientation=DendrogramWidget.Left,
+            selectionMode=DendrogramWidget.NoSelection,
+            hoverHighlightEnabled=False
+        )
         self.left_dendrogram.setAcceptedMouseButtons(Qt.NoButton)
         self.left_dendrogram.setAcceptHoverEvents(False)
 
         self.top_dendrogram = DendrogramWidget(
-            self.grid_widget, orientation=DendrogramWidget.Top)
+            self.grid_widget, orientation=DendrogramWidget.Top,
+            selectionMode=DendrogramWidget.NoSelection,
+            hoverHighlightEnabled=False
+        )
         self.top_dendrogram.setAcceptedMouseButtons(Qt.NoButton)
         self.top_dendrogram.setAcceptHoverEvents(False)
 

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -211,6 +211,8 @@ class DendrogramWidget(QGraphicsWidget):
     #: Selection flags
     NoSelection, SingleSelection, ExtendedSelection = 0, 1, 2
 
+    #: Emitted when a user clicks on the cluster item.
+    itemClicked = Signal(ClusterGraphicsItem)
     selectionChanged = Signal()
     selectionEdited = Signal()
 
@@ -623,6 +625,7 @@ class DendrogramWidget(QGraphicsWidget):
 
                 if current_selection != self._selection:
                     self.selectionEdited.emit()
+                self.itemClicked.emit(obj)
                 event.accept()
                 return True
 

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -208,10 +208,15 @@ class DendrogramWidget(QGraphicsWidget):
     #: Orientation
     Left, Top, Right, Bottom = 1, 2, 3, 4
 
+    #: Selection flags
+    NoSelection, SingleSelection, ExtendedSelection = 0, 1, 2
+
     selectionChanged = Signal()
     selectionEdited = Signal()
 
-    def __init__(self, parent=None, root=None, orientation=Left):
+    def __init__(self, parent=None, root=None, orientation=Left,
+                 hoverHighlightEnabled=True, selectionMode=ExtendedSelection):
+
         QGraphicsWidget.__init__(self, parent)
         self.orientation = orientation
         self._root = None
@@ -224,7 +229,8 @@ class DendrogramWidget(QGraphicsWidget):
         self._itemgroup = QGraphicsWidget(self)
         self._itemgroup.setGeometry(self.contentsRect())
         self._cluster_parent = {}
-
+        self.__hoverHighlightEnabled = hoverHighlightEnabled
+        self.__selectionMode = selectionMode
         self.setContentsMargins(5, 5, 5, 5)
         self.set_root(root)
 
@@ -592,18 +598,31 @@ class DendrogramWidget(QGraphicsWidget):
 
     def sceneEventFilter(self, obj, event):
         if isinstance(obj, DendrogramWidget.ClusterGraphicsItem):
-            if event.type() == QEvent.GraphicsSceneHoverEnter:
+            if event.type() == QEvent.GraphicsSceneHoverEnter and \
+                    self.__hoverHighlightEnabled:
                 self._set_hover_item(obj)
                 event.accept()
                 return True
             elif event.type() == QEvent.GraphicsSceneMousePress and \
                     event.button() == Qt.LeftButton:
-                if event.modifiers() & Qt.ControlModifier:
-                    self.select_item(obj, not self.is_selected(obj))
-                else:
-                    self.set_selected_items([obj])
-                self.selectionEdited.emit()
-                assert self._highlighted_item is obj
+
+                is_selected = self.is_selected(obj)
+                current_selection = list(self._selection)
+
+                if self.__selectionMode == DendrogramWidget.SingleSelection:
+                    if event.modifiers() & Qt.ControlModifier:
+                        self.set_selected_items(
+                            [obj] if not is_selected else [])
+                    elif current_selection != [obj]:
+                        self.set_selected_items([obj])
+                elif self.__selectionMode == DendrogramWidget.ExtendedSelection:
+                    if event.modifiers() & Qt.ControlModifier:
+                        self.select_item(obj, not self.is_selected(obj))
+                    elif current_selection != [obj]:
+                        self.set_selected_items([obj])
+
+                if current_selection != self._selection:
+                    self.selectionEdited.emit()
                 event.accept()
                 return True
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1300,6 +1300,7 @@ class GraphicsHeatmapWidget(QtGui.QGraphicsWidget):
                 lut = None
             argb, _ = pg.makeARGB(
                 self.__data, lut=lut, levels=self.__levels, scale=250)
+            argb[np.isnan(self.__data)] = (100, 100, 100, 255)
 
             qimage = pg.makeQImage(argb, transpose=False)
             self.__pixmap = QPixmap.fromImage(qimage)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1024,7 +1024,9 @@ class OWHeatMap(widget.OWWidget):
         rects = self.selection_manager.selection_rects
         for rect in rects:
             item = QtGui.QGraphicsRectItem(rect, None)
-            item.setPen(QPen(Qt.black, 2))
+            pen = QPen(Qt.black, 2)
+            pen.setCosmetic(True)
+            item.setPen(pen)
             self.heatmap_scene.addItem(item)
             self.selection_rects.append(item)
 


### PR DESCRIPTION
* Fix an graphics error where the selection rectangle[s] would go out of sync with the underlying
  heatmap images on annotation visibility change
* Allow row selection by clicking on the dendrogram.