### PR TITLE
Paint data: Do not output class column if only a single class is present

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1187,7 +1187,7 @@ class OWPaintData(widget.OWWidget):
         else:
             X, Y = self.data[:, np.newaxis, 0], self.data[:, 2]
             attrs = (Orange.data.ContinuousVariable(self.attr1),)
-        if len(self.class_model) > 1:
+        if len(np.unique(Y)) >= 2:
             domain = Orange.data.Domain(
                 attrs,
                 Orange.data.DiscreteVariable(


### PR DESCRIPTION
Say that the user paints some data with a single class only. The widget still outputs the class column, with all instances belonging to this class. To remove this column from the output, the user must delete the second class from the listbox in the control area.

I changed this so that the widget checks whether two classes are actually present in the data. This is more convenient for the user.

The drawback is that the user now cannot paint a data with a single class but still have the class column. This scenario is very unlikely, though, and I think it's better cover the common scenario.