### PR TITLE
canvas/readwrite: Fix `parse_ows_stream`

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -7,7 +7,7 @@ import sys
 import logging
 import operator
 from functools import partial
-from io import BytesIO
+from io import BytesIO, StringIO
 
 import pkg_resources
 
@@ -963,7 +963,7 @@ class CanvasMainWindow(QMainWindow):
 
     def load_scheme_xml(self, xml):
         new_scheme = widgetsscheme.WidgetsScheme(parent=self)
-        scheme_load(new_scheme, xml)
+        scheme_load(new_scheme, StringIO(xml))
         self.set_new_scheme(new_scheme)
         return QDialog.Accepted
 

--- a/Orange/canvas/scheme/readwrite.py
+++ b/Orange/canvas/scheme/readwrite.py
@@ -6,8 +6,7 @@ import base64
 import sys
 import warnings
 
-from xml.etree.ElementTree import (TreeBuilder, Element, ElementTree, parse,
-                                   fromstring)
+from xml.etree.ElementTree import TreeBuilder, Element, ElementTree, parse
 
 from collections import defaultdict, namedtuple
 from itertools import chain, count
@@ -566,10 +565,7 @@ def parse_ows_etree_v_1_0(tree):
 
 
 def parse_ows_stream(stream):
-    if isinstance(stream, str):
-        doc = ElementTree(fromstring(stream))
-    else:
-        doc = parse(stream)
+    doc = parse(stream)
     scheme_el = doc.getroot()
     version = scheme_el.get("version", None)
     if version is None:


### PR DESCRIPTION
Revert changes to `parse_ows_stream` introduced in 6182d62cdbf701739315a5d06f666adb11a551db.
If the `stream` parameter is a string it should be interpreted as a filename path (as `ElementTree.parse` does).

This fixes workflow preview rendering (which uses `parse_ows_stream`)