### PR TITLE
owscatterplotgraph: Zoom/Select error without data

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -878,16 +878,16 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
                                 symbol=self.CurveSymbols[i]), escape(value))
 
     def zoom_button_clicked(self):
-        self.scatterplot_item.getViewBox().setMouseMode(
-            self.scatterplot_item.getViewBox().RectMode)
+        self.plot_widget.getViewBox().setMouseMode(
+            self.plot_widget.getViewBox().RectMode)
 
     def pan_button_clicked(self):
-        self.scatterplot_item.getViewBox().setMouseMode(
-            self.scatterplot_item.getViewBox().PanMode)
+        self.plot_widget.getViewBox().setMouseMode(
+            self.plot_widget.getViewBox().PanMode)
 
     def select_button_clicked(self):
-        self.scatterplot_item.getViewBox().setMouseMode(
-            self.scatterplot_item.getViewBox().RectMode)
+        self.plot_widget.getViewBox().setMouseMode(
+            self.plot_widget.getViewBox().RectMode)
 
     def reset_button_clicked(self):
         self.view_box.autoRange()


### PR DESCRIPTION
When no data is present in the Scatterplot, clicking on Zoom/Select caused an error.
`getViewBox()` now works with `plot_widget` instead of `scatterplot_item`.