### PR TITLE
Popup short survey and show feedback link on the Welcome screen

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -16,8 +16,8 @@ import signal
 
 import pkg_resources
 
-from PyQt4.QtGui import QFont, QColor
-from PyQt4.QtCore import Qt, QDir
+from PyQt4.QtGui import QFont, QColor, QDesktopServices
+from PyQt4.QtCore import Qt, QDir, QUrl
 
 from Orange import canvas
 from Orange.canvas.application.application import CanvasApplication
@@ -355,6 +355,13 @@ def main(argv=None):
     if stderr_redirect:
         sys.excepthook = ExceptHook()
         sys.excepthook.handledException.connect(output_view.parent().show)
+
+    # If run for the first time, open a browser tab with a survey
+    first_run = settings.value("startup/first-run", True, type=bool)
+    if first_run:
+        success = QDesktopServices.openUrl(
+            QUrl("http://orange.biolab.si/survey/short.html"));
+        settings.setValue("startup/first-run", not success)
 
     with redirect_stdout(stdout), redirect_stderr(stderr):
         log.info("Entering main event loop.")

--- a/Orange/canvas/application/welcomedialog.py
+++ b/Orange/canvas/application/welcomedialog.py
@@ -6,7 +6,7 @@ Orange Canvas Welcome Dialog
 from PyQt4.QtGui import (
     QDialog, QWidget, QToolButton, QCheckBox, QAction,
     QHBoxLayout, QVBoxLayout, QFont, QSizePolicy,
-    QPixmap, QIcon, QPainter, QColor, QBrush
+    QPixmap, QIcon, QPainter, QColor, QBrush, QLabel
 )
 
 from PyQt4.QtCore import Qt, QRect, QPoint
@@ -117,8 +117,15 @@ class WelcomeDialog(QDialog):
 
         self.__showAtStartupCheck = check
 
+        feedback = QLabel(
+            '<a href="http://orange.biolab.si/survey/long.html">Help us improve!</a>')
+        feedback.setTextInteractionFlags(Qt.TextBrowserInteraction)
+        feedback.setOpenExternalLinks(True)
+
         bottom_bar_layout.addWidget(check, alignment=Qt.AlignVCenter | \
                                     Qt.AlignLeft)
+        bottom_bar_layout.addWidget(feedback, alignment=Qt.AlignVCenter | \
+                                    Qt.AlignRight)
 
         self.layout().addWidget(bottom_bar, alignment=Qt.AlignBottom,
                                 stretch=1)


### PR DESCRIPTION
The two links are:
* http://orange.biolab.si/short-survey.html should redirect to short survey shown when Orange is first run;
* http://orange.biolab.si/long-survey.html should redirect to longer feedback form.

@markotoplak and @ajdapretnar are on it.