### PR TITLE
[REF] Remove unnecessary parentheses

### DIFF
--- a/doc/development/source/orange-demo/setup.py
+++ b/doc/development/source/orange-demo/setup.py
@@ -5,5 +5,5 @@ setup(name="Demo",
       package_data={"orangedemo": ["icons/*.svg"]},
       classifiers=["Example :: Invalid"],
       # Declare orangedemo package to contain widgets for the "Demo" category
-      entry_points={"orange.widgets": ("Demo = orangedemo")},
+      entry_points={"orange.widgets": "Demo = orangedemo"},
       )


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

As discovered in [discussion around issue #1184](https://github.com/biolab/orange3/issues/1184#issuecomment-214215811), the tuple is not necessary here. Only a single string is necessary, as is documented in the setuptools official [entry_points example](https://pythonhosted.org/setuptools/setuptools.html#dynamic-discovery-of-services-and-plugins).