### PR TITLE
Distributions: set maximal width of control area

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -191,6 +191,7 @@ class OWDistributions(widget.OWWidget):
         self._legend.hide()
         self._legend.anchor((1, 0), (1, 0))
         self.graphButton.clicked.connect(self.save_graph)
+        self.controlArea.setMaximumWidth(260)
 
     def update_views(self):
         self.plot_prob.setGeometry(self.plot.vb.sceneBoundingRect())


### PR DESCRIPTION
Distributions widget's combo has the width of the largest class (try, for instance, GDS4182). It can expand controlArea by too much. I now set a reasonable maximum.

@ales-erjavec, this probably happens in other widgets, too. What about a class attribute `maximal_control_area_width` (or something shorter), and then `OWWidget` would do something like

    if self.maximal_control_area_width is not None:
        self.controlArea.setMaximumWidth(self.maximal_control_area_width)

We could also have a class attribute `control_area_width` for setting a fixed size.