### PR TITLE
[FIX] Settings: Warn when setting values are not present on instance

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -174,7 +174,12 @@ class SettingProvider:
         instance : OWWidget
         """
         if setting.packable:
-            yield setting.name, getattr(instance, setting.name)
+            if hasattr(instance, setting.name):
+                yield setting.name, getattr(instance, setting.name)
+            else:
+                warnings.warn("{0} is declared as setting on {1} "
+                              "but not present on instance."
+                              .format(setting.name, instance))
 
     def pack(self, instance, packer=None):
         """Pack instance settings in a name:value dict.

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -60,7 +60,6 @@ class OWScatterPlot(OWWidget):
     attr_y = ContextSetting("")
 
     graph = SettingProvider(OWScatterPlotGraph)
-    zoom_select_toolbar = SettingProvider(ZoomSelectToolbar)
 
     jitter_sizes = [0, 0.1, 0.5, 1, 2, 3, 4, 5, 7, 10]
 


### PR DESCRIPTION
Fixes a problem that can be reproduced by deleting scatter plot from the following schema:

<img width="242" alt="screen shot 2016-03-29 at 23 32 53" src="https://cloud.githubusercontent.com/assets/588601/14124619/ba80982a-f606-11e5-9412-805249ccf74f.png">
