### PR TITLE
canvas: Disable bsp index on the main canvas scene Pt2

### DIFF
--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -630,6 +630,7 @@ class SchemeEditWidget(QWidget):
             self.__undoStack.clear()
 
             self.__scene = CanvasScene()
+            self.__scene.setItemIndexMethod(CanvasScene.NoIndex)
             self.__setupScene(self.__scene)
 
             self.__view.setScene(self.__scene)


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

A workaround for a segfault in `QGraphicsSceneFindItemBspTreeVisitor::visit`

Continues from biolab/orange3@c7f138083948aaf9941795340d505dfa82845fdf

This time for the *actuall* scene instance that is used.