### PR TITLE
owpreprocess: Use unique qualified names for PCA and CUR preprocessors

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -868,13 +868,13 @@ PREPROCESSORS = [
         Randomize
     ),
     PreprocessAction(
-        "PCA", "orange.preprocess.preprocess", "PCA",
+        "PCA", "orange.preprocess.pca", "PCA",
         Description("Principal Component Analysis",
                     icon_path("PCA.svg")),
         PCA
     ),
     PreprocessAction(
-        "CUR", "orange.preprocess.preprocess", "CUR",
+        "CUR", "orange.preprocess.cur", "CUR",
         Description("CUR Matrix Decomposition",
                     icon_path("SelectColumns.svg")),
         CUR


### PR DESCRIPTION
Fix an error where a wrong preprocessor would be created as a result of
a drag/drop.