### PR TITLE
Scoring: Add average kwarg to Precision and Recall

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -76,14 +76,16 @@ class Precision(Score):
     __wraps__ = skl_metrics.precision_score
 
     def compute_score(self, results):
-        return self.from_predicted(results, skl_metrics.precision_score)
+        return self.from_predicted(results, skl_metrics.precision_score,
+                                   average="weighted")
 
 
 class Recall(Score):
     __wraps__ = skl_metrics.recall_score
 
     def compute_score(self, results):
-        return self.from_predicted(results, skl_metrics.recall_score)
+        return self.from_predicted(results, skl_metrics.recall_score,
+                                   average="weighted")
 
 
 class F1(Score):

--- a/Orange/tests/test_evaluation_scoring.py
+++ b/Orange/tests/test_evaluation_scoring.py
@@ -4,8 +4,27 @@ from Orange.data import DiscreteVariable, Domain
 import numpy as np
 
 import Orange
-from Orange.evaluation import AUC, CA, Results, F1
+from Orange.data import Table
+from Orange.classification import LogisticRegressionLearner
+from Orange.evaluation import AUC, CA, Results, Recall, \
+    Precision, TestOnTrainingData
 from Orange.preprocess import discretize
+
+
+class ScoringTest(unittest.TestCase):
+    def test_Recall(self):
+        data = Table('iris')
+        learner = LogisticRegressionLearner()
+        results = TestOnTrainingData(data, [learner])
+        self.assertGreater(Recall(results)[0], 0.9)
+        self.assertEqual(round(Recall(results)[0], 3), 0.927)
+
+    def test_Precision(self):
+        data = Table('iris')
+        learner = LogisticRegressionLearner()
+        results = TestOnTrainingData(data, [learner])
+        self.assertGreater(Precision(results)[0], 0.9)
+        self.assertEqual(round(Precision(results)[0], 3), 0.928)
 
 
 class Scoring_CA_Test(unittest.TestCase):


### PR DESCRIPTION
Add argument, since its default value is deprecated and removed in Sklearn 0.18.