### PR TITLE
Change the URL line edit in the File widget back to combo box

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -203,7 +203,7 @@ class OWFile(widget.OWWidget):
                                 callback=self.load_data, addToLayout=False)
 
         rb_button = gui.appendRadioButton(vbox, "File", addToLayout=False)
-        layout.addWidget(rb_button, 0, 0, QtCore.Qt.AlignCenter)
+        layout.addWidget(rb_button, 0, 0, QtCore.Qt.AlignVCenter)
 
         box = gui.hBox(None, addToLayout=False, margin=0)
         box.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
@@ -222,7 +222,7 @@ class OWFile(widget.OWWidget):
         layout.addWidget(box, 0, 1,  QtCore.Qt.AlignVCenter)
 
         rb_button = gui.appendRadioButton(vbox, "URL", addToLayout=False)
-        layout.addWidget(rb_button, 1, 0, QtCore.Qt.AlignCenter)
+        layout.addWidget(rb_button, 1, 0, QtCore.Qt.AlignVCenter)
 
         box = gui.hBox(vbox, addToLayout=False)
         self.url_combo = url_combo = QtGui.QComboBox()
@@ -237,7 +237,7 @@ class OWFile(widget.OWWidget):
         url_edit.setTextMargins(l + 5, t, r, b)
         box.layout().addWidget(url_combo)
         url_combo.activated.connect(self._url_set)
-        layout.addWidget(box, 1, 1, QtCore.Qt.AlignCenter)
+        layout.addWidget(box, 1, 1, QtCore.Qt.AlignVCenter)
 
         box = gui.vBox(self.controlArea, "Info")
         self.info = gui.widgetLabel(box, 'No data loaded.')

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -552,6 +552,14 @@ def widgetBox(widget, box=None, orientation='vertical', margin=None, spacing=4,
     return b
 
 
+def hBox(*args, **kwargs):
+    return widgetBox(orientation="horizontal", *args, **kwargs)
+
+
+def vBox(*args, **kwargs):
+    return widgetBox(orientation="vertical", *args, **kwargs)
+
+
 def indentedBox(widget, sep=20, orientation="vertical", **misc):
     """
     Creates an indented box. The function can also be used "on the fly"::


### PR DESCRIPTION
URL Combo is again editable.

For Google sheets, the combo shows the last known sheet name for this URL (the underlying model maps the URL through dictionary of known names). In the line edit, the URL is shown as placeholder. The user is not expected to edit Google sheet URLs.

Other URLs are editable since they may be human friendly. Also, other URLs don't have any associated names so they're not mapped.

Alternative is that Google sheets get a separate radio button in which the user can either enter a new URL or select one from history. In this case, we could also show additional data, such as time stamps, last editors, previous versions... if available.