### PR TITLE
SignalManager: Fix canvas signal propagation

### DIFF
--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -616,7 +616,9 @@ class WidgetsSignalManager(SignalManager):
         SignalManager.send(self, node, channel, value, signal_id)
 
     def is_blocking(self, node):
-        return self.scheme().widget_manager.node_processing_state(node) != 0
+        """Reimplemented from `SignalManager`"""
+        return (self.scheme().widget_manager.node_processing_state(node) &
+                (WidgetManager.InputUpdate | WidgetManager.BlockingUpdate))
 
     def send_to_node(self, node, signals):
         """


### PR DESCRIPTION
Do not block signal delivery to dependent widgets between calls to
OWWidget.progressBarInit/Finish