### PR TITLE
OWTreeGraph: Prune node hover tooltip

### DIFF
--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -1,5 +1,5 @@
 import sys
-
+from collections import OrderedDict
 import numpy
 
 from sklearn.tree._tree import TREE_LEAF
@@ -286,7 +286,7 @@ class TreeNode(GraphicsNode):
                     else "≠ " * is_left_child + values[parent_attr_cv.value]
             else:
                 thresh = self.tree.threshold[self.parent.i]
-                return "%s %s" % ([">", "<="][is_left_child],
+                return "%s %s" % ([">", "≤"][is_left_child],
                                   attribute.str_val(thresh))
         else:
             return ""
@@ -321,7 +321,7 @@ class TreeNode(GraphicsNode):
                                    is_left_child * (len(values) == 2))]
             else:
                 attr_name = parent_attr.name
-                sign = [">", "<="][is_left_child]
+                sign = [">", "≤"][is_left_child]
                 value = "%.3f" % self.tree.threshold[self.parent.i]
             if (attr_name, sign) in pr:
                 old_val = pr[(attr_name, sign)]
@@ -329,13 +329,13 @@ class TreeNode(GraphicsNode):
                     pr[(attr_name, sign)] = max(float(value), float(old_val))
                 elif sign == "≠":
                     pr[(attr_name, sign)] = "{}, {}".format(old_val, value)
-                elif sign == "<=":
+                elif sign == "≤":
                     pr[(attr_name, sign)] = min(float(value), float(old_val))
             else:
                 pr[(attr_name, sign)] = value
             return pr
         else:
-            return {}
+            return OrderedDict()
 
     def is_leaf(self):
         """

--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -123,7 +123,7 @@ class OWTreeGraph(OWTreeViewer2D):
     def node_tooltip(self, node):
         if node.i > 0:
             text = " AND\n".join(
-                "%s %s %s" % (n, s, v) for n, s, v in node.rule())
+                "%s %s %s" % (n, s, v) for (n, s), v in node.rule().items())
         else:
             text = "Root"
         return text
@@ -323,10 +323,19 @@ class TreeNode(GraphicsNode):
                 attr_name = parent_attr.name
                 sign = [">", "<="][is_left_child]
                 value = "%.3f" % self.tree.threshold[self.parent.i]
-            pr.append((attr_name, sign, value))
+            if (attr_name, sign) in pr:
+                old_val = pr[(attr_name, sign)]
+                if sign == ">":
+                    pr[(attr_name, sign)] = max(float(value), float(old_val))
+                elif sign == "≠":
+                    pr[(attr_name, sign)] = "{}, {}".format(old_val, value)
+                elif sign == "<=":
+                    pr[(attr_name, sign)] = min(float(value), float(old_val))
+            else:
+                pr[(attr_name, sign)] = value
             return pr
         else:
-            return []
+            return {}
 
     def is_leaf(self):
         """


### PR DESCRIPTION
Text was redundant when split by the same attribute more than once.