### PR TITLE
Combo box size adjust policy

### DIFF
--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -46,7 +46,8 @@ class OWClassificationTreeGraph(OWTreeViewer2D):
         box = gui.widgetBox(self.controlArea, "Nodes", addSpace=True)
         self.target_combo = gui.comboBox(
             box, self, "target_class_index", orientation=0, items=[],
-            label="Target class", callback=self.toggle_target_class)
+            label="Target class", callback=self.toggle_target_class,
+            contentsLengthHint=8)
         gui.separator(box)
         gui.button(box, self, "Set Colors", callback=self.set_colors)
         dlg = self.create_color_dialog()

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -212,7 +212,9 @@ class FeatureEditor(QtGui.QFrame):
         self.expressionedit = QtGui.QLineEdit()
 
         self.attrs_model = itemmodels.VariableListModel(["Select feature"])
-        self.attributescb = QtGui.QComboBox()
+        self.attributescb = QtGui.QComboBox(
+            minimumContentsLength=12,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
         self.attributescb.setModel(self.attrs_model)
 
         sorted_funcs = sorted(self.FUNCTIONS)

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -351,7 +351,8 @@ class OWImageViewer(widget.OWWidget):
             box="Image Filename Attribute",
             tooltip="Attribute with image filenames",
             callback=[self.clearScene, self.setupScene],
-            addSpace=True
+            contentsLengthHint=12,
+            addSpace=True,
         )
 
         self.titleAttrCB = gui.comboBox(
@@ -359,6 +360,7 @@ class OWImageViewer(widget.OWWidget):
             box="Title Attribute",
             tooltip="Attribute with image title",
             callback=self.updateTitles,
+            contentsLengthHint=12,
             addSpace=True
         )
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -233,7 +233,10 @@ class OWImpute(OWWidget):
         assert self.METHODS[-1].short == "value"
 
         self.value_stack = value_stack = QStackedLayout()
-        self.value_combo = QComboBox(activated=self._on_value_changed)
+        self.value_combo = QComboBox(
+            minimumContentsLength=8,
+            sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLength,
+            activated=self._on_value_changed)
         self.value_line = QLineEdit(editingFinished=self._on_value_changed)
         self.value_line.setValidator(QDoubleValidator())
         value_stack.addWidget(self.value_combo)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -107,7 +107,9 @@ class OWSelectRows(widget.OWWidget):
         row = model.rowCount()
         model.insertRow(row)
 
-        attr_combo = QtGui.QComboBox()
+        attr_combo = QtGui.QComboBox(
+            minimumContentsLength=12,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
         attr_combo.row = row
         for var in chain(self.data.domain.variables, self.data.domain.metas):
             attr_combo.addItem(*gui.attributeItem(var))

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -54,7 +54,8 @@ class OWCalibrationPlot(widget.OWWidget):
         tbox.setFlat(True)
 
         self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._replot)
+            tbox, self, "target_index", callback=self._replot,
+            contentsLengthHint=8)
 
         cbox = gui.widgetBox(box, "Classifier")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -83,7 +83,8 @@ class OWLiftCurve(widget.OWWidget):
         tbox.setFlat(True)
 
         self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._on_target_changed)
+            tbox, self, "target_index", callback=self._on_target_changed,
+            contentsLengthHint=8)
 
         cbox = gui.widgetBox(box, "Classifiers")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -315,7 +315,8 @@ class OWROCAnalysis(widget.OWWidget):
         tbox.setFlat(True)
 
         self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._on_target_changed)
+            tbox, self, "target_index", callback=self._on_target_changed,
+            contentsLengthHint=8)
 
         cbox = gui.widgetBox(box, "Classifiers")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -189,7 +189,8 @@ class OWTestLearners(widget.OWWidget):
         self.class_selection_combo = gui.comboBox(
             self.cbox, self, "class_selection", items=[],
             sendSelectedValue=True, valueType=str,
-            callback=self._on_target_class_changed)
+            callback=self._on_target_class_changed,
+            contentsLengthHint=8)
 
         gui.rubber(self.controlArea)
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1710,6 +1710,7 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
              orientation='vertical', items=(), callback=None,
              sendSelectedValue=False, valueType=str,
              control2attributeDict=None, emptyString=None, editable=False,
+             contentsLengthHint=None,
              **misc):
     """
     Construct a combo box.
@@ -1753,6 +1754,13 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
     :type emptyString: str
     :param editable: a flag telling whether the combo is editable
     :type editable: bool
+    :param int contentsLengthHint: Contents character length to use for the
+        size hint. Equivalent to::
+
+            combo.setSizeAdjustPolicy(
+                QComboBox.AdjustToMinimumContentsLengthWithIcon)
+            combo.setMinimumContentsLength(contentsLengthHint)
+
     :rtype: PyQt4.QtGui.QComboBox
     """
     if box or label:
@@ -1763,6 +1771,11 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
         hb = widget
     combo = QtGui.QComboBox(hb)
     combo.setEditable(editable)
+    if contentsLengthHint is not None:
+        combo.setSizeAdjustPolicy(
+            QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        combo.setMinimumContentsLength(contentsLengthHint)
+
     combo.box = hb
     for item in items:
         if isinstance(item, (tuple, list)):

--- a/Orange/widgets/regression/owunivariateregression.py
+++ b/Orange/widgets/regression/owunivariateregression.py
@@ -57,7 +57,8 @@ class OWUnivariateRegression(widget.OWWidget):
         self.comboBoxAttributesX = gui.comboBox(
             box, self, value='x_var_index',
             label="Input ", orientation="horizontal",
-            callback=self.apply)
+            callback=self.apply,
+            contentsLengthHint=12)
         self.comboBoxAttributesX.setSizePolicy(
             QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Fixed)
         self.comboBoxAttributesX.setModel(self.x_var_model)
@@ -71,7 +72,8 @@ class OWUnivariateRegression(widget.OWWidget):
         self.comboBoxAttributesY = gui.comboBox(
             box, self, value='y_var_index',
             label='Target', orientation="horizontal",
-            callback=self.apply)
+            callback=self.apply,
+            contentsLengthHint=12)
         self.comboBoxAttributesY.setSizePolicy(
             QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Fixed)
         self.comboBoxAttributesY.setModel(self.y_var_model)

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -305,7 +305,8 @@ class OWDistanceMap(widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Annotations")
         self.annot_combo = gui.comboBox(box, self, "annotation_idx",
-                                        callback=self._invalidate_annotations)
+                                        callback=self._invalidate_annotations,
+                                        contentsLengthHint=12)
         self.annot_combo.setModel(itemmodels.VariableListModel())
         self.annot_combo.model()[:] = ["None", "Enumeration"]
         self.controlArea.layout().addStretch()

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -709,7 +709,8 @@ class OWHierarchicalClustering(widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Annotation")
         self.label_cb = gui.comboBox(
-            box, self, "annotation_idx", callback=self._update_labels)
+            box, self, "annotation_idx", callback=self._update_labels,
+            contentsLengthHint=12)
 
         self.label_cb.setModel(itemmodels.VariableListModel())
         self.label_cb.model()[:] = ["None", "Enumeration"]

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -200,7 +200,8 @@ class OWMDS(widget.OWWidget):
         self.colorvar_model = itemmodels.VariableListModel()
 
         common_options = {"sendSelectedValue": True, "valueType": str,
-                          "orientation": "horizontal", "labelWidth": 50, }
+                          "orientation": "horizontal", "labelWidth": 50,
+                          "contentsLengthHint": 12}
 
         self.cb_color_value = gui.comboBox(
             box, self, "color_value", label="Color",

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -143,7 +143,8 @@ class OWDistributions(widget.OWWidget):
         box = gui.widgetBox(self.controlArea, "Group by")
         self.icons = gui.attributeIconDict
         self.groupvarview = gui.comboBox(box, self, "groupvar_idx",
-             callback=self._on_groupvar_idx_changed, valueType=str)
+             callback=self._on_groupvar_idx_changed, valueType=str,
+             contentsLengthHint=12)
         box2 = gui.indentedBox(box, sep=4)
         self.cb_rel_freq = gui.checkBox(
             box2, self, "relative_freq", "Show relative frequencies",

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -338,7 +338,8 @@ class OWLinearProjection(widget.OWWidget):
         box.layout().addLayout(form)
 
         cb = gui.comboBox(box, self, "color_index",
-                          callback=self._on_color_change)
+                          callback=self._on_color_change,
+                          contentsLengthHint=12)
         cb.setModel(self.colorvar_model)
         form.addRow("Colors", cb)
 
@@ -349,12 +350,16 @@ class OWLinearProjection(widget.OWWidget):
         form.addRow("Opacity", alpha_slider)
 
         cb = gui.comboBox(box, self, "shape_index",
-                          callback=self._on_shape_change)
+                          callback=self._on_shape_change,
+                          contentsLengthHint=12)
+
         cb.setModel(self.shapevar_model)
         form.addRow("Shape", cb)
 
         cb = gui.comboBox(box, self, "size_index",
-                          callback=self._on_size_change)
+                          callback=self._on_size_change,
+                          contentsLengthHint=12)
+
         cb.setModel(self.sizevar_model)
         form.addRow("Size", cb)
 

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -181,7 +181,8 @@ class OWMosaicDisplay(OWWidget):
                                  # label="Variable {}".format(i),
                                  orientation="horizontal",
                                  callback=self.updateGraphAndPermList,
-                                 sendSelectedValue=True, valueType=str)
+                                 sendSelectedValue=True, valueType=str,
+                                 contentsLengthHint=12)
 
             butt = gui.button(inbox, self, "", callback=self.orderAttributeValues,
                               tooltip="Change the order of attribute values")

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -497,19 +497,22 @@ class OWScatterMap(widget.OWWidget):
         box = gui.widgetBox(self.controlArea, "Axes")
         self.x_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesX = gui.comboBox(
-            box, self, value='x_var_index', callback=self.replot)
+            box, self, value='x_var_index', callback=self.replot,
+            contentsLenghtHint=12)
         self.comboBoxAttributesX.setModel(self.x_var_model)
 
         self.y_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesY = gui.comboBox(
-            box, self, value='y_var_index', callback=self.replot)
+            box, self, value='y_var_index', callback=self.replot,
+            contentsLengthHint=12)
         self.comboBoxAttributesY.setModel(self.y_var_model)
 
         box = gui.widgetBox(self.controlArea, "Color")
         self.z_var_model = itemmodels.VariableListModel()
         self.comboBoxClassvars = gui.comboBox(
             box, self, value='z_var_index',
-            callback=self._on_z_var_changed)
+            callback=self._on_z_var_changed,
+            contentsLengthHint=12)
         self.comboBoxClassvars.setModel(self.z_var_model)
 
         self.z_values_view = gui.listBox(

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -64,14 +64,31 @@ class OWSieveDiagram(OWWidget):
         #GUI
         self.attrSelGroup = gui.widgetBox(self.controlArea, box = "Shown attributes")
 
-        self.attrXCombo = gui.comboBox(self.attrSelGroup, self, value="attrX", label="X attribute:", orientation="horizontal", tooltip = "Select an attribute to be shown on the X axis", callback = self.updateGraph, sendSelectedValue = 1, valueType = str, labelWidth = 70)
-        self.attrYCombo = gui.comboBox(self.attrSelGroup, self, value="attrY", label="Y attribute:", orientation="horizontal", tooltip = "Select an attribute to be shown on the Y axis", callback = self.updateGraph, sendSelectedValue = 1, valueType = str, labelWidth = 70)
+        self.attrXCombo = gui.comboBox(
+            self.attrSelGroup, self, value="attrX", label="X attribute:",
+            orientation="horizontal", tooltip="Select an attribute to be shown on the X axis",
+            callback=self.updateGraph, sendSelectedValue=1, valueType=str,
+            labelWidth=70, contentsLengthHint=12)
+
+        self.attrYCombo = gui.comboBox(
+            self.attrSelGroup, self, value="attrY", label="Y attribute:",
+            orientation="horizontal", tooltip="Select an attribute to be shown on the Y axis",
+            callback=self.updateGraph, sendSelectedValue=1, valueType=str,
+            labelWidth=70, contentsLengthHint=12)
 
         gui.separator(self.controlArea)
 
         self.conditionGroup = gui.widgetBox(self.controlArea, box = "Condition")
-        self.attrConditionCombo      = gui.comboBox(self.conditionGroup, self, value="attrCondition", label="Attribute:", orientation="horizontal", callback = self.updateConditionAttr, sendSelectedValue = 1, valueType = str, labelWidth = 70)
-        self.attrConditionValueCombo = gui.comboBox(self.conditionGroup, self, value="attrConditionValue", label="Value:", orientation="horizontal", callback = self.updateGraph, sendSelectedValue = 1, valueType = str, labelWidth = 70)
+        self.attrConditionCombo = gui.comboBox(
+            self.conditionGroup, self, value="attrCondition",
+            label="Attribute:", orientation="horizontal",
+            callback=self.updateConditionAttr, sendSelectedValue=True,
+            valueType=str, labelWidth=70, contentsLengthHint=12)
+        self.attrConditionValueCombo = gui.comboBox(
+            self.conditionGroup, self, value="attrConditionValue",
+            label="Value:", orientation="horizontal", callback=self.updateGraph,
+            sendSelectedValue=True, valueType=str, labelWidth=70,
+            contentsLengthHint=10)
 
         gui.separator(self.controlArea)
 

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -95,7 +95,9 @@ class OWVennDiagram(widget.OWWidget):
                                 addSpace=False)
             box.setFlat(True)
             model = itemmodels.VariableListModel(parent=self)
-            cb = QComboBox()
+            cb = QComboBox(
+                minimumContentsLength=12,
+                sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon)
             cb.setModel(model)
             cb.activated[int].connect(self._on_inputAttrActivated)
             box.setEnabled(False)


### PR DESCRIPTION
Fix widget layout by explicitly setting/fixing combo box's contents sizeHint. Specifically when the combo box is used to display variables or variable values (from the widget inputs) and the name/values are long strings the comboBox's size hint could force the controlArea to grow horizontally to display the whole string.

This is solved by setting an appropriate sizeAdjustPolicy and minimumContentsLength on the QComboBox.