### PR TITLE
[ENH] OWFile: Open dragged files

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -193,6 +193,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         # explicitly re-enters the event loop (by a progress bar)
         QtCore.QTimer.singleShot(0, self.load_data)
 
+        self.setAcceptDrops(True)
+
     def reload(self):
         if self.recent_paths:
             basename = self.file_combo.currentText()
@@ -404,6 +406,23 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         self.report_data("Data", self.data)
 
+    def dragEnterEvent(self, event):
+        """Accept drops of valid file urls"""
+        urls = event.mimeData().urls()
+        if urls:
+            try:
+                FileFormat.get_reader(urls[0].toLocalFile())
+                event.acceptProposedAction()
+            except IOError:
+                pass
+
+    def dropEvent(self, event):
+        """Handle file drops"""
+        urls = event.mimeData().urls()
+        if urls:
+            self.add_path(urls[0].toLocalFile())  # add first file
+            self.source = self.LOCAL_FILE
+            self.load_data()
 
 if __name__ == "__main__":
     import sys

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -1,0 +1,64 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from os import path
+from unittest.mock import Mock
+
+from PyQt4.QtCore import QMimeData, QPoint, Qt, QUrl
+from PyQt4.QtGui import QDragEnterEvent, QDropEvent
+
+import Orange
+from Orange.widgets.data.owfile import OWFile
+from Orange.widgets.tests.base import GuiTest
+
+TITANIC_URL = path.join(path.dirname(Orange.__file__), 'datasets', 'titanic.tab')
+
+
+class TestOWFile(GuiTest):
+    def setUp(self):
+        self.widget = OWFile()
+        self.event_data = None
+
+    def test_dragEnterEvent_accepts_urls(self):
+        event = self._drag_enter_event(TITANIC_URL)
+        self.widget.dragEnterEvent(event)
+        self.assertTrue(event.isAccepted())
+
+    def test_dragEnterEvent_skips_osx_file_references(self):
+        event = self._drag_enter_event('/.file/id=12345')
+        self.widget.dragEnterEvent(event)
+        self.assertFalse(event.isAccepted())
+
+    def test_dragEnterEvent_skips_usupported_files(self):
+        event = self._drag_enter_event('file.unsupported')
+        self.widget.dragEnterEvent(event)
+        self.assertFalse(event.isAccepted())
+
+    def _drag_enter_event(self, url):
+        # make sure data does not get garbage collected before it used
+        self.event_data = data = QMimeData()
+        data.setUrls([QUrl(url)])
+        return QDragEnterEvent(
+            QPoint(0, 0), Qt.MoveAction, data,
+            Qt.NoButton, Qt.NoModifier)
+
+    def test_dropEvent_selects_file(self):
+        self.widget.load_data = Mock()
+        self.widget.source = OWFile.URL
+
+        event = self._drop_event(TITANIC_URL)
+        self.widget.dropEvent(event)
+
+        self.assertEqual(self.widget.source, OWFile.LOCAL_FILE)
+        self.assertEqual(self.widget.last_path(), TITANIC_URL)
+        self.widget.load_data.assert_called_with()
+
+    def _drop_event(self, url):
+        # make sure data does not get garbage collected before it used
+        self.event_data = data = QMimeData()
+        data.setUrls([QUrl(url)])
+
+        return QDropEvent(
+            QPoint(0, 0), Qt.MoveAction, data,
+            Qt.NoButton, Qt.NoModifier, QDropEvent.Drop)
+
+


### PR DESCRIPTION
Allow files to be opened by dragging them to OWFile window. 

Does not work on OSX10.10+ with Qt4 (see https://bugreports.qt.io/browse/QTBUG-40449).
When applied on top of #1171, it should work as expected.

Could use some testing on other platforms.