### PR TITLE
VizRank: Fix sorting of candidate pairs

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -555,8 +555,8 @@ class OWScatterPlot(OWWidget):
                                      self.parent_widget.data.Y)
             weights = ReliefF(n_iterations=100, k_nearest=self.k)(data)
             attrs = sorted(zip(weights,
-                               self.parent_widget.data.domain.attributes))
-            return [a.name for s, a in attrs][::-1]
+                               (x.name for x in self.parent_widget.data.domain.attributes)))
+            return [a for _, a in attrs][::-1]
 
 
 def test_main(argv=None):

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -554,9 +554,12 @@ class OWScatterPlot(OWWidget):
             data = Orange.data.Table(self.parent_widget.graph.scaled_data.T,
                                      self.parent_widget.data.Y)
             weights = ReliefF(n_iterations=100, k_nearest=self.k)(data)
-            attrs = sorted(zip(weights,
-                               (x.name for x in self.parent_widget.data.domain.attributes)))
-            return [a for _, a in attrs][::-1]
+            attrs = sorted(
+                zip(weights,
+                    (x.name for x in self.parent_widget.data.domain.attributes)
+                    ),
+                reverse=True)
+            return [a for _, a in attrs]
 
 
 def test_main(argv=None):


### PR DESCRIPTION
VizRank sorted attributes by ReliefF and then by their instance (Variable). These are not orderable, e.g.

File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/Orange/widgets/visualize/owscatterplot.py", line 558, in score_heuristic
self.parent_widget.data.domain.attributes))
TypeError: unorderable types: ContinuousVariable() < ContinuousVariable()

I changed this to sort by names, assuming that no two variables have the same name (if they do, sorting is ambiguous but so is any other operation on such data). This is better than using id's because the widget later constructs a list of names anyway. The fix thus does not impose any memory or time overhead.