### PR TITLE
Bolder colors for both Distributions graph and legend

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -349,7 +349,7 @@ class OWDistributions(widget.OWWidget):
 
         cvar_values = cvar.values
         palette = colorpalette.ColorPaletteGenerator(len(cvar_values))
-        colors = [palette[i].lighter() for i in range(len(cvar_values))]
+        colors = [palette[i] for i in range(len(cvar_values))]
 
         if var and var.is_continuous:
             bottomaxis.setTicks(None)


### PR DESCRIPTION
See task #231. @BlazZupan Check if this is what you had in mind. Legend now takes argument from overall color palette, but we might want to separate args for legend and plot.