### PR TITLE
remove.py: purge domain now handles meta attributes

### DIFF
--- a/Orange/tests/test9.tab
+++ b/Orange/tests/test9.tab
@@ -1,0 +1,1 @@
+a	b	c	d	e	f	gd	d	d	d	string	d	string		meta	meta	meta	meta	meta1	1	1	1	1	1	11	2	2	1	2	1	11	3	3	1	3	1	huh1	4	4	2	4	hey	hoy2	5	5	2	5	2	22	6	6	2	6	2	22	7	7	3	7	3	oh yeah2	8	8	3	8	3	3

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -80,7 +80,7 @@ class TestRemover(unittest.TestCase):
         np.testing.assert_equal(new_data.X, data.X)
         np.testing.assert_equal(new_data.Y, data.Y)
         self.assertEqual([a.name for a in new_data.domain.attributes],
-                         ["c1", "c0", "d1", "R_d0"])
+                         ["c1", "c0", "d1", "d0"])
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
@@ -106,7 +106,7 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([a.name for a in new_data.domain.attributes],
                          ["c1", "c0", "d1", "d0"])
         self.assertEqual([c.name for c in new_data.domain.class_vars],
-                         ["R_cl1", "cl0", "cl3", "cl4"])
+                         ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
                           if a.is_discrete], [['1'], ['4', '6']])
         self.assertEqual([c.values for c in new_data.domain.class_vars
@@ -115,3 +115,14 @@ class TestRemover(unittest.TestCase):
                              {'removed': 0, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
                              {'removed': 0, 'reduced': 1, 'sorted': 0})
+
+    def test_remove_unused_values_metas(self):
+        data = Table("test9.tab")
+        subset = data[:4]
+        res = Remove(subset,
+                     attr_flags=Remove.RemoveUnusedValues,
+                     meta_flags=Remove.RemoveUnusedValues)
+
+        self.assertEqual(res.domain["b"].values, res.domain["c"].values)
+        self.assertEqual(res.domain["d"].values, ["1", "2"])
+        self.assertEqual(res.domain["f"].values, ['1', 'hey'])

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -359,7 +359,8 @@ class OWSelectRows(widget.OWWidget):
                                   Remove.RemoveUnusedValues * purge_attrs])
                 class_flags = sum([Remove.RemoveConstant * purge_classes,
                                   Remove.RemoveUnusedValues * purge_classes])
-                remover = Remove(attr_flags, class_flags)
+                # same settings used for attributes and meta features
+                remover = Remove(attr_flags, class_flags, attr_flags)
 
                 matching_output = remover(matching_output)
                 non_matching_output = remover(non_matching_output)


### PR DESCRIPTION
Before, remove.py handled only attributes and classes. The only strange piece of code is line 273, `column = np.array(column, dtype=np.float64)`, which I had to add since for meta attributes the column values were of type float, and this caused problems for `np.isnan()`.