### PR TITLE
gui.py: Add verticalBox, horizontalBox

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -552,6 +552,14 @@ def widgetBox(widget, box=None, orientation='vertical', margin=None, spacing=4,
     return b
 
 
+def hBox(*args, **kwargs):
+    return widgetBox(orientation="horizontal", *args, **kwargs)
+
+
+def vBox(*args, **kwargs):
+    return widgetBox(orientation="vertical", *args, **kwargs)
+
+
 def indentedBox(widget, sep=20, orientation="vertical", **misc):
     """
     Creates an indented box. The function can also be used "on the fly"::


### PR DESCRIPTION
Most calls of `gui.widgetBox` have argument `orientation="horizontal"` or `orientation="vertical"`, which is annoyingly long and uses strings instead of constants.

Functions `gui.verticalBox` and `gui.horizontalBox` call `gui.widgetBox` and supply the `orientation` argument.