### PR TITLE
Sieve enhancements

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -1131,23 +1131,30 @@ class OWCanvasText(QGraphicsTextItem):
         QGraphicsTextItem.setPos(self, x, y)
 
 
-def OWCanvasRectangle(canvas, x=0, y=0, width=0, height=0, penColor=QColor(128, 128, 128), brushColor=None, penWidth=1,
-                      z=0,
-                      penStyle=Qt.SolidLine, pen=None, tooltip=None, show=1):
-    rect = QGraphicsRectItem(x, y, width, height, None, canvas)
-    if brushColor: rect.setBrush(QBrush(brushColor))
-    if pen:
-        rect.setPen(pen)
-    else:
-        rect.setPen(QPen(penColor, penWidth, penStyle))
-    rect.setZValue(z)
-    if tooltip: rect.setToolTip(tooltip)
-    if show:
-        rect.show()
-    else:
-        rect.hide()
-    return rect
+class OWCanvasRectangle(QGraphicsRectItem):
+    def __init__(self, canvas, x=0, y=0, width=0, height=0,
+                 penColor=QColor(128, 128, 128), brushColor=None, penWidth=1,
+                 z=0, penStyle=Qt.SolidLine, pen=None, tooltip=None, show=1,
+                 onclick=None):
+        super().__init__(x, y, width, height, None, canvas)
+        self.onclick = onclick
+        if brushColor:
+            self.setBrush(QBrush(brushColor))
+        if pen:
+            self.setPen(pen)
+        else:
+            self.setPen(QPen(QBrush(penColor), penWidth, penStyle))
+        self.setZValue(z)
+        if tooltip:
+            self.setToolTip(tooltip)
+        if show:
+            self.show()
+        else:
+            self.hide()
 
+    def mousePressEvent(self, ev):
+        if self.onclick:
+            self.onclick(self, ev)
 
 def OWCanvasLine(canvas, x1=0, y1=0, x2=0, y2=0, penWidth=2, penColor=QColor(255, 255, 255, 128), pen=None, z=0,
                  tooltip=None, show=1):

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -2,8 +2,6 @@ from collections import defaultdict
 from itertools import product
 from math import sqrt, floor, ceil
 
-import numpy as np
-
 from PyQt4.QtCore import Qt, QSize
 from PyQt4.QtGui import (QGraphicsScene, QGraphicsView, QColor, QPen, QBrush,
                          QDialog, QApplication, QSizePolicy)
@@ -107,10 +105,10 @@ class OWSieveDiagram(OWWidget):
             self.attrX = self.attrY = None
         self.openContext(self.data)
 
-        self.warning(0, "")
+        self.information(0, "")
         if data and any(attr.is_continuous for attr in data.domain):
-            self.warning(0, "Data contains continuous variables. " +
-                            "Discretize the data to use them.")
+            self.information(0, "Data contains continuous variables. "
+                                "Discretize the data to use them.")
         self.resolve_shown_attributes()
         self.update_selection()
 


### PR DESCRIPTION
Sieve is ancient. It contains, for instance, its own simple implementation of context settings. So far, I:

- removed checkboxes that were never used,
- removed conditions combos haven't been used since Gregor defended his thesis,
- removed code for "optimization" that was never used, not ported to Orange 3 and commented out,
- reorganized controls to save space (the layout is non-standard now, but the control area would be almost empty),
- refactored controls to use models and context settings,
- properly implemented handling of input signal Features (other widgets should follow this model, IMHO; set the values in combos and disable them for as long as the signal is present and useful)
- let the user select areas; the widget outputs them without apply button, since this is more intuitive, expected and useful in this case

The drawing part needs some refactoring, but I leave this for another PR.