### PR TITLE
Refactor data.io

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -267,6 +267,44 @@ class FileFormat(metaclass=FileFormatMeta):
     def write(cls, filename, data):
         return cls.write_file(filename, data)
 
+    @classmethod
+    def locate(cls, filename, search_dirs=('.',)):
+        """Locate a file with given filename that can be opened by one
+        of the available readers.
+
+        Parameters
+        ----------
+        filename : str
+        search_dirs : Iterable[str]
+
+        Returns
+        -------
+        str
+            Absolute path to the file
+        """
+        if path.exists(filename):
+            return filename
+
+        for directory in search_dirs:
+            absolute_filename = path.join(directory, filename)
+            if path.exists(absolute_filename):
+                break
+            for ext in cls.readers:
+                if filename.endswith(ext):
+                    break
+                if path.exists(absolute_filename + ext):
+                    absolute_filename += ext
+                    break
+            if path.exists(absolute_filename):
+                break
+        else:
+            absolute_filename = ""
+
+        if not path.exists(absolute_filename):
+            raise IOError('File "{}" was not found.'.format(filename))
+
+        return absolute_filename
+
     @staticmethod
     def open(filename, *args, **kwargs):
         """

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -205,8 +205,7 @@ class FileFormat(metaclass=FileFormatMeta):
         DESCRIPTION = 'human-readable file format description'
         SUPPORT_COMPRESSED = False
 
-        @classmethod
-        def read_file(cls, filename, wrapper=_IDENTITY):
+        def read(self):
             ...  # load headers, data, ...
             return wrapper(self.data_table(data, headers))
 
@@ -629,7 +628,9 @@ class FileFormat(metaclass=FileFormatMeta):
                    for var, val in zip(vars, flatten(row))])
 
 
-class CSVFormat(FileFormat):
+class CSVReader(FileFormat):
+    """Reader for comma separated files"""
+
     EXTENSIONS = ('.csv',)
     DESCRIPTION = 'Comma-separated values'
     DELIMITERS = ',;:\t$ '
@@ -686,14 +687,16 @@ class CSVFormat(FileFormat):
             cls.write_data(writer.writerow, data)
 
 
-class TabFormat(CSVFormat):
+class TabReader(CSVReader):
+    """Reader for tab separated files"""
     EXTENSIONS = ('.tab', '.tsv')
     DESCRIPTION = 'Tab-separated values'
     DELIMITERS = '\t'
     PRIORITY = 10
 
 
-class PickleFormat(FileFormat):
+class PickleReader(FileFormat):
+    """Reader for pickled Table objects"""
     EXTENSIONS = ('.pickle', '.pkl')
     DESCRIPTION = 'Pickled Python object file'
 
@@ -707,7 +710,8 @@ class PickleFormat(FileFormat):
             pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
 
 
-class BasketFormat(FileFormat):
+class BasketReader(FileFormat):
+    """Reader for basket (sparse) files"""
     EXTENSIONS = ('.basket', '.bsk')
     DESCRIPTION = 'Basket file'
 
@@ -731,7 +735,8 @@ class BasketFormat(FileFormat):
             domain, attrs and X, classes and Y, metas and meta_attrs)
 
 
-class ExcelFormat(FileFormat):
+class ExcelReader(FileFormat):
+    """Reader for excel files"""
     EXTENSIONS = ('.xls', '.xlsx')
     DESCRIPTION = 'Mircosoft Excel spreadsheet'
 
@@ -767,7 +772,8 @@ class ExcelFormat(FileFormat):
         return self.wrapper(table)
 
 
-class DotFormat(FileFormat):
+class DotReader(FileFormat):
+    """Writer for dot (graph) files"""
     EXTENSIONS = ('.dot', '.gv')
     DESCRIPTION = 'Dot graph description'
     SUPPORT_COMPRESSED = True

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -500,23 +500,8 @@ class Table(MutableSequence, Storage):
         :rtype: Orange.data.Table
         """
         from Orange.data.io import FileFormat
-        for dir in dataset_dirs:
-            absolute_filename = os.path.join(dir, filename)
-            if os.path.exists(absolute_filename):
-                break
-            for ext in FileFormat.readers:
-                if filename.endswith(ext):
-                    break
-                if os.path.exists(absolute_filename + ext):
-                    absolute_filename += ext
-                    break
-            if os.path.exists(absolute_filename):
-                break
-        else:
-            absolute_filename = ext = ""
 
-        if not os.path.exists(absolute_filename):
-            raise IOError('File "{}" was not found.'.format(filename))
+        absolute_filename = FileFormat.locate(filename, dataset_dirs)
         reader = FileFormat.get_reader(absolute_filename)
         if wrapper or cls != Table:
             reader.set_wrapper(wrapper or cls)

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -503,9 +503,9 @@ class Table(MutableSequence, Storage):
 
         absolute_filename = FileFormat.locate(filename, dataset_dirs)
         reader = FileFormat.get_reader(absolute_filename)
-        if wrapper or cls != Table:
-            reader.set_wrapper(wrapper or cls)
         data = reader.read()
+        if wrapper:
+            data = wrapper(data)
         data.name = os.path.splitext(os.path.split(filename)[-1])[0]
         # no need to call _init_ids as fuctions from .io already
         # construct a table with .ids

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -487,7 +487,7 @@ class Table(MutableSequence, Storage):
                     format(desc.lower()))
             else:
                 raise IOError("Unknown file name extension.")
-        writer().write_file(filename, self)
+        writer.write_file(filename, self)
 
     @classmethod
     def from_file(cls, filename, wrapper=None):
@@ -517,7 +517,10 @@ class Table(MutableSequence, Storage):
 
         if not os.path.exists(absolute_filename):
             raise IOError('File "{}" was not found.'.format(filename))
-        data = FileFormat.read(absolute_filename, wrapper or cls)
+        reader = FileFormat.get_reader(absolute_filename)
+        if wrapper or cls != Table:
+            reader.set_wrapper(wrapper or cls)
+        data = reader.read()
         data.name = os.path.splitext(os.path.split(filename)[-1])[0]
         # no need to call _init_ids as fuctions from .io already
         # construct a table with .ids

--- a/Orange/tests/test_basket_reader.py
+++ b/Orange/tests/test_basket_reader.py
@@ -8,7 +8,7 @@ import unittest
 
 import numpy as np
 
-from Orange.data.io import BasketFormat
+from Orange.data.io import BasketReader
 
 
 def with_file(s):
@@ -28,7 +28,7 @@ def with_file(s):
 
 
 def read_basket(filename):
-    return BasketFormat(filename).read()
+    return BasketReader(filename).read()
 
 
 class TestBasketReader(unittest.TestCase):

--- a/Orange/tests/test_basket_reader.py
+++ b/Orange/tests/test_basket_reader.py
@@ -27,11 +27,14 @@ def with_file(s):
     return fle_decorator
 
 
+def read_basket(filename):
+    return BasketFormat(filename).read()
+
 
 class TestBasketReader(unittest.TestCase):
     @with_file("""a=1,b=2,c=3""")
     def test_read_variable_is_value_syntax(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 3)
         self.assertEqual(["a", "b", "c"],
                          list(map(lambda x: x.name, table.domain.variables)))
@@ -40,28 +43,28 @@ class TestBasketReader(unittest.TestCase):
 
     @with_file("""a,b,c,d,e""")
     def test_read_variable_only_syntax(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 5)
         np.testing.assert_almost_equal(table.X.todense(),
                                        np.array([[1, 1, 1, 1, 1]]))
 
     @with_file("""a=1, b=2, c=3""")
     def test_handles_spaces_between_variables(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 3)
         self.assertEqual(set(x for x in table[0]), {1, 2, 3})
 
     @with_file("""a=1, b=2, a=3""")
     def test_handles_duplicate_variables(self, fname):
-        self.assertRaises(ValueError, BasketFormat().read_file, fname)
+        self.assertRaises(ValueError, read_basket, fname)
 
     @with_file("""a, b, b, a, a, c, c, d, e""")
     def test_handles_duplicate_variables2(self, fname):
-        self.assertRaises(ValueError, BasketFormat().read_file, fname)
+        self.assertRaises(ValueError, read_basket, fname)
 
     @with_file("""a=1, b=2\na=1, b=4""")
     def test_variables_can_be_listed_in_any_order(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 2)
         np.testing.assert_almost_equal(table.X.todense(),
                                        np.array([[1, 2], [1, 4]]))
@@ -69,21 +72,21 @@ class TestBasketReader(unittest.TestCase):
 
     @with_file("""a,b\nc,b,a""")
     def test_variables_can_be_listed_in_any_order(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 3)
         np.testing.assert_almost_equal(table.X.todense(),
                                        np.array([[1, 1, 0], [1, 1, 1]]))
 
     @with_file("""č,š,ž""")
     def test_handles_unicode(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 3)
         np.testing.assert_almost_equal(table.X.todense(),
                                        np.array([[1, 1, 1]]))
 
     @with_file("""a=4,"x"=1.0,"y"=2.0,b=5\n"x"=1.0""")
     def test_handles_quote(self, fname):
-        table = BasketFormat().read_file(fname)
+        table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 4)
 
 

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -9,11 +9,11 @@ from unittest.mock import Mock
 import numpy as np
 
 from Orange.data import Table, ContinuousVariable, DiscreteVariable
-from Orange.data.io import TabFormat
+from Orange.data.io import TabReader
 
 
 def read_tab_file(filename):
-    return TabFormat(filename).read()
+    return TabReader(filename).read()
 
 
 class TestTabReader(unittest.TestCase):
@@ -67,7 +67,7 @@ class TestTabReader(unittest.TestCase):
         self.assertEqual(c1.attributes, {'x': 'a longer string'})
         outf = io.StringIO()
         outf.close = lambda: None
-        TabFormat.write_file(outf, table)
+        TabReader.write_file(outf, table)
         saved = outf.getvalue()
 
         file = io.StringIO(saved)
@@ -140,7 +140,7 @@ class TestTabReader(unittest.TestCase):
     def test_wrapper(self):
         wrapper = Mock()
         file1 = io.StringIO("\n".join("xd dbac"))
-        reader = TabFormat(file1)
+        reader = TabReader(file1)
         reader.set_wrapper(wrapper)
         reader.read()
 
@@ -148,6 +148,6 @@ class TestTabReader(unittest.TestCase):
 
     def test_sheets(self):
         file1 = io.StringIO("\n".join("xd dbac"))
-        reader = TabFormat(file1)
+        reader = TabReader(file1)
 
         self.assertEqual(reader.sheets, ())

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -4,11 +4,16 @@
 import io
 from os import path
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
 
 from Orange.data import Table, ContinuousVariable, DiscreteVariable
 from Orange.data.io import TabFormat
+
+
+def read_tab_file(filename):
+    return TabFormat(filename).read()
 
 
 class TestTabReader(unittest.TestCase):
@@ -27,7 +32,7 @@ class TestTabReader(unittest.TestCase):
         """
 
         file = io.StringIO(simplefile)
-        table = TabFormat().read_file(file)
+        table = read_tab_file(file)
 
         f1, f2, c1, c2 = table.domain
         self.assertIsInstance(f1, DiscreteVariable)
@@ -50,7 +55,7 @@ class TestTabReader(unittest.TestCase):
         1.0      \tM        \t5      \trich
         """
         file = io.StringIO(samplefile)
-        table = TabFormat().read_file(file)
+        table = read_tab_file(file)
 
         f1, f2, c1, c2 = table.domain.variables
         self.assertIsInstance(f2, DiscreteVariable)
@@ -66,7 +71,7 @@ class TestTabReader(unittest.TestCase):
         saved = outf.getvalue()
 
         file = io.StringIO(saved)
-        table = TabFormat().read_file(file)
+        table = read_tab_file(file)
 
         f1, f2, c1, c2 = table.domain.variables
         self.assertIsInstance(f2, DiscreteVariable)
@@ -84,7 +89,7 @@ class TestTabReader(unittest.TestCase):
         1.1\t1.2\t1.5
         """
         file = io.StringIO(samplefile)
-        table = TabFormat().read_file(file)
+        table = read_tab_file(file)
 
         self.assertEqual(len(table), 2)
         self.assertEqual(len(table.domain), 3)
@@ -96,7 +101,7 @@ class TestTabReader(unittest.TestCase):
         1.1\t1.2\t1.5
         """
         file = io.StringIO(samplefile)
-        table = TabFormat().read_file(file)
+        table = read_tab_file(file)
 
         self.assertEqual(len(table), 2)
         self.assertEqual(len(table.domain), 3)
@@ -105,13 +110,13 @@ class TestTabReader(unittest.TestCase):
 
     def test_reuse_variables(self):
         file1 = io.StringIO("\n".join("xd dbac"))
-        t1 = TabFormat().read_file(file1)
+        t1 = read_tab_file(file1)
 
         self.assertSequenceEqual(t1.domain['x'].values, 'abcd')
         np.testing.assert_almost_equal(t1.X.ravel(), [3, 1, 0, 2])
 
         file2 = io.StringIO("\n".join("xd hgacb"))
-        t2 = TabFormat().read_file(file2)
+        t2 = read_tab_file(file2)
 
         self.assertSequenceEqual(t2.domain['x'].values, 'abcdgh')
         np.testing.assert_almost_equal(t2.X.ravel(), [5, 4, 0, 2, 1])
@@ -131,3 +136,12 @@ class TestTabReader(unittest.TestCase):
             Replicate=['1', '2'],
         )
         self.assertEqual(data.domain[0].attributes, ATTRIBUTES)
+
+    def test_wrapper(self):
+        wrapper = Mock()
+        file1 = io.StringIO("\n".join("xd dbac"))
+        reader = TabFormat(file1)
+        reader.set_wrapper(wrapper)
+        reader.read()
+
+        self.assertEqual(wrapper.call_count, 1)

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -145,3 +145,9 @@ class TestTabReader(unittest.TestCase):
         reader.read()
 
         self.assertEqual(wrapper.call_count, 1)
+
+    def test_sheets(self):
+        file1 = io.StringIO("\n".join("xd dbac"))
+        reader = TabFormat(file1)
+
+        self.assertEqual(reader.sheets, ())

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -137,15 +137,6 @@ class TestTabReader(unittest.TestCase):
         )
         self.assertEqual(data.domain[0].attributes, ATTRIBUTES)
 
-    def test_wrapper(self):
-        wrapper = Mock()
-        file1 = io.StringIO("\n".join("xd dbac"))
-        reader = TabReader(file1)
-        reader.set_wrapper(wrapper)
-        reader.read()
-
-        self.assertEqual(wrapper.call_count, 1)
-
     def test_sheets(self):
         file1 = io.StringIO("\n".join("xd dbac"))
         reader = TabReader(file1)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -32,7 +32,8 @@ def assert_array_nanequal(*args, **kwargs):
 class TableTestCase(unittest.TestCase):
     def setUp(self):
         Variable._clear_all_caches()
-        data.table.dataset_dirs.append("Orange/tests")
+        test_dir = os.path.dirname(__file__)
+        data.table.dataset_dirs.append(test_dir)
 
     def test_indexing_class(self):
         d = data.Table("test1")
@@ -1256,27 +1257,17 @@ class CreateTableWithFilename(TableTests):
     filename = "data.tab"
 
     @patch("os.path.exists", Mock(return_value=True))
-    @patch("Orange.data.io.TabFormat")
-    def test_read_data_calls_reader(self, reader_mock):
-        table_mock = Mock(data.Table)
-        reader_instance = reader_mock.return_value = \
-            Mock(read_file=Mock(return_value=table_mock))
-
-        table = data.Table.from_file(self.filename)
-
-        reader_instance.read_file.assert_called_with(self.filename, data.Table)
-        self.assertEqual(table, table_mock)
-
-    @patch("os.path.exists", Mock(return_value=True))
     def test_read_data_calls_reader(self):
         table_mock = Mock(data.Table)
-        reader_instance = Mock(read_file=Mock(return_value=table_mock))
+        reader_instance = Mock(read=Mock(return_value=table_mock))
+        reader_mock = Mock(return_value=reader_instance)
 
         with patch.dict(data.io.FileFormat.readers,
-                        {'.xlsx': reader_instance}):
+                        {'.xlsx': reader_mock}):
             table = data.Table.from_file("test.xlsx")
 
-        reader_instance.read_file.assert_called_with("test.xlsx", data.Table)
+        reader_mock.assert_called_with("test.xlsx")
+        reader_instance.read.assert_called_with()
         self.assertEqual(table, table_mock)
 
     @patch("os.path.exists", Mock(return_value=False))

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1317,7 +1317,7 @@ a\tb\tc
 
     urlopen = _MockUrlOpen()
 
-    @patch('Orange.data.table.urlopen', urlopen)
+    @patch('Orange.data.io.urlopen', urlopen)
     def test_google_sheets(self):
         d = data.Table(self.urlopen.url)
         self.urlopen.assert_called_with('https://docs.google.com/spreadsheets/d/ABCD/export?format=tsv',

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -50,7 +50,7 @@ class TestTabReader(unittest.TestCase):
         try:
             file.write(s)
             file.close()
-            table = CSVFormat().read_file(filename)
+            table = CSVFormat(filename).read()
 
             f1, f2, f3 = table.domain
             self.assertIsInstance(f1, DiscreteVariable)
@@ -85,5 +85,5 @@ class TestTabReader(unittest.TestCase):
         file.write(noncont_marked_cont)
         file.close()
         with self.assertRaises(ValueError) as cm:
-            table = CSVFormat().read_file(file.name)
+            table = CSVFormat(file.name).read()
         self.assertIn('line 5, column 2', cm.exception.args[0])

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -10,7 +10,7 @@ from io import StringIO
 import numpy as np
 
 from Orange.data import Table, ContinuousVariable, DiscreteVariable
-from Orange.data.io import CSVFormat
+from Orange.data.io import CSVReader
 
 tab_file = """\
 Feature 1\tFeature 2\tFeature 3
@@ -50,7 +50,7 @@ class TestTabReader(unittest.TestCase):
         try:
             file.write(s)
             file.close()
-            table = CSVFormat(filename).read()
+            table = CSVReader(filename).read()
 
             f1, f2, f3 = table.domain
             self.assertIsInstance(f1, DiscreteVariable)
@@ -85,5 +85,5 @@ class TestTabReader(unittest.TestCase):
         file.write(noncont_marked_cont)
         file.close()
         with self.assertRaises(ValueError) as cm:
-            table = CSVFormat(file.name).read()
+            table = CSVReader(file.name).read()
         self.assertIn('line 5, column 2', cm.exception.args[0])

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -315,7 +315,7 @@ time,continuous
         for stream in (output_csv, input_csv):
             stream.close = lambda: None  # HACK: Prevent closing of streams
 
-        table = CSVFormat.read_file(input_csv)
+        table = CSVFormat(input_csv).read()
         self.assertIsInstance(table.domain['Date'], TimeVariable)
         self.assertEqual(table[0, 'Date'], '1920-12-12')
         # Dates before 1970 are negative

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -11,7 +11,7 @@ import numpy as np
 from Orange.testing import create_pickling_tests
 from Orange.data import Variable, ContinuousVariable, DiscreteVariable, \
     StringVariable, TimeVariable, Unknown, Value
-from Orange.data.io import CSVFormat
+from Orange.data.io import CSVReader
 
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
@@ -315,13 +315,13 @@ time,continuous
         for stream in (output_csv, input_csv):
             stream.close = lambda: None  # HACK: Prevent closing of streams
 
-        table = CSVFormat(input_csv).read()
+        table = CSVReader(input_csv).read()
         self.assertIsInstance(table.domain['Date'], TimeVariable)
         self.assertEqual(table[0, 'Date'], '1920-12-12')
         # Dates before 1970 are negative
         self.assertTrue(all(inst['Date'] < 0 for inst in table))
 
-        CSVFormat.write_file(output_csv, table)
+        CSVReader.write_file(output_csv, table)
         self.assertEqual(input_csv.getvalue().splitlines(),
                          output_csv.getvalue().splitlines())
 

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -14,7 +14,7 @@ def get_dataset(name):
 
 
 def read_file(name):
-    return io.ExcelFormat(get_dataset(name)).read()
+    return io.ExcelReader(get_dataset(name)).read()
 
 
 class TestExcelHeader0(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestExcelHeader0(unittest.TestCase):
 
 class TextExcelSheets(unittest.TestCase):
     def setUp(self):
-        self.reader = io.ExcelFormat(get_dataset("header_0_sheet.xlsx"))
+        self.reader = io.ExcelReader(get_dataset("header_0_sheet.xlsx"))
 
     def test_sheets(self):
         self.assertSequenceEqual(self.reader.sheets,

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -34,11 +34,16 @@ class TestExcelHeader0(unittest.TestCase):
 
 
 class TextExcelSheets(unittest.TestCase):
-    def test_named_sheet(self):
+    def setUp(self):
+        self.reader = io.ExcelFormat(get_dataset("header_0_sheet.xlsx"))
 
-        reader = io.ExcelFormat(get_dataset("header_0_sheet.xlsx"))
-        reader.set_sheet("my_sheet")
-        table = reader.read()
+    def test_sheets(self):
+        self.assertSequenceEqual(self.reader.sheets,
+                                 ["Sheet1", "my_sheet", "Sheet3"])
+
+    def test_named_sheet(self):
+        self.reader.select_sheet("my_sheet")
+        table = self.reader.read()
         self.assertEqual(len(table.domain.attributes), 4)
 
 

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -9,9 +9,12 @@ import numpy as np
 from Orange.data import io, ContinuousVariable, DiscreteVariable, StringVariable
 
 
+def get_dataset(name):
+    return os.path.join(os.path.dirname(__file__), "xlsx_files", name)
+
+
 def read_file(name):
-    return io.ExcelFormat().read_file(
-        os.path.join(os.path.dirname(__file__), "xlsx_files", name))
+    return io.ExcelFormat(get_dataset(name)).read()
 
 
 class TestExcelHeader0(unittest.TestCase):
@@ -32,7 +35,10 @@ class TestExcelHeader0(unittest.TestCase):
 
 class TextExcelSheets(unittest.TestCase):
     def test_named_sheet(self):
-        table = read_file("header_0_sheet.xlsx:my_sheet")
+
+        reader = io.ExcelFormat(get_dataset("header_0_sheet.xlsx"))
+        reader.set_sheet("my_sheet")
+        table = reader.read()
         self.assertEqual(len(table.domain.attributes), 4)
 
 

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -9,7 +9,7 @@ from Orange.widgets.settings import Setting, ContextHandler, ContextSetting
 from Orange.widgets.utils.itemmodels import PyListModel
 from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
 from Orange.data.table import Table, get_sample_datasets_dir
-from Orange.data.io import FileFormat, ExcelFormat
+from Orange.data.io import FileFormat, ExcelReader
 
 # Backward compatibility: class RecentPath used to be defined in this module,
 # and it is used in saved (pickled) settings. It must be imported into the
@@ -290,7 +290,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
                                  .format(filename))
 
             reader = FileFormat.get_reader(filename)
-            if isinstance(reader, ExcelFormat):
+            if isinstance(reader, ExcelReader):
                 reader.select_sheet(self.xls_sheet)
             try:
                 return load(lambda x: reader.read(), filename)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -267,10 +267,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
     @staticmethod
     def is_multisheet_excel(fn):
-        try:
-            return open_workbook(fn).nsheets > 1
-        except XLRDError:
-            return False
+        return len(FileFormat.get_reader(fn).sheets) > 0
 
     # Open a file, create data from it and send it over the data channel
     def load_data(self):
@@ -282,22 +279,21 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             return data, fn
 
         def load_from_file():
-            fn = self.last_path()
-            if not fn:
+            filename = self.last_path()
+            if not filename:
                 return None, ""
-            if not os.path.exists(fn):
-                dir_name, basename = os.path.split(fn)
-                if os.path.exists(os.path.join(".", basename)):
-                    fn = os.path.join(".", basename)
-                    self.information("Loading '{}' from the current directory."
-                                     .format(basename))
-            if self.is_multisheet_excel(fn):
-                data = ExcelFormat.read_file(fn + ':' + self.xls_sheet)
-                if data:
-                    return data, fn
 
+            if not os.path.exists(filename):
+                filename = os.path.basename(filename)
+                filename = FileFormat.locate(filename, "")
+                self.information("Loading '{}' from the current directory."
+                                 .format(filename))
+
+            reader = FileFormat.get_reader(filename)
+            if isinstance(reader, ExcelFormat):
+                reader.select_sheet(self.xls_sheet)
             try:
-                return load(Table.from_file, fn)
+                return load(lambda x: reader.read(), filename)
             except Exception as exc:
                 self.warnings.setText(str(exc))
                 # Let us not remove from recent files: user may fix them

--- a/Orange/widgets/tests/test_io.py
+++ b/Orange/widgets/tests/test_io.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 from Orange.data import Table
-from Orange.data.io import CSVFormat
+from Orange.data.io import CSVReader
 
 
 class IOFileFormatTest(unittest.TestCase):
@@ -11,7 +11,7 @@ class IOFileFormatTest(unittest.TestCase):
         os.remove(self.CSV_FILE)
 
     def test_csv_format_missing_values(self):
-        f = CSVFormat()
+        f = CSVReader()
         data = Table("../../tests/test9.tab")
         self.assertTrue(any([x is "" for instance in
                              data.metas for x in instance]))


### PR DESCRIPTION
Current singleton implementation of file readers/writers is hard to extend when additional features are needed (such as selecting sheet for excel files and overwriting header in #1012).

This PR replaces
    FileFormat.read(filename)
with
    FileFormat.get_reader(filename).read()

The new way enables us to set additional properties on reader before the read method is called.