### PR TITLE
DendrogramWidget: Change the dendrogram widget's layout

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -48,9 +48,10 @@ def dendrogram_layout(tree, expand_leaves=False):
         cluster = node.value
         if node.is_leaf:
             if expand_leaves:
-                start, end = float(cluster.first), float(cluster.last - 1)
+                start = float(cluster.first) + 0.5
+                end = float(cluster.last - 1) + 0.5
             else:
-                start = end = leaf_idx
+                start = end = leaf_idx + 0.5
                 leaf_idx += 1
             center = (start + end) / 2.0
             cluster_geometry[node] = (start, center, end)
@@ -235,7 +236,7 @@ class DendrogramWidget(QGraphicsWidget):
         self._cluster_parent = {}
         self.__hoverHighlightEnabled = hoverHighlightEnabled
         self.__selectionMode = selectionMode
-        self.setContentsMargins(5, 5, 5, 5)
+        self.setContentsMargins(0, 0, 0, 0)
         self.set_root(root)
 
     def clear(self):
@@ -599,9 +600,9 @@ class DendrogramWidget(QGraphicsWidget):
         crect = self.contentsRect()
         leaf_count = len(list(leaves(self._root)))
         if self.orientation in [Left, Right]:
-            drect = QSizeF(self._root.value.height, leaf_count - 1)
+            drect = QSizeF(self._root.value.height, leaf_count)
         else:
-            drect = QSizeF(self._root.value.last - 1, self._root.value.height)
+            drect = QSizeF(leaf_count, self._root.value.height)
 
         transform = QTransform().scale(
             crect.width() / drect.width(),
@@ -911,11 +912,6 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.dendrogram.selectionChanged.connect(self._invalidate_output)
         self.dendrogram.selectionEdited.connect(self._selection_edited)
 
-        fm = self.fontMetrics()
-        self.dendrogram.setContentsMargins(
-            5, fm.lineSpacing() / 2,
-            5, fm.lineSpacing() / 2
-        )
         self.labels = GraphicsSimpleTextList()
         self.labels.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         self.labels.setAlignment(Qt.AlignLeft)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1220,8 +1220,8 @@ class OWHeatMap(widget.OWWidget):
 
     def __update_margins(self):
         """
-        Update dendrogram and text list widgets margins to include the
-        space for average stripe.
+        Update horizontal dendrogram and text list widgets margins to
+        include the space for average stripe.
         """
         def offset(hm):
             if hm.show_averages:
@@ -1230,36 +1230,22 @@ class OWHeatMap(widget.OWWidget):
                 return 0
 
         hm_row = self.heatmap_widget_grid[0]
-        hm_col = next(zip(*self.heatmap_widget_grid))
         dendrogram_col = self.col_dendrograms
-        dendrogram_row = self.row_dendrograms
 
         col_annot = zip(self.col_annotation_widgets_top,
                         self.col_annotation_widgets_bottom)
-        row_annot = self.row_annotation_widgets
 
         for hm, annot, dendrogram in zip(hm_row, col_annot, dendrogram_col):
             left_offset = offset(hm)
             if dendrogram is not None:
-                width = hm.size().width()
-                col_count = hm.heatmap_data().shape[1]
-                half_col = (width - left_offset) / col_count / 2
-                _, top, _, bottom = dendrogram.getContentsMargins()
+                _, top, right, bottom = dendrogram.getContentsMargins()
                 dendrogram.setContentsMargins(
-                    left_offset + half_col, top, half_col, bottom)
+                    left_offset, top, right, bottom)
 
             _, top, right, bottom = annot[0].getContentsMargins()
             annot[0].setContentsMargins(left_offset, top, right, bottom)
             _, top, right, bottom = annot[1].getContentsMargins()
             annot[1].setContentsMargins(left_offset, top, right, bottom)
-
-        for hm, annot, dendrogram in zip(hm_col, row_annot, dendrogram_row):
-            if dendrogram is not None:
-                height = hm.size().height()
-                row_count = hm.heatmap_data().shape[0]
-                half_row = height / row_count / 2
-                left, _, right, _ = dendrogram.getContentsMargins()
-                dendrogram.setContentsMargins(left, half_row, right, half_row)
 
     def __update_clustering_enable_state(self, data):
         def enable(item, state):


### PR DESCRIPTION
Change where tree's leaf nodes are anchored. Before the left/rightmost
leafs would coincide exactly with the widgets's contentsRect().left/right
(or top/bottom). Now the anchors are placed more naturally in the center
of N subdivisions of the contents width/height.

This simplifies the client code, which before had to set/match the contents
rect in order to ensure proper visual alignment with side by side
dendrogram, labels, images, ...