### PR TITLE
Changed layout of File widget

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -164,10 +164,14 @@ class OWFile(widget.OWWidget):
     want_main_area = False
     resizing_enabled = False
 
+    FILE, URL = range(2)
+
     #: back-compatibility: List[str] saved files list
     recent_files = Setting([])
     #: List[RecentPath]
     recent_paths = Setting([])
+    source = Setting(0)
+    url = Setting("")
 
     new_variables = Setting(False)
 
@@ -187,28 +191,24 @@ class OWFile(widget.OWWidget):
         self.loaded_file = ""
         self._relocate_recent_files()
 
-        vbox = gui.widgetBox(self.controlArea, "Data File / URL",
-                             addSpace=True)
+        vbox = gui.radioButtons(self.controlArea, self, "source", box="Source",
+                                addSpace=True)
         box = gui.widgetBox(vbox, orientation=0)
+        gui.appendRadioButton(vbox, "File", insertInto=box)
         self.file_combo = QtGui.QComboBox(box, sizeAdjustPolicy=QtGui.QComboBox.AdjustToContents)
         self.file_combo.setMinimumWidth(300)
-        self.file_combo.setEditable(True)
-        self.file_combo.lineEdit().setStyleSheet("padding-left: 1px;")
         box.layout().addWidget(self.file_combo)
         self.file_combo.activated[int].connect(self.select_file)
-
         button = gui.button(box, self, '...', callback=self.browse_file,
                             autoDefault=False)
         button.setIcon(self.style().standardIcon(QtGui.QStyle.SP_DirOpenIcon))
         button.setSizePolicy(
-            QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Fixed)
+                QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Fixed)
 
-        button = gui.button(box, self, "Reload",
-                            callback=self.reload, autoDefault=False)
-        button.setIcon(
-            self.style().standardIcon(QtGui.QStyle.SP_BrowserReload))
-        button.setSizePolicy(
-            QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        box = gui.widgetBox(vbox, orientation=0)
+        gui.appendRadioButton(vbox, "URL", insertInto=box)
+        gui.lineEdit(box, self, "url")
+        gui.separator(vbox, height=16)
 
         gui.checkBox(vbox, self, "new_variables",
                      "Columns with same name in different files " +
@@ -218,7 +218,21 @@ class OWFile(widget.OWWidget):
         self.info = gui.widgetLabel(box, 'No data loaded.')
         self.warnings = gui.widgetLabel(box, ' ')
         gui.rubber(box)
-        #Set word wrap, so long warnings won't expand the widget
+
+
+        box = gui.widgetBox(self.controlArea, orientation="horizontal")
+        button = gui.button(box, self, "Reload",
+                            callback=self.reload, autoDefault=False)
+        button.setIcon(
+                self.style().standardIcon(QtGui.QStyle.SP_BrowserReload))
+        button.setSizePolicy(
+                QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        gui.rubber(box)
+        box.layout().addWidget(self.report_button)
+        self.report_button.setMaximumWidth(150)
+
+
+    #Set word wrap, so long warnings won't expand the widget
         self.warnings.setWordWrap(True)
         self.warnings.setSizePolicy(
             QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.MinimumExpanding)
@@ -266,7 +280,7 @@ class OWFile(widget.OWWidget):
             self.file_combo.model().item(0).setEnabled(False)
         else:
             for i, recent in enumerate(self.recent_paths):
-                self.file_combo.addItem(recent.icon, recent.value)
+                self.file_combo.addItem(recent.value)
                 self.file_combo.model().item(i).setToolTip(recent.abspath)
         self.file_combo.addItem("Browse documentation data sets...")
 

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -1,18 +1,14 @@
 import os
-import sys
-import urllib
 from warnings import catch_warnings
 
 from PyQt4 import QtGui, QtCore
-from PyQt4.QtCore import Qt
-from PyQt4.QtGui import QCompleter, QLineEdit, QSizePolicy
+from PyQt4.QtGui import QSizePolicy
 
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
+from Orange.widgets.utils.itemmodels import PyListModel
 from Orange.data.table import Table, get_sample_datasets_dir
 from Orange.data.io import FileFormat
-from Orange.widgets.utils.itemmodels import PyListModel
-from Orange.widgets.widget import OutputSignal
 
 
 def add_origin(examples, filename):
@@ -155,7 +151,7 @@ class OWFile(widget.OWWidget):
     priority = 10
     category = "Data"
     keywords = ["data", "file", "load", "read"]
-    outputs = [OutputSignal(
+    outputs = [widget.OutputSignal(
         "Data", Table,
         doc="Attribute-valued data set read from the input file.")]
 
@@ -170,7 +166,7 @@ class OWFile(widget.OWWidget):
     source = Setting(LOCAL_FILE)
     url = Setting("")
 
-    dlgFormats = (
+    dlg_formats = (
         "All readable files ({});;".format(
             '*' + ' *'.join(FileFormat.readers.keys())) +
         ";;".join("{} (*{})".format(f.DESCRIPTION, ' *'.join(f.EXTENSIONS))
@@ -182,7 +178,6 @@ class OWFile(widget.OWWidget):
         self.domain = None
         self.data = None
         self.loaded_file = ""
-        self.recent_urls = ["asdf", "qwer"]  # TODO Remove!
         self._relocate_recent_files()
 
         vbox = gui.radioButtons(
@@ -208,7 +203,7 @@ class OWFile(widget.OWWidget):
 
         box = gui.widgetBox(vbox, orientation="horizontal")
         gui.appendRadioButton(vbox, "URL", insertInto=box)
-        self.le_url = le_url = QLineEdit(self.url)
+        self.le_url = le_url = QtGui.QLineEdit(self.url)
         l, t, r, b = le_url.getTextMargins()
         le_url.setTextMargins(l + 5, t, r, b)
         le_url.returnPressed.connect(self._url_set)
@@ -216,10 +211,10 @@ class OWFile(widget.OWWidget):
 
         self.completer_model = PyListModel()
         self.completer_model.wrap(self.recent_urls)
-        completer = QCompleter()
+        completer = QtGui.QCompleter()
         completer.setModel(self.completer_model)
-        completer.setCompletionMode(QCompleter.PopupCompletion)
-        completer.setCaseSensitivity(Qt.CaseInsensitive)
+        completer.setCompletionMode(completer.PopupCompletion)
+        completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
         le_url.setCompleter(completer)
 
         box = gui.widgetBox(self.controlArea, "Info")
@@ -329,7 +324,7 @@ class OWFile(widget.OWWidget):
                 start_file = os.path.expanduser("~/")
 
         filename = QtGui.QFileDialog.getOpenFileName(
-            self, 'Open Orange Data File', start_file, self.dlgFormats)
+            self, 'Open Orange Data File', start_file, self.dlg_formats)
         if not filename:
             return
 
@@ -343,12 +338,9 @@ class OWFile(widget.OWWidget):
         basedir = self.workflowEnv().get("basedir", None)
         if basedir is not None:
             searchpaths.append(("basedir", basedir))
-
         recent = RecentPath.create(filename, searchpaths)
-
         if recent in self.recent_paths:
             self.recent_paths.remove(recent)
-
         self.recent_paths.insert(0, recent)
 
     # Open a file, create data from it and send it over the data channel
@@ -485,6 +477,7 @@ class OWFile(widget.OWWidget):
 
 
 if __name__ == "__main__":
+    import sys
     a = QtGui.QApplication(sys.argv)
     ow = OWFile()
     ow.show()


### PR DESCRIPTION
The existing layout is ugly (which is my fault, not @VesnaT or anybody else's).

- Editable combo box is not intuitive - will users really know they can type URLs and that they should not type file names?
- Button "..." applies just to file and not to URL
- Icons in front of files names look ugly.
- "Browse documentation data sets" is hidden, especially for fresh users

The new layout is nicer, more intuitive and also allows for future extensions with additional sources.

![image](https://cloud.githubusercontent.com/assets/2387315/12833729/dfa4b76e-cba2-11e5-870d-eb839d72a3fa.png)

URL is refreshed on Return key, like in web browsers.

The button for documentation data sets does not take any extra space because we have the Report button anyway.