### PR TITLE
provider: Remove non-existent argument (Py3.5)

### DIFF
--- a/Orange/canvas/help/provider.py
+++ b/Orange/canvas/help/provider.py
@@ -197,8 +197,7 @@ class HtmlIndexProvider(BaseInventoryProvider):
             log.exception("Error parsing")
 
     def _parse(self, stream):
-        parser = HtmlIndexProvider._XHTMLParser(
-            strict=True, convert_charrefs=True)
+        parser = HtmlIndexProvider._XHTMLParser(convert_charrefs=True)
         parser.feed(stream)
         self.root = parser.builder.close()
 


### PR DESCRIPTION
`strict` has been deprecated since Python 3.3 and removed in 3.5
https://docs.python.org/3.4/library/html.parser.html