### PR TITLE
Combo box size adjust policy with comboBox and varComboBox

### DIFF
--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -44,9 +44,10 @@ class OWClassificationTreeGraph(OWTreeViewer2D):
         self.scene.selectionChanged.connect(self.update_selection)
 
         box = gui.widgetBox(self.controlArea, "Nodes", addSpace=True)
-        self.target_combo = gui.comboBox(
+        self.target_combo = gui.varComboBox(
             box, self, "target_class_index", orientation=0, items=[],
-            label="Target class", callback=self.toggle_target_class)
+            label="Target class", callback=self.toggle_target_class,
+            contentsLengthHint=8)
         gui.separator(box)
         gui.button(box, self, "Set Colors", callback=self.set_colors)
         dlg = self.create_color_dialog()

--- a/Orange/widgets/classify/owloadclassifier.py
+++ b/Orange/widgets/classify/owloadclassifier.py
@@ -34,11 +34,9 @@ class OWLoadClassifier(widget.OWWidget):
             self.controlArea, self.tr("File"), orientation=QtGui.QHBoxLayout()
         )
 
-        self.filesCB = gui.comboBox(
-            box, self, "selectedIndex", callback=self._on_recent)
-        self.filesCB.setMinimumContentsLength(20)
-        self.filesCB.setSizeAdjustPolicy(
-            QtGui.QComboBox.AdjustToMinimumContentsLength)
+        self.filesCB = gui.varComboBox(
+            box, self, "selectedIndex", callback=self._on_recent,
+            contentsLengthHint=20)
 
         self.loadbutton = gui.button(box, self, "...", callback=self.browse)
         self.loadbutton.setIcon(

--- a/Orange/widgets/classify/owsaveclassifier.py
+++ b/Orange/widgets/classify/owsaveclassifier.py
@@ -35,11 +35,9 @@ class OWSaveClassifier(widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, self.tr("File"),
                             orientation=QtGui.QHBoxLayout())
-        self.filesCB = gui.comboBox(box, self, "selectedIndex",
-                                    callback=self._on_recent)
-        self.filesCB.setMinimumContentsLength(20)
-        self.filesCB.setSizeAdjustPolicy(
-            QtGui.QComboBox.AdjustToMinimumContentsLength)
+        self.filesCB = gui.varComboBox(
+            box, self, "selectedIndex", callback=self._on_recent,
+            contentsLengthHint=20)
 
         button = gui.button(
             box, self, "...", callback=self.browse, default=True

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -212,7 +212,9 @@ class FeatureEditor(QtGui.QFrame):
         self.expressionedit = QtGui.QLineEdit()
 
         self.attrs_model = itemmodels.VariableListModel(["Select feature"])
-        self.attributescb = QtGui.QComboBox()
+        self.attributescb = QtGui.QComboBox(
+            minimumContentsLength=12,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
         self.attributescb.setModel(self.attrs_model)
 
         sorted_funcs = sorted(self.FUNCTIONS)

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -346,7 +346,7 @@ class OWImageViewer(widget.OWWidget):
             "Waiting for input\n"
         )
 
-        self.imageAttrCB = gui.comboBox(
+        self.imageAttrCB = gui.varComboBox(
             self.controlArea, self, "imageAttr",
             box="Image Filename Attribute",
             tooltip="Attribute with image filenames",
@@ -354,7 +354,7 @@ class OWImageViewer(widget.OWWidget):
             addSpace=True
         )
 
-        self.titleAttrCB = gui.comboBox(
+        self.titleAttrCB = gui.varComboBox(
             self.controlArea, self, "titleAttr",
             box="Title Attribute",
             tooltip="Attribute with image title",

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -233,7 +233,10 @@ class OWImpute(OWWidget):
         assert self.METHODS[-1].short == "value"
 
         self.value_stack = value_stack = QStackedLayout()
-        self.value_combo = QComboBox(activated=self._on_value_changed)
+        self.value_combo = QComboBox(
+            minimumContentsLength=8,
+            sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLength,
+            activated=self._on_value_changed)
         self.value_line = QLineEdit(editingFinished=self._on_value_changed)
         self.value_line.setValidator(QDoubleValidator())
         value_stack.addWidget(self.value_combo)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -107,7 +107,9 @@ class OWSelectRows(widget.OWWidget):
         row = model.rowCount()
         model.insertRow(row)
 
-        attr_combo = QtGui.QComboBox()
+        attr_combo = QtGui.QComboBox(
+            minimumContentsLength=12,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
         attr_combo.row = row
         for var in chain(self.data.domain.variables, self.data.domain.metas):
             attr_combo.addItem(*gui.attributeItem(var))

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -53,8 +53,9 @@ class OWCalibrationPlot(widget.OWWidget):
         tbox = gui.widgetBox(box, "Target Class")
         tbox.setFlat(True)
 
-        self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._replot)
+        self.target_cb = gui.varComboBox(
+            tbox, self, "target_index", callback=self._replot,
+            contentsLengthHint=8)
 
         cbox = gui.widgetBox(box, "Classifier")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -82,8 +82,9 @@ class OWLiftCurve(widget.OWWidget):
         tbox = gui.widgetBox(box, "Target Class")
         tbox.setFlat(True)
 
-        self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._on_target_changed)
+        self.target_cb = gui.varComboBox(
+            tbox, self, "target_index", callback=self._on_target_changed,
+            contentsLengthHint=8)
 
         cbox = gui.widgetBox(box, "Classifiers")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -314,8 +314,9 @@ class OWROCAnalysis(widget.OWWidget):
         tbox = gui.widgetBox(box, "Target Class")
         tbox.setFlat(True)
 
-        self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._on_target_changed)
+        self.target_cb = gui.varComboBox(
+            tbox, self, "target_index", callback=self._on_target_changed,
+            contentsLengthHint=8)
 
         cbox = gui.widgetBox(box, "Classifiers")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -186,10 +186,11 @@ class OWTestLearners(widget.OWWidget):
         gui.appendRadioButton(rbox, "Test on test data")
 
         self.cbox = gui.widgetBox(self.controlArea, "Target class")
-        self.class_selection_combo = gui.comboBox(
+        self.class_selection_combo = gui.varComboBox(
             self.cbox, self, "class_selection", items=[],
             sendSelectedValue=True, valueType=str,
-            callback=self._on_target_class_changed)
+            callback=self._on_target_class_changed,
+            contentsLengthHint=8)
 
         gui.rubber(self.controlArea)
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1701,19 +1701,21 @@ def valueSlider(widget, master, value, box=None, label=None,
     return slider
 
 
-# TODO comboBox looks overly complicated:
+# TODO varComboBox looks overly complicated:
 # - is the argument control2attributeDict needed? doesn't emptyString do the
 #    job?
-# - can valueType be anything else than str?
 # - sendSelectedValue is not a great name
-def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
-             orientation='vertical', items=(), callback=None,
-             sendSelectedValue=False, valueType=str,
-             control2attributeDict=None, emptyString=None, editable=False,
-             contentsLengthHint=None,
-             **misc):
+def varComboBox(widget, master, value, box=None, label=None, labelWidth=None,
+                orientation='vertical', items=(), callback=None,
+                sendSelectedValue=False, valueType=str,
+                control2attributeDict=None, emptyString=None, editable=False,
+                contentsLengthHint=12, **misc):
     """
-    Construct a combo box.
+    Construct a combo box suitable for variable content.
+
+    This function is recommended over `comboBox` since it sets the hint to 12
+    by default, thus preventing extending of the combo by long variable or
+    attribute names.
 
     The `value` attribute of the `master` contains either the index of the
     selected row (if `sendSelected` is left at default, `False`) or a value
@@ -1755,7 +1757,7 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
     :param editable: a flag telling whether the combo is editable
     :type editable: bool
     :param int contentsLengthHint: Contents character length to use for the
-        size hint. Equivalent to::
+        size hint. Default is 12. Equivalent to::
 
             combo.setSizeAdjustPolicy(
                 QComboBox.AdjustToMinimumContentsLengthWithIcon)
@@ -1810,6 +1812,47 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
                 CallFrontComboBox(combo, None, control2attributeDict))
     miscellanea(combo, hb, widget, **misc)
     return combo
+
+
+def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
+             orientation='vertical', items=(), callback=None,
+             contentsLengthHint=None, **misc):
+    """
+    Construct a combo box.
+
+    Calls varComboBox with contentsLengthHint set to `None`, thus the width
+    adjusts to the content.
+
+    :param widget: the widget into which the box is inserted
+    :type widget: PyQt4.QtGui.QWidget or None
+    :param master: master widget
+    :type master: OWWidget or OWComponent
+    :param value: the master's attribute with which the value is synchronized
+    :type value:  str
+    :param box: tells whether the widget has a border, and its label
+    :type box: int or str or None
+    :param orientation: orientation of the layout in the box
+    :type orientation: str or int or bool
+    :param label: a label that is inserted into the box
+    :type label: str
+    :param labelWidth: the width of the label
+    :type labelWidth: int
+    :param callback: a function that is called when the value is changed
+    :type callback: function
+    :param items: items (optionally with data) that are put into the box
+    :type items: tuple of str or tuples
+    :param int contentsLengthHint: Contents character length to use for the
+        size hint. Equivalent to::
+
+            combo.setSizeAdjustPolicy(
+                QComboBox.AdjustToMinimumContentsLengthWithIcon)
+            combo.setMinimumContentsLength(contentsLengthHint)
+
+    :rtype: PyQt4.QtGui.QComboBox
+    """
+    return varComboBox(widget, master, value, box, label, labelWidth,
+                       orientation, items, callback,
+                       contentsLengthHint=contentsLengthHint, **misc)
 
 
 class OrangeListBox(QtGui.QListWidget):

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1710,6 +1710,7 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
              orientation='vertical', items=(), callback=None,
              sendSelectedValue=False, valueType=str,
              control2attributeDict=None, emptyString=None, editable=False,
+             contentsLengthHint=None,
              **misc):
     """
     Construct a combo box.
@@ -1753,6 +1754,13 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
     :type emptyString: str
     :param editable: a flag telling whether the combo is editable
     :type editable: bool
+    :param int contentsLengthHint: Contents character length to use for the
+        size hint. Equivalent to::
+
+            combo.setSizeAdjustPolicy(
+                QComboBox.AdjustToMinimumContentsLengthWithIcon)
+            combo.setMinimumContentsLength(contentsLengthHint)
+
     :rtype: PyQt4.QtGui.QComboBox
     """
     if box or label:
@@ -1763,6 +1771,11 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
         hb = widget
     combo = QtGui.QComboBox(hb)
     combo.setEditable(editable)
+    if contentsLengthHint is not None:
+        combo.setSizeAdjustPolicy(
+            QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        combo.setMinimumContentsLength(contentsLengthHint)
+
     combo.box = hb
     for item in items:
         if isinstance(item, (tuple, list)):

--- a/Orange/widgets/regression/owunivariateregression.py
+++ b/Orange/widgets/regression/owunivariateregression.py
@@ -54,12 +54,10 @@ class OWUnivariateRegression(widget.OWWidget):
         box = gui.widgetBox(self.controlArea, "Variables")
 
         self.x_var_model = itemmodels.VariableListModel()
-        self.comboBoxAttributesX = gui.comboBox(
+        self.comboBoxAttributesX = gui.varComboBox(
             box, self, value='x_var_index',
             label="Input ", orientation="horizontal",
             callback=self.apply)
-        self.comboBoxAttributesX.setSizePolicy(
-            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Fixed)
         self.comboBoxAttributesX.setModel(self.x_var_model)
         gui.doubleSpin(
             gui.indentedBox(box),
@@ -68,12 +66,10 @@ class OWUnivariateRegression(widget.OWWidget):
 
         gui.separator(box, height=8)
         self.y_var_model = itemmodels.VariableListModel()
-        self.comboBoxAttributesY = gui.comboBox(
+        self.comboBoxAttributesY = gui.varComboBox(
             box, self, value='y_var_index',
             label='Target', orientation="horizontal",
             callback=self.apply)
-        self.comboBoxAttributesY.setSizePolicy(
-            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Fixed)
         self.comboBoxAttributesY.setModel(self.y_var_model)
 
         gui.rubber(self.controlArea)

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -78,12 +78,12 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
         axes_box = gui.widgetBox(self.controlArea, "Axes")
         box = gui.widgetBox(axes_box, "Axis X", margin=0)
         box.setFlat(True)
-        self.axis_x_cb = gui.comboBox(
+        self.axis_x_cb = gui.varComboBox(
             box, self, "component_x", callback=self._component_changed)
 
         box = gui.widgetBox(axes_box, "Axis Y", margin=0)
         box.setFlat(True)
-        self.axis_y_cb = gui.comboBox(
+        self.axis_y_cb = gui.varComboBox(
             box, self, "component_y", callback=self._component_changed)
 
         self.infotext = gui.widgetLabel(

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -304,8 +304,8 @@ class OWDistanceMap(widget.OWWidget):
         box.layout().addLayout(form)
 
         box = gui.widgetBox(self.controlArea, "Annotations")
-        self.annot_combo = gui.comboBox(box, self, "annotation_idx",
-                                        callback=self._invalidate_annotations)
+        self.annot_combo = gui.varComboBox(
+            box, self, "annotation_idx", callback=self._invalidate_annotations)
         self.annot_combo.setModel(itemmodels.VariableListModel())
         self.annot_combo.model()[:] = ["None", "Enumeration"]
         self.controlArea.layout().addStretch()

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -708,9 +708,8 @@ class OWHierarchicalClustering(widget.OWWidget):
                      callback=self._invalidate_clustering)
 
         box = gui.widgetBox(self.controlArea, "Annotation")
-        self.label_cb = gui.comboBox(
+        self.label_cb = gui.varComboBox(
             box, self, "annotation_idx", callback=self._update_labels)
-
         self.label_cb.setModel(itemmodels.VariableListModel())
         self.label_cb.model()[:] = ["None", "Enumeration"]
 

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -200,27 +200,28 @@ class OWMDS(widget.OWWidget):
         self.colorvar_model = itemmodels.VariableListModel()
 
         common_options = {"sendSelectedValue": True, "valueType": str,
-                          "orientation": "horizontal", "labelWidth": 50, }
+                          "orientation": "horizontal", "labelWidth": 50,
+                          "contentsLengthHint": 8}
 
-        self.cb_color_value = gui.comboBox(
+        self.cb_color_value = gui.varComboBox(
             box, self, "color_value", label="Color",
             callback=self._on_color_index_changed, **common_options)
         self.cb_color_value.setModel(self.colorvar_model)
 
         self.shapevar_model = itemmodels.VariableListModel()
-        self.cb_shape_value = gui.comboBox(
+        self.cb_shape_value = gui.varComboBox(
             box, self, "shape_value", label="Shape",
             callback=self._on_shape_index_changed, **common_options)
         self.cb_shape_value.setModel(self.shapevar_model)
 
         self.sizevar_model = itemmodels.VariableListModel()
-        self.cb_size_value = gui.comboBox(
+        self.cb_size_value = gui.varComboBox(
             box, self, "size_value", label="Size",
             callback=self._on_size_index_changed, **common_options)
         self.cb_size_value.setModel(self.sizevar_model)
 
         self.labelvar_model = itemmodels.VariableListModel()
-        self.cb_label_value = gui.comboBox(
+        self.cb_label_value = gui.varComboBox(
             box, self, "label_value", label="Label",
             callback=self._on_label_index_changed, **common_options)
         self.cb_label_value.setModel(self.labelvar_model)

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -142,17 +142,17 @@ class OWDistributions(widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Group by")
         self.icons = gui.attributeIconDict
-        self.groupvarview = gui.comboBox(box, self, "groupvar_idx",
+        self.groupvarview = gui.varComboBox(box, self, "groupvar_idx",
              callback=self._on_groupvar_idx_changed, valueType=str)
         box2 = gui.indentedBox(box, sep=4)
         self.cb_rel_freq = gui.checkBox(
             box2, self, "relative_freq", "Show relative frequencies",
             callback=self._on_relative_freq_changed)
         gui.separator(box2)
-        self.cb_prob = gui.comboBox(
+        self.cb_prob = gui.varComboBox(
             box2, self, "show_prob", label="Show probabilities",
             orientation="horizontal",
-            callback=self._on_relative_freq_changed)
+            callback=self._on_relative_freq_changed, contentsLengthHint=8)
 
         plotview = pg.PlotWidget(background=None)
         self.mainArea.layout().addWidget(plotview)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -280,9 +280,9 @@ class OWHeatMap(widget.OWWidget):
 
         annotbox = gui.widgetBox(box, "Row Annotations")
         annotbox.setFlat(True)
-        self.annotations_cb = gui.comboBox(annotbox, self, "annotation_index",
-                                           items=self.annotation_vars,
-                                           callback=self.update_annotations)
+        self.annotations_cb = gui.varComboBox(
+            annotbox, self, "annotation_index", items=self.annotation_vars,
+            callback=self.update_annotations)
 
         posbox = gui.widgetBox(box, "Column Labels Position")
         posbox.setFlat(True)

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -337,8 +337,8 @@ class OWLinearProjection(widget.OWWidget):
         )
         box.layout().addLayout(form)
 
-        cb = gui.comboBox(box, self, "color_index",
-                          callback=self._on_color_change)
+        cb = gui.varComboBox(box, self, "color_index",
+                             callback=self._on_color_change)
         cb.setModel(self.colorvar_model)
         form.addRow("Colors", cb)
 
@@ -348,13 +348,13 @@ class OWLinearProjection(widget.OWWidget):
         alpha_slider.valueChanged.connect(self._set_alpha)
         form.addRow("Opacity", alpha_slider)
 
-        cb = gui.comboBox(box, self, "shape_index",
-                          callback=self._on_shape_change)
+        cb = gui.varComboBox(box, self, "shape_index",
+                             callback=self._on_shape_change)
         cb.setModel(self.shapevar_model)
         form.addRow("Shape", cb)
 
-        cb = gui.comboBox(box, self, "size_index",
-                          callback=self._on_size_change)
+        cb = gui.varComboBox(box, self, "size_index",
+                             callback=self._on_size_change)
         cb.setModel(self.sizevar_model)
         form.addRow("Size", cb)
 

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -177,11 +177,11 @@ class OWMosaicDisplay(OWWidget):
         box = gui.widgetBox(self.controlArea, "Variables")
         for i in range(1, 5):
             inbox = gui.widgetBox(box, orientation="horizontal")
-            combo = gui.comboBox(inbox, self, value="variable{}".format(i),
-                                 # label="Variable {}".format(i),
-                                 orientation="horizontal",
-                                 callback=self.updateGraphAndPermList,
-                                 sendSelectedValue=True, valueType=str)
+            combo = gui.varComboBox(inbox, self, value="variable{}".format(i),
+                                    # label="Variable {}".format(i),
+                                    orientation="horizontal",
+                                    callback=self.updateGraphAndPermList,
+                                    sendSelectedValue=True, valueType=str)
 
             butt = gui.button(inbox, self, "", callback=self.orderAttributeValues,
                               tooltip="Change the order of attribute values")
@@ -204,10 +204,10 @@ class OWMosaicDisplay(OWWidget):
         # self.permutationList.hide()
 
         box5 = gui.widgetBox(self.controlArea, "Visual Settings")
-        self.cb_color = gui.comboBox(box5, self, "interior_coloring",
-                                     label="Color", orientation="horizontal",
-                                     items=self.interior_coloring_opts,
-                                     callback=self.updateGraph)
+        self.cb_color = gui.varComboBox(box5, self, "interior_coloring",
+                                        label="Color", orientation="horizontal",
+                                        items=self.interior_coloring_opts,
+                                        callback=self.updateGraph)
 
         gui.checkBox(box5, self, "remove_unused_labels",
                      "Remove unused attribute labels",

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -496,18 +496,18 @@ class OWScatterMap(widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Axes")
         self.x_var_model = itemmodels.VariableListModel()
-        self.comboBoxAttributesX = gui.comboBox(
+        self.comboBoxAttributesX = gui.varComboBox(
             box, self, value='x_var_index', callback=self.replot)
         self.comboBoxAttributesX.setModel(self.x_var_model)
 
         self.y_var_model = itemmodels.VariableListModel()
-        self.comboBoxAttributesY = gui.comboBox(
+        self.comboBoxAttributesY = gui.varComboBox(
             box, self, value='y_var_index', callback=self.replot)
         self.comboBoxAttributesY.setModel(self.y_var_model)
 
         box = gui.widgetBox(self.controlArea, "Color")
         self.z_var_model = itemmodels.VariableListModel()
-        self.comboBoxClassvars = gui.comboBox(
+        self.comboBoxClassvars = gui.varComboBox(
             box, self, value='z_var_index',
             callback=self._on_z_var_changed)
         self.comboBoxClassvars.setModel(self.z_var_model)

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -89,12 +89,12 @@ class OWScatterPlot(OWWidget):
         common_options = {"labelWidth": 50, "orientation": "horizontal",
                           "sendSelectedValue": True, "valueType": str}
         box = gui.widgetBox(self.controlArea, "Axis Data")
-        self.cb_attr_x = gui.comboBox(box, self, "attr_x", label="Axis x:",
-                                      callback=self.update_attr,
-                                      **common_options)
-        self.cb_attr_y = gui.comboBox(box, self, "attr_y", label="Axis y:",
-                                      callback=self.update_attr,
-                                      **common_options)
+        self.cb_attr_x = gui.varComboBox(box, self, "attr_x", label="Axis x:",
+                                         callback=self.update_attr,
+                                         **common_options)
+        self.cb_attr_y = gui.varComboBox(box, self, "attr_y", label="Axis y:",
+                                         callback=self.update_attr,
+                                         **common_options)
 
         self.vizrank = self.VizRank(self)
         vizrank_box = gui.widgetBox(box, None, orientation='horizontal')
@@ -115,19 +115,19 @@ class OWScatterPlot(OWWidget):
             'Jitter continuous values', callback=self.reset_graph_data)
 
         box = gui.widgetBox(self.controlArea, "Points")
-        self.cb_attr_color = gui.comboBox(
+        self.cb_attr_color = gui.varComboBox(
             box, self, "graph.attr_color", label="Color:",
             emptyString="(Same color)", callback=self.update_colors,
             **common_options)
-        self.cb_attr_label = gui.comboBox(
+        self.cb_attr_label = gui.varComboBox(
             box, self, "graph.attr_label", label="Label:",
             emptyString="(No labels)", callback=self.graph.update_labels,
             **common_options)
-        self.cb_attr_shape = gui.comboBox(
+        self.cb_attr_shape = gui.varComboBox(
             box, self, "graph.attr_shape", label="Shape:",
             emptyString="(Same shape)", callback=self.graph.update_shapes,
             **common_options)
-        self.cb_attr_size = gui.comboBox(
+        self.cb_attr_size = gui.varComboBox(
             box, self, "graph.attr_size", label="Size:",
             emptyString="(Same size)", callback=self.graph.update_sizes,
             **common_options)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -64,14 +64,29 @@ class OWSieveDiagram(OWWidget):
         #GUI
         self.attrSelGroup = gui.widgetBox(self.controlArea, box = "Shown attributes")
 
-        self.attrXCombo = gui.comboBox(self.attrSelGroup, self, value="attrX", label="X attribute:", orientation="horizontal", tooltip = "Select an attribute to be shown on the X axis", callback = self.updateGraph, sendSelectedValue = 1, valueType = str, labelWidth = 70)
-        self.attrYCombo = gui.comboBox(self.attrSelGroup, self, value="attrY", label="Y attribute:", orientation="horizontal", tooltip = "Select an attribute to be shown on the Y axis", callback = self.updateGraph, sendSelectedValue = 1, valueType = str, labelWidth = 70)
+        self.attrXCombo = gui.varComboBox(
+            self.attrSelGroup, self, value="attrX", label="X attribute:",
+            orientation="horizontal",
+            tooltip="Select an attribute to be shown on the X axis",
+            callback=self.updateGraph, sendSelectedValue=True,labelWidth=70)
+        self.attrYCombo = gui.varComboBox(
+            self.attrSelGroup, self, value="attrY", label="Y attribute:",
+            orientation="horizontal",
+            tooltip="Select an attribute to be shown on the Y axis",
+            callback=self.updateGraph, sendSelectedValue=True, labelWidth=70)
 
         gui.separator(self.controlArea)
 
         self.conditionGroup = gui.widgetBox(self.controlArea, box = "Condition")
-        self.attrConditionCombo      = gui.comboBox(self.conditionGroup, self, value="attrCondition", label="Attribute:", orientation="horizontal", callback = self.updateConditionAttr, sendSelectedValue = 1, valueType = str, labelWidth = 70)
-        self.attrConditionValueCombo = gui.comboBox(self.conditionGroup, self, value="attrConditionValue", label="Value:", orientation="horizontal", callback = self.updateGraph, sendSelectedValue = 1, valueType = str, labelWidth = 70)
+        self.attrConditionCombo = gui.varComboBox(
+            self.conditionGroup, self, value="attrCondition",
+            label="Attribute:", orientation="horizontal",
+            callback=self.updateConditionAttr, sendSelectedValue=True,
+            labelWidth=70)
+        self.attrConditionValueCombo = gui.varComboBox(
+            self.conditionGroup, self, value="attrConditionValue",
+            label="Value:", orientation="horizontal", callback=self.updateGraph,
+            sendSelectedValue=True, labelWidth=70)
 
         gui.separator(self.controlArea)
 

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -95,7 +95,9 @@ class OWVennDiagram(widget.OWWidget):
                                 addSpace=False)
             box.setFlat(True)
             model = itemmodels.VariableListModel(parent=self)
-            cb = QComboBox()
+            cb = QComboBox(
+                minimumContentsLength=12,
+                sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon)
             cb.setModel(model)
             cb.activated[int].connect(self._on_inputAttrActivated)
             box.setEnabled(False)


### PR DESCRIPTION
Implementation of changes suggested by @ales-erjavec in the discussion following #717.

Function `comboBox` works like before (any arguments that were passed as keyword arguments are still used, too), so these changes should not break anything.

Function `varComboBox` sets the default `contentsLengthHint` to 12; calls of `comboBox` are replaced by `varComboBox` where necessary, and the length hint is set to 8 if the `comboBox` contains values, not variable names.