### PR TITLE
KNNLearner returns KNNClassifier

### DIFF
--- a/Orange/classification/knn.py
+++ b/Orange/classification/knn.py
@@ -1,11 +1,14 @@
 import sklearn.neighbors as skl_neighbors
-from Orange.classification import SklLearner
+from Orange.classification import SklLearner, SklModel
 
 __all__ = ["KNNLearner"]
 
+class KNNClassifier(SklModel):
+    pass
 
 class KNNLearner(SklLearner):
     __wraps__ = skl_neighbors.KNeighborsClassifier
+    __returns__ = KNNClassifier
     name = 'knn'
 
     def __init__(self, n_neighbors=5, metric="euclidean", weights="uniform",


### PR DESCRIPTION
Running for example:

`Orange.evaluation.testing.CrossValidation(Orange.data.Table(primary-tumor), [Orange.classification.knn.KNNLearner()], k=5)`

throws an error in Orange.evaluation.testing.py:338: 
`ValueError: could not broadcast input array from shape (71,20) into shape (71,21)`

The fix in pull request fixes it (the result gets extended to proper dimensions according to domain classes if testing set doesn't cover all of them). Hopefully that doesn't break anything else. Please review.