### PR TITLE
heatmap: clear redraw artefacts

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -326,7 +326,9 @@ class OWHeatMap(widget.OWWidget):
         self.sceneView = QGraphicsView(
             self.scene,
             verticalScrollBarPolicy=policy,
-            horizontalScrollBarPolicy=policy)
+            horizontalScrollBarPolicy=policy,
+            viewportUpdateMode=QGraphicsView.FullViewportUpdate,
+        )
 
         self.sceneView.viewport().installEventFilter(self)
 


### PR DESCRIPTION
Ocassionaly some old artefacts remain on the plot after the image updated; e.g. when turning on the row annotations the end of the previous scale could be seen in the top right corner. This PR clears these problems.
<img width="1070" alt="screen shot 2015-10-09 at 21 17 08" src="https://cloud.githubusercontent.com/assets/713026/10403363/49d95386-6ecb-11e5-8556-4a417904a2d4.png">
