### PR TITLE
SqlTable: Improved approx_len handling in Data Table

### DIFF
--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -225,8 +225,11 @@ class SqlTable(table.Table):
     def _fetch_row(self, row_index):
         attributes = self.domain.variables + self.domain.metas
         rows = [row_index]
-        values = list(self._query(attributes, rows=rows))[0]
-        return SqlRowInstance(self.domain, values)
+        values = list(self._query(attributes, rows=rows))
+        if not values:
+            raise IndexError('Could not retrieve row {} from table {}'.format(
+                row_index, self.name))
+        return SqlRowInstance(self.domain, values[0])
 
     def __iter__(self):
         """ Iterating through the rows executes the query using a cursor and

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -694,6 +694,9 @@ class SqlTable(table.Table):
 
         sampled_table = self.copy()
         sampled_table.table_name = self.quote_identifier(sample_table)
+        with sampled_table._execute_sql_query(
+                'ANALYZE {}'.format(sampled_table.table_name)):
+            pass
         return sampled_table
 
     @contextmanager

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -105,6 +105,11 @@ class SqlTableTests(PostgresTest):
 
         self.assertEqual(len(results), 150)
 
+    def test_unavailable_row(self):
+        table = sql_table.SqlTable(self.conn, self.iris)
+        with self.assertRaises(IndexError):
+            table[151]
+
     def test_query_subset_of_attributes(self):
         table = sql_table.SqlTable(self.conn, self.iris)
         attributes = [

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -28,7 +28,6 @@ from Orange.widgets import widget, gui
 from Orange.widgets.settings import (Setting, ContextSetting,
                                      DomainContextHandler)
 from Orange.widgets.utils import datacaching
-from Orange.widgets.utils import itemmodels
 from Orange.widgets.utils.itemmodels import TableModel
 
 
@@ -60,7 +59,7 @@ class RichTableDecorator(QIdentityProxyModel):
 
     def setSourceModel(self, source):
         if source is not None and \
-                not isinstance(source, itemmodels.TableModel):
+                not isinstance(source, TableModel):
             raise TypeError()
 
         if source is not None:

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -827,7 +827,7 @@ class TableModel(QAbstractTableModel):
         else:
             return False
 
-    def parent(self, index):
+    def parent(self, index=QModelIndex()):
         """Reimplemented from `QAbstractTableModel.parent`."""
         return QModelIndex()
 

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -788,7 +788,15 @@ class TableModel(QAbstractTableModel):
         if self.__sortInd is not None:
             row = self.__sortInd[row]
 
-        instance = self._row_instance(row)
+        try:
+            instance = self._row_instance(row)
+        except IndexError:
+            self.layoutAboutToBeChanged.emit()
+            self.beginRemoveRows(self.parent(), row, max(self.rowCount(), row))
+            self.__rowCount = min(row, self.__rowCount)
+            self.endRemoveRows()
+            self.layoutChanged.emit()
+            return None
         coldesc = self.columns[col]
 
         if role == _Qt_DisplayRole:


### PR DESCRIPTION
Fixes bug where Data Table widget crashed with IndexError when trying to display nonexistent rows (expected because of approximate size)

Various improvements described in individual commits.