### PR TITLE
Fix rstripped 0 in number of decimals

### DIFF
--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -27,8 +27,8 @@ class Discretizer(Transformation):
         assert low is None or high is None or low < high
         assert decimals >= 0
 
-        def fmt_value(value, decimals):
-            return (("%%.%if" % decimals) % value).rstrip("0").rstrip(".")
+        def fmt_value(value, decimals=4):
+            return str(round(value, decimals)).rstrip('.0')
 
         if (low is None or np.isinf(low)) and \
                 not (high is None or np.isinf(high)):


### PR DESCRIPTION
Rstriping was intended for numbers like 4.0, but it also stripped the right zero from 60 (changing it into 6).