### PR TITLE
Distances: Fix _preprocess()

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -1,10 +1,10 @@
 import numpy as np
 from scipy import stats, sparse
 import sklearn.metrics as skl_metrics
-import sklearn.preprocessing as skl_preprocessing
 
 from Orange import data
 from Orange.misc import DistMatrix
+from Orange.preprocess import SklImpute
 
 
 def _preprocess(table):
@@ -15,7 +15,7 @@ def _preprocess(table):
                              table.domain.class_vars,
                              table.domain.metas)
     new_data = data.Table(new_domain, table)
-    new_data.X = skl_preprocessing.Imputer().fit_transform(new_data.X)
+    new_data = SklImpute(new_data)
     return new_data
 
 

--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -12,11 +12,10 @@ def _preprocess(table):
     if not len(table):
         return table
     new_domain = data.Domain([a for a in table.domain.attributes if a.is_continuous],
-                             table.domain.class_var,
+                             table.domain.class_vars,
                              table.domain.metas)
     new_data = data.Table(new_domain, table)
     new_data.X = skl_preprocessing.Imputer().fit_transform(new_data.X)
-    new_data.X = new_data.X if sparse.issparse(new_data.X) else np.squeeze(new_data.X)
     return new_data
 
 

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -559,8 +559,9 @@ class TestDistances(TestCase):
         np.testing.assert_equal(new_table.X, table.X[:, 0].reshape(2, 1))
         np.testing.assert_equal(new_table.Y, table.Y)
         np.testing.assert_equal(new_table.metas, table.metas)
-        self.assertEqual(list(new_table.domain.attributes),
-                         [a for a in table.domain.attributes if a.is_continuous])
+        self.assertEqual([a.name for a in new_table.domain.attributes],
+                         [a.name for a in table.domain.attributes
+                          if a.is_continuous])
         self.assertEqual(new_table.domain.class_vars, table.domain.class_vars)
         self.assertEqual(new_table.domain.metas, table.domain.metas)
 
@@ -568,6 +569,12 @@ class TestDistances(TestCase):
         table = Table('test5.tab')
         new_table = _preprocess(table)
         np.testing.assert_equal(new_table.Y, table.Y)
-        self.assertEqual(list(new_table.domain.attributes),
-                         [a for a in table.domain.attributes if a.is_continuous])
+        self.assertEqual([a.name for a in new_table.domain.attributes],
+                         [a.name for a in table.domain.attributes
+                          if a.is_continuous])
         self.assertEqual(new_table.domain.class_vars, table.domain.class_vars)
+
+    def test_preprocess_impute(self):
+        table = Table('test5.tab')
+        new_table = _preprocess(table)
+        self.assertFalse(np.isnan(new_table.X).any())


### PR DESCRIPTION
The method used to remove one dimension from table.X if there was only one feature left in the table.
Beside that, the method used to replace class_vars with class_var which resulted in incorrect domain for multiclass datasets.