### PR TITLE
DistanceMatrixContextHandler: error after closing DistanceMatrix

### DIFF
--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -182,8 +182,9 @@ class DistanceMatrixContextHandler(ContextHandler):
 
     def settings_from_widget(self, widget):
         context = widget.current_context
-        context.annotation = widget.annot_combo.currentText()
-        context.selection = widget.tableview.selectionModel().selected_items()
+        if context is not None:
+            context.annotation = widget.annot_combo.currentText()
+            context.selection = widget.tableview.selectionModel().selected_items()
 
     def settings_to_widget(self, widget):
         context = widget.current_context


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->


Error occured during closing unused DistanceMatrix widget.
Added context checker in settings_from_widget method.