### PR TITLE
OWLinearRegression: Set coefficient table name to 'coefficients'

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -146,6 +146,7 @@ class Columns:
 # noinspection PyPep8Naming
 class Table(MutableSequence, Storage):
     __file__ = None
+    name = "untitled"
 
     @property
     def columns(self):

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -145,6 +145,7 @@ class OWLinearRegression(widget.OWWidget):
                 names = ["intercept"] + \
                     [attr.name for attr in predictor.domain.attributes]
                 coef_table = Table(domain, list(zip(coefs, names)))
+                coef_table.name = "coefficients"
 
         self.send("Linear Regression", learner)
         self.send("Model", predictor)


### PR DESCRIPTION
For unnamed data in the input of OWDataTable (e.g. coefficients) the tab had no name. 
Now the name is set to 'untitled' by default and renamed if possible (e.g. coefficients in OWLinearRegression).