### PR TITLE
owpca: Improvements (normalization option, sql inputs)

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -6,6 +6,7 @@ import pyqtgraph as pg
 
 from Orange.data import Table, Domain, StringVariable
 from Orange.data.sql.table import SqlTable
+from Orange.preprocess import Normalize
 import Orange.projection
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.io import FileFormat
@@ -26,12 +27,14 @@ class OWPCA(widget.OWWidget):
     inputs = [("Data", Table, "set_data")]
     outputs = [("Transformed data", Table),
                ("Components", Table)]
+
     ncomponents = settings.Setting(2)
     variance_covered = settings.Setting(100)
     batch_size = settings.Setting(100)
     address = settings.Setting('')
     auto_update = settings.Setting(True)
     auto_commit = settings.Setting(True)
+    normalize = settings.Setting(True)
 
     want_graph = True
 
@@ -94,6 +97,11 @@ class OWPCA(widget.OWWidget):
         self.__timer.timeout.connect(self.get_model)
 
         self.sampling_box.setVisible(remotely)
+
+        self.options_box = gui.widgetBox(self.controlArea, "Options")
+        gui.checkBox(self.options_box, self, "normalize", "Normalize data",
+                     callback=self.fit)
+
         self.controlArea.layout().addStretch()
 
         gui.auto_commit(self.controlArea, self, "auto_commit", "Send data",
@@ -136,33 +144,38 @@ class OWPCA(widget.OWWidget):
             self.start_button.setText("Abort remote computation")
 
     def set_data(self, data):
-        self.clear()
         self.data = data
+        self.fit()
 
+    def fit(self):
+        self.clear()
         self.start_button.setEnabled(False)
-        if data is not None:
-            self._transformed = None
-            if remotely and isinstance(data, SqlTable):
-                self.sampling_box.setVisible(True)
-                self.start_button.setText("Start remote computation")
-                self.start_button.setEnabled(True)
-            else:
-                self.sampling_box.setVisible(False)
-                pca = Orange.projection.PCA()
-                pca = pca(self.data)
-                variance_ratio = pca.explained_variance_ratio_
-                cumulative = numpy.cumsum(variance_ratio)
-                self.components_spin.setRange(0, len(cumulative))
+        if self.data is None:
+            return
+        data = self.data
+        if self.normalize:
+            data = Normalize(data)
+        self._transformed = None
+        if remotely and isinstance(data, SqlTable):
+            self.sampling_box.setVisible(True)
+            self.start_button.setText("Start remote computation")
+            self.start_button.setEnabled(True)
+        else:
+            self.sampling_box.setVisible(False)
+            pca = Orange.projection.PCA()
+            pca = pca(data)
+            variance_ratio = pca.explained_variance_ratio_
+            cumulative = numpy.cumsum(variance_ratio)
+            self.components_spin.setRange(0, len(cumulative))
 
-                self._pca = pca
-                self._variance_ratio = variance_ratio
-                self._cumulative = cumulative
-                self._setup_plot()
+            self._pca = pca
+            self._variance_ratio = variance_ratio
+            self._cumulative = cumulative
+            self._setup_plot()
 
-                self.unconditional_commit()
+            self.unconditional_commit()
 
     def clear(self):
-        self.data = None
         self._pca = None
         self._transformed = None
         self._variance_ratio = None

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -162,14 +162,16 @@ class OWPCA(widget.OWWidget):
         if self.data is None:
             return
         data = self.data
-        if self.normalize:
-            data = Normalize(data)
         self._transformed = None
         if isinstance(data, SqlTable): # data was big and remote available
             self.sampling_box.setVisible(True)
             self.start_button.setText("Start remote computation")
             self.start_button.setEnabled(True)
         else:
+            # TODO move the following normalization outside
+            # so it is applied for SqlTables as well (when it works on them)
+            if self.normalize:
+                data = Normalize(data)
             self.sampling_box.setVisible(False)
             pca = Orange.projection.PCA()
             pca = pca(data)


### PR DESCRIPTION
1) Adds option to normalize data
2) Downloads small SqlTables (incremental learning not sensible), and samples when remote execution not supported

Last commit disables normalization for SqlTables (currently broken) and should be reverted when it is implemented correctly.