### PR TITLE
Revert "setup.py: Install desktop file and icon on GNU/Linux/FreeBSD"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,38 +216,6 @@ class CoverageCommand(Command):
         ''', shell=True, cwd=os.path.dirname(os.path.abspath(__file__))))
 
 
-# Install desktop file and icon on GNU/Linux/BSD
-DATA_FILES = []
-if any(sys.platform.startswith(platform)
-       for platform in ('linux', 'freebsd')):
-    # Patch desktop file executable to work with virtualenv
-    try:
-        sys.real_prefix
-    except AttributeError:
-        pass  # Not in virtualenv
-    else:
-        with open(os.path.join(os.path.dirname(__file__),
-                               'distribute',
-                               'orange-canvas.desktop'), 'r+') as desktop:
-            spec = []
-            for line in desktop:
-                if line.startswith('Exec='):
-                    line = 'Exec="{}" -m Orange.canvas\n'.format(sys.executable)
-                spec.append(line)
-            desktop.seek(0)
-            desktop.truncate(0)
-            desktop.writelines(spec)
-
-    usr_share = os.path.join(sys.prefix, "share")
-    if not usr_share.startswith('/usr/') or not os.access(usr_share, os.W_OK):
-        usr_share = os.environ.get('XDG_DATA_HOME',
-                                   os.path.expanduser('~/.local/share'))
-    DATA_FILES += [
-        (os.path.join(usr_share, 'applications'),
-         ['distribute/orange-canvas.desktop']),
-        (os.path.join(usr_share, 'icons', 'hicolor', 'scalable', 'apps'),
-         ['distribute/orange-canvas.svg'])
-    ]
 
 
 def setup_package():
@@ -267,7 +235,6 @@ def setup_package():
         package_data=PACKAGE_DATA,
         install_requires=INSTALL_REQUIRES,
         entry_points=ENTRY_POINTS,
-        data_files=DATA_FILES,
         zip_safe=False,
         test_suite='Orange.tests.test_suite',
         cmdclass={


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

This reverts commit 6afe45865fedaeb2e37dad5beaba3c817f8dfaef.

The setup.py should not assume that the python env (or even the user)
which runs the setup.py has any relation to where the package will
eventually be installed.

As it stands, wheel format does no even (currently) support absolute paths
(they end up in e.g. site-pacakges/usr/local/share).