### PR TITLE
OWRank: Add ANOVA, Chi2 and Univariate Linear Regression

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -7,7 +7,7 @@ from Orange.misc.wrapper_meta import WrapperMeta
 
 from Orange.statistics import contingency, distribution
 from Orange.data import Domain, Variable, DiscreteVariable, ContinuousVariable
-from Orange.preprocess.preprocess import Discretize
+from Orange.preprocess.preprocess import Discretize, Impute
 from Orange.util import abstract
 
 
@@ -79,7 +79,8 @@ class Chi2(SklScorer):
     feature_type = DiscreteVariable
     class_type = DiscreteVariable
     preprocessors = [
-        Discretize(remove_const=False)
+        Discretize(remove_const=False),
+        Impute()
     ]
 
     def score(self, X, y):
@@ -97,6 +98,9 @@ class ANOVA(SklScorer):
     __wraps__ = skl_fss.f_classif
     feature_type = ContinuousVariable
     class_type = DiscreteVariable
+    preprocessors = [
+        Impute()
+    ]
 
     def score(self, X, y):
         f, p = skl_fss.f_classif(X, y)
@@ -113,6 +117,9 @@ class UnivariateLinearRegression(SklScorer):
     __wraps__ = skl_fss.f_regression
     feature_type = ContinuousVariable
     class_type = ContinuousVariable
+    preprocessors = [
+        Impute()
+    ]
 
     def score(self, X, y):
         f, p = skl_fss.f_regression(X, y)

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -541,10 +541,19 @@ class ScoreValueItem(QtGui.QStandardItem):
 
 
 class MySortProxyModel(QtGui.QSortFilterProxyModel):
+
+    @staticmethod
+    def comparable(val):
+        return val is not None and float('-inf') < val < float('inf')
+
     def lessThan(self, left, right):
         role = self.sortRole()
         left_data = left.data(role)
+        if not self.comparable(left_data):
+            left_data = float('-inf')
         right_data = right.data(role)
+        if not self.comparable(right_data):
+            right_data = float('-inf')
         try:
             return left_data < right_data
         except TypeError:

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -157,6 +157,9 @@ class OWRank(widget.OWWidget):
         self.discRanksView.horizontalHeader().sectionClicked.connect(
             self.headerClick
         )
+        self.discRanksView.verticalHeader().sectionClicked.connect(
+            self.onSelectItem
+        )
 
         if self.headerState[0] is not None:
             self.discRanksView.horizontalHeader().restoreState(
@@ -177,7 +180,7 @@ class OWRank(widget.OWWidget):
         self.contRanksProxyModel.setSourceModel(self.contRanksModel)
         self.contRanksView.setModel(self.contRanksProxyModel)
 
-        self.discRanksView.setColumnWidth(0, 20)
+        self.contRanksView.setColumnWidth(0, 20)
         self.contRanksView.sortByColumn(1, Qt.DescendingOrder)
         self.contRanksView.selectionModel().selectionChanged.connect(
             self.commit
@@ -186,6 +189,10 @@ class OWRank(widget.OWWidget):
         self.contRanksView.horizontalHeader().sectionClicked.connect(
             self.headerClick
         )
+        self.contRanksView.verticalHeader().sectionClicked.connect(
+            self.onSelectItem
+        )
+
         if self.headerState[1] is not None:
             self.contRanksView.horizontalHeader().restoreState(
             self.headerState[1]
@@ -224,6 +231,7 @@ class OWRank(widget.OWWidget):
 
     @check_sql_input
     def setData(self, data):
+        self.information([0])
         self.error([0, 100])
         self.resetInternals()
 
@@ -298,6 +306,8 @@ class OWRank(widget.OWWidget):
         """
         if not self.data:
             return
+        if self.data.has_missing():
+            self.information(0, "Missing values have been imputed.")
 
         measures = self.measures + [v for k, v in self.learners.items()]
         # Invalidate all warnings

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -40,6 +40,9 @@ SCORES = [
     score_meta("Information Gain", "Inf. gain", score.InfoGain),
     score_meta("Gain Ratio", "Gain Ratio", score.GainRatio),
     score_meta("Gini Gain", "Gini", score.Gini),
+    score_meta("ANOVA", "ANOVA", score.ANOVA),
+    score_meta("Chi2", "Chi2", score.Chi2),
+    score_meta("Univariate Linear Regression", "Univar. Lin. Reg.", score.UnivariateLinearRegression),
     score_meta("ReliefF", "ReliefF", score.ReliefF),
     score_meta("RReliefF", "RReliefF", score.RReliefF),
     score_meta("FCBF", "FCBF", score.FCBF),
@@ -315,7 +318,15 @@ class OWRank(widget.OWWidget):
                 continue
             if index < len(self.measures):
                 estimator = meas.score()
-                self.measure_scores[index] = estimator(data)
+                try:
+                    self.measure_scores[index] = estimator(data)
+                except ValueError:
+                    self.measure_scores[index] = []
+                    for attr in data.domain.attributes:
+                        try:
+                            self.measure_scores[index].append(estimator(data,attr))
+                        except ValueError:
+                            self.measure_scores[index].append(None)
             else:
                 learner = meas.score
                 if isinstance(learner, Learner) and \

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -401,6 +401,7 @@ class OWRank(widget.OWWidget):
         if self.selectMethod in [OWRank.SelectNone, OWRank.SelectAll,
                                  OWRank.SelectNBest]:
             self.autoSelection()
+        self.ranksView.setFocus()
 
     def nSelectedChanged(self):
         self.selectMethod = OWRank.SelectNBest
@@ -420,8 +421,6 @@ class OWRank(widget.OWWidget):
                 model.index(0, 0),
                 model.index(rowCount - 1, columnCount - 1)
             )
-            selModel.select(selection,
-                            QtGui.QItemSelectionModel.ClearAndSelect)
         elif self.selectMethod == OWRank.SelectNBest:
             nSelected = min(self.nSelected, rowCount)
             selection = QtGui.QItemSelection(


### PR DESCRIPTION
- Add existing feature scorers from sklearn to the widget (ANOVA, Chi2, Univariate Linear Regression)
- Add imputation to preprocessors for scores from sklearn (they fail with missing data)
- Attempt to score individual attributes in datasets with mixed attribute types