### PR TITLE
Unknown str value fix

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -388,7 +388,7 @@ class Table(MutableSequence, Storage):
         :return:
         """
         X, Y, W = _check_arrays(X, Y, W, dtype='float64')
-        metas, = _check_arrays(metas)
+        metas, = _check_arrays(metas, dtype=object)
 
         if Y is not None and Y.ndim == 1:
             Y = Y.reshape(Y.shape[0], 1)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -168,10 +168,10 @@ class Value(float):
         return super().__eq__(other)
 
     def __contains__(self, other):
-        if (self.value is not None
-                and isinstance(self.value, str)
+        if (self._value is not None
+                and isinstance(self._value, str)
                 and isinstance(other, str)):
-            return other in self.value
+            return other in self._value
         raise TypeError("invalid operation on Value()")
 
     def __hash__(self):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -135,15 +135,16 @@ class Value(float):
         :type variable: Orange.data.Variable
         :param value: value
         """
-        if not isinstance(value, str):
-            try:
-                self = super().__new__(cls, value)
-            except:
-                self = super().__new__(cls, -1)
+        if variable.is_primitive():
+            self = super().__new__(cls, value)
+            self.variable = variable
+            self._value = None
         else:
-            self = super().__new__(cls, -1)
-        self._value = value
-        self.variable = variable
+            isunknown = value == variable.Unknown
+            self = super().__new__(
+                cls, np.nan if isunknown else np.finfo(float).min)
+            self.variable = variable
+            self._value = value
         return self
 
     def __init__(self, _, __=Unknown):
@@ -757,6 +758,7 @@ class StringVariable(Variable):
     Descriptor for string variables. String variables can only appear as
     meta attributes.
     """
+    Unknown = ""
     TYPE_HEADERS = ('string', 's', 'text')
 
     def to_val(self, s):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -175,10 +175,10 @@ class Value(float):
         raise TypeError("invalid operation on Value()")
 
     def __hash__(self):
-        if self.value is None:
+        if self._value is None:
             return super().__hash__()
         else:
-            return super().__hash__() ^ hash(self.value)
+            return hash((super().__hash__(), self._value))
 
     @property
     def value(self):

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -1,4 +1,6 @@
 from time import time
+from numbers import Real
+from itertools import starmap
 import unittest
 import pickle
 
@@ -425,7 +427,16 @@ class TestDomainInit(unittest.TestCase):
         x, y, metas = domain.convert([42, 13, "White"])
         assert_array_equal(x, np.array([42, 13]))
         assert_array_equal(y, np.array([0]))
-        self.assertTrue(all(np.isnan(np.array(metas, dtype=float))))
+        metas_exp = [gender.Unknown, education.Unknown, ssn.Unknown]
+
+        def eq(a, b):
+            if isinstance(a, Real) and isinstance(b, Real) and \
+                    np.isnan(a) and np.isnan(b):
+                return True
+            else:
+                return a == b
+
+        self.assertTrue(all(starmap(eq, zip(metas, metas_exp))))
 
         x, y, metas = domain.convert([42, 13, "White", "M", "HS", "1234567"])
         assert_array_equal(x, np.array([42, 13]))

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -73,7 +73,9 @@ class TestInstance(unittest.TestCase):
         self.assertTrue(all(isnan(x) for x in inst._y))
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
-            assert_array_equal(inst._metas, np.array([Unknown, Unknown, Unknown], dtype=object))
+            assert_array_equal(inst._metas,
+                               np.array([var.Unknown for var in domain.metas],
+                                        dtype=object))
 
     def test_init_x_arr(self):
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")])


### PR DESCRIPTION
* Change `Value` constructor to better handle missing values for StringVariables
* Update the StringVariable.Unknown constant (now a `""`)
* Change tests which which assumed a single unknown value representation
* Fix `Value.__hash__` and `Value.__contains__`
