### PR TITLE
owimpute: Create copy of table before imputation

### DIFF
--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -5,6 +5,7 @@ from Orange.widgets.tests import test_setting_provider, \
     test_settings_handler, test_context_handler, \
     test_class_values_context_handler, test_domain_context_handler, \
     test_owselectcolumns, test_scatterplot_density
+from Orange.widgets.data import owimpute
 
 try:
     from Orange.widgets.tests import test_widget
@@ -28,7 +29,8 @@ def suite():
         load(test_class_values_context_handler),
         load(test_domain_context_handler),
         load(test_owselectcolumns),
-        load(test_scatterplot_density)
+        load(test_scatterplot_density),
+        load(owimpute)
     ])
     if run_widget_tests:
         all_tests.extend([

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -807,7 +807,7 @@ class ImputerModel(object):
         Xp = translate_domain(X, self.codomain)
 
         if Xp is X:
-            Xp = Orange.data.Table(Xp)
+            Xp = X.copy()
 
         nattrs = len(Xp.domain.attributes)
         for var in X.domain:
@@ -1000,6 +1000,8 @@ class Test(unittest.TestCase):
             [2.0, 1.0, 3.0],
             [nan, nan, nan]
         ]
+        unknowns = numpy.isnan(data)
+
         domain = Orange.data.Domain(
             (Orange.data.DiscreteVariable("A", values=["0", "1", "2"]),
              Orange.data.ContinuousVariable("B"),
@@ -1021,6 +1023,10 @@ class Test(unittest.TestCase):
              data.domain[2]: cimp3}
         )
         idata = imputer(data)
+
+        # Original data should keep unknowns
+        self.assertClose(numpy.isnan(data.X), unknowns)
+
         self.assertClose(idata.X,
                          [[1.0, 1.0, 0.0],
                           [2.0, 1.0, 3.0],
@@ -1033,6 +1039,8 @@ class Test(unittest.TestCase):
             [2.0, 1.0, 3.0],
             [nan, nan, nan]
         ]
+        unknowns = numpy.isnan(data)
+
         domain = Orange.data.Domain(
             (Orange.data.DiscreteVariable("A", values=["0", "1", "2"]),
              Orange.data.ContinuousVariable("B"),
@@ -1056,6 +1064,10 @@ class Test(unittest.TestCase):
              data.domain[2]: cimp3}
         )
         idata = imputer(data)
+
+        # Original data should keep unknowns
+        self.assertClose(numpy.isnan(data.X), unknowns)
+
         self.assertTrue(not numpy.any(numpy.isnan(idata.X)))
 
         definedmask = ~numpy.isnan(data.X)


### PR DESCRIPTION
Fixing the problem mentioned in #495 based on fix suggestion by @ales-erjavec.

Does not fix the problem of missing compute_value on imputed variables.