### PR TITLE
[WIP] LearnerScorer: Change signature of score method

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -14,7 +14,9 @@ class _FeatureScorerMixin(LearnerScorer):
     feature_type = Variable
     class_type = DiscreteVariable
 
-    def score(self, model):
+    def score(self, data):
+        data = Normalize(data)
+        model = self(data)
         # Take the maximum attribute score across all classes
         return np.max(np.abs(model.coefficients), axis=0)
 
@@ -33,7 +35,7 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_linear_model.LogisticRegression
     __returns__ = LogisticRegressionClassifier
     name = 'logreg'
-    preprocessors = SklLearner.preprocessors + [Normalize()]
+    preprocessors = SklLearner.preprocessors
 
     def __init__(self, penalty="l2", dual=False, tol=0.0001, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -11,7 +11,8 @@ class _FeatureScorerMixin(LearnerScorer):
     feature_type = Variable
     class_type = DiscreteVariable
 
-    def score(self, model):
+    def score(self, data):
+        model = self(data)
         return model.skl_model.feature_importances_
 
 

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -122,12 +122,11 @@ class UnivariateLinearRegression(SklScorer):
 class LearnerScorer(Scorer):
 
     @abstract
-    def score(self, model):
+    def score(self, data):
         pass
 
     def score_data(self, data, feature=None):
-        model = self(data)
-        scores = self.score(model)
+        scores = self.score(data)
 
         if data.domain != self.domain:
             scores_grouped = defaultdict(list)

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -24,7 +24,8 @@ class _FeatureScorerMixin(LearnerScorer):
     feature_type = Variable
     component = 0
 
-    def score(self, model):
+    def score(self, data):
+        model = self(data)
         return np.abs(model.components_[self.component])
 
 

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -5,7 +5,7 @@ import sklearn.pipeline as skl_pipeline
 import sklearn.preprocessing as skl_preprocessing
 
 from Orange.data import Variable, ContinuousVariable
-from Orange.preprocess import Continuize, RemoveNaNColumns, SklImpute
+from Orange.preprocess import Continuize, Normalize, RemoveNaNColumns, SklImpute
 from Orange.preprocess.score import LearnerScorer
 from Orange.regression import Learner, Model, SklLearner, SklModel
 
@@ -20,7 +20,9 @@ class _FeatureScorerMixin(LearnerScorer):
     feature_type = Variable
     class_type = ContinuousVariable
 
-    def score(self, model):
+    def score(self, data):
+        data = Normalize(data)
+        model = self(data)
         return np.abs(model.coefficients)
 
 

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -10,7 +10,8 @@ class _FeatureScorerMixin(LearnerScorer):
     feature_type = Variable
     class_type = ContinuousVariable
 
-    def score(self, model):
+    def score(self, data):
+        model = self(data)
         return model.skl_model.feature_importances_
 
 

--- a/Orange/tests/test_evaluation_scoring.py
+++ b/Orange/tests/test_evaluation_scoring.py
@@ -14,17 +14,15 @@ from Orange.preprocess import discretize
 class ScoringTest(unittest.TestCase):
     def test_Recall(self):
         data = Table('iris')
-        learner = LogisticRegressionLearner()
+        learner = LogisticRegressionLearner(preprocessors=[])
         results = TestOnTrainingData(data, [learner])
-        self.assertGreater(Recall(results)[0], 0.9)
-        self.assertEqual(round(Recall(results)[0], 3), 0.927)
+        self.assertAlmostEqual(Recall(results)[0], 0.960, 3)
 
     def test_Precision(self):
         data = Table('iris')
-        learner = LogisticRegressionLearner()
+        learner = LogisticRegressionLearner(preprocessors=[])
         results = TestOnTrainingData(data, [learner])
-        self.assertGreater(Precision(results)[0], 0.9)
-        self.assertEqual(round(Precision(results)[0], 3), 0.928)
+        self.assertAlmostEqual(Precision(results)[0], 0.962, 3)
 
 
 class Scoring_CA_Test(unittest.TestCase):

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -45,7 +45,7 @@ class LinearRegressionTest(unittest.TestCase):
         data = Table('housing')
         learner = LinearRegressionLearner()
         scores = learner.score_data(data)
-        self.assertEqual('NOX',
+        self.assertEqual('LSTAT',
                          data.domain.attributes[np.argmax(scores)].name)
         self.assertEqual(len(scores), len(data.domain.attributes))
 
@@ -57,7 +57,7 @@ class LinearRegressionTest(unittest.TestCase):
                     ElasticNetLearner(alpha=0.01)]
         for learner in learners:
             scores = learner.score_data(data)
-            self.assertEqual('NOX',
+            self.assertEqual('LSTAT',
                              data.domain.attributes[np.argmax(scores)].name)
             self.assertEqual(len(scores), len(data.domain.attributes))
 

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -14,7 +14,8 @@ class LogisticRegressionTest(unittest.TestCase):
         ca = CA(results)
         self.assertTrue(0.8 < ca < 1.0)
 
-    def test_LogisticRegressionPreprocessors(self):
+    @unittest.skip("Re-enable when Logistic regression supports normalization.")
+    def test_LogisticRegressionNormalization(self):
         np.random.seed(42)
         table = Table('iris')
         new_attrs = (ContinuousVariable('c0'),) + table.domain.attributes
@@ -25,11 +26,24 @@ class LogisticRegressionTest(unittest.TestCase):
             1000000 * np.random.random((table.X.shape[0], 1)),
             table))
         table = table.from_numpy(new_domain, new_table)
-        learners = [LogisticRegressionLearner(preprocessors=[]),
-                    LogisticRegressionLearner()]
-        results = CrossValidation(table, learners, k=3)
+        lr = LogisticRegressionLearner(normalize=False)
+        lr_norm = LogisticRegressionLearner(normalize=True)
+
+        # check that normalization produces better results
+        results = CrossValidation(table, [lr_norm, lr], k=3)
         ca = CA(results)
-        self.assertTrue(ca[0] < ca[1])
+        self.assertGreater(ca[0], ca[1])
+
+        # check that coefficients are properly scaled back to unnormalized data
+        model = lr_norm(table)
+        y = np.argmax(np.dot(table.X, model.coefficients.T) + model.intercept,
+                      axis=1)
+        np.testing.assert_array_equal(model(table), y)
+
+    def test_LogisticRegressionNormalization_todo(self):
+        with self.assertRaises(TypeError):
+            lr = LogisticRegressionLearner(normalize=True)
+            # Do not skip the above test when this is implemented
 
     def test_probability(self):
         table = Table('iris')


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

It used to have model as a parameter and now it gets the data directly.
This allows more freedom for individual learners to define how to score
variables.
E.g. Logistic regression and Linear regression models need to normalize
the data first, before the coefficient make sense.
Random forest on the other hand does not require normalization.