### PR TITLE
canvas/preview: Do not render link names in preview thumbnails

### DIFF
--- a/Orange/canvas/preview/scanner.py
+++ b/Orange/canvas/preview/scanner.py
@@ -81,6 +81,7 @@ def scheme_svg_thumbnail(scheme_file):
     scheme_load(scheme, scheme_file, error_handler=errors.append)
 
     tmp_scene = scene.CanvasScene()
+    tmp_scene.set_channel_names_visible(False)
     tmp_scene.set_registry(global_registry())
     tmp_scene.set_scheme(scheme)
 


### PR DESCRIPTION
They clutter the view.