### PR TITLE
owsvmregression: renamed widget to SVM regression

### DIFF
--- a/Orange/widgets/regression/owsvmregression.py
+++ b/Orange/widgets/regression/owsvmregression.py
@@ -11,7 +11,7 @@ from Orange.widgets import widget, settings, gui
 
 
 class OWSVMRegression(widget.OWWidget):
-    name = "SVM"
+    name = "SVM Regression"
     description = "Support vector machine regression algorithm."
     icon = "icons/SVMRegression.svg"
     inputs = [("Data", Table, "set_data"),


### PR DESCRIPTION
This name is now also consistent with the name used in the widget documentation.