### PR TITLE
Chdir when loading schema; OWFile checks for recent files in cwd

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -938,6 +938,7 @@ class CanvasMainWindow(QMainWindow):
         dirname = os.path.dirname(filename)
 
         self.last_scheme_dir = dirname
+        os.chdir(dirname)
 
         new_scheme = self.new_scheme_from(filename)
         if new_scheme is not None:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -46,9 +46,8 @@ class OWFile(widget.OWWidget):
     def __init__(self):
         super().__init__()
         self.domain = None
-        self.recent_files = [fn for fn in self.recent_files
-                             if os.path.exists(fn)]
         self.loaded_file = ""
+        self._relocate_recent_files()
 
         vbox = gui.widgetBox(self.controlArea, "Data File", addSpace=True)
         box = gui.widgetBox(vbox, orientation=0)
@@ -85,6 +84,17 @@ class OWFile(widget.OWWidget):
         self.set_file_list()
         if len(self.recent_files) > 0:
             self.open_file(self.recent_files[0])
+
+    def _relocate_recent_files(self):
+        rec = []
+        for fn in self.recent_files:
+            if os.path.exists(fn):
+                rec.append(fn)
+            else:
+                name = os.path.split(fn)[1]
+                if os.path.exists(name):
+                    rec.append(name)
+        self.recent_files = rec
 
     def set_file_list(self):
         self.file_combo.clear()


### PR DESCRIPTION
If we save a schema and some files, reloading schema on another machine does not work since absolute paths to the files change. This cannot be solved in general, but file widget can check whether the missing files are in the same directory as the schema.

Instead of having a global variable with the schema directory, I suggest we change the current directory when loading schema. @ales-erjavec , is this OK?