### PR TITLE
[WIP] Add control for editing domains, include it in OWFile

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -1,11 +1,16 @@
 import os
+from itertools import chain
+from itertools import count
 from warnings import catch_warnings
 from xlrd import open_workbook, XLRDError
 from PyQt4 import QtGui, QtCore
 from PyQt4.QtGui import QSizePolicy as Policy
 
+from Orange.data import Domain
 from Orange.widgets import widget, gui
-from Orange.widgets.settings import Setting, ContextHandler, ContextSetting
+from Orange.widgets.settings import Setting, ContextHandler, ContextSetting, \
+    PerfectDomainContextHandler
+from Orange.widgets.utils.domaineditor import DomainEditor
 from Orange.widgets.utils.itemmodels import PyListModel
 from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
 from Orange.data.table import Table, get_sample_datasets_dir
@@ -73,13 +78,13 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         doc="Attribute-valued data set read from the input file.")]
 
     want_main_area = False
-    resizing_enabled = False
 
     SEARCH_PATHS = [("sample-datasets", get_sample_datasets_dir())]
 
     LOCAL_FILE, URL = range(2)
 
     settingsHandler = XlsContextHandler()
+    settingsHandler = PerfectDomainContextHandler()
 
     # Overload RecentPathsWidgetMixin.recent_paths to set defaults
     recent_paths = Setting([
@@ -92,6 +97,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     xls_sheet = ContextSetting("")
     sheet_names = Setting({})
     url = Setting("")
+
+    variables = []
 
     dlg_formats = (
         "All readable files ({});;".format(
@@ -167,12 +174,18 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         url_edit = url_combo.lineEdit()
         l, t, r, b = url_edit.getTextMargins()
         url_edit.setTextMargins(l + 5, t, r, b)
-        layout.addWidget(url_combo, 3, 1, 3, 3)
+        layout.addWidget(url_combo, 3, 1, 1, 3)
         url_combo.activated.connect(self._url_set)
 
-        box = gui.vBox(self.controlArea, "Info")
-        self.info = gui.widgetLabel(box, 'No data loaded.')
-        self.warnings = gui.widgetLabel(box, '')
+        self.info = gui.widgetLabel(vbox, 'No data loaded.', addToLayout=False)
+        layout.addWidget(self.info, 5, 0, 1, 4)
+        self.info.setWordWrap(True)
+        self.info.setSizePolicy(Policy.Ignored, Policy.Minimum)
+
+        box = gui.widgetBox(self.controlArea, "Columns (Double click to edit)")
+        domain_editor = DomainEditor(self.variables)
+        self.editor_model = domain_editor.model()
+        box.layout().addWidget(domain_editor)
 
         box = gui.hBox(self.controlArea)
         gui.button(
@@ -182,9 +195,11 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         box.layout().addWidget(self.report_button)
         self.report_button.setFixedWidth(170)
 
-        # Set word wrap, so long warnings won't expand the widget
-        self.warnings.setWordWrap(True)
-        self.warnings.setSizePolicy(Policy.Ignored, Policy.MinimumExpanding)
+        self.apply_button = gui.button(
+            box, self, "Apply", callback=self.apply_domain_edit)
+        self.apply_button.hide()
+        self.apply_button.setFixedWidth(170)
+        self.editor_model.dataChanged.connect(self.apply_button.show)
 
         self.set_file_list()
         if self.last_path() is not None:
@@ -192,6 +207,9 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         # Must not call open_file from within __init__. open_file
         # explicitly re-enters the event loop (by a progress bar)
         QtCore.QTimer.singleShot(0, self.load_data)
+
+    def sizeHint(self):
+        return QtCore.QSize(600, 550)
 
     def reload(self):
         if self.recent_paths:
@@ -216,8 +234,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             if os.path.exists(path):
                 self.add_path(path)
             else:
-                self.info.setText('Data was not loaded:')
-                self.warnings.setText("File {} does not exist".format(path))
+                self.info.setText(
+                    'Data was not loaded: File {} does not exist'.format(path))
                 self.file_combo.removeItem(n)
                 self.file_combo.lineEdit().setText(path)
                 return
@@ -254,14 +272,14 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
     def fill_sheet_combo(self, path):
         if os.path.exists(path) and self.is_multisheet_excel(path):
-            self.closeContext()
+            # self.closeContext()
             self.sheet_combo.clear()
             self.sheet_box.show()
             book = open_workbook(path)
             sheet_names = [str(book.sheet_by_index(i).name)
                            for i in range(book.nsheets)]
             self.sheet_combo.addItems(sheet_names)
-            self.openContext(path, sheet_names)
+            # self.openContext(path, sheet_names)
         else:
             self.sheet_box.hide()
 
@@ -299,7 +317,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             try:
                 return load(Table.from_file, fn)
             except Exception as exc:
-                self.warnings.setText(str(exc))
+                self.info.setText(str(exc))
                 # Let us not remove from recent files: user may fix them
                 raise
 
@@ -316,7 +334,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             try:
                 data, url = load(Table.from_url, url)
             except:
-                self.warnings.setText(
+                self.info.setText(
                     "URL '{}' does not contain valid data".format(url))
                 # Don't remove from recent_urls:
                 # resource may reappear, or the user mistyped it
@@ -336,6 +354,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         self.warning()
         self.information()
 
+        # self.closeContext()
         try:
             loader = [load_from_file, load_from_network][self.source]
             self.data, self.loaded_file = loader()
@@ -345,7 +364,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             self.loaded_file = ""
             return
         else:
-            self.warnings.setText("")
+            self.info.setText("")
 
         data = self.data
         if data is None:
@@ -354,26 +373,57 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             return
 
         domain = data.domain
-        text = "{} instance(s), {} feature(s), {} meta attribute(s)".format(
+        text = "{} instance(s), {} feature(s), {} meta attribute(s). ".format(
             len(data), len(domain.attributes), len(domain.metas))
         if domain.has_continuous_class:
-            text += "\nRegression; numerical class."
+            text += "Regression; numerical class."
         elif domain.has_discrete_class:
-            text += "\nClassification; discrete class with {} values.".format(
+            text += "Classification; discrete class with {} values.".format(
                 len(domain.class_var.values))
         elif data.domain.class_vars:
-            text += "\nMulti-target; {} target variables.".format(
+            text += "Multi-target; {} target variables.".format(
                 len(data.domain.class_vars))
         else:
-            text += "\nData has no target variable."
+            text += "Data has no target variable."
         if 'Timestamp' in data.domain:
             # Google Forms uses this header to timestamp responses
-            text += '\n\nFirst entry: {}\nLast entry: {}'.format(
+            text += '\nFirst entry: {} Last entry: {}'.format(
                 data[0, 'Timestamp'], data[-1, 'Timestamp'])
         self.info.setText(text)
 
         add_origin(data, self.loaded_file)
+        self.editor_model.set_domain(data.domain)
+        # self.openContext(data.domain)
         self.send("Data", data)
+
+    def storeSpecificSettings(self):
+        self.current_context.modified_variables = self.variables[:]
+
+    def retrieveSpecificSettings(self):
+        if hasattr(self.current_context, "modified_variables"):
+            self.variables[:] = self.current_context.modified_variables
+
+    def apply_domain_edit(self):
+        attributes = []
+        class_vars = []
+        metas = []
+        weight = []
+        places = [attributes, class_vars, metas, weight]
+        cols = [[], [], [], []]  # Xcols, Ycols, Mcols, Wcols
+        for column, (name, tpe, place, vals), orig_var in \
+            zip(count(), self.editor_model.variables,
+                chain(self.data.domain.variables, self.data.domain.metas)):
+            if place == 3:
+                continue
+            if name == orig_var.name and tpe == type(orig_var):
+                var = orig_var
+            else:
+                var = tpe(name)
+            places[place].append(var)
+            cols[place].append(column)  # This assumes that no columns were skipped in the original file!
+        domain = Domain(attributes, class_vars, metas)
+        # data = Table.from_file(self.loaded_file, domain=domain, columns=cols)
+        self.apply_button.hide()
 
     def get_widget_name_extension(self):
         _, name = os.path.split(self.loaded_file)

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -1,0 +1,164 @@
+from PyQt4 import QtCore, QtGui
+from PyQt4.QtGui import QTableView, QSizePolicy
+
+from Orange.data import DiscreteVariable, ContinuousVariable, StringVariable
+from Orange.widgets import gui
+from Orange.widgets.data.owcolor import HorizontalGridDelegate
+from Orange.widgets.utils.itemmodels import TableModel
+
+
+class VarTableModel(QtCore.QAbstractTableModel):
+    places = "feature", "class", "meta", "skip"
+    typenames = "nominal", "numeric", "string"
+    vartypes = DiscreteVariable, ContinuousVariable, StringVariable
+    name2type = dict(zip(typenames, vartypes))
+    type2name = dict(zip(vartypes, typenames))
+
+    def __init__(self, variables):
+        super().__init__()
+        self.variables = self.original = variables
+
+    def set_domain(self, domain):
+        def may_be_numeric(var):
+            if var.is_continuous:
+                return True
+            if var.is_discrete:
+                try:
+                    sum(float(x) for x in var.values)
+                    return True
+                except ValueError:
+                    return False
+            return False
+
+        self.modelAboutToBeReset.emit()
+        self.variables[:] = self.original = [
+            [var.name, type(var), place,
+             ", ".join(var.values) if var.is_discrete else "",
+             may_be_numeric(var)]
+            for place, vars in enumerate(
+                (domain.attributes, domain.class_vars, domain.metas))
+            for var in vars
+        ]
+        self.modelReset.emit()
+
+    def rowCount(self, parent):
+        return 0 if parent.isValid() else len(self.variables)
+
+    def columnCount(self, parent):
+        return 0 if parent.isValid() else 4
+
+    def data(self, index, role):
+        row, col = index.row(), index.column()
+        val = self.variables[row][col]
+        if role == QtCore.Qt.DisplayRole or role == QtCore.Qt.EditRole:
+            if col == 1:
+                return self.type2name[val]
+            if col == 2:
+                return self.places[val]
+            else:
+                return val
+        if role == QtCore.Qt.DecorationRole:
+            if col == 1:
+                return gui.attributeIconDict[self.vartypes.index(val) + 1]
+        if role == QtCore.Qt.ForegroundRole:
+            if self.variables[row][2] == 3 and col != 2:
+                return QtGui.QColor(160, 160, 160)
+        if role == QtCore.Qt.BackgroundRole:
+            place = self.variables[row][2]
+            return TableModel.ColorForRole.get(place, None)
+
+    def setData(self, index, value, role):
+        row, col = index.row(), index.column()
+        row_data = self.variables[row]
+        if role == QtCore.Qt.EditRole:
+            if col == 0:
+                row_data[col] = value
+            elif col == 1:
+                vartype = self.name2type[value]
+                row_data[col] = vartype
+                if not vartype.is_primitive() and row_data[2] < 2:
+                    row_data[2] = 2
+            elif col == 2:
+                row_data[col] = self.places.index(value)
+            else:
+                return False
+            # Settings may change background colors
+            self.dataChanged.emit(index.sibling(row, 0), index.sibling(row, 3))
+            return True
+
+    def flags(self, index):
+        return super().flags(index) | QtCore.Qt.ItemIsEditable
+
+
+class ComboDelegate(HorizontalGridDelegate):
+    def __init__(self, view, items):
+        super().__init__()
+        self.view = view
+        self.items = items
+
+    def createEditor(self, parent, option, index):
+        # This ugly hack closes the combo when the user selects an item
+        class Combo(QtGui.QComboBox):
+            def __init__(self, *args):
+                super().__init__(*args)
+                self.popup_shown = False
+                self.highlighted_text = None
+
+            def highlight(self, index):
+                self.highlighted_text = index
+
+            def showPopup(self, *args):
+                super().showPopup(*args)
+                self.popup_shown = True
+
+            def hidePopup(me):
+                if me.popup_shown:
+                    self.view.model().setData(
+                            index, me.highlighted_text, QtCore.Qt.EditRole)
+                    self.popup_shown = False
+                super().hidePopup()
+                self.view.closeEditor(me, self.NoHint)
+
+        combo = Combo(parent)
+        combo.highlighted[str].connect(combo.highlight)
+        return combo
+
+
+class VarTypeDelegate(ComboDelegate):
+    def setEditorData(self, combo, index):
+        combo.clear()
+        no_numeric = not self.view.model().variables[index.row()][4]
+        ind = self.items.index(index.data())
+        combo.addItems(self.items[:1] + self.items[1 + no_numeric:])
+        combo.setCurrentIndex(ind - (no_numeric and ind > 1))
+
+
+class PlaceDelegate(ComboDelegate):
+    def setEditorData(self, combo, index):
+        combo.clear()
+        to_meta = not self.view.model().variables[index.row()][1].is_primitive()
+        combo.addItems(self.items[2 * to_meta:])
+        combo.setCurrentIndex(self.items.index(index.data()) - 2 * to_meta)
+
+
+class DomainEditor(QTableView):
+    def __init__(self, variables):
+        super().__init__()
+        self.setModel(VarTableModel(variables))
+        self.setSelectionMode(QTableView.NoSelection)
+        self.horizontalHeader().hide()
+        self.horizontalHeader().setStretchLastSection(True)
+        self.setShowGrid(False)
+        self.setEditTriggers(
+            QTableView.SelectedClicked | QTableView.DoubleClicked)
+        self.setSizePolicy(
+            QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        # setItemDelegate(ForColumn) apparently does not take ownership
+        # of delegates, and coredumps if a a references is not stored somewhere.
+        # We thus store delegates as attributes
+        self.grid_delegate = HorizontalGridDelegate()
+        self.setItemDelegate(self.grid_delegate)
+        self.vartype_delegate = VarTypeDelegate(self, VarTableModel.typenames)
+        self.setItemDelegateForColumn(1, self.vartype_delegate)
+        self.place_delegate = PlaceDelegate(self, VarTableModel.places)
+        self.setItemDelegateForColumn(2, self.place_delegate)


### PR DESCRIPTION
Rebased #1012.

The control (table view, corresponding models and delegates) have been moved from OWFile.py to a separate module and can be included in other widgets.

Contexts are broken: OWFile widget now has two separate contexts and we need to decide how to handle this. Since this is the first time it happened in a decade, a hack will suffice.

Apply button cannot be implemented before i/o refactoring.