### PR TITLE
FilterString: Fix is_defined filtering

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -369,7 +369,8 @@ class FileFormat(metaclass=FileFormatMeta):
 
             if type_flag in StringVariable.TYPE_HEADERS:
                 coltype = StringVariable
-
+                values = [None if isinstance(i, float)
+                          else i for i in orig_values]
             elif type_flag in ContinuousVariable.TYPE_HEADERS:
                 coltype = ContinuousVariable
                 try:

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -352,9 +352,12 @@ class FileFormat(metaclass=FileFormatMeta):
             flag = Flags(Flags.split(flags[col]))
             if flag.i: continue
 
+            type_flag = types and types[col].strip()
             try:
-                orig_values = [np.nan if i.strip() in MISSING_VALUES else i.strip()
-                               for i in data[:, col]]
+                orig_values = [np.nan if i.strip() in MISSING_VALUES and
+                                         type_flag not in
+                                         StringVariable.TYPE_HEADERS
+                               else i.strip() for i in data[:, col]]
             except IndexError:
                 # No data instances leads here
                 orig_values = []
@@ -362,15 +365,12 @@ class FileFormat(metaclass=FileFormatMeta):
                 # only to satisfy test_table.TableTestCase.test_append
                 coltype = DiscreteVariable
 
-            type_flag = types and types[col].strip()
             coltype_kwargs = {}
             valuemap = []
             values = orig_values
 
             if type_flag in StringVariable.TYPE_HEADERS:
                 coltype = StringVariable
-                values = [None if isinstance(i, float)
-                          else i for i in orig_values]
             elif type_flag in ContinuousVariable.TYPE_HEADERS:
                 coltype = ContinuousVariable
                 try:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1144,9 +1144,9 @@ class Table(MutableSequence, Storage):
             elif isinstance(f, data_filter.FilterString) and \
                             f.oper == f.IsDefined:
                 if conjunction:
-                    sel *= (col != "")
+                    sel *= col.astype(bool)
                 else:
-                    sel += (col != "")
+                    sel += col.astype(bool)
             elif isinstance(f, data_filter.FilterDiscrete):
                 if conjunction:
                     s2 = np.zeros(len(self), dtype=bool)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -775,11 +775,11 @@ class StringVariable(Variable):
     @staticmethod
     def str_val(val):
         """Return a string representation of the value."""
-        if isinstance(val, Real) and isnan(val):
+        if val is None:
             return "?"
         if isinstance(val, Value):
             if val.value is None:
-                return "None"
+                return "?"
             val = val.value
         return str(val)
 

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -775,10 +775,10 @@ class StringVariable(Variable):
     @staticmethod
     def str_val(val):
         """Return a string representation of the value."""
-        if val is None:
+        if val is "":
             return "?"
         if isinstance(val, Value):
-            if val.value is None:
+            if val.value is "":
                 return "?"
             val = val.value
         return str(val)

--- a/Orange/tests/test9.tab
+++ b/Orange/tests/test9.tab
@@ -1,1 +1,1 @@
-a	b	c	d	e	f	gd	d	d	d	string	d	string		meta	meta	meta	meta	meta1	1	1	1	1	1	11	2	2	1	2	1	11	3	3	1	3	1	huh1	4	4	2	4	hey	hoy2	5	5	2	5	2	22	6	6	2	6	2	22	7	7	3	7	3	oh yeah2	8	8	3	8	3	3
+a	b	c	d	e	f	gd	d	d	d	string	d	string		meta	meta	meta	meta	meta1	1	1	1	1	1	11	2	2	1	2	1	11	3	3	1	3	1	huh1	4	4	2	4	hey	hoy2	5	5	2	5	22	6	6	2	6	2	22	7	7	3	7	3	oh yeah2	8	8	3	8	3	3

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -973,6 +973,12 @@ class TableTestCase(unittest.TestCase):
         d[:5, v.hair] = Unknown
         self.assertEqual(len(filter.Values([f])(d)), len(d) - 5)
 
+    def test_valueFilter_string_is_defined(self):
+        d = data.Table("test9.tab")
+        f = filter.FilterString(-5, filter.FilterString.IsDefined)
+        x = filter.Values([f])(d)
+        self.assertEqual(len(x), 7)
+
     def test_valueFilter_string_case_sens(self):
         d = data.Table("zoo")
         col = d[:, "name"].metas[:, 0]

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -237,8 +237,8 @@ class StringVariableTest(VariableTest):
     def test_val(self):
         a = StringVariable("a")
         self.assertEqual(a.to_val(None), "")
-        self.assertEqual(a.str_val(None), "?")
-        self.assertEqual(a.str_val(Value(a, None)), "?")
+        self.assertEqual(a.str_val(""), "?")
+        self.assertEqual(a.str_val(Value(a, "")), "?")
         self.assertEqual(a.repr_val(Value(a, "foo")), '"foo"')
 
 

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -237,9 +237,8 @@ class StringVariableTest(VariableTest):
     def test_val(self):
         a = StringVariable("a")
         self.assertEqual(a.to_val(None), "")
-
-        self.assertEqual(a.str_val(Unknown), "?")
-        self.assertEqual(a.str_val(Value(a, None)), "None")
+        self.assertEqual(a.str_val(None), "?")
+        self.assertEqual(a.str_val(Value(a, None)), "?")
         self.assertEqual(a.repr_val(Value(a, "foo")), '"foo"')
 
 

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -1,0 +1,18 @@
+import unittest
+from collections import defaultdict
+from Orange.data import Table
+from Orange.widgets.data.owmergedata import group_table_indices
+
+
+class MergeDataTest(unittest.TestCase):
+    def test_group_table_indices(self):
+        table = Table("../../../tests/test9.tab")
+        dd = defaultdict(list)
+        dd[("1",)] = [0, 1]
+        dd[("huh",)] = [2]
+        dd[("hoy",)] = [3]
+        dd[("?",)] = [4]
+        dd[("2",)] = [5]
+        dd[("oh yeah",)] = [6]
+        dd[("3",)] = [7]
+        self.assertEqual(dd, group_table_indices(table, ["g"]))

--- a/Orange/widgets/tests/test_io.py
+++ b/Orange/widgets/tests/test_io.py
@@ -1,0 +1,21 @@
+import unittest
+import os
+from Orange.data import Table
+from Orange.data.io import CSVFormat
+
+
+class IOFileFormatTest(unittest.TestCase):
+    CSV_FILE = "test_format.csv"
+
+    def tearDown(self):
+        os.remove(self.CSV_FILE)
+
+    def test_csv_format_missing_values(self):
+        f = CSVFormat()
+        data = Table("../../tests/test9.tab")
+        self.assertTrue(any([x is None for instance in
+                             data.metas for x in instance]))
+        f.write_file(self.CSV_FILE, data)
+        new_data = f.read_file(self.CSV_FILE)
+        for new_instance, old_instance in zip(new_data, data):
+            self.assertEqual(new_instance, old_instance)

--- a/Orange/widgets/tests/test_io.py
+++ b/Orange/widgets/tests/test_io.py
@@ -13,7 +13,7 @@ class IOFileFormatTest(unittest.TestCase):
     def test_csv_format_missing_values(self):
         f = CSVFormat()
         data = Table("../../tests/test9.tab")
-        self.assertTrue(any([x is None for instance in
+        self.assertTrue(any([x is "" for instance in
                              data.metas for x in instance]))
         f.write_file(self.CSV_FILE, data)
         new_data = f.read_file(self.CSV_FILE)

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -37,6 +37,16 @@ class TestOWVennDiagram(unittest.TestCase):
         np.testing.assert_equal(data.metas, np.array([[ca, cb, item_id]],
                                                      dtype=object))
 
+    def test_reshape_wide_missing_vals(self):
+        data = Table("../../../tests/test9.tab")
+        reshaped_data = reshape_wide(data, [], [data.domain[0]],
+                                     [data.domain[0]])
+        self.assertEqual(2, len(reshaped_data))
+
+    def test_varying_between_missing_vals(self):
+        data = Table("../../../tests/test9.tab")
+        self.assertEqual(6, len(varying_between(data, [data.domain[0]])))
+
     def test_venn_diagram(self):
         sources = ["SVM Learner", "Naive Bayes", "Random Forest"]
         item_id_var = StringVariable("item_id")


### PR DESCRIPTION
IsDefined filtering did not work because String missing values were represented as np.nan.
Now String missing values are represented as None.