### PR TITLE
Scatter Plot: fix filtering of points with missing values

### DIFF
--- a/Orange/widgets/utils/scaling.py
+++ b/Orange/widgets/utils/scaling.py
@@ -152,7 +152,7 @@ class ScaleData:
                                                                                                  "visualizationData")
         else:
             no_jittering_data = np.c_[full_data.X, full_data.Y].T
-            valid_data_array = no_jittering_data != np.NaN
+            valid_data_array = ~np.isnan(no_jittering_data)
             original_data = no_jittering_data.copy()
 
             for index in range(len(data.domain)):

--- a/Orange/widgets/utils/scaling.py
+++ b/Orange/widgets/utils/scaling.py
@@ -310,9 +310,6 @@ class ScaleScatterPlotData(ScaleData):
         """
         xattr_index = self.attribute_name_index[xattr]
         yattr_index = self.attribute_name_index[yattr]
-
-        xattr_index = self.attribute_name_index[xattr]
-        yattr_index = self.attribute_name_index[yattr]
         if filter_valid is True:
             filter_valid = self.get_valid_list([xattr_index, yattr_index])
         if isinstance(filter_valid, np.ndarray):

--- a/Orange/widgets/utils/scaling.py
+++ b/Orange/widgets/utils/scaling.py
@@ -1,9 +1,10 @@
 from datetime import time
-import sys
 import random
-import numpy as np
-import Orange
+import sys
 
+import numpy as np
+
+import Orange
 from Orange.statistics.basic_stats import DomainBasicStats
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.datacaching import getCached, setCached

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -6,17 +6,16 @@ from PyQt4 import QtGui
 from PyQt4.QtGui import QApplication
 
 import Orange
-from Orange.data import Table, Variable
+from Orange.data import Table
 from Orange.data.sql.table import SqlTable, LARGE_TABLE, DEFAULT_SAMPLE_TIME
 from Orange.widgets import gui
+from Orange.widgets.io import FileFormats
 from Orange.widgets.settings import \
     DomainContextHandler, Setting, ContextSetting, SettingProvider
 from Orange.widgets.utils.colorpalette import ColorPaletteDlg
-from Orange.widgets.utils.plot import OWPlotGUI
 from Orange.widgets.utils.toolbar import ZoomSelectToolbar
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotGraph
 from Orange.widgets.widget import OWWidget, Default, AttributeList
-from Orange.widgets.io import FileFormats
 
 
 def font_resize(font, factor, minsize=None, maxsize=None):

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -2,6 +2,7 @@ import itertools
 from collections import Counter
 from xml.sax.saxutils import escape
 from math import log10, floor, ceil
+
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ViewBox import ViewBox
@@ -15,7 +16,6 @@ from PyQt4.QtCore import Qt, QObject, QEvent, QRectF, QPointF
 from PyQt4 import QtCore
 from PyQt4.QtGui import QApplication, QColor, QPen, QBrush, QToolTip
 from PyQt4.QtGui import QStaticText, QPainterPath, QTransform, QPinchGesture, QPainter
-
 from sklearn.neighbors import NearestNeighbors
 
 from Orange.widgets import gui

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -505,8 +505,6 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         self.valid_data = self.get_valid_list([index_x, index_y])
         x_data, y_data = self.get_xy_data_positions(
             attr_x, attr_y, self.valid_data)
-        x_data = x_data[self.valid_data]
-        y_data = y_data[self.valid_data]
         self.n_points = len(x_data)
 
         min_x, max_x = np.nanmin(x_data), np.nanmax(x_data)


### PR DESCRIPTION
Incorrect mask computation crashed class density visualization
(and probably introduced other bugs).