### PR TITLE
Fix for Mosaic and Sieve attributes

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -294,7 +294,7 @@ class OWMosaicDisplay(OWWidget):
         self.attr3Combo.addItem("(None)")
         self.attr4Combo.addItem("(None)")
 
-        for attr in chain(data.domain.attributes, data.domain.metas):
+        for attr in chain(data.domain, data.domain.metas):
             if attr.is_discrete:
                 for combo in [self.attr1Combo, self.attr2Combo, self.attr3Combo, self.attr4Combo]:
                     combo.addItem(self.icons[attr], attr.name)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -98,7 +98,7 @@ class OWSieveDiagram(OWWidget):
             self.attrs[:] = []
         else:
             self.attrs[:] = [
-                var for var in chain(self.data.domain.attributes,
+                var for var in chain(self.data.domain,
                                      self.data.domain.metas)
                 if var.is_discrete
             ]


### PR DESCRIPTION
Fixes bug introduced in the previous PR, pointed out by @lanzagar.  It was introduced when I was trying to iterate through both `data.domain` and `data.domain.metas` using `+` and a type mismatch occurred. `chain` does not have any such issues.