### PR TITLE
setup.py: added docutils as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ INSTALL_REQUIRES = (
     'chardet>=2.3.0',
     'bottlechest',
     'xlrd>=0.9.2',
+    'docutils',
 )
 
 if sys.version_info < (3, 4):


### PR DESCRIPTION
`docutils` was missing as a requirement and consequently in the bundle on our website. This caused the description of add-ons not to be properly formatted.
![screen shot 2015-12-11 at 10 18 02](https://cloud.githubusercontent.com/assets/713026/11740083/8149c962-9ff0-11e5-9fa7-3f3462015156.png)
