### PR TITLE
domain: Index domain instead of domain.variables

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -385,7 +385,7 @@ class Domain:
             if col_idx.indices(s) == (0, s, 1):
                 return None, None
             else:
-                return (self.variables[col_idx],
+                return (self[col_idx],
                         np.arange(start, end, stride))
         elif isinstance(col_idx, Iterable) and not isinstance(col_idx, str):
             attributes = [self[col] for col in col_idx]

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -533,7 +533,7 @@ class SqlTable(table.Table):
     def _filter_is_defined(self, columns=None, negate=False):
         if columns is None:
             columns = range(len(self.domain.variables))
-        columns = [self.domain.variables[i].to_sql() for i in columns]
+        columns = [self.domain[i].to_sql() for i in columns]
 
         t2 = self.copy()
         t2.row_filters += (sql_filter.IsDefinedSql(columns, negate),)

--- a/Orange/projection/cur.py
+++ b/Orange/projection/cur.py
@@ -127,7 +127,7 @@ class CURModel(Projection):
 
         if axis == 0:
             def cur_variable(i):
-                var = data.domain.variables[i]
+                var = data.domain[i]
                 return var.copy(compute_value=Projector(self, i))
 
             domain = Orange.data.Domain(

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -17,7 +17,7 @@ class TestEqualFreq(TestCase):
         X = np.array(s).reshape((100, 1))
         table = data.Table(X)
         disc = discretize.EqualFreq(n=4)
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 2)
         self.assertEqual(dvar.compute_value.points, [0.5])
 
@@ -25,7 +25,7 @@ class TestEqualFreq(TestCase):
         X = np.arange(100).reshape((100, 1))
         table = data.Table(X)
         disc = discretize.EqualFreq(n=4)
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 4)
         self.assertEqual(dvar.compute_value.points, [24.5, 49.5, 74.5])
 
@@ -33,7 +33,7 @@ class TestEqualFreq(TestCase):
         X = np.array([[1], [2], [3], [4]])
         table = data.Table(X)
         disc = discretize.EqualFreq(n=4)
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 4)
         self.assertEqual(dvar.compute_value.points, [1.5, 2.5, 3.5])
 
@@ -46,7 +46,7 @@ class TestEqualWidth(TestCase):
         X = np.array(s).reshape((100, 1))
         table = data.Table(X)
         disc = discretize.EqualWidth(n=4)
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 4)
         self.assertEqual(dvar.compute_value.points, [0.25, 0.5, 0.75])
 
@@ -54,7 +54,7 @@ class TestEqualWidth(TestCase):
         X = np.arange(101).reshape((101, 1))
         table = data.Table(X)
         disc = discretize.EqualWidth(n=4)
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 4)
         self.assertEqual(dvar.compute_value.points, [25, 50, 75])
 
@@ -62,7 +62,7 @@ class TestEqualWidth(TestCase):
         X = np.ones((100, 1))
         table = data.Table(X)
         disc = discretize.EqualFreq(n=4)
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 1)
         self.assertEqual(dvar.compute_value.points, [])
 
@@ -75,7 +75,7 @@ class TestEntropyMDL(TestCase):
         X = np.array(s).reshape((100, 1))
         table = data.Table(X, X)
         disc = discretize.EntropyMDL()
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 2)
         self.assertEqual(dvar.compute_value.points, [0.5])
 
@@ -84,7 +84,7 @@ class TestEntropyMDL(TestCase):
         Y = np.array([0] * 25 + [1] * 50 + [0] * 25)
         table = data.Table(X, Y)
         disc = discretize.EntropyMDL()
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 1)
         self.assertEqual(dvar.compute_value.points, [])
 
@@ -94,7 +94,7 @@ class TestEntropyMDL(TestCase):
                         [DiscreteVariable('c1', values=[1])])
         table = data.Table(domain, X, X)
         disc = discretize.EntropyMDL()
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 1)
         self.assertEqual(dvar.compute_value.points, [])
 
@@ -104,7 +104,7 @@ class TestEntropyMDL(TestCase):
         Y = np.array([0] * 25 + [1] * 75)
         table = data.Table(X, Y)
         disc = discretize.EntropyMDL()
-        dvar = disc(table, table.domain.variables[0])
+        dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 2)
         self.assertEqual(dvar.compute_value.points, [0.5])
 

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -26,7 +26,7 @@ class TestTabReader(unittest.TestCase):
         file = io.StringIO(simplefile)
         table = TabFormat().read_file(file)
 
-        f1, f2, c1, c2 = table.domain.variables
+        f1, f2, c1, c2 = table.domain
         self.assertIsInstance(f1, DiscreteVariable)
         self.assertEqual(f1.name, "Feature 1")
         self.assertIsInstance(f2, DiscreteVariable)

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -49,7 +49,7 @@ class TestTabReader(unittest.TestCase):
             file.close()
             table = CSVFormat().read_file(filename)
 
-            f1, f2, f3 = table.domain.variables
+            f1, f2, f3 = table.domain
             self.assertIsInstance(f1, DiscreteVariable)
             self.assertEqual(f1.name, name + "1")
             self.assertIsInstance(f2, ContinuousVariable)

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -39,11 +39,11 @@ class TestExcelHeader1(unittest.TestCase):
         domain = table.domain
         self.assertEqual(len(domain.metas), 0)
         self.assertEqual(len(domain.attributes), 4)
-        self.assertIsInstance(domain.variables[0], DiscreteVariable)
-        self.assertIsInstance(domain.variables[1], ContinuousVariable)
-        self.assertIsInstance(domain.variables[2], DiscreteVariable)
-        self.assertIsInstance(domain.variables[3], ContinuousVariable)
-        for i, var in enumerate(domain.variables):
+        self.assertIsInstance(domain[0], DiscreteVariable)
+        self.assertIsInstance(domain[1], ContinuousVariable)
+        self.assertIsInstance(domain[2], DiscreteVariable)
+        self.assertIsInstance(domain[3], ContinuousVariable)
+        for i, var in enumerate(domain):
             self.assertEqual(var.name, chr(97 + i))
         self.assertEqual(domain[0].values, ["green", "red"])
         np.testing.assert_almost_equal(table.X,

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -282,7 +282,7 @@ class OWDistributions(widget.OWWidget):
             data = self.data[:, (self.var, self.cvar) if self.cvar else self.var ]
             disc = Orange.preprocess.discretize.EqualWidth(n=self.bins[self.smoothing_index])
             data = Orange.preprocess.Discretize(data, method=disc)
-            self.var = data.domain.variables[0]
+            self.var = data.domain[0]
         self.set_left_axis_name()
         self.enable_disable_rel_freq()
         if self.cvar:


### PR DESCRIPTION
When using positive indices, the result is the same, but indexing of
domain is shorter.