### PR TITLE
canvas/addons: Fix an error when PyPi package meta data is empty

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -597,16 +597,19 @@ def list_pypi_addons():
     packages = []
 
     for release, urls in zip(release_data, release_urls):
-        urls = [ReleaseUrl(url["filename"], url["url"],
-                           url["size"], url["python_version"],
-                           url["packagetype"])
-                for url in urls]
-        packages.append(
-            Installable(release["name"], release["version"],
-                        release["summary"], release["description"],
-                        release["package_url"],
-                        urls)
-        )
+        if release and urls:
+            # ignore releases without actual source/wheel/egg files,
+            # or with empty metadata (deleted from PyPi?).
+            urls = [ReleaseUrl(url["filename"], url["url"],
+                               url["size"], url["python_version"],
+                               url["packagetype"])
+                    for url in urls]
+            packages.append(
+                Installable(release["name"], release["version"],
+                            release["summary"], release["description"],
+                            release["package_url"],
+                            urls)
+            )
 
     return packages
 


### PR DESCRIPTION
Fixes  #966