### PR TITLE
Table: Fix extends method

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -848,12 +848,10 @@ class Table(MutableSequence, Storage):
             else:
                 for i, example in enumerate(instances):
                     self[old_length + i] = example
-                try:
-                    self[old_length + i] = example.id
-                except:
-                    with type(self)._next_instance_lock:
-                        self.ids[old_length + i] = type(self)._next_instance_id
-                        type(self)._next_instance_id += 1
+                    try:
+                        self.ids[old_length + i] = example.id
+                    except AttributeError:
+                        self.ids[old_length + i] = self.new_id()
         except Exception:
             self._resize_all(old_length)
             raise

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -598,6 +598,12 @@ class TableTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             d.extend(x)
 
+        y = d[:2, 1]
+        x.ensure_copy()
+        x.extend(y)
+        np.testing.assert_almost_equal(x[-2:, 1].X, y.X)
+        self.assertEqual(np.isnan(x).sum(), 8)
+
     def test_copy(self):
         t = data.Table(np.zeros((5, 3)), np.arange(5), np.zeros((5, 3)))
 


### PR DESCRIPTION
When a dataset with non matching domain was passed in extends, the last
inserted row was overwritten with the id of the last instance.