### PR TITLE
Improve Qt5 forward compatibility

### DIFF
--- a/Orange/canvas/application/canvastooldock.py
+++ b/Orange/canvas/application/canvastooldock.py
@@ -40,7 +40,7 @@ class SplitterResizer(QObject):
         self.__animationEnabled = True
         self.__size = -1
         self.__expanded = False
-        self.__animation = QPropertyAnimation(self, "size_", self)
+        self.__animation = QPropertyAnimation(self, b"size_", self)
 
         self.__action = QAction("toogle-expanded", self, checkable=True)
         self.__action.triggered[bool].connect(self.setExpanded)
@@ -431,7 +431,7 @@ class CategoryPopupMenu(FramelessWindow):
         drag_data = QMimeData()
         drag_data.setData(
             "application/vnv.orange-canvas.registry.qualified-name",
-            desc.qualified_name
+            desc.qualified_name.encode('utf-8')
         )
         drag = QDrag(self)
         drag.setPixmap(icon.pixmap(38))

--- a/Orange/canvas/application/tests/test_widgettoolbox.py
+++ b/Orange/canvas/application/tests/test_widgettoolbox.py
@@ -29,7 +29,7 @@ class TestWidgetToolBox(test.QAppTestCase):
         data_descriptions = qt_reg.widgets("Data")
 
         file_action = qt_reg.action_for_widget(
-            "Orange.OrangeWidgets.Data.OWFile.OWFile"
+            "Orange.widgets.data.owfile.OWFile"
         )
 
         actions = list(map(qt_reg.action_for_widget, data_descriptions))
@@ -75,7 +75,7 @@ class TestWidgetToolBox(test.QAppTestCase):
         model = qt_reg.model()
 
         file_action = qt_reg.action_for_widget(
-            "Orange.OrangeWidgets.Data.OWFile.OWFile"
+            "Orange.widgets.data.owfile.OWFile"
         )
 
         box = WidgetToolBox()

--- a/Orange/canvas/application/widgettoolbox.py
+++ b/Orange/canvas/application/widgettoolbox.py
@@ -193,7 +193,7 @@ class WidgetToolGrid(ToolGrid):
         drag_data = QMimeData()
         drag_data.setData(
             "application/vnv.orange-canvas.registry.qualified-name",
-            desc.qualified_name
+            desc.qualified_name.encode("utf-8")
         )
         drag = QDrag(button)
         drag.setPixmap(icon.pixmap(self.iconSize()))

--- a/Orange/canvas/canvas/items/annotationitem.py
+++ b/Orange/canvas/canvas/items/annotationitem.py
@@ -8,11 +8,13 @@ from PyQt4.QtGui import (
 )
 
 from PyQt4.QtCore import (
-    Qt, QPointF, QSizeF, QRectF, QLineF, QEvent, qVersion
+    Qt, QPointF, QSizeF, QRectF, QLineF, QEvent, QT_VERSION
 )
 
-from PyQt4.QtCore import pyqtSignal as Signal
-from PyQt4.QtCore import pyqtProperty as Property
+from PyQt4.QtCore import (
+    pyqtSignal as Signal,
+    pyqtProperty as Property
+)
 
 log = logging.getLogger(__name__)
 
@@ -25,12 +27,14 @@ class Annotation(QGraphicsWidget):
     def __init__(self, parent=None, **kwargs):
         QGraphicsWidget.__init__(self, parent, **kwargs)
 
-    if qVersion() < "4.7":
+    if QT_VERSION < 0x40700:
         geometryChanged = Signal()
-
         def setGeometry(self, rect):
             QGraphicsWidget.setGeometry(self, rect)
             self.geometryChanged.emit()
+    else:
+        def setGeometry(self, rect):
+            QGraphicsWidget.setGeometry(self, rect)
 
 
 class GraphicsTextEdit(QGraphicsTextItem):

--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -103,12 +103,12 @@ class NodeBodyItem(GraphicsPathObject):
         self.setGraphicsEffect(self.shadow)
         self.shadow.setEnabled(True)
 
-        self.__blurAnimation = QPropertyAnimation(self.shadow, "blurRadius",
+        self.__blurAnimation = QPropertyAnimation(self.shadow, b"blurRadius",
                                                   self)
         self.__blurAnimation.setDuration(100)
         self.__blurAnimation.finished.connect(self.__on_finished)
 
-        self.__pingAnimation = QPropertyAnimation(self, "scale", self)
+        self.__pingAnimation = QPropertyAnimation(self, b"scale", self)
         self.__pingAnimation.setDuration(250)
         self.__pingAnimation.setKeyValues([(0.0, 1.0), (0.5, 1.1), (1.0, 1.0)])
 

--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -310,7 +310,6 @@ class AnchorPoint(QGraphicsObject):
     def itemChange(self, change, value):
         if change == QGraphicsItem.ItemScenePositionHasChanged:
             self.scenePositionChanged.emit(value)
-
         return QGraphicsObject.itemChange(self, change, value)
 
     def boundingRect(self,):

--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -322,7 +322,6 @@ class NodeAnchorItem(GraphicsPathObject):
     """
 
     def __init__(self, parent, *args):
-        self.__boundingRect = None
         GraphicsPathObject.__init__(self, parent, *args)
         self.setAcceptHoverEvents(True)
         self.setPen(QPen(Qt.NoPen))
@@ -354,9 +353,6 @@ class NodeAnchorItem(GraphicsPathObject):
         self.__fullStroke = None
         self.__dottedStroke = None
         self.__shape = None
-
-        self.prepareGeometryChange()
-        self.__boundingRect = None
 
     def parentNodeItem(self):
         """
@@ -540,28 +536,17 @@ class NodeAnchorItem(GraphicsPathObject):
         else:
             return GraphicsPathObject.shape(self)
 
-    def boundingRect(self):
-        if self.__boundingRect is None:
-            self.__boundingRect = super().boundingRect().adjusted(-5, -5, 5, 5)
-        return self.__boundingRect
-
     def hoverEnterEvent(self, event):
-        self.prepareGeometryChange()
-        self.__boundingRect = None
         self.shadow.setEnabled(True)
         return GraphicsPathObject.hoverEnterEvent(self, event)
 
     def hoverLeaveEvent(self, event):
-        self.prepareGeometryChange()
-        self.__boundingRect = None
         self.shadow.setEnabled(False)
         return GraphicsPathObject.hoverLeaveEvent(self, event)
 
     def __updatePositions(self):
         """Update anchor points positions.
         """
-        self.prepareGeometryChange()
-        self.__boundingRect = None
         for point, t in zip(self.__points, self.__pointPositions):
             pos = self.__anchorPath.pointAtPercent(t)
             point.setPos(pos)

--- a/Orange/canvas/canvas/items/tests/test_linkitem.py
+++ b/Orange/canvas/canvas/items/tests/test_linkitem.py
@@ -15,7 +15,7 @@ class TestLinkItem(TestItems):
 
         data_desc = reg.category("Data")
 
-        file_desc = reg.widget("Orange.OrangeWidgets.Data.OWFile.OWFile")
+        file_desc = reg.widget("Orange.widgets.data.owfile.OWFile")
 
         file_item = NodeItem()
         file_item.setWidgetDescription(file_desc)
@@ -23,7 +23,7 @@ class TestLinkItem(TestItems):
         file_item.setPos(0, 100)
 
         discretize_desc = reg.widget(
-            "Orange.OrangeWidgets.Data.OWDiscretize.OWDiscretize"
+            "Orange.widgets.data.owdiscretize.OWDiscretize"
         )
 
         discretize_item = NodeItem()
@@ -33,7 +33,7 @@ class TestLinkItem(TestItems):
         classify_desc = reg.category("Classify")
 
         bayes_desc = reg.widget(
-            "Orange.OrangeWidgets.Classify.OWNaiveBayes.OWNaiveBayes"
+            "Orange.widgets.classify.ownaivebayes.OWNaiveBayes"
         )
 
         nb_item = NodeItem()

--- a/Orange/canvas/canvas/items/tests/test_nodeitem.py
+++ b/Orange/canvas/canvas/items/tests/test_nodeitem.py
@@ -15,13 +15,13 @@ class TestNodeItem(TestItems):
         self.classify_desc = self.reg.category("Classify")
 
         self.file_desc = self.reg.widget(
-            "Orange.OrangeWidgets.Data.OWFile.OWFile"
+            "Orange.widgets.data.owfile.OWFile"
         )
         self.discretize_desc = self.reg.widget(
-            "Orange.OrangeWidgets.Data.OWDiscretize.OWDiscretize"
+            "Orange.widgets.data.owdiscretize.OWDiscretize"
         )
         self.bayes_desc = self.reg.widget(
-            "Orange.OrangeWidgets.Classify.OWNaiveBayes.OWNaiveBayes"
+            "Orange.widgets.classify.ownaivebayes.OWNaiveBayes"
         )
 
     def test_nodeitem(self):

--- a/Orange/canvas/canvas/items/utils.py
+++ b/Orange/canvas/canvas/items/utils.py
@@ -62,44 +62,6 @@ def toGraphicsObjectIfPossible(item):
     return item if obj is None else obj
 
 
-def typed_signal_mapper(pyType):
-    """Create a TypedSignalMapper class supporting signal
-    mapping for `pyType` (the default QSigalMapper only supports
-    int, string, QObject and QWidget (but not for instance QGraphicsItem).
-
-    """
-
-    def unwrap(obj):
-        return sip.unwrapinstance(sip.cast(obj, QObject))
-
-    class TypedSignalMapper(QSignalMapper):
-        pyMapped = Signal(pyType)
-
-        def __init__(self, parent=None):
-            QSignalMapper.__init__(self, parent)
-            self.__mapping = {}
-
-        def setPyMapping(self, sender, mapped):
-            sender_id = unwrap(sender)
-            self.__mapping[sender_id] = mapped
-            sender.destroyed.connect(self.removePyMappings)
-
-        def removePyMappings(self, sender):
-            sender_id = unwrap(sender)
-            del self.__mapping[sender_id]
-            sender.destroyed.disconnect(self.removePyMappings)
-
-        def pyMap(self, sender=None):
-            if sender is None:
-                sender = self.sender()
-
-            sender_id = unwrap(sender)
-            mapped = self.__mapping[sender_id]
-            self.pyMapped.emit(mapped)
-
-    return TypedSignalMapper
-
-
 def linspace(count):
     """Return `count` evenly spaced points from 0..1 interval excluding
     both end points, e.g. `linspace(3) == [0.25, 0.5, 0.75]`.

--- a/Orange/canvas/canvas/layout.py
+++ b/Orange/canvas/canvas/layout.py
@@ -12,11 +12,8 @@ from PyQt4.QtGui import QGraphicsObject, QApplication
 from PyQt4.QtCore import QRectF, QLineF, QEvent
 
 from .items import NodeItem, LinkItem, SourceAnchorItem, SinkAnchorItem
-from .items.utils import typed_signal_mapper, invert_permutation_indices, \
-                         linspace
+from .items.utils import invert_permutation_indices, linspace
 from functools import reduce
-
-LinkItemSignalMapper = typed_signal_mapper(LinkItem)
 
 
 def composition(f, g):

--- a/Orange/canvas/canvas/scene.py
+++ b/Orange/canvas/canvas/scene.py
@@ -18,8 +18,7 @@ from PyQt4.QtGui import QGraphicsScene, QPainter, QBrush, QColor, QFont, \
 from PyQt4.QtCore import Qt, QPointF, QRectF, QSizeF, QLineF, QBuffer, QEvent
 
 from PyQt4.QtCore import pyqtSignal as Signal
-from PyQt4.QtCore import PYQT_VERSION_STR
-
+from PyQt4.QtCore import PYQT_VERSION
 
 from .. import scheme
 
@@ -778,7 +777,7 @@ class CanvasScene(QGraphicsScene):
 
         return items[0] if items else None
 
-    if list(map(int, PYQT_VERSION_STR.split('.'))) < [4, 9]:
+    if PYQT_VERSION < 0x40900:
         # For QGraphicsObject subclasses items, itemAt ... return a
         # QGraphicsItem wrapper instance and not the actual class instance.
         def itemAt(self, *args, **kwargs):

--- a/Orange/canvas/canvas/scene.py
+++ b/Orange/canvas/canvas/scene.py
@@ -13,9 +13,10 @@ from operator import attrgetter
 from xml.sax.saxutils import escape
 
 from PyQt4.QtGui import QGraphicsScene, QPainter, QBrush, QColor, QFont, \
-                        QGraphicsItem
+                        QGraphicsItem, QGraphicsObject
 
-from PyQt4.QtCore import Qt, QPointF, QRectF, QSizeF, QLineF, QBuffer, QEvent
+from PyQt4.QtCore import Qt, QPointF, QRectF, QSizeF, QLineF, QBuffer, \
+                         QEvent, QObject, QSignalMapper
 
 from PyQt4.QtCore import pyqtSignal as Signal
 from PyQt4.QtCore import PYQT_VERSION
@@ -24,12 +25,9 @@ from .. import scheme
 
 from . import items
 from .layout import AnchorLayout
-from .items.utils import toGraphicsObjectIfPossible, typed_signal_mapper
+from .items.utils import toGraphicsObjectIfPossible
 
 log = logging.getLogger(__name__)
-
-
-NodeItemSignalMapper = typed_signal_mapper(items.NodeItem)
 
 
 class CanvasScene(QGraphicsScene):
@@ -38,39 +36,39 @@ class CanvasScene(QGraphicsScene):
     """
 
     #: Signal emitted when a :class:`NodeItem` has been added to the scene.
-    node_item_added = Signal(items.NodeItem)
+    node_item_added = Signal(object)
 
     #: Signal emitted when a :class:`NodeItem` has been removed from the
     #: scene.
-    node_item_removed = Signal(items.LinkItem)
+    node_item_removed = Signal(object)
 
     #: Signal emitted when a new :class:`LinkItem` has been added to the
     #: scene.
-    link_item_added = Signal(items.LinkItem)
+    link_item_added = Signal(object)
 
     #: Signal emitted when a :class:`LinkItem` has been removed.
-    link_item_removed = Signal(items.LinkItem)
+    link_item_removed = Signal(object)
 
     #: Signal emitted when a :class:`Annotation` item has been added.
-    annotation_added = Signal(items.annotationitem.Annotation)
+    annotation_added = Signal(object)
 
     #: Signal emitted when a :class:`Annotation` item has been removed.
-    annotation_removed = Signal(items.annotationitem.Annotation)
+    annotation_removed = Signal(object)
 
     #: Signal emitted when the position of a :class:`NodeItem` has changed.
-    node_item_position_changed = Signal(items.NodeItem, QPointF)
+    node_item_position_changed = Signal(object, QPointF)
 
     #: Signal emitted when an :class:`NodeItem` has been double clicked.
-    node_item_double_clicked = Signal(items.NodeItem)
+    node_item_double_clicked = Signal(object)
 
     #: An node item has been activated (clicked)
-    node_item_activated = Signal(items.NodeItem)
+    node_item_activated = Signal(object)
 
     #: An node item has been hovered
-    node_item_hovered = Signal(items.NodeItem)
+    node_item_hovered = Signal(object)
 
     #: Link item has been hovered
-    link_item_hovered = Signal(items.LinkItem)
+    link_item_hovered = Signal(object)
 
     def __init__(self, *args, **kwargs):
         QGraphicsScene.__init__(self, *args, **kwargs)
@@ -104,21 +102,18 @@ class CanvasScene(QGraphicsScene):
 
         self.user_interaction_handler = None
 
-        self.activated_mapper = NodeItemSignalMapper(self)
-        self.activated_mapper.pyMapped.connect(
-            self.node_item_activated
+        self.activated_mapper = QSignalMapper(self)
+        self.activated_mapper.mapped[QObject].connect(
+            lambda node: self.node_item_activated.emit(node)
         )
-
-        self.hovered_mapper = NodeItemSignalMapper(self)
-        self.hovered_mapper.pyMapped.connect(
-            self.node_item_hovered
+        self.hovered_mapper = QSignalMapper(self)
+        self.hovered_mapper.mapped[QObject].connect(
+            lambda node: self.node_item_hovered.emit(node)
         )
-
-        self.position_change_mapper = NodeItemSignalMapper(self)
-        self.position_change_mapper.pyMapped.connect(
+        self.position_change_mapper = QSignalMapper(self)
+        self.position_change_mapper.mapped[QObject].connect(
             self._on_position_change
         )
-
         log.info("'%s' intitialized." % self)
 
     def clear_scene(self):
@@ -286,14 +281,14 @@ class CanvasScene(QGraphicsScene):
         item.setFont(self.font())
 
         # Set signal mappings
-        self.activated_mapper.setPyMapping(item, item)
-        item.activated.connect(self.activated_mapper.pyMap)
+        self.activated_mapper.setMapping(item, item)
+        item.activated.connect(self.activated_mapper.map)
 
-        self.hovered_mapper.setPyMapping(item, item)
-        item.hovered.connect(self.hovered_mapper.pyMap)
+        self.hovered_mapper.setMapping(item, item)
+        item.hovered.connect(self.hovered_mapper.map)
 
-        self.position_change_mapper.setPyMapping(item, item)
-        item.positionChanged.connect(self.position_change_mapper.pyMap)
+        self.position_change_mapper.setMapping(item, item)
+        item.positionChanged.connect(self.position_change_mapper.map)
 
         self.addItem(item)
 
@@ -369,8 +364,9 @@ class CanvasScene(QGraphicsScene):
         """
         Remove `item` (:class:`.NodeItem`) from the scene.
         """
-        self.activated_mapper.removePyMappings(item)
-        self.hovered_mapper.removePyMappings(item)
+        self.activated_mapper.removeMappings(item)
+        self.hovered_mapper.removeMappings(item)
+        self.position_change_mapper.removeMappings(item)
 
         item.hide()
         self.removeItem(item)

--- a/Orange/canvas/canvas/tests/test_layout.py
+++ b/Orange/canvas/canvas/tests/test_layout.py
@@ -53,7 +53,7 @@ class TestAnchorLayout(QAppTestCase):
         layout.activate()
 
         p1, p2 = file_item.outputAnchorItem.anchorPositions()
-        self.assertTrue(p1 > p2)
+        self.assertGreater(p1, p2)
 
         self.scene.node_item_position_changed.connect(layout.invalidateNode)
 
@@ -76,15 +76,15 @@ class TestAnchorLayout(QAppTestCase):
         reg = small_testing_registry()
 
         file_desc = reg.widget(
-            "Orange.OrangeWidgets.Data.OWFile.OWFile"
+            "Orange.widgets.data.owfile.OWFile"
         )
 
         discretize_desc = reg.widget(
-            "Orange.OrangeWidgets.Data.OWDiscretize.OWDiscretize"
+            "Orange.widgets.data.owdiscretize.OWDiscretize"
         )
 
         bayes_desc = reg.widget(
-            "Orange.OrangeWidgets.Classify.OWNaiveBayes.OWNaiveBayes"
+            "Orange.widgets.classify.ownaivebayes.OWNaiveBayes"
         )
 
         return file_desc, discretize_desc, bayes_desc

--- a/Orange/canvas/canvas/tests/test_scene.py
+++ b/Orange/canvas/canvas/tests/test_scene.py
@@ -220,15 +220,15 @@ class TestScene(QAppTestCase):
         reg = small_testing_registry()
 
         file_desc = reg.widget(
-            "Orange.OrangeWidgets.Data.OWFile.OWFile"
+            "Orange.widgets.data.owfile.OWFile"
         )
 
         discretize_desc = reg.widget(
-            "Orange.OrangeWidgets.Data.OWDiscretize.OWDiscretize"
+            "Orange.widgets.data.owdiscretize.OWDiscretize"
         )
 
         bayes_desc = reg.widget(
-            "Orange.OrangeWidgets.Classify.OWNaiveBayes.OWNaiveBayes"
+            "Orange.widgets.classify.ownaivebayes.OWNaiveBayes"
         )
 
         return file_desc, discretize_desc, bayes_desc

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -49,8 +49,8 @@ log = logging.getLogger(__name__)
 # TODO: Should this be moved to CanvasScene?
 class GraphicsSceneFocusEventListener(QGraphicsObject):
 
-    itemFocusedIn = Signal(QGraphicsItem)
-    itemFocusedOut = Signal(QGraphicsItem)
+    itemFocusedIn = Signal(object)
+    itemFocusedOut = Signal(object)
 
     def __init__(self, parent=None):
         QGraphicsObject.__init__(self, parent)

--- a/Orange/canvas/document/tests/test_editlinksdialog.py
+++ b/Orange/canvas/document/tests/test_editlinksdialog.py
@@ -13,8 +13,8 @@ class TestLinksEditDialog(test.QAppTestCase):
 
         dlg = EditLinksDialog()
         reg = small_testing_registry()
-        file_desc = reg.widget("Orange.OrangeWidgets.Data.OWFile.OWFile")
-        bayes_desc = reg.widget("Orange.OrangeWidgets.Classify.OWNaiveBayes."
+        file_desc = reg.widget("Orange.widgets.data.owfile.OWFile")
+        bayes_desc = reg.widget("Orange.widgets.classify.ownaivebayes."
                                 "OWNaiveBayes")
         source_node = SchemeNode(file_desc, title="This is File")
         sink_node = SchemeNode(bayes_desc)
@@ -50,8 +50,8 @@ class TestLinksEditDialog(test.QAppTestCase):
         from ...registry.tests import small_testing_registry
 
         reg = small_testing_registry()
-        file_desc = reg.widget("Orange.OrangeWidgets.Data.OWFile.OWFile")
-        bayes_desc = reg.widget("Orange.OrangeWidgets.Classify.OWNaiveBayes."
+        file_desc = reg.widget("Orange.widgets.data.owfile.OWFile")
+        bayes_desc = reg.widget("Orange.widgets.classify.ownaivebayes."
                                 "OWNaiveBayes")
         source_node = SchemeNode(file_desc, title="This is File")
         sink_node = SchemeNode(bayes_desc)

--- a/Orange/canvas/document/tests/test_schemeedit.py
+++ b/Orange/canvas/document/tests/test_schemeedit.py
@@ -35,9 +35,9 @@ class TestSchemeEdit(QAppTestCase):
 
         w.show()
 
-        base = "Orange.OrangeWidgets."
-        file_desc = reg.widget(base + "Data.OWFile.OWFile")
-        disc_desc = reg.widget(base + "Data.OWDiscretize.OWDiscretize")
+        base = "Orange.widgets."
+        file_desc = reg.widget(base + "data.owfile.OWFile")
+        disc_desc = reg.widget(base + "data.owdiscretize.OWDiscretize")
 
         node_list = []
         link_list = []

--- a/Orange/canvas/gui/framelesswindow.py
+++ b/Orange/canvas/gui/framelesswindow.py
@@ -52,7 +52,7 @@ class FramelessWindow(QWidget):
 
     def __updateMask(self):
         opt = QStyleOption()
-        opt.init(self)
+        opt.initFrom(self)
         rect = opt.rect
 
         size = rect.size()
@@ -70,7 +70,7 @@ class FramelessWindow(QWidget):
     def paintEvent(self, event):
         if self.__isTransparencySupported:
             opt = QStyleOption()
-            opt.init(self)
+            opt.initFrom(self)
             rect = opt.rect
 
             p = QPainter(self)

--- a/Orange/canvas/gui/stackedwidget.py
+++ b/Orange/canvas/gui/stackedwidget.py
@@ -126,7 +126,7 @@ class AnimatedStackedWidget(QFrame):
         self.__fadeWidget = CrossFadePixmapWidget(self)
 
         self.transitionAnimation = \
-            QPropertyAnimation(self.__fadeWidget, "blendingFactor_", self)
+            QPropertyAnimation(self.__fadeWidget, b"blendingFactor_", self)
         self.transitionAnimation.setStartValue(0.0)
         self.transitionAnimation.setEndValue(1.0)
         self.transitionAnimation.setDuration(100 if animationEnabled else 0)

--- a/Orange/canvas/gui/utils.py
+++ b/Orange/canvas/gui/utils.py
@@ -63,7 +63,7 @@ def StyledWidget_paintEvent(self, event):
     """A default styled QWidget subclass  paintEvent function.
     """
     opt = QStyleOption()
-    opt.init(self)
+    opt.initFrom(self)
     painter = QPainter(self)
     self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
 

--- a/Orange/canvas/help/manager.py
+++ b/Orange/canvas/help/manager.py
@@ -7,6 +7,7 @@ import string
 import itertools
 import logging
 import email
+import urllib.parse
 
 from distutils.version import StrictVersion
 
@@ -16,7 +17,7 @@ import pkg_resources
 
 from . import provider
 
-from PyQt4.QtCore import QObject, QUrl, QDir
+from PyQt4.QtCore import QObject, QUrl, QDir, QT_VERSION
 
 log = logging.getLogger(__name__)
 
@@ -111,11 +112,19 @@ def get_by_id(registry, descriptor_id):
     raise KeyError(descriptor_id)
 
 
-def qurl_query_items(url):
-    items = []
-    for key, value in url.queryItems():
-        items.append((str(key), str(value)))
-    return items
+if QT_VERSION < 0x50000:
+    def qurl_query_items(url):
+        items = []
+        for key, value in url.queryItems():
+            items.append((str(key), str(value)))
+        return items
+else:
+    # QUrl has no queryItems
+    def qurl_query_items(url):
+        if not url.hasQuery():
+            return []
+        querystr = url.query()
+        return urllib.parse.parse_qsl(querystr)
 
 
 def get_help_provider_for_description(desc):

--- a/Orange/canvas/help/provider.py
+++ b/Orange/canvas/help/provider.py
@@ -227,14 +227,3 @@ class HtmlIndexProvider(BaseInventoryProvider):
             return self.inventory.resolved(QUrl(entry))
         else:
             raise KeyError()
-
-
-def qurl_query_items(url):
-    items = []
-    for key, value in url.queryItems():
-        items.append((str(key), str(value)))
-    return items
-
-
-def is_url_local(url):
-    return bool(QUrl(url).toLocalFile())

--- a/Orange/canvas/preview/tests/test_previewbrowser.py
+++ b/Orange/canvas/preview/tests/test_previewbrowser.py
@@ -18,10 +18,11 @@ svg2 = pkg_resources.resource_string("Orange.canvas",
 
 
 def construct_test_preview_model():
-    items = [("Name1", "A preview item 1", svg1, "~/bla", ),
-             ("Name2", "A preview item 2" + "long text" * 5, svg2, "~/item")
-             ]
-
+    items = [
+        ("Name1", "A preview item 1", svg1.decode("ascii"), "~/bla", ),
+        ("Name2", "A preview item 2" + "long text" * 5, svg2.decode("ascii"),
+         "~/item")
+    ]
     items = [PreviewItem(*arg[:-1], path=arg[-1]) for arg in items]
     model = PreviewModel(items=items)
     return model

--- a/Orange/canvas/registry/base.py
+++ b/Orange/canvas/registry/base.py
@@ -24,7 +24,7 @@ class WidgetRegistry(object):
 
     >>> reg = WidgetRegistry()
     >>> file_desc = WidgetDescription.from_module(
-    ...     "Orange.OrangeWidgets.Data.OWFile"
+    ...     "Orange.widgets.data.owfile"
     ... )
     ...
     >>> reg.register_widget(file_desc)  # register the description

--- a/Orange/canvas/registry/tests/__init__.py
+++ b/Orange/canvas/registry/tests/__init__.py
@@ -11,22 +11,22 @@ def small_testing_registry():
     registry = WidgetRegistry()
 
     data_desc = CategoryDescription.from_package(
-        "Orange.OrangeWidgets.Data"
+        "Orange.widgets.data"
     )
 
     file_desc = WidgetDescription.from_module(
-        "Orange.OrangeWidgets.Data.OWFile"
+        "Orange.widgets.data.owfile"
     )
     discretize_desc = WidgetDescription.from_module(
-        "Orange.OrangeWidgets.Data.OWDiscretize"
+        "Orange.widgets.data.owdiscretize"
     )
 
     classify_desc = CategoryDescription.from_package(
-        "Orange.OrangeWidgets.Classify"
+        "Orange.widgets.classify"
     )
 
     bayes_desc = WidgetDescription.from_module(
-        "Orange.OrangeWidgets.Classify.OWNaiveBayes"
+        "Orange.widgets.classify.ownaivebayes"
     )
 
     registry.register_category(data_desc)

--- a/Orange/canvas/registry/tests/test_base.py
+++ b/Orange/canvas/registry/tests/test_base.py
@@ -19,7 +19,7 @@ class TestRegistry(unittest.TestCase):
         reg = WidgetRegistry()
 
         data_desc = description.CategoryDescription.from_package(
-            "Orange.OrangeWidgets.Data"
+            "Orange.widgets.data"
         )
 
         reg.register_category(data_desc)
@@ -29,9 +29,9 @@ class TestRegistry(unittest.TestCase):
         self.assertIs(reg.category(data_desc.name), data_desc)
 
         file_desc = description.WidgetDescription.from_module(
-            "Orange.OrangeWidgets.Data.OWFile"
+            "Orange.widgets.data.owfile"
         )
-
+        file_desc.category = "Data"
         reg.register_widget(file_desc)
 
         self.assertTrue(reg.has_widget(file_desc.qualified_name))
@@ -48,8 +48,9 @@ class TestRegistry(unittest.TestCase):
             reg.register_widget(desc)
 
         discretize_desc = description.WidgetDescription.from_module(
-            "Orange.OrangeWidgets.Data.OWDiscretize"
+            "Orange.widgets.data.owdiscretize"
         )
+        discretize_desc.category = "Data"
         reg.register_widget(discretize_desc)
 
         self.assertTrue(reg.has_widget(discretize_desc.qualified_name))
@@ -60,8 +61,9 @@ class TestRegistry(unittest.TestCase):
                             set([file_desc, discretize_desc]))
 
         classify_desc = description.CategoryDescription.from_package(
-            "Orange.OrangeWidgets.Classify"
+            "Orange.widgets.classify"
         )
+        classify_desc.category = "Classify"
         reg.register_category(classify_desc)
 
         self.assertTrue(reg.has_category(classify_desc.name))
@@ -70,19 +72,14 @@ class TestRegistry(unittest.TestCase):
                             set([data_desc, classify_desc]))
 
         bayes_desc = description.WidgetDescription.from_module(
-            "Orange.OrangeWidgets.Classify.OWNaiveBayes"
+            "Orange.widgets.classify.ownaivebayes"
         )
+        bayes_desc.category = "Classify"
         reg.register_widget(bayes_desc)
 
         self.assertTrue(reg.has_widget(bayes_desc.qualified_name))
         self.assertIs(reg.widget(bayes_desc.qualified_name), bayes_desc)
         self.assertSequenceEqual(reg.widgets("Classify"), [bayes_desc])
-
-        info_desc = description.WidgetDescription.from_file(
-            __import__("Orange.OrangeWidgets.Data.OWDataInfo",
-                       fromlist=[""]).__file__
-        )
-        reg.register_widget(info_desc)
 
         # Test copy constructor
         reg1 = WidgetRegistry(reg)
@@ -92,17 +89,15 @@ class TestRegistry(unittest.TestCase):
 
         # Test 'widgets()'
         self.assertSetEqual(set(reg1.widgets()),
-                            set([file_desc, info_desc, discretize_desc,
-                                 bayes_desc]))
+                            set([file_desc, discretize_desc, bayes_desc]))
 
         # Test ordering by priority
         self.assertSequenceEqual(
              reg.widgets("Data"),
-             sorted([file_desc, discretize_desc, info_desc],
-                    key=attrgetter("priority"))
+             sorted([file_desc, discretize_desc], key=attrgetter("priority"))
         )
 
         self.assertTrue(all(isinstance(desc.priority, int)
-                            for desc in [file_desc, info_desc, discretize_desc,
+                            for desc in [file_desc, discretize_desc,
                                          bayes_desc])
                         )

--- a/Orange/canvas/registry/tests/test_discovery.py
+++ b/Orange/canvas/registry/tests/test_discovery.py
@@ -32,27 +32,13 @@ class TestDiscovery(unittest.TestCase):
                                  category="C",)
         disc.handle_widget(desc)
 
-    def test_file(self):
-        from Orange.OrangeWidgets.Data import OWFile
-        disc = self.discovery_class()
-        disc.process_file(OWFile.__file__)
-
-    def test_process_directory(self):
-        from Orange.OrangeWidgets import Data, Visualize
-        data_dirname = os.path.dirname(Data.__file__)
-        visualize_dirname = os.path.dirname(Visualize.__file__)
-
-        disc = self.discovery_class()
-        disc.process_directory(data_dirname)
-        disc.process_directory(visualize_dirname)
-
     def test_process_module(self):
         disc = self.discovery_class()
         disc.process_category_package(
-            "Orange.OrangeWidgets.Data"
+            "Orange.widgets.data"
         )
         disc.process_widget_module(
-            "Orange.OrangeWidgets.Classify.OWNaiveBayes"
+            "Orange.widgets.classify.ownaivebayes"
         )
 
     def test_process_loader(self):
@@ -65,7 +51,7 @@ class TestDiscovery(unittest.TestCase):
             discovery.handle_category(desc)
 
             desc = WidgetDescription.from_module(
-                "Orange.OrangeWidgets.Data.OWFile"
+                "Orange.widgets.data.owfile"
             )
             discovery.handle_widget(desc)
 
@@ -74,10 +60,10 @@ class TestDiscovery(unittest.TestCase):
     def test_process_iter(self):
         disc = self.discovery_class()
         cat_desc = CategoryDescription.from_package(
-            "Orange.OrangeWidgets.Data"
+            "Orange.widgets.data"
         )
         wid_desc = widget_descriptions_from_package(
-            "Orange.OrangeWidgets.Data"
+            "Orange.widgets.data"
         )
         disc.process_iter([cat_desc] + wid_desc)
 

--- a/Orange/canvas/resources.py
+++ b/Orange/canvas/resources.py
@@ -221,7 +221,7 @@ class TestIconLoader(unittest.TestCase):
         )
 
         desc = WidgetDescription.from_module(
-            "Orange.OrangeWidgets.Data.OWFile"
+            "Orange.widgets.data.owfile"
         )
 
         loader = icon_loader.from_description(desc)
@@ -230,7 +230,7 @@ class TestIconLoader(unittest.TestCase):
         icon = loader.get(desc.icon)
         self.assertTrue(not icon.isNull())
 
-        desc = CategoryDescription.from_package("Orange.OrangeWidgets.Data")
+        desc = CategoryDescription.from_package("Orange.widgets.data")
         loader = icon_loader.from_description(desc)
         path = loader.find("icons/file.svg")
         self.assertTrue(os.path.isfile(path))
@@ -238,23 +238,23 @@ class TestIconLoader(unittest.TestCase):
         self.assertTrue(not icon.isNull())
 
     def test_package_reflection(self):
-        from Orange.OrangeWidgets.Data import OWFile
-        from Orange.OrangeWidgets import Data
-        package_name = Data.__name__
-        p1 = package("Orange.OrangeWidgets.Data.OWFile.OWFile")
+        from Orange.widgets.data import owfile
+        from Orange.widgets import data
+        package_name = data.__name__
+        p1 = package("Orange.widgets.data.owfile.OWFile")
         self.assertEqual(p1, package_name)
 
-        p2 = package("Orange.OrangeWidgets.Data.OWFile")
+        p2 = package("Orange.widgets.data.owfile")
         self.assertEqual(p2, package_name)
 
-        p3 = package("Orange.OrangeWidgets.Data")
+        p3 = package("Orange.widgets.data")
         self.assertEqual(p3, package_name)
 
-        p4 = package(OWFile.__name__)
+        p4 = package(owfile.__name__)
         self.assertEqual(p4, package_name)
 
         dirname = package_dirname(package_name)
-        self.assertEqual(dirname, os.path.dirname(Data.__file__))
+        self.assertEqual(dirname, os.path.dirname(data.__file__))
 
 
 if __name__ == "__main__":

--- a/Orange/canvas/scheme/readwrite.py
+++ b/Orange/canvas/scheme/readwrite.py
@@ -95,11 +95,15 @@ def terminal_eval(source):
 def _terminal_value(node):
     if isinstance(node, ast.Str):
         return node.s
+    elif isinstance(node, ast.Bytes):
+        return node.s
     elif isinstance(node, ast.Num):
         return node.n
-    elif isinstance(node, ast.Name) and \
+    elif sys.version_info < (3, 4) and isinstance(node, ast.Name) and \
             node.id in ["True", "False", "None"]:
         return __builtins__[node.id]
+    elif sys.version_info >= (3, 4) and isinstance(node, ast.NameConstant):
+        return node.value
 
     raise ValueError("Not a terminal")
 

--- a/Orange/canvas/scheme/tests/test_links.py
+++ b/Orange/canvas/scheme/tests/test_links.py
@@ -13,10 +13,10 @@ class TestSchemeLink(test.QAppTestCase):
     def test_link(self):
         import Orange
         reg = small_testing_registry()
-        base = "Orange.OrangeWidgets"
-        file_desc = reg.widget(base + ".Data.OWFile.OWFile")
-        discretize_desc = reg.widget(base + ".Data.OWDiscretize.OWDiscretize")
-        bayes_desc = reg.widget(base + ".Classify.OWNaiveBayes.OWNaiveBayes")
+        base = "Orange.widgets"
+        file_desc = reg.widget(base + ".data.owfile.OWFile")
+        discretize_desc = reg.widget(base + ".data.owdiscretize.OWDiscretize")
+        bayes_desc = reg.widget(base + ".classify.ownaivebayes.OWNaiveBayes")
 
         file_node = SchemeNode(file_desc)
         discretize_node = SchemeNode(discretize_desc)

--- a/Orange/canvas/scheme/tests/test_nodes.py
+++ b/Orange/canvas/scheme/tests/test_nodes.py
@@ -13,7 +13,7 @@ class TestScheme(test.QAppTestCase):
         """Test SchemeNode.
         """
         reg = small_testing_registry()
-        file_desc = reg.widget("Orange.OrangeWidgets.Data.OWFile.OWFile")
+        file_desc = reg.widget("Orange.widgets.data.owfile.OWFile")
 
         node = SchemeNode(file_desc)
 

--- a/Orange/canvas/scheme/tests/test_readwrite.py
+++ b/Orange/canvas/scheme/tests/test_readwrite.py
@@ -1,7 +1,7 @@
 """Test read write
 """
 from xml.etree import ElementTree as ET
-from io import StringIO
+from io import BytesIO
 
 from ...gui import test
 from ...registry import global_registry, WidgetRegistry, WidgetDescription
@@ -17,10 +17,10 @@ class TestReadWrite(test.QAppTestCase):
     def test_io(self):
         reg = global_registry()
 
-        base = "Orange.OrangeWidgets"
-        file_desc = reg.widget(base + ".Data.OWFile.OWFile")
-        discretize_desc = reg.widget(base + ".Data.OWDiscretize.OWDiscretize")
-        bayes_desc = reg.widget(base + ".Classify.OWNaiveBayes.OWNaiveBayes")
+        base = "Orange.widgets"
+        file_desc = reg.widget(base + ".data.owfile.OWFile")
+        discretize_desc = reg.widget(base + ".data.owdiscretize.OWDiscretize")
+        bayes_desc = reg.widget(base + ".classify.ownaivebayes.OWNaiveBayes")
 
         scheme = Scheme()
         file_node = SchemeNode(file_desc)
@@ -40,7 +40,7 @@ class TestReadWrite(test.QAppTestCase):
         scheme.add_annotation(SchemeArrowAnnotation((0, 0), (10, 10)))
         scheme.add_annotation(SchemeTextAnnotation((0, 100, 200, 200), "$$"))
 
-        stream = StringIO()
+        stream = BytesIO()
         scheme_to_ows_stream(scheme, stream)
 
         stream.seek(0)
@@ -79,10 +79,10 @@ class TestReadWrite(test.QAppTestCase):
     def test_io2(self):
         reg = global_registry()
 
-        base = "Orange.OrangeWidgets"
-        file_desc = reg.widget(base + ".Data.OWFile.OWFile")
-        discretize_desc = reg.widget(base + ".Data.OWDiscretize.OWDiscretize")
-        bayes_desc = reg.widget(base + ".Classify.OWNaiveBayes.OWNaiveBayes")
+        base = "Orange.widgets"
+        file_desc = reg.widget(base + ".data.owfile.OWFile")
+        discretize_desc = reg.widget(base + ".data.owdiscretize.OWDiscretize")
+        bayes_desc = reg.widget(base + ".classify.ownaivebayes.OWNaiveBayes")
 
         scheme = Scheme()
         file_node = SchemeNode(file_desc)
@@ -102,7 +102,7 @@ class TestReadWrite(test.QAppTestCase):
         scheme.add_annotation(SchemeArrowAnnotation((0, 0), (10, 10)))
         scheme.add_annotation(SchemeTextAnnotation((0, 100, 200, 200), "$$"))
 
-        stream = StringIO()
+        stream = BytesIO()
         scheme_to_ows_stream(scheme, stream)
 
         stream.seek(0)
@@ -178,7 +178,7 @@ class TestReadWrite(test.QAppTestCase):
             readwrite.literal_dumps(self)
 
     def test_1_0_parse(self):
-        tree = ET.parse(StringIO(FOOBAR_v10))
+        tree = ET.parse(BytesIO(FOOBAR_v10))
         parsed = readwrite.parse_ows_etree_v_1_0(tree)
         self.assertIsInstance(parsed, readwrite._scheme)
         self.assertEqual(parsed.version, "1.0")
@@ -199,7 +199,7 @@ class TestReadWrite(test.QAppTestCase):
         self.assertSetEqual(set(projects), set(["Foo", "Bar"]))
 
     def test_resolve_replaced(self):
-        tree = ET.parse(StringIO(FOOBAR_v20))
+        tree = ET.parse(BytesIO(FOOBAR_v20))
         parsed = readwrite.parse_ows_etree_v_2_0(tree)
 
         self.assertIsInstance(parsed, readwrite._scheme)
@@ -244,7 +244,7 @@ def foo_registry():
     return reg
 
 
-FOOBAR_v10 = """<?xml version="1.0" ?>
+FOOBAR_v10 = b"""<?xml version="1.0" ?>
 <schema>
     <widgets>
         <widget caption="Foo" widgetName="foo" xPos="1" yPos="2"/>
@@ -260,7 +260,7 @@ FOOBAR_v10 = """<?xml version="1.0" ?>
 </schema>
 """
 
-FOOBAR_v20 = """<?xml version="1.0" ?>
+FOOBAR_v20 = b"""<?xml version="1.0" ?>
 <scheme title="FooBar" description="Foo to the bar" version="2.0">
     <nodes>
         <node id="0" title="Foo" position="1, 2" project_name="Foo"

--- a/Orange/canvas/scheme/tests/test_scheme.py
+++ b/Orange/canvas/scheme/tests/test_scheme.py
@@ -15,10 +15,10 @@ from .. import (
 class TestScheme(test.QCoreAppTestCase):
     def test_scheme(self):
         reg = small_testing_registry()
-        base = "Orange.OrangeWidgets"
-        file_desc = reg.widget(base + ".Data.OWFile.OWFile")
-        discretize_desc = reg.widget(base + ".Data.OWDiscretize.OWDiscretize")
-        bayes_desc = reg.widget(base + ".Classify.OWNaiveBayes.OWNaiveBayes")
+        base = "Orange.widgets"
+        file_desc = reg.widget(base + ".data.owfile.OWFile")
+        discretize_desc = reg.widget(base + ".data.owdiscretize.OWDiscretize")
+        bayes_desc = reg.widget(base + ".classify.ownaivebayes.OWNaiveBayes")
         # Create the scheme
         scheme = Scheme()
 

--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -92,6 +92,7 @@ class OWTreeGraph(OWTreeViewer2D):
                 self.scene.colors = [QColor(*col) for col in class_var.colors]
             self.openContext(self.domain.class_var)
             self.root_node = self.walkcreate(self.tree, 0, None)
+            self.scene.addItem(self.root_node)
             self.info.setText(
                 '{} nodes, {} leaves'.
                 format(self.tree.node_count,
@@ -106,11 +107,12 @@ class OWTreeGraph(OWTreeViewer2D):
         self.send("Data", None)
 
     def walkcreate(self, tree, node_id, parent=None):
-        node = self.NODE(tree, self.domain, parent, None,
-                         self.scene, i=node_id)
+        node = self.NODE(tree, self.domain, parent, i=node_id)
+        self.scene.addItem(node)
         if parent:
-            parent.graph_add_edge(
-                GraphicsEdge(None, self.scene, node1=parent, node2=node))
+            edge = GraphicsEdge(node1=parent, node2=node)
+            self.scene.addItem(edge)
+            parent.graph_add_edge(edge)
         left_child_index = tree.children_left[node_id]
         right_child_index = tree.children_right[node_id]
 
@@ -169,8 +171,8 @@ class OWTreeGraph(OWTreeViewer2D):
 
 
 class PieChart(QGraphicsRectItem):
-    def __init__(self, dist, r, parent, scene):
-        super().__init__(parent, scene)
+    def __init__(self, dist, r, parent):
+        super().__init__(parent)
         self.dist = dist
         self.r = r
 
@@ -248,8 +250,8 @@ def _assign_samples(tree, X):
 
 class TreeNode(GraphicsNode):
     def __init__(self, tree, domain, parent=None, parent_item=None,
-                 scene=None, i=0, distr=None):
-        super().__init__(tree, parent, parent_item, scene)
+                 i=0, distr=None):
+        super().__init__(tree, parent, parent_item)
         self.distribution = distr
         self.tree = tree
         self.domain = domain
@@ -402,10 +404,10 @@ class TreeNode(GraphicsNode):
 
 class ClassificationTreeNode(TreeNode):
     def __init__(self, tree, domain, parent=None, parent_item=None,
-                 scene=None, i=0, distr=None):
+                 i=0, distr=None):
         super().__init__(tree, domain, parent, parent_item,
-                         scene, i, distr)
-        self.pie = PieChart(self.get_distribution(), 8, self, scene)
+                         i, distr)
+        self.pie = PieChart(self.get_distribution(), 8, self)
 
     def get_distribution(self):
         """
@@ -494,11 +496,11 @@ class OWClassificationTreeGraph(OWTreeGraph):
             total = numpy.sum(distr)
             if self.target_class_index:
                 p = distr[self.target_class_index - 1] / total
-                color = colors[self.target_class_index - 1].light(200 - 100 * p)
+                color = colors[self.target_class_index - 1].lighter(200 - 100 * p)
             else:
                 modus = node.majority()
                 p = distr[modus] / (total or 1)
-                color = colors[int(modus)].light(400 - 300 * p)
+                color = colors[int(modus)].lighter(400 - 300 * p)
             node.backgroundBrush = QBrush(color)
         self.scene.update()
 

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -166,7 +166,7 @@ class OWSVMClassification(SVMBaseMixin, widget.OWWidget):
 
         form.addWidget(gui.appendRadioButton(box, "ν-SVM", addToLayout=False),
                        1, 0, Qt.AlignLeft)
-        form.addWidget(QtGui.QLabel(self.trUtf8("Complexity (\u03bd)")),
+        form.addWidget(QtGui.QLabel(self.tr("Complexity (ν)".encode("utf-8"))),
                        1, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "nu", 0.05, 1.0, 0.05,
                                       decimals=2, alignment=Qt.AlignRight,

--- a/Orange/widgets/classify/owtreeviewer2d.py
+++ b/Orange/widgets/classify/owtreeviewer2d.py
@@ -35,8 +35,10 @@ class GraphEdge:
         self.node1 = node1
         self.node2 = node2
         self.type = atype
-        node1.graph_add_edge(self)
-        node2.graph_add_edge(self)
+        if node1 is not None:
+            node1.graph_add_edge(self)
+        if node2 is not None:
+            node2.graph_add_edge(self)
 
 
 class GraphicsDroplet(QGraphicsEllipseItem):
@@ -98,7 +100,7 @@ class TextTreeNode(QGraphicsTextItem, GraphNode):
         font = self.font()
         font.setPointSize(10)
         self.setFont(font)
-        self.droplet = GraphicsDroplet(-5, 0, 10, 10, self, self.scene())
+        self.droplet = GraphicsDroplet(-5, 0, 10, 10, self)
         self.droplet.setPos(self.rect().center().x(), self.rect().height())
         self.document().contentsChanged.connect(self.update_contents)
         self.isOpen = True

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -1,4 +1,4 @@
-from PyQt4.QtCore import Qt, QAbstractTableModel, SIGNAL
+from PyQt4.QtCore import Qt, QAbstractTableModel
 from PyQt4.QtGui import QStyledItemDelegate, QColor, QHeaderView, QFont, \
     QColorDialog, QTableView, qRgb, QImage
 import numpy as np
@@ -34,9 +34,9 @@ class ColorTableModel(QAbstractTableModel):
         return Qt.ItemIsEditable | Qt.ItemIsEnabled | Qt.ItemIsSelectable
 
     def set_data(self, variables):
-        self.emit(SIGNAL("modelAboutToBeReset()"))
+        self.modelAboutToBeReset.emit()
         self.variables = variables
-        self.emit(SIGNAL("modelReset()"))
+        self.modelReset.emit()
 
     def rowCount(self, parent):
         return 0 if parent.isValid() else self.n_rows()
@@ -65,7 +65,7 @@ class ColorTableModel(QAbstractTableModel):
             self.variables[index.row()].name = value
         else:
             return False
-        self.emit(SIGNAL("dataChanged(QModelIndex, QModelIndex)"), index, index)
+        self.dataChanged.emit(index, index)
         return True
 
 
@@ -105,7 +105,7 @@ class DiscColorTableModel(ColorTableModel):
             self.variables[row].values[col - 1] = value
         else:
             return False
-        self.emit(SIGNAL("dataChanged(QModelIndex, QModelIndex)"), index, index)
+        self.dataChanged.emit(index, index)
         return True
 
 
@@ -147,7 +147,7 @@ class ContColorTableModel(ColorTableModel):
             self.variables[row].colors = value
         else:
             return False
-        self.emit(SIGNAL("dataChanged(QModelIndex, QModelIndex)"), index, index)
+        self.dataChanged.emit(index, index)
         return True
 
 

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -674,7 +674,7 @@ class ImageLoader(QObject):
         future = Future()
         url = url = QUrl(url)
         request = QNetworkRequest(url)
-        request.setRawHeader("User-Agent", "OWImageViewer/1.0")
+        request.setRawHeader(b"User-Agent", b"OWImageViewer/1.0")
         request.setAttribute(
             QNetworkRequest.CacheLoadControlAttribute,
             QNetworkRequest.PreferCache

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -36,7 +36,7 @@ class OWMergeData(widget.OWWidget):
         w = QtGui.QWidget(self)
         self.controlArea.layout().addWidget(w)
         grid = QtGui.QGridLayout()
-        grid.setMargin(0)
+        grid.setContentsMargins(0, 0, 0, 0)
         w.setLayout(grid)
 
         # attribute A selection

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1336,8 +1336,9 @@ class SequenceFlow(QWidget):
 
         def focusOutEvent(self, event):
             event.accept()
-            self.__focusframe.deleteLater()
-            self.__focusframe = None
+            if self.__focusframe is not None:
+                self.__focusframe.deleteLater()
+                self.__focusframe = None
             self.__deleteaction.setEnabled(False)
 
         def closeEvent(self, event):

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1322,7 +1322,7 @@ class SequenceFlow(QWidget):
         def paintEvent(self, event):
             painter = QStylePainter(self)
             opt = QStyleOptionFrame()
-            opt.init(self)
+            opt.initFrom(self)
             painter.drawPrimitive(QStyle.PE_FrameDockWidget, opt)
             painter.end()
 
@@ -1580,7 +1580,7 @@ class SequenceFlow(QWidget):
         if hotSpot is not None:
             drag.setHotSpot(hotSpot)
         mime = QMimeData()
-        mime.setData("application/x-internal-move", "")
+        mime.setData("application/x-internal-move", b"")
         drag.setMimeData(mime)
         return drag.exec_(Qt.MoveAction)
 
@@ -1638,7 +1638,7 @@ class OWPreprocess(widget.OWWidget):
             index = indexlist[0]
             qname = index.data(DescriptionRole).qualname
             m = QMimeData()
-            m.setData("application/x-qwidget-ref", qname)
+            m.setData("application/x-qwidget-ref", qname.encode("utf-8"))
             return m
         # TODO: Fix this (subclass even if just to pass a function
         # for mimeData delegate)

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -65,7 +65,7 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
             index = exp.indexIn(text)
             while index >= 0:
                 length = exp.matchedLength()
-                if exp.numCaptures() > 0:
+                if exp.captureCount() > 0:
                     self.setFormat(exp.pos(1), len(str(exp.cap(1))), format)
                 else:
                     self.setFormat(exp.pos(0), len(str(exp.cap(0))), format)

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -95,7 +95,8 @@ class VariablesListItemModel(itemmodels.VariableListModel):
             descriptors.append((var.name, vartype(var)))
             vars.append(var)
         mime = QtCore.QMimeData()
-        mime.setData(self.MIME_TYPE, QtCore.QByteArray(str(descriptors).encode()))
+        mime.setData(self.MIME_TYPE,
+                     QtCore.QByteArray(str(descriptors).encode("utf-8")))
         mime._vars = vars
         return mime
 
@@ -312,7 +313,7 @@ class OWSelectAttributes(widget.OWWidget):
         self.layout().addWidget(self.controlArea)
         layout = QtGui.QGridLayout()
         self.controlArea.setLayout(layout)
-        layout.setMargin(4)
+        layout.setContentsMargins(4, 4, 4, 4)
         box = gui.widgetBox(self.controlArea, "Available Variables",
                             addToLayout=False)
         self.filter_edit = QtGui.QLineEdit()

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from itertools import chain
 
-from PyQt4 import QtGui, Qt, QtCore
+from PyQt4 import QtGui, QtCore
 
 from Orange.data import (ContinuousVariable, DiscreteVariable, StringVariable,
                          Table)
@@ -212,7 +212,7 @@ class OWSelectRows(widget.OWWidget):
             le = gui.lineEdit(box, self, None)
             if contents:
                 le.setText(contents)
-            le.setAlignment(Qt.Qt.AlignRight)
+            le.setAlignment(QtCore.Qt.AlignRight)
             le.editingFinished.connect(self.conditions_changed)
             return le
 

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -584,7 +584,7 @@ class OWDataTable(widget.OWWidget):
                             # paint by hand (borrowed from QTableCornerButton)
                             btn = o
                             opt = QtGui.QStyleOptionHeader()
-                            opt.init(btn)
+                            opt.initFrom(btn)
                             state = QtGui.QStyle.State_None
                             if btn.isEnabled():
                                 state |= QtGui.QStyle.State_Enabled

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -547,7 +547,7 @@ def widgetBox(widget, box=None, orientation='vertical', margin=None, spacing=4,
             margin = 0
     setLayout(b, orientation)
     b.layout().setSpacing(spacing)
-    b.layout().setMargin(margin)
+    b.layout().setContentsMargins(margin, margin, margin, margin)
     misc.setdefault('addSpace', bool(box))
     miscellanea(b, None, widget, **misc)
     return b

--- a/Orange/widgets/regression/owregressiontreegraph.py
+++ b/Orange/widgets/regression/owregressiontreegraph.py
@@ -77,7 +77,7 @@ class OWRegressionTreeGraph(OWTreeGraph):
         for node in self.scene.nodes():
             li = [0.5, node.num_instances() / all_instances,
                   node.impurity() / max_impurity][self.color_index]
-            node.backgroundBrush = QBrush(palette[self.color_index].light(
+            node.backgroundBrush = QBrush(palette[self.color_index].lighter(
                 180 - li * 150))
         self.scene.update()
 

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -496,7 +496,7 @@ class OWDistanceMap(widget.OWWidget):
         self._clear_plot()
         self.matrix_item = DistanceMapItem(self._sorted_matrix)
         # Scale the y axis to compensate for pg.ViewBox's y axis invert
-        self.matrix_item.scale(1, -1)
+        self.matrix_item.setTransform(QTransform.fromScale(1, -1), )
         self.viewbox.addItem(self.matrix_item)
         # Set fixed view box range.
         h, w = self._sorted_matrix.shape

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -4,7 +4,7 @@ import itertools
 import numpy as np
 from PyQt4.QtGui import QTableView, QColor, QItemSelectionModel, \
     QItemDelegate, QPen, QBrush, QItemSelection, QHeaderView
-from PyQt4.QtCore import Qt, SIGNAL, QAbstractTableModel, QModelIndex, QSize
+from PyQt4.QtCore import Qt, QAbstractTableModel, QModelIndex, QSize
 
 from Orange.data import Table, Variable, ContinuousVariable, DiscreteVariable
 from Orange.misc import DistMatrix
@@ -29,7 +29,7 @@ class DistanceMatrixModel(QAbstractTableModel):
         self.zero_diag = True
 
     def set_data(self, distances):
-        self.emit(SIGNAL("modelAboutToBeReset()"))
+        self.beginResetModel()
         self.distances = distances
         if distances is None:
             return
@@ -37,9 +37,10 @@ class DistanceMatrixModel(QAbstractTableModel):
         self.colors = \
             (distances * (170 / span if span > 1e-10 else 0)).astype(np.int)
         self.zero_diag = all(distances.diagonal() < 1e-6)
+        self.endResetModel()
 
     def set_labels(self, labels, variable=None, values=None):
-        self.emit(SIGNAL("modelReset()"))
+        self.beginResetModel()
         self.labels = labels
         self.variable = variable
         self.values = values
@@ -51,7 +52,8 @@ class DistanceMatrixModel(QAbstractTableModel):
                                  for x in (values - off) * fact]
         else:
             self.label_colors = None
-        self.emit(SIGNAL("modelReset()"))
+
+        self.endResetModel()
 
     def dimension(self, parent=None):
         if parent and parent.isValid() or self.distances is None:

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -579,7 +579,6 @@ class DendrogramWidget(QGraphicsWidget):
 
             item.setPath(Path_toQtPath(geom))
             item.setZValue(-node.value.height)
-            item.setPen(QPen(Qt.blue))
             r = item.boundingRect()
             base = self._root.value.height
 

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1449,7 +1449,7 @@ class WrapperLayoutItem(QGraphicsLayoutItem):
         self.orientation = orientation
         self.item = item
         if orientation == Qt.Vertical:
-            self.item.rotate(-90)
+            self.item.setRotation(-90)
             self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         else:
             self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -579,7 +579,7 @@ class DendrogramWidget(QGraphicsWidget):
 
             item.setPath(Path_toQtPath(geom))
             item.setZValue(-node.value.height)
-            r = item.boundingRect()
+            r = item.path().boundingRect()
             base = self._root.value.height
 
             if self.orientation == Left:

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -77,7 +77,7 @@ class OWKMeans(widget.OWWidget):
         layout.addWidget(
             gui.appendRadioButton(bg, "Optimized", addToLayout=False), 2, 1)
         ftobox = gui.widgetBox(None, orientation="horizontal")
-        ftobox.layout().setMargin(0)
+        ftobox.layout().setContentsMargins(0, 0, 0, 0)
         layout.addWidget(ftobox)
         gui.spin(
             ftobox, self, "k_from", minv=2, maxv=29,

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -268,7 +268,7 @@ class OWMDS(widget.OWWidget):
 
         box = QtGui.QGroupBox("Zoom/Select", )
         box.setLayout(QtGui.QHBoxLayout())
-        box.layout().setMargin(2)
+        box.layout().setContentsMargins(2, 2, 2, 2)
 
         group = QtGui.QActionGroup(self, exclusive=True)
 

--- a/Orange/widgets/utils/colorpalette.py
+++ b/Orange/widgets/utils/colorpalette.py
@@ -50,7 +50,7 @@ class ColorPaletteDlg(QDialog):
     def __init__(self, parent, windowTitle="Color Palette"):
         super().__init__(parent, windowTitle=windowTitle)
         self.setLayout(QVBoxLayout())
-        self.layout().setMargin(4)
+        self.layout().setContentsMargins(4, 4, 4, 4)
 
         self.contPaletteNames = []
         self.exContPaletteNames = []
@@ -360,7 +360,7 @@ class ColorPalleteListing(QDialog):
                  **kwargs):
         super().__init__(parent, windowTitle=windowTitle, **kwargs)
         self.setLayout(QVBoxLayout())
-        self.layout().setMargin(0)
+        self.layout().setContentsMargins(0, 0, 0, 0)
         sa = QScrollArea(
             horizontalScrollBarPolicy=Qt.ScrollBarAlwaysOff,
             verticalScrollBarPolicy=Qt.ScrollBarAlwaysOn
@@ -447,7 +447,7 @@ class PaletteEditor(QDialog):
                  **kwargs):
         super().__init__(parent, **kwargs)
         self.setLayout(QVBoxLayout())
-        self.layout().setMargin(4)
+        self.layout().setContentsMargins(4, 4, 4, 4)
 
         hbox = gui.widgetBox(self, "Information", orientation='horizontal')
         gui.widgetLabel(
@@ -841,7 +841,7 @@ class ColorButton(QWidget):
             self.parent.layout().addWidget(self)
 
         self.setLayout(QHBoxLayout())
-        self.layout().setMargin(0)
+        self.layout().setContentsMargins(0, 0, 0, 0)
         self.icon = QFrame(self)
         self.icon.setFixedSize(ColorButtonSize, ColorButtonSize)
         self.icon.setAutoFillBackground(1)

--- a/Orange/widgets/utils/colorpalette.py
+++ b/Orange/widgets/utils/colorpalette.py
@@ -82,7 +82,7 @@ class ColorPaletteDlg(QDialog):
                 if QMessageBox.information(
                         self, 'Question',
                         'The color schema has changed. Save?',
-                        'Yes', 'Discard', '', 0, 1):
+                        QMessageBox.Yes | QMessageBox.Discard) == QMessageBox.Discard:
                     QDialog.reject(self)
                 else:
                     self.selectedSchemaIndex = self.schemaCombo.count() - 1

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -91,9 +91,10 @@ class PyListModel(QAbstractListModel):
         """ Wrap the list with this model. All changes to the model
         are done in place on the passed list
         """
+        self.beginResetModel()
         self._list = lst
         self._other_data = [_store() for _ in lst]
-        self.reset()
+        self.endResetModel()
 
 
     # noinspection PyMethodOverriding

--- a/Orange/widgets/utils/overlay.py
+++ b/Orange/widgets/utils/overlay.py
@@ -98,7 +98,7 @@ class OverlayWidget(QWidget):
 
     def paintEvent(self, event):
         opt = QStyleOption()
-        opt.init(self)
+        opt.initFrom(self)
         painter = QPainter(self)
         self.style().drawPrimitive(QStyle.PE_Widget, opt, painter, self)
 

--- a/Orange/widgets/utils/toolbar.py
+++ b/Orange/widgets/utils/toolbar.py
@@ -106,7 +106,7 @@ class ZoomSelectToolbar(QGroupBox):
 
     def setup_toolbar(self, parent):
         self.setLayout(QHBoxLayout())
-        self.layout().setMargin(6)
+        self.layout().setContentsMargins(6, 6, 6, 6)
         self.layout().setSpacing(4)
         if parent.layout() is not None:
             parent.layout().addWidget(self)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -585,7 +585,8 @@ class OWHeatMap(widget.OWWidget):
             self.on_selection_finished)
         self.heatmap_scene.set_selection_manager(self.selection_manager)
 
-        item = QtGui.QGraphicsRectItem(0, 0, 10, 10, None, self.heatmap_scene)
+        item = QtGui.QGraphicsRectItem(0, 0, 10, 10, None)
+        self.heatmap_scene.addItem(item)
         self.heatmap_scene.itemsBoundingRect()
         self.heatmap_scene.removeItem(item)
 
@@ -1041,10 +1042,10 @@ class OWHeatMap(widget.OWWidget):
                 if sort_j[j] is not None:
                     X_part = X_part[:, sort_j[j]]
 
-                hw.set_heatmap_data(X_part)
                 hw.set_levels(parts.levels)
                 hw.set_color_table(palette)
                 hw.set_show_averages(self.averages)
+                hw.set_heatmap_data(X_part)
 
                 grid.addItem(hw, Row0 + i * 2 + 1, Col0 + j)
                 grid.setRowStretchFactor(Row0 + i * 2 + 1, X_part.shape[0] * 100)

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -771,6 +771,7 @@ class OWLinearProjection(widget.OWWidget):
         for i, axis in enumerate(axes.T):
             axis_item = AxisItem(line=QLineF(0, 0, axis[0], axis[1]),
                                  label=variables[i].name)
+            axis_item.setPen(QtGui.QPen(Qt.darkGray, 0))
             self.viewbox.addItem(axis_item)
 
         if reset_view:

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -456,7 +456,8 @@ class OWMosaicDisplay(OWWidget):
                         onclick=select_area, **args)
 
             def line(x1, y1, x2, y2):
-                r = QGraphicsLineItem(x1, y1, x2, y2, None, self.canvas)
+                r = QGraphicsLineItem(x1, y1, x2, y2, None)
+                self.canvas.addItem(r)
                 r.setPen(QPen(Qt.white, 2))
                 r.setZValue(30)
 
@@ -725,7 +726,7 @@ class CanvasText(QGraphicsTextItem):
     def __init__(self, canvas, text="", x=0, y=0,
                  alignment=Qt.AlignLeft | Qt.AlignTop, bold=0, font=None, z=0,
                  html_text=None, tooltip=None, show=1, vertical=False):
-        QGraphicsTextItem.__init__(self, text, None, canvas)
+        QGraphicsTextItem.__init__(self, text, None)
 
         if font:
             self.setFont(font)
@@ -751,6 +752,9 @@ class CanvasText(QGraphicsTextItem):
         else:
             self.hide()
 
+        if canvas is not None:
+            canvas.addItem(self)
+
     def setPos(self, x, y):
         self.x, self.y = x, y
         rect = QGraphicsTextItem.boundingRect(self)
@@ -774,7 +778,7 @@ class CanvasRectangle(QGraphicsRectItem):
                  pen_color=QColor(128, 128, 128), brush_color=None, pen_width=1,
                  z=0, pen_style=Qt.SolidLine, pen=None, tooltip=None, show=1,
                  onclick=None):
-        super().__init__(x, y, width, height, None, canvas)
+        super().__init__(x, y, width, height, None)
         self.onclick = onclick
         if brush_color:
             self.setBrush(QBrush(brush_color))
@@ -789,6 +793,9 @@ class CanvasRectangle(QGraphicsRectItem):
             self.show()
         else:
             self.hide()
+
+        if canvas is not None:
+            canvas.addItem(self)
 
     def mousePressEvent(self, ev):
         if self.onclick:

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -913,7 +913,7 @@ class OWScatterMap(widget.OWWidget):
         with self.progressBar(len(scored_rects)) as progress_bar:
             for i, (_, rect) in enumerate(scored_rects):
                 root = sharpen_region_recur(
-                    root, rect.intersect(region),
+                    root, rect.intersected(region),
                     nbins, depth + 1, bin_func)
                 tick = time.time() - update_time
                 if tick > 2.0:
@@ -1217,7 +1217,7 @@ def stack_tile_blocks(blocks):
 
 def bindices(node, rect):
     assert rect.normalized() == rect
-    assert not rect.intersect(QRectF(*node.brect)).isEmpty()
+    assert not rect.intersected(QRectF(*node.brect)).isEmpty()
 
     xs = np.searchsorted(node.xbins, rect.left(), side="left") - 1
     xe = np.searchsorted(node.xbins, rect.right(), side="right")

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -355,13 +355,15 @@ class OWSieveDiagram(OWWidget):
         temp = dist
         canvas = self.canvas
         while temp < w:
-            r = QGraphicsLineItem(temp + x, y, temp + x, y + h, None, canvas)
+            r = QGraphicsLineItem(temp + x, y, temp + x, y + h, None)
+            canvas.addItem(r)
             r.setPen(pen)
             temp += dist
 
         temp = dist
         while temp < h:
-            r = QGraphicsLineItem(x, y + temp, x + w, y + temp, None, canvas)
+            r = QGraphicsLineItem(x, y + temp, x + w, y + temp, None)
+            canvas.addItem(r)
             r.setPen(pen)
             temp += dist
 

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -360,7 +360,7 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
             # Update the saved geometry only between explicit show/hide
             # events (i.e. changes initiated by the user not by Qt's default
             # window management).
-            self.savedWidgetGeometry = self.saveGeometry()
+            self.savedWidgetGeometry = bytes(self.saveGeometry())
 
     # when widget is resized, save the new width and height
     def resizeEvent(self, ev):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -234,7 +234,7 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
             return w
 
         self.setLayout(QVBoxLayout())
-        self.layout().setMargin(2)
+        self.layout().setContentsMargins(2, 2, 2, 2)
 
         self.warning_bar = gui.widgetBox(self, orientation="horizontal",
                                          margin=0, spacing=0)
@@ -291,7 +291,7 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
             self.widgetStatusArea.setLayout(QHBoxLayout(self.widgetStatusArea))
             self.widgetStatusArea.layout().addWidget(self.statusBarIconArea)
             self.widgetStatusArea.layout().addWidget(self.widgetStatusBar)
-            self.widgetStatusArea.layout().setMargin(0)
+            self.widgetStatusArea.layout().setContentsMargins(0, 0, 0, 0)
             self.widgetStatusArea.setFrameShape(QFrame.StyledPanel)
 
             self.statusBarIconArea.setLayout(QHBoxLayout())


### PR DESCRIPTION
Mostly replacing uses of obsolete methods.

~~Testers might want to also ales-erjavec@76a503f6617cb80d8307e9a5203122aabd8635e7, install https://github.com/ales-erjavec/anyqt and start orange with:
```QT_API=pyqt5 python -m Orange.canvas```~~

The second part bringing full PyQt5 support is in https://github.com/ales-erjavec/orange3/tree/anyqt (ales-erjavec/orange3@f2d696d66a31a939cc6d06c0b1c783b4d9ebd8ff)