### PR TITLE
Confusion matrix: Cell width adjustments (2)

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -2,7 +2,7 @@ import unicodedata
 
 from PyQt4.QtGui import (
     QGridLayout, QLabel, QTableView, QStandardItemModel, QStandardItem,
-    QItemSelectionModel, QItemSelection, QFont
+    QItemSelectionModel, QItemSelection, QFont, QHeaderView
 )
 from PyQt4.QtCore import Qt
 
@@ -81,12 +81,13 @@ class OWConfusionMatrix(widget.OWWidget):
         grid.addWidget(VerticalLabel("Actual Class"), 1, 0, Qt.AlignCenter)
 
         self.tablemodel = QStandardItemModel(self)
-        self.tableview = QTableView(editTriggers=QTableView.NoEditTriggers)
-        self.tableview.setModel(self.tablemodel)
-        self.tableview.selectionModel().selectionChanged.connect(
-            self._invalidate
-        )
-        grid.addWidget(self.tableview, 1, 1)
+        view = self.tableview = QTableView(
+            editTriggers=QTableView.NoEditTriggers)
+        view.setModel(self.tablemodel)
+        view.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
+        view.horizontalHeader().setMinimumSectionSize(60)
+        view.selectionModel().selectionChanged.connect(self._invalidate)
+        grid.addWidget(view, 1, 1)
         self.mainArea.layout().addLayout(grid)
 
     def sizeHint(self):

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -44,6 +44,7 @@ class OWConfusionMatrix(widget.OWWidget):
         self.data = None
         self.results = None
         self.learners = []
+        self.headers = []
 
         box = gui.widgetBox(self.controlArea, "Learners")
 
@@ -84,7 +85,6 @@ class OWConfusionMatrix(widget.OWWidget):
         view = self.tableview = QTableView(
             editTriggers=QTableView.NoEditTriggers)
         view.setModel(self.tablemodel)
-        view.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
         view.horizontalHeader().setMinimumSectionSize(60)
         view.selectionModel().selectionChanged.connect(self._invalidate)
         grid.addWidget(view, 1, 1)
@@ -120,7 +120,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
         if results is not None:
             nmodels, ntests = results.predicted.shape
-            headers = class_values + [unicodedata.lookup("N-ARY SUMMATION")]
+            self.headers = class_values + [unicodedata.lookup("N-ARY SUMMATION")]
 
             # NOTE: The 'learner_names' is set in 'Test Learners' widget.
             if hasattr(results, "learner_names"):
@@ -128,8 +128,15 @@ class OWConfusionMatrix(widget.OWWidget):
             else:
                 self.learners = ["L %i" % (i + 1) for i in range(nmodels)]
 
-            self.tablemodel.setVerticalHeaderLabels(headers)
-            self.tablemodel.setHorizontalHeaderLabels(headers)
+            self.tablemodel.setVerticalHeaderLabels(self.headers)
+            self.tablemodel.setHorizontalHeaderLabels(self.headers)
+            if len(' '.join(self.headers)) < 120:
+                self.tableview.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
+            else:
+                self.tableview.horizontalHeader().setDefaultSectionSize(60)
+                self.tableview.horizontalHeader().setResizeMode(QHeaderView.Interactive)
+                for i, h in enumerate(self.headers):
+                    self.tablemodel.horizontalHeaderItem(i).setToolTip(h)
             self.tablemodel.setRowCount(len(class_values) + 1)
             self.tablemodel.setColumnCount(len(class_values) + 1)
             self.selected_learner = [0]
@@ -139,6 +146,7 @@ class OWConfusionMatrix(widget.OWWidget):
         self.results = None
         self.data = None
         self.tablemodel.clear()
+        self.headers = []
         # Clear learners last. This action will invoke `_learner_changed`
         # method
         self.learners = []
@@ -265,6 +273,8 @@ class OWConfusionMatrix(widget.OWWidget):
                     item.setData(value(i, j), Qt.DisplayRole)
                     item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
                     item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
+                    item.setToolTip("actual: {}\npredicted: {}".format(
+                        self.headers[i], self.headers[j]))
                     model.setItem(i, j, item)
 
             font = model.invisibleRootItem().font()


### PR DESCRIPTION
Some improvements applied to #638 

The fixed ResizeToContents column width is better for smaller matrices, but for many columns and/or long header names it is awkward to _see_ the matrix structure (e.g. the diagonal is not straight). And the columns can't be resized by the user...

This changes the presentation for big matrices as explained in the commit message.

(compare on primary-tumor or audiology datasets to see the difference)