### PR TITLE
[WIP] Orange.data.Domain: reworked iterating, indexing, member access

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -7,6 +7,8 @@ import weakref
 from .variable import *
 import numpy as np
 
+from Orange.util import deprecated
+
 
 class DomainConversion:
     """
@@ -445,14 +447,13 @@ class Domain:
             col_idx = self.index(attr)
         return [attr], np.array([col_idx])
 
+    @deprecated
     def checksum(self):
         return hash(self)
 
     def __eq__(self, other):
-        if not isinstance(other, Domain):
-            return False
-
-        return (self.attributes == other.attributes and
+        return (isinstance(other, Domain) and
+                self.attributes == other.attributes and
                 self.class_vars == other.class_vars and
                 self.metas == other.metas)
 

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -349,10 +349,22 @@ class Domain:
         """
         Return the index of the given variable (represented as
         `int`, `str`, or instance of :class:`Variable`) in the domain.
+
+        If `var` is an iterable of above values, then return three tuples:
+        indices in attributes, indices in class_vars, and indices in metas.
         """
         if isinstance(var, (int, np.integer)):
             return int(var)
         try:
+            if isinstance(var, Iterable):
+                vars = [self[val] for val in var]
+                Xind = tuple(self.attributes.index(v)
+                             for v in vars if v in self.attributes)
+                Yind = tuple(self.class_vars.index(v)
+                             for v in vars if v in self.class_vars)
+                Mind = tuple(self.metas.index(v)
+                             for v in vars if v in self.metas)
+                return Xind, Yind, Mind
             return self._indices[var]
         except KeyError:
             raise ValueError("Variable '{}' is not in domain".format(var))

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -187,7 +187,7 @@ class Domain:
         attr_vars = [ContinuousVariable(name=get_name("Feature", a, places))
                      for a in range(n_attrs)]
         class_vars = []
-        if Y is not None:
+        if Y is not None and Y.size:
             if Y.ndim == 1:
                 Y = Y.reshape(len(Y), 1)
             elif Y.ndim != 2:
@@ -195,14 +195,14 @@ class Domain:
             n_classes = Y.shape[1]
             places = get_places(n_classes)
             for i, values in enumerate(Y.T):
-                if set(values) == {0, 1}:
+                values = is_discrete_values(values)
+                if values:
                     name = get_name('Class', i, places)
-                    values = ['v1', 'v2']
-                    class_vars.append(DiscreteVariable(name, values))
+                    class_vars.append(DiscreteVariable(name, sorted(values)))
                 else:
                     name = get_name('Target', i + 1, places)
                     class_vars.append(ContinuousVariable(name))
-        if metas is not None:
+        if metas is not None and metas.size:
             n_metas = metas.shape[1]
             places = get_places(n_metas)
             meta_vars = [StringVariable(get_name("Meta", m, places))

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -193,8 +193,8 @@ class Domain:
         return self._metas
 
     def __len__(self):
-        """The number of variables (features and class attributes)."""
-        return len(self._variables)
+        """The number of variables in the domain."""
+        return len(self.attributes) + len(self.class_vars) + len(self.metas)
 
     def __getitem__(self, idx):
         """
@@ -224,10 +224,8 @@ class Domain:
         return item in self._indices
 
     def __iter__(self):
-        """
-        Return an iterator through variables (features and class attributes).
-        """
-        return iter(self._variables)
+        """Return an iterator through all variables in the domain."""
+        return chain(self.attributes, self.class_vars, self.metas)
 
     def __str__(self):
         """

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -217,7 +217,7 @@ class Domain:
             The (Domain of) variable(s) corresponding to index(es) `idx`.
         """
         try:
-            if isinstance(idx, int):
+            if isinstance(idx, (int, np.integer)):
                 if idx < 0:
                     idx += len(self)
                 which = idx
@@ -305,8 +305,8 @@ class Domain:
         Return the index of the given variable (represented as
         `int`, `str`, or instance of :class:`Variable`) in the domain.
         """
-        if isinstance(var, int):
-            return var
+        if isinstance(var, (int, np.integer)):
+            return int(var)
         try:
             return self._indices[var]
         except KeyError:
@@ -376,15 +376,16 @@ class Domain:
                 return inst._x, inst._y, inst._metas
             c = self.get_conversion(inst.domain)
             l = len(inst.domain.attributes)
+            lc = len(inst.domain.class_vars)
             values = [(inst._x[i] if 0 <= i < l
-                       else inst._y[i - l] if i >= l
-                       else inst._metas[-i - 1])
+                       else inst._y[i - l] if l <= i < l + lc
+                       else inst._metas[i - l - lc])
                       if isinstance(i, int)
                       else (Unknown if not i else i(inst))
                       for i in c.variables]
             metas = [(inst._x[i] if 0 <= i < l
-                      else inst._y[i - l] if i >= l
-                      else inst._metas[-i - 1])
+                      else inst._y[i - l] if l <= i < l + lc
+                      else inst._metas[i - l - lc])
                      if isinstance(i, int)
                      else (Unknown if not i else i(inst))
                      for i in c.metas]

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -113,7 +113,6 @@ class Domain:
         self._indices = dict(chain.from_iterable(
             ((var, i), (var.name, i)) for i, var in enumerate(self)))
 
-        self.anonymous = False
         self._known_domains = weakref.WeakKeyDictionary()
         self._last_conversion = None
 
@@ -128,8 +127,6 @@ class Domain:
         "Feature <n>". Target variables are discrete if the only two values
         are 0 and 1; otherwise they are continuous. Discrete
         targets are named "Class <n>" and continuous are named "Target <n>".
-        Domain is marked as :attr:`anonymous`, so data from any other domain of
-        the same shape can be converted into this one and vice-versa.
 
         :param `numpy.ndarray` X: 2-dimensional array with data
         :param Y: 1- of 2- dimensional data for target
@@ -177,7 +174,6 @@ class Domain:
             meta_vars = []
 
         domain = cls(attr_vars, class_vars, meta_vars)
-        domain.anonymous = True
         return domain
 
     @property

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -1,3 +1,4 @@
+import re
 import logging
 from math import log
 from collections import Iterable
@@ -12,6 +13,10 @@ from Orange.util import deprecated
 
 
 LOG = logging.getLogger()
+
+
+def _normcase(str, replace_special=re.compile(r'[^\w]+').sub):
+    return replace_special('_', str).lower()
 
 
 class DomainConversion:
@@ -143,6 +148,12 @@ class Domain:
 
         self._indices = dict(chain.from_iterable(
             ((var, i), (var.name, i)) for i, var in enumerate(self)))
+
+        # Allow attribute-like access to variables in the domain
+        for var in self:
+            name = _normcase(var.name)
+            if not hasattr(self, name):
+                setattr(self, name, var)
 
         self._known_domains = weakref.WeakKeyDictionary()
         self._last_conversion = None

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -346,32 +346,28 @@ class Domain:
         except KeyError:
             raise ValueError("Variable '{}' is not in domain".format(var))
 
-    def has_discrete_attributes(self, include_class=False):
-        """
-        Return `True` if domain has any discrete attributes. If `include_class`
-                is set, the check includes the class attribute(s).
-        """
-        if not include_class:
-            return any(var.is_discrete for var in self.attributes)
-        else:
-            return any(var.is_discrete for var in self.variables)
+    @property
+    def has_discrete(self):
+        """Return `True` if domain has any discrete attributes."""
+        return any(var.is_discrete for var in self.attributes)
 
-    def has_continuous_attributes(self, include_class=False):
-        """
-        Return `True` if domain has any continuous attributes. If
-        `include_class` is set, the check includes the class attribute(s).
-        """
-        if not include_class:
-            return any(var.is_continuous for var in self.attributes)
-        else:
-            return any(var.is_continuous for var in self.variables)
+    @property
+    def has_continuous(self):
+        """Return `True` if domain has any continuous attributes."""
+        return any(var.is_continuous for var in self.attributes)
 
     @property
     def has_continuous_class(self):
+        """
+        Returrn `True` if the first class variable of domain is continuous.
+        """
         return bool(self.class_var and self.class_var.is_continuous)
 
     @property
     def has_discrete_class(self):
+        """
+        Returrn `True` if the first class variable of domain is discrete.
+        """
         return bool(self.class_var and self.class_var.is_discrete)
 
     def get_conversion(self, source):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -307,13 +307,13 @@ class Variable(metaclass=VariableMeta):
         for cls in Variable.registry.values():
             cls._clear_cache()
 
-    @classmethod
-    def is_primitive(cls):
+    @property
+    def is_primitive(self):
         """
         `True` if the variable's values are stored as floats.
         Non-primitive variables can appear in the data only as meta attributes.
         """
-        return issubclass(cls, (DiscreteVariable, ContinuousVariable))
+        return isinstance(self, (DiscreteVariable, ContinuousVariable))
 
     @property
     def is_discrete(self):

--- a/Orange/statistics/basic_stats.py
+++ b/Orange/statistics/basic_stats.py
@@ -46,7 +46,5 @@ class DomainBasicStats:
         """
         if not isinstance(index, int):
             index = self.domain.index(index)
-        if index < 0:
-            index = len(self.domain) + (-1 - index)
         return self.stats[index]
 

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -479,5 +479,5 @@ class SqlTableTests(PostgresTest):
 
     def assertFirstMetaIsInstance(self, table, variable_type):
         self.assertGreater(len(table.domain.metas), 0)
-        attr = table.domain[-1]
+        attr = table.domain.metas[0]
         self.assertIsInstance(attr, variable_type)

--- a/Orange/tests/test_contingency.py
+++ b/Orange/tests/test_contingency.py
@@ -239,7 +239,7 @@ class Discrete_Test(unittest.TestCase):
 
     def test_compute_contingency_metas(self):
         d = data.Table("test9.tab")
-        var1, var2 = d.domain[-2], d.domain[-4]
+        var1, var2 = d.domain.metas[1], d.domain.metas[3]
         cont, _ = d._compute_contingency([var1], var2)[0][0]
         np.testing.assert_almost_equal(cont, [[3, 0, 0], [0, 2, 0],
                                               [0, 0, 2], [0, 1, 0]])

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -446,7 +446,7 @@ class Domain_Distribution_Test(unittest.TestCase):
 
     def test_compute_distributions_metas(self):
         d = data.Table("test9.tab")
-        variable = d.domain[-2]
+        variable = d.domain.metas[1]
         dist, _ = d._compute_distributions([variable])[0]
         np.testing.assert_almost_equal(dist, [3, 3, 2])
 

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -217,9 +217,11 @@ class TestDomainInit(unittest.TestCase):
 
         self.assertEqual(d[ssn], ssn)
         self.assertEqual(d["SSN"], ssn)
-        self.assertEqual(d[-1], ssn)
+        self.assertEqual(d[-2], ssn)
+        self.assertEqual(d[3], ssn)
 
-        self.assertEqual(d[-2], race)
+        self.assertEqual(d[4], race)
+        self.assertEqual(d[-1], race)
 
     def test_index(self):
         d = Domain((age, gender, income), metas=(ssn, race))

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -305,14 +305,8 @@ class TestDomainInit(unittest.TestCase):
             [] in d
 
     def test_iter(self):
-        d = Domain((age, gender, income), metas=(ssn,))
-        self.assertEqual([var for var in d], [age, gender, income])
-
-        d = Domain((age, ), metas=(ssn,))
-        self.assertEqual([var for var in d], [age])
-
-        d = Domain((), metas=(ssn,))
-        self.assertEqual([var for var in d], [])
+        d = Domain((age, gender), (income,), metas=(ssn,))
+        self.assertEqual([var for var in d], [age, gender, income, ssn])
 
     def test_str(self):
         cases = (

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -227,7 +227,7 @@ class TestInstance(unittest.TestCase):
         l = inst.list
         self.assertIsInstance(l, list)
         self.assertEqual(l, [42, "M", "B", "X", 43, "Foo"])
-        self.assertGreater(len(l), len(inst))
+        self.assertEqual(len(l), len(inst))
         self.assertEqual(len(l), 6)
 
     def test_set_item(self):
@@ -260,12 +260,12 @@ class TestInstance(unittest.TestCase):
         inst[domain.class_var] = "B"
         self.assertEqual(inst[2], "B")
 
-        inst[-1] = "Y"
-        self.assertEqual(inst[-1], "Y")
+        inst[-3] = "Y"
+        self.assertEqual(inst[-3], "Y")
         inst["Meta 1"] = "Z"
-        self.assertEqual(inst[-1], "Z")
+        self.assertEqual(inst[-3], "Z")
         inst[domain.metas[0]] = "X"
-        self.assertEqual(inst[-1], "X")
+        self.assertEqual(inst[-3], "X")
 
     def test_str(self):
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")])
@@ -339,7 +339,7 @@ class TestInstance(unittest.TestCase):
         self.assertFalse(inst == inst2)
 
         inst2 = Instance(domain, vals)
-        inst2[-1] = "Y"
+        inst2[-3] = "Y"
         self.assertFalse(inst == inst2)
 
         inst2 = Instance(domain, vals)
@@ -347,7 +347,7 @@ class TestInstance(unittest.TestCase):
         self.assertFalse(inst == inst2)
 
         inst2 = Instance(domain, vals)
-        inst2[-3] = "Bar"
+        inst2[-1] = "Bar"
         self.assertFalse(inst == inst2)
 
     def test_instance_id(self):

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -116,7 +116,7 @@ class TestTabReader(unittest.TestCase):
     def test_dataset_with_weird_names_and_column_attributes(self):
         data = Table(path.join(path.dirname(__file__), 'weird.tab'))
         self.assertEqual(len(data), 6)
-        self.assertEqual(len(data.domain), 1)
+        self.assertEqual(len(data.domain), 2)
         self.assertEqual(len(data.domain.metas), 1)
         NAME = ['5534fab7fad58d5df50061f1', '5534fab8fad58d5de20061f8']
         self.assertEqual(data.domain[0].name, str(NAME))

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -572,7 +572,7 @@ class TableTestCase(unittest.TestCase):
         d = data.Table("test3")
         d.append([None] * 3)
         self.assertEqual(1, len(d))
-        self.assertTrue(all(isnan(i) for i in d[0]))
+        self.assertTrue(all(isnan(i) for i in d[0].x))
 
         d.append([42, "0", None])
         self.assertEqual(2, len(d))

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -619,7 +619,7 @@ class DomainContextHandler(ContextHandler):
                 attributes = encode(domain.attributes, False)
                 attributes.update(encode(domain.class_vars, True))
             else:
-                attributes = encode(domain, match == self.MATCH_VALUES_ALL)
+                attributes = encode(domain.variables, match == self.MATCH_VALUES_ALL)
         else:
             attributes = {}
 
@@ -638,7 +638,7 @@ class DomainContextHandler(ContextHandler):
         context.ordered_domain = []
         if self.has_ordinary_attributes:
             context.ordered_domain += [(attr.name, vartype(attr))
-                                       for attr in domain]
+                                       for attr in domain.variables]
         if self.has_meta_attributes:
             context.ordered_domain += [(attr.name, vartype(attr))
                                        for attr in domain.metas]


### PR DESCRIPTION
Summary of changes:
* `for var in data.domain` (`iter(domain)`) iterates over _all_ Variables in the domain, including meta variables. The are several arguments for this change:
  * String variables are also Variables. There are tickets about extending widgets' functionality to include meta features. Lots of widgets already use metas by `data.domain.variables + data.domain.metas` (40+ results in the codebase, excluding any `chain()` calls).
  * It is easy enough to filter out only the primitive variables with `... for var in data.domain if var.is_primitive` or apply just about any other condition.
  * `data.domain.variables` is still accessible and works as before (although it is deprecated as its utility is questionable and is yet to be assessed). 
  * This is consistent with `str()` of `Table` and `RowInstance` instances.
* Indexing and slicing is reworked. Most importantly, negative indexes no longer return metas but are just plain true Pythonic negative indexes, i.e. from the back. It works almost the same, except that the order of returned metas is reversed, e.g. in domain with three metas `domain[-1]` now is what `domain[-3]` was before. I doubt much code is relying on this.
* `Domain.anonymous` attribute is removed. It is used nowhere besides tests.
* `Domain.checksum()` is depreacted in favor of the equality operator.
* Some more basic `is_*`/`has_*` boolean members are converted to properties for consistency.
* Domain has a new constructor which acts mostly the same. The more significant of changes is that any non-primitive variables passed as `attributes` or `class_vars` are put into `metas` instead.

Please see individual commits.

It is expected for some tests to fail. I didn't want to touch tests or auxiliaries until the interface is agreed on.

Some relevant discussion: https://github.com/biolab/orange3-text/pull/23#discussion_r49006804