### PR TITLE
official addons: Add Orange3-Network

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -39,6 +39,7 @@ OFFICIAL_ADDONS = [
     "Orange3-DataFusion",
     "Orange3-Prototypes",
     "Orange3-Text",
+    "Orange3-Network",
 ]
 
 Installable = namedtuple(


### PR DESCRIPTION
Add Orange3-Network to the list of add-ons that are shown in the add-ons dialog, even if pypi does not return them.

This list will not be needed once

https://bitbucket.org/pypa/pypi/issues/325/searching-by-keywords-stopped-working

is resolved.