### PR TITLE
Learner: Handle multiclass datasets

### DIFF
--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -10,7 +10,7 @@ class LearnerClassification(Learner):
     learner_adequacy_err_msg = "Discrete class variable expected."
 
     def check_learner_adequacy(self, domain):
-        return domain.has_discrete_class or domain.class_var is None
+        return domain.has_discrete_class
 
 
 class ModelClassification(Model):

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -286,7 +286,7 @@ class Domain:
 
     @property
     def has_continuous_class(self):
-        return self.class_var and self.class_var.is_continuous
+        return bool(self.class_var and self.class_var.is_continuous)
 
     @property
     def has_discrete_class(self):

--- a/Orange/regression/base_regression.py
+++ b/Orange/regression/base_regression.py
@@ -8,7 +8,7 @@ class LearnerRegression(Learner):
     learner_adequacy_err_msg = "Continuous class variable expected."
 
     def check_learner_adequacy(self, domain):
-        return domain.has_continuous_class or domain.class_var is None
+        return domain.has_continuous_class
 
 
 class ModelRegression(Model):

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -15,6 +15,7 @@ from Orange.data import ContinuousVariable, DiscreteVariable, Domain, Table, Var
 from Orange.data.io import BasketFormat
 from Orange.evaluation import CrossValidation
 from Orange.tests.dummy_learners import DummyLearner, DummyMulticlassLearner
+from Orange.data.table import dataset_dirs
 
 
 class MultiClassTest(unittest.TestCase):
@@ -219,6 +220,13 @@ class ClassfierListInputTest(unittest.TestCase):
 
 
 class LearnerAccessibility(unittest.TestCase):
+    def setUp(self):
+        Variable._clear_all_caches()
+        dataset_dirs.append("Orange/tests")
+
+    def tearDown(self):
+        dataset_dirs.pop()
+
     def all_learners(self):
         classification_modules = pkgutil.walk_packages(
             path=Orange.classification.__path__,
@@ -266,6 +274,16 @@ class LearnerAccessibility(unittest.TestCase):
             try:
                 learner = learner()
                 table = Table("housing")
+                self.assertRaises(ValueError, learner, table)
+            except TypeError as err:
+                traceback.print_exc()
+                continue
+
+    def test_adequacy_all_learners_multiclass(self):
+        for learner in self.all_learners():
+            try:
+                learner = learner()
+                table = Table("test8.tab")
                 self.assertRaises(ValueError, learner, table)
             except TypeError as err:
                 traceback.print_exc()

--- a/Orange/tests/test_regression.py
+++ b/Orange/tests/test_regression.py
@@ -4,11 +4,19 @@ import pkgutil
 import traceback
 
 import Orange
-from Orange.data import Table
+from Orange.data import Table, Variable
 from Orange.regression import Learner
+from Orange.data.table import dataset_dirs
 
 
 class RegressionLearnersTest(unittest.TestCase):
+    def setUp(self):
+        Variable._clear_all_caches()
+        dataset_dirs.append("Orange/tests")
+
+    def tearDown(self):
+        dataset_dirs.pop()
+
     def all_learners(self):
         regression_modules = pkgutil.walk_packages(
             path=Orange.regression.__path__,
@@ -29,6 +37,16 @@ class RegressionLearnersTest(unittest.TestCase):
             try:
                 learner = learner()
                 table = Table("iris")
+                self.assertRaises(ValueError, learner, table)
+            except TypeError as err:
+                traceback.print_exc()
+                continue
+
+    def test_adequacy_all_learners_multiclass(self):
+        for learner in self.all_learners():
+            try:
+                learner = learner()
+                table = Table("test8.tab")
                 self.assertRaises(ValueError, learner, table)
             except TypeError as err:
                 traceback.print_exc()


### PR DESCRIPTION
Learner widgets used to crash when given multiclass datasets.
Widgets should show error message instead.