### PR TITLE
Consistent install requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ install:
 script:
     - cd "$ORANGE_DIR"
     - python -c "from Orange.tests import *"
-    - PYTHONUNBUFFERED=x coverage run --source=Orange --rcfile=$TRAVIS_BUILD_DIR/.coveragerc -m unittest Orange.tests
+    - cp "$TRAVIS_BUILD_DIR"/.coveragerc ./  # for covereage and codecov
+    - PYTHONUNBUFFERED=x coverage run --source=Orange -m unittest -v Orange.tests
 
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ install:
     - pip install codecov
 
 script:
-    - cd $TRAVIS_BUILD_DIR/dist/Orange-*
+    - cd "$ORANGE_DIR"
     - python -c "from Orange.tests import *"
-    - PYTHONUNBUFFERED=x coverage run --source=Orange setup.py test
+    - PYTHONUNBUFFERED=x coverage run --source=Orange --rcfile=$TRAVIS_BUILD_DIR/.coveragerc -m unittest Orange.tests
 
 after_success:
     - codecov

--- a/.travis/build_doc.sh
+++ b/.travis/build_doc.sh
@@ -1,7 +1,12 @@
-cd $ORANGE_DIR/doc/development
+cd "$TRAVIS_BUILD_DIR"
+
+# build Orange inplace (needed for docs to build)
+python setup.py build_ext --inplace
+
+cd $TRAVIS_BUILD_DIR/doc/development
 make html
-cd $ORANGE_DIR/doc/data-mining-library
+cd $TRAVIS_BUILD_DIR/doc/data-mining-library
 make html
-cd $ORANGE_DIR/doc/visual-programming
+cd $TRAVIS_BUILD_DIR/doc/visual-programming
 make html
 ./build_widget_catalog.py --input build/html/index.html --output build/html/widgets.json --url-prefix "http://docs.orange.biolab.si/3/visual-programming/"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,11 +10,13 @@ cat requirements-core.txt \
             pip install $dep
     done
 
-# Create a source tarball, unpack it, and run its tests
+# Create a source tarball from the git checkout
 python setup.py sdist
-cd dist
-tar xzf Orange-*.tar.gz
-cd Orange-*
-export ORANGE_DIR="$(pwd)"
-python setup.py build_ext -i
+# Create a binary wheel from the packed source
+pip wheel --no-deps -w dist dist/Orange-*.tar.gz
+# Install into a testing folder
+ORANGE_DIR="$(pwd)"/build/travis-test
+mkdir -p "$ORANGE_DIR"
+pip install --no-deps --target "$ORANGE_DIR"  dist/Orange-*.whl
+
 cd $TRAVIS_BUILD_DIR

--- a/.travis/install_postgres.sh
+++ b/.travis/install_postgres.sh
@@ -41,5 +41,5 @@ $POSTGRES/bin/createdb -p 12345 test
 $POSTGRES/bin/psql test -c 'CREATE EXTENSION quantile;' -p 12345
 $POSTGRES/bin/psql test -c 'CREATE EXTENSION tsm_system_time;' -p 12345
 
-pip install -r $ORANGE_DIR/requirements-sql.txt
+pip install -r $TRAVIS_BUILD_DIR/requirements-sql.txt
 export ORANGE_TEST_DB_URI=postgres://localhost:12345/test

--- a/.travis/upload_doc.sh
+++ b/.travis/upload_doc.sh
@@ -1,4 +1,4 @@
-cd $ORANGE_DIR
+cd "$TRAVIS_BUILD_DIR"
 
 # Decrypt private key
 openssl aes-256-cbc -K $encrypted_3fc26dee5a84_key -iv $encrypted_3fc26dee5a84_iv -in .travis/upload_doc_id -out .travis/key.private -d
@@ -13,6 +13,6 @@ cp -r doc/visual-programming/build/html doc/orange3doc/visual-programming
 Host orange.biolab.si
     StrictHostKeyChecking no
     User uploaddocs
-    IdentityFile $ORANGE_DIR/.travis/key.private
+    IdentityFile $TRAVIS_BUILD_DIR/.travis/key.private
 "
 rsync -a --delete doc/orange3doc/ orange.biolab.si:/orange3doc/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,20 @@
+
+recursive-include Orange *.pyx *.py *.c *.cpp
+recursive-include Orange/datasets *.tab *.basket *.info
+
+recursive-include Orange/tests *.tab *.basket *.xlsx
+
+recursive-include Orange/canvas *.qss *ico *.png *.svg *.ico *.html
+recursive-include Orange/canvas/application/tutorials *.ows
+
+recursive-include Orange/widgets *.png *.svg
+recursive-include Orange/widgets/utils/plot *.fs *.vs *.gs *.obj
+
+include requirements*.txt
+
+include README.md
+include CONTRIBUTING.md
+include COPYING
+include LICENSE
+include setup.py
+include setup.cfg

--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -26,12 +26,16 @@ def named_file(content, encoding=None):
         os.remove(name)
 
 
-def suite():
+def suite(loader=None, pattern='test*.py'):
     test_dir = os.path.dirname(__file__)
+    if loader is None:
+        loader = unittest.TestLoader()
+    if pattern is None:
+        pattern = 'test*.py'
     all_tests = [
-        unittest.TestLoader().discover(test_dir),
+        loader.discover(test_dir, pattern),
     ]
-    load = unittest.TestLoader().loadTestsFromModule
+    load = loader.loadTestsFromModule
 
     if run_widget_tests:
         all_tests.extend([
@@ -49,6 +53,11 @@ def suite():
 
 
 test_suite = suite()
+
+
+def load_tests(loader, tests, pattern):
+    return suite(loader, pattern)
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ have access to the installed PyQt4.
 To start Orange GUI from the command line, assuming it was successfully
 installed, run:
 
-    orange
+    orange-canvas
     # or
     python3 -m Orange.canvas
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ it in a development environment, run:
     pip install -r requirements-core.txt  # For Orange Python library
     pip install -r requirements-gui.txt   # For Orange GUI
 
-    pip install -r requirements-dev.txt   # For development and creating sdists
     pip install -r requirements-sql.txt   # To use SQL support
     pip install -r requirements-opt.txt   # Optional dependencies, may fail
 
-    # Finally install Orange
-    python setup.py develop
+    # Finally install Orange in editable/development mode.
+    pip install -e .
 
 Installation of SciPy and qt-graph-helpers is sometimes challenging because of
 their non-python dependencies that have to be installed manually. More

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-# To not need to update MANIFEST.in manually
-setuptools-git

--- a/scripts/build-osx-app.sh
+++ b/scripts/build-osx-app.sh
@@ -107,6 +107,10 @@ PIP=$TEMPLATE/Contents/MacOS/pip
 PREFIX=$("$PYTHON" -c'import sys; print(sys.prefix)')
 SITE_PACKAGES=$("$PYTHON" -c'import sysconfig as sc; print(sc.get_path("platlib"))')
 
+echo "Installing/updating setuptools and pip"
+echo "======================================"
+"$PIP" install setuptools==18.* pip==7.*
+
 echo "Installing Bottlechest"
 echo "======================"
 "$PIP" install --find-links http://orange.biolab.si/download/files/wheelhouse/ \
@@ -135,11 +139,6 @@ sed -i.bak "s@/.*\.app/@$TEMPLATE/@g" "${SITE_PACKAGES}"/sipconfig.py
     "$PIP" install qt-graph-helpers
 )
 
-echo "Installing pyqtgraph sqlparse"
-echo "============================="
-
-"$PIP" install pyqtgraph sqlparse
-
 echo "Installing Orange"
 echo "================="
 
@@ -161,13 +160,6 @@ cat <<-'EOF' > "$TEMPLATE"/Contents/MacOS/Orange
 EOF
 
 chmod +x "$TEMPLATE"/Contents/MacOS/Orange
-
-echo "Installing extra dependencies"
-echo "============================="
-# Install a delocated pygraphviz wheel (https://pypi.python.org/pypi/delocate).
-"$PIP" install --no-index --trusted-host orange.biolab.si \
-               --find-links http://orange.biolab.si/download/files/wheelhouse/ \
-              'pygraphviz>=1.3rc2'
 
 
 if [[ ! $INPLACE ]]; then

--- a/scripts/windows/build-win-application.sh
+++ b/scripts/windows/build-win-application.sh
@@ -284,6 +284,11 @@ function prepare_req {
 }
 
 function prepare_orange {
+    # ensure that correct numpy and scipy are installed in the build env
+    pip install --no-index -f "$BUILDBASE/wheelhouse" \
+                --only-binary numpy,scipy \
+                numpy==$NUMPY_VER, scipy==$SCIPY_VER
+
     python setup.py egg_info
     local version=$(grep -E "^Version: .*$" Orange.egg-info/PKG-INFO | awk '{ print $2 }')
 
@@ -291,8 +296,8 @@ function prepare_orange {
         build --compiler=msvc \
         bdist_wheel -d "$BUILDBASE/wheelhouse"
 
-	# Ensure all install_requires dependencies are available in the wheelhouse
-	prepare_req --only-binary numpy,scipy -r Orange.egg-info/requires.txt
+    # Ensure all install dependencies are available in the wheelhouse
+    prepare_req --only-binary numpy,scipy,scikit-learn,bottlechest .
 
     echo "# Orange " >> "$BUILDBASE/requirements.txt"
     echo "Orange==$version" >> "$BUILDBASE/requirements.txt"

--- a/scripts/windows/build-win-application.sh
+++ b/scripts/windows/build-win-application.sh
@@ -57,8 +57,8 @@ done
 
 PLATTAG=win32
 
-PYTHON_VER=3.4.3
-PYTHON_MD5=cb450d1cc616bfc8f7a2d6bd88780bf6
+PYTHON_VER=3.4.4
+PYTHON_MD5=e96268f7042d2a3d14f7e23b2535738b
 
 PYTHON_VER_SHORT=${PYTHON_VER%.[0-9]*}
 PYVER=$(echo $PYTHON_VER_SHORT | sed s/\\.//g)
@@ -70,8 +70,8 @@ PYQT_MD5=b4164a0f97780fbb7c5c1e265dd37473
 NUMPY_VER=1.9.2
 NUMPY_MD5=0c06b7beabdc053ef63699ada0ee5e98
 
-SCIPY_VER=0.15.1
-SCIPY_MD5=e24c435e96dc7fbde8eac62ca8c969c8
+SCIPY_VER=0.16.1
+SCIPY_MD5=30bf5159326d859a42ed7718a8a09704
 
 DISTDIR=${DISTDIR:-dist}
 
@@ -105,49 +105,14 @@ mkdir -p "$DISTDIR"
 
 touch "$BUILDBASE"/requirements.txt
 
+# pinned requirements (numpy and scipy are handled separately)
 echo "
 #:wheel: scikit-learn https://pypi.python.org/packages/cp34/s/scikit-learn/scikit_learn-0.16.1-cp34-none-win32.whl#md5=ca5864cdf9f1938aa1a55d6092bf5c86
 scikit-learn==0.16.1
 
-#:wheel: matplotlib https://pypi.python.org/packages/cp34/m/matplotlib/matplotlib-1.4.2-cp34-none-win32.whl#md5=f18b7568493bece5c7b3eb7bb4203826
-matplotlib==1.4.2
-
-#:wheel: ipython https://pypi.python.org/packages/3.4/i/ipython/ipython-2.4.1-py3-none-any.whl#md5=7e377fe675a88eb49e720c98de4a7ee4
-ipython==2.4.1
-
-#:wheel: pyzmq https://pypi.python.org/packages/3.4/p/pyzmq/pyzmq-14.5.0-cp34-none-win32.whl#md5=333bc2f02d24aa2455ce4208b9d8666e
-pyzmq==14.5.0
-
-#:source: Markupsafe
-Markupsafe==0.23
-
-#:source: certifi
-certifi==14.05.14
-
-#:source: Jinja2
-jinja2==2.7.3
-
-#:source: tornado
-tornado==4.1
-
-#:wheel: pygments https://pypi.python.org/packages/3.3/P/Pygments/Pygments-2.0.2-py3-none-any.whl#md5=b38281817abc47c82cf3533b8c6608f6
-pygments==2.0.2
-
-#:wheel: networkx https://pypi.python.org/packages/2.7/n/networkx/networkx-1.9.1-py2.py3-none-any.whl#md5=15bb60c9b386563a6d4765264f5bf687
-networkx==1.9.1
-
-#:source: decorator
-decorator==3.4.0
-
-#:source: sqlparse
-sqlparse==0.1.13
-
 #:wheel: Bottlecheset https://dl.dropboxusercontent.com/u/100248799/Bottlechest-0.7.1-cp34-none-win32.whl#md5=629ba2a148dfa784d0e6817497d42e97
 --find-links https://dl.dropboxusercontent.com/u/100248799/Bottlechest-0.7.1-cp34-none-win32.whl
 Bottlechest==0.7.1
-
-#:source: pyqtgraph
-pyqtgraph==0.9.10
 " > "$BUILDBASE"/requirements.txt
 
 function __download_url {

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python3
+
 import os
 import sys
 import subprocess
-from itertools import chain
 from setuptools import find_packages
 
 if sys.version_info < (3, 4):
@@ -11,7 +11,6 @@ try:
     from numpy.distutils.core import setup
 except ImportError:
     sys.exit('setup requires numpy; install numpy first')
-
 
 NAME = 'Orange'
 
@@ -59,8 +58,6 @@ INSTALL_REQUIRES = sorted(set(
                  for file in requirements)
     for line in open(file)
 ) - {''})
-
-SETUP_REQUIRES = ["setuptools-git"]
 
 ENTRY_POINTS = {
     "orange.canvas.help": (
@@ -159,86 +156,30 @@ def configuration(parent_package='', top_path=None):
     return config
 
 
-def find_package_data(
-    where='.',
-    package='',
-    exclude=('*.py', '*.pyc', '*$py.class', '*~', '.*', '*.bak'),
-    exclude_directories=('.*', 'CVS', '_darcs', './build',
-                         './dist', 'EGG-INFO', '*.egg-info'),
-    only_in_packages=True,
-    show_ignored=False):
+PACKAGES = find_packages()
 
-    """
-    Adapted from: http://svn.w4py.org/Paste/trunk/paste/util/finddata.py :
-    (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
-    Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
-    ------
-
-    Return a dictionary suitable for use in ``package_data``
-    in a distutils ``setup.py`` file.
-
-    The dictionary looks like::
-
-        {'package': [files]}
-
-    Where ``files`` is a list of all the files in that package that
-    don't match anything in ``exclude``.
-
-    If ``only_in_packages`` is true, then top-level directories that
-    are not packages won't be included (but directories under packages
-    will).
-
-    Directories matching any pattern in ``exclude_directories`` will
-    be ignored.
-
-    If ``show_ignored`` is true, then all the files that aren't
-    included in package data are shown on stderr (for debugging
-    purposes).
-
-    Note patterns use wildcards, or can be exact paths (including
-    leading ``./``), and all searching is case-insensitive.
-    """
-    from fnmatch import fnmatchcase
-    from distutils.util import convert_path
-    from os.path import join, isfile, isdir, sep
-    out = {}
-    stack = [(convert_path(where), '', package, only_in_packages)]
-    while stack:
-        where, prefix, package, only_in_packages = stack.pop(0)
-        for name in os.listdir(where):
-            fn = join(where, name)
-            if isdir(fn):
-                bad_name = False
-                for pattern in exclude_directories:
-                    if fnmatchcase(name, pattern) or fn.lower() == pattern.lower():
-                        bad_name = True
-                        if show_ignored:
-                            print("find_package_data: Directory %s ignored"
-                                  "by pattern %s" % (fn, pattern),
-                                  file=sys.stderr)
-                        break
-                if bad_name:
-                    continue
-                if isfile(join(fn, '__init__.py')) and not prefix:
-                    new_package = (package + '.' + name) if package else name
-                    stack.append((fn, '', new_package, False))
-                else:
-                    stack.append((fn, prefix + name + sep, package, only_in_packages))
-            elif package or not only_in_packages:
-                # is a file
-                bad_name = False
-                for pattern in exclude:
-                    if fnmatchcase(name, pattern) or fn.lower() == pattern.lower():
-                        bad_name = True
-                        if show_ignored:
-                            print("find_package_data: File %s ignored"
-                                  "by pattern %s" % (fn, pattern),
-                                  file=sys.stderr)
-                        break
-                if bad_name:
-                    continue
-                out.setdefault(package, []).append(prefix + name)
-    return out
+# Extra non .py, .{so,pyd} files that are installed within the package dir
+# hierarchy
+PACKAGE_DATA = {
+    "Orange": ["datasets/*.{}".format(ext)
+               for ext in ["tab", "csv", "basket", "info"]],
+    "Orange.canvas": ["icons/*.png", "icons/*.svg"],
+    "Orange.canvas.styles": ["*.qss", "orange/*.svg"],
+    "Orange.canvas.application.tutorials": ["*.ows"],
+    "Orange.canvas.report": ["icons/*.svg", "*.html"],
+    "Orange.widgets": ["icons/*.png", "icons/*.svg"],
+    "Orange.widgets.classify": ["icons/*.svg"],
+    "Orange.widgets.data": ["icons/*.svg",
+                            "icons/paintdata/*.png",
+                            "icons/paintdata/*.svg"],
+    "Orange.widgets.evaluate": ["icons/*.svg"],
+    "Orange.widgets.visualize": ["icons/*.svg"],
+    "Orange.widgets.regression": ["icons/*.svg"],
+    "Orange.widgets.unsupervised": ["icons/*.svg"],
+    "Orange.widgets.utils.plot": ["*.fs", "*.gs", "*.vs"],
+    "Orange.widgets.utils.plot.primitives": ["*.obj"],
+    "Orange.tests": ["xlsx_files/*.xlsx", "*.tab", "*.basket", "*.csv"]
+}
 
 
 def setup_package():
@@ -254,13 +195,11 @@ def setup_package():
         license=LICENSE,
         keywords=KEYWORDS,
         classifiers=CLASSIFIERS,
-        packages=find_packages(),
-        package_data=find_package_data('Orange', 'Orange'),
+        packages=PACKAGES,
+        package_data=PACKAGE_DATA,
         install_requires=INSTALL_REQUIRES,
-        setup_requires=SETUP_REQUIRES,
         entry_points=ENTRY_POINTS,
         zip_safe=False,
-        include_package_data=True,
         test_suite='Orange.tests.test_suite',
     )
 

--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,8 @@ ENTRY_POINTS = {
     "orange.canvas.help": (
         "html-index = Orange.widgets:WIDGET_HELP_PATH",
     ),
-    "console_scripts": (
-        "orange = Orange.canvas.__main__:main",
-    ),
     "gui_scripts": (
-        "orange = Orange.canvas.__main__:main",
+        "orange-canvas = Orange.canvas.__main__:main",
     ),
 }
 

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,7 @@ CLASSIFIERS = (
     'Intended Audience :: Developers',
 )
 
-requirements = ['requirements-core.txt']
-if 'install' in sys.argv or 'develop' in sys.argv:
-    requirements.append('requirements-gui.txt')
-if 'develop' in sys.argv:
-    requirements.append('requirements-dev.txt')
+requirements = ['requirements-core.txt', 'requirements-gui.txt']
 
 INSTALL_REQUIRES = sorted(set(
     line.partition('#')[0].strip()
@@ -63,6 +59,8 @@ INSTALL_REQUIRES = sorted(set(
                  for file in requirements)
     for line in open(file)
 ) - {''})
+
+SETUP_REQUIRES = ["setuptools-git"]
 
 ENTRY_POINTS = {
     "orange.canvas.help": (
@@ -262,6 +260,7 @@ def setup_package():
         packages=find_packages(),
         package_data=find_package_data('Orange', 'Orange'),
         install_requires=INSTALL_REQUIRES,
+        setup_requires=SETUP_REQUIRES,
         entry_points=ENTRY_POINTS,
         zip_safe=False,
         include_package_data=True,


### PR DESCRIPTION
* Always use the same consistent `install_requires` (fixes a incomplete install using `pip install [-e]`; docutils and pyqtgraph would not get installed but still listed as requirements in the package metadata, causing pkg_resources to raise errors)
* Remove dependency on setuptools-git
* Rename gui_script entry point from "orange" to "orange-canvas".