### PR TITLE
[WIP] Model based imputer 2

### DIFF
--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -29,8 +29,6 @@ from Orange.preprocess.transformation import \
 
 from functools import reduce
 import numpy as np
-import warnings
-
 
 
 def _margins(margins, container):
@@ -353,21 +351,22 @@ class OWImpute(OWWidget):
                     if learner is None:
                         learner = learner_pointer
                     else:
-                        print("Multiple regression models ; using %s" \
+
+                        print("Multiple regression models ; using %s"
                               % str(learner.name))
                 if not var.is_continuous and \
                         isinstance(learner_pointer, LearnerClassification):
                     if learner is None:
                         learner = learner_pointer
                     else:
-                        print("Multiple classification models ; using %s" \
+                        print("Multiple classification models ; using %s"
                               % str(learner.name))
 
             # No suitable model was found for this variable type,
             # default to MeanLearner
             if learner is None:
-                print("No suitable model for attribute \"%s\"; " + \
-                      " imputing average/most frequent." % var.name)
+                print("No suitable model for attribute \"%s\"; " % var.name + \
+                      " imputing average/most frequent." )
                 learner = MeanLearner()
             return column_imputer_by_model(var, data, learner=learner)
 


### PR DESCRIPTION
Extended model-based imputation to multiple Learners.
- User can specify separate learners for continuous and discrete variables. If not specified, models default to Mean Learner (average / most frequent value). 
- Models now impute only unknown values and not the whole column.
- Fixed a bug for Model based and Random imputation where the *data on input* was overriden by imputation results.