### PR TITLE
Distributions: both plot and legend colors made bolder.

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -377,7 +377,7 @@ class OWDistributions(widget.OWWidget):
         bottomaxis.resizeEvent()
 
         cvar_values = cvar.values
-        colors = [QtGui.QColor(*col).lighter() for col in cvar.colors]
+        colors = [QtGui.QColor(*col) for col in cvar.colors]
 
         if var and var.is_continuous:
             bottomaxis.setTicks(None)


### PR DESCRIPTION
Task no231. @BlazZupan Check if this is what you had in mind. Legend now takes argument from overall color palette, but we might want to separate args for legend and plot.