### PR TITLE
[FIX] Feature constructor Python 3.5 ast support

### DIFF
--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -119,14 +119,25 @@ class TestTools(unittest.TestCase):
         self.assertEqual(freevars_("{a, b}"), ["a", "b"])
         self.assertEqual(freevars_("0 if abs(a) < 0.1 else b", ["abs"]),
                          ["a", "b"])
+        self.assertEqual(freevars_("lambda a: b + 1"), ["b"])
+        self.assertEqual(freevars_("lambda a: b + 1", ["b"]), [])
+        self.assertEqual(freevars_("lambda a: a + 1"), [])
+        self.assertEqual(freevars_("(lambda a: a + 1)(a)"), ["a"])
+        self.assertEqual(freevars_("lambda a, *arg: arg + (a,)"), [])
+        self.assertEqual(freevars_("lambda a, *arg, **kwargs: arg + (a,)"), [])
+
+        self.assertEqual(freevars_("[a for a in b]"), ["b"])
+        self.assertEqual(freevars_("[1 + a for c in b if c]"), ["a", "b"])
+        self.assertEqual(freevars_("{a for _ in [] if b}"), ["a", "b"])
+        self.assertEqual(freevars_("{a for _ in [] if b}", ["a", "b"]), [])
 
     def test_validate_exp(self):
 
         stmt = ast.parse("1", mode="single")
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             validate_exp(stmt)
         suite = ast.parse("a; b", mode="exec")
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             validate_exp(suite)
 
         def validate_(source):


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
* Fix an error in Feature Constructor widget due to a change in Python 3.5 ast (`AttributeError: 'Call' object has no attribute 'starargs'`)
* Add tests
* Some other minor fixes and code cleanup