### PR TITLE
LearnerScorer: Support multiclass ranking

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -17,8 +17,7 @@ class _FeatureScorerMixin(LearnerScorer):
     def score(self, data):
         data = Normalize(data)
         model = self(data)
-        # Take the maximum attribute score across all classes
-        return np.max(np.abs(model.coefficients), axis=0)
+        return np.abs(model.coefficients)
 
 
 class LogisticRegressionClassifier(SklModel):

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -26,7 +26,8 @@ class _FeatureScorerMixin(LearnerScorer):
 
     def score(self, data):
         model = self(data)
-        return np.abs(model.components_[self.component])
+        return np.abs(model.components_[:self.component]) \
+            if self.component else np.abs(model.components_)
 
 
 class PCA(SklProjector, _FeatureScorerMixin):

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -50,9 +50,9 @@ class LinearRegressionTest(unittest.TestCase):
     def test_linear_scorer(self):
         learner = LinearRegressionLearner()
         scores = learner.score_data(self.housing)
-        self.assertEqual('LSTAT',
-                         self.housing.domain.attributes[np.argmax(scores)].name)
-        self.assertEqual(len(scores), len(self.housing.domain.attributes))
+        self.assertEqual(
+            'LSTAT', self.housing.domain.attributes[np.argmax(scores[0])].name)
+        self.assertEqual(scores.shape[1], len(self.housing.domain.attributes))
 
     def test_scorer(self):
         learners = [LinearRegressionLearner(),
@@ -61,9 +61,11 @@ class LinearRegressionTest(unittest.TestCase):
                     ElasticNetLearner(alpha=0.01)]
         for learner in learners:
             scores = learner.score_data(self.housing)
-            self.assertEqual('LSTAT',
-                             self.housing.domain.attributes[np.argmax(scores)].name)
-            self.assertEqual(len(scores), len(self.housing.domain.attributes))
+            self.assertEqual(
+                'LSTAT',
+                self.housing.domain.attributes[np.argmax(scores[0])].name)
+            self.assertEqual(scores.shape[1],
+                             len(self.housing.domain.attributes))
 
     def test_scorer_feature(self):
         learners = [LinearRegressionLearner(),
@@ -74,7 +76,7 @@ class LinearRegressionTest(unittest.TestCase):
             scores = learner.score_data(self.housing)
             for i, attr in enumerate(self.housing.domain.attributes):
                 score = learner.score_data(self.housing, attr)
-                self.assertEqual(score, scores[i])
+                np.testing.assert_array_almost_equal(score, scores[:, i])
 
     def test_coefficients(self):
         data = Table([[11], [12], [13]], [0, 1, 2])

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -64,7 +64,35 @@ class LogisticRegressionTest(unittest.TestCase):
         scores = learner.score_data(self.voting)
         self.assertEqual('physician-fee-freeze',
                          self.voting.domain.attributes[np.argmax(scores)].name)
-        self.assertEqual(len(scores), len(self.voting.domain.attributes))
+        self.assertEqual(scores.shape, (1, len(self.voting.domain.attributes)))
+
+    def test_learner_scorer_feature(self):
+        learner = LogisticRegressionLearner()
+        scores = learner.score_data(self.voting)
+        for i, attr in enumerate(self.voting.domain.attributes):
+            score = learner.score_data(self.voting, attr)
+            np.testing.assert_array_almost_equal(score, scores[:, i])
+
+    def test_learner_scorer_multiclass(self):
+        attr = self.zoo.domain.attributes
+        learner = LogisticRegressionLearner()
+        scores = learner.score_data(self.zoo)
+        self.assertEqual('aquatic', attr[np.argmax(scores[0])].name)
+        self.assertEqual('feathers', attr[np.argmax(scores[1])].name)
+        self.assertEqual('fins', attr[np.argmax(scores[2])].name)
+        self.assertEqual('backbone', attr[np.argmax(scores[3])].name)
+        self.assertEqual('backbone', attr[np.argmax(scores[4])].name)
+        self.assertEqual('milk', attr[np.argmax(scores[5])].name)
+        self.assertEqual('hair', attr[np.argmax(scores[6])].name)
+        self.assertEqual(scores.shape,
+                         (len(self.zoo.domain.class_var.values), len(attr)))
+
+    def test_learner_scorer_multiclass_feature(self):
+        learner = LogisticRegressionLearner()
+        scores = learner.score_data(self.zoo)
+        for i, attr in enumerate(self.zoo.domain.attributes):
+            score = learner.score_data(self.zoo, attr)
+            np.testing.assert_array_almost_equal(score, scores[:, i])
 
     def test_coefficients(self):
         learn = LogisticRegressionLearner()

--- a/Orange/tests/test_pca.py
+++ b/Orange/tests/test_pca.py
@@ -116,10 +116,11 @@ class TestPCA(unittest.TestCase):
     def test_PCA_scorer(self):
         data = self.iris
         pca = PCA(preprocessors=[Normalize()])
+        pca.component = 1
         scores = pca.score_data(data)
-        self.assertEqual(len(scores), len(data.domain.attributes))
+        self.assertEqual(scores.shape[1], len(data.domain.attributes))
         self.assertEqual(['petal length', 'petal width'],
                          sorted([data.domain.attributes[i].name
-                                 for i in np.argsort(scores)[-2:]]))
-        self.assertEqual([round(s, 4) for s in scores],
+                                 for i in np.argsort(scores[0])[-2:]]))
+        self.assertEqual([round(s, 4) for s in scores[0]],
                          [0.5224, 0.2634, 0.5813, 0.5656])

--- a/Orange/tests/test_random_forest.py
+++ b/Orange/tests/test_random_forest.py
@@ -70,18 +70,18 @@ class RandomForestTest(unittest.TestCase):
     def test_classification_scorer(self):
         learner = RandomForestLearner()
         scores = learner.score_data(self.iris)
-        self.assertEqual(len(scores), len(self.iris.domain.attributes))
-        self.assertNotEqual(sum(scores), 0)
+        self.assertEqual(scores.shape[1], len(self.iris.domain.attributes))
+        self.assertNotEqual(sum(scores[0]), 0)
         self.assertEqual(['petal length', 'petal width'],
                          sorted([self.iris.domain.attributes[i].name
-                                 for i in np.argsort(scores)[-2:]]))
+                                 for i in np.argsort(scores[0])[-2:]]))
 
     def test_regression_scorer(self):
         learner = RandomForestRegressionLearner()
         scores = learner.score_data(self.house)
         self.assertEqual(['LSTAT', 'RM'],
                          sorted([self.house.domain.attributes[i].name
-                                 for i in np.argsort(scores)[-2:]]))
+                                 for i in np.argsort(scores[0])[-2:]]))
 
     def test_scorer_feature(self):
         np.random.seed(42)
@@ -91,4 +91,4 @@ class RandomForestTest(unittest.TestCase):
         for i, attr in enumerate(data.domain.attributes):
             np.random.seed(42)
             score = learner.score_data(data, attr)
-            self.assertEqual(score, scores[i])
+            np.testing.assert_array_almost_equal(score, scores[:, i])

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -51,7 +51,7 @@ class OWPCA(widget.OWWidget):
         self._cumulative = None
         self._line = False
         self._pca_projector = PCA()
-        self._pca_projector.component = 0
+        self._pca_projector.component = self.ncomponents
         self._pca_preprocessors = PCA.preprocessors
 
         # Components Selection
@@ -263,6 +263,7 @@ class OWPCA(widget.OWWidget):
     def _update_selection_component_spin(self):
         # cut changed by "ncomponents" spin.
         if self._pca is None:
+            self._invalidate_selection()
             return
 
         if self.ncomponents == 0:
@@ -351,6 +352,7 @@ class OWPCA(widget.OWWidget):
                                metas=metas)
             components.name = 'components'
 
+        self._pca_projector.component = self.ncomponents
         self.send("Transformed data", transformed)
         self.send("Components", components)
         self.send("PCA", self._pca_projector)


### PR DESCRIPTION
score_data now returns numpy array, to support multiclass ranking (e.g. logistic regression coeficients for each class value). Scores for each class can be shown in Rank widget.
Similarly multiple PCA components can bw shown in Rank widget.
