### PR TITLE
extensions: Change how ctypes 'extensions' are located/loaded

### DIFF
--- a/Orange/classification/simple_tree.py
+++ b/Orange/classification/simple_tree.py
@@ -1,5 +1,3 @@
-import os
-import sysconfig
 import ctypes as ct
 
 import numpy as np
@@ -7,10 +5,8 @@ from Orange.base import Learner, Model
 
 __all__ = ['SimpleTreeLearner']
 
-path = os.path.dirname(os.path.abspath(__file__))
-
-_tree = ct.pydll.LoadLibrary(
-    os.path.join(path, "_simple_tree" + sysconfig.get_config_var("SO")))
+from . import _simple_tree
+_tree = ct.pydll.LoadLibrary(_simple_tree.__file__)
 
 DiscreteNode = 0
 ContinuousNode = 1

--- a/Orange/widgets/utils/classdensity.py
+++ b/Orange/widgets/utils/classdensity.py
@@ -1,15 +1,15 @@
-import os
 import ctypes
-import sysconfig
 import numpy as np
 
 from PyQt4.QtCore import QRectF
 from pyqtgraph.graphicsItems.ImageItem import ImageItem
 
 
-# load C++ library
-path = os.path.dirname(os.path.abspath(__file__))
-lib = ctypes.pydll.LoadLibrary(os.path.join(path, "_grid_density" + sysconfig.get_config_var("SO")))
+# load the C++ library; The _grid_density is build and distributed as a
+# python extension but does not export any python objects (apart from PyInit),
+from . import _grid_density
+lib = ctypes.pydll.LoadLibrary(_grid_density.__file__)
+
 
 # compute the color/class density image
 def class_density_image(min_x, max_x, min_y, max_y, resolution, x_data, y_data, rgb_data):


### PR DESCRIPTION
In Python 3.5 windows extension modules (.pyd) are ABI tagged, but
`sysconfig.get_config_var("EXT_SUFFIX"), contains the untaged suffix.

Import the actual stub modules and use the module's `__file__`
attribute to locate the library.