### PR TITLE
io: New heuristic for discerning headers from data

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -504,7 +504,7 @@ class FileFormat(metaclass=FileFormatMeta):
 class CSVFormat(FileFormat):
     EXTENSIONS = ('.csv',)
     DESCRIPTION = 'Comma-separated values'
-    DELIMITER = ','
+    DELIMITERS = ',;:\t$ '
     SUPPORT_COMPRESSED = True
 
     @classmethod
@@ -517,12 +517,12 @@ class CSVFormat(FileFormat):
             with cls.open(filename, mode='rt', newline='', encoding=encoding) as file:
                 # Sniff the CSV dialect (delimiter, quotes, ...)
                 try:
-                    dialect = csv.Sniffer().sniff(file.read(1024), list(',\t;:$ '))
+                    dialect = csv.Sniffer().sniff(file.read(1024), cls.DELIMITERS)
                 except UnicodeDecodeError:
                     continue
                 except csv.Error:
                     dialect = csv.excel()
-                    dialect.delimiter = cls.DELIMITER
+                    dialect.delimiter = cls.DELIMITERS[0]
 
                 file.seek(0)
                 dialect.skipinitialspace = True
@@ -539,7 +539,7 @@ class CSVFormat(FileFormat):
     def write_file(cls, filename, data):
         import csv
         with cls.open(filename, mode='wt', newline='', encoding='utf-8') as file:
-            writer = csv.writer(file, delimiter=cls.DELIMITER)
+            writer = csv.writer(file, delimiter=cls.DELIMITERS[0])
             cls.write_headers(writer.writerow, data)
             writer.writerows(inst.list for inst in data)
 
@@ -547,7 +547,7 @@ class CSVFormat(FileFormat):
 class TabFormat(CSVFormat):
     EXTENSIONS = ('.tab', '.tsv')
     DESCRIPTION = 'Tab-separated values'
-    DELIMITER = '\t'
+    DELIMITERS = '\t'
 
 
 class PickleFormat(FileFormat):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -41,7 +41,7 @@ def is_discrete_values(values):
         [float(v) for _, v in zip(range(min(3, len(values))), values)]
     except ValueError:
         is_numeric = False
-        max_values = int(max(len(values)**.6, DISCRETE_MAX_VALUES))
+        max_values = int(round(len(values)**.7))
     else:
         is_numeric = True
         max_values = DISCRETE_MAX_VALUES

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -74,6 +74,32 @@ class TestTabReader(unittest.TestCase):
         self.assertEqual(c1.name, "Class 1")
         self.assertEqual(c1.attributes, {'x': 'a longer string'})
 
+    def test_read_data_oneline_header(self):
+        samplefile = """\
+        data1\tdata2\tdata3
+        0.1\t0.2\t0.3
+        1.1\t1.2\t1.5
+        """
+        file = io.StringIO(samplefile)
+        table = TabFormat().read_file(file)
+
+        self.assertEqual(len(table), 2)
+        self.assertEqual(len(table.domain), 3)
+        self.assertEqual(table.domain[0].name, 'data1')
+
+    def test_read_data_no_header(self):
+        samplefile = """\
+        0.1\t0.2\t0.3
+        1.1\t1.2\t1.5
+        """
+        file = io.StringIO(samplefile)
+        table = TabFormat().read_file(file)
+
+        self.assertEqual(len(table), 2)
+        self.assertEqual(len(table.domain), 3)
+        self.assertTrue(table.domain[0].is_continuous)
+        self.assertEqual(table.domain[0].name, 'Feature 1')
+
     def test_reuse_variables(self):
         file1 = io.StringIO("\n".join("xd dbac"))
         t1 = TabFormat().read_file(file1)

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -1,9 +1,10 @@
 import io
+from os import path
 import unittest
 
 import numpy as np
 
-from Orange.data import ContinuousVariable, DiscreteVariable
+from Orange.data import Table, ContinuousVariable, DiscreteVariable
 from Orange.data.io import TabFormat
 
 
@@ -112,3 +113,18 @@ class TestTabReader(unittest.TestCase):
 
         self.assertSequenceEqual(t2.domain['x'].values, 'abcdgh')
         np.testing.assert_almost_equal(t2.X.ravel(), [5, 4, 0, 2, 1])
+
+    def test_dataset_with_weird_names_and_column_attributes(self):
+        data = Table(path.join(path.dirname(__file__), 'weird.tab'))
+        self.assertEqual(len(data), 6)
+        self.assertEqual(len(data.domain), 1)
+        self.assertEqual(len(data.domain.metas), 1)
+        NAME = "['5534fab7fad58d5df50061f1', '5534fab8fad58d5de20061f8']"
+        self.assertEqual(data.domain[0].name, NAME)
+        ATTRIBUTES = dict(
+            Timepoint='20',
+            id=NAME,
+            Name="['Gene expressions (dd_AX4_on_Ka_20Hr_bio1_mapped.bam)', 'Gene expressions (dd_AX4_on_Ka_20Hr_bio2_mapped.bam)']",
+            Replicate="['1', '2']",
+        )
+        self.assertEqual(data.domain[0].attributes, ATTRIBUTES)

--- a/Orange/tests/weird.tab
+++ b/Orange/tests/weird.tab
@@ -1,0 +1,9 @@
+['5534fab7fad58d5df50061f1', '5534fab8fad58d5de20061f8']	DDB
+c	string
+Timepoint=20 id=['5534fab7fad58d5df50061f1',\ '5534fab8fad58d5de20061f8'] Name=['Gene\ expressions\ (dd_AX4_on_Ka_20Hr_bio1_mapped.bam)',\ 'Gene\ expressions\ (dd_AX4_on_Ka_20Hr_bio2_mapped.bam)'] Replicate=['1',\ '2']	m
+2.219	DDB_G0267178
+1.055	DDB_G0267180
+3.271	DDB_G0267182
+2.123	DDB_G0267184
+1.566	DDB_G0267186
+3.111	DDB_G0267188


### PR DESCRIPTION
If the first three lines of a dataset match the three-line header
format => it's a three-line header (regardless of the column names
used in the first line).

Otherwise, if the first and second line don't have all-digits in
exactly the same places and not-all-digits everywhere else => it's
a single-line header.

Otherwise, no header.

Also, (@BlazZupan) string variables are considered discrete only if at most `int(round(len(values)**.7))` values, so for 5 instances, there can be at most 3 distinct values for the variable to be considered discrete, and for 100, 25.