### PR TITLE
Score: Remove zero columns

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -194,6 +194,8 @@ class GainRatio(ClassificationScorer):
         h_class = _entropy(np.sum(cont, axis=1))
         h_residual = _entropy(np.compress(np.sum(cont, axis=0), cont, axis=1))
         h_attribute = _entropy(np.sum(cont, axis=0))
+        if h_attribute == 0:
+            h_attribute = 1
         return nan_adjustment * (h_class - h_residual) / h_attribute
 
 

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -192,7 +192,7 @@ class GainRatio(ClassificationScorer):
     """
     def from_contingency(self, cont, nan_adjustment):
         h_class = _entropy(np.sum(cont, axis=1))
-        h_residual = _entropy(cont)
+        h_residual = _entropy(np.compress(np.sum(cont, axis=0), cont, axis=1))
         h_attribute = _entropy(np.sum(cont, axis=0))
         return nan_adjustment * (h_class - h_residual) / h_attribute
 

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -176,7 +176,7 @@ class InfoGain(ClassificationScorer):
     """
     def from_contingency(self, cont, nan_adjustment):
         h_class = _entropy(np.sum(cont, axis=1))
-        h_residual = _entropy(cont)
+        h_residual = _entropy(np.compress(np.sum(cont, axis=0), cont, axis=1))
         return nan_adjustment * (h_class - h_residual)
 
 


### PR DESCRIPTION
When the data domain is not fully represented (i.e. no appearances of some value of Discrete attribute), there are zero columns in contingency array. These columns are now removed to be able to devide by np.sum(D, axis=0) when calculating entropy.