### PR TITLE
Add tests for declarations of widget outputs

### DIFF
--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -4,7 +4,7 @@ import unittest
 from Orange.widgets.tests import test_setting_provider, \
     test_settings_handler, test_context_handler, \
     test_class_values_context_handler, test_domain_context_handler, \
-    test_owselectcolumns, test_scatterplot_density
+    test_owselectcolumns, test_scatterplot_density, test_widgets_outputs
 from Orange.widgets.data import owimpute
 
 try:
@@ -30,6 +30,7 @@ def suite():
         load(test_domain_context_handler),
         load(test_owselectcolumns),
         load(test_scatterplot_density),
+        load(test_widgets_outputs),
         load(owimpute)
     ])
     if run_widget_tests:

--- a/Orange/tests/test_widgets_outputs.py
+++ b/Orange/tests/test_widgets_outputs.py
@@ -1,0 +1,25 @@
+import re
+import unittest
+import importlib.util
+
+from Orange.canvas.registry import global_registry
+
+
+class TestWidgetOutputs(unittest.TestCase):
+    def test_outputs(self):
+        re_send = re.compile('\\n\s+self.send\("([^"]*)"')
+        registry = global_registry()
+        errors = []
+        for desc in registry.widgets():
+            signal_names = {output.name for output in desc.outputs}
+            module_name, class_name = desc.qualified_name.rsplit(".", 1)
+            fname = importlib.util.find_spec(module_name).origin
+            widget_code = open(fname).read()
+            used = set(re_send.findall(widget_code))
+            undeclared = used - signal_names
+            if undeclared:
+                errors.append("- {} ({})".
+                              format(desc.name, ", ".join(undeclared)))
+        if errors:
+            self.fail("Some widgets send to undeclared outputs:\n"+"\n".
+                      join(errors))

--- a/Orange/widgets/tests/test_widgets_outputs.py
+++ b/Orange/widgets/tests/test_widgets_outputs.py
@@ -14,7 +14,8 @@ class TestWidgetOutputs(unittest.TestCase):
             signal_names = {output.name for output in desc.outputs}
             module_name, class_name = desc.qualified_name.rsplit(".", 1)
             fname = importlib.util.find_spec(module_name).origin
-            widget_code = open(fname).read()
+            with open(fname) as f:
+                widget_code = f.read()
             used = set(re_send.findall(widget_code))
             undeclared = used - signal_names
             if undeclared:


### PR DESCRIPTION
A tests that parses all widget files for `self.send("<signal name>"` and checks whether the <signal name> is defined as an output.

The test uses regular expression which requires that this is the first non-white thing in the line; this excludes sends that are commented out. There may be false positives (e.g. commented within triple quotes) or false negatives (if sends are written in a more contrived way). The former are easy to fix and the latter do not and should not appear. The test is thus sufficient.

The test takes some time since it requires the widget registry to scan for all widget files (and even import them, if run on Travis).