### PR TITLE
Select columns: unconditionally commit new data

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -486,7 +486,7 @@ class OWSelectAttributes(widget.OWWidget):
             self.meta_attrs[:] = []
             self.available_attrs[:] = []
 
-        self.commit()
+        self.unconditional_commit()
 
     def update_domain_role_hints(self):
         """ Update the domain hints to be stored in the widgets settings.


### PR DESCRIPTION
Widgets with Apply button usually don't output anything before the apply button is clicked. Although this is the norm, in this particular widget, this behaviour is unexpected (I was confused yesterday by it, and I though we had a bug...).

Typically, application of settings takes time (e.g. for building the model), which is why the settings are not applied immediately. This case is different: the application is free, but the user performs multiple actions in a row and we don't won't to commit all, due to further widgets. But the first application should happen immediately.