### PR TITLE
Simplify 'Feature Constuctor' widget GUI

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -124,8 +124,11 @@ class FeatureEditor(QtGui.QFrame):
         self.attrs_model = itemmodels.VariableListModel(
             ["Select feature"], parent=self)
         self.attributescb = QtGui.QComboBox(
-            minimumContentsLength=12,
-            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+            minimumContentsLength=16,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon,
+            sizePolicy=QtGui.QSizePolicy(QtGui.QSizePolicy.Minimum,
+                                         QtGui.QSizePolicy.Minimum)
+        )
         self.attributescb.setModel(self.attrs_model)
 
         sorted_funcs = sorted(self.FUNCTIONS)
@@ -137,7 +140,11 @@ class FeatureEditor(QtGui.QFrame):
             [''],
             [self.FUNCTIONS[func].__doc__ for func in sorted_funcs])
 
-        self.functionscb = QtGui.QComboBox()
+        self.functionscb = QtGui.QComboBox(
+            minimumContentsLength=16,
+            sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon,
+            sizePolicy=QtGui.QSizePolicy(QtGui.QSizePolicy.Minimum,
+                                         QtGui.QSizePolicy.Minimum))
         self.functionscb.setModel(self.funcs_model)
 
         hbox = QtGui.QHBoxLayout()
@@ -340,11 +347,12 @@ class OWFeatureConstructor(widget.OWWidget):
 
         self.editorstack.setEnabled(False)
 
-        buttonlayout = QtGui.QVBoxLayout()
+        buttonlayout = QtGui.QVBoxLayout(spacing=10)
         buttonlayout.setContentsMargins(0, 0, 0, 0)
 
         self.addbutton = QtGui.QPushButton(
             "New", toolTip="Create a new variable",
+            minimumWidth=120,
             shortcut=QtGui.QKeySequence.New
         )
 
@@ -388,6 +396,7 @@ class OWFeatureConstructor(widget.OWWidget):
 
         self.removebutton = QtGui.QPushButton(
             "Remove", toolTip="Remove selected variable",
+            minimumWidth=120,
             shortcut=QtGui.QKeySequence.Delete
         )
         self.removebutton.clicked.connect(self.removeSelectedFeature)

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -323,6 +323,10 @@ class OWFeatureConstructor(widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Variable Definitions")
 
+        toplayout = QtGui.QHBoxLayout()
+        toplayout.setContentsMargins(0, 0, 0, 0)
+        box.layout().addLayout(toplayout)
+
         self.editorstack = QtGui.QStackedWidget(
             sizePolicy=QSizePolicy(QSizePolicy.MinimumExpanding,
                                    QSizePolicy.MinimumExpanding)
@@ -336,13 +340,11 @@ class OWFeatureConstructor(widget.OWWidget):
 
         self.editorstack.setEnabled(False)
 
-        box.layout().addWidget(self.editorstack)
-
-        buttonlayout = QtGui.QHBoxLayout()
-        buttonlayout.setContentsMargins(4, 4, 4, 4)
+        buttonlayout = QtGui.QVBoxLayout()
+        buttonlayout.setContentsMargins(0, 0, 0, 0)
 
         self.addbutton = QtGui.QPushButton(
-            "Add", toolTip="Create a new feature",
+            "New", toolTip="Create a new variable",
             shortcut=QtGui.QKeySequence.New
         )
 
@@ -393,7 +395,9 @@ class OWFeatureConstructor(widget.OWWidget):
         buttonlayout.addWidget(self.addbutton)
         buttonlayout.addWidget(self.removebutton)
         buttonlayout.addStretch(10)
-        box.layout().addLayout(buttonlayout)
+
+        toplayout.addLayout(buttonlayout, 0)
+        toplayout.addWidget(self.editorstack, 10)
 
         # Layout for the list view
         layout = QtGui.QVBoxLayout(spacing=1, margin=0)

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -563,30 +563,6 @@ class OWFeatureConstructor(widget.OWWidget):
 import ast
 
 
-class RewriteNames(ast.NodeTransformer):
-    def __init__(self, names):
-        self.names = names
-        self.rewrites = []
-
-    def visit_Str(self, node):
-        if node.s in self.names:
-            new = ast.Subscript(
-                value=ast.Name(id="value", ctx=ast.Load()),
-                slice=ast.Index(value=ast.Str(s=node.s)),
-                ctx=ast.Load()
-            )
-            self.rewrites.append((node.s))
-            return ast.copy_location(new)
-        else:
-            return node
-
-
-def bind_names(exp, domain):
-    names = [f.name for f in domain.features]
-    transf = RewriteNames(names)
-    return transf.visit(exp)
-
-
 def freevars(exp, env):
     etype = type(exp)
     if etype in [ast.Expr, ast.Expression]:


### PR DESCRIPTION
* Remove GUI controls for setting the number of decimals, base value, ...
* Replace the QListView controls for editing discrete variable's values
  with a QLineEdit (values are comma separated, escaped with '\' if necessary.
* Move the QListView with defined variables below the 'Editor'.
