### PR TITLE
linear: fixed parameter handling to linear regression learner

### DIFF
--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -30,9 +30,8 @@ class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):
         super().__init__(preprocessors=preprocessors)
 
     def fit(self, X, Y, W):
-        sk = self.__wraps__()
-        sk.fit(X, Y)
-        return LinearModel(sk)
+        model = super().fit(X, Y, W)
+        return LinearModel(model.skl_model)
 
 
 class RidgeRegressionLearner(LinearRegressionLearner):

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -8,6 +8,7 @@ from Orange.regression import (LinearRegressionLearner,
                                ElasticNetCVLearner,
                                MeanLearner)
 from Orange.evaluation import CrossValidation, RMSE
+from sklearn import linear_model
 
 
 class LinearRegressionTest(unittest.TestCase):
@@ -90,3 +91,17 @@ class LinearRegressionTest(unittest.TestCase):
         self.assertAlmostEqual(float(model.intercept), -11)
         self.assertEqual(len(model.coefficients), 1)
         self.assertAlmostEqual(float(model.coefficients[0]), 1)
+
+    def test_comparison_with_sklearn(self):
+        alphas = [0.001, 0.1, 1, 10, 100]
+        data = Table("housing")
+        learners = [(LassoRegressionLearner, linear_model.Lasso),
+                    (RidgeRegressionLearner, linear_model.Ridge)]
+        for o_learner, s_learner in learners:
+            for a in alphas:
+                lr = o_learner(alpha=a)
+                o_model = lr(data)
+                s_model = s_learner(alpha=a, fit_intercept=True)
+                s_model.fit(data.X, data.Y)
+                delta = np.sum(s_model.coef_ - o_model.coefficients)
+                self.assertAlmostEqual(delta, 0.0)


### PR DESCRIPTION
Any parameters passed to LassoRegressionLearner and RidgeRegressionLearner were ignored with introduction of LinearModel. Now fixed. Noticed it while running Linear Regression widget, where change of alpha did not change Coefficients nor the Model.