### PR TITLE
[WIP] Control the control area width in OWWidget

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -18,6 +18,8 @@ class OWKMeans(widget.OWWidget):
     icon = "icons/KMeans.svg"
     priority = 2100
 
+    max_control_area_width = None
+
     inputs = [("Data", Table, "set_data")]
 
     outputs = [("Annotated Data", Table, widget.Default),

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -88,6 +88,8 @@ class OWWidget(QDialog, metaclass=WidgetMetaClass):
     want_status_bar = False
     no_report = False
 
+    max_control_area_width = 260
+
     save_position = True
     resizing_enabled = True
 
@@ -190,6 +192,8 @@ class OWWidget(QDialog, metaclass=WidgetMetaClass):
         if self.want_control_area:
             self.controlArea = gui.widgetBox(self.leftWidgetPart,
                                              orientation="vertical", margin=4)
+            if self.want_main_area and self.max_control_area_width is not None:
+                self.controlArea.setMaximumWidth(self.max_control_area_width)
 
         if self.want_graph and self.show_save_graph:
             graphButtonBackground = gui.widgetBox(self.leftWidgetPart,


### PR DESCRIPTION
A proposal for limiting the size of the control area.

We need something like this in general, to prevent variables with long names or values from expanding the control area. If we apply this patch, we would need to check all widgets. For instance, this had problems with k-means that have mainArea, but hide when it is not needed.

This approach is good since in cases when we don't want to limit the size, the widget will always have a bad layout and we can spot is just by opening it - so we can fix it. With what we have now (that is, no control), widgets usually look good and the problem appears only in weird data sets, so the problem went unnoticed so far for most widgets.