### PR TITLE
owscatterplotgraph: Unselect by click fixed

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -904,6 +904,7 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
     def unselect_all(self):
         self.selection = None
         self.update_colors(keep_colors=True)
+        self.master.selection_changed()
 
     def select(self, points):
         # noinspection PyArgumentList


### PR DESCRIPTION
When unselecting the data by mouse click the points were unselected on the plot but the empty selection was not sent to the output. The `unselect_all` now also calls `self.master.selection_changed()` to propagate empty selection to output.