### PR TITLE
travis: Use Postgres 9.5.0

### DIFF
--- a/travis/install_postgres.sh
+++ b/travis/install_postgres.sh
@@ -1,4 +1,4 @@
-VERSION=9.5alpha1
+VERSION=9.5.0
 POSTGRES=$TRAVIS_BUILD_DIR/postgres/$VERSION
 
 if [ ! "$(ls $POSTGRES)" ]; then


### PR DESCRIPTION
Since Postgres 9.5.0 has been released, travis can use that instead of the alpha version.