### PR TITLE
Replace "horizontal" and "vertical" with Qt.Horizontal and Qt.Vertical

### DIFF
--- a/Orange/canvas/report/owreport.py
+++ b/Orange/canvas/report/owreport.py
@@ -1,10 +1,12 @@
 import os
+from PyQt4 import QtWebKit
+
 import pkg_resources
 import pickle
 from enum import IntEnum
-from PyQt4.QtCore import Qt, pyqtSlot
+from PyQt4.QtCore import Qt, pyqtSlot, QUrl, QSize
 from PyQt4.QtGui import (QApplication, QDialog, QPrinter, QIcon, QCursor,
-                         QPrintDialog, QFileDialog, QTableView,
+                         QPrintDialog, QFileDialog, QTableView, QSizePolicy,
                          QStandardItemModel, QStandardItem, QHeaderView)
 from Orange.widgets import gui
 from Orange.widgets.widget import OWWidget
@@ -101,6 +103,59 @@ class ReportTable(QTableView):
             model.item(i, Column.scheme).setIcon(QIcon())
 
 
+class WebviewWidget(QtWebKit.QWebView):
+    """WebKit window in a window"""
+    def __init__(self, parent=None, bridge=None, html=None, debug=None):
+        """
+        Parameters
+        ----------
+        parent: QObject
+            Parent QObject. If parent has layout(), this widget is added to it.
+        bridge: QObject
+            The "bridge" object exposed as ``window.pybridge`` in JavaScript.
+            Any bridge methods desired to be accessible from JS need to be
+            decorated ``@QtCore.pyqtSlot(<*args>, result=<type>)``.
+        html: str
+            HTML content to set in the webview.
+        debug: bool
+            If True, enable context menu and webkit inspector.
+        """
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Expanding,
+                                       QSizePolicy.Expanding))
+        self._bridge = bridge
+        try:
+            parent.layout().addWidget(self)
+        except (AttributeError, TypeError):
+            pass
+        settings = self.settings()
+        settings.setAttribute(settings.LocalContentCanAccessFileUrls, True)
+        if debug is None:
+            import logging
+            debug = logging.getLogger().level <= logging.DEBUG
+        if debug:
+            settings.setAttribute(settings.DeveloperExtrasEnabled, True)
+        else:
+            self.setContextMenuPolicy(Qt.NoContextMenu)
+        if html:
+            self.setHtml(html)
+
+    def setContent(self, data, mimetype, url=''):
+        super().setContent(data, mimetype, QUrl(url))
+        if self._bridge:
+            self.page().mainFrame().addToJavaScriptWindowObject(
+                    'pybridge', self._bridge)
+
+    def setHtml(self, html, url=''):
+        self.setContent(html.encode('utf-8'), 'text/html', url)
+
+    def sizeHint(self):
+        return QSize(600, 500)
+
+    def evalJS(self, javascript):
+        self.page().mainFrame().evaluateJavaScript(javascript)
+
+
 class OWReport(OWWidget):
     name = "Report"
     save_dir = Setting("")
@@ -147,7 +202,7 @@ class OWReport(OWWidget):
         self.print_button = gui.button(
             box, self, "Print", callback=self._print_report
         )
-        self.report_view = gui.WebviewWidget(self.mainArea, bridge=self)
+        self.report_view = WebviewWidget(self.mainArea, bridge=self)
 
     def __getstate__(self):
         rep_dict = self.__dict__.copy()

--- a/Orange/widgets/classify/owadaboost.py
+++ b/Orange/widgets/classify/owadaboost.py
@@ -39,7 +39,7 @@ class OWAdaBoostClassification(OWBaseLearner):
 
     def add_specific_parameters(self, box):
         gui.comboBox(box, self, "algorithm", label="Algorithm",
-                     orientation="horizontal", items=self.losses,
+                     orientation=Qt.Horizontal, items=self.losses,
                      callback=self.settings_changed)
 
     def create_learner(self):

--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -26,13 +26,12 @@ class OWClassificationTree(OWBaseLearner):
     scores = (("Entropy", "entropy"), ("Gini Index", "gini"))
 
     def add_main_layout(self):
-
         gui.comboBox(self.controlArea, self, "attribute_score",
                      box='Feature selection',
                      items=[name for name, _ in self.scores],
                      callback=self.settings_changed)
 
-        box = gui.widgetBox(self.controlArea, 'Pruning')
+        box = gui.vBox(self.controlArea, 'Pruning')
         gui.spin(box, self, "min_leaf", 1, 1000,
                  label="Min. instances in leaves ", checked="limit_min_leaf",
                  callback=self.settings_changed)

--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -4,6 +4,9 @@ import numpy
 
 from sklearn.tree._tree import TREE_LEAF
 
+# This is not needed yet because it is imported from owtreeviewer2d :(
+from PyQt4.QtCore import Qt
+
 from Orange.widgets.classify.owtreeviewer2d import *
 
 from Orange.data import Table
@@ -463,8 +466,9 @@ class OWClassificationTreeGraph(OWTreeGraph):
     def __init__(self):
         super().__init__()
         self.target_combo = gui.comboBox(
-            None, self, "target_class_index", orientation=0, items=[],
-            callback=self.toggle_color, contentsLength=8, addToLayout=False,
+            None, self, "target_class_index", orientation=Qt.Horizontal,
+            items=[], callback=self.toggle_color, contentsLength=8,
+            addToLayout=False,
             sizePolicy=QSizePolicy(QSizePolicy.MinimumExpanding,
                                    QSizePolicy.Fixed))
         self.display_box.layout().addRow("Target class ", self.target_combo)

--- a/Orange/widgets/classify/owknn.py
+++ b/Orange/widgets/classify/owknn.py
@@ -24,15 +24,15 @@ class OWKNNLearner(OWBaseLearner):
     weight_type = Setting(0)
 
     def add_main_layout(self):
-        box = gui.widgetBox(self.controlArea, "Neighbors")
+        box = gui.vBox(self.controlArea, "Neighbors")
         gui.spin(box, self, "n_neighbors", 1, 100, label="Number of neighbors",
                  alignment=Qt.AlignRight, callback=self.settings_changed)
         gui.comboBox(box, self, "metric_index", label="Metric",
-                     orientation="horizontal",
+                     orientation=Qt.Horizontal,
                      items=[i.capitalize() for i in self.metrics],
                      callback=self.settings_changed)
         gui.comboBox(box, self, "weight_type", label='Weight',
-                     orientation="horizontal",
+                     orientation=Qt.Horizontal,
                      items=[i.capitalize() for i in self.weights],
                      callback=self.settings_changed)
 

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -40,16 +40,16 @@ class OWLogisticRegression(OWBaseLearner):
     def add_main_layout(self):
         box = gui.widgetBox(self.controlArea, box=True)
         gui.comboBox(box, self, "penalty_type", label="Regularization type: ",
-                     items=self.penalty_types, orientation="horizontal",
+                     items=self.penalty_types, orientation=Qt.Horizontal,
                      addSpace=4, callback=self.settings_changed)
         gui.widgetLabel(box, "Strength:")
-        box2 = gui.widgetBox(gui.indentedBox(box), orientation="horizontal")
+        box2 = gui.hBox(gui.indentedBox(box))
         gui.widgetLabel(box2, "Weak").setStyleSheet("margin-top:6px")
         gui.hSlider(box2, self, "C_index",
                     minValue=0, maxValue=len(self.C_s) - 1,
                     callback=self.set_c, createLabel=False)
         gui.widgetLabel(box2, "Strong").setStyleSheet("margin-top:6px")
-        box2 = gui.widgetBox(box, orientation="horizontal")
+        box2 = gui.hBox(box)
         box2.layout().setAlignment(Qt.AlignCenter)
         self.c_label = gui.widgetLabel(box2)
         self.set_c()

--- a/Orange/widgets/classify/owmajority.py
+++ b/Orange/widgets/classify/owmajority.py
@@ -1,6 +1,5 @@
 from Orange.data import Table
 from Orange.classification.majority import MajorityLearner
-from Orange.widgets.settings import Setting
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 

--- a/Orange/widgets/classify/owsaveclassifier.py
+++ b/Orange/widgets/classify/owsaveclassifier.py
@@ -34,8 +34,7 @@ class OWSaveClassifier(widget.OWWidget):
         #: input model/classifier
         self.model = None
 
-        box = gui.widgetBox(self.controlArea, self.tr("File"),
-                            orientation=QtGui.QHBoxLayout())
+        box = gui.hBox(self.controlArea, self.tr("File"))
         self.filesCB = gui.comboBox(box, self, "selectedIndex",
                                     callback=self._on_recent)
         self.filesCB.setMinimumContentsLength(20)

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -33,8 +33,7 @@ class OWBaseSVM(OWBaseLearner):
         # Initialize with the widest label to measure max width
         self.kernel_eq = self.kernels[-1][1]
 
-        self.kernel_box = box = gui.widgetBox(
-            self.controlArea, "Kernel", orientation="horizontal")
+        self.kernel_box = box = gui.hBox(self.controlArea, "Kernel")
 
         buttonbox = gui.radioButtonsInBox(
             box, self, "kernel_type", btnLabels=[k[0] for k in self.kernels],
@@ -42,13 +41,13 @@ class OWBaseSVM(OWBaseLearner):
         buttonbox.layout().setSpacing(10)
         gui.rubber(buttonbox)
 
-        parambox = gui.widgetBox(box)
+        parambox = gui.vBox(box)
         gui.label(parambox, self, "Kernel: %(kernel_eq)s")
-        common = dict(orientation="horizontal", callback=self.settings_changed,
+        common = dict(orientation=Qt.Horizontal, callback=self.settings_changed,
                       alignment=Qt.AlignRight, controlWidth=80)
-        spbox = gui.widgetBox(parambox, orientation="horizontal")
+        spbox = gui.hBox(parambox)
         gui.rubber(spbox)
-        inbox = gui.widgetBox(spbox)
+        inbox = gui.vBox(spbox)
         gamma = gui.doubleSpin(
             inbox, self, "gamma", 0.0, 10.0, 0.01, label=" g: ", **common)
         coef0 = gui.doubleSpin(
@@ -65,8 +64,8 @@ class OWBaseSVM(OWBaseLearner):
         box.setMinimumWidth(box.sizeHint().width())
 
     def _add_optimization_box(self):
-        self.optimization_box = gui.widgetBox(self.controlArea,
-                                              "Optimization parameters")
+        self.optimization_box = gui.vBox(
+            self.controlArea, "Optimization parameters")
         gui.doubleSpin(
             self.optimization_box, self, "tol", 1e-6, 1.0, 1e-5,
             label="Numerical Tolerance",

--- a/Orange/widgets/classify/owtreeviewer2d.py
+++ b/Orange/widgets/classify/owtreeviewer2d.py
@@ -369,7 +369,7 @@ class OWTreeViewer2D(OWWidget):
         self.root_node = None
         self.tree = None
 
-        box = gui.widgetBox(
+        box = gui.vBox(
             self.controlArea, 'Tree', addSpace=20,
             sizePolicy=QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed))
         self.info = gui.widgetLabel(box, 'No tree.')

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -240,16 +240,14 @@ class OWColor(widget.OWWidget):
         self.disc_colors = []
         self.cont_colors = []
 
-        box = gui.widgetBox(self.controlArea, "Discrete variables",
-                            orientation="horizontal")
+        box = gui.hBox(self.controlArea, "Discrete variables")
         self.disc_model = DiscColorTableModel()
         disc_view = self.disc_view = DiscreteTable(self.disc_model)
         disc_view.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
         self.disc_model.dataChanged.connect(self._on_data_changed)
         box.layout().addWidget(disc_view)
 
-        box = gui.widgetBox(self.controlArea, "Numeric variables",
-                            orientation="horizontal")
+        box = gui.hBox(self.controlArea, "Numeric variables")
         self.cont_model = ContColorTableModel()
         cont_view = self.cont_view = ContinuousTable(self, self.cont_model)
         cont_view.setColumnWidth(1, 256)
@@ -257,7 +255,7 @@ class OWColor(widget.OWWidget):
         box.layout().addWidget(cont_view)
 
         box = gui.auto_commit(self.controlArea, self, "auto_apply", "Send data",
-                              orientation="horizontal",
+                              orientation=Qt.Horizontal,
                               checkbox_label="Resend data on every change")
         box.layout().insertSpacing(0, 20)
         box.layout().insertWidget(0, self.report_button)

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -61,7 +61,7 @@ class OWConcatenate(widget.OWWidget):
         self.primary_data = None
         self.more_data = OrderedDict()
 
-        mergebox = gui.widgetBox(self.controlArea, "Domains merging")
+        mergebox = gui.vBox(self.controlArea, "Domains merging")
         box = gui.radioButtons(
             mergebox, self, "merge_type",
             callback=self._merge_type_changed)
@@ -82,7 +82,7 @@ class OWConcatenate(widget.OWWidget):
         label.setWordWrap(True)
 
         ###
-        box = gui.widgetBox(
+        box = gui.vBox(
             self.controlArea, self.tr("Source identification"),
             addSpace=False)
 
@@ -117,7 +117,7 @@ class OWConcatenate(widget.OWWidget):
 
         gui.separator(self.controlArea, 8)
 
-        box = gui.widgetBox(self.controlArea, True, orientation="horizontal",)
+        box = gui.hBox(self.controlArea, box=True)
         box.layout().addWidget(self.report_button)
         gui.separator(box, 20)
         gui.button(

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -59,25 +59,25 @@ class OWContinuize(widget.OWWidget):
     def __init__(self):
         super().__init__()
 
-        box = gui.widgetBox(self.controlArea, "Multinomial attributes")
+        box = gui.vBox(self.controlArea, "Multinomial attributes")
         gui.radioButtonsInBox(
             box, self, "multinomial_treatment",
             btnLabels=[x[0] for x in self.multinomial_treats],
             callback=self.settings_changed)
 
-        box = gui.widgetBox(self.controlArea, "Continuous attributes")
+        box = gui.vBox(self.controlArea, "Continuous attributes")
         gui.radioButtonsInBox(
             box, self, "continuous_treatment",
             btnLabels=[x[0] for x in self.continuous_treats],
             callback=self.settings_changed)
 
-        box = gui.widgetBox(self.controlArea, "Discrete class attribute")
+        box = gui.vBox(self.controlArea, "Discrete class attribute")
         gui.radioButtonsInBox(
             box, self, "class_treatment",
             btnLabels=[t[0] for t in self.class_treats],
             callback=self.settings_changed)
 
-        zbbox = gui.widgetBox(self.controlArea, "Value range")
+        zbbox = gui.vBox(self.controlArea, "Value range")
 
         gui.radioButtonsInBox(
             zbbox, self, "zero_based",

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -36,8 +36,8 @@ class OWDataInfo(widget.OWWidget):
         for box in ("Data Set Size", "Features", "Targets", "Meta Attributes",
                     "Location"):
             name = box.lower().replace(" ", "_")
-            bo = gui.widgetBox(self.controlArea, box,
-                               addSpace=False and box != "Meta Attributes")
+            bo = gui.vBox(self.controlArea, box,
+                          addSpace=False and box != "Meta Attributes")
             gui.label(bo, self, "%%(%s)s" % name)
 
         # ensure the widget has some decent minimum width.

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -50,11 +50,11 @@ class OWDataSampler(widget.OWWidget):
         self.indices = None
         self.sampled_instances = self.remaining_instances = None
 
-        box = gui.widgetBox(self.controlArea, "Information")
+        box = gui.vBox(self.controlArea, "Information")
         self.dataInfoLabel = gui.widgetLabel(box, 'No data on input.')
         self.outputInfoLabel = gui.widgetLabel(box, ' ')
 
-        self.sampling_box = gui.widgetBox(self.controlArea, "Sampling Type")
+        self.sampling_box = gui.vBox(self.controlArea, "Sampling Type")
         sampling = gui.radioButtons(self.sampling_box, self, "sampling_type",
                                     callback=self.sampling_type_changed)
 
@@ -101,7 +101,7 @@ class OWDataSampler(widget.OWWidget):
 
         gui.appendRadioButton(sampling, "Boostrap")
 
-        self.sql_box = gui.widgetBox(self.controlArea, "Sampling Type")
+        self.sql_box = gui.vBox(self.controlArea, "Sampling Type")
         sampling = gui.radioButtons(self.sql_box, self, "sampling_type",
                                     callback=self.sampling_type_changed)
         gui.appendRadioButton(sampling, "Time:")
@@ -118,7 +118,7 @@ class OWDataSampler(widget.OWWidget):
         self.sql_box.setVisible(False)
 
 
-        self.options_box = gui.widgetBox(self.controlArea, "Options")
+        self.options_box = gui.vBox(self.controlArea, "Options")
         self.cb_seed = gui.checkBox(
             self.options_box, self, "use_seed",
             "Replicable (deterministic) sampling",

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -158,8 +158,7 @@ class OWDiscretize(widget.OWWidget):
         self.method = 0
         self.k = 5
 
-        box = gui.widgetBox(
-            self.controlArea, self.tr("Default Discretization"))
+        box = gui.vBox(self.controlArea, self.tr("Default Discretization"))
         self.default_bbox = rbox = gui.radioButtons(
             box, self, "default_method", callback=self._default_disc_changed)
 
@@ -223,7 +222,7 @@ class OWDiscretize(widget.OWWidget):
 
         box = gui.auto_commit(
             self.controlArea, self, "autosend", "Apply",
-            orientation="horizontal",
+            orientation=Qt.Horizontal,
             checkbox_label="Send data after every change")
         box.layout().insertSpacing(0, 20)
         box.layout().insertWidget(0, self.report_button)

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -369,7 +369,7 @@ class OWEditDomain(widget.OWWidget):
         self.input_vars = ()
         self._invalidated = False
 
-        box = gui.widgetBox(self.controlArea, "Domain Features")
+        box = gui.vBox(self.controlArea, "Domain Features")
 
         self.domain_model = itemmodels.VariableListModel()
         self.domain_view = QListView(
@@ -380,14 +380,14 @@ class OWEditDomain(widget.OWWidget):
             self._on_selection_changed)
         box.layout().addWidget(self.domain_view)
 
-        box = gui.widgetBox(self.controlArea, "Reset")
+        box = gui.vBox(self.controlArea, "Reset")
         gui.button(box, self, "Reset selected", callback=self.reset_selected)
         gui.button(box, self, "Reset all", callback=self.reset_all)
 
         gui.auto_commit(self.controlArea, self, "autocommit", "Commit",
                         "Commit on change is on")
 
-        box = gui.widgetBox(self.mainArea, "Edit")
+        box = gui.vBox(self.mainArea, "Edit")
         self.editor_stack = QtGui.QStackedWidget()
 
         self.editor_stack.addWidget(DiscreteVariableEditor())

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -312,7 +312,7 @@ class OWFeatureConstructor(widget.OWWidget):
         self.data = None
         self.editors = {}
 
-        box = gui.widgetBox(self.controlArea, "Variable Definitions")
+        box = gui.vBox(self.controlArea, "Variable Definitions")
 
         toplayout = QtGui.QHBoxLayout()
         toplayout.setContentsMargins(0, 0, 0, 0)
@@ -412,7 +412,7 @@ class OWFeatureConstructor(widget.OWWidget):
 
         box.layout().addLayout(layout, 1)
 
-        box = gui.widgetBox(self.controlArea, orientation="horizontal")
+        box = gui.hBox(self.controlArea)
         box.layout().addWidget(self.report_button)
         self.report_button.setMinimumWidth(180)
         gui.rubber(box)

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -341,7 +341,7 @@ class OWImageViewer(widget.OWWidget):
         super().__init__()
 
         self.info = gui.widgetLabel(
-            gui.widgetBox(self.controlArea, "Info"),
+            gui.vBox(self.controlArea, "Info"),
             "Waiting for input\n"
         )
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -260,7 +260,7 @@ class OWImpute(OWWidget):
 
         box = gui.auto_commit(
             self.controlArea, self, "autocommit", "Commit",
-            orientation="horizontal", checkbox_label="Commit on any change")
+            orientation=Qt.Horizontal, checkbox_label="Commit on any change")
         box.layout().insertSpacing(0, 80)
         box.layout().insertWidget(0, self.report_button)
         self.data = None

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -40,8 +40,7 @@ class OWMergeData(widget.OWWidget):
         w.setLayout(grid)
 
         # attribute A selection
-        boxAttrA = gui.widgetBox(
-            self, self.tr("Attribute A"), addToLayout=False)
+        boxAttrA = gui.vBox(self, self.tr("Attribute A"), addToLayout=False)
         grid.addWidget(boxAttrA, 0, 0)
         self.attrViewA = QtGui.QListView(
             selectionMode=QtGui.QListView.SingleSelection
@@ -55,8 +54,7 @@ class OWMergeData(widget.OWWidget):
         boxAttrA.layout().addWidget(self.attrViewA)
 
         # attribute  B selection
-        boxAttrB = gui.widgetBox(
-            self, self.tr("Attribute B"), addToLayout=False)
+        boxAttrB = gui.vBox(self, self.tr("Attribute B"), addToLayout=False)
         grid.addWidget(boxAttrB, 0, 1)
         self.attrViewB = QtGui.QListView(
             selectionMode=QtGui.QListView.SingleSelection
@@ -70,14 +68,12 @@ class OWMergeData(widget.OWWidget):
         boxAttrB.layout().addWidget(self.attrViewB)
 
         # info A
-        boxDataA = gui.widgetBox(
-            self, self.tr("Data A Input"), addToLayout=False)
+        boxDataA = gui.vBox(self, self.tr("Data A Input"), addToLayout=False)
         grid.addWidget(boxDataA, 1, 0)
         self.infoBoxDataA = gui.widgetLabel(boxDataA, self.dataInfoText(None))
 
         # info B
-        boxDataB = gui.widgetBox(
-            self, self.tr("Data B Input"), addToLayout=False)
+        boxDataB = gui.vBox(self, self.tr("Data B Input"), addToLayout=False)
         grid.addWidget(boxDataB, 1, 1)
         self.infoBoxDataB = gui.widgetLabel(boxDataB, self.dataInfoText(None))
 

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -41,12 +41,12 @@ class OWOutliers(widget.OWWidget):
         self.data = None
         self.n_inliers = self.n_outliers = None
 
-        box = gui.widgetBox(self.controlArea, "Information")
+        box = gui.vBox(self.controlArea, "Information")
         self.data_info_label = gui.widgetLabel(box, self.data_info_default)
         self.in_out_info_label = gui.widgetLabel(box,
                                                  self.in_out_info_default)
 
-        box = gui.widgetBox(self.controlArea, "Outlier detection method")
+        box = gui.vBox(self.controlArea, "Outlier detection method")
         detection = gui.radioButtons(box, self, "outlier_method")
 
         gui.appendRadioButton(detection,
@@ -70,7 +70,7 @@ class OWOutliers(widget.OWWidget):
             ibox, self, "cont", minValue=0, maxValue=100, ticks=10,
             labelFormat="%d %%", callback=self.cont_changed)
 
-        ebox = gui.widgetBox(ibox, box=None, orientation='horizontal')
+        ebox = gui.hBox(ibox)
         self.cb_emp_cov = gui.checkBox(
             ebox, self, "empirical_covariance",
             "Support fraction:", callback=self.empirical_changed)

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -806,17 +806,18 @@ class OWPaintData(widget.OWWidget):
         self._init_ui()
 
     def _init_ui(self):
-        namesBox = gui.widgetBox(self.controlArea, "Names")
+        namesBox = gui.vBox(self.controlArea, "Names")
 
-        hbox = gui.widgetBox(namesBox, orientation='horizontal', margin=0, spacing=0)
+        hbox = gui.hBox(namesBox, margin=0, spacing=0)
         gui.lineEdit(hbox, self, "attr1", "Variable X ",
-                     controlWidth=80, orientation="horizontal",
+                     controlWidth=80, orientation=Qt.Horizontal,
                      enterPlaceholder=True, callback=self._attr_name_changed)
         gui.separator(hbox, 18)
-        hbox = gui.widgetBox(namesBox, orientation='horizontal', margin=0, spacing=0)
+        hbox = gui.hBox(namesBox, margin=0, spacing=0)
         attr2 = gui.lineEdit(hbox, self, "attr2", "Variable Y ",
-                             controlWidth=80, orientation="horizontal",
-                             enterPlaceholder=True, callback=self._attr_name_changed)
+                             controlWidth=80, orientation=Qt.Horizontal,
+                             enterPlaceholder=True,
+                             callback=self._attr_name_changed)
         gui.checkBox(hbox, self, "hasAttr2", '', disables=attr2,
                      labelWidth=0,
                      callback=self.set_dimensions)
@@ -851,8 +852,8 @@ class OWPaintData(widget.OWWidget):
         actionsWidget.layout().setSpacing(1)
         namesBox.layout().addWidget(actionsWidget)
 
-        tBox = gui.widgetBox(self.controlArea, "Tools", addSpace=True)
-        buttonBox = gui.widgetBox(tBox, orientation="horizontal")
+        tBox = gui.vBox(self.controlArea, "Tools", addSpace=True)
+        buttonBox = gui.hBox(tBox)
         toolsBox = gui.widgetBox(buttonBox, orientation=QtGui.QGridLayout())
 
         self.toolActions = QtGui.QActionGroup(self)

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1649,7 +1649,7 @@ class OWPreprocess(widget.OWWidget):
         # for mimeData delegate)
         self.preprocessors.mimeData = mimeData
 
-        box = gui.widgetBox(self.controlArea, "Preprocessors")
+        box = gui.vBox(self.controlArea, "Preprocessors")
 
         self.preprocessorsView = view = QListView(
             selectionMode=QListView.SingleSelection,
@@ -1687,7 +1687,7 @@ class OWPreprocess(widget.OWWidget):
         self.mainArea.layout().addWidget(self.scroll_area)
         self.flow_view.installEventFilter(self)
 
-        box = gui.widgetBox(self.controlArea, "Output")
+        box = gui.vBox(self.controlArea, "Output")
         gui.auto_commit(box, self, "autocommit", "Commit", box=False)
 
         self._initialize()

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -1,4 +1,5 @@
 from PyQt4 import QtGui
+from PyQt4.QtCore import Qt
 
 from Orange.data import Table
 from Orange.preprocess.remove import Remove
@@ -56,27 +57,27 @@ class OWPurgeDomain(widget.OWWidget):
         self.reducedClasses = "-"
         self.resortedClasses = "-"
 
-        boxAt = gui.widgetBox(self.controlArea, "Features")
+        boxAt = gui.vBox(self.controlArea, "Features")
         for not_first, (value, label) in enumerate(self.feature_options):
             if not_first:
                 gui.separator(boxAt, 2)
             gui.checkBox(boxAt, self, value, label,
                          callback=self.optionsChanged)
 
-        boxAt = gui.widgetBox(self.controlArea, "Classes", addSpace=True)
+        boxAt = gui.vBox(self.controlArea, "Classes", addSpace=True)
         for not_first, (value, label) in enumerate(self.class_options):
             if not_first:
                 gui.separator(boxAt, 2)
             gui.checkBox(boxAt, self, value, label,
                          callback=self.optionsChanged)
 
-        box3 = gui.widgetBox(self.controlArea, 'Statistics', addSpace=True)
+        box3 = gui.vBox(self.controlArea, 'Statistics', addSpace=True)
         for label, value in self.stat_labels:
             gui.label(box3, self, "{}: %({})s".format(label, value))
 
         gui.auto_commit(self.controlArea, self, "autoSend", "Send Data",
                         checkbox_label="Send automatically",
-                        orientation="horizontal")
+                        orientation=Qt.Horizontal)
         gui.rubber(self.controlArea)
 
     @check_sql_input

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -389,7 +389,7 @@ class OWPythonScript(widget.OWWidget):
 
         self._cachedDocuments = {}
 
-        self.infoBox = gui.widgetBox(self.controlArea, 'Info')
+        self.infoBox = gui.vBox(self.controlArea, 'Info')
         gui.label(
             self.infoBox, self,
             "<p>Execute python script.</p><p>Input variables:<ul><li> " + \
@@ -405,7 +405,7 @@ class OWPythonScript(widget.OWWidget):
 
         self.libraryList.wrap(self.libraryListSource)
 
-        self.controlBox = gui.widgetBox(self.controlArea, 'Library')
+        self.controlBox = gui.vBox(self.controlArea, 'Library')
         self.controlBox.layout().setSpacing(1)
 
         self.libraryView = QListView(
@@ -468,7 +468,7 @@ class OWPythonScript(widget.OWWidget):
         self.defaultFont = defaultFont = \
             "Monaco" if sys.platform == "darwin" else "Courier"
 
-        self.textBox = gui.widgetBox(self, 'Python script')
+        self.textBox = gui.vBox(self, 'Python script')
         self.splitCanvas.addWidget(self.textBox)
         self.text = PythonScriptEditor(self)
         self.textBox.layout().addWidget(self.text)
@@ -484,7 +484,7 @@ class OWPythonScript(widget.OWWidget):
         action.setShortcutContext(Qt.WidgetWithChildrenShortcut)
         action.triggered.connect(self.saveScript)
 
-        self.consoleBox = gui.widgetBox(self, 'Console')
+        self.consoleBox = gui.vBox(self, 'Console')
         self.splitCanvas.addWidget(self.consoleBox)
         self.console = PythonConsole(self.__dict__, self)
         self.consoleBox.layout().addWidget(self.console)

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -92,8 +92,8 @@ class OWRank(widget.OWWidget):
         self.contMeasures = [m for m in self.all_measures
                              if issubclass(ContinuousVariable, m.score.class_type)]
 
-        selMethBox = gui.widgetBox(
-            self.controlArea, "Select attributes", addSpace=True)
+        selMethBox = gui.vBox(
+                self.controlArea, "Select attributes", addSpace=True)
 
         grid = QtGui.QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -314,8 +314,8 @@ class OWSelectAttributes(widget.OWWidget):
         layout = QtGui.QGridLayout()
         self.controlArea.setLayout(layout)
         layout.setContentsMargins(4, 4, 4, 4)
-        box = gui.widgetBox(self.controlArea, "Available Variables",
-                            addToLayout=False)
+        box = gui.vBox(self.controlArea, "Available Variables",
+                       addToLayout=False)
         self.filter_edit = QtGui.QLineEdit()
         self.filter_edit.setToolTip("Filter the list of available variables.")
         box.layout().addWidget(self.filter_edit)
@@ -355,7 +355,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.available_attrs_view)
         layout.addWidget(box, 0, 0, 3, 1)
 
-        box = gui.widgetBox(self.controlArea, "Features", addToLayout=False)
+        box = gui.vBox(self.controlArea, "Features", addToLayout=False)
         self.used_attrs = VariablesListItemModel()
         self.used_attrs_view = VariablesListItemView(
             acceptedType=(Orange.data.DiscreteVariable,
@@ -367,8 +367,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.used_attrs_view)
         layout.addWidget(box, 0, 2, 1, 1)
 
-        box = gui.widgetBox(self.controlArea, "Target Variable",
-                            addToLayout=False)
+        box = gui.vBox(self.controlArea, "Target Variable", addToLayout=False)
         self.class_attrs = ClassVarListItemModel()
         self.class_attrs_view = ClassVariableItemView(
             acceptedType=(Orange.data.DiscreteVariable,
@@ -380,8 +379,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.class_attrs_view)
         layout.addWidget(box, 1, 2, 1, 1)
 
-        box = gui.widgetBox(self.controlArea, "Meta Attributes",
-                            addToLayout=False)
+        box = gui.vBox(self.controlArea, "Meta Attributes", addToLayout=False)
         self.meta_attrs = VariablesListItemModel()
         self.meta_attrs_view = VariablesListItemView(
             acceptedType=Orange.data.Variable)
@@ -391,7 +389,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.meta_attrs_view)
         layout.addWidget(box, 2, 2, 1, 1)
 
-        bbox = gui.widgetBox(self.controlArea, addToLayout=False, margin=0)
+        bbox = gui.vBox(self.controlArea, addToLayout=False, margin=0)
         layout.addWidget(bbox, 0, 1, 1, 1)
 
         self.up_attr_button = gui.button(bbox, self, "Up",
@@ -401,13 +399,13 @@ class OWSelectAttributes(widget.OWWidget):
         self.down_attr_button = gui.button(bbox, self, "Down",
             callback=partial(self.move_down, self.used_attrs_view))
 
-        bbox = gui.widgetBox(self.controlArea, addToLayout=False, margin=0)
+        bbox = gui.vBox(self.controlArea, addToLayout=False, margin=0)
         layout.addWidget(bbox, 1, 1, 1, 1)
         self.move_class_button = gui.button(bbox, self, ">",
             callback=partial(self.move_selected,
                              self.class_attrs_view, exclusive=True))
 
-        bbox = gui.widgetBox(self.controlArea, addToLayout=False, margin=0)
+        bbox = gui.vBox(self.controlArea, addToLayout=False, margin=0)
         layout.addWidget(bbox, 2, 1, 1, 1)
         self.up_meta_button = gui.button(bbox, self, "Up",
             callback=partial(self.move_up, self.meta_attrs_view))

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -60,7 +60,7 @@ class OWSelectRows(widget.OWWidget):
         self.data = None
         self.data_desc = self.match_desc = self.nonmatch_desc = None
 
-        box = gui.widgetBox(self.controlArea, 'Conditions', stretch=100)
+        box = gui.vBox(self.controlArea, 'Conditions', stretch=100)
         self.cond_list = QtGui.QTableWidget(box)
         box.layout().addWidget(self.cond_list)
         self.cond_list.setShowGrid(False)
@@ -74,7 +74,7 @@ class OWSelectRows(widget.OWWidget):
             QtGui.QHeaderView.Stretch)
         self.cond_list.viewport().setBackgroundRole(QtGui.QPalette.Window)
 
-        box2 = gui.widgetBox(box, orientation="horizontal")
+        box2 = gui.hBox(box)
         self.add_button = gui.button(box2, self, "Add condition",
                                      callback=self.add_row)
         self.add_all_button = gui.button(box2, self, "Add all variables",
@@ -83,19 +83,19 @@ class OWSelectRows(widget.OWWidget):
                                             callback=self.remove_all)
         gui.rubber(box2)
 
-        info = gui.widgetBox(self.controlArea, '', orientation="horizontal")
-        box_data_in = gui.widgetBox(info, 'Data In')
+        info = gui.hBox(self.controlArea)
+        box_data_in = gui.vBox(info, 'Data In')
 #        self.data_in_rows = gui.widgetLabel(box_data_in, " ")
         self.data_in_variables = gui.widgetLabel(box_data_in, " ")
         gui.rubber(box_data_in)
 
-        box_data_out = gui.widgetBox(info, 'Data Out')
+        box_data_out = gui.vBox(info, 'Data Out')
         self.data_out_rows = gui.widgetLabel(box_data_out, " ")
 #        self.dataOutAttributesLabel = gui.widgetLabel(box_data_out, " ")
         gui.rubber(box_data_out)
 
-        box = gui.widgetBox(self.controlArea, orientation="horizontal")
-        box_setting = gui.widgetBox(box, 'Purging')
+        box = gui.hBox(self.controlArea)
+        box_setting = gui.vBox(box, 'Purging')
         self.cb_pa = gui.checkBox(
             box_setting, self, "purge_attributes", "Remove unused features",
             callback=self.conditions_changed)
@@ -252,8 +252,7 @@ class OWSelectRows(widget.OWWidget):
                 self.cond_list.setCellWidget(oper_combo.row, 2, combo)
                 combo.currentIndexChanged.connect(self.conditions_changed)
         else:
-            box = gui.widgetBox(self, orientation="horizontal",
-                                addToLayout=False)
+            box = gui.hBox(self, addToLayout=False)
             box.var_type = vartype(var)
             self.cond_list.setCellWidget(oper_combo.row, 2, box)
             if var.is_continuous:

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -58,8 +58,8 @@ class OWSql(widget.OWWidget):
         self.data_desc_table = None
         self.database_desc = None
 
-        vbox = gui.widgetBox(self.controlArea, "Server", addSpace=True)
-        box = gui.widgetBox(vbox)
+        vbox = gui.vBox(self.controlArea, "Server", addSpace=True)
+        box = gui.vBox(vbox)
         self.servertext = QtGui.QLineEdit(box)
         self.servertext.setPlaceholderText('Server')
         self.servertext.setToolTip('Server')
@@ -89,7 +89,7 @@ class OWSql(widget.OWWidget):
             self.passwordtext.setText(self.password)
         box.layout().addWidget(self.passwordtext)
 
-        tables = gui.widgetBox(box, orientation='horizontal')
+        tables = gui.hBox(box)
         self.tablecombo = QtGui.QComboBox(
             tables,
             minimumContentsLength=35,
@@ -104,13 +104,13 @@ class OWSql(widget.OWWidget):
             QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
         tables.layout().addWidget(self.connectbutton)
 
-        self.custom_sql = gui.widgetBox(box, orientation='vertical')
+        self.custom_sql = gui.vBox(box)
         self.custom_sql.setVisible(False)
         self.sqltext = QtGui.QTextEdit(self.custom_sql)
         self.sqltext.setPlainText(self.sql)
         self.custom_sql.layout().addWidget(self.sqltext)
 
-        mt = gui.widgetBox(self.custom_sql, orientation='horizontal')
+        mt = gui.hBox(self.custom_sql)
         cb = gui.checkBox(mt, self, 'materialize', 'Materialize to table ')
         cb.setToolTip('Save results of the query in a table')
         le = gui.lineEdit(mt, self, 'materialize_table_name')

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -380,7 +380,7 @@ class OWDataTable(widget.OWWidget):
 
         self.dist_color = QtGui.QColor(*self.dist_color_RGB)
 
-        info_box = gui.widgetBox(self.controlArea, "Info")
+        info_box = gui.vBox(self.controlArea, "Info")
         self.info_ex = gui.widgetLabel(info_box, 'No data on input.', )
         self.info_ex.setWordWrap(True)
         self.info_attr = gui.widgetLabel(info_box, ' ')
@@ -398,7 +398,7 @@ class OWDataTable(widget.OWWidget):
         info_box.setMinimumWidth(200)
         gui.separator(self.controlArea)
 
-        box = gui.widgetBox(self.controlArea, "Variables")
+        box = gui.vBox(self.controlArea, "Variables")
         self.c_show_attribute_labels = gui.checkBox(
             box, self, "show_attribute_labels",
             "Show variable labels (if present)",
@@ -410,7 +410,7 @@ class OWDataTable(widget.OWWidget):
         gui.checkBox(box, self, "color_by_class", 'Color by instance classes',
                      callback=self._on_distribution_color_changed)
 
-        box = gui.widgetBox(self.controlArea, "Selection")
+        box = gui.vBox(self.controlArea, "Selection")
 
         gui.checkBox(box, self, "select_rows", "Select full rows",
                      callback=self._on_select_rows_changed)

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -50,15 +50,15 @@ class OWCalibrationPlot(widget.OWWidget):
         self.colors = []
         self._curve_data = {}
 
-        box = gui.widgetBox(self.controlArea, "Plot")
-        tbox = gui.widgetBox(box, "Target Class")
+        box = gui.vBox(self.controlArea, "Plot")
+        tbox = gui.vBox(box, "Target Class")
         tbox.setFlat(True)
 
         self.target_cb = gui.comboBox(
             tbox, self, "target_index", callback=self._replot,
             contentsLength=8)
 
-        cbox = gui.widgetBox(box, "Classifier")
+        cbox = gui.vBox(box, "Classifier")
         cbox.setFlat(True)
 
         self.classifiers_list_box = gui.listBox(

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -79,18 +79,18 @@ class OWConfusionMatrix(widget.OWWidget):
         self.learners = []
         self.headers = []
 
-        box = gui.widgetBox(self.controlArea, "Learners")
+        box = gui.vBox(self.controlArea, "Learners")
 
         self.learners_box = gui.listBox(
             box, self, "selected_learner", "learners",
             callback=self._learner_changed
         )
-        box = gui.widgetBox(self.controlArea, "Show")
+        box = gui.vBox(self.controlArea, "Show")
 
         gui.comboBox(box, self, "selected_quantity", items=self.quantities,
                      callback=self._update)
 
-        box = gui.widgetBox(self.controlArea, "Select")
+        box = gui.vBox(self.controlArea, "Select")
 
         gui.button(box, self, "Correct",
                    callback=self.select_correct, autoDefault=False)
@@ -99,7 +99,7 @@ class OWConfusionMatrix(widget.OWWidget):
         gui.button(box, self, "None",
                    callback=self.select_none, autoDefault=False)
 
-        self.outputbox = box = gui.widgetBox(self.controlArea, "Output")
+        self.outputbox = box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "append_predictions",
                      "Predictions", callback=self._invalidate)
         gui.checkBox(box, self, "append_probabilities",

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -79,15 +79,15 @@ class OWLiftCurve(widget.OWWidget):
         self.colors = []
         self._curve_data = {}
 
-        box = gui.widgetBox(self.controlArea, "Plot")
-        tbox = gui.widgetBox(box, "Target Class")
+        box = gui.vBox(self.controlArea, "Plot")
+        tbox = gui.vBox(box, "Target Class")
         tbox.setFlat(True)
 
         self.target_cb = gui.comboBox(
             tbox, self, "target_index", callback=self._on_target_changed,
             contentsLength=8)
 
-        cbox = gui.widgetBox(box, "Classifiers")
+        cbox = gui.vBox(box, "Classifiers")
         cbox.setFlat(True)
         self.classifiers_list_box = gui.listBox(
             cbox, self, "selected_classifiers", "classifier_names",

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -71,7 +71,7 @@ class OWPredictions(widget.OWWidget):
         #: List of (discrete) class variable's values
         self.class_values = []  # type: List[str]
 
-        box = gui.widgetBox(self.controlArea, "Info")
+        box = gui.vBox(self.controlArea, "Info")
         self.infolabel = gui.widgetLabel(
             box, "No data on input\nPredictors: 0\nTask: N/A")
         self.infolabel.setMinimumWidth(150)
@@ -79,7 +79,7 @@ class OWPredictions(widget.OWWidget):
                    callback=self._reset_order,
                    tooltip="Show rows in the original order")
 
-        self.classification_options = box = gui.widgetBox(
+        self.classification_options = box = gui.vBox(
             self.controlArea, "Options (classification)", spacing=-1,
             addSpace=False)
 
@@ -97,11 +97,11 @@ class OWPredictions(widget.OWWidget):
         gui.checkBox(box, self, "draw_dist", "Draw distribution bars",
                      callback=self._update_prediction_delegate)
 
-        box = gui.widgetBox(self.controlArea, "Data view")
+        box = gui.vBox(self.controlArea, "Data view")
         gui.checkBox(box, self, "show_attrs", "Show full data set",
                      callback=self._update_column_visibility)
 
-        box = gui.widgetBox(self.controlArea, "Output", spacing=-1)
+        box = gui.vBox(self.controlArea, "Output", spacing=-1)
         self.checkbox_class = gui.checkBox(
             box, self, "output_attrs", "Original data",
             callback=self.commit)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -311,36 +311,36 @@ class OWROCAnalysis(widget.OWWidget):
         self._rocch = None
         self._perf_line = None
 
-        box = gui.widgetBox(self.controlArea, "Plot")
-        tbox = gui.widgetBox(box, "Target Class")
+        box = gui.vBox(self.controlArea, "Plot")
+        tbox = gui.vBox(box, "Target Class")
         tbox.setFlat(True)
 
         self.target_cb = gui.comboBox(
             tbox, self, "target_index", callback=self._on_target_changed,
             contentsLength=8)
 
-        cbox = gui.widgetBox(box, "Classifiers")
+        cbox = gui.vBox(box, "Classifiers")
         cbox.setFlat(True)
         self.classifiers_list_box = gui.listBox(
             cbox, self, "selected_classifiers", "classifier_names",
             selectionMode=QtGui.QListView.MultiSelection,
             callback=self._on_classifiers_changed)
 
-        abox = gui.widgetBox(box, "Combine ROC Curves From Folds")
+        abox = gui.vBox(box, "Combine ROC Curves From Folds")
         abox.setFlat(True)
         gui.comboBox(abox, self, "roc_averaging",
                      items=["Merge predictions from folds", "Mean TP rate",
                             "Mean TP and FP at threshold", "Show individual curves"],
                      callback=self._replot)
 
-        hbox = gui.widgetBox(box, "ROC Convex Hull")
+        hbox = gui.vBox(box, "ROC Convex Hull")
         hbox.setFlat(True)
         gui.checkBox(hbox, self, "display_convex_curve",
                      "Show convex ROC curves", callback=self._replot)
         gui.checkBox(hbox, self, "display_convex_hull",
                      "Show ROC convex hull", callback=self._replot)
 
-        box = gui.widgetBox(self.controlArea, "Analysis")
+        box = gui.vBox(self.controlArea, "Analysis")
 
         gui.checkBox(box, self, "display_def_threshold",
                      "Default threshold (0.5) point",

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -172,7 +172,7 @@ class OWTestLearners(widget.OWWidget):
         #: results.
         self.learners = OrderedDict()
 
-        sbox = gui.widgetBox(self.controlArea, "Sampling")
+        sbox = gui.vBox(self.controlArea, "Sampling")
         rbox = gui.radioButtons(
             sbox, self, "resampling", callback=self._param_changed
         )
@@ -204,7 +204,7 @@ class OWTestLearners(widget.OWWidget):
         self.apply_button = gui.button(
             rbox, self, "Apply", callback=self.apply, default=True)
 
-        self.cbox = gui.widgetBox(self.controlArea, "Target class")
+        self.cbox = gui.vBox(self.controlArea, "Target class")
         self.class_selection_combo = gui.comboBox(
             self.cbox, self, "class_selection", items=[],
             sendSelectedValue=True, valueType=str,
@@ -229,7 +229,7 @@ class OWTestLearners(widget.OWWidget):
         self.view.setModel(self.result_model)
         self.view.setItemDelegate(ItemDelegate())
 
-        box = gui.widgetBox(self.mainArea, "Evaluation Results")
+        box = gui.vBox(self.mainArea, "Evaluation Results")
         box.layout().addWidget(self.view)
 
     def sizeHint(self):

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -941,7 +941,7 @@ def lineEdit(widget, master, value, label=None, labelWidth=None,
             b.layout().addWidget(ledit)
     elif focusInCallback or callback and not callbackOnType:
         if not hasHBox:
-            outer = widgetBox(b, "", 0, addToLayout=(b is not widget))
+            outer = hBox(b, addToLayout=(b is not widget))
         else:
             outer = b
         ledit = LineEditWFocusOut(outer, callback, focusInCallback,
@@ -2069,7 +2069,7 @@ class widgetHider(QtGui.QWidget):
 
 
 def auto_commit(widget, master, value, label, auto_label=None, box=True,
-                checkbox_label=None, orientation=Qt.Horizontal, commit=None,
+                checkbox_label=None, orientation=None, commit=None,
                 callback=None, **misc):
     """
     Add a commit button with auto-commit check box.
@@ -2157,8 +2157,8 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
 
     b.checkbox = cb = checkBox(b, master, value, checkbox_label,
                                callback=checkbox_toggled, tooltip=auto_label)
-    if checkbox_label and _is_horizontal(orientation):
-        b.layout().insertSpacing(-1, 10)
+    if _is_horizontal(orientation):
+        b.layout().addSpacing(10)
     cb.setSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Preferred)
     b.button = btn = button(b, master, label, callback=lambda: do_commit())
     if not checkbox_label:
@@ -3128,7 +3128,7 @@ def tabWidget(widget):
 
 def createTabPage(tab_widget, name, widgetToAdd=None, canScroll=False):
     if widgetToAdd is None:
-        widgetToAdd = widgetBox(tab_widget, addToLayout=0, margin=4)
+        widgetToAdd = vBox(tab_widget, addToLayout=0, margin=4)
     if canScroll:
         scrollArea = QtGui.QScrollArea()
         tab_widget.addTab(scrollArea, name)

--- a/Orange/widgets/regression/owadaboostregression.py
+++ b/Orange/widgets/regression/owadaboostregression.py
@@ -1,3 +1,5 @@
+from PyQt4.QtCore import Qt
+
 from Orange.regression.base_regression import LearnerRegression
 from Orange.data import Table
 from Orange.ensembles import SklAdaBoostRegressionLearner
@@ -21,7 +23,7 @@ class OWAdaBoostRegression(owadaboost.OWAdaBoostClassification):
 
     def add_specific_parameters(self, box):
         gui.comboBox(box, self, "loss", label="Loss",
-                     orientation="horizontal", items=self.losses,
+                     orientation=Qt.Horizontal, items=self.losses,
                      callback=self.settings_changed)
 
     def create_learner(self):

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -43,28 +43,27 @@ class OWLinearRegression(OWBaseLearner):
                         range(100, 1001, 100)))
 
     def add_main_layout(self):
-        box = gui.widgetBox(self.controlArea, "Regularization",
-                            orientation="horizontal")
+        box = gui.hBox(self.controlArea, "Regularization")
         gui.radioButtons(box, self, "reg_type",
-            btnLabels=self.REGULARIZATION_TYPES,
-            callback=self._reg_type_changed)
+                         btnLabels=self.REGULARIZATION_TYPES,
+                         callback=self._reg_type_changed)
 
         gui.separator(box, 20, 20)
-        self.alpha_box = box2 = gui.widgetBox(box, margin=0)
+        self.alpha_box = box2 = gui.vBox(box, margin=0)
         gui.widgetLabel(box2, "Regularization strength")
         self.alpha_slider = gui.hSlider(
             box2, self, "alpha_index",
             minValue=0, maxValue=len(self.alphas) - 1,
             callback=self._alpha_changed, createLabel=False)
-        box3 = gui.widgetBox(box2, orientation="horizontal")
+        box3 = gui.hBox(box2)
         box3.layout().setAlignment(Qt.AlignCenter)
         self.alpha_label = gui.widgetLabel(box3, "")
         self._set_alpha_label()
 
         gui.separator(box2, 10, 10)
-        box4 = gui.widgetBox(box2, margin=0)
+        box4 = gui.vBox(box2, margin=0)
         gui.widgetLabel(box4, "Elastic net mixing")
-        box5 = gui.widgetBox(box4, orientation="horizontal")
+        box5 = gui.hBox(box4)
         gui.widgetLabel(box5, "L1")
         self.l1_ratio_slider = gui.hSlider(
             box5, self, "l1_ratio", minValue=0.01, maxValue=1,
@@ -73,7 +72,7 @@ class OWLinearRegression(OWBaseLearner):
         gui.widgetLabel(box5, "L2")
 
     def add_bottom_buttons(self):
-        box5 = gui.widgetBox(self.controlArea, orientation="horizontal")
+        box5 = gui.hBox(self.controlArea)
         box5.layout().setAlignment(Qt.AlignCenter)
         self.l1_ratio_label = gui.widgetLabel(box5, "")
         self._set_l1_ratio_label()
@@ -159,7 +158,6 @@ class OWLinearRegression(OWBaseLearner):
                                       self.l1_ratio,
                                       1 - self.l1_ratio))
         return ("Regularization", regularization),
-
 
 if __name__ == "__main__":
     import sys

--- a/Orange/widgets/regression/owregressiontreegraph.py
+++ b/Orange/widgets/regression/owregressiontreegraph.py
@@ -1,4 +1,6 @@
 from PyQt4.QtGui import QBrush
+from PyQt4.QtCore import Qt
+
 from Orange.regression.tree import TreeRegressor
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting, ClassValuesContextHandler
@@ -37,9 +39,9 @@ class OWRegressionTreeGraph(OWTreeGraph):
 
     def __init__(self):
         super().__init__()
-        box = gui.widgetBox(self.controlArea, "Nodes", addSpace=True)
+        box = gui.vBox(self.controlArea, "Nodes", addSpace=True)
         self.color_combo = gui.comboBox(
-            box, self, "color_index", orientation=0, items=[],
+            box, self, "color_index", orientation=Qt.Horizontal, items=[],
             label="Colors", callback=self.toggle_color,
             contentsLength=8)
         gui.separator(box)

--- a/Orange/widgets/regression/owsgdregression.py
+++ b/Orange/widgets/regression/owsgdregression.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict
 
 from PyQt4 import QtGui
+from PyQt4.QtCore import Qt
 
 from Orange.data import Table
 from Orange.regression.linear import SGDRegressionLearner
@@ -53,7 +54,7 @@ class OWSGDRegression(OWBaseLearner):
         box = gui.radioButtons(
             self.controlArea, self, "loss_function", box="Loss function",
             btnLabels=self.LOSS_FUNCTIONS, callback=self._on_func_changed,
-            orientation="horizontal")
+            orientation=Qt.Vertical)
         form = add_form(box)
         epsilon = gui.doubleSpin(
             box, self, "epsilon", 0.0, 10.0, 0.01, controlWidth=70)
@@ -64,7 +65,7 @@ class OWSGDRegression(OWBaseLearner):
         box = gui.radioButtons(
             self.controlArea, self, "penalty_type", box="Penalty",
             btnLabels=self.PENALTIES, callback=self._on_penalty_changed,
-            orientation="horizontal")
+            orientation=Qt.Vertical)
         form = add_form(box)
         alpha = gui.doubleSpin(
             box, self, "alpha", 0.0, 10.0, 0.0001, controlWidth=80)
@@ -78,7 +79,7 @@ class OWSGDRegression(OWBaseLearner):
         box = gui.radioButtons(
             self.controlArea, self, "learning_rate", box="Learning rate",
             btnLabels=self.LEARNING_RATES, callback=self._on_lrate_changed,
-            orientation="horizontal")
+            orientation=Qt.Vertical)
         form = add_form(box)
         spin = gui.doubleSpin(
             box, self, "eta0", 0.0, 10, 0.01, controlWidth=70)

--- a/Orange/widgets/regression/owunivariateregression.py
+++ b/Orange/widgets/regression/owunivariateregression.py
@@ -1,13 +1,12 @@
-from PyQt4 import QtGui
-from PyQt4.QtGui import QColor
-from PyQt4.QtCore import QRectF
+from PyQt4.QtGui import QColor, QSizePolicy, QPalette, QPen, QFont
+from PyQt4.QtCore import Qt, QRectF
 
 import pyqtgraph as pg
 import numpy as np
 
 from Orange.data import Table, Domain
-from Orange.regression.linear import (RidgeRegressionLearner, PolynomialLearner,
-                                      LinearRegressionLearner)
+from Orange.regression.linear import (
+    RidgeRegressionLearner,  LinearRegressionLearner, PolynomialLearner)
 from Orange.regression import Learner
 from Orange.widgets import settings, gui
 from Orange.widgets.utils import itemmodels
@@ -41,16 +40,14 @@ class OWUnivariateRegression(OWBaseLearner):
         self.x_label = 'x'
         self.y_label = 'y'
 
-        box = gui.widgetBox(self.controlArea, "Variables")
+        box = gui.vBox(self.controlArea, "Variables")
 
         self.x_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesX = gui.comboBox(
-            box, self, value='x_var_index',
-            label="Input ", orientation="horizontal",
-            callback=self.apply,
-            contentsLength=12)
+            box, self, value='x_var_index', label="Input ",
+            orientation=Qt.Horizontal, callback=self.apply, contentsLength=12)
         self.comboBoxAttributesX.setSizePolicy(
-            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Fixed)
+            QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
         self.comboBoxAttributesX.setModel(self.x_var_model)
         gui.doubleSpin(
             gui.indentedBox(box),
@@ -60,12 +57,10 @@ class OWUnivariateRegression(OWBaseLearner):
         gui.separator(box, height=8)
         self.y_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesY = gui.comboBox(
-            box, self, value='y_var_index',
-            label='Target', orientation="horizontal",
-            callback=self.apply,
-            contentsLength=12)
+            box, self, value='y_var_index', label='Target',
+            orientation=Qt.Horizontal, callback=self.apply, contentsLength=12)
         self.comboBoxAttributesY.setSizePolicy(
-            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Fixed)
+            QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
         self.comboBoxAttributesY.setModel(self.y_var_model)
 
         gui.rubber(self.controlArea)
@@ -74,10 +69,10 @@ class OWUnivariateRegression(OWBaseLearner):
         self.plotview = pg.PlotWidget(background="w")
         self.plot = self.plotview.getPlotItem()
 
-        axis_color = self.palette().color(QtGui.QPalette.Text)
-        axis_pen = QtGui.QPen(axis_color)
+        axis_color = self.palette().color(QPalette.Text)
+        axis_pen = QPen(axis_color)
 
-        tickfont = QtGui.QFont(self.font())
+        tickfont = QFont(self.font())
         tickfont.setPixelSize(max(int(tickfont.pixelSize() * 2 // 3), 11))
 
         axis = self.plot.getAxis("bottom")

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -65,29 +65,27 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
         self.component_x = 0
         self.component_y = 1
 
-        box = gui.widgetBox(self.controlArea, "Variables")
+        box = gui.vBox(self.controlArea, "Variables")
         self.varlist = itemmodels.VariableListModel()
-        self.varview = view = QListView(
-            selectionMode=QListView.MultiSelection
-        )
+        self.varview = view = QListView(selectionMode=QListView.MultiSelection)
         view.setModel(self.varlist)
         view.selectionModel().selectionChanged.connect(self._var_changed)
 
         box.layout().addWidget(view)
 
-        axes_box = gui.widgetBox(self.controlArea, "Axes")
-        box = gui.widgetBox(axes_box, "Axis X", margin=0)
+        axes_box = gui.vBox(self.controlArea, "Axes")
+        box = gui.vBox(axes_box, "Axis X", margin=0)
         box.setFlat(True)
         self.axis_x_cb = gui.comboBox(
             box, self, "component_x", callback=self._component_changed)
 
-        box = gui.widgetBox(axes_box, "Axis Y", margin=0)
+        box = gui.vBox(axes_box, "Axis Y", margin=0)
         box.setFlat(True)
         self.axis_y_cb = gui.comboBox(
             box, self, "component_y", callback=self._component_changed)
 
         self.infotext = gui.widgetLabel(
-            gui.widgetBox(self.controlArea, "Contribution to Inertia"), "\n"
+            gui.vBox(self.controlArea, "Contribution to Inertia"), "\n"
         )
 
         gui.rubber(self.controlArea)

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -279,17 +279,14 @@ class OWDistanceMap(widget.OWWidget):
         self._sort_indices = None
         self._selection = None
 
-        box = gui.widgetBox(self.controlArea, "Element sorting", margin=0)
         self.sorting_cb = gui.comboBox(
-            box, self, "sorting",
+            self.controlArea, self, "sorting", box="Element sorting",
             items=["None", "Clustering", "Clustering with ordered leaves"],
             callback=self._invalidate_ordering)
 
-        box = gui.widgetBox(self.controlArea, "Colors")
-
+        box = gui.vBox(self.controlArea, "Colors")
         self.colormap_cb = gui.comboBox(
-            box, self, "colormap", callback=self._update_color
-        )
+            box, self, "colormap", callback=self._update_color)
         self.colormap_cb.setIconSize(QSize(64, 16))
         self.palettes = list(_color_palettes)
 
@@ -321,10 +318,9 @@ class OWDistanceMap(widget.OWWidget):
         )
         box.layout().addLayout(form)
 
-        box = gui.widgetBox(self.controlArea, "Annotations")
-        self.annot_combo = gui.comboBox(box, self, "annotation_idx",
-                                        callback=self._invalidate_annotations,
-                                        contentsLength=12)
+        self.annot_combo = gui.comboBox(
+            self.controlArea, self, "annotation_idx", box="Annotations",
+            callback=self._invalidate_annotations, contentsLength=12)
         self.annot_combo.setModel(itemmodels.VariableListModel())
         self.annot_combo.model()[:] = ["None", "Enumeration"]
         self.controlArea.layout().addStretch()

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -233,11 +233,11 @@ class OWDistanceMatrix(widget.OWWidget):
         view.setSelectionBehavior(QTableView.SelectItems)
         self.mainArea.layout().addWidget(view)
 
-        settings_box = gui.widgetBox(self.mainArea, orientation="horizontal")
+        settings_box = gui.hBox(self.mainArea)
 
         self.annot_combo = gui.comboBox(
             settings_box, self, "annotation_idx", label="Labels: ",
-            orientation="horizontal",
+            orientation=Qt.Horizontal,
             callback=self._invalidate_annotations, contentsLength=12)
         self.annot_combo.setModel(VariableListModel())
         self.annot_combo.model()[:] = ["None", "Enumeration"]

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -38,18 +38,13 @@ class OWDistances(widget.OWWidget):
 
         self.data = None
 
-        box = gui.widgetBox(self.controlArea, self.tr("Distances Between"))
-        gui.radioButtons(
-            box, self, "axis",
-            [self.tr("rows"), self.tr("columns")],
-            callback=self._invalidate
+        gui.radioButtons(self.controlArea, self, "axis", ["rows", "columns"],
+                         box="Distances between", callback=self._invalidate
         )
-
-        box = gui.widgetBox(self.controlArea, self.tr("Distance Metric"))
-        gui.comboBox(box, self, "metric_idx",
-                     items=list(zip(*_METRICS))[0],
-                     callback=self._invalidate)
-
+        gui.comboBox(self.controlArea, self, "metric_idx",
+                     box="Distance Metric", items=list(zip(*_METRICS))[0],
+                     callback=self._invalidate
+        )
         gui.auto_commit(self.controlArea, self, "autocommit", "Apply",
                         checkbox_label="Apply on any change")
 

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -40,17 +40,16 @@ class OWDistanceTransformation(widget.OWWidget):
 
         self.data = None
 
-        box = gui.widgetBox(self.controlArea, "Normalization")
-        gui.radioButtons(box, self, "normalization_method",
+        gui.radioButtons(self.controlArea, self, "normalization_method",
+                         box="Normalization",
                          btnLabels=[x[0] for x in self.normalization_options],
                          callback=self._invalidate)
 
-        box = gui.widgetBox(self.controlArea, "Inversion")
-        gui.radioButtons(box, self, "inversion_method",
+        gui.radioButtons(self.controlArea, self, "inversion_method",
+                         box="Inversion",
                          btnLabels=[x[0] for x in self.inversion_options],
                          callback=self._invalidate)
 
-        box = gui.widgetBox(self.controlArea, True, orientation="vertical")
         box = gui.auto_commit(self.controlArea, self, "autocommit", "Apply",
                               checkbox_label="Apply on any change")
         gui.separator(box, 20)

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -752,22 +752,19 @@ class OWHierarchicalClustering(widget.OWWidget):
         self._displayed_root = None
         self.cutoff_height = 0.0
 
-        gui.comboBox(gui.widgetBox(self.controlArea, "Linkage"),
-                     self, "linkage", items=LINKAGE,
-                     callback=self._invalidate_clustering)
+        gui.comboBox(
+            self.controlArea, self, "linkage", items=LINKAGE, box="Linkage",
+            callback=self._invalidate_clustering)
 
-        box = gui.widgetBox(self.controlArea, "Annotation")
         self.label_cb = gui.comboBox(
-            box, self, "annotation_idx", callback=self._update_labels,
-            contentsLength=12)
-
+            self.controlArea, self, "annotation_idx", box="Annotation",
+            callback=self._update_labels, contentsLength=12)
         self.label_cb.setModel(itemmodels.VariableListModel())
         self.label_cb.model()[:] = ["None", "Enumeration"]
 
         box = gui.radioButtons(
             self.controlArea, self, "pruning", box="Pruning",
-            callback=self._invalidate_pruning
-        )
+            callback=self._invalidate_pruning)
         grid = QGridLayout()
         box.layout().addLayout(grid)
         grid.addWidget(
@@ -817,10 +814,9 @@ class OWHierarchicalClustering(widget.OWWidget):
         grid.addWidget(self.top_n_spin, 2, 1)
         box.layout().addLayout(grid)
 
-        zoom_box = gui.widgetBox(self.controlArea, "Zoom")
         self.zoom_slider = gui.hSlider(
-            zoom_box, self, "zoom_factor", minValue=-6, maxValue=3, step=1,
-            ticks=True, createLabel=False,
+            self.controlArea, self, "zoom_factor", box="Zoom",
+            minValue=-6, maxValue=3, step=1, ticks=True, createLabel=False,
             callback=self.__zoom_factor_changed)
 
         zoom_in = QAction(
@@ -840,7 +836,7 @@ class OWHierarchicalClustering(widget.OWWidget):
 
         self.controlArea.layout().addStretch()
 
-        box = gui.widgetBox(self.controlArea, "Output")
+        box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "append_clusters", "Append cluster IDs",
                      callback=self._invalidate_output)
 

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -59,7 +59,7 @@ class OWKMeans(widget.OWWidget):
         self.km = None
         self.optimization_runs = []
 
-        box = gui.widgetBox(self.controlArea, "Number of Clusters")
+        box = gui.vBox(self.controlArea, "Number of Clusters")
         layout = QGridLayout()
         bg = gui.radioButtonsInBox(
             box, self, "optimize_k", [], orientation=layout,
@@ -67,7 +67,7 @@ class OWKMeans(widget.OWWidget):
         layout.addWidget(
             gui.appendRadioButton(bg, "Fixed", addToLayout=False),
             1, 1)
-        sb = gui.widgetBox(None, margin=0, orientation="horizontal")
+        sb = gui.hBox(None, margin=0)
         self.fixedSpinBox = gui.spin(
             sb, self, "k", minv=2, maxv=30,
             controlWidth=60, alignment=Qt.AlignRight, callback=self.update_k)
@@ -76,7 +76,7 @@ class OWKMeans(widget.OWWidget):
 
         layout.addWidget(
             gui.appendRadioButton(bg, "Optimized", addToLayout=False), 2, 1)
-        ftobox = gui.widgetBox(None, orientation="horizontal")
+        ftobox = gui.hBox(None)
         ftobox.layout().setContentsMargins(0, 0, 0, 0)
         layout.addWidget(ftobox)
         gui.spin(
@@ -98,7 +98,7 @@ class OWKMeans(widget.OWWidget):
                 items=list(zip(*self.SCORING_METHODS))[0],
                 callback=self.update), 5, 2)
 
-        box = gui.widgetBox(self.controlArea, "Initialization")
+        box = gui.vBox(self.controlArea, "Initialization")
         gui.comboBox(
             box, self, "smart_init", items=self.INIT_METHODS,
             callback=self.update)
@@ -108,7 +108,7 @@ class OWKMeans(widget.OWWidget):
         box2.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
         layout.addWidget(gui.widgetLabel(None, "Re-runs: "),
                          0, 0, Qt.AlignLeft)
-        sb = gui.widgetBox(None, margin=0, orientation="horizontal")
+        sb = gui.hBox(None, margin=0)
         layout.addWidget(sb, 0, 1)
         gui.lineEdit(
             sb, self, "n_init", controlWidth=60,
@@ -116,31 +116,31 @@ class OWKMeans(widget.OWWidget):
             callback=self.update)
         layout.addWidget(gui.widgetLabel(None, "Maximal iterations: "),
                          1, 0, Qt.AlignLeft)
-        sb = gui.widgetBox(None, margin=0, orientation="horizontal")
+        sb = gui.hBox(None, margin=0)
         layout.addWidget(sb, 1, 1)
         gui.lineEdit(sb, self, "max_iterations",
                      controlWidth=60, valueType=int,
                      validator=QIntValidator(),
                      callback=self.update)
 
-        box = gui.widgetBox(self.controlArea, "Output")
+        box = gui.vBox(self.controlArea, "Output")
         gui.comboBox(box, self, "place_cluster_ids",
-                     label="Append cluster id as ", orientation="horizontal",
+                     label="Append cluster id as ", orientation=Qt.Horizontal,
                      callback=self.send_data, items=self.OUTPUT_METHODS)
         gui.lineEdit(box, self, "output_name",
-                     label="Name ", orientation="horizontal",
+                     label="Name ", orientation=Qt.Horizontal,
                      callback=self.send_data)
 
         gui.auto_commit(self.controlArea, self, "auto_run", "Run",
                         checkbox_label="Run after any change  ",
-                        orientation="horizontal")
+                        orientation=Qt.Horizontal)
         gui.rubber(self.controlArea)
 
         self.table_model = QStandardItemModel(self)
         self.table_model.setHorizontalHeaderLabels(["k", "Score"])
         self.table_model.setColumnCount(2)
 
-        self.table_box = gui.widgetBox(
+        self.table_box = gui.vBox(
             self.mainArea, "Optimization Report", addSpace=0)
         table = self.table_view = QTableView(self.table_box)
         table.setHorizontalScrollMode(QTableView.ScrollPerPixel)

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -177,7 +177,7 @@ class OWMDS(widget.OWWidget):
         self.__in_next_step = False
         self.__draw_similar_pairs = False
 
-        box = gui.widgetBox(self.controlArea, "MDS Optimization")
+        box = gui.vBox(self.controlArea, "MDS Optimization")
         form = QtGui.QFormLayout(
             labelAlignment=Qt.AlignLeft,
             formAlignment=Qt.AlignLeft,
@@ -203,12 +203,12 @@ class OWMDS(widget.OWWidget):
         self.runbutton = gui.button(
             box, self, "Run", callback=self._toggle_run)
 
-        box = gui.widgetBox(self.controlArea, "Graph")
+        box = gui.vBox(self.controlArea, "Graph")
         self.colorvar_model = itemmodels.VariableListModel()
 
-        common_options = {"sendSelectedValue": True, "valueType": str,
-                          "orientation": "horizontal", "labelWidth": 50,
-                          "contentsLength": 12}
+        common_options = dict(
+            sendSelectedValue=True, valueType=str, orientation=Qt.Horizontal,
+            labelWidth=50, contentsLength=12)
 
         self.cb_color_value = gui.comboBox(
             box, self, "color_value", label="Color",
@@ -251,8 +251,7 @@ class OWMDS(widget.OWWidget):
                                 createLabel=False))
         form.addRow("Show similar pairs",
                     gui.hSlider(
-                        gui.widgetBox(self.controlArea,
-                                      orientation="horizontal"),
+                        gui.hBox(self.controlArea),
                         self, "connected_pairs", minValue=0, maxValue=20,
                         createLabel=False,
                         callback=self._on_connected_changed))
@@ -314,7 +313,7 @@ class OWMDS(widget.OWWidget):
 
         self.controlArea.layout().addWidget(box)
 
-        box = gui.widgetBox(self.controlArea, "Output")
+        box = gui.vBox(self.controlArea, "Output")
         self.output_combo = gui.comboBox(
             box, self, "output_embedding_role",
             items=["Original features only",

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -55,7 +55,7 @@ class OWPCA(widget.OWWidget):
         self._pca_preprocessors = PCA.preprocessors
 
         # Components Selection
-        box = gui.widgetBox(self.controlArea, "Components Selection")
+        box = gui.vBox(self.controlArea, "Components Selection")
         form = QFormLayout()
         box.layout().addLayout(form)
 
@@ -77,9 +77,7 @@ class OWPCA(widget.OWWidget):
         form.addRow("Variance covered", self.variance_spin)
 
         # Incremental learning
-        self.sampling_box = gui.widgetBox(self.controlArea,
-                                          "Incremental learning")
-
+        self.sampling_box = gui.vBox(self.controlArea, "Incremental learning")
         self.addresstext = QLineEdit(box)
         self.addresstext.setPlaceholderText('Remote server')
         if self.address:
@@ -107,7 +105,7 @@ class OWPCA(widget.OWWidget):
         self.sampling_box.setVisible(remotely)
 
         # Options
-        self.options_box = gui.widgetBox(self.controlArea, "Options")
+        self.options_box = gui.vBox(self.controlArea, "Options")
         gui.checkBox(self.options_box, self, "normalize", "Normalize data",
                      callback=self._update_normalize)
         self.maxp_spin = gui.spin(

--- a/Orange/widgets/unsupervised/owsilhouetteplot.py
+++ b/Orange/widgets/unsupervised/owsilhouetteplot.py
@@ -65,7 +65,7 @@ class OWSilhouettePlot(widget.OWWidget):
         self._labels = None
         self._silplot = None
 
-        box = gui.widgetBox(self.controlArea, "Settings",)
+        box = gui.vBox(self.controlArea, "Settings",)
         gui.comboBox(box, self, "distance_idx", label="Distance",
                      items=[name for name, _ in OWSilhouettePlot.Distances],
                      callback=self._invalidate_distances)
@@ -90,7 +90,7 @@ class OWSilhouettePlot(widget.OWWidget):
 
         gui.rubber(self.controlArea)
 
-        box = gui.widgetBox(self.controlArea, "Output")
+        box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "add_scores", "Add silhouette scores",)
         gui.auto_commit(box, self, "auto_commit", "Commit", box=False)
 

--- a/Orange/widgets/utils/colorpalette.py
+++ b/Orange/widgets/utils/colorpalette.py
@@ -59,13 +59,13 @@ class ColorPaletteDlg(QDialog):
         self.colorSchemas = []
         self.selectedSchemaIndex = 0
 
-        self.mainArea = gui.widgetBox(self, spacing=4)
+        self.mainArea = gui.vBox(self, spacing=4)
         self.layout().addWidget(self.mainArea)
         self.schemaCombo = gui.comboBox(
             self.mainArea, self, "selectedSchemaIndex", box="Saved Profiles",
             callback=self.paletteSelected)
 
-        self.hbox = gui.widgetBox(self, orientation="horizontal")
+        self.hbox = gui.hBox(self)
         self.okButton = gui.button(self.hbox, self, "OK", self.acceptChanges)
         self.cancelButton = gui.button(self.hbox, self, "Cancel", self.reject)
         self.setMinimumWidth(230)
@@ -96,7 +96,7 @@ class ColorPaletteDlg(QDialog):
                 QDialog.accept(self)
 
     def createBox(self, boxName, boxCaption=None):
-        box = gui.widgetBox(self.mainArea, boxCaption)
+        box = gui.vBox(self.mainArea, boxCaption)
         box.setAlignment(Qt.AlignLeft)
         return box
 
@@ -109,8 +109,8 @@ class ColorPaletteDlg(QDialog):
     def createContinuousPalette(self, paletteName, boxCaption,
                                 passThroughBlack=0,
                                 initialColor1=Qt.blue, initialColor2=Qt.yellow):
-        buttBox = gui.widgetBox(self.mainArea, boxCaption)
-        box = gui.widgetBox(buttBox, orientation="horizontal")
+        buttBox = gui.vBox(self.mainArea, boxCaption)
+        box = gui.hBox(buttBox)
 
         self.__dict__["cont" + paletteName + "Left"] = ColorButton(self, box, color=QColor(initialColor1))
         self.__dict__["cont" + paletteName + "View"] = PaletteView(box)
@@ -129,8 +129,8 @@ class ColorPaletteDlg(QDialog):
                                         extendedPassThroughColors=((Qt.red, 1),
                                                                    (Qt.black, 1),
                                                                    (Qt.green, 1))):
-        buttBox = gui.widgetBox(self.mainArea, boxCaption)
-        box = gui.widgetBox(buttBox, orientation="horizontal")
+        buttBox = gui.vBox(self.mainArea, boxCaption)
+        box = gui.hBox(buttBox)
 
         self.__dict__["exCont" + paletteName + "Left"] = ColorButton(self, box, color=QColor(initialColor1))
         self.__dict__["exCont" + paletteName + "View"] = PaletteView(box)
@@ -142,7 +142,7 @@ class ColorPaletteDlg(QDialog):
                                                                                            "Use pass-through colors",
                                                                                            callback=self.colorSchemaChange)
 
-        box = gui.widgetBox(buttBox, "Pass-through colors", orientation="horizontal")
+        box = gui.hBox(buttBox, "Pass-through colors")
         for i, (color, check) in enumerate(extendedPassThroughColors):
             self.__dict__["exCont" + paletteName + "passThroughColor" + str(i)] = check
             self.__dict__["exCont" + paletteName + "passThroughColor" + str(i) + "Checkbox"] = cb = gui.checkBox(box,
@@ -163,11 +163,11 @@ class ColorPaletteDlg(QDialog):
     # DISCRETE COLOR PALETTE
     # #####################################################
     def createDiscretePalette(self, paletteName, boxCaption, rgbColors=DefaultRGBColors):
-        vbox = gui.widgetBox(self.mainArea, boxCaption, orientation='vertical')
+        vbox = gui.vBox(self.mainArea, boxCaption)
         self.__dict__["disc" + paletteName + "View"] = PaletteView(vbox)
         self.__dict__["disc" + paletteName + "View"].rgbColors = rgbColors
 
-        hbox = gui.widgetBox(vbox, orientation='horizontal')
+        hbox = gui.hBox(vbox)
         self.__dict__["disc" + paletteName + "EditButt"] = gui.button(hbox, self, "Edit palette", self.editPalette,
                                                                       tooltip="Edit the order and colors of the palette",
                                                                       toggleButton=1)
@@ -377,7 +377,7 @@ class ColorPalleteListing(QDialog):
         self.buttons = []
         self.setMinimumWidth(400)
 
-        box = gui.widgetBox(space, "Information", addSpace=True)
+        box = gui.vBox(space, "Information", addSpace=True)
         gui.widgetLabel(
             box,
             '<p align="center">This dialog shows a list of predefined '
@@ -385,7 +385,7 @@ class ColorPalleteListing(QDialog):
             'in Orange.<br/>You can select a palette by clicking on it.</p>'
         )
 
-        box = gui.widgetBox(space, "Default Palette", addSpace=True)
+        box = gui.vBox(space, "Default Palette", addSpace=True)
 
         butt = _ColorButton(
             DefaultRGBColors, flat=True, toolTip="Default color palette",
@@ -398,7 +398,7 @@ class ColorPalleteListing(QDialog):
         for type in ["Qualitative", "Spectral", "Diverging", "Sequential", "Pastels"]:
             colorGroup = colorbrewer.colorSchemes.get(type.lower(), {})
             if colorGroup:
-                box = gui.widgetBox(space, type + " Palettes", addSpace=True)
+                box = gui.vBox(space, type + " Palettes", addSpace=True)
                 items = sorted(colorGroup.items())
                 for key, colors in items:
                     butt = _ColorButton(colors, self, toolTip=key, flat=True,
@@ -449,7 +449,7 @@ class PaletteEditor(QDialog):
         self.setLayout(QVBoxLayout())
         self.layout().setContentsMargins(4, 4, 4, 4)
 
-        hbox = gui.widgetBox(self, "Information", orientation='horizontal')
+        hbox = gui.hBox(self, "Information")
         gui.widgetLabel(
             hbox,
             '<p align="center">You can reorder colors in the list using the'
@@ -457,10 +457,10 @@ class PaletteEditor(QDialog):
             '<br/>To change a specific color double click the item in the '
             'list.</p>')
 
-        hbox = gui.widgetBox(self, box=True, orientation="horizontal")
+        hbox = gui.hBox(self, box=True)
         self.discListbox = gui.listBox(hbox, self, enableDragDrop=1)
 
-        vbox = gui.widgetBox(hbox, orientation='vertical')
+        vbox = gui.vBox(hbox)
         buttonUPAttr = gui.button(vbox, self, "", callback=self.moveAttrUP, tooltip="Move selected colors up")
         buttonDOWNAttr = gui.button(vbox, self, "", callback=self.moveAttrDOWN, tooltip="Move selected colors down")
         buttonUPAttr.setIcon(QIcon(gui.resource_filename("icons/Dlg_up3.png")))

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -223,7 +223,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
                      tooltip='The name will identify this model in other widgets')
 
     def add_bottom_buttons(self):
-        box = gui.widgetBox(self.controlArea, True, orientation="horizontal")
+        box = gui.hBox(self.controlArea, True)
         box.layout().addWidget(self.report_button)
         gui.separator(box, 15)
         self.apply_button = gui.button(box, self, "&Apply", callback=self.apply,

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -433,7 +433,7 @@ class OWPlotGUI:
             The ``ids`` argument is a list of widget ID's that will be added to this box
         '''
         if box is None:
-            box = gui.widgetBox(widget, name)
+            box = gui.vBox(widget, name)
         self.add_widgets(ids, box)
         return box
 

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -161,7 +161,7 @@ class OWBoxPlot(widget.OWWidget):
         self.attr_list_box.setSizePolicy(QSizePolicy.Fixed,
                                          QSizePolicy.MinimumExpanding)
 
-        box = gui.widgetBox(self.controlArea, "Grouping")
+        box = gui.vBox(self.controlArea, "Grouping")
         self.group_list_box = gui.listBox(
             box, self, 'grouping_select', "grouping",
             callback=self.attr_changed,
@@ -170,7 +170,7 @@ class OWBoxPlot(widget.OWWidget):
                                           QSizePolicy.MinimumExpanding)
 
         # TODO: move Compare median/mean to grouping box
-        self.display_box = gui.widgetBox(self.controlArea, "Display")
+        self.display_box = gui.vBox(self.controlArea, "Display")
 
         gui.checkBox(self.display_box, self, "show_annotations", "Annotate",
                      callback=self.display_changed)
@@ -183,7 +183,7 @@ class OWBoxPlot(widget.OWWidget):
             self.controlArea, self, 'stretched', "Stretch bars", box='Display',
             callback=self.display_changed).box
 
-        gui.widgetBox(self.mainArea, addSpace=True)
+        gui.vBox(self.mainArea, addSpace=True)
         self.box_scene = QtGui.QGraphicsScene()
         self.box_view = QtGui.QGraphicsView(self.box_scene)
         self.box_view.setRenderHints(QtGui.QPainter.Antialiasing |
@@ -193,7 +193,7 @@ class OWBoxPlot(widget.OWWidget):
 
         self.mainArea.layout().addWidget(self.box_view)
 
-        e = gui.widgetBox(self.mainArea, addSpace=False, orientation=0)
+        e = gui.hBox(self.mainArea, addSpace=False)
         self.infot1 = gui.widgetLabel(e, "<center>No test results.</center>")
         self.mainArea.setMinimumWidth(650)
 

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -112,7 +112,7 @@ class OWDistributions(widget.OWWidget):
         self.distributions = None
         self.contingencies = None
         self.var = self.cvar = None
-        varbox = gui.widgetBox(self.controlArea, "Variable")
+        varbox = gui.vBox(self.controlArea, "Variable")
 
         self.varmodel = itemmodels.VariableListModel()
         self.groupvarmodel = []
@@ -128,11 +128,11 @@ class OWDistributions(widget.OWWidget):
             self._on_variable_idx_changed)
         varbox.layout().addWidget(self.varview)
 
-        box = gui.widgetBox(self.controlArea, "Precision")
+        box = gui.vBox(self.controlArea, "Precision")
 
         gui.separator(self.controlArea, 4, 4)
 
-        box2 = gui.widgetBox(box, orientation="horizontal")
+        box2 = gui.hBox(box)
         self.l_smoothing_l = gui.widgetLabel(box2, "Smooth")
         gui.hSlider(box2, self, "smoothing_index",
                     minValue=0, maxValue=len(self.smoothing_facs) - 1,
@@ -145,7 +145,7 @@ class OWDistributions(widget.OWWidget):
             callback=self._on_groupvar_idx_changed,
             tooltip="Show continuous variables as discrete.")
 
-        box = gui.widgetBox(self.controlArea, "Group by")
+        box = gui.vBox(self.controlArea, "Group by")
         self.icons = gui.attributeIconDict
         self.groupvarview = gui.comboBox(box, self, "groupvar_idx",
              callback=self._on_groupvar_idx_changed, valueType=str,
@@ -158,7 +158,7 @@ class OWDistributions(widget.OWWidget):
         gui.separator(box2)
         self.cb_prob = gui.comboBox(
             box2, self, "show_prob", label="Show probabilities",
-            orientation="horizontal",
+            orientation=Qt.Horizontal,
             callback=self._on_relative_freq_changed,
             tooltip="Show probabilities for a chosen group-by value (at each point probabilities for all group-by values sum to 1).")
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -483,7 +483,7 @@ class OWHeatMap(widget.OWWidget):
         self.__columns_cache = {}
 
         # GUI definition
-        colorbox = gui.widgetBox(self.controlArea, "Color")
+        colorbox = gui.vBox(self.controlArea, "Color")
         self.color_cb = gui.comboBox(colorbox, self, "palette_index")
         self.color_cb.setIconSize(QSize(64, 16))
         palettes = _color_palettes + self.user_palettes
@@ -524,7 +524,7 @@ class OWHeatMap(widget.OWWidget):
 
         colorbox.layout().addLayout(form)
 
-        mergebox = gui.widgetBox(self.controlArea, "Merge",)
+        mergebox = gui.vBox(self.controlArea, "Merge",)
         gui.checkBox(mergebox, self, "merge_kmeans", "Merge by k-means",
                      callback=self.update_sorting_examples)
         ibox = gui.indentedBox(mergebox)
@@ -532,7 +532,7 @@ class OWHeatMap(widget.OWWidget):
                  label="Clusters:", keyboardTracking=False,
                  callbackOnReturn=True, callback=self.update_merge)
 
-        sortbox = gui.widgetBox(self.controlArea, "Sorting")
+        sortbox = gui.vBox(self.controlArea, "Sorting")
         # For columns
         self.colsortcb = gui.comboBox(
             sortbox, self, "sort_columns_idx",
@@ -545,7 +545,7 @@ class OWHeatMap(widget.OWWidget):
             items=[name for _, name in self.RowOrdering],
             label='Rows', callback=self.update_sorting_examples)
 
-        box = gui.widgetBox(self.controlArea, 'Annotation && Legends')
+        box = gui.vBox(self.controlArea, 'Annotation && Legends')
 
         gui.checkBox(box, self, 'legend', 'Show legend',
                      callback=self.update_legend)
@@ -553,14 +553,13 @@ class OWHeatMap(widget.OWWidget):
         gui.checkBox(box, self, 'averages', 'Stripes with averages',
                      callback=self.update_averages_stripe)
 
-        annotbox = gui.widgetBox(box, "Row Annotations", addSpace=False)
+        annotbox = gui.vBox(box, "Row Annotations", addSpace=False)
         annotbox.setFlat(True)
         self.annotations_cb = gui.comboBox(annotbox, self, "annotation_index",
                                            items=self.annotation_vars,
                                            callback=self.update_annotations)
 
-        posbox = gui.widgetBox(box, "Column Labels Position",
-                               addSpace=False)
+        posbox = gui.vBox(box, "Column Labels Position", addSpace=False)
         posbox.setFlat(True)
 
         gui.comboBox(

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -261,9 +261,9 @@ class OWLinearProjection(widget.OWWidget):
         self.__selection_item = None
         self.__replot_requested = False
 
-        box = gui.widgetBox(self.controlArea, "Axes")
+        box = gui.vBox(self.controlArea, "Axes")
 
-        box1 = gui.widgetBox(box, "Displayed", margin=0)
+        box1 = gui.vBox(box, "Displayed", margin=0)
         box1.setFlat(True)
         self.active_view = view = QListView(
             sizePolicy=QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Ignored),
@@ -295,7 +295,7 @@ class OWLinearProjection(widget.OWWidget):
 
         box1.layout().addWidget(view)
 
-        box1 = gui.widgetBox(box, "Other", margin=0)
+        box1 = gui.vBox(box, "Other", margin=0)
         box1.setFlat(True)
         self.other_view = view = QListView(
             sizePolicy=QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Ignored),
@@ -320,7 +320,7 @@ class OWLinearProjection(widget.OWWidget):
 
         box1.layout().addWidget(view)
 
-        box = gui.widgetBox(self.controlArea, "Plot Properties")
+        box = gui.vBox(self.controlArea, "Plot Properties")
         box.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Maximum)
 
         self.colorvar_model = itemmodels.VariableListModel(parent=self)
@@ -378,7 +378,7 @@ class OWLinearProjection(widget.OWWidget):
                                              callback=self._update_density)
         form.addRow("Class density", self.cb_class_density)
 
-        toolbox = gui.widgetBox(self.controlArea, "Zoom/Select")
+        toolbox = gui.vBox(self.controlArea, "Zoom/Select")
         toollayout = QtGui.QHBoxLayout()
         toolbox.layout().addLayout(toollayout)
 

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -77,7 +77,7 @@ class OWMosaicDisplay(OWWidget):
         self.attr_combos = [
             gui.comboBox(
                     box, self, value="variable{}".format(i),
-                    orientation="horizontal", contentsLength=12,
+                    orientation=Qt.Horizontal, contentsLength=12,
                     callback=self.reset_graph,
                     sendSelectedValue=True, valueType=str)
             for i in range(1, 5)]

--- a/Orange/widgets/visualize/owparallelcoordinates.py
+++ b/Orange/widgets/visualize/owparallelcoordinates.py
@@ -1,6 +1,7 @@
 import sys
 
 from PyQt4.QtGui import QApplication
+from PyQt4.QtCore import Qt
 
 from Orange.canvas.registry.description import Default
 import Orange.data
@@ -81,28 +82,29 @@ class OWParallelCoordinates(OWVisWidget):
         self.zoom_select_toolbar.buttonSendSelections.clicked.connect(self.sendSelections)
 
     def add_visual_settings(self, parent):
-        box = gui.widgetBox(parent, "Visual Settings")
+        box = gui.vBox(parent, "Visual Settings")
         gui.checkBox(box, self, 'graph.show_attr_values', 'Show attribute values', callback=self.update_graph)
         gui.checkBox(box, self, 'graph.use_splines', 'Show splines', callback=self.update_graph,
                      tooltip="Show lines using splines")
         self.graph.gui.show_legend_check_box(box)
 
     def add_annotation_settings(self, parent):
-        box = gui.widgetBox(parent, "Statistical Information")
-        gui.comboBox(box, self, "graph.show_statistics", label="Statistics: ", orientation="horizontal", labelWidth=90,
+        box = gui.vBox(parent, "Statistical Information")
+        gui.comboBox(box, self, "graph.show_statistics", label="Statistics: ",
+                     orientation=Qt.Horizontal, labelWidth=90,
                      items=["No statistics", "Means, deviations", "Median, quartiles"], callback=self.update_graph,
                      sendSelectedValue=False, valueType=int)
         gui.checkBox(box, self, 'graph.show_distributions', 'Show distributions', callback=self.update_graph,
                      tooltip="Show bars with distribution of class values (only for discrete attributes)")
 
     def add_group_settings(self, parent):
-        box = gui.widgetBox(parent, "Groups", orientation="vertical")
-        box2 = gui.widgetBox(box, orientation="horizontal")
+        box = gui.vBox(parent, "Groups")
+        box2 = gui.hBox(box)
         gui.checkBox(box2, self, "graph.group_lines", "Group lines into", tooltip="Show clusters instead of lines",
                      callback=self.update_graph)
         gui.spin(box2, self, "graph.number_of_groups", 0, 30, callback=self.update_graph)
         gui.label(box2, self, "groups")
-        box2 = gui.widgetBox(box, orientation="horizontal")
+        box2 = gui.hBox(box)
         gui.spin(box2, self, "graph.number_of_steps", 0, 100, label="In no more than", callback=self.update_graph)
         gui.label(box2, self, "steps")
 

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -495,7 +495,7 @@ class OWScatterMap(widget.OWWidget):
 
         self.colors = colorpalette.ColorPaletteGenerator(10)
 
-        box = gui.widgetBox(self.controlArea, "Axes")
+        box = gui.vBox(self.controlArea, "Axes")
         self.x_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesX = gui.comboBox(
             box, self, value='x_var_index', callback=self.replot,
@@ -508,7 +508,7 @@ class OWScatterMap(widget.OWWidget):
             contentsLength=12)
         self.comboBoxAttributesY.setModel(self.y_var_model)
 
-        box = gui.widgetBox(self.controlArea, "Color")
+        box = gui.vBox(self.controlArea, "Color")
         self.z_var_model = itemmodels.VariableListModel()
         self.comboBoxClassvars = gui.comboBox(
             box, self, value='z_var_index',
@@ -523,11 +523,11 @@ class OWScatterMap(widget.OWWidget):
             addSpace=False
         )
         gui.comboBox(box, self, "color_scale", label="Scale: ",
-                     orientation="horizontal",
+                     orientation=Qt.Horizontal,
                      items=["Linear", "Square root", "Logarithmic"],
                      callback=self._on_color_scale_changed)
 
-        self.sampling_box = gui.widgetBox(self.controlArea, "Sampling")
+        self.sampling_box = gui.vBox(self.controlArea, "Sampling")
         sampling_options = (self.sample_times_captions +
                             self.sample_percentages_captions)
         self.sample_combo = gui.comboBox(

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -68,7 +68,7 @@ class OWScatterPlot(OWWidget):
     def __init__(self):
         super().__init__()
 
-        box = gui.widgetBox(self.mainArea, True, margin=0)
+        box = gui.vBox(self.mainArea, True, margin=0)
         self.graph = OWScatterPlotGraph(self, box, "ScatterPlot")
         box.layout().addWidget(self.graph.plot_widget)
         plot = self.graph.plot_widget
@@ -88,9 +88,10 @@ class OWScatterPlot(OWWidget):
         self.__timer = QTimer(self, interval=1200)
         self.__timer.timeout.connect(self.add_data)
 
-        common_options = {"labelWidth": 50, "orientation": "horizontal",
-                          "sendSelectedValue": True, "valueType": str}
-        box = gui.widgetBox(self.controlArea, "Axis Data")
+        common_options = dict(
+            labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True,
+            valueType=str)
+        box = gui.vBox(self.controlArea, "Axis Data")
         self.cb_attr_x = gui.comboBox(box, self, "attr_x", label="Axis x:",
                                       callback=self.update_attr,
                                       **common_options)
@@ -99,7 +100,7 @@ class OWScatterPlot(OWWidget):
                                       **common_options)
 
         self.vizrank = self.VizRank(self)
-        vizrank_box = gui.widgetBox(box, None, orientation='horizontal')
+        vizrank_box = gui.hBox(box)
         gui.separator(vizrank_box, width=common_options["labelWidth"])
         self.vizrank_button = gui.button(
             vizrank_box, self, "Rank projections", callback=self.vizrank.reshow,
@@ -121,7 +122,7 @@ class OWScatterPlot(OWWidget):
             callback=self.switch_sampling, commit=lambda: self.add_data(1))
         self.sampling.setVisible(False)
 
-        box = gui.widgetBox(self.controlArea, "Points")
+        box = gui.vBox(self.controlArea, "Points")
         self.cb_attr_color = gui.comboBox(
             box, self, "graph.attr_color", label="Color:",
             emptyString="(Same color)", callback=self.update_colors,
@@ -142,7 +143,7 @@ class OWScatterPlot(OWWidget):
         g = self.graph.gui
         box2 = g.point_properties_box(self.controlArea, box)
 
-        box = gui.widgetBox(self.controlArea, "Plot Properties")
+        box = gui.vBox(self.controlArea, "Plot Properties")
         g.add_widgets([g.ShowLegend, g.ShowGridLines], box)
         gui.checkBox(box, self, value='graph.tooltip_shows_all',
                      label='Show all data on mouse hover')
@@ -151,7 +152,7 @@ class OWScatterPlot(OWWidget):
             callback=self.update_density)
 
         self.zoom_select_toolbar = g.zoom_select_toolbar(
-            gui.widgetBox(self.controlArea, "Zoom/Select"), nomargin=True,
+            gui.vBox(self.controlArea, "Zoom/Select"), nomargin=True,
             buttons=[g.StateButtonsBegin, g.SimpleSelect, g.Pan, g.Zoom,
                      g.StateButtonsEnd, g.ZoomReset]
         )

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -71,7 +71,7 @@ class OWVennDiagram(widget.OWWidget):
         self.itemsets = OrderedDict()
 
         # GUI
-        box = gui.widgetBox(self.controlArea, "Info")
+        box = gui.vBox(self.controlArea, "Info")
         self.info = gui.widgetLabel(box, "No data on input\n")
 
         self.identifiersBox = gui.radioButtonsInBox(
@@ -91,8 +91,8 @@ class OWVennDiagram(widget.OWWidget):
         self.inputsBox.setEnabled(bool(self.useidentifiers))
 
         for i in range(5):
-            box = gui.widgetBox(self.inputsBox, "Data set #%i" % (i + 1),
-                                addSpace=False)
+            box = gui.vBox(self.inputsBox, "Data set #%i" % (i + 1),
+                           addSpace=False)
             box.setFlat(True)
             model = itemmodels.VariableListModel(parent=self)
             cb = QComboBox(
@@ -107,7 +107,7 @@ class OWVennDiagram(widget.OWWidget):
 
         gui.rubber(self.controlArea)
 
-        box = gui.widgetBox(self.controlArea, "Output")
+        box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "output_duplicates", "Output duplicates",
                      callback=lambda: self.commit())
         gui.auto_commit(box, self, "autocommit", "Commit", box=False)

--- a/Orange/widgets/visualize/owviswidget.py
+++ b/Orange/widgets/visualize/owviswidget.py
@@ -66,7 +66,7 @@ class OWVisWidget(OWWidget):
 
     #noinspection PyAttributeOutsideInit
     def add_shown_attributes(self, parent):
-        self.shown_attributes_area = gui.widgetBox(parent, " Shown attributes ")
+        self.shown_attributes_area = gui.vBox(parent, " Shown attributes ")
         self.shown_attributes_listbox = gui.listBox(
             self.shown_attributes_area, self, "selected_shown", "_shown_attributes",
             dragDropCallback=self.trigger_attributes_changed,
@@ -74,11 +74,12 @@ class OWVisWidget(OWWidget):
 
     #noinspection PyAttributeOutsideInit
     def add_hidden_attributes(self, parent):
-        self.hidden_attributes_area = gui.widgetBox(parent, " Hidden attributes ")
-        self.hidden_attributes_listbox = gui.listBox(self.hidden_attributes_area, self, "selected_hidden",
-                                                     "_hidden_attributes",
-                                                     dragDropCallback=self.trigger_attributes_changed,
-                                                     enableDragDrop=True, selectionMode=QListWidget.ExtendedSelection)
+        self.hidden_attributes_area = gui.vBox(parent, " Hidden attributes ")
+        self.hidden_attributes_listbox = gui.listBox(
+            self.hidden_attributes_area, self, "selected_hidden",
+            "_hidden_attributes",
+            dragDropCallback=self.trigger_attributes_changed,
+            enableDragDrop=True, selectionMode=QListWidget.ExtendedSelection)
 
     def get_data_domain(self):
         if hasattr(self, "data") and self.data:

--- a/doc/development/source/code/owNumber.py
+++ b/doc/development/source/code/owNumber.py
@@ -1,7 +1,6 @@
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
 from PyQt4.QtGui import QIntValidator
-from Orange.widgets.widget import OutputSignal
 
 
 class OWWidgetNumber(widget.OWWidget):
@@ -24,7 +23,7 @@ class OWWidgetNumber(widget.OWWidget):
         super().__init__()
 
         gui.lineEdit(self.controlArea, self, "number", "Enter a number",
-                     orientation="horizontal", box="Number",
+                     box="Number",
                      callback=self.number_changed,
                      valueType=int, validator=QIntValidator())
         self.number_changed()

--- a/doc/development/source/tutorial.rst
+++ b/doc/development/source/tutorial.rst
@@ -52,7 +52,6 @@ We will start with a very simple example. A widget that will output
 a single integer specified by the user.
 
 .. code-block:: python
-
     from Orange.widgets import widget, gui
 
     class IntNumber(widget.OWWidget):
@@ -108,11 +107,11 @@ widget functionality:
 
 .. code-block:: python
 
-       def __init__(self) 
+       def __init__(self)
            super().__init__()
 
            gui.lineEdit(self.controlArea, self, "number", "Enter a number",
-                        orientation="horizontal", box="Number",
+                        box="Number",
                         callback=self.number_changed,
                         valueType=int, validator=QIntValidator())
            self.number_changed()


### PR DESCRIPTION
Some of us have endured `"horizontal"` and `"vertical"` for more than a decade. I've had enough.

Let us use `Qt.Horizontal` and `Qt.Vertical` instead. This requires an additional import unless `Qt` is already imported, but that's cheap. String literals still work, but I still volunteer to patch all widgets. (Happy rebasing, everybody.)

@kernc, @astaric, please agree.