### PR TITLE
OWDistances, SklDistance: support discrete variables

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -19,11 +19,34 @@ def _preprocess(table):
     return new_data
 
 
-def _orange_to_numpy(x):
+def one_hot_encode(domain, X):
+    """
+    Encode discrete Orange.data.Variables into one binary column for each value.
+    Return a dummy table.
+    """
+    if not domain.has_discrete_attributes():
+        return X
+    cols = []
+    for i, (var, x) in enumerate(zip(domain.attributes, X.T)):
+        if var.is_discrete:
+            n_values = len(var.values)
+            for val in range(n_values):
+                # Make the diffs across cols of same variable sum to 1
+                cols.append((x == val) / n_values)
+        else:
+            cols.append(x)
+    return np.column_stack(cols)
+
+
+def _orange_to_numpy(x, axis=1):
     """Convert :class:`Orange.data.Table` and :class:`Orange.data.RowInstance` to :class:`numpy.ndarray`."""
     if isinstance(x, data.Table):
+        if axis == 1 and x.domain.has_discrete_attributes():
+            return one_hot_encode(x.domain, x.X)
         return x.X
     elif isinstance(x, data.RowInstance):
+        if axis == 1 and x.domain.has_discrete_attributes():
+            return one_hot_encode(x.domain, x.x)
         return np.atleast_2d(x.x)
     elif isinstance(x, np.ndarray):
         return np.atleast_2d(x)
@@ -60,8 +83,8 @@ class SklDistance(Distance):
         self.metric = metric
 
     def __call__(self, e1, e2=None, axis=1, impute=False):
-        x1 = _orange_to_numpy(e1)
-        x2 = _orange_to_numpy(e2)
+        x1 = _orange_to_numpy(e1, axis)
+        x2 = _orange_to_numpy(e2, axis)
         if axis == 0:
             x1 = x1.T
             if x2 is not None:

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -603,3 +603,13 @@ class TestDistances(TestCase):
         table = Table('test5.tab')
         new_table = _preprocess(table)
         self.assertFalse(np.isnan(new_table.X).any())
+
+    def test_discrete(self):
+        data = Table(Domain([DiscreteVariable('a', values='01'),
+                             DiscreteVariable('b', values='01')]),
+                     np.array([[1, 0],
+                               [0, 1]]))
+        dist = Manhattan(data)
+        dist = np.diag(np.rot90(dist))
+        self.assertEqual(*dist)
+        np.testing.assert_almost_equal(dist[0], 2)


### PR DESCRIPTION
Distances widget traditionally stripped discrete variables, requiring an additional Continuize step, which finally would make Distances favor fewer-valued features. Now, it counts distance between two values of a discrete variable as binary, either 1 (different) or 0 (same).