### PR TITLE
Reduce count of false positive lint warnings in tests

### DIFF
--- a/Orange/tests/sql/test_filter.py
+++ b/Orange/tests/sql/test_filter.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from Orange.data.sql.table import SqlTable, SqlRowInstance
 from Orange.data import filter, domain

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 from Orange.data import Table

--- a/Orange/tests/test_basket_reader.py
+++ b/Orange/tests/test_basket_reader.py
@@ -1,4 +1,6 @@
-# coding=utf-8
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import io
 import functools
 import os, tempfile

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import inspect
 import pickle
 import pkgutil

--- a/Orange/tests/test_clustering_dbscan.py
+++ b/Orange/tests/test_clustering_dbscan.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import Orange

--- a/Orange/tests/test_clustering_hierarchical.py
+++ b/Orange/tests/test_clustering_hierarchical.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from itertools import chain, tee
 

--- a/Orange/tests/test_clustering_kmeans.py
+++ b/Orange/tests/test_clustering_kmeans.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import Orange

--- a/Orange/tests/test_color.py
+++ b/Orange/tests/test_color.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_contingency.py
+++ b/Orange/tests/test_contingency.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from unittest.mock import Mock
 

--- a/Orange/tests/test_continuize.py
+++ b/Orange/tests/test_continuize.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 from Orange.data import Table, Variable

--- a/Orange/tests/test_cur.py
+++ b/Orange/tests/test_cur.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 import scipy.sparse.linalg as sla

--- a/Orange/tests/test_datasets.py
+++ b/Orange/tests/test_datasets.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import os

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import random
 from unittest import TestCase
 from unittest.mock import Mock

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 from unittest import TestCase
 import pickle
 

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from unittest.mock import Mock
 

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 from time import time
 from numbers import Real
 from itertools import starmap

--- a/Orange/tests/test_elliptic_envelope.py
+++ b/Orange/tests/test_elliptic_envelope.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_evaluation_clustering.py
+++ b/Orange/tests/test_evaluation_clustering.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_evaluation_scoring.py
+++ b/Orange/tests/test_evaluation_scoring.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 import Orange

--- a/Orange/tests/test_fss.py
+++ b/Orange/tests/test_fss.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_impute.py
+++ b/Orange/tests/test_impute.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from functools import reduce
 import numpy as np

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 from math import isnan
 import warnings
 import unittest

--- a/Orange/tests/test_knn.py
+++ b/Orange/tests/test_knn.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_linear_bfgs_regression.py
+++ b/Orange/tests/test_linear_bfgs_regression.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 from Orange.data import Table

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 from Orange.data import Table

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 

--- a/Orange/tests/test_majority.py
+++ b/Orange/tests/test_majority.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_manifold.py
+++ b/Orange/tests/test_manifold.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 

--- a/Orange/tests/test_mean.py
+++ b/Orange/tests/test_mean.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import Orange

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 from Orange.data import Table

--- a/Orange/tests/test_pca.py
+++ b/Orange/tests/test_pca.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import pickle
 import numpy as np

--- a/Orange/tests/test_polynomial_learner.py
+++ b/Orange/tests/test_polynomial_learner.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from unittest.mock import Mock, MagicMock, patch
 import numpy as np

--- a/Orange/tests/test_preprocess_cur.py
+++ b/Orange/tests/test_preprocess_cur.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 from Orange.data import Table

--- a/Orange/tests/test_preprocess_pca.py
+++ b/Orange/tests/test_preprocess_pca.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 from Orange.data import Table

--- a/Orange/tests/test_random_forest.py
+++ b/Orange/tests/test_random_forest.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 from Orange.data import Table

--- a/Orange/tests/test_randomize.py
+++ b/Orange/tests/test_randomize.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_regression.py
+++ b/Orange/tests/test_regression.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import inspect
 import pkgutil

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_sgd.py
+++ b/Orange/tests/test_sgd.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_simple_random_forest.py
+++ b/Orange/tests/test_simple_random_forest.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import numpy as np
 import Orange

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import pickle
 

--- a/Orange/tests/test_softmax_regression.py
+++ b/Orange/tests/test_softmax_regression.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 from Orange.data import Table

--- a/Orange/tests/test_sparse_reader.py
+++ b/Orange/tests/test_sparse_reader.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import os
 import tempfile
 import unittest

--- a/Orange/tests/test_sparse_table.py
+++ b/Orange/tests/test_sparse_table.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 from scipy.sparse import csr_matrix
 
 from Orange import data

--- a/Orange/tests/test_svm.py
+++ b/Orange/tests/test_svm.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import io
 from os import path
 import unittest

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import os
 import unittest
 from itertools import chain

--- a/Orange/tests/test_tree.py
+++ b/Orange/tests/test_tree.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 
 import numpy as np

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 from tempfile import NamedTemporaryFile
 import os

--- a/Orange/tests/test_value.py
+++ b/Orange/tests/test_value.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import pickle
 import unittest
 

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import math
 import unittest
 import pickle

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -1,3 +1,6 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
 import unittest
 import os
 

--- a/pylintrc
+++ b/pylintrc
@@ -208,7 +208,8 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-zA-Z0-9_]{2,30}$
+# TODO: find a better way to allow long method names in test classes.
+method-rgx=[a-z_][a-zA-Z0-9_]{2,80}$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-zA-Z0-9_]{2,30}$


### PR DESCRIPTION
Disable required docstring for test modules that contain classes with descriptive method names.