### PR TITLE
Travis: allow build failures for Python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ python:
     - '3.5'
     - 'nightly'
 
+matrix:
+  allow_failures:
+    - python: nightly
+
 cache:
     apt: true
     directories:


### PR DESCRIPTION
The dist fails to download on the Travis worker far too often.