### PR TITLE
Change working dir on schema load and fix file widget

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -938,6 +938,7 @@ class CanvasMainWindow(QMainWindow):
         dirname = os.path.dirname(filename)
 
         self.last_scheme_dir = dirname
+        os.chdir(dirname)
 
         new_scheme = self.new_scheme_from(filename)
         if new_scheme is not None:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -46,8 +46,10 @@ class OWFile(widget.OWWidget):
     def __init__(self):
         super().__init__()
         self.domain = None
-        self.recent_files = [fn for fn in self.recent_files
-                             if os.path.exists(fn)]
+        self.recent_files = [
+            fn for fn in self.recent_files
+            if os.path.exists(fn) or
+            os.path.exists(os.path.join(".", os.path.split(fn)[1]))]
         self.loaded_file = ""
 
         vbox = gui.widgetBox(self.controlArea, "Data File", addSpace=True)


### PR DESCRIPTION
A better alternative for #710 because it keeps absolute paths.

The problem is: If we save a schema and some files, reloading schema on another machine does not work since absolute paths to the files change. The problem was that non-existing files are filtered out, although when it opens the file it also looks for them in the working directory.

I suggest we change the current directory when loading schema. @ales-erjavec , is this OK?