### PR TITLE
Add auto save to OWSave; Move saving of graphs to separate function

### DIFF
--- a/Orange/canvas/report/report.py
+++ b/Orange/canvas/report/report.py
@@ -6,6 +6,7 @@ from PyQt4.QtCore import Qt, QAbstractItemModel, QByteArray, QBuffer, QIODevice
 from PyQt4.QtGui import QGraphicsScene, QStandardItemModel, QColor
 from Orange.widgets.io import PngFormat
 from Orange.data.sql.table import SqlTable
+from Orange.widgets.utils import getdeepattr
 
 
 class Report:
@@ -122,22 +123,34 @@ class Report:
         name, data = self._fix_args(name, data)
         self.report_items(name, describe_data_brief(data))
 
-    def report_plot(self, name, plot=None):
+    def report_plot(self, name=None, plot=None):
         """
         Add a plot to the report.
 
-        The first argument, `name` can be omitted.
+        Both arguments can be omitted.
+
+        - `report_plot("graph name", self.plotView)` reports plot
+            `self.plotView` with name `"graph name"`
+        - `report_plot(self.plotView) reports plot without name
+        - `report_plot()` reports plot stored in attribute whose name is
+            taken from `self.graph_name`
+        - `report_plot("graph name")` reports plot stored in attribute
+            whose name is taken from `self.graph_name`
 
         :param name: report section name (can be omitted)
         :param name: str or tuple or OrderedDict
         :param plot: plot widget
         :type plot:
             QGraphicsScene or pyqtgraph.PlotItem or pyqtgraph.PlotWidget
-            or pyqtgraph.GraphicsWidget
+            or pyqtgraph.GraphicsWidget. If omitted, the name of the
+            attribute storing the graph is taken from `self.graph_name`
         """
-        name, plot = self._fix_args(name, plot)
+        if not (isinstance(name, str) and plot is None):
+            name, plot = self._fix_args(name, plot)
         from pyqtgraph import PlotWidget, PlotItem, GraphicsWidget
         self.report_name(name)
+        if plot is None:
+            plot = getdeepattr(self, self.graph_name)
         if isinstance(plot, QGraphicsScene):
             self.report_html += get_html_img(plot)
         elif isinstance(plot, PlotItem):

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -213,7 +213,7 @@ class FileFormat(metaclass=FileFormatMeta):
     desired output class (if other than Table).
     """
 
-    OWSAVE_PRIORITY = 10000  # Sort order in OWSave widget combo box, lower is better
+    PRIORITY = 10000  # Sort order in OWSave widget combo box, lower is better
 
     @staticmethod
     def open(filename, *args, **kwargs):
@@ -531,7 +531,7 @@ class CSVFormat(FileFormat):
     DESCRIPTION = 'Comma-separated values'
     DELIMITERS = ',;:\t$ '
     SUPPORT_COMPRESSED = True
-    OWSAVE_PRIORITY = 20
+    PRIORITY = 20
 
     @classmethod
     def read_file(cls, filename, wrapper=None):
@@ -590,7 +590,7 @@ class TabFormat(CSVFormat):
     EXTENSIONS = ('.tab', '.tsv')
     DESCRIPTION = 'Tab-separated values'
     DELIMITERS = '\t'
-    OWSAVE_PRIORITY = 10
+    PRIORITY = 10
 
 
 class PickleFormat(FileFormat):

--- a/Orange/widgets/classify/owtreeviewer2d.py
+++ b/Orange/widgets/classify/owtreeviewer2d.py
@@ -1,11 +1,13 @@
 from itertools import chain
-from Orange.widgets import gui
-from Orange.widgets.widget import OWWidget
-from Orange.widgets.settings import Setting
-from Orange.widgets.io import FileFormat
 
 from PyQt4.QtCore import *
 from PyQt4.QtGui import *
+
+from Orange.widgets import gui
+from Orange.widgets.widget import OWWidget
+from Orange.widgets.settings import Setting
+from Orange.widgets.utils.saveplot import save_plot
+from Orange.widgets.io import FileFormat
 
 DefDroppletBrush = QBrush(Qt.darkGray)
 
@@ -357,7 +359,7 @@ class OWTreeViewer2D(OWWidget):
     _DEF_NODE_WIDTH = 24
     _DEF_NODE_HEIGHT = 20
 
-    want_graph = True
+    graph_name = True
 
     def __init__(self):
         super().__init__()
@@ -404,7 +406,6 @@ class OWTreeViewer2D(OWWidget):
                          addToLayout=False,
                          callback=self.toggle_line_width, sizePolicy=policy))
         self.resize(800, 500)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def send_report(self):
         from PyQt4.QtSvg import QSvgGenerator
@@ -545,10 +546,6 @@ class OWTreeViewer2D(OWWidget):
         # else None)
 
     def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data={'scene': self.scene, 'tree': self.tree},
-                          file_formats=dict(chain(
-                              FileFormat.img_writers.items(),
-                              FileFormat.graph_writers.items())))
-        save_img.exec_()
+        save_plot(data=dict(scene=self.scene, tree=self.tree),
+                  file_formats=dict(chain(FileFormat.img_writers.items(),
+                                          FileFormat.graph_writers.items())))

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -335,7 +335,7 @@ class OWImageViewer(widget.OWWidget):
     zoom = settings.Setting(25)
     autoCommit = settings.Setting(False)
 
-    want_graph = True
+    graph_name = "scene"
 
     def __init__(self):
         super().__init__()
@@ -390,7 +390,6 @@ class OWImageViewer(widget.OWWidget):
         self.scene.selectionRectPointChanged.connect(
             self.onSelectionRectPointChanged, Qt.QueuedConnection
         )
-        self.graphButton.clicked.connect(self.saveScene)
         self.resize(800, 600)
 
         self.thumbnailWidget = None
@@ -596,13 +595,6 @@ class OWImageViewer(widget.OWWidget):
             self.send("Data", selected)
         else:
             self.send("Data", None)
-
-    def saveScene(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.scene,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
 
     def _updateStatus(self, future):
         if future.cancelled():

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -775,7 +775,7 @@ class OWPaintData(widget.OWWidget):
     brushRadius = Setting(75)
     density = Setting(7)
 
-    want_graph = True
+    graph_name = "plot"
 
     def __init__(self):
         super().__init__()
@@ -949,7 +949,6 @@ class OWPaintData(widget.OWWidget):
         # enable brush tool
         self.toolActions.actions()[0].setChecked(True)
         self.set_current_tool(self.TOOLS[0][2])
-        self.graphButton.clicked.connect(self.save_graph)
 
         self.set_dimensions()
 
@@ -1207,13 +1206,6 @@ class OWPaintData(widget.OWWidget):
     def onDeleteWidget(self):
         self.plot.clear()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plotview.plotItem,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.data is None:
             return
@@ -1222,7 +1214,7 @@ class OWPaintData(widget.OWWidget):
             settings += [("Axis x", self.attr1), ("Axis y", self.attr2)]
         settings += [("Number of points", len(self.data))]
         self.report_items("Painted data", settings)
-        self.report_plot(self.plot)
+        self.report_plot()
 
 def test():
     import gc

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -1,4 +1,5 @@
 import os.path
+from operator import attrgetter
 
 from PyQt4 import QtGui
 
@@ -22,66 +23,70 @@ class OWSave(widget.OWWidget):
     resizing_enabled = False
 
     last_dir = Setting("")
+    last_filter = Setting("")
+    auto_save = Setting(False)
 
-    def __init__(self, data=None, file_formats=None):
+    formats = [(f.DESCRIPTION, f.EXTENSIONS)
+               for f in sorted(set(FileFormat.writers.values()),
+                               key=attrgetter("PRIORITY"))]
+    filters = ['{} (*{})'.format(x[0], ' *'.join(x[1])) for x in formats]
+
+    def __init__(self):
         super().__init__()
         self.data = None
         self.filename = ""
-        self.format_index = 0
-        self.file_formats = file_formats or FileFormat.writers
-        self.formats = [(f.DESCRIPTION, f.EXTENSIONS)
-                        for f in sorted(set(self.file_formats.values()),
-                                        key=lambda f: f.OWSAVE_PRIORITY)]
-        self.comboBoxFormat = gui.comboBox(
-            self.controlArea, self, value='format_index',
-            items=['{} (*{})'.format(x[0], ' *'.join(x[1]))
-                   for x in self.formats],
-            box='File Format')
-        box = gui.widgetBox(self.controlArea)
-        self.save = gui.button(box, self, "Save", callback=self.save_file,
-                               default=True, disabled=True)
-        gui.separator(box)
-        self.saveAs = gui.button(box, self, "Save as ...",
-                                 callback=self.save_file_as, disabled=True)
-        self.setMinimumWidth(320)
+
+        self.save = gui.auto_commit(
+            self.controlArea, self, "auto_save", "Save", box=False,
+            commit=self.save_file, callback=self.adjust_label,
+            disabled=True, addSpace=True)
+        self.saveAs = gui.button(
+            self.controlArea, self, "Save as ...",
+            callback=self.save_file_as, disabled=True)
+        self.saveAs.setMinimumWidth(220)
         self.adjustSize()
-        if data:
-            self.dataset(data)
+
+    def adjust_label(self):
+        if self.filename:
+            filename = os.path.split(self.filename)[1]
+            text = ["Save as '{}'", "Auto save as '{}'"][self.auto_save]
+            self.save.button.setText(text.format(filename))
 
     def dataset(self, data):
         self.data = data
         self.save.setDisabled(data is None)
         self.saveAs.setDisabled(data is None)
+        if data is not None:
+            self.save_file()
 
     def save_file_as(self):
-        format_name, format_extensions = self.formats[self.format_index]
-        home_dir = os.path.expanduser("~")
-        filename = QtGui.QFileDialog.getSaveFileName(
-            self, 'Save as ...',
-            self.filename or os.path.join((self.last_dir or home_dir), getattr(self.data, 'name', '')),
-            '{} (*{})'.format(format_name, ' *'.join(format_extensions)))
+        file_name = self.filename or \
+            os.path.join(self.last_dir or os.path.expanduser("~"),
+                         getattr(self.data, 'name', ''))
+        filename, filter = QtGui.QFileDialog.getSaveFileNameAndFilter(
+            self, 'Save as ...', file_name,
+            ";;".join(self.filters), self.last_filter or self.filters[0])
         if not filename:
             return
-        for ext in format_extensions:
-            if filename.endswith(ext):
-                break
-        else:
+        ext = os.path.splitext(filename)[1]
+        format_extensions = self.formats[self.filters.index(filter)][1]
+        if ext not in format_extensions:
             filename += format_extensions[0]
         self.filename = filename
-        self.last_dir, file_name = os.path.split(self.filename)
-        self.save.setText("Save as '%s'" % file_name)
-        self.save.setDisabled(False)
-        self.save_file()
+        self.unconditional_save_file()
+        self.last_dir = os.path.split(self.filename)[0]
+        self.last_filter = filter
+        self.adjust_label()
 
     def save_file(self):
+        if self.data is None:
+            return
         if not self.filename:
             self.save_file_as()
-        elif self.data is not None:
+        else:
             try:
-                ext = self.formats[self.format_index][1]
-                if not isinstance(ext, str):
-                    ext = ext[0]  # is e.g. a tuple of extensions
-                self.file_formats[ext].write(self.filename, self.data)
+                ext = os.path.splitext(self.filename)[1]
+                FileFormat.writers[ext].write(self.filename, self.data)
                 self.error()
             except Exception as errValue:
                 self.error(str(errValue))

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -40,7 +40,7 @@ class OWCalibrationPlot(widget.OWWidget):
     selected_classifiers = settings.Setting([])
     display_rug = settings.Setting(True)
 
-    want_graph = True
+    graph_name = "plot"
 
     def __init__(self):
         super().__init__()
@@ -80,7 +80,6 @@ class OWCalibrationPlot(widget.OWWidget):
         self.plotview.setCentralItem(self.plot)
 
         self.mainArea.layout().addWidget(self.plotview)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def set_results(self, results):
         self.clear()
@@ -190,20 +189,13 @@ class OWCalibrationPlot(widget.OWWidget):
     def _on_display_rug_changed(self):
         self._replot()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.results is None:
             return
         caption = report.list_legend(self.classifiers_list_box,
                                      self.selected_classifiers)
         self.report_items((("Target class", self.target_cb.currentText()),))
-        self.report_plot(self.plot)
+        self.report_plot()
         self.report_caption(caption)
 
 

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -69,7 +69,7 @@ class OWLiftCurve(widget.OWWidget):
     fn_cost = settings.Setting(500)
     target_prior = settings.Setting(50.0)
 
-    want_graph = True
+    graph_name = "plot"
 
     def __init__(self):
         super().__init__()
@@ -123,7 +123,6 @@ class OWLiftCurve(widget.OWWidget):
 
         self.plotview.setCentralItem(self.plot)
         self.mainArea.layout().addWidget(self.plotview)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def set_results(self, results):
         """Set the input evaluation results."""
@@ -223,20 +222,13 @@ class OWLiftCurve(widget.OWWidget):
     def _on_classifiers_changed(self):
         self._replot()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.results is None:
             return
         caption = report.list_legend(self.classifiers_list_box,
                                      self.selected_classifiers)
         self.report_items((("Target class", self.target_cb.currentText()),))
-        self.report_plot(self.plot)
+        self.report_plot()
         self.report_caption(caption)
 
 

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -297,7 +297,7 @@ class OWROCAnalysis(widget.OWWidget):
     display_convex_hull = settings.Setting(False)
     display_convex_curve = settings.Setting(False)
 
-    want_graph = True
+    graph_name = "plot"
 
     def __init__(self):
         super().__init__()
@@ -394,7 +394,6 @@ class OWROCAnalysis(widget.OWWidget):
 
         self.plotview.setCentralItem(self.plot)
         self.mainArea.layout().addWidget(self.plotview)
-        self.graphButton.clicked.connect(self.save_graph)
         self.inline_graph_report()
 
     def set_results(self, results):
@@ -616,13 +615,6 @@ class OWROCAnalysis(widget.OWWidget):
     def onDeleteWidget(self):
         self.clear()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.results is None:
             return
@@ -635,7 +627,7 @@ class OWROCAnalysis(widget.OWWidget):
         caption = report.list_legend(self.classifiers_list_box,
                                      self.selected_classifiers)
         self.report_items(items)
-        self.report_plot(self.plot)
+        self.report_plot()
         self.report_caption(caption)
 
 

--- a/Orange/widgets/io.py
+++ b/Orange/widgets/io.py
@@ -61,7 +61,7 @@ class ImgFormat(FileFormat):
 class PngFormat(ImgFormat):
     EXTENSIONS = ('.png',)
     DESCRIPTION = 'Portable Network Graphics'
-    OWSAVE_PRIORITY = 50
+    PRIORITY = 50
 
     @staticmethod
     def _get_buffer(size, filename):
@@ -93,7 +93,7 @@ class PngFormat(ImgFormat):
 class SvgFormat(ImgFormat):
     EXTENSIONS = ('.svg',)
     DESCRIPTION = 'Scalable Vector Graphics'
-    OWSAVE_PRIORITY = 100
+    PRIORITY = 100
 
     @staticmethod
     def _get_buffer(size, filename):

--- a/Orange/widgets/io.py
+++ b/Orange/widgets/io.py
@@ -61,6 +61,7 @@ class ImgFormat(FileFormat):
 class PngFormat(ImgFormat):
     EXTENSIONS = ('.png',)
     DESCRIPTION = 'Portable Network Graphics'
+    OWSAVE_PRIORITY = 50
 
     @staticmethod
     def _get_buffer(size, filename):
@@ -92,6 +93,7 @@ class PngFormat(ImgFormat):
 class SvgFormat(ImgFormat):
     EXTENSIONS = ('.svg',)
     DESCRIPTION = 'Scalable Vector Graphics'
+    OWSAVE_PRIORITY = 100
 
     @staticmethod
     def _get_buffer(size, filename):

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -56,7 +56,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
 
     selected_var_indices = settings.ContextSetting([])
 
-    want_graph = True
+    graph_name = "plot.plotItem"
 
     def __init__(self):
         super().__init__()
@@ -96,7 +96,6 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
         self.plot = pg.PlotWidget(background="w")
         self.plot.setMenuEnabled(False)
         self.mainArea.layout().addWidget(self.plot)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def set_data(self, data):
         self.closeContext()
@@ -239,13 +238,6 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
             ax1, ax2 = self._p_axes()
             self.infotext.setText(fmt.format(inertia[ax1], inertia[ax2]))
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot.plotItem,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.data is None:
             return
@@ -263,7 +255,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
                 ", ".join(var.name for var in vars[:-1]), vars[-1].name)
         self.report_items(items)
 
-        self.report_plot(self.plot)
+        self.report_plot()
 
 
 def burt_table(data, variables):

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -261,7 +261,7 @@ class OWDistanceMap(widget.OWWidget):
 
     autocommit = settings.Setting(True)
 
-    want_graph = True
+    graph_name = "grid_widget"
 
     # Disable clustering for inputs bigger than this
     _MaxClustering = 3000
@@ -384,7 +384,6 @@ class OWDistanceMap(widget.OWWidget):
         self.dendrogram = None
 
         self.grid_widget.scene().installEventFilter(self)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def set_distances(self, matrix):
         self.closeContext()
@@ -634,13 +633,6 @@ class OWDistanceMap(widget.OWWidget):
         self.send("Data", datasubset)
         self.send("Features", featuresubset)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.grid_widget,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def onDeleteWidget(self):
         super().onDeleteWidget()
         self.clear()
@@ -654,7 +646,7 @@ class OWDistanceMap(widget.OWWidget):
             ("Annotations", annot)
         ))
         if self.matrix is not None:
-            self.report_plot(self.grid_widget)
+            self.report_plot()
 
 
 class TextList(GraphicsSimpleTextList):

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -736,7 +736,7 @@ class OWHierarchicalClustering(widget.OWWidget):
     cluster_name = settings.Setting("Cluster")
     autocommit = settings.Setting(True)
 
-    want_graph = True
+    graph_name = "scene"
 
     #: Cluster variable domain role
     AttributeRole, ClassRole, MetaRole = 0, 1, 2
@@ -940,7 +940,6 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.top_axis.line.valueChanged.connect(self._axis_slider_changed)
         self.dendrogram.geometryChanged.connect(self._dendrogram_geom_changed)
         self._set_cut_line_visible(self.selection_method == 1)
-        self.graphButton.clicked.connect(self.save_graph)
 
         self.inline_graph_report()
 
@@ -1295,13 +1294,6 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.selection_method = 0
         self._selection_method_changed()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.scene,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def __zoom_in(self):
         def clip(minval, maxval, val):
             return min(max(val, minval), maxval)
@@ -1359,7 +1351,7 @@ class OWHierarchicalClustering(widget.OWWidget):
                  self.cluster_name,
                  self.cluster_roles[self.cluster_role].lower()))
         ))
-        self.report_plot(self.scene)
+        self.report_plot()
 
 
 def qfont_scaled(font, factor):

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -149,7 +149,7 @@ class OWMDS(widget.OWWidget):
 
     legend_anchor = settings.Setting(((1, 0), (1, 0)))
 
-    want_graph = True
+    graph_name = "plot.plotItem"
 
     def __init__(self):
         super().__init__()
@@ -358,7 +358,6 @@ class OWMDS(widget.OWWidget):
             self.plot.getViewBox().setCursor(QtGui.QCursor(cur))
 
         group.triggered[QtGui.QAction].connect(activate_tool)
-        self.graphButton.clicked.connect(self.save_graph)
 
         self._initialize()
 
@@ -1051,17 +1050,10 @@ class OWMDS(widget.OWWidget):
         else:
             self._selection_mask[indices] = True
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot.plotItem,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.data is None:
             return
-        self.report_plot(self.plot)
+        self.report_plot()
         caption = report.render_items_vert((
             ("Color", self.color_value != "Same color" and self.color_value),
             ("Shape", self.shape_value != "Same shape" and self.shape_value),

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -38,7 +38,7 @@ class OWPCA(widget.OWWidget):
     maxp = settings.Setting(20)
     axis_labels = settings.Setting(10)
 
-    want_graph = True
+    graph_name = "plot.plotItem"
 
     def __init__(self):
         super().__init__()
@@ -130,7 +130,6 @@ class OWPCA(widget.OWWidget):
         self.plot.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0))
 
         self.mainArea.layout().addWidget(self.plot)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def update_model(self):
         self.get_model()
@@ -346,13 +345,6 @@ class OWPCA(widget.OWWidget):
         self.send("Transformed data", transformed)
         self.send("Components", components)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot.plotItem,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
         if self.data is None:
             return
@@ -360,7 +352,7 @@ class OWPCA(widget.OWWidget):
             ("Selected components", self.ncomponents),
             ("Explained variance", "{:.3f} %".format(self.variance_covered))
         ))
-        self.report_plot(self.plot)
+        self.report_plot()
 
 def main():
     import gc

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -1,0 +1,87 @@
+import os
+
+from PyQt4.QtGui import QMessageBox, QFileDialog
+
+
+def fix_extension(ext, format, suggested_ext, suggested_format):
+    dlg = QMessageBox(
+        QMessageBox.Warning,
+        "Mismatching extension",
+        "Extension '{}' does not match the chosen file format, {}.\n\n"
+        "Would you like to fix this?".format(ext, format))
+    role = QMessageBox.AcceptRole
+    change_ext = \
+        suggested_ext and \
+        dlg.addButton("Change extension to " + suggested_ext, role)
+    change_format =\
+        suggested_format and \
+        dlg.addButton("Save as " + suggested_format, role)
+    cancel = dlg.addButton("Back", role)
+    dlg.setEscapeButton(cancel)
+    dlg.exec()
+    if dlg.clickedButton() == cancel:
+        return fix_extension.CANCEL
+    elif dlg.clickedButton() == change_ext:
+        return fix_extension.CHANGE_EXT
+    elif dlg.clickedButton() == change_format:
+        return fix_extension.CHANGE_FORMAT
+
+fix_extension.CHANGE_EXT = 0
+fix_extension.CHANGE_FORMAT = 1
+fix_extension.CANCEL = 2
+
+
+def format_filter(writer):
+    return '{} (*{})'.format(writer.DESCRIPTION, ' *'.join(writer.EXTENSIONS))
+
+
+def get_file_name(start_dir, start_filter, file_formats):
+    """
+    Get filename for the given possible file formats
+
+    The function uses the standard save file dialog with filters from the
+    given file formats. Extension is added automatically, if missing. If the
+    user enters file extension that does not match the file format, (s)he is
+    given a dialog to decide whether to fix the extension or the format.
+
+    Function also returns the writer and filter to cover the case where the
+    same extension appears in multiple filters. Although `file_format` is a
+    dictionary that associates its extension with one writer, writers can
+    still have other extensions that are allowed.
+
+    Args:
+        start_dir (str): initial directory, optionally including the filename
+        start_filter (str): initial filter
+        file_formats (list of Orange.data.io.FileFormat): file formats
+    Returns:
+        (filename, filter, writer), or `(None, None, None)` on cancel
+    """
+    writers = sorted(set(file_formats.values()), key=lambda w: w.PRIORITY)
+    filters = [format_filter(w) for w in writers]
+    if start_filter not in filters:
+        start_filter = filters[0]
+
+    while True:
+        filename, filter = QFileDialog.getSaveFileNameAndFilter(
+            None, 'Save as ...', start_dir, ';;'.join(filters), start_filter)
+        if not filename:
+            return None, None, None
+
+        writer = writers[filters.index(filter)]
+        base, ext = os.path.splitext(filename)
+        if not ext:
+            filename += writer.EXTENSIONS[0]
+        elif ext not in writer.EXTENSIONS:
+            format = writer.DESCRIPTION
+            suggested_ext = writer.EXTENSIONS[0]
+            suggested_format = \
+                ext in file_formats and file_formats[ext].DESCRIPTION
+            res = fix_extension(ext, format, suggested_ext, suggested_format)
+            if res == fix_extension.CANCEL:
+                continue
+            if res == fix_extension.CHANGE_EXT:
+                filename = base + suggested_ext
+            elif res == fix_extension.CHANGE_FORMAT:
+                writer = file_formats[ext]
+                filter = format_filter(writer)
+        return filename, writer, filter

--- a/Orange/widgets/utils/saveplot.py
+++ b/Orange/widgets/utils/saveplot.py
@@ -2,76 +2,32 @@ import os.path
 
 from PyQt4 import QtGui, QtCore
 
-
-CHANGE_EXT, CHANGE_FORMAT, KEEP = range(3)
-
-
-def fix_extension(ext, format, suggested_ext, suggested_format):
-    dlg = QtGui.QMessageBox(
-        QtGui.QMessageBox.Warning,
-        "Mismatching extension",
-        "Extension '{}' does not match the chosen file format, {}.\n\n"
-        "Would you like to fix this?".format(ext, format))
-    role = QtGui.QMessageBox.AcceptRole
-    keep_settings = dlg.addButton("Save as it is", role)
-    change_ext = \
-        suggested_ext and dlg.addButton("Use extension " + suggested_ext, role)
-    change_format = \
-        suggested_format and dlg.addButton("Save as " + suggested_format, role)
-    dlg.exec()
-    if dlg.clickedButton() == keep_settings:
-        return KEEP
-    elif dlg.clickedButton() == change_ext:
-        return CHANGE_EXT
-    elif dlg.clickedButton() == change_format:
-        return CHANGE_FORMAT
+from Orange.widgets.utils import filedialogs
 
 
 # noinspection PyBroadException
 def save_plot(data, file_formats, filename=""):
-    writers = sorted(set(file_formats.values()), key=lambda w: w.PRIORITY)
-    filters = ['{} (*{})'.format(w.DESCRIPTION, ' *'.join(w.EXTENSIONS))
-               for w in writers]
-
     _LAST_DIR_KEY = "directories/last_graph_directory"
-    _LAST_FMT_KEY = "directories/last_graph_format"
+    _LAST_FILTER_KEY = "directories/last_graph_filter"
     settings = QtCore.QSettings()
     start_dir = settings.value(_LAST_DIR_KEY, filename)
     if not start_dir or \
             (not os.path.exists(start_dir) and
              not os.path.exists(os.path.split(start_dir)[0])):
         start_dir = os.path.expanduser("~")
-    last_ext = settings.value(_LAST_FMT_KEY, "")
-    if last_ext not in filters:
-        last_ext = filters[0]
-
-    filename, filter = QtGui.QFileDialog.getSaveFileNameAndFilter(
-        None, 'Save as ...', start_dir, ';;'.join(filters), last_ext)
+    last_filter = settings.value(_LAST_FILTER_KEY, "")
+    filename, writer, filter = \
+        filedialogs.get_file_name(start_dir, last_filter, file_formats)
     if not filename:
         return
-
-    writer = writers[filters.index(filter)]
-    base, ext = os.path.splitext(filename)
-    if not ext:
-        filename += writer.EXTENSIONS[0]
-    elif ext not in writer.EXTENSIONS:
-        format = writer.DESCRIPTION
-        suggested_ext = writer.EXTENSIONS[0]
-        suggested_format = ext in file_formats and file_formats[ext].DESCRIPTION
-        res = fix_extension(ext, format, suggested_ext, suggested_format)
-        if res == CHANGE_EXT:
-            filename = base + suggested_ext
-        elif res == CHANGE_FORMAT:
-            writer = file_formats[ext]
-
     try:
         writer.write(filename, data)
     except:
         QtGui.QMessageBox.critical(
             None, "Error", "Error occurred while saving file\n" + filename)
-
-    settings.setValue(_LAST_DIR_KEY, os.path.split(filename)[0])
-    settings.setValue(_LAST_FMT_KEY, filter)
+    else:
+        settings.setValue(_LAST_DIR_KEY, os.path.split(filename)[0])
+        settings.setValue(_LAST_FILTER_KEY, filter)
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/utils/saveplot.py
+++ b/Orange/widgets/utils/saveplot.py
@@ -1,0 +1,42 @@
+import os.path
+from operator import attrgetter
+
+from PyQt4 import QtGui, QtCore
+
+
+# noinspection PyBroadException
+def save_plot(data, file_formats, filename=""):
+    formats = [(f.DESCRIPTION, f.EXTENSIONS)
+               for f in sorted(set(file_formats.values()),
+                               key=attrgetter("OWSAVE_PRIORITY"))]
+    filters = ['{} (*{})'.format(desc, ' *'.join(exts))
+               for desc, exts in formats]
+
+    _LAST_DIR_KEY = "directories/last_graph_directory"
+    _LAST_EXT_KEY = "directories/last_graph_extension"
+    settings = QtCore.QSettings()
+    start_dir = settings.value(_LAST_DIR_KEY, filename)
+    if not start_dir or not os.path.exists(start_dir):
+        start_dir = os.path.expanduser("~")
+    last_ext = settings.value(_LAST_EXT_KEY, "")
+    if last_ext not in filters:
+        last_ext = filters[0]
+
+    filename, filter = QtGui.QFileDialog.getSaveFileNameAndFilter(
+        None, 'Save as ...', start_dir, ';;'.join(filters), last_ext)
+    if not filename:
+        return
+
+    ext = os.path.splitext(filename)[1]
+    exts = formats[filters.index(filter)][1]
+    if ext not in exts:
+        ext = exts[0]
+        filename += ext
+    try:
+        file_formats[ext].write(filename, data)
+    except:
+        QtGui.QMessageBox.critical(
+            None, "Error", "Error occurred while saving file")
+
+    settings.setValue(_LAST_DIR_KEY, os.path.split(filename)[0])
+    settings.setValue(_LAST_EXT_KEY, filter)

--- a/Orange/widgets/utils/saveplot.py
+++ b/Orange/widgets/utils/saveplot.py
@@ -1,24 +1,23 @@
 import os.path
-from operator import attrgetter
 
 from PyQt4 import QtGui, QtCore
 
 
 # noinspection PyBroadException
 def save_plot(data, file_formats, filename=""):
-    formats = [(f.DESCRIPTION, f.EXTENSIONS)
-               for f in sorted(set(file_formats.values()),
-                               key=attrgetter("OWSAVE_PRIORITY"))]
-    filters = ['{} (*{})'.format(desc, ' *'.join(exts))
-               for desc, exts in formats]
+    writers = sorted(set(file_formats.values()), key=lambda w: w.PRIORITY)
+    filters = ['{} (*{})'.format(w.DESCRIPTION, ' *'.join(w.EXTENSIONS))
+               for w in writers]
 
     _LAST_DIR_KEY = "directories/last_graph_directory"
-    _LAST_EXT_KEY = "directories/last_graph_extension"
+    _LAST_FMT_KEY = "directories/last_graph_format"
     settings = QtCore.QSettings()
     start_dir = settings.value(_LAST_DIR_KEY, filename)
-    if not start_dir or not os.path.exists(start_dir):
+    if not start_dir or \
+            (not os.path.exists(start_dir) and
+             not os.path.exists(os.path.split(start_dir)[0])):
         start_dir = os.path.expanduser("~")
-    last_ext = settings.value(_LAST_EXT_KEY, "")
+    last_ext = settings.value(_LAST_FMT_KEY, "")
     if last_ext not in filters:
         last_ext = filters[0]
 
@@ -27,16 +26,14 @@ def save_plot(data, file_formats, filename=""):
     if not filename:
         return
 
-    ext = os.path.splitext(filename)[1]
-    exts = formats[filters.index(filter)][1]
-    if ext not in exts:
-        ext = exts[0]
-        filename += ext
+    writer = writers[filters.index(filter)]
+    if not os.path.splitext(filename)[1] and writer.EXTENSIONS:
+        filename += writer.EXTENSIONS[0]
     try:
-        file_formats[ext].write(filename, data)
+        writer.write(filename, data)
     except:
         QtGui.QMessageBox.critical(
-            None, "Error", "Error occurred while saving file")
+            None, "Error", "Error occurred while saving file\n" + filename)
 
     settings.setValue(_LAST_DIR_KEY, os.path.split(filename)[0])
-    settings.setValue(_LAST_EXT_KEY, filter)
+    settings.setValue(_LAST_FMT_KEY, filter)

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -136,7 +136,7 @@ class OWBoxPlot(widget.OWWidget):
     _label_font.setPixelSize(11)
     _attr_brush = QtGui.QBrush(QtGui.QColor(0x33, 0x00, 0xff))
 
-    want_graph = True
+    graph_name = "box_scene"
 
     def __init__(self):
         super().__init__()
@@ -203,7 +203,6 @@ class OWBoxPlot(widget.OWWidget):
         self.is_continuous = False
 
         self.update_display_box()
-        self.graphButton.clicked.connect(self.save_graph)
 
     def eventFilter(self, obj, event):
         if obj is self.box_view.viewport() and \
@@ -781,19 +780,12 @@ class OWBoxPlot(widget.OWWidget):
             self.posthoc_lines.append(it)
             last_to = to
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.box_scene,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def get_widget_name_extension(self):
         if self.attributes_select and len(self.attributes):
             return self.attributes[self.attributes_select[0]][0]
 
     def send_report(self):
-        self.report_plot(self.box_scene)
+        self.report_plot()
         text = ""
         if self.attributes_select and len(self.attributes):
             text += "Box plot for attribute '{}' ".format(

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -98,7 +98,8 @@ class OWDistributions(widget.OWWidget):
     smoothing_index = settings.Setting(5)
     show_prob = settings.ContextSetting(0)
 
-    want_graph = True
+    graph_name = "plot"
+
     ASH_HIST = 50
 
     bins = [ 2, 3, 4, 5, 8, 10, 12, 15, 20, 30, 50 ]
@@ -204,7 +205,6 @@ class OWDistributions(widget.OWWidget):
         self._legend.setParentItem(self.plot)
         self._legend.hide()
         self._legend.anchor((1, 0), (1, 0))
-        self.graphButton.clicked.connect(self.save_graph)
 
     def update_views(self):
         self.plot_prob.setGeometry(self.plot.sceneBoundingRect())
@@ -549,13 +549,6 @@ class OWDistributions(widget.OWWidget):
         self.plot.clear()
         super().onDeleteWidget()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.ploti,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def get_widget_name_extension(self):
         if self.variable_idx >= 0:
             return self.varmodel[self.variable_idx]
@@ -563,7 +556,7 @@ class OWDistributions(widget.OWWidget):
     def send_report(self):
         if self.variable_idx < 0:
             return
-        self.report_plot(self.plot_prob)
+        self.report_plot()
         text = "Distribution of '{}'".format(
             self.varmodel[self.variable_idx])
         if self.groupvar_idx:

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -450,7 +450,7 @@ class OWHeatMap(widget.OWWidget):
 
     auto_commit = settings.Setting(True)
 
-    want_graph = True
+    graph_name = "scene"
 
     def __init__(self):
         super().__init__()
@@ -609,7 +609,6 @@ class OWHeatMap(widget.OWWidget):
 
         self.selection_rects = []
         self.selected_rows = []
-        self.graphButton.clicked.connect(self.save_graph)
 
     def sizeHint(self):
         return QSize(800, 400)
@@ -1497,13 +1496,6 @@ class OWHeatMap(widget.OWWidget):
 
         self.send("Selected Data", data)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.scene,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def onDeleteWidget(self):
         self.clear()
         super().onDeleteWidget()
@@ -1516,7 +1508,7 @@ class OWHeatMap(widget.OWWidget):
              self.annotation_index > 0 and
              self.annotation_vars[self.annotation_index])
         ))
-        self.report_plot(self.heatmap_scene)
+        self.report_plot()
 
 
 class GraphicsWidget(QtGui.QGraphicsWidget):

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -246,7 +246,7 @@ class OWLinearProjection(widget.OWWidget):
 
     ReplotRequest = QEvent.registerEventType()
 
-    want_graph = True
+    graph_name = "viewbox"
 
     def __init__(self):
         super().__init__()
@@ -477,7 +477,6 @@ class OWLinearProjection(widget.OWWidget):
         toollayout.addWidget(button(actions.zoomtofit))
         toollayout.addStretch()
         toolbox.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Maximum)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def sizeHint(self):
         return QSize(800, 500)
@@ -1036,15 +1035,8 @@ class OWLinearProjection(widget.OWWidget):
 
         self.send("Selected Data", subset)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.viewbox,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
-        self.report_plot(self.viewbox)
+        self.report_plot()
         caption = report.render_items_vert((
             ("Colors",
              self.color_index > 0 and self.colorvar_model[self.color_index]),

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -123,7 +123,7 @@ class OWMosaicDisplay(OWWidget):
     _box_size = 5
     _cellspace = 4
 
-    want_graph = True
+    graph_name = "canvas"
 
     def __init__(self):
         super().__init__()
@@ -242,7 +242,6 @@ class OWMosaicDisplay(OWWidget):
         self.selectionColorPalette = [QColor(*col) for col in DefaultRGBColors]
 
         gui.rubber(self.controlArea)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def permutationListToggle(self):
         if self.exploreAttrPermutations:
@@ -1081,15 +1080,8 @@ class OWMosaicDisplay(OWWidget):
                     self.attributeList.item(i + 2).setSelected(True)
                     self.attributeList.takeItem(i)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.canvas,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
-        self.report_plot(self.canvas)
+        self.report_plot()
 
 
 class OWCanvasText(QGraphicsTextItem):

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -480,7 +480,7 @@ class OWScatterMap(widget.OWWidget):
 
     mouse_mode = 0
 
-    want_graph = True
+    graph_name = "plot.plotItem"
 
     def __init__(self):
         super().__init__()
@@ -567,7 +567,6 @@ class OWScatterMap(widget.OWWidget):
         self.plot.getViewBox().sigTransformChanged.connect(
             self._on_transform_changed)
         self.mainArea.layout().addWidget(self.plot)
-        self.graphButton.clicked.connect(self.save_graph)
 
     def set_data(self, dataset):
         self.closeContext()
@@ -973,13 +972,6 @@ class OWScatterMap(widget.OWWidget):
         self.clear()
         super().onDeleteWidget()
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.plot.plotItem,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def get_widget_name_extension(self):
         if self.dataset is None:
             return
@@ -994,7 +986,7 @@ class OWScatterMap(widget.OWWidget):
             return
         caption = report.list_legend(self.z_values_view,
                                      self.selected_z_values)
-        self.report_plot(self.plot.plotItem)
+        self.report_plot()
         self.report_caption(caption)
 
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -16,7 +16,6 @@ from Orange.canvas import report
 from Orange.data.sql.table import SqlTable, AUTO_DL_LIMIT
 from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.widgets import gui
-from Orange.widgets.io import FileFormat
 from Orange.widgets.settings import \
     DomainContextHandler, Setting, ContextSetting, SettingProvider
 from Orange.widgets.utils.toolbar import ZoomSelectToolbar
@@ -65,7 +64,7 @@ class OWScatterPlot(OWWidget):
 
     jitter_sizes = [0, 0.1, 0.5, 1, 2, 3, 4, 5, 7, 10]
 
-    want_graph = True
+    graph_name = "graph.plot_widget.plotItem"
 
     def __init__(self):
         super().__init__()
@@ -197,7 +196,6 @@ class OWScatterPlot(OWWidget):
             triggered=fit_to_view
         )
         self.addActions([zoom_in, zoom_out, zoom_fit])
-        self.graphButton.clicked.connect(self.save_graph)
 
     # def settingsFromWidgetCallback(self, handler, context):
     #     context.selectionPolygons = []
@@ -423,13 +421,6 @@ class OWScatterPlot(OWWidget):
         self.vizrank.hide()
         super().hideEvent(he)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.graph.plot_widget.plotItem,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def get_widget_name_extension(self):
         if self.data is not None:
             return "{} vs {}".format(self.combo_value(self.cb_attr_x),
@@ -448,7 +439,7 @@ class OWScatterPlot(OWWidget):
              ("Size", self.combo_value(self.cb_attr_size)),
              ("Jittering", (self.graph.jitter_continuous or disc_attr) and
               self.graph.jitter_size)))
-        self.report_plot(self.graph.plot_widget)
+        self.report_plot()
         if caption:
             self.report_caption(caption)
 

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -35,7 +35,7 @@ class OWSieveDiagram(OWWidget):
 
     settingsList = ["showLines", "showCases", "showInColor"]
 
-    want_graph = True
+    graph_name = "canvas"
 
     def __init__(self):
         super().__init__()
@@ -111,8 +111,6 @@ class OWSieveDiagram(OWWidget):
         self.icons = gui.attributeIconDict
         self.resize(800, 550)
         random.seed()
-        self.graphButton.clicked.connect(self.save_graph)
-
 
     # receive new data and update all fields
     def setData(self, data):
@@ -449,19 +447,12 @@ class OWSieveDiagram(OWWidget):
         # self.optimizationDlg.hide()
         QDialog.closeEvent(self, ce)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.canvas,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def get_widget_name_extension(self):
         if self.data is not None:
             return "{} vs {}".format(self.attrX, self.attrY)
 
     def send_report(self):
-        self.report_plot(self.canvas)
+        self.report_plot()
 
 
             # class OWSieveOptimization(OWMosaicOptimization, orngMosaic):

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -51,7 +51,7 @@ class OWVennDiagram(widget.OWWidget):
     useidentifiers = settings.Setting(True)
     autocommit = settings.Setting(True)
 
-    want_graph = True
+    graph_name = "scene"
 
     def __init__(self):
         super().__init__()
@@ -126,7 +126,6 @@ class OWVennDiagram(widget.OWWidget):
                     max(self.controlArea.sizeHint().height(), 550))
 
         self._queue = []
-        self.graphButton.clicked.connect(self.save_graph)
 
     @check_sql_input
     def setData(self, data, key=None):
@@ -560,15 +559,8 @@ class OWVennDiagram(widget.OWWidget):
         self._storeHints()
         return super().getSettings(self, *args, **kwargs)
 
-    def save_graph(self):
-        from Orange.widgets.data.owsave import OWSave
-
-        save_img = OWSave(data=self.scene,
-                          file_formats=FileFormat.img_writers)
-        save_img.exec_()
-
     def send_report(self):
-        self.report_plot(self.scene)
+        self.report_plot()
 
 
 def pairwise(iterable):


### PR DESCRIPTION
Alternative to #940, w.r.t. auto save: the file name is here shown as button text. This design is cleaner than an extra label.

Abusing this widget for saving graphs was a bad idea and did not really work. When reused for this purpose the widget showed Save As button that doesn't make sense, the widget didn't close but remained as a modal dialog after saving.

Save graph button in all widgets now opens the standard dialog for saving files, without detour to the modal `OWSave` with format selection and two buttons with the same function. This works on Linux, too, since it uses `getSaveFilenameAndFilter` function.

- `want_graph` is replaced with `graph_name` that can contain the name of the attribute with the graph (e.g. `plot.plotItem`). This attribute is used for both, saving and reports.
- If `graph_name` is specified, `OWWidget` adds the button to the layout (as before), but now also connects the (new) method `OWWidget.save_graph`. Widget therefore no longer need to connect the button.
- `save_graph` is eliminated in all widgets, except for tree viewer; the implementation in `OWWidget` reads `want_graph` to obtain the graph objects.
- `report_plot` no longer requires the graph object since it is read from `graph_name`
- the layout of Save Graph and Report buttons is improved: now they are both in the same box
- the function for saving graphs remembers the last used directory and file format.

If the extension does not match the format (not possible on Os X), user is prompted to change the extension or the format.

The same dialog is now also used in OWSave.

In summary, this removes all code for saving graphs from widgets; widgets only need to specify the name of the attribute with the graph.
