### PR TITLE
k-Means widget: Fix the signal name in send

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -315,7 +315,7 @@ class OWKMeans(widget.OWWidget):
         else:
             km = self.km
         if not self.data or not km:
-            self.send("Data", None)
+            self.send("Annotated Data", None)
             self.send("Centroids", None)
             return
 


### PR DESCRIPTION
There was a call self.send("Data", None) instead of self.send("Annotated Data", None)