### PR TITLE
ImgFormat: Use sceneRect instead of itemsBoundingRect

### DIFF
--- a/Orange/widgets/io.py
+++ b/Orange/widgets/io.py
@@ -39,7 +39,7 @@ class ImgFormat(FileFormat):
             exporter = cls._get_exporter()
             cls._export(exporter(scene), filename)
         except:
-            source = scene.itemsBoundingRect().adjusted(-15, -15, 15, 15)
+            source = scene.sceneRect().adjusted(-15, -15, 15, 15)
             buffer = cls._get_buffer(source.size(), filename)
 
             painter = QtGui.QPainter()


### PR DESCRIPTION
Some widgets (i.e. BoxPlot) resize sceneRect (usually make it smaller than itemsBoundingRect).
Therefore, when saving an image or showing it in report, an image with to much empty space is produced.