### PR TITLE
OutputView: Do not yield control to the event loop

### DIFF
--- a/Orange/canvas/application/outputview.py
+++ b/Orange/canvas/application/outputview.py
@@ -102,7 +102,7 @@ class OutputView(QWidget):
         self.write("".join(lines))
 
     def flush(self):
-        QCoreApplication.flush()
+        pass
 
     def writeWithFormat(self, string, charformat):
         self.__text.moveCursor(QTextCursor.End, QTextCursor.MoveAnchor)
@@ -277,7 +277,7 @@ class TextStream(QObject):
     def writelines(self, lines):
         self.stream.emit("".join(lines))
 
-    @queued_blocking
+    @queued
     def flush(self):
         self.flushed.emit()
 


### PR DESCRIPTION
The canvas workflow model/executor requires that model
changes and notifications do not yield control to the event loop.
However they use Python's logging extensively. This would not be a
problem unless the logger for the root or Orange.canvas namespace is
reconfigured to write to the OutputView's "redirected" sys.stdout/err.
