### PR TITLE
Testing: ShuffleSplit replaces Bootstrap

### DIFF
--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -2,11 +2,10 @@ import numpy as np
 
 import sklearn.cross_validation as skl_cross_validation
 
-import Orange.data
-from Orange.data import Domain, Table
+from Orange.data import Table
 
 __all__ = ["Results", "CrossValidation", "LeaveOneOut", "TestOnTrainingData",
-           "Bootstrap", "TestOnTestData", "sample"]
+           "ShuffleSplit", "TestOnTestData", "sample"]
 
 
 class Results:
@@ -366,21 +365,22 @@ class TestOnTrainingData(Results):
         self.call_callback(1)
 
 
-class Bootstrap(Results):
-    def __init__(self, data, learners, n_resamples=10, p=0.75, random_state=0,
-                 store_data=False, store_models=False, preprocessor=None,
-                 callback=None):
+class ShuffleSplit(Results):
+    def __init__(self, data, learners, n_resamples=10, train_size=None,
+                 test_size=0.1, random_state=0, store_data=False,
+                 store_models=False, preprocessor=None, callback=None):
         super().__init__(data, len(learners), store_data=store_data,
                          store_models=store_models, preprocessor=preprocessor,
                          callback=callback)
         self.store_models = store_models
         self.n_resamples = n_resamples
-        self.p = p
+        self.train_size = train_size
+        self.test_size = test_size
         self.random_state = random_state
 
-        indices = skl_cross_validation.Bootstrap(
-            len(data), n_iter=self.n_resamples, train_size=self.p,
-            random_state=self.random_state
+        indices = skl_cross_validation.ShuffleSplit(
+            len(data), n_iter=self.n_resamples, train_size=self.train_size,
+            test_size=test_size, random_state=self.random_state
         )
 
         self.folds = []

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -460,3 +460,14 @@ class TestTrainTestSplit(unittest.TestCase):
         train, test = Orange.evaluation.sample(data, 0.9, replace=True)
         self.assertEqual(len(train), 135)
         self.assertGreater(len(train) + len(test), len(data))
+
+
+class TestShuffleSplit(unittest.TestCase):
+    def test_results(self):
+        nrows, ncols = 100, 10
+        data = random_data(nrows, ncols)
+        train_size, n_resamples = 0.6, 10
+        res = ShuffleSplit(data, [NaiveBayesLearner()], train_size=train_size,
+                           test_size=1 - train_size, n_resamples=n_resamples)
+        self.assertEqual(len(res.predicted[0]),
+                         n_resamples * nrows * (1 - train_size))

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -138,15 +138,15 @@ class OWTestLearners(widget.OWWidget):
     settingsHandler = settings.ClassValuesContextHandler()
 
     #: Resampling/testing types
-    KFold, LeaveOneOut, Bootstrap, TestOnTrain, TestOnTest = 0, 1, 2, 3, 4
+    KFold, LeaveOneOut, ShuffleSplit, TestOnTrain, TestOnTest = 0, 1, 2, 3, 4
 
     #: Selected resampling type
     resampling = settings.Setting(0)
     #: Number of folds for K-fold cross validation
     k_folds = settings.Setting(10)
-    #: Number of repeats for bootstrap sampling
+    #: Number of repeats for ShuffleSplit sampling
     n_repeat = settings.Setting(10)
-    #: Bootstrap sampling p
+    #: ShuffleSplit sampling p
     sample_p = settings.Setting(75)
 
     TARGET_AVERAGE = "(Average over classes)"
@@ -175,11 +175,11 @@ class OWTestLearners(widget.OWWidget):
         gui.appendRadioButton(rbox, "Random sampling")
         ibox = gui.indentedBox(rbox)
         gui.spin(ibox, self, "n_repeat", 2, 50, label="Repeat train/test",
-                 callback=self.bootstrap_changed)
+                 callback=self.shuffle_split_changed)
         gui.widgetLabel(ibox, "Relative training set size:")
-        gui.hSlider(ibox, self, "sample_p", minValue=1, maxValue=100,
+        gui.hSlider(ibox, self, "sample_p", minValue=1, maxValue=99,
                     ticks=20, vertical=False, labelFormat="%d %%",
-                    callback=self.bootstrap_changed)
+                    callback=self.shuffle_split_changed)
 
         gui.appendRadioButton(rbox, "Test on train data")
         gui.appendRadioButton(rbox, "Test on test data")
@@ -273,8 +273,8 @@ class OWTestLearners(widget.OWWidget):
         self.resampling = OWTestLearners.KFold
         self._param_changed()
 
-    def bootstrap_changed(self):
-        self.resampling = OWTestLearners.Bootstrap
+    def shuffle_split_changed(self):
+        self.resampling = OWTestLearners.ShuffleSplit
         self._param_changed()
 
     def _param_changed(self):
@@ -327,11 +327,12 @@ class OWTestLearners(widget.OWWidget):
         elif self.resampling == OWTestLearners.LeaveOneOut:
             results = Orange.evaluation.LeaveOneOut(
                 self.data, learners, **common_args)
-        elif self.resampling == OWTestLearners.Bootstrap:
-            results = Orange.evaluation.Bootstrap(
+        elif self.resampling == OWTestLearners.ShuffleSplit:
+            train_size = self.sample_p / 100
+            results = Orange.evaluation.ShuffleSplit(
                 self.data, learners, n_resamples=self.n_repeat,
-                p=self.sample_p / 100, random_state=rstate,
-                **common_args)
+                train_size=train_size, test_size=None,
+                random_state=rstate, **common_args)
         elif self.resampling == OWTestLearners.TestOnTrain:
             results = Orange.evaluation.TestOnTrainingData(
                 self.data, learners, **common_args)


### PR DESCRIPTION
ShuffleSplit replaces Bootstrap, because Bootstrap will be removed in 0.17 version of Scikit-learn.