### PR TITLE
OWHierarchicalClustering: Selection

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -387,6 +387,9 @@ class DendrogramWidget(QGraphicsWidget):
     def is_selected(self, item):
         return item in self._selection
 
+    def is_included(self, item):
+        return self._selected_super_item(item) is not None
+
     def select_item(self, item, state):
         """Set the `item`s selection state to `select_state`
 
@@ -609,17 +612,28 @@ class DendrogramWidget(QGraphicsWidget):
                     event.button() == Qt.LeftButton:
 
                 is_selected = self.is_selected(obj)
+                is_included = self.is_included(obj)
                 current_selection = list(self._selection)
 
                 if self.__selectionMode == DendrogramWidget.SingleSelection:
                     if event.modifiers() & Qt.ControlModifier:
                         self.set_selected_items(
                             [obj] if not is_selected else [])
+                    elif event.modifiers() & Qt.AltModifier:
+                        self.set_selected_items([])
+                    elif event.modifiers() & Qt.ShiftModifier:
+                        if not is_included:
+                            self.set_selected_items([obj])
                     elif current_selection != [obj]:
                         self.set_selected_items([obj])
                 elif self.__selectionMode == DendrogramWidget.ExtendedSelection:
                     if event.modifiers() & Qt.ControlModifier:
-                        self.select_item(obj, not self.is_selected(obj))
+                        self.select_item(obj, not is_selected)
+                    elif event.modifiers() & Qt.AltModifier:
+                        self.select_item(self._selected_super_item(obj), False)
+                    elif event.modifiers() & Qt.ShiftModifier:
+                        if not is_included:
+                            self.select_item(obj, True)
                     elif current_selection != [obj]:
                         self.set_selected_items([obj])
 
@@ -627,7 +641,7 @@ class DendrogramWidget(QGraphicsWidget):
                     self.selectionEdited.emit()
                 self.itemClicked.emit(obj)
                 event.accept()
-                return True
+            return True
 
         if event.type() == QEvent.GraphicsSceneHoverLeave:
             self._set_hover_item(None)


### PR DESCRIPTION
Selection with keys Shift, Ctrl and Alt is now consistent to selection in OWScatterPlot.