### PR TITLE
Mosaic: Fix a minor bug

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -335,6 +335,7 @@ class OWMosaicDisplay(OWWidget):
 
         self.closeContext()
         self.data = data
+        self.initCombos(self.data)
         self.bestPlacements = None
         self.manualAttributeValuesDict = {}
         self.attributeValuesDict = {}
@@ -366,7 +367,6 @@ class OWMosaicDisplay(OWWidget):
         else:
             self.interior_coloring = PEARSON
 
-        self.initCombos(self.data)
         self.openContext(self.data)
 
         # if we first received subset data


### PR DESCRIPTION
Mosaic Display crashed occasionally when changing the input data.

Resetting the information dialog in setData causes a redraw. This happened
after changing the data and before updating the combo boxes, which led to
a crash because of inconsistent attributes and data.