### PR TITLE
travis: Use master branch of orange-requirements.

### DIFF
--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,6 +1,6 @@
 pip install -U setuptools pip wheel
 if [ ! "$(ls wheelhouse)" ]; then
-    git clone -b pyqt --depth=1 https://github.com/astaric/orange3-requirements wheelhouse
+    git clone --depth=1 https://github.com/astaric/orange3-requirements wheelhouse
 else
     echo 'Using cached wheelhouse.';
 fi


### PR DESCRIPTION
Orange3-requirements are only used for scipy, everything else can be installed on travis, and cached using provided caching mechanisms.

After this pull request is merged, travis caches should be deleted and rebuilt.