### PR TITLE
Widgets for saving and loading distances

### DIFF
--- a/Orange/misc/distmatrix.py
+++ b/Orange/misc/distmatrix.py
@@ -189,12 +189,12 @@ class DistMatrix(np.ndarray):
             for j, e in enumerate(line[:i + 1 if symmetric else n]):
                 try:
                     matrix[i, j] = float(e)
-                except ValueError:
+                except ValueError as exc:
                     raise ValueError("invalid element at row {}, column {}".
                                      format("'{}'".format(row_labels[i])
                                             if row_labels else i + 1,
                                             "'{}'".format(col_labels[j])
-                                            if col_labels else j + 1))
+                                            if col_labels else j + 1)) from exc
                 if symmetric:
                     matrix[j, i] = matrix[i, j]
         if col_labels:

--- a/Orange/misc/distmatrix.py
+++ b/Orange/misc/distmatrix.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from Orange.data import Table, StringVariable, Domain
+from Orange.data.io import detect_encoding
 from Orange.util import deprecated
 
 
@@ -42,7 +43,8 @@ class DistMatrix(np.ndarray):
 
     def __array_finalize__(self, obj):
         """See http://docs.scipy.org/doc/numpy/user/basics.subclassing.html"""
-        if obj is None: return
+        if obj is None:
+            return
         self.row_items = getattr(obj, 'row_items', None)
         self.col_items = getattr(obj, 'col_items', None)
         self.axis = getattr(obj, 'axis', 1)
@@ -60,6 +62,7 @@ class DistMatrix(np.ndarray):
         newstate = state[2] + (self.row_items, self.col_items, self.axis)
         return state[0], state[1], newstate
 
+    # noinspection PyMethodOverriding,PyArgumentList
     def __setstate__(self, state):
         self.row_items = state[-3]
         self.col_items = state[-2]
@@ -72,6 +75,7 @@ class DistMatrix(np.ndarray):
         """Returns the single dimension of the symmetric square matrix."""
         return self.shape[0]
 
+    # noinspection PyPep8Naming
     @property
     @deprecated
     def X(self):
@@ -81,37 +85,68 @@ class DistMatrix(np.ndarray):
     def flat(self):
         return self[np.triu_indices(self.shape[0], 1)]
 
-    def get_KNN(self, i, k):
-        """Return k columns with the lowest value in the i-th row.
-
-        :param i: i-th row
-        :type i: int
-        :param k: number of neighbors
-        :type k: int
-        """
-        idxs = np.argsort(self[i, :])[:]
-        return self[:, idxs]
-
     def submatrix(self, row_items, col_items=None):
-        """Return a submatrix of self, describing only distances between items"""
+        """
+        Return a submatrix
+
+        Args:
+            row_items: indices of rows
+            col_items: incides of columns
+        """
         if not col_items:
             col_items = row_items
         obj = self[np.ix_(row_items, col_items)]
-        if obj.row_items:
+        if self.row_items is not None:
             obj.row_items = self.row_items[row_items]
-        if obj.col_items:
-            obj.col_items = self.col_items[col_items]
+        if self.col_items is not None:
+            if self.col_items is self.row_items and row_items is col_items:
+                obj.col_items = obj.row_items
+            else:
+                obj.col_items = self.col_items[col_items]
         return obj
 
     @classmethod
     def from_file(cls, filename):
-        fle = open(filename)
+        """
+        Load distance matrix from a file
+
+        The file should be preferrably encoded in ascii/utf-8. White space at
+        the beginning and end of lines is ignored.
+
+        The first line of the file starts with the matrix dimension. It
+        can be followed by a list flags
+
+        - *axis=<number>*: the axis number
+        - *symmetric*: the matrix is symmetric; when reading the element (i, j)
+          it's value is also assigned to (j, i)
+        - *asymmetric*: the matrix is asymmetric
+        - *row_labels*: the file contains row labels
+        - *col_labels*: the file contains column labels
+
+        By default, matrices are symmetric, have axis 1 and no labels are given.
+        Flags *labeled* and *labelled* are obsolete aliases for *row_labels*.
+
+        If the file has column labels, they follow in the second line.
+        Row labels appear at the beginning of each row.
+        Labels are arbitrary strings that connot contain newlines and
+        tabulators. Labels are stored as instances of `Table` with a single
+        meta attribute named "label".
+
+        The remaining lines contain tab-separated numbers, preceded with labels,
+        if present. Lines are padded with zeros if necessary. If the matrix is
+        symmetric, the file contains the lower triangle; any data above the
+        diagonal is ignored.
+
+        Args:
+            filename: file name
+        """
+        fle = open(filename, encoding=detect_encoding(filename))
         line = fle.readline()
         if not line:
-            raise ValueError("Empty file")
-        data = line.strip().split("\t")
+            raise ValueError("empty file")
+        data = line.strip().split()
         if not data[0].strip().isdigit():
-            raise ValueError("distance file must begin with dimensions")
+            raise ValueError("distance file must begin with dimension")
         n = int(data.pop(0))
         symmetric = True
         axis = 1
@@ -134,32 +169,32 @@ class DistMatrix(np.ndarray):
                 if name == "axis" and value.isdigit():
                     axis = int(value)
                 else:
-                    raise ValueError("invalid flag '{}' in distance file '{}'"
-                                     .format(flag, filename))
+                    raise ValueError("invalid flag '{}'".format(flag, filename))
         if col_labels is not None:
-            col_labels = fle.readline().split("\t")
+            col_labels = [x.strip() for x in fle.readline().strip().split("\t")]
             if len(col_labels) != n:
                 raise ValueError("mismatching number of column labels")
 
         matrix = np.zeros((n, n))
         for i, line in enumerate(fle):
             if i >= n:
-                raise ValueError(
-                        "too many rows in distance file {}".format(filename))
-            line = line.split("\t")
+                raise ValueError("too many rows".format(filename))
+            line = line.strip().split("\t")
             if row_labels is not None:
-                row_labels.append(line.pop(0))
-            for j, e in enumerate(line):
-                if j >= n:
-                    raise ValueError(
-                            "too many columns in matrix row {}".format(i))
+                row_labels.append(line.pop(0).strip())
+            if len(line) > n:
+                raise ValueError("too many columns in matrix row {}".
+                                 format("'{}'".format(row_labels[i])
+                                        if row_labels else i + 1))
+            for j, e in enumerate(line[:i + 1 if symmetric else n]):
                 try:
                     matrix[i, j] = float(e)
                 except ValueError:
-                    raise ValueError("invalid element at ({}, {})".
-                        format(
-                            "'{}'".format(row_labels[i] if row_labels else i),
-                            "'{}'".format(col_labels[j] if col_labels else j)))
+                    raise ValueError("invalid element at row {}, column {}".
+                                     format("'{}'".format(row_labels[i])
+                                            if row_labels else i + 1,
+                                            "'{}'".format(col_labels[j])
+                                            if col_labels else j + 1))
                 if symmetric:
                     matrix[j, i] = matrix[i, j]
         if col_labels:
@@ -167,8 +202,6 @@ class DistMatrix(np.ndarray):
                 Domain([], metas=[StringVariable("label")]),
                 [[item] for item in col_labels])
         if row_labels:
-            if len(row_labels) != n:
-                raise ValueError("mismatching number of rows")
             row_labels = Table.from_list(
                 Domain([], metas=[StringVariable("label")]),
                 [[item] for item in row_labels])
@@ -176,20 +209,44 @@ class DistMatrix(np.ndarray):
 
     @staticmethod
     def _trivial_labels(items):
-        return items and len(items.domain.metas) == 1 and \
-            isinstance(items.domain.metas[0], StringVariable)
+        return items and \
+               isinstance(items, Table) and \
+               len(items.domain.metas) == 1 and \
+               isinstance(items.domain.metas[0], StringVariable)
 
     def has_row_labels(self):
+        """
+        Returns `True` if row labels can be automatically determined from data
+
+        For this, the `row_items` must be an instance of ``Orange.data.Table`
+        whose domain contains a single meta attribute, which has to be a string.
+        The domain may contain other variables, but not meta attributes.
+        """
         return self._trivial_labels(self.row_items)
 
     def has_col_labels(self):
+        """
+        Returns `True` if column labels can be automatically determined from
+        data
+
+        For this, the `col_items` must be an instance of ``Orange.data.Table`
+        whose domain contains a single meta attribute, which has to be a string.
+        The domain may contain other variables, but not meta attributes.
+        """
         return self._trivial_labels(self.col_items)
 
     def save(self, filename):
+        """
+        Save the distance matrix to a file in the file format described at
+        :obj:`~Orange.misc.distmatrix.DistMatrix.from_file`.
+
+        Args:
+            filename: file name
+        """
         n = len(self)
         data = "{}\taxis={}".format(n, self.axis)
         row_labels = col_labels = None
-        if self.has_col_labels():# and self.col_items is not self.row_items:
+        if self.has_col_labels():
             data += "\tcol_labels"
             col_labels = self.col_items
         if self.has_row_labels():

--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from contextlib import contextmanager
 
 from Orange.widgets.tests import test_setting_provider, \
     test_settings_handler, test_context_handler, \
@@ -12,6 +13,20 @@ try:
     run_widget_tests = True
 except ImportError:
     run_widget_tests = False
+
+
+@contextmanager
+def named_file(content, encoding=None):
+    import tempfile
+    import os
+    file = tempfile.NamedTemporaryFile("wt", delete=False, encoding=encoding)
+    file.write(content)
+    name = file.name
+    file.close()
+    try:
+        yield name
+    finally:
+        os.remove(name)
 
 
 def suite():

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from unittest import TestCase
 import pickle
 

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest import TestCase
 import pickle
 
@@ -9,6 +10,8 @@ from Orange.data import (Table, Domain, ContinuousVariable,
 from Orange.distance import (Euclidean, SpearmanR, SpearmanRAbsolute,
                              PearsonR, PearsonRAbsolute, Manhattan, Cosine,
                              Jaccard, _preprocess)
+from Orange.misc import DistMatrix
+from Orange.util import OrangeDeprecationWarning
 
 
 def tables_equal(tab1, tab2):
@@ -33,6 +36,157 @@ class TestDistMatrix(TestCase):
         self.assertTrue(tables_equal(unpickled_dist.row_items, self.dist.row_items))
         self.assertTrue(tables_equal(unpickled_dist.col_items, self.dist.col_items))
         self.assertEqual(unpickled_dist.axis, self.dist.axis)
+
+    @contextmanager
+    def named_file(self, content, encoding=None):
+        import tempfile
+        import os
+        file = tempfile.NamedTemporaryFile(
+                "wt", delete=False, encoding=encoding)
+        file.write(content)
+        name = file.name
+        file.close()
+        yield name
+        os.remove(name)
+
+    def test_deprecated(self):
+        a9 = np.arange(9).reshape(3, 3)
+        m = DistMatrix(a9)
+        with self.assertWarns(OrangeDeprecationWarning):
+            self.assertEqual(m.dim, 3)
+        with self.assertWarns(OrangeDeprecationWarning):
+            np.testing.assert_almost_equal(m.X, a9)
+
+    def test_from_file(self):
+        with self.named_file(
+                """3 axis=0 asymmetric col_labels row_labels
+                         ann	bert	chad
+                danny	0.12	3.45	6.78
+                  eve	9.01	2.34	5.67
+                frank	8.90	1.23	4.56""") as name:
+            m = DistMatrix.from_file(name)
+            np.testing.assert_almost_equal(m, np.array([[0.12, 3.45, 6.78],
+                                                        [9.01, 2.34, 5.67],
+                                                        [8.90, 1.23, 4.56]]))
+            self.assertIsInstance(m.row_items, Table)
+            self.assertIsInstance(m.col_items, Table)
+            self.assertEqual([e.metas[0] for e in m.col_items],
+                             ["ann", "bert", "chad"])
+            self.assertEqual([e.metas[0] for e in m.row_items],
+                             ["danny", "eve", "frank"])
+            self.assertEqual(m.axis, 0)
+
+        with self.named_file(
+                """3 axis=1 row_labels
+                danny	0.12	3.45	6.78
+                eve 	9.01	2.34	5.67
+                frank	8.90""") as name:
+            m = DistMatrix.from_file(name)
+            np.testing.assert_almost_equal(m, np.array([[0.12, 9.01, 8.90],
+                                                        [9.01, 2.34, 0],
+                                                        [8.90, 0, 0]]))
+            self.assertIsInstance(m.row_items, Table)
+            self.assertIsNone(m.col_items)
+            self.assertEqual([e.metas[0] for e in m.row_items],
+                             ["danny", "eve", "frank"])
+            self.assertEqual(m.axis, 1)
+
+        with self.named_file(
+                """3 axis=1 symmetric
+                0.12	3.45	6.78
+                9.01	2.34	5.67
+                8.90""") as name:
+            m = DistMatrix.from_file(name)
+        np.testing.assert_almost_equal(m, np.array([[0.12, 9.01, 8.90],
+                                                    [9.01, 2.34, 0],
+                                                    [8.90, 0, 0]]))
+
+        with self.named_file(
+                """3 row_labels
+                starič	0.12	3.45	6.78
+                aleš	9.01	2.34	5.67
+                anže	8.90""", encoding="utf-8""") as name:
+            m = DistMatrix.from_file(name)
+            np.testing.assert_almost_equal(m, np.array([[0.12, 9.01, 8.90],
+                                                        [9.01, 2.34, 0],
+                                                        [8.90, 0, 0]]))
+            self.assertIsInstance(m.row_items, Table)
+            self.assertIsNone(m.col_items)
+            self.assertEqual([e.metas[0] for e in m.row_items],
+                             ["starič", "aleš", "anže"])
+            self.assertEqual(m.axis, 1)
+
+
+        def assertErrorMsg(content, msg):
+            with self.named_file(content) as name:
+                with self.assertRaises(ValueError) as cm:
+                    DistMatrix.from_file(name)
+                self.assertEqual(str(cm.exception), msg)
+
+        assertErrorMsg("",
+                       "empty file")
+        assertErrorMsg("axis=1\n1\t3\n4",
+                       "distance file must begin with dimension")
+        assertErrorMsg("3 col_labels\na\tb\n1\n\2\n3",
+                       "mismatching number of column labels")
+        assertErrorMsg("3 col_labels\na\tb\tc\td\n1\n\2\n3",
+                       "mismatching number of column labels")
+        assertErrorMsg("2\n  1\t2\t3\n  5",
+                       "too many columns in matrix row 1")
+        assertErrorMsg("2 row_labels\na\t1\t2\t3\nb\t5",
+                       "too many columns in matrix row 'a'")
+        assertErrorMsg("2 noflag\n  1\t2\t3\n  5",
+                       "invalid flag 'noflag'")
+        assertErrorMsg("2 noflag=5\n  1\t2\t3\n  5",
+                       "invalid flag 'noflag=5'")
+        assertErrorMsg("2\n1\n2\n3",
+                       "too many rows")
+        assertErrorMsg("2\n1\nasd",
+                       "invalid element at row 2, column 1")
+        assertErrorMsg("2 row_labels\na\t1\nb\tasd",
+                       "invalid element at row 'b', column 1")
+        assertErrorMsg("2 col_labels row_labels\nd\te\na\t1\nb\tasd",
+                       "invalid element at row 'b', column 'd'")
+        assertErrorMsg("2 col_labels\nd\te\n1\nasd",
+                       "invalid element at row 2, column 'd'")
+
+    def test_save(self):
+        with self.named_file(
+                """3 axis=1 row_labels
+                danny	0.12	3.45	6.78
+                eve 	9.01	2.34	5.67
+                frank	8.90""") as name:
+            m = DistMatrix.from_file(name)
+            m.save(name)
+            m = DistMatrix.from_file(name)
+            np.testing.assert_almost_equal(m, np.array([[0.12, 9.01, 8.90],
+                                                        [9.01, 2.34, 0],
+                                                        [8.90, 0, 0]]))
+            self.assertIsInstance(m.row_items, Table)
+            self.assertIsNone(m.col_items)
+            self.assertEqual([e.metas[0] for e in m.row_items],
+                             ["danny", "eve", "frank"])
+            self.assertEqual(m.axis, 1)
+
+        with self.named_file(
+                """3 axis=0 asymmetric col_labels row_labels
+                         ann	bert	chad
+                danny	0.12	3.45	6.78
+                  eve	9.01	2.34	5.67
+                frank	8.90	1.23	4.56""") as name:
+            m = DistMatrix.from_file(name)
+            m.save(name)
+            m = DistMatrix.from_file(name)
+            np.testing.assert_almost_equal(m, np.array([[0.12, 3.45, 6.78],
+                                                        [9.01, 2.34, 5.67],
+                                                        [8.90, 1.23, 4.56]]))
+            self.assertIsInstance(m.row_items, Table)
+            self.assertIsInstance(m.col_items, Table)
+            self.assertEqual([e.metas[0] for e in m.col_items],
+                             ["ann", "bert", "chad"])
+            self.assertEqual([e.metas[0] for e in m.row_items],
+                             ["danny", "eve", "frank"])
+            self.assertEqual(m.axis, 0)
 
 
 class TestEuclidean(TestCase):

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -11,6 +11,7 @@ from Orange.distance import (Euclidean, SpearmanR, SpearmanRAbsolute,
                              PearsonR, PearsonRAbsolute, Manhattan, Cosine,
                              Jaccard, _preprocess)
 from Orange.misc import DistMatrix
+from Orange.tests import named_file
 from Orange.util import OrangeDeprecationWarning
 
 
@@ -37,18 +38,6 @@ class TestDistMatrix(TestCase):
         self.assertTrue(tables_equal(unpickled_dist.col_items, self.dist.col_items))
         self.assertEqual(unpickled_dist.axis, self.dist.axis)
 
-    @contextmanager
-    def named_file(self, content, encoding=None):
-        import tempfile
-        import os
-        file = tempfile.NamedTemporaryFile(
-                "wt", delete=False, encoding=encoding)
-        file.write(content)
-        name = file.name
-        file.close()
-        yield name
-        os.remove(name)
-
     def test_deprecated(self):
         a9 = np.arange(9).reshape(3, 3)
         m = DistMatrix(a9)
@@ -58,7 +47,7 @@ class TestDistMatrix(TestCase):
             np.testing.assert_almost_equal(m.X, a9)
 
     def test_from_file(self):
-        with self.named_file(
+        with named_file(
                 """3 axis=0 asymmetric col_labels row_labels
                          ann	bert	chad
                 danny	0.12	3.45	6.78
@@ -76,7 +65,7 @@ class TestDistMatrix(TestCase):
                              ["danny", "eve", "frank"])
             self.assertEqual(m.axis, 0)
 
-        with self.named_file(
+        with named_file(
                 """3 axis=1 row_labels
                 danny	0.12	3.45	6.78
                 eve 	9.01	2.34	5.67
@@ -91,7 +80,7 @@ class TestDistMatrix(TestCase):
                              ["danny", "eve", "frank"])
             self.assertEqual(m.axis, 1)
 
-        with self.named_file(
+        with named_file(
                 """3 axis=1 symmetric
                 0.12	3.45	6.78
                 9.01	2.34	5.67
@@ -101,7 +90,7 @@ class TestDistMatrix(TestCase):
                                                     [9.01, 2.34, 0],
                                                     [8.90, 0, 0]]))
 
-        with self.named_file(
+        with named_file(
                 """3 row_labels
                 starič	0.12	3.45	6.78
                 aleš	9.01	2.34	5.67
@@ -118,7 +107,7 @@ class TestDistMatrix(TestCase):
 
 
         def assertErrorMsg(content, msg):
-            with self.named_file(content) as name:
+            with named_file(content) as name:
                 with self.assertRaises(ValueError) as cm:
                     DistMatrix.from_file(name)
                 self.assertEqual(str(cm.exception), msg)
@@ -151,7 +140,7 @@ class TestDistMatrix(TestCase):
                        "invalid element at row 2, column 'd'")
 
     def test_save(self):
-        with self.named_file(
+        with named_file(
                 """3 axis=1 row_labels
                 danny	0.12	3.45	6.78
                 eve 	9.01	2.34	5.67
@@ -168,7 +157,7 @@ class TestDistMatrix(TestCase):
                              ["danny", "eve", "frank"])
             self.assertEqual(m.axis, 1)
 
-        with self.named_file(
+        with named_file(
                 """3 axis=0 asymmetric col_labels row_labels
                          ann	bert	chad
                 danny	0.12	3.45	6.78

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -10,6 +10,10 @@ from Orange.widgets.utils.itemmodels import PyListModel
 from Orange.data.table import Table, get_sample_datasets_dir
 from Orange.data.io import FileFormat
 
+# Backward compatibility: class RecentPath used to be defined in this module,
+# and it is used in saved (pickled) settings. It must be imported into the
+# module's namespace so that old saved settings still work
+from Orange.widgets.utils.filedialogs import RecentPath
 
 def add_origin(examples, filename):
     """Adds attribute with file location to each variable"""
@@ -289,7 +293,7 @@ class OWFile(widget.OWWidget):
         if self.recent_paths:
             basename = self.file_combo.currentText()
             path = self.recent_paths[0]
-            if basename in [path.relpath, path.value]:
+            if basename in [path.relpath, path.basename]:
                 self.source = self.LOCAL_FILE
                 return self.load_data()
         self.select_file(len(self.recent_paths) + 1)
@@ -321,23 +325,11 @@ class OWFile(widget.OWWidget):
 
     def browse_file(self, in_demos=False):
         if in_demos:
-            try:
-                start_file = get_sample_datasets_dir()
-            except AttributeError:
-                start_file = ""
-            if not start_file or not os.path.exists(start_file):
-                widgets_dir = os.path.dirname(gui.__file__)
-                orange_dir = os.path.dirname(widgets_dir)
-                start_file = os.path.join(orange_dir, "doc", "datasets")
-            if not start_file or not os.path.exists(start_file):
-                d = os.getcwd()
-                if os.path.basename(d) == "canvas":
-                    d = os.path.dirname(d)
-                start_file = os.path.join(os.path.dirname(d), "doc", "datasets")
+            start_file = get_sample_datasets_dir()
             if not os.path.exists(start_file):
                 QtGui.QMessageBox.information(
                     None, "File",
-                    "Cannot find the directory with example data sets")
+                    "Cannot find the directory with documentation data sets")
                 return
         else:
             if self.recent_paths:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -91,10 +91,9 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         box = gui.hBox(None, addToLayout=False, margin=0)
         box.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
-        file_combo = self.file_combo
-        file_combo.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
-        file_combo.activated[int].connect(self.select_file)
-        box.layout().addWidget(file_combo)
+        self.file_combo.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
+        self.file_combo.activated[int].connect(self.select_file)
+        box.layout().addWidget(self.file_combo)
         button = gui.button(
             box, self, '...', callback=self.browse_file, autoDefault=False)
         button.setIcon(self.style().standardIcon(QtGui.QStyle.SP_DirOpenIcon))

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -7,6 +7,7 @@ from PyQt4.QtGui import QSizePolicy as Policy
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.itemmodels import PyListModel
+from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
 from Orange.data.table import Table, get_sample_datasets_dir
 from Orange.data.io import FileFormat
 
@@ -25,127 +26,6 @@ def add_origin(examples, filename):
             var.attributes["origin"] = dir_name
 
 
-class RecentPath:
-    abspath = ''
-    prefix = None   #: Option[str]  # BASEDIR | SAMPLE-DATASETS | ...
-    relpath = ''  #: Option[str]  # path relative to `prefix`
-    title = ''    #: Option[str]  # title of filename (e.g. from URL)
-
-    def __init__(self, abspath, prefix, relpath, title=''):
-        if os.name == "nt":
-            # always use a cross-platform pathname component separator
-            abspath = abspath.replace(os.path.sep, "/")
-            if relpath is not None:
-                relpath = relpath.replace(os.path.sep, "/")
-        self.abspath = abspath
-        self.prefix = prefix
-        self.relpath = relpath
-        self.title = title
-
-    def __eq__(self, other):
-        return (self.abspath == other.abspath or
-                (self.prefix is not None and self.relpath is not None and
-                 self.prefix == other.prefix and
-                 self.relpath == other.relpath))
-
-    @staticmethod
-    def create(path, searchpaths):
-        """
-        Create a RecentPath item inferring a suitable prefix name and relpath.
-
-        Parameters
-        ----------
-        path : str
-            File system path.
-        searchpaths : List[Tuple[str, str]]
-            A sequence of (NAME, prefix) pairs. The sequence is searched
-            for a item such that prefix/relpath == abspath. The NAME is
-            recorded in the `prefix` and relpath in `relpath`.
-            (note: the first matching prefixed path is chosen).
-
-        """
-        def isprefixed(prefix, path):
-            """
-            Is `path` contained within the directory `prefix`.
-
-            >>> isprefixed("/usr/local/", "/usr/local/shared")
-            True
-            """
-            normalize = lambda path: os.path.normcase(os.path.normpath(path))
-            prefix, path = normalize(prefix), normalize(path)
-            if not prefix.endswith(os.path.sep):
-                prefix = prefix + os.path.sep
-            return os.path.commonprefix([prefix, path]) == prefix
-
-        abspath = os.path.normpath(os.path.abspath(path))
-        for prefix, base in searchpaths:
-            if isprefixed(base, abspath):
-                relpath = os.path.relpath(abspath, base)
-                return RecentPath(abspath, prefix, relpath)
-
-        return RecentPath(abspath, None, None)
-
-    def search(self, searchpaths):
-        """
-        Return a file system path, substituting the variable paths if required
-
-        If the self.abspath names an existing path it is returned. Else if
-        the `self.prefix` and `self.relpath` are not `None` then the
-        `searchpaths` sequence is searched for the matching prefix and
-        if found and the {PATH}/self.relpath exists it is returned.
-
-        If all fails return None.
-
-        Parameters
-        ----------
-        searchpaths : List[Tuple[str, str]]
-            A sequence of (NAME, prefixpath) pairs.
-
-        """
-        if os.path.exists(self.abspath):
-            return os.path.normpath(self.abspath)
-
-        for prefix, base in searchpaths:
-            if self.prefix == prefix:
-                path = os.path.join(base, self.relpath)
-                if os.path.exists(path):
-                    return os.path.normpath(path)
-        else:
-            return None
-
-    def resolve(self, searchpaths):
-        if self.prefix is None and os.path.exists(self.abspath):
-            return self
-        elif self.prefix is not None:
-            for prefix, base in searchpaths:
-                if self.prefix == prefix:
-                    path = os.path.join(base, self.relpath)
-                    if os.path.exists(path):
-                        return RecentPath(
-                            os.path.normpath(path), self.prefix, self.relpath)
-        return None
-
-    @property
-    def value(self):
-        return os.path.basename(self.abspath)
-
-    @property
-    def icon(self):
-        provider = QtGui.QFileIconProvider()
-        return provider.icon(QtGui.QFileIconProvider.Drive)
-
-    @property
-    def dirname(self):
-        return os.path.dirname(self.abspath)
-
-    def __repr__(self):
-        return ("{0.__class__.__name__}(abspath={0.abspath!r}, "
-                "prefix={0.prefix!r}, relpath={0.relpath!r}, "
-                "title={0.title!r})").format(self)
-
-    __str__ = __repr__
-
-
 class NamedURLModel(PyListModel):
     def __init__(self, mapping):
         self.mapping = mapping
@@ -162,7 +42,7 @@ class NamedURLModel(PyListModel):
         self.modelReset.emit()
 
 
-class OWFile(widget.OWWidget):
+class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     name = "File"
     id = "orange.widgets.data.file"
     description = "Read a data from an input file or network" \
@@ -178,10 +58,10 @@ class OWFile(widget.OWWidget):
     want_main_area = False
     resizing_enabled = False
 
+    SEARCH_PATH = [("sample-datasets", get_sample_datasets_dir())]
+
     LOCAL_FILE, URL = range(2)
 
-    #: List[RecentPath]
-    recent_paths = Setting([])
     recent_urls = Setting([])
     source = Setting(LOCAL_FILE)
     sheet_names = Setting({})
@@ -196,10 +76,10 @@ class OWFile(widget.OWWidget):
 
     def __init__(self):
         super().__init__()
+        RecentPathsWComboMixin.__init__(self)
         self.domain = None
         self.data = None
         self.loaded_file = ""
-        self._relocate_recent_files()
 
         layout = QtGui.QGridLayout()
         gui.widgetBox(self.controlArea, margin=0, orientation=layout)
@@ -211,7 +91,7 @@ class OWFile(widget.OWWidget):
 
         box = gui.hBox(None, addToLayout=False, margin=0)
         box.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
-        self.file_combo = file_combo = QtGui.QComboBox(box)
+        file_combo = self.file_combo
         file_combo.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
         file_combo.activated[int].connect(self.select_file)
         box.layout().addWidget(file_combo)
@@ -234,6 +114,7 @@ class OWFile(widget.OWWidget):
         url_model.wrap(self.recent_urls)
         url_combo.setModel(url_model)
         url_combo.setSizePolicy(Policy.MinimumExpanding, Policy.Fixed)
+        url_combo.setMaximumWidth(500)
         url_combo.setEditable(True)
         url_combo.setInsertPolicy(url_combo.InsertAtTop)
         url_edit = url_combo.lineEdit()
@@ -264,31 +145,6 @@ class OWFile(widget.OWWidget):
         # explicitly re-enters the event loop (by a progress bar)
         QtCore.QTimer.singleShot(0, self.load_data)
 
-    def _relocate_recent_files(self):
-        paths = [("sample-datasets", get_sample_datasets_dir())]
-        basedir = self.workflowEnv().get("basedir", None)
-        if basedir is not None:
-            paths.append(("basedir", basedir))
-
-        rec = []
-        for recent in self.recent_paths:
-            resolved = recent.resolve(paths)
-            if resolved is not None:
-                rec.append(RecentPath.create(resolved.abspath, paths))
-            elif recent.search(paths) is not None:
-                rec.append(RecentPath.create(recent.search(paths), paths))
-        self.recent_paths = rec
-
-    def set_file_list(self):
-        self.file_combo.clear()
-        if not self.recent_paths:
-            self.file_combo.addItem("(none)")
-            self.file_combo.model().item(0).setEnabled(False)
-        else:
-            for i, recent in enumerate(self.recent_paths):
-                self.file_combo.addItem(recent.value)
-                self.file_combo.model().item(i).setToolTip(recent.abspath)
-
     def reload(self):
         if self.recent_paths:
             basename = self.file_combo.currentText()
@@ -300,13 +156,14 @@ class OWFile(widget.OWWidget):
 
     def select_file(self, n):
         if n < len(self.recent_paths):
-            recent = self.recent_paths[n]
-            del self.recent_paths[n]
-            self.recent_paths.insert(0, recent)
+            super().select_file(n)
+        # TODO: This is weird. Has it remained here from "Browse data sets"
+        # or from when this combo was editable? A `n` this large can come from
+        # `reload`, but ... how?!
         elif n:
             path = self.file_combo.currentText()
             if os.path.exists(path):
-                self._add_path(path)
+                self.add_path(path)
             else:
                 self.info.setText('Data was not loaded:')
                 self.warnings.setText("File {} does not exist".format(path))
@@ -314,7 +171,7 @@ class OWFile(widget.OWWidget):
                 self.file_combo.lineEdit().setText(path)
                 return
 
-        if len(self.recent_paths) > 0:
+        if self.recent_paths:
             self.source = self.LOCAL_FILE
             self.load_data()
             self.set_file_list()
@@ -332,30 +189,17 @@ class OWFile(widget.OWWidget):
                     "Cannot find the directory with documentation data sets")
                 return
         else:
-            if self.recent_paths:
-                start_file = self.recent_paths[0].abspath
-            else:
-                start_file = os.path.expanduser("~/")
+            start_file = self.last_path() or os.path.expanduser("~/")
 
         filename = QtGui.QFileDialog.getOpenFileName(
             self, 'Open Orange Data File', start_file, self.dlg_formats)
         if not filename:
             return
 
-        self._add_path(filename)
-        self.set_file_list()
+        self.add_path(filename)
         self.source = self.LOCAL_FILE
         self.load_data()
 
-    def _add_path(self, filename):
-        searchpaths = [("sample-datasets", get_sample_datasets_dir())]
-        basedir = self.workflowEnv().get("basedir", None)
-        if basedir is not None:
-            searchpaths.append(("basedir", basedir))
-        recent = RecentPath.create(filename, searchpaths)
-        if recent in self.recent_paths:
-            self.recent_paths.remove(recent)
-        self.recent_paths.insert(0, recent)
 
     # Open a file, create data from it and send it over the data channel
     def load_data(self):
@@ -363,12 +207,12 @@ class OWFile(widget.OWWidget):
             with catch_warnings(record=True) as warnings:
                 data = method(fn)
                 self.warning(
-                        33, warnings[-1].message.args[0] if warnings else '')
+                    33, warnings[-1].message.args[0] if warnings else '')
             return data, fn
 
         def load_from_file():
-            fn = fn_original = self.recent_paths[0].abspath
-            if fn == "(none)":
+            fn = self.last_path()
+            if not fn:
                 return None, ""
             if not os.path.exists(fn):
                 dir_name, basename = os.path.split(fn)
@@ -380,11 +224,7 @@ class OWFile(widget.OWWidget):
                 return load(Table.from_file, fn)
             except Exception as exc:
                 self.warnings.setText(str(exc))
-                ind = self.file_combo.currentIndex()
-                self.file_combo.removeItem(ind)
-                if ind < len(self.recent_paths) and \
-                        self.recent_paths[ind].abspath == fn_original:
-                    del self.recent_paths[ind]
+                # Let us not remove from recent files: user may fix them
                 raise
 
         def load_from_network():
@@ -490,10 +330,6 @@ class OWFile(widget.OWWidget):
 
         self.report_data("Data", self.data)
 
-    def workflowEnvChanged(self, key, value, oldvalue):
-        if key == "basedir":
-            self._relocate_recent_files()
-            self.set_file_list()
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/unsupervised/icons/DistanceFile.svg
+++ b/Orange/widgets/unsupervised/icons/DistanceFile.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="48px" height="48px" viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
+<g>
+	<path fill="#FFFFFF" d="M23.213,6.189H11.47V36H33V14.573c0-3.841-7.829-0.932-7.829-0.932C26.149,9.915,25.171,6.189,23.213,6.189
+		z"/>
+	<path fill="#666666" d="M25.547,6.189H13.126H11.47v1.656v26.499V36h1.656h18.218H33v-1.656V14.47v-1.656L25.547,6.189z
+		 M31.344,34.344H13.126V7.845h9.937c1.656,0,2.484,3.312,1.656,6.625c0,0,6.625-2.586,6.625,0.828V34.344z"/>
+</g>
+<g>
+	<path fill="#333333" d="M32.118,17.627h0.687l11.071,24H21.031L32.118,17.627z M24.444,39.561l13.613,0.021l-6.652-15.349
+		L24.444,39.561z"/>
+</g>
+</svg>

--- a/Orange/widgets/unsupervised/icons/SaveDistances.svg
+++ b/Orange/widgets/unsupervised/icons/SaveDistances.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="48px" height="48px" viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
+<g>
+	<path fill="#666666" d="M30.025,10.23H7.717V37H33V13.2L30.025,10.23z M13.666,11.717h13.385v6.688l-0.743,0.749H14.41
+		l-0.744-0.749V11.717z M30.025,35.513H10.692V23.615h2.227h13.364h3.742V35.513z"/>
+	<polygon fill="#FFFFFF" points="12.919,23.615 10.692,23.615 10.692,35.513 30.025,35.513 30.025,23.615 26.283,23.615 	"/>
+	<path fill="#FFFFFF" d="M26.308,19.153l0.743-0.749v-6.688H13.666v6.688l0.744,0.749H26.308z M22.59,12.461h2.974v5.949H22.59
+		V12.461z"/>
+	<rect x="22.59" y="12.461" fill="#666666" width="2.974" height="5.949"/>
+</g>
+<g>
+	<path fill="#333333" d="M32.118,17.627h0.687l11.071,24H21.031L32.118,17.627z M24.444,39.561l13.613,0.021l-6.652-15.349
+		L24.444,39.561z"/>
+</g>
+</svg>

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -1,0 +1,177 @@
+import os, sys
+
+from PyQt4 import QtGui
+
+from Orange.misc import DistMatrix
+from Orange.widgets import widget, gui
+from Orange.widgets.settings import Setting
+from Orange.data import get_sample_datasets_dir
+
+
+class OWDistanceFile(widget.OWWidget):
+    name = "Distance File"
+    id = "orange.widgets.unsupervised.distancefile"
+    description = "Read distances from file"
+    icon = "icons/DistanceFile.svg"
+    priority = 10
+    category = "Data"
+    keywords = ["data", "distances", "load", "read"]
+    outputs = [("Distances", DistMatrix)]
+
+    want_main_area = False
+    resizing_enabled = False
+
+    recent_files = Setting(["(none)"])
+
+    def __init__(self):
+        super().__init__()
+        self.recent_files = [fn for fn in self.recent_files
+                             if os.path.exists(fn)]
+        self.loaded_file = ""
+
+        vbox = gui.vBox(self.controlArea, "Distance File", addSpace=True)
+        box = gui.hBox(vbox)
+        self.file_combo = QtGui.QComboBox(box)
+        self.file_combo.setMinimumWidth(300)
+        box.layout().addWidget(self.file_combo)
+        self.file_combo.activated[int].connect(self.select_file)
+
+        button = gui.button(box, self, '...', callback=self.browse_file)
+        button.setIcon(self.style().standardIcon(QtGui.QStyle.SP_DirOpenIcon))
+        button.setSizePolicy(
+            QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Fixed)
+
+        button = gui.button(
+            box, self, "Reload", callback=self.reload, default=True)
+        button.setIcon(self.style().standardIcon(QtGui.QStyle.SP_BrowserReload))
+        button.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+
+        box = gui.vBox(self.controlArea, "Info", addSpace=True)
+        self.infoa = gui.widgetLabel(box, 'No data loaded.')
+        self.warnings = gui.widgetLabel(box, ' ')
+        #Set word wrap, so long warnings won't expand the widget
+        self.warnings.setWordWrap(True)
+        self.warnings.setSizePolicy(
+            QtGui.QSizePolicy.Ignored, QtGui.QSizePolicy.MinimumExpanding)
+
+        self.set_file_list()
+        if len(self.recent_files) > 0:
+            self.open_file(self.recent_files[0])
+
+    def set_file_list(self):
+        self.file_combo.clear()
+        if not self.recent_files:
+            self.file_combo.addItem("(none)")
+        for file in self.recent_files:
+            if file == "(none)":
+                self.file_combo.addItem("(none)")
+            else:
+                self.file_combo.addItem(os.path.split(file)[1])
+        self.file_combo.addItem("Browse documentation data sets...")
+
+    def reload(self):
+        if self.recent_files:
+            return self.open_file(self.recent_files[0])
+
+    def select_file(self, n):
+        if n < len(self.recent_files) :
+            name = self.recent_files[n]
+            del self.recent_files[n]
+            self.recent_files.insert(0, name)
+        elif n:
+            self.browse_file(True)
+
+        if len(self.recent_files) > 0:
+            self.set_file_list()
+            self.open_file(self.recent_files[0])
+
+    def browse_file(self, in_demos=0):
+        if in_demos:
+            try:
+                start_file = get_sample_datasets_dir()
+            except AttributeError:
+                start_file = ""
+            if not start_file or not os.path.exists(start_file):
+                widgets_dir = os.path.dirname(gui.__file__)
+                orange_dir = os.path.dirname(widgets_dir)
+                start_file = os.path.join(orange_dir, "doc", "datasets")
+            if not start_file or not os.path.exists(start_file):
+                d = os.getcwd()
+                if os.path.basename(d) == "canvas":
+                    d = os.path.dirname(d)
+                start_file = os.path.join(os.path.dirname(d), "doc", "datasets")
+            if not os.path.exists(start_file):
+                QtGui.QMessageBox.information(
+                    None, "File",
+                    "Cannot find the directory with example files")
+                return
+        else:
+            if self.recent_files and self.recent_files[0] != "(none)":
+                start_file = self.recent_files[0]
+            else:
+                start_file = os.path.expanduser("~/")
+
+        filename = QtGui.QFileDialog.getOpenFileName(
+            self, 'Open Distance File', start_file)
+        if not filename:
+            return
+        if filename in self.recent_files:
+            self.recent_files.remove(filename)
+        self.recent_files.insert(0, filename)
+        self.set_file_list()
+        self.open_file(self.recent_files[0])
+
+    # Open a file, create data from it and send it over the data channel
+    def open_file(self, fn):
+        self.error()
+        self.warning()
+        self.information()
+
+        if not os.path.exists(fn):
+            dir_name, basename = os.path.split(fn)
+            if os.path.exists(os.path.join(".", basename)):
+                fn = os.path.join(".", basename)
+                self.information("Loading '{}' from the current directory."
+                                 .format(basename))
+        if fn == "(none)":
+            self.send("Distances", None)
+            self.infoa.setText("No data loaded")
+            self.infob.setText("")
+            self.warnings.setText("")
+            return
+
+        self.loaded_file = ""
+
+        try:
+            distances = DistMatrix.from_file(fn)
+            self.loaded_file = fn
+        except Exception as exc:
+            err_value = str(exc)
+            self.error("Invalid file format")
+            self.infoa.setText('Data was not loaded due to an error.')
+            self.warnings.setText(err_value)
+            distances = None
+
+        if distances is not None:
+            self.infoa.setText(
+                "{} points(s), ".format(len(distances)) +
+                (["unlabelled", "labelled"][distances.row_items is not None]))
+            self.warnings.setText("")
+            file_name = os.path.split(fn)[1]
+            if "." in file_name:
+                distances.name = file_name[:file_name.rfind('.')]
+            else:
+                distances.name = file_name
+
+        self.send("Distances", distances)
+
+    def sendReport(self):
+        if self.loaded_file:
+            self.reportSettings("File", [("File name", self.loaded_file)])
+
+if __name__ == "__main__":
+    a = QtGui.QApplication(sys.argv)
+    ow = OWDistanceFile()
+    ow.show()
+    a.exec_()
+    ow.saveSettings()

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -71,23 +71,11 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
 
     def browse_file(self, in_demos=0):
         if in_demos:
-            try:
-                start_file = get_sample_datasets_dir()
-            except AttributeError:
-                start_file = ""
-            if not start_file or not os.path.exists(start_file):
-                widgets_dir = os.path.dirname(gui.__file__)
-                orange_dir = os.path.dirname(widgets_dir)
-                start_file = os.path.join(orange_dir, "doc", "datasets")
-            if not start_file or not os.path.exists(start_file):
-                d = os.getcwd()
-                if os.path.basename(d) == "canvas":
-                    d = os.path.dirname(d)
-                start_file = os.path.join(os.path.dirname(d), "doc", "datasets")
+            start_file = get_sample_datasets_dir()
             if not os.path.exists(start_file):
                 QtGui.QMessageBox.information(
                     None, "File",
-                    "Cannot find the directory with example files")
+                    "Cannot find the directory with documentation data sets")
                 return
         else:
             start_file = self.last_path() or os.path.expanduser("~/")

--- a/Orange/widgets/unsupervised/owsavedistances.py
+++ b/Orange/widgets/unsupervised/owsavedistances.py
@@ -1,0 +1,93 @@
+import os.path
+
+from PyQt4.QtGui import QFileDialog
+
+from Orange.misc import DistMatrix
+from Orange.widgets import gui, widget
+from Orange.widgets.settings import Setting
+
+
+class OWSaveDistances(widget.OWWidget):
+    name = "Save Distance Matrix"
+    description = "Save distance matrix to an output file."
+    icon = "icons/SaveDistances.svg"
+    category = "Unsupervised"
+    keywords = ["distance matrix", "save"]
+
+    inputs = [("Distances", DistMatrix, "set_distances")]
+
+    want_main_area = False
+    resizing_enabled = False
+
+    last_dir = Setting("")
+    auto_save = Setting(False)
+
+    def __init__(self):
+        super().__init__()
+        self.distances = None
+        self.filename = ""
+
+        self.save = gui.auto_commit(
+            self.controlArea, self, "auto_save", "Save", box=False,
+            commit=self.save_file, callback=self.adjust_label,
+            disabled=True, addSpace=True)
+        self.saveAs = gui.button(
+            self.controlArea, self, "Save as ...",
+            callback=self.save_file_as, disabled=True)
+        self.saveAs.setMinimumWidth(300)
+        self.adjustSize()
+
+    def adjust_label(self):
+        if self.filename:
+            filename = os.path.split(self.filename)[1]
+            text = ["Save as '{}'", "Auto save as '{}'"][self.auto_save]
+            self.save.button.setText(text.format(filename))
+
+    def set_distances(self, distances):
+        self.distances = distances
+        self.save.setDisabled(distances is None)
+        self.saveAs.setDisabled(distances is None)
+        if distances is not None:
+            self.save_file()
+
+    def save_file_as(self):
+        file_name = self.filename or self.last_dir or os.path.expanduser("~")
+        filename = QFileDialog.getSaveFileName(
+            self, "Select file", file_name, 'Distance files (*.dst)')
+        if not filename:
+            return
+        self.filename = filename
+        self.unconditional_save_file()
+        self.last_dir = os.path.split(self.filename)[0]
+        self.adjust_label()
+
+    def save_file(self):
+        dist = self.distances
+        if dist is None:
+            return
+        if not self.filename:
+            self.save_file_as()
+        else:
+            dist.save(self.filename)
+            skip_row = not dist.has_row_labels() and dist.row_items is not None
+            skip_col = not dist.has_col_labels() and dist.col_items is not None
+            if skip_row and skip_col:
+                self.warning("Associated data table was not saved")
+            elif skip_row or skip_col:
+                self.warning("Data associated with {} was not saved".
+                             format(["rows", "columns"][skip_col]))
+            else:
+                self.warning()
+
+
+if __name__ == "__main__":
+    import sys
+    from PyQt4 import QtGui
+
+    a = QtGui.QApplication(sys.argv)
+    table = Table("iris")
+    ow = OWSaveDistances()
+    ow.show()
+    ow.set_distances(table)
+    a.exec()
+    ow.saveSettings()

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -1,6 +1,8 @@
 import os
 
-from PyQt4.QtGui import QMessageBox, QFileDialog
+from PyQt4.QtGui import QMessageBox, QFileDialog, QFileIconProvider
+
+from Orange.widgets.settings import Setting
 
 
 def fix_extension(ext, format, suggested_ext, suggested_format):
@@ -85,3 +87,186 @@ def get_file_name(start_dir, start_filter, file_formats):
                 writer = file_formats[ext]
                 filter = format_filter(writer)
         return filename, writer, filter
+
+
+class RecentPath:
+    abspath = ''
+    prefix = None   #: Option[str]  # BASEDIR | SAMPLE-DATASETS | ...
+    relpath = ''  #: Option[str]  # path relative to `prefix`
+    title = ''    #: Option[str]  # title of filename (e.g. from URL)
+
+    def __init__(self, abspath, prefix, relpath, title=''):
+        if os.name == "nt":
+            # always use a cross-platform pathname component separator
+            abspath = abspath.replace(os.path.sep, "/")
+            if relpath is not None:
+                relpath = relpath.replace(os.path.sep, "/")
+        self.abspath = abspath
+        self.prefix = prefix
+        self.relpath = relpath
+        self.title = title
+
+    def __eq__(self, other):
+        return (self.abspath == other.abspath or
+                (self.prefix is not None and self.relpath is not None and
+                 self.prefix == other.prefix and
+                 self.relpath == other.relpath))
+
+    @staticmethod
+    def create(path, searchpaths):
+        """
+        Create a RecentPath item inferring a suitable prefix name and relpath.
+
+        Parameters
+        ----------
+        path : str
+            File system path.
+        searchpaths : List[Tuple[str, str]]
+            A sequence of (NAME, prefix) pairs. The sequence is searched
+            for a item such that prefix/relpath == abspath. The NAME is
+            recorded in the `prefix` and relpath in `relpath`.
+            (note: the first matching prefixed path is chosen).
+
+        """
+        def isprefixed(prefix, path):
+            """
+            Is `path` contained within the directory `prefix`.
+
+            >>> isprefixed("/usr/local/", "/usr/local/shared")
+            True
+            """
+            normalize = lambda path: os.path.normcase(os.path.normpath(path))
+            prefix, path = normalize(prefix), normalize(path)
+            if not prefix.endswith(os.path.sep):
+                prefix = prefix + os.path.sep
+            return os.path.commonprefix([prefix, path]) == prefix
+
+        abspath = os.path.normpath(os.path.abspath(path))
+        for prefix, base in searchpaths:
+            if isprefixed(base, abspath):
+                relpath = os.path.relpath(abspath, base)
+                return RecentPath(abspath, prefix, relpath)
+
+        return RecentPath(abspath, None, None)
+
+    def search(self, searchpaths):
+        """
+        Return a file system path, substituting the variable paths if required
+
+        If the self.abspath names an existing path it is returned. Else if
+        the `self.prefix` and `self.relpath` are not `None` then the
+        `searchpaths` sequence is searched for the matching prefix and
+        if found and the {PATH}/self.relpath exists it is returned.
+
+        If all fails return None.
+
+        Parameters
+        ----------
+        searchpaths : List[Tuple[str, str]]
+            A sequence of (NAME, prefixpath) pairs.
+
+        """
+        if os.path.exists(self.abspath):
+            return os.path.normpath(self.abspath)
+
+        for prefix, base in searchpaths:
+            if self.prefix == prefix:
+                path = os.path.join(base, self.relpath)
+                if os.path.exists(path):
+                    return os.path.normpath(path)
+        else:
+            return None
+
+    def resolve(self, searchpaths):
+        if self.prefix is None and os.path.exists(self.abspath):
+            return self
+        elif self.prefix is not None:
+            for prefix, base in searchpaths:
+                if self.prefix == prefix:
+                    path = os.path.join(base, self.relpath)
+                    if os.path.exists(path):
+                        return RecentPath(
+                            os.path.normpath(path), self.prefix, self.relpath)
+        return None
+
+    @property
+    def value(self):
+        return os.path.basename(self.abspath)
+
+    @property
+    def icon(self):
+        provider = QFileIconProvider()
+        return provider.icon(QFileIconProvider.Drive)
+
+    @property
+    def dirname(self):
+        return os.path.dirname(self.abspath)
+
+    def __repr__(self):
+        return ("{0.__class__.__name__}(abspath={0.abspath!r}, "
+                "prefix={0.prefix!r}, relpath={0.relpath!r}, "
+                "title={0.title!r})").format(self)
+
+    __str__ = __repr__
+
+
+class RecentPathsWidgetMixin:
+    SEARCH_PATHS = []
+
+    #: List[RecentPath]
+    recent_paths = Setting([])
+
+    _init_called = False
+
+    def __init__(self):
+        super().__init__()
+        self._init_called = True
+        self.relocate_recent_files()
+
+    def _check_init(self):
+        if not self._init_called:
+            raise RuntimeError("RecentPathsWidgetMixin.__init__ was not called")
+
+    def _search_paths(self):
+        basedir = self.workflowEnv().get("basedir", None)
+        if basedir is None:
+            return self.SEARCH_PATHS
+        return self.SEARCH_PATHS + [("basedir", basedir)]
+
+    def relocate_recent_files(self):
+        self._check_init()
+        search_paths = self._search_paths()
+        rec = []
+        for recent in self.recent_paths:
+            resolved = recent.resolve(search_paths)
+            if resolved is not None:
+                rec.append(
+                    RecentPath.create(resolved.abspath, search_paths))
+            elif recent.search(search_paths) is not None:
+                rec.append(
+                    RecentPath.create(recent.search(search_paths), search_paths)
+                )
+        self.recent_paths = rec
+
+    def set_file_list(self):
+        self._check_init()
+        self.file_combo.clear()
+        if not self.recent_paths:
+            self.file_combo.addItem("(none)")
+            self.file_combo.model().item(0).setEnabled(False)
+        else:
+            for i, recent in enumerate(self.recent_paths):
+                self.file_combo.addItem(recent.value)
+                self.file_combo.model().item(i).setToolTip(recent.abspath)
+
+    def add_path(self, filename):
+        self._check_init()
+        recent = RecentPath.create(filename, self._search_paths())
+        if recent in self.recent_paths:
+            self.recent_paths.remove(recent)
+        self.recent_paths.insert(0, recent)
+
+    def workflowEnvChanged(self, key, value, oldvalue):
+        if key == "basedir":
+            self.relocate_recent_files()
+            self.set_file_list()

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -1,5 +1,6 @@
 import os
 
+from PyQt4.QtCore import QFileInfo
 from PyQt4.QtGui import QMessageBox, QFileDialog, QFileIconProvider, QComboBox
 
 from Orange.widgets.settings import Setting
@@ -190,13 +191,13 @@ class RecentPath:
         return None
 
     @property
-    def value(self):
+    def basename(self):
         return os.path.basename(self.abspath)
 
     @property
     def icon(self):
         provider = QFileIconProvider()
-        return provider.icon(QFileIconProvider.Drive)
+        return provider.icon(QFileInfo(self.abspath))
 
     @property
     def dirname(self):
@@ -306,9 +307,7 @@ class RecentPathsWidgetMixin:
 
     def last_path(self):
         """Return the most recent absolute path or `None` if there is none"""
-        abspath = self.recent_paths and self.recent_paths[0].abspath
-        if abspath != "(none)":
-            return abspath
+        return self.recent_paths and self.recent_paths[0].abspath or None
 
 
 class RecentPathsWComboMixin(RecentPathsWidgetMixin):
@@ -346,7 +345,7 @@ class RecentPathsWComboMixin(RecentPathsWidgetMixin):
             self.file_combo.model().item(0).setEnabled(False)
         else:
             for i, recent in enumerate(self.recent_paths):
-                self.file_combo.addItem(recent.value)
+                self.file_combo.addItem(recent.basename)
                 self.file_combo.model().item(i).setToolTip(recent.abspath)
 
     def workflowEnvChanged(self, key, value, oldvalue):


### PR DESCRIPTION
The PR contains

- methods for loading and saving to `DistMatrix` from/to file
- the corresponding widgets
- some additional tests
- removal of `DistMatrix.get_KNN`

It also pulls the code for recent paths from the file widget into a separate module, so it can be reused in multiple widgets.

Widgets for file distances intentionally support just a single data format. Let's try to keep it simple this time.
