### PR TITLE
io: Fall back to UTF-8 if everything else fails

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -509,10 +509,10 @@ class CSVFormat(FileFormat):
     def read_file(cls, filename, wrapper=None):
         wrapper = wrapper or _IDENTITY
         import csv
-        for encoding in (lambda: 'utf-8',
-                         lambda: detect_encoding(filename)):
-            encoding = encoding()
-            with cls.open(filename, mode='rt', newline='', encoding=encoding) as file:
+        for encoding in (lambda: 'us-ascii',                 # fast
+                         lambda: detect_encoding(filename),  # precise
+                         lambda: 'utf-8'):                   # fallback
+            with cls.open(filename, mode='rt', newline='', encoding=encoding()) as file:
                 # Sniff the CSV dialect (delimiter, quotes, ...)
                 try:
                     dialect = csv.Sniffer().sniff(file.read(1024), cls.DELIMITERS)


### PR DESCRIPTION
This is (probably) what 0aeda0934ab19f290580e35b576cef9ca8b82d53 should be.