### PR TITLE
[FIX] Disable bsp index on the main canvas scene

### DIFF
--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -359,6 +359,7 @@ class SchemeEditWidget(QWidget):
         layout.setSpacing(0)
 
         scene = CanvasScene()
+        scene.setItemIndexMethod(CanvasScene.NoIndex)
         self.__setupScene(scene)
 
         view = CanvasView(scene)


### PR DESCRIPTION
A workaround for a segfault in `QGraphicsSceneFindItemBspTreeVisitor::visit`