### PR TITLE
gui.lineEdit: commit button should accept default action

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -439,7 +439,9 @@ def _enterButton(parent, control, placeholder=True):
     if not _enter_icon:
         _enter_icon = QtGui.QIcon(
             os.path.dirname(__file__) + "/icons/Dlg_enter.png")
-    button = QtGui.QToolButton(parent)
+    button = QtGui.QPushButton(parent)
+    button.setAutoDefault(True)
+    button.setDefault(True)
     height = control.sizeHint().height()
     button.setFixedSize(height, height)
     button.setIcon(_enter_icon)


### PR DESCRIPTION
If lineEdit and some other default push button are on the same page, pressing Enter after typing into lineEdit activated the default push button as well.