### PR TITLE
gui: Render text of selected link as other highlighted text

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -3054,7 +3054,11 @@ class LinkStyledItemDelegate(QtGui.QStyledItemDelegate):
             if not isinstance(font, QtGui.QFont):
                 font = option.font
             painter.setFont(font)
-            painter.setPen(QtGui.QPen(Qt.blue))
+            if option.state & QtGui.QStyle.State_Selected:
+                color = option.palette.highlightedText().color()
+            else:
+                color = option.palette.link().color()
+            painter.setPen(QtGui.QPen(color))
             painter.drawText(textRect, option.displayAlignment, elideText)
             painter.restore()
         else:


### PR DESCRIPTION
Fixes a todo related to GEO Browser (ID 145) where it was very hard to read the ID (blue on blue) in the line of a selected data set.