### PR TITLE
[FIX] Transformation: fix a bug in nested transformation of instance

### DIFF
--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -38,7 +38,7 @@ class Transformation:
         else:
             data = data.get_column_view(self.attr_index)[0]
         transformed = self.transform(data)
-        if inst and isinstance(transformed, np.ndarray):
+        if inst and isinstance(transformed, np.ndarray) and transformed.shape:
             transformed = transformed[0]
         return transformed
 

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -14,6 +14,7 @@ class LogisticRegressionTest(unittest.TestCase):
     def setUpClass(cls):
         cls.iris = Table('iris')
         cls.voting = Table('voting')
+        cls.zoo = Table('zoo')
 
     def test_LogisticRegression(self):
         learn = LogisticRegressionLearner()
@@ -70,3 +71,10 @@ class LogisticRegressionTest(unittest.TestCase):
         model = learn(self.voting)
         coef = model.coefficients
         self.assertEqual(len(coef[0]), len(model.domain.attributes))
+
+    def test_predict_on_instance(self):
+        lr = LogisticRegressionLearner()
+        m = lr(self.zoo)
+        probs = m(self.zoo[50], m.Probs)
+        probs2 = m(self.zoo[50, :], m.Probs)
+        np.testing.assert_almost_equal(probs, probs2)


### PR DESCRIPTION
Transformation.transform can sometimes return 0d ndarray.
    
This happens for instance in ReplaceUnknowns, when np.where is called on a Float value (produced by a nested call of compute_value).