### PR TITLE
OWSaveClassifier: append .pickle extension if not already provided

### DIFF
--- a/Orange/widgets/classify/owloadclassifier.py
+++ b/Orange/widgets/classify/owloadclassifier.py
@@ -7,6 +7,8 @@ from Orange.base import Model
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
 
+from Orange.widgets.classify import owsaveclassifier
+
 
 class OWLoadClassifier(widget.OWWidget):
     name = "Load Classifier"
@@ -21,7 +23,7 @@ class OWLoadClassifier(widget.OWWidget):
     #: Current (last selected) filename or None.
     filename = Setting(None)
 
-    FILTER = "Pickle files (*.pickle *.pck)\nAll files (*.*)"
+    FILTER = owsaveclassifier.OWSaveClassifier.FILTER
 
     want_main_area = False
     resizing_enabled = False

--- a/Orange/widgets/classify/owsaveclassifier.py
+++ b/Orange/widgets/classify/owsaveclassifier.py
@@ -22,7 +22,9 @@ class OWSaveClassifier(widget.OWWidget):
     #: A list of recent filenames.
     history = Setting([])
 
-    FILTER = "Pickle files (*.pickle *.pck)\nAll files (*.*)"
+
+    FILE_EXT = '.pkcls'
+    FILTER = "Pickled classifier (*" + FILE_EXT + ");;All Files (*)"
 
     want_main_area = False
     resizing_enabled = False
@@ -111,6 +113,8 @@ class OWSaveClassifier(widget.OWWidget):
             self, self.tr("Save"), directory=startdir, filter=self.FILTER
         )
         if filename:
+            if not filename.endswith(self.FILE_EXT):
+                filename += self.FILE_EXT
             if self.model is not None:
                 self.save(filename)
             else:


### PR DESCRIPTION
Fixes:
http://stackoverflow.com/questions/34489451/orange3-save-classifier-widget