### PR TITLE
Mlp issue

### DIFF
--- a/Orange/canvas/__init__.py
+++ b/Orange/canvas/__init__.py
@@ -3,9 +3,4 @@
 # default resource loader, but it python3 it does not. As a result,
 # pkg_resources is unable to select a resource loader and load resources.
 # By settings __loader__ to None, we workaround the pkg_resources bug.
-
-# A hack seems not to work for python 3.5 and orange-canvas fails to start (throws) when pkg_resources.__init__.py
-# calls resource_exists with orange.qss
-# when loader is commented out it all works
-# __loader__ = None
-
+__loader__ = None

--- a/Orange/canvas/__init__.py
+++ b/Orange/canvas/__init__.py
@@ -3,4 +3,9 @@
 # default resource loader, but it python3 it does not. As a result,
 # pkg_resources is unable to select a resource loader and load resources.
 # By settings __loader__ to None, we workaround the pkg_resources bug.
-__loader__ = None
+
+# A hack seems not to work for python 3.5 and orange-canvas fails to start (throws) when pkg_resources.__init__.py
+# calls resource_exists with orange.qss
+# when loader is commented out it all works
+# __loader__ = None
+

--- a/Orange/classification/mlp.py
+++ b/Orange/classification/mlp.py
@@ -177,7 +177,7 @@ class MLPLearner(Learner):
         if np.isnan(np.sum(X)) or np.isnan(np.sum(Y)):
             raise ValueError('MLP does not support unknown values')
 
-        if (len(Y.shape) == 1) or (Y.shape[1] == 1):
+        if Y.ndim == 1 or Y.shape[1] == 1:
             num_classes = np.unique(Y).size
             Y = np.eye(num_classes)[Y.ravel().astype(int)]
 

--- a/Orange/classification/mlp.py
+++ b/Orange/classification/mlp.py
@@ -177,7 +177,7 @@ class MLPLearner(Learner):
         if np.isnan(np.sum(X)) or np.isnan(np.sum(Y)):
             raise ValueError('MLP does not support unknown values')
 
-        if Y.shape[1] == 1:
+        if (len(Y.shape) == 1) or (Y.shape[1] == 1):
             num_classes = np.unique(Y).size
             Y = np.eye(num_classes)[Y.ravel().astype(int)]
 


### PR DESCRIPTION
As mentioned here https://github.com/biolab/orange3/issues/1001

```
dataset = Orange.data.Table('iris')
attrs_num = len(dataset.domain.attributes)
cls_num = len(dataset.domain.class_var.values)
hidden = int((attrs_num+cls_num)/2)
ann_learner = Orange.classification.MLPLearner(
        [attrs_num, hidden, cls_num],
        num_epochs=10,
        learning_rate=0.8,
        dropout=[0.2, 0.5])
Orange.evaluation.testing.CrossValidation(dataset, [ann_learner])
```

The exception is thrown from **mlp.py** **fit** function when it checks for Y shape: ` if Y.shape[1] == 1:`
Y has a shape (n,) and so it throws.

Should it be this or something similar instead?
```if (len(Y.shape) == 1) or  (len(Y.shape) == 2 and Y.shape[1] == 1)```

Also, `__loader__` hack does not seem to work for an environment where I start it: anaconda over python 3.5 Commenting out that hack fixes the problem. Probably needs further investigation