### PR TITLE
gui.auto_commit: Add spacing between label and button

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2313,8 +2313,10 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
                       addToLayout=False)
         b.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Maximum)
 
-    b.checkbox = cb = checkBox(b, master, value, checkbox_label or " ",
+    b.checkbox = cb = checkBox(b, master, value, checkbox_label,
                                callback=u, tooltip=auto_label)
+    if checkbox_label and orientation == 'horizontal' or not orientation:
+        b.layout().insertSpacing(-1, 10)
     cb.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Preferred)
     b.button = btn = button(b, master, label, callback=do_commit)
     if not checkbox_label:


### PR DESCRIPTION
In the horizontal layout, the should be some space between the checkbox label and the button.

The problem becomes apparent if another button is added to box created by `gui.auto_commit`, like in https://github.com/biolab/orange3/commit/ea37c2f1cbf5aed84588b0caf2007ee07758de32#diff-a2cbec3457e61cdb3228e0e4b7b95585R227.