### PR TITLE
Unite preprocessor handling in Learner-outputting widgets

### DIFF
--- a/Orange/widgets/classify/owknn.py
+++ b/Orange/widgets/classify/owknn.py
@@ -1,17 +1,16 @@
 from Orange.data import Table
 from Orange.classification import KNNLearner, SklModel
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWKNNLearner(widget.OWWidget):
+class OWKNNLearner(OWProvidesLearner, widget.OWWidget):
     name = "Nearest Neighbors"
     description = "k-nearest neighbors classification algorithm."
     icon = "icons/KNN.svg"
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", KNNLearner), ("Classifier", SklModel)]
 
     want_main_area = False
@@ -50,15 +49,10 @@ class OWKNNLearner(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = KNNLearner
 
     def apply(self):
-        learner = KNNLearner(
+        learner = self.LEARNER(
             n_neighbors=self.n_neighbors,
             metric=self.metrics[self.metric_index],
             preprocessors=self.preprocessors

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -5,19 +5,18 @@ from PyQt4.QtCore import Qt
 
 from Orange.data import Table
 from Orange.classification import logistic_regression as lr
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWLogisticRegression(widget.OWWidget):
+class OWLogisticRegression(OWProvidesLearner, widget.OWWidget):
     name = "Logistic Regression"
     description = "Logistic regression classification algorithm with " \
                   "LASSO (L1) or ridge (L2) regularization."
     icon = "icons/LogisticRegression.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", lr.LogisticRegressionLearner),
                ("Classifier", lr.LogisticRegressionClassifier)]
 
@@ -85,16 +84,11 @@ class OWLogisticRegression(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = lr.LogisticRegressionLearner
 
     def apply(self):
         penalty = ["l1", "l2"][self.penalty_type]
-        learner = lr.LogisticRegressionLearner(
+        learner = self.LEARNER(
             penalty=penalty,
             dual=self.dual,
             tol=self.tol,

--- a/Orange/widgets/classify/owmajority.py
+++ b/Orange/widgets/classify/owmajority.py
@@ -1,19 +1,18 @@
 from Orange.data import Table
 from Orange.classification.majority import MajorityLearner, ConstantModel
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 
 
-class OWMajority(widget.OWWidget):
+class OWMajority(OWProvidesLearner, widget.OWWidget):
     name = "Majority"
     description = "Classification to the most frequent class " \
                   "from the training set."
     priority = 20
     icon = "icons/Majority.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", MajorityLearner),
                ("Classifier", ConstantModel)]
 
@@ -44,15 +43,10 @@ class OWMajority(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = MajorityLearner
 
     def apply(self):
-        learner = MajorityLearner(
+        learner = self.LEARNER(
             preprocessors=self.preprocessors
         )
         learner.name = self.learner_name

--- a/Orange/widgets/classify/ownaivebayes.py
+++ b/Orange/widgets/classify/ownaivebayes.py
@@ -5,16 +5,15 @@ Naive Bayes Learner
 
 from  Orange.data import Table
 from Orange.classification.naive_bayes import NaiveBayesLearner, NaiveBayesModel
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 
 
-class OWNaiveBayes(widget.OWWidget):
+class OWNaiveBayes(OWProvidesLearner, widget.OWWidget):
     name = "Naive Bayes"
     description = "Naive Bayesian classifier."
     icon = "icons/NaiveBayes.svg"
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", NaiveBayesLearner),
                ("Classifier", NaiveBayesModel)]
 
@@ -56,15 +55,10 @@ class OWNaiveBayes(widget.OWWidget):
         else:
             self.send("Classifier", None)
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = NaiveBayesLearner
 
     def apply(self):
-        learner = NaiveBayesLearner(
+        learner = self.LEARNER(
             preprocessors=self.preprocessors
         )
         learner.name = self.learner_name

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -5,20 +5,19 @@ from PyQt4.QtGui import QLabel, QGridLayout
 from PyQt4.QtCore import Qt
 
 from Orange.data import Table
-from Orange.preprocess.preprocess import Preprocess
 from Orange.classification.random_forest import (RandomForestLearner,
                                                  RandomForestClassifier)
 from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWRandomForest(widget.OWWidget):
+class OWRandomForest(OWProvidesLearner, widget.OWWidget):
     name = "Random Forest Classification"
     description = "Random forest classification algorithm."
     icon = "icons/RandomForest.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", RandomForestLearner),
                ("Model", RandomForestClassifier)]
 
@@ -26,6 +25,7 @@ class OWRandomForest(widget.OWWidget):
     resizing_enabled = False
 
     LEARNER = RandomForestLearner
+
     learner_name = settings.Setting("RF Classification Learner")
     n_estimators = settings.Setting(10)
     max_features = settings.Setting(5)
@@ -134,13 +134,6 @@ class OWRandomForest(widget.OWWidget):
         self.data = data
         if data is not None:
             self.apply()
-
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
 
     def apply(self):
         common_args = dict()

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -7,19 +7,18 @@ from PyQt4.QtCore import Qt
 
 from Orange.data import Table
 from Orange.classification.svm import SVMLearner, SVMClassifier, NuSVMLearner
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWSVMClassification(widget.OWWidget):
+class OWSVMClassification(OWProvidesLearner, widget.OWWidget):
     name = "SVM"
     description = "Support vector machines classifier with standard " \
                   "selection of kernels."
     icon = "icons/SVM.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", SVMLearner, widget.Default),
                ("Classifier", SVMClassifier),
                ("Support vectors", Table)]
@@ -132,12 +131,7 @@ class OWSVMClassification(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = SVMLearner  # OWProvidesLearner uses this
 
     def apply(self):
         kernel = ["linear", "poly", "rbf", "sigmoid"][self.kernel_type]

--- a/Orange/widgets/regression/owknnregression.py
+++ b/Orange/widgets/regression/owknnregression.py
@@ -4,21 +4,20 @@
 from Orange.data import Table
 from  Orange.regression.knn import KNNRegressionLearner
 from Orange.regression import SklModel
-from Orange.preprocess.preprocess import Preprocess
 
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWKNNRegression(widget.OWWidget):
+class OWKNNRegression(OWProvidesLearner, widget.OWWidget):
     name = "Nearest Neighbors"
     description = "k-nearest neighbours regression algorithm."
     icon = "icons/kNearestNeighbours.svg"
     priority = 20
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", KNNRegressionLearner),
                ("Predictor", SklModel)]
 
@@ -63,19 +62,13 @@ class OWKNNRegression(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        """Set preprocessor to apply on training data."""
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = KNNRegressionLearner
 
     def apply(self):
         """
         Construct the learner and apply it on the training data if available.
         """
-        learner = KNNRegressionLearner(
+        learner = self.LEARNER(
             n_neighbors=self.n_neighbors,
             metric=self.metrics[self.metric_index],
             preprocessors=self.preprocessors

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -7,20 +7,19 @@ from Orange.data import Table, Domain, ContinuousVariable, StringVariable
 from Orange.regression.linear import (
     LassoRegressionLearner, LinearModel, LinearRegressionLearner,
     RidgeRegressionLearner)
-from Orange.preprocess.preprocess import Preprocess
 from Orange.preprocess import RemoveNaNClasses
 from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWLinearRegression(widget.OWWidget):
+class OWLinearRegression(OWProvidesLearner, widget.OWWidget):
     name = "Linear Regression"
     description = "A linear regression algorithm with optional L1 and L2 " \
                   "regularization."
     icon = "icons/LinearRegression.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Linear Regression", LinearRegressionLearner),
                ("Model", LinearModel),
                ("Coefficients", Table)]
@@ -83,12 +82,6 @@ class OWLinearRegression(widget.OWWidget):
     def set_data(self, data):
         self.data = data
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-
     def handleNewSignals(self):
         self.commit()
 
@@ -103,6 +96,11 @@ class OWLinearRegression(widget.OWWidget):
     def _alpha_changed(self):
         self._set_alpha_label()
         self.commit()
+
+    LEARNER = LinearRegressionLearner  # OWProvidesLearner uses this
+
+    def apply(self):
+        return self.commit()
 
     def commit(self):
         alpha = self.alphas[self.alpha_index]

--- a/Orange/widgets/regression/owmean.py
+++ b/Orange/widgets/regression/owmean.py
@@ -2,16 +2,15 @@ from Orange.widgets import widget, settings, gui
 
 from Orange.data import Table
 from Orange.regression.mean import MeanLearner, MeanModel
-from Orange.preprocess.preprocess import Preprocess
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 
 
-class OWMean(widget.OWWidget):
+class OWMean(OWProvidesLearner, widget.OWWidget):
     name = "Mean Learner"
     description = "Regression to the average class value from the training set."
     icon = "icons/Mean.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", MeanLearner), ("Predictor", MeanModel)]
 
     learner_name = settings.Setting("Mean Learner")
@@ -36,15 +35,10 @@ class OWMean(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = MeanLearner
 
     def apply(self):
-        learner = MeanLearner(preprocessors=self.preprocessors)
+        learner = self.LEARNER(preprocessors=self.preprocessors)
         learner.name = self.learner_name
         predictor = None
         if self.data is not None:

--- a/Orange/widgets/regression/owsgdregression.py
+++ b/Orange/widgets/regression/owsgdregression.py
@@ -6,18 +6,17 @@ from PyQt4.QtCore import Qt
 
 from Orange.data import Table
 from Orange.regression.linear import SGDRegressionLearner, LinearModel
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWSGDRegression(widget.OWWidget):
+class OWSGDRegression(OWProvidesLearner, widget.OWWidget):
     name = "Stochastic Gradient Descent"
     description = "Stochastic gradient descent algorithm for regression."
     icon = "icons/SGDRegression.svg"
 
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", SGDRegressionLearner),
                ("Predictor", LinearModel)]
 
@@ -137,12 +136,7 @@ class OWSGDRegression(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = SGDRegressionLearner
 
     def apply(self):
         loss = ["squared_loss", "huber", "epsilon_insensitive", "squared_epsilon_insensitive"][self.loss_function]
@@ -160,7 +154,7 @@ class OWSGDRegression(widget.OWWidget):
             n_iter=self.n_iter,
         )
 
-        learner = SGDRegressionLearner(
+        learner = self.LEARNER(
             preprocessors=self.preprocessors, **common_args)
         learner.name = self.learner_name
 

--- a/Orange/widgets/regression/owsvmregression.py
+++ b/Orange/widgets/regression/owsvmregression.py
@@ -7,17 +7,16 @@ from PyQt4.QtCore import Qt
 
 from Orange.data import Table
 from Orange.regression import SVRLearner, NuSVRLearner, SklModel
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, settings, gui
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWSVMRegression(widget.OWWidget):
+class OWSVMRegression(OWProvidesLearner, widget.OWWidget):
     name = "SVM Regression"
     description = "Support vector machine regression algorithm."
     icon = "icons/SVMRegression.svg"
-    inputs = [("Data", Table, "set_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    inputs = [("Data", Table, "set_data")] + OWProvidesLearner.inputs
     outputs = [("Learner", SVRLearner, widget.Default),
                ("Predictor", SklModel),
                ("Support vectors", Table)]
@@ -151,12 +150,7 @@ class OWSVMRegression(widget.OWWidget):
         if data is not None:
             self.apply()
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-        self.apply()
+    LEARNER = SVRLearner  # OWProvidesLearner uses this
 
     def apply(self):
         kernel = ["linear", "poly", "rbf", "sigmoid"][self.kernel_type]

--- a/Orange/widgets/regression/owunivariateregression.py
+++ b/Orange/widgets/regression/owunivariateregression.py
@@ -11,20 +11,19 @@ from Orange.data import Table, Domain
 from Orange.regression.linear import (RidgeRegressionLearner, LinearModel,
                                       LinearRegressionLearner, PolynomialLearner)
 from Orange.regression import Learner
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import widget, settings, gui
 from Orange.widgets.utils import itemmodels
+from Orange.widgets.utils.owlearnerwidget import OWProvidesLearner
 from Orange.widgets.utils.sql import check_sql_input
 
 
-class OWUnivariateRegression(widget.OWWidget):
+class OWUnivariateRegression(OWProvidesLearner, widget.OWWidget):
     name = "Univariate Regression"
     description = "Univariate regression with polynomial expansion."
     icon = "icons/UnivariateRegression.svg"
 
     inputs = [("Data", Table, "set_data", widget.Default),
-              ("Preprocessor", Preprocess, "set_preprocessor"),
-              ("Learner", Learner, "set_learner")]
+              ("Learner", Learner, "set_learner")] + OWProvidesLearner.inputs
     outputs = [("Learner", Learner),
                ("Predictor", LinearModel)]
 
@@ -144,12 +143,6 @@ class OWUnivariateRegression(widget.OWWidget):
             else:
                 self.y_var_index = min(max(0, nvars-1), nvars - 1)
 
-    def set_preprocessor(self, preproc):
-        if preproc is None:
-            self.preprocessors = None
-        else:
-            self.preprocessors = (preproc,)
-
     def set_learner(self, learner):
         self.learner = learner
 
@@ -187,13 +180,15 @@ class OWUnivariateRegression(widget.OWWidget):
         self.plotview.addItem(self.plot_item)
         self.plotview.replot()
 
+    LEARNER = LinearRegressionLearner
+
     def apply(self):
         learner = self.learner
         predictor = None
 
         if self.data is not None:
             if self.learner is None:
-                learner = LinearRegressionLearner(preprocessors=self.preprocessors)
+                learner = self.LEARNER(preprocessors=self.preprocessors)
 
             attributes = self.x_var_model[self.x_var_index]
             class_var = self.y_var_model[self.y_var_index]

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -1,0 +1,26 @@
+from Orange.preprocess.preprocess import Preprocess
+
+
+class _OWAcceptsPreprocessor:
+    """
+    Accepts Preprocessor input.
+
+    Requires `LEARNER` attribute with default `LEARNER.preprocessors` be set on it.
+
+    Sets `self.preprocessors` tuple.
+
+    Calls `apply()` method after setting preprocessors.
+    """
+    inputs = [("Preprocessor", Preprocess, "set_preprocessor")]
+
+    def set_preprocessor(self, preproc):
+        """Add user-set preprocessors before the default, mandatory ones"""
+        self.preprocessors = ((preproc,) if preproc else ()) + tuple(self.LEARNER.preprocessors)
+        self.apply()
+
+
+class OWProvidesLearner(_OWAcceptsPreprocessor):
+    """
+    Base class for all classification / regression learner-providing widgets
+    that extend it.
+    """


### PR DESCRIPTION
Apply user-provided preprocessors first, but always apply learner-dependent default ones afterwards so that algos just work™.

Requires default preprocessors to be idempotent, which `SklLearner.preprocessors` are.

@lanzagar, @VesnaT, @BlazZupan might want to review this?