### PR TITLE
owselectcolumns: renamed Class to Target Variable in GUI

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -339,7 +339,8 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.used_attrs_view)
         layout.addWidget(box, 0, 2, 1, 1)
 
-        box = gui.widgetBox(self.controlArea, "Class", addToLayout=False)
+        box = gui.widgetBox(self.controlArea, "Target Variable",
+                            addToLayout=False)
         self.class_attrs = ClassVarListItemModel()
         self.class_attrs_view = ClassVariableItemView()
         self.class_attrs_view.setModel(self.class_attrs)


### PR DESCRIPTION
With this we match the notation in Data Table widget, where "target variable" is used. Class in some way implies that this feature is discrete, not continuous, and hence we (Janez and myself) voted for renaming.