### PR TITLE
canvas: add noop paintEvent() to DockableWindow => fix QPainter wall-of-text error

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -136,6 +136,18 @@ class DockableWindow(QDockWidget):
             if self.isFloating():
                 self.__fixWindowFlags()
 
+    def paintEvent(self, event):
+        # HACK: Preventing calls to QDockWidget.paintEvent() seems to fix the
+        #
+        #     QPainter::begin: Paint device returned engine == 0, type: 3
+        #     QPainter...
+        #
+        # wall-of-text error that filled the buffers of our consoles.
+        #
+        # Without understanding reasons or implications, but with
+        # no immediate apparent negative side effects:
+        pass
+
     def floatingWindowFlags(self):
         """
         Return the `windowFlags` used when the widget is floating.


### PR DESCRIPTION
Don't know if anyone else experienced it, but I did and it is pretty obnoxious to have had to scroll hundreds of lines in the console whenever the "red window" gained or lost focus to see the just-appeared traceback again.

    QPainter::begin: Paint device returned engine == 0, type: 3
    QPainter::save: Painter not active
    QPainter::setPen: Painter not active
    QPainter::setBrush: Painter not active
    QPainter::setRenderHint: Painter must be active to set rendering hints
    QPainter::setRenderHint: Painter must be active to set rendering hints
    QPainter::brush: Painter not active
    QPainter::setBrush: Painter not active
    QPainter::pen: Painter not active
    QPainter::pen: Painter not active
    QPainter::setPen: Painter not active
    ...
    (600 more lines)

Unsure if the "solution" is right, but it does seem to work. Also the red window seems to paint correctly after it looses focus and is put into background, so the traceback output in it remains visible. Again, it may be a problem only on Linux and under some configurations, but if it works for you, I'd appreciate this (or a similar fix) merged eventually. :boat: 