### PR TITLE
Output coefficients from Linear regression widget

### DIFF
--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -19,7 +19,7 @@ class _FeatureScorerMixin(LearnerScorer):
     class_type = ContinuousVariable
 
     def score(self, model):
-        return np.abs(model.skl_model.coef_)
+        return np.abs(model.coefficients)
 
 
 class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):
@@ -121,16 +121,13 @@ class PolynomialLearner(Learner):
 
 
 class LinearModel(SklModel):
-    def __init__(self, model):
-        self.model = model
-
     @property
     def intercept(self):
-        return self.model.intercept_
+        return self.skl_model.intercept_
 
     @property
     def coefficients(self):
-        return self.model.coef_
+        return self.skl_model.coef_
 
     def predict(self, X):
         vals = self.skl_model.predict(X)

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -30,12 +30,12 @@ class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):
         super().__init__(preprocessors=preprocessors)
 
     def fit(self, X, Y, W):
-        sk = skl_linear_model.LinearRegression()
+        sk = self.__wraps__()
         sk.fit(X, Y)
         return LinearModel(sk)
 
 
-class RidgeRegressionLearner(SklLearner, _FeatureScorerMixin):
+class RidgeRegressionLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.Ridge
     name = 'ridge'
 
@@ -46,7 +46,7 @@ class RidgeRegressionLearner(SklLearner, _FeatureScorerMixin):
         self.params = vars()
 
 
-class LassoRegressionLearner(SklLearner, _FeatureScorerMixin):
+class LassoRegressionLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.Lasso
     name = 'lasso'
 
@@ -58,7 +58,7 @@ class LassoRegressionLearner(SklLearner, _FeatureScorerMixin):
         self.params = vars()
 
 
-class ElasticNetLearner(SklLearner):
+class ElasticNetLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.ElasticNet
     name = 'elastic'
 
@@ -70,7 +70,7 @@ class ElasticNetLearner(SklLearner):
         self.params = vars()
 
 
-class ElasticNetCVLearner(SklLearner):
+class ElasticNetCVLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.ElasticNetCV
     name = 'elasticCV'
 
@@ -82,7 +82,7 @@ class ElasticNetCVLearner(SklLearner):
         self.params = vars()
 
 
-class SGDRegressionLearner(SklLearner):
+class SGDRegressionLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.SGDRegressor
     name = 'sgd'
 
@@ -121,6 +121,17 @@ class PolynomialLearner(Learner):
 
 
 class LinearModel(SklModel):
+    def __init__(self, model):
+        self.model = model
+
+    @property
+    def intercept(self):
+        return self.model.intercept_
+
+    @property
+    def coefficients(self):
+        return self.model.coef_
+
     def predict(self, X):
         vals = self.skl_model.predict(X)
         if len(vals.shape) == 1:

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -83,3 +83,10 @@ class LinearRegressionTest(unittest.TestCase):
         for i, attr in enumerate(data.domain.attributes):
             score = learner.score_data(data, attr)
             self.assertEqual(score, scores[i])
+
+    def test_coefficients(self):
+        data = Table([[11], [12], [13]], [0, 1, 2])
+        model = LinearRegressionLearner()(data)
+        self.assertAlmostEqual(float(model.intercept), -11)
+        self.assertEqual(len(model.coefficients), 1)
+        self.assertAlmostEqual(float(model.coefficients[0]), 1)

--- a/Orange/tests/test_regression.py
+++ b/Orange/tests/test_regression.py
@@ -6,7 +6,7 @@ import traceback
 import Orange
 from Orange.data import Table
 from Orange.regression import Learner
-
+from Orange.regression import LinearRegressionLearner
 
 class RegressionLearnersTest(unittest.TestCase):
     def all_learners(self):
@@ -33,3 +33,16 @@ class RegressionLearnersTest(unittest.TestCase):
             except TypeError as err:
                 traceback.print_exc()
                 continue
+
+    def test_coefficients(self):
+        data = Table([[11], [12], [13]], [0, 1, 2])
+        model = LinearRegressionLearner()(data)
+        self.assertAlmostEqual(float(model.intercept), -11)
+        self.assertEqual(len(model.coefficients), 1)
+        self.assertAlmostEqual(float(model.coefficients[0]), 1)
+
+        for learner in self.all_learners():
+            if isinstance(learner, LinearRegressionLearner):
+                data = Table([[1, 2, 3], [1, 2, 3]], [0, 1.1])
+                model = learner()(data)
+                self.assertEqual(len(model.coefficients), 3)

--- a/Orange/tests/test_regression.py
+++ b/Orange/tests/test_regression.py
@@ -6,7 +6,7 @@ import traceback
 import Orange
 from Orange.data import Table
 from Orange.regression import Learner
-from Orange.regression import LinearRegressionLearner
+
 
 class RegressionLearnersTest(unittest.TestCase):
     def all_learners(self):
@@ -33,16 +33,3 @@ class RegressionLearnersTest(unittest.TestCase):
             except TypeError as err:
                 traceback.print_exc()
                 continue
-
-    def test_coefficients(self):
-        data = Table([[11], [12], [13]], [0, 1, 2])
-        model = LinearRegressionLearner()(data)
-        self.assertAlmostEqual(float(model.intercept), -11)
-        self.assertEqual(len(model.coefficients), 1)
-        self.assertAlmostEqual(float(model.coefficients[0]), 1)
-
-        for learner in self.all_learners():
-            if isinstance(learner, LinearRegressionLearner):
-                data = Table([[1, 2, 3], [1, 2, 3]], [0, 1.1])
-                model = learner()(data)
-                self.assertEqual(len(model.coefficients), 3)


### PR DESCRIPTION
I added properties `intercept` and `coefficients` to `LinearModel`.

All linear regression fitters are now derived from `LinearRegressionModel`; the models are thus wrapped into `LinearModel` (they were not before).