### PR TITLE
[ENH] Support context cloning in FeatureConstructor and SelectRows

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -463,6 +463,8 @@ class OWFeatureConstructor(widget.OWWidget):
         if self.data is not None:
             descriptors = list(self.descriptors)
             currindex = self.currentIndex
+            self.descriptors = []
+            self.currentIndex = -1
             self.openContext(data)
 
             if descriptors != self.descriptors or \

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -21,7 +21,7 @@ from PyQt4.QtCore import Qt, pyqtSignal as Signal, pyqtProperty as Property
 
 import Orange
 from Orange.widgets import widget, gui
-from Orange.widgets.settings import DomainContextHandler, ContextSetting
+from Orange.widgets.settings import ContextSetting, DomainContextHandler
 from Orange.widgets.utils import itemmodels, vartype
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.canvas import report
@@ -287,6 +287,30 @@ class DescriptorModel(itemmodels.PyListModel):
             return super().data(index, role)
 
 
+class FeatureConstructorSettingsHandler(DomainContextHandler):
+    """Context handler that filters descriptors"""
+
+    def is_valid_item(self, setting, descriptor, attrs, metas):
+        """Check if descriptor can be used with given domain.
+
+        Return True if descriptor's expression contains only
+        available variables and descriptors name does not clash with
+        existing variables.
+        """
+        if descriptor.name in attrs or descriptor.name in metas:
+            return False
+
+        try:
+            exp_ast = ast.parse(descriptor.expression, mode="eval")
+        except Exception:
+            return False
+
+        for name in freevars(exp_ast, []):
+            if not (name in attrs or name in metas):
+                return False
+        return True
+
+
 class OWFeatureConstructor(widget.OWWidget):
     name = "Feature Constructor"
     description = "Construct new features (data columns) from a set of " \
@@ -297,7 +321,7 @@ class OWFeatureConstructor(widget.OWWidget):
 
     want_main_area = False
 
-    settingsHandler = DomainContextHandler()
+    settingsHandler = FeatureConstructorSettingsHandler()
     descriptors = ContextSetting([])
     currentIndex = ContextSetting(-1)
 

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -9,10 +9,18 @@ import Orange.data.filter as data_filter
 from Orange.data.sql.table import SqlTable
 from Orange.preprocess import Remove
 from Orange.widgets import widget, gui
-from Orange.widgets.settings import \
-    PerfectDomainContextHandler, Setting, ContextSetting
+from Orange.widgets.settings import Setting, ContextSetting, DomainContextHandler
 from Orange.widgets.utils import vartype
 from Orange.canvas import report
+
+
+class SelectRowsContextHandler(DomainContextHandler):
+    """Context handler that filters conditions"""
+
+    def is_valid_item(self, setting, condition, attrs, metas):
+        """Return True if condition applies to a variable in given domain."""
+        varname, *_ = condition
+        return varname in attrs or varname in metas
 
 
 class OWSelectRows(widget.OWWidget):
@@ -27,7 +35,7 @@ class OWSelectRows(widget.OWWidget):
 
     want_main_area = False
 
-    settingsHandler = PerfectDomainContextHandler()
+    settingsHandler = SelectRowsContextHandler()
     conditions = ContextSetting([])
     update_on_change = Setting(True)
     purge_attributes = Setting(True)

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -859,24 +859,24 @@ class DomainContextHandler(ContextHandler):
 
         super().open_context(widget, domain, *self.encode_domain(domain))
 
-    def filter_value(self, setting, data, domain, attributes, metas):
+    def filter_value(self, setting, data, domain, attrs, metas):
         value = data.get(setting.name, None)
         if isinstance(value, list):
             sel_name = getattr(setting, "selected", None)
             selected = set(data.pop(sel_name, []))
             new_selected, new_value = [], []
-            for i, val in enumerate(value):
-                if self._var_exists(setting, val, attributes, metas):
+            for i, item in enumerate(value):
+                if self.is_valid_item(setting, item, attrs, metas):
                     if i in selected:
                         new_selected.append(len(new_value))
-                    new_value.append(val)
+                    new_value.append(item)
 
             data[setting.name] = new_value
             if hasattr(setting, 'selected'):
                 data[setting.selected] = new_selected
         elif value is not None:
             if (value[1] >= 0 and
-                    not self._var_exists(setting, value, attributes, metas)):
+                    not self._var_exists(setting, value, attrs, metas)):
                 del data[setting.name]
 
     def settings_to_widget(self, widget):
@@ -975,7 +975,7 @@ class DomainContextHandler(ContextHandler):
             selected = set()
 
         for i, item in enumerate(value):
-            if self._var_exists(setting, item, attrs, metas):
+            if self.is_valid_item(setting, item, attrs, metas):
                 matched += 1
             else:
                 if setting.required == ContextSetting.REQUIRED:
@@ -994,6 +994,14 @@ class DomainContextHandler(ContextHandler):
             return 1, 1
         else:
             raise IncompatibleContext()
+
+    def is_valid_item(self, setting, item, attrs, metas):
+        """Return True if given item can be used with attrs and metas
+
+        Subclasses can override this method to checks data in alternative
+        representations.
+        """
+        return self._var_exists(setting, item, attrs, metas)
 
     def mergeBack(self, widget):
         """Merge contexts loaded from schema with localy available list of

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -742,17 +742,16 @@ class ContextHandler(SettingsHandler):
     def fast_save(self, widget, name, value):
         """Update value of `name` setting in the current context to `value`
         """
+        setting = self.known_settings.get(name)
+        if isinstance(setting, ContextSetting):
+            context = widget.current_context
+            if context is None:
+                return
 
-        super().fast_save(widget, name, value)
-
-        context = widget.current_context
-        if context is None:
-            return
-
-        if name in self.known_settings:
-            setting = self.known_settings[name]
             value = self.encode_setting(context, setting, value)
             self.update_packed_data(context.values, name, value)
+        else:
+            super().fast_save(widget, name, value)
 
     @staticmethod
     def update_packed_data(data, name, value):
@@ -909,23 +908,6 @@ class DomainContextHandler(ContextHandler):
                 self.attributes_in_res and get_attribute(a[0]) == a[1] or
                 self.metas_in_res and get_meta(a[0]) == a[1])]
             setattr(widget, self.reservoir, ll)
-
-    def fast_save(self, widget, name, value):
-        super().fast_save(widget, name, value)
-
-        context = widget.current_context
-        if not context:
-            return
-
-        if name in self.known_settings:
-            setting = self.known_settings[name]
-
-            if name == setting.name or name.endswith(".{0}".format(setting.name)):
-                value = self.encode_setting(context, setting, value)
-            else:
-                value = list(value)
-
-            self.update_packed_data(context.values, name, value)
 
     def encode_setting(self, context, setting, value):
         value = copy.copy(value)

--- a/Orange/widgets/tests/test_context_handler.py
+++ b/Orange/widgets/tests/test_context_handler.py
@@ -38,3 +38,5 @@ class ContextHandlerTestCase(TestCase):
         context = widget.current_context = handler.new_context()
         handler.fast_save(widget, 'context_setting', 55)
         self.assertEqual(context.values['context_setting'], 55)
+        self.assertEqual(handler.known_settings['context_setting'].default,
+                         SimpleWidget.context_setting.default)


### PR DESCRIPTION
Fix a bug when changing dataset with descriptors in FeatureConstructor would cause an error.
Implement partial matching of contexts (feature constructed on adult_sample that uses variable age can also be used on titanic dataset)