### PR TITLE
settings: Simplify ClassValuesContextHandler

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -4,6 +4,7 @@ import copy
 import itertools
 import pickle
 import warnings
+from Orange.util import abstract
 
 from Orange.misc.environ import widget_settings_dir
 from Orange.data import Domain, Variable
@@ -395,7 +396,10 @@ class Context:
 
 
 class ContextHandler(SettingsHandler):
-    """Base class for setting handlers that can handle contexts."""
+    """Base class for setting handlers that can handle contexts.
+
+    Classes deriving from it need to implement method `match`.
+    """
 
     MAX_SAVED_CONTEXTS = 50
 
@@ -466,6 +470,7 @@ class ContextHandler(SettingsHandler):
         else:
             self.settings_to_widget(widget)
 
+    @abstract
     def match(self, context, *args):
         """Return the degree to which the stored `context` matches the data
         passed in additional arguments). A match of 0 zero indicates that
@@ -476,7 +481,7 @@ class ContextHandler(SettingsHandler):
         return 0 and 2.
 
         Derived classes must overload this method."""
-        raise TypeError(self.__class__.__name__ + " does not overload match")
+        pass
 
     def find_or_create_context(self, widget, *args):
         """Find the best matching context or create a new one if nothing

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -542,14 +542,30 @@ class ContextHandler(SettingsHandler):
         self.settings_from_widget(widget)
         widget.current_context = None
 
-    # TODO this method has misleading name (method 'initialize' does what
-    #      this method's name would indicate.
     def settings_to_widget(self, widget):
+        """Apply context settings stored in currently opened context
+        to the widget.
+        """
+
         widget.retrieveSpecificSettings()
 
-    # TODO similar to settings_to_widget; update_class_defaults does this for
-    #      context independent settings
+        context = widget.current_context
+        if context is None:
+            return
+
+        for setting, data, instance in \
+                self.provider.traverse_settings(data=context.values, instance=widget):
+            if not isinstance(setting, ContextSetting) or setting.name not in data:
+                continue
+
+            value = self.decode_setting(setting, data[setting.name])
+            setattr(instance, setting.name, value)
+            if hasattr(setting, "selected") and setting.selected in data:
+                setattr(instance, setting.selected, data[setting.selected])
+
     def settings_from_widget(self, widget):
+        """Update the current context with the setting values from the widget.
+        """
         widget.storeSpecificSettings()
 
         context = widget.current_context
@@ -565,10 +581,27 @@ class ContextHandler(SettingsHandler):
 
         context.values = self.provider.pack(widget, packer=packer)
 
+    def fast_save(self, widget, name, value):
+        """Update value of `name` setting in the current context to `value`
+        """
+
+        super().fast_save(widget, name, value)
+
+        context = widget.current_context
+        if context is None:
+            return
+
+        if name in self.known_settings:
+            setting = self.known_settings[name]
+            value = self.encode_setting(context, setting, value)
+            self.update_packed_data(context.values, name, value)
+
     def encode_setting(self, context, setting, value):
+        """Encode setting value for storing in the context."""
         return copy.copy(value)
 
     def decode_setting(self, setting, value):
+        """Decode setting value."""
         return value
 
 
@@ -689,9 +722,6 @@ class DomainContextHandler(ContextHandler):
                 continue
 
             value = self.decode_setting(setting, data[setting.name])
-            setattr(instance, setting.name, value)
-            if hasattr(setting, "selected") and setting.selected in data:
-                setattr(instance, setting.selected, data[setting.selected])
 
             if isinstance(value, list):
                 excluded |= set(value)
@@ -708,6 +738,8 @@ class DomainContextHandler(ContextHandler):
             setattr(widget, self.reservoir, ll)
 
     def fast_save(self, widget, name, value):
+        super().fast_save(widget, name, value)
+
         context = widget.current_context
         if not context:
             return
@@ -852,18 +884,6 @@ class ClassValuesContextHandler(ContextHandler):
             return context.classes is None and 2
         else:
             return context.classes == classes and 2
-
-    def settings_to_widget(self, widget):
-        super().settings_to_widget(widget)
-        context = widget.current_context
-        self.provider.unpack(widget, context.values)
-
-    def fast_save(self, widget, name, value):
-        if widget.current_context is None:
-            return
-
-        if name in self.known_settings:
-            self.update_packed_data(widget.current_context.values, name, copy.copy(value))
 
 
 ### Requires the same the same attributes in the same order

--- a/Orange/widgets/tests/test_context_handler.py
+++ b/Orange/widgets/tests/test_context_handler.py
@@ -1,12 +1,14 @@
 from unittest import TestCase
 from unittest.mock import Mock
-from Orange.widgets.settings import ContextHandler, Setting
+from Orange.widgets.settings import ContextHandler, Setting, ContextSetting
 
 __author__ = 'anze'
 
 
 class SimpleWidget:
     setting = Setting(42)
+
+    context_setting = ContextSetting(42)
 
 
 class ContextHandlerTestCase(TestCase):
@@ -25,3 +27,14 @@ class ContextHandlerTestCase(TestCase):
         handler.initialize(widget)
         self.assertTrue(hasattr(widget, 'context_settings'))
         self.assertEqual(widget.context_settings, handler.global_contexts)
+
+    def test_fast_save(self):
+        handler = ContextHandler()
+        handler.bind(SimpleWidget)
+
+        widget = SimpleWidget()
+        handler.initialize(widget)
+
+        context = widget.current_context = handler.new_context()
+        handler.fast_save(widget, 'context_setting', 55)
+        self.assertEqual(context.values['context_setting'], 55)


### PR DESCRIPTION
Pull methods that can be used in other context handlers to
ContextHandler base class.