### PR TITLE
Fixed Variable equality...

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -274,7 +274,7 @@ class Variable(metaclass=VariableMeta):
 
     def __eq__(self, other):
         """Two variables are equivalent if the originate from the same master"""
-        return self.master is other.master
+        return hasattr(other, "master") and self.master is other.master
 
     def __hash__(self):
         return super().__hash__()

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -67,6 +67,13 @@ class BaseVariableTest(unittest.TestCase):
         self.assertFalse(a.is_primitive())
 
 
+    def test_strange_eq(self):
+        a = ContinuousVariable()
+        b = ContinuousVariable()
+        self.assertTrue(a == a)
+        self.assertFalse(a == b)
+        self.assertFalse(a == "somestring")
+
 def variabletest(varcls):
     def decorate(cls):
         return type(cls.__name__, (cls, unittest.TestCase), {'varcls': varcls})


### PR DESCRIPTION
... which crashed if we compared a Variable with some different type. This crashed the Distributions widget.