### PR TITLE
OWRank: Get scores from linear regression and random forest

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -1,16 +1,29 @@
+import numpy as np
+
 import sklearn.linear_model as skl_linear_model
 
 from Orange.classification import SklLearner, SklModel
 from Orange.preprocess import Normalize
+from Orange.preprocess.score import LearnerScorer
+from Orange.data import Variable, DiscreteVariable
 
 __all__ = ["LogisticRegressionLearner"]
+
+
+class _FeatureScorerMixin(LearnerScorer):
+    feature_type = Variable
+    class_type = DiscreteVariable
+
+    def score(self, model):
+        # Take the maximum attribute score across all classes
+        return np.max(np.abs(model.skl_model.coef_), axis=0)
 
 
 class LogisticRegressionClassifier(SklModel):
     pass
 
 
-class LogisticRegressionLearner(SklLearner):
+class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_linear_model.LogisticRegression
     __returns__ = LogisticRegressionClassifier
     name = 'logreg'

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -1,15 +1,25 @@
 import sklearn.ensemble as skl_ensemble
 
 from Orange.classification import SklLearner, SklModel
+from Orange.data import Variable, DiscreteVariable
+from Orange.preprocess.score import LearnerScorer
 
 __all__ = ["RandomForestLearner"]
+
+
+class _FeatureScorerMixin(LearnerScorer):
+    feature_type = Variable
+    class_type = DiscreteVariable
+
+    def score(self, model):
+        return model.skl_model.feature_importances_
 
 
 class RandomForestClassifier(SklModel):
     pass
 
 
-class RandomForestLearner(SklLearner):
+class RandomForestLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_ensemble.RandomForestClassifier
     __returns__ = RandomForestClassifier
     name = 'random forest'

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -2,7 +2,9 @@ import sklearn.linear_model as skl_linear_model
 import sklearn.pipeline as skl_pipeline
 import sklearn.preprocessing as skl_preprocessing
 
-from Orange.regression import Learner, Model, SklLearner
+from Orange.regression import Learner, Model, SklLearner, SklModel
+from Orange.data import Variable, ContinuousVariable
+from Orange.preprocess.score import LearnerScorer
 
 __all__ = ["LinearRegressionLearner", "RidgeRegressionLearner",
            "LassoRegressionLearner", "SGDRegressionLearner",
@@ -10,7 +12,15 @@ __all__ = ["LinearRegressionLearner", "RidgeRegressionLearner",
            "PolynomialLearner"]
 
 
-class LinearRegressionLearner(SklLearner):
+class _FeatureScorerMixin(LearnerScorer):
+    feature_type = Variable
+    class_type = ContinuousVariable
+
+    def score(self, model):
+        return model.skl_model.coef_
+
+
+class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_linear_model.LinearRegression
     name = 'linreg'
 
@@ -23,7 +33,7 @@ class LinearRegressionLearner(SklLearner):
         return LinearModel(sk)
 
 
-class RidgeRegressionLearner(SklLearner):
+class RidgeRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_linear_model.Ridge
     name = 'ridge'
 
@@ -34,7 +44,7 @@ class RidgeRegressionLearner(SklLearner):
         self.params = vars()
 
 
-class LassoRegressionLearner(SklLearner):
+class LassoRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_linear_model.Lasso
     name = 'lasso'
 
@@ -108,12 +118,9 @@ class PolynomialLearner(Learner):
         return PolynomialModel(model, polyfeatures)
 
 
-class LinearModel(Model):
-    def __init__(self, model):
-        self.model = model
-
+class LinearModel(SklModel):
     def predict(self, X):
-        vals = self.model.predict(X)
+        vals = self.skl_model.predict(X)
         if len(vals.shape) == 1:
             # Prevent IndexError for 1D array
             return vals
@@ -123,7 +130,7 @@ class LinearModel(Model):
             return vals
 
     def __str__(self):
-        return 'LinearModel {}'.format(self.model)
+        return 'LinearModel {}'.format(self.skl_model)
 
 
 class PolynomialModel(Model):

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import sklearn.linear_model as skl_linear_model
 import sklearn.pipeline as skl_pipeline
 import sklearn.preprocessing as skl_preprocessing
@@ -17,7 +19,7 @@ class _FeatureScorerMixin(LearnerScorer):
     class_type = ContinuousVariable
 
     def score(self, model):
-        return model.skl_model.coef_
+        return np.abs(model.skl_model.coef_)
 
 
 class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -1,14 +1,24 @@
 import sklearn.ensemble as skl_ensemble
 from Orange.regression import SklLearner, SklModel
+from Orange.data import Variable, ContinuousVariable
+from Orange.preprocess.score import LearnerScorer
 
 __all__ = ["RandomForestRegressionLearner"]
+
+
+class _FeatureScorerMixin(LearnerScorer):
+    feature_type = Variable
+    class_type = ContinuousVariable
+
+    def score(self, model):
+        return model.skl_model.feature_importances_
 
 
 class RandomForestRegressor(SklModel):
     pass
 
 
-class RandomForestRegressionLearner(SklLearner):
+class RandomForestRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_ensemble.RandomForestRegressor
     __returns__ = RandomForestRegressor
     name = 'random forest regression'

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -1,6 +1,14 @@
 import unittest
 import numpy as np
-import Orange
+from Orange.data import Table
+from Orange.regression import (LinearRegressionLearner,
+                               RidgeRegressionLearner,
+                               LassoRegressionLearner,
+                               ElasticNetLearner,
+                               ElasticNetCVLearner,
+                               MeanLearner)
+from Orange.evaluation import CrossValidation, RMSE
+
 
 class LinearRegressionTest(unittest.TestCase):
     def test_LinearRegression(self):
@@ -13,21 +21,63 @@ class LinearRegressionTest(unittest.TestCase):
 
         x1, x2 = np.split(x, 2)
         y1, y2 = np.split(y, 2)
-        t = Orange.data.Table(x1, y1)
-        learn = Orange.regression.LinearRegressionLearner()
+        t = Table(x1, y1)
+        learn = LinearRegressionLearner()
         clf = learn(t)
         z = clf(x2)
         self.assertTrue((abs(z.reshape(-1, 1) - y2) < 2.0).all())
 
     def test_Regression(self):
-        data = Orange.data.Table("housing")
-        ridge = Orange.regression.RidgeRegressionLearner()
-        lasso = Orange.regression.LassoRegressionLearner()
-        elastic = Orange.regression.ElasticNetLearner()
-        elasticCV = Orange.regression.ElasticNetCVLearner()
-        mean = Orange.regression.MeanLearner()
+        data = Table("housing")
+        ridge = RidgeRegressionLearner()
+        lasso = LassoRegressionLearner()
+        elastic = ElasticNetLearner()
+        elasticCV = ElasticNetCVLearner()
+        mean = MeanLearner()
         learners = [ridge, lasso, elastic, elasticCV, mean]
-        res = Orange.evaluation.CrossValidation(data, learners, k=2)
-        rmse = Orange.evaluation.RMSE(res)
-        for i in range(len(learners)-1):
+        res = CrossValidation(data, learners, k=2)
+        rmse = RMSE(res)
+        for i in range(len(learners) - 1):
             self.assertTrue(rmse[i] < rmse[-1])
+
+    def test_linear_scorer(self):
+        data = Table('housing')
+        learner = LinearRegressionLearner()
+        scores = learner.score_data(data)
+        self.assertEqual(len(scores), len(data.domain.attributes))
+
+    def test_ridge_scorer(self):
+        data = Table('housing')
+        learner = RidgeRegressionLearner()
+        scores = learner.score_data(data)
+        self.assertEqual(len(scores), len(data.domain.attributes))
+
+    def test_lasso_scorer(self):
+        data = Table('housing')
+        learner = LassoRegressionLearner()
+        scores = learner.score_data(data)
+        self.assertEqual(len(scores), len(data.domain.attributes))
+
+    def test_linear_scorer_feature(self):
+        data = Table('housing')
+        learner = LinearRegressionLearner()
+        scores = learner.score_data(data)
+        for i, attr in enumerate(data.domain.attributes):
+            score = learner.score_data(data, attr)
+            self.assertEqual(score, scores[i])
+
+    def test_ridge_scorer_feature(self):
+        data = Table('housing')
+        learner = RidgeRegressionLearner()
+        scores = learner.score_data(data)
+        for i, attr in enumerate(data.domain.attributes):
+            score = learner.score_data(data, attr)
+            self.assertEqual(score, scores[i])
+
+    def test_lasso_scorer_feature(self):
+        data = Table('housing')
+        learner = LassoRegressionLearner()
+        scores = learner.score_data(data)
+        for i, attr in enumerate(data.domain.attributes):
+            score = learner.score_data(data, attr)
+            self.assertEqual(score, scores[i])

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -44,6 +44,8 @@ class LinearRegressionTest(unittest.TestCase):
         data = Table('housing')
         learner = LinearRegressionLearner()
         scores = learner.score_data(data)
+        self.assertEqual('NOX',
+                         data.domain.attributes[np.argmax(scores)].name)
         self.assertEqual(len(scores), len(data.domain.attributes))
 
     def test_ridge_scorer(self):

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -37,3 +37,11 @@ class LogisticRegressionTest(unittest.TestCase):
         clf = learn(table[:100])
         p = clf(table[100:], ret=Model.Probs)
         self.assertTrue(all(abs(p.sum(axis=1) - 1) < 1e-6))
+
+    def test_learner_scorer(self):
+        data = Table('voting')
+        learner = LogisticRegressionLearner()
+        scores = learner.score_data(data)
+        self.assertEqual('physician-fee-freeze',
+                         data.domain.attributes[np.argmax(scores)].name)
+        self.assertEqual(len(scores), len(data.domain.attributes))

--- a/Orange/tests/test_random_forest.py
+++ b/Orange/tests/test_random_forest.py
@@ -1,5 +1,5 @@
 import unittest
-
+import numpy as np
 from Orange.data import Table
 from Orange.evaluation import CrossValidation, CA, RMSE
 from Orange.classification import RandomForestLearner
@@ -66,3 +66,20 @@ class RandomForestTest(unittest.TestCase):
         pred = model(table.X)
         self.assertEqual(len(table), len(pred))
         self.assertTrue(all(pred) > 0)
+
+    def test_scorer(self):
+        data = Table('test4.tab')
+        learner = RandomForestLearner()
+        scores = learner.score_data(data)
+        self.assertEqual(len(scores), len(data.domain.attributes))
+        self.assertNotEqual(sum(scores), 0)
+
+    def test_scorer_feature(self):
+        np.random.seed(42)
+        data = Table('test4.tab')
+        learner = RandomForestLearner()
+        scores = learner.score_data(data)
+        for i, attr in enumerate(data.domain.attributes):
+            np.random.seed(42)
+            score = learner.score_data(data, attr)
+            self.assertEqual(score, scores[i])

--- a/Orange/tests/test_random_forest.py
+++ b/Orange/tests/test_random_forest.py
@@ -67,12 +67,23 @@ class RandomForestTest(unittest.TestCase):
         self.assertEqual(len(table), len(pred))
         self.assertTrue(all(pred) > 0)
 
-    def test_scorer(self):
-        data = Table('test4.tab')
+    def test_classification_scorer(self):
+        data = Table('iris')
         learner = RandomForestLearner()
         scores = learner.score_data(data)
         self.assertEqual(len(scores), len(data.domain.attributes))
         self.assertNotEqual(sum(scores), 0)
+        self.assertEqual(['petal length', 'petal width'],
+                         sorted([data.domain.attributes[i].name
+                                 for i in np.argsort(scores)[-2:]]))
+
+    def test_regression_scorer(self):
+        data = Table('housing')
+        learner = RandomForestRegressionLearner()
+        scores = learner.score_data(data)
+        self.assertEqual(['LSTAT', 'RM'],
+                         sorted([data.domain.attributes[i].name
+                                 for i in np.argsort(scores)[-2:]]))
 
     def test_scorer_feature(self):
         np.random.seed(42)

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -19,7 +19,7 @@ class OWRandomForest(widget.OWWidget):
 
     inputs = [("Data", Table, "set_data"),
               ("Preprocessor", Preprocess, "set_preprocessor")]
-    outputs = [("Random Forest", RandomForestLearner),
+    outputs = [("Learner", RandomForestLearner),
                ("Model", RandomForestClassifier)]
 
     want_main_area = False
@@ -164,7 +164,7 @@ class OWRandomForest(widget.OWWidget):
                 model = learner(self.data)
                 model.name = self.learner_name
 
-        self.send("Random Forest", learner)
+        self.send("Learner", learner)
         self.send("Model", model)
 
     def settingsChanged(self):

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -19,7 +19,7 @@ class OWRandomForest(widget.OWWidget):
 
     inputs = [("Data", Table, "set_data"),
               ("Preprocessor", Preprocess, "set_preprocessor")]
-    outputs = [("Learner", RandomForestLearner),
+    outputs = [("Random Forest", RandomForestLearner),
                ("Model", RandomForestClassifier)]
 
     want_main_area = False
@@ -164,7 +164,7 @@ class OWRandomForest(widget.OWWidget):
                 model = learner(self.data)
                 model.name = self.learner_name
 
-        self.send("Learner", learner)
+        self.send("Random Forest", learner)
         self.send("Model", model)
 
     def settingsChanged(self):

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -21,8 +21,8 @@ class OWLinearRegression(widget.OWWidget):
 
     inputs = [("Data", Table, "set_data"),
               ("Preprocessor", Preprocess, "set_preprocessor")]
-    outputs = [("Learner", RidgeRegressionLearner),
-               ("Predictor", LinearModel)]
+    outputs = [("Linear Regression", LinearRegressionLearner),
+               ("Model", LinearModel)]
 
     #: Types
     OLS, Ridge, Lasso = 0, 1, 2
@@ -137,8 +137,8 @@ class OWLinearRegression(widget.OWWidget):
                 predictor = learner(self.data)
                 predictor.name = self.learner_name
 
-        self.send("Learner", learner)
-        self.send("Predictor", predictor)
+        self.send("Linear Regression", learner)
+        self.send("Model", predictor)
 
 
 


### PR DESCRIPTION
OWRnk can now get signals from OWLinearRegression and OWRandomForest.
Therefore Liner regression learner and Random forest learner extend Scorer, which is additional input to OWRank.

When attribute is continuized, an average of related scores in given.