### PR TITLE
Classification and regression widgets: Put Report button at better position

### DIFF
--- a/Orange/widgets/classify/owknn.py
+++ b/Orange/widgets/classify/owknn.py
@@ -40,6 +40,7 @@ class OWKNNLearner(OWProvidesLearner, widget.OWWidget):
 
         gui.button(self.controlArea, self, "Apply",
                    callback=self.apply, default=True)
+        self.controlArea.layout().addWidget(self.report_button)
 
         self.apply()
 

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -66,8 +66,10 @@ class OWLogisticRegression(OWProvidesLearner, widget.OWWidget):
         box2 = gui.widgetBox(box, orientation="horizontal")
         box2.layout().setAlignment(Qt.AlignCenter)
         self.c_label = gui.widgetLabel(box2)
-        gui.button(self.controlArea, self, "&Apply",
-                   callback=self.apply, default=True)
+        box = gui.widgetBox(self.controlArea, orientation="horizontal",
+                            margin=0)
+        box.layout().addWidget(self.report_button)
+        gui.button(box, self, "&Apply", callback=self.apply, default=True)
         self.set_c()
         self.apply()
 

--- a/Orange/widgets/classify/owmajority.py
+++ b/Orange/widgets/classify/owmajority.py
@@ -33,6 +33,7 @@ class OWMajority(OWProvidesLearner, widget.OWWidget):
         )
         gui.button(self.controlArea, self, "Apply", callback=self.apply,
                    default=True)
+        self.controlArea.layout().addWidget(self.report_button)
 
         self.apply()
 

--- a/Orange/widgets/classify/ownaivebayes.py
+++ b/Orange/widgets/classify/ownaivebayes.py
@@ -33,6 +33,7 @@ class OWNaiveBayes(OWProvidesLearner, widget.OWWidget):
 
         gui.button(self.controlArea, self, self.tr("&Apply"),
                    callback=self.apply)
+        self.controlArea.layout().addWidget(self.report_button)
 
         self.data = None
         self.preprocessors = None

--- a/Orange/widgets/regression/owknnregression.py
+++ b/Orange/widgets/regression/owknnregression.py
@@ -51,6 +51,7 @@ class OWKNNRegression(OWProvidesLearner, widget.OWWidget):
 
         gui.button(self.controlArea, self, "Apply",
                    callback=self.apply, default=True)
+        self.controlArea.layout().addWidget(self.report_button)
 
         layout = self.layout()
         self.layout().setSizeConstraint(layout.SetFixedSize)

--- a/Orange/widgets/regression/owmean.py
+++ b/Orange/widgets/regression/owmean.py
@@ -29,8 +29,9 @@ class OWMean(OWProvidesLearner, widget.OWWidget):
 
         box = gui.widgetBox(self.controlArea, "Learner Name")
         gui.lineEdit(box, self, "learner_name")
-        gui.button(self.controlArea, self, "Apply", callback=self.apply,
-                   default=True)
+        gui.button(self.controlArea, self, "Apply",
+                   callback=self.apply, default=True)
+        self.controlArea.layout().addWidget(self.report_button)
         self.apply()
 
     def set_data(self, data):


### PR DESCRIPTION
Report button was under Apply, but slightly wider.

Blocked by #951: before merging, check whether #951 solves the problem. In this case, we keep only the changes where Report is put beside Apply since the widget is wide enough for that.