### PR TITLE
SklLearner: Set correct __returns__ values for subclasses

### DIFF
--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -17,10 +17,6 @@ class ModelClassification(Model):
     pass
 
 
-class SklLearnerClassification(SklLearner, LearnerClassification):
-    pass
-
-
 class SklModelClassification(SklModel, ModelClassification):
     def __call__(self, data, ret=Model.Value):
         prediction = super().__call__(data, ret=ret)
@@ -58,3 +54,7 @@ class SklModelClassification(SklModel, ModelClassification):
             return probs
         else:  # ret == Model.ValueProbs
             return value, probs
+
+
+class SklLearnerClassification(SklLearner, LearnerClassification):
+    __returns__ = SklModelClassification

--- a/Orange/regression/base_regression.py
+++ b/Orange/regression/base_regression.py
@@ -15,9 +15,9 @@ class ModelRegression(Model):
     pass
 
 
-class SklLearnerRegression(SklLearner, LearnerRegression):
-    pass
-
-
 class SklModelRegression(SklModel, ModelRegression):
     pass
+
+
+class SklLearnerRegression(SklLearner, LearnerRegression):
+    __returns__ = SklModelRegression

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -24,14 +24,15 @@ class MultiClassTest(unittest.TestCase):
         x = np.random.random_integers(1, 3, (nrows, ncols))
 
         # multiple class variables
-        y = np.random.random_integers(10, 11, (nrows, 2))
+        y = np.random.random_integers(0, 1, (nrows, 2))
         t = Table(x, y)
         learn = DummyLearner()
-        with self.assertRaises(TypeError):
+        # TODO: Errors raised from various data checks should be made consistent
+        with self.assertRaises((ValueError, TypeError)):
             clf = learn(t)
 
         # single class variable
-        y = np.random.random_integers(10, 11, (nrows, 1))
+        y = np.random.random_integers(0, 1, (nrows, 1))
         t = Table(x, y)
         learn = DummyLearner()
         clf = learn(t)
@@ -42,7 +43,7 @@ class MultiClassTest(unittest.TestCase):
         nrows = 20
         ncols = 10
         x = np.random.random_integers(1, 3, (nrows, ncols))
-        y = np.random.random_integers(10, 11, (nrows, 2))
+        y = np.random.random_integers(0, 1, (nrows, 2))
         t = Table(x, y)
         learn = DummyMulticlassLearner()
         clf = learn(t)


### PR DESCRIPTION
Fix `SklLearnerClassification` to use the correct default return model `SklModelClassification`.
Previously, this was not set, which meant the base class `SklModel` was used for classification and probability predictions were not expanded correctly for unseen classes.

Similar fix for regression, although the correct class does not do anything special there.

Replaces #1011.