### PR TITLE
[RFC] Attribute names in gui functions

### DIFF
--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -59,33 +59,34 @@ class OWContinuize(widget.OWWidget):
 
     def __init__(self):
         super().__init__()
+        my = self.my  # type: OWContinuize
 
         box = gui.vBox(self.controlArea, "Multinomial attributes")
         gui.radioButtonsInBox(
-            box, self, "multinomial_treatment",
+            box, self, my.multinomial_treatment,
             btnLabels=[x[0] for x in self.multinomial_treats],
             callback=self.settings_changed)
 
         box = gui.vBox(self.controlArea, "Continuous attributes")
         gui.radioButtonsInBox(
-            box, self, "continuous_treatment",
+            box, self, my.continuous_treatment,
             btnLabels=[x[0] for x in self.continuous_treats],
             callback=self.settings_changed)
 
         box = gui.vBox(self.controlArea, "Discrete class attribute")
         gui.radioButtonsInBox(
-            box, self, "class_treatment",
+            box, self, my.class_treatment,
             btnLabels=[t[0] for t in self.class_treats],
             callback=self.settings_changed)
 
         zbbox = gui.vBox(self.controlArea, "Value range")
 
         gui.radioButtonsInBox(
-            zbbox, self, "zero_based",
+            zbbox, self, my.zero_based,
             btnLabels=self.value_ranges,
             callback=self.settings_changed)
 
-        gui.auto_commit(self.buttonsArea, self, "autosend", "Apply", box=False)
+        gui.auto_commit(self.buttonsArea, self, my.autosend, "Apply", box=False)
 
         self.data = None
 

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -149,6 +149,14 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
     #: :type: list of :class:`Message`
     UserAdviceMessages = []
 
+    class _AttributeName:
+        def __init__(self, obj):
+            self.obj = obj
+
+        def __getattr__(self, name):
+            getattr(self.obj, name)  # raise error if attribute does not exist
+            return name
+
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, None, cls.get_flags())
         QDialog.__init__(self, None, self.get_flags())
@@ -198,6 +206,7 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
         sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
         sc.activated.connect(self.__quicktip)
 
+        self.my = self._AttributeName(self)
         return self
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Widget has an attribute `my` whose `__getattr__` checks for existence of attribute and returns its name.

Intended use is illustrated in the code of `OWContinuize`.

    my = self.my  # type: OWContinuize

This pulls `my` into `__init__`'s namespace and tricks PyCharm to provide completion. Later we use, e.g.

     gui.radioButtonsInBox(box, self, my.multinomial_treatment, btnLabels=labels)

String literals still work as before, of course.

Advantages: no string literals (ehm, so what?); PyCharm completion; potential for more control, e.g. warning if an attribute is not declared as setting

Disadvantages: one more piece of magic (but not too mystic)