### PR TITLE
Manually specify plugins path

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -43,6 +43,9 @@ def init():
     QCoreApplication.setApplicationName("Orange Canvas")
     QCoreApplication.setApplicationVersion(version)
     QSettings.setDefaultFormat(QSettings.IniFormat)
+    
+    # Hack to make sure the correct plugin search path is added. (Github issue #1143)
+    QCoreApplication.addLibraryPath('./Lib/site-packages/PyQt4/plugins')
 
     # Make it a null op.
     global init

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -5,6 +5,7 @@ Orange Canvas Configuration
 
 import os
 import sys
+import site
 import logging
 import pickle as pickle
 import itertools
@@ -45,7 +46,9 @@ def init():
     QSettings.setDefaultFormat(QSettings.IniFormat)
     
     # Hack to make sure the correct plugin search path is added. (Github issue #1143)
-    QCoreApplication.addLibraryPath('./Lib/site-packages/PyQt4/plugins')
+    for path in site.getsitepackages():
+        if path.endswith("site-packages"):
+            QCoreApplication.addLibraryPath(path + "\\PyQt4\\plugins")
 
     # Make it a null op.
     global init

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -48,7 +48,8 @@ def init():
     # Hack to make sure the correct plugin search path is added. (Github issue #1143)
     for path in site.getsitepackages():
         if path.endswith("site-packages"):
-            QCoreApplication.addLibraryPath(os.path.join(path, "PyQt4", "plugins"))
+            QCoreApplication.setLibraryPaths(
+                QCoreApplication.libraryPaths() + [os.path.join(path, "PyQt4", "plugins")])
 
     # Make it a null op.
     global init

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -48,7 +48,7 @@ def init():
     # Hack to make sure the correct plugin search path is added. (Github issue #1143)
     for path in site.getsitepackages():
         if path.endswith("site-packages"):
-            QCoreApplication.addLibraryPath(path + "\\PyQt4\\plugins")
+            QCoreApplication.addLibraryPath(os.path.join(path, "PyQt4", "plugins"))
 
     # Make it a null op.
     global init

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -44,7 +44,7 @@ def init():
     QCoreApplication.setApplicationName("Orange Canvas")
     QCoreApplication.setApplicationVersion(version)
     QSettings.setDefaultFormat(QSettings.IniFormat)
-    
+
     # Hack to make sure the correct plugin search path is added. (Github issue #1143)
     for path in site.getsitepackages():
         if path.endswith("site-packages"):


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

A hack for issue #1143, where Qt failed to find the correct path for SVG plugin.