### PR TITLE
setup.py: Remove build date from the public version identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,9 +131,7 @@ if not release:
         GIT_REVISION = "Unknown"
 
     if not ISRELEASED:
-        from datetime import datetime
-        timestamp = datetime.now().strftime('%y%m%d')
-        FULLVERSION += '.{}.dev0+{}'.format(timestamp, GIT_REVISION[:7])
+        FULLVERSION += '.dev0+' + GIT_REVISION[:7]
 
     a = open(filename, 'w')
     try:


### PR DESCRIPTION
This partially reverts commit 36f27c48c2c16a0c4da781e6ff01e1291bcc27db.