### PR TITLE
Orange GUI: strings improvement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,13 @@ Please ensure your commits pass code quality assurance by executing:
 
 Human Interface Guidelines
 --------------------------
-For UI design, conform to the [OS X Human Interface Guidelines](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/TerminologyWording.html).
-Of special note are the capitalization, ellipsis and colon guidelines.
+For UI design, conform to the [OS X Human Interface Guidelines].
+In a nutshell, use title case for titles, push buttons, menu titles
+and menu options. Elsewhere, use sentence case. Use title case for
+combo box options where the item is imperative (e.g. Initialize with Method)
+and sentence case otherwise.
+
+[OS X Human Interface Guidelines]: (https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/TerminologyWording.html).
 
 
 Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,6 @@ reproducible) and a screenshot (if applicable).
 [bug reporting guidelines]: https://www.google.com/search?q=reporting+bugs
 
 
-Human interface guidelines 
---------------------------
-
-Use title case for titles, push buttons, menu titles and menu options. Elsewhere, use sentence case.
-
-
 Coding style
 ------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ and menu options. Elsewhere, use sentence case. Use title case for
 combo box options where the item is imperative (e.g. Initialize with Method)
 and sentence case otherwise.
 
-[OS X Human Interface Guidelines]: (https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/TerminologyWording.html).
+[OS X Human Interface Guidelines]: https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/TerminologyWording.html
 
 
 Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,12 @@ Please ensure your commits pass code quality assurance by executing:
 [keyword args to the constructor]: http://pyqt.sourceforge.net/Docs/PyQt5/qt_properties.html
 
 
+Human Interface Guidelines
+--------------------------
+For UI design, conform to the [OS X Human Interface Guidelines](https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/TerminologyWording.html).
+Of special note are the capitalization, ellipsis and colon guidelines.
+
+
 Tests
 -----
 [tests]: #tests

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -427,7 +427,7 @@ class CanvasMainWindow(QMainWindow):
                     )
 
         self.save_as_action = \
-            QAction(self.tr("Save As ..."), self,
+            QAction(self.tr("Save As..."), self,
                     objectName="action-save-as",
                     toolTip=self.tr("Save current workflow as."),
                     triggered=self.save_scheme_as,
@@ -596,7 +596,7 @@ class CanvasMainWindow(QMainWindow):
             self.set_scheme_margins_enabled)
 
         self.reset_widget_settings_action = \
-            QAction(self.tr("Reset widget settings..."), self,
+            QAction(self.tr("Reset Widget Settings..."), self,
                     triggered=self.reset_widget_settings)
 
     def setup_menu(self):

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -1032,7 +1032,7 @@ class NewArrowAnnotation(UserInteraction):
         helpevent = QuickHelpTipEvent(
             self.tr("Click and drag to create a new arrow"),
             self.tr('<h3>New arrow annotation</h3>'
-                    '<p>Click and drag to create a new arrow annotation</p>'
+                    '<p>Click and drag to create a new arrow annotation.</p>'
 #                    '<a href="help://orange-canvas/arrow-annotations>'
 #                    'More ...</a>'
                     )

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -178,7 +178,7 @@ class SchemeEditWidget(QWidget):
         self.__cleanUpAction = \
             QAction(self.tr("Clean Up"), self,
                     objectName="cleanup-action",
-                    toolTip=self.tr("Align widget to a grid."),
+                    toolTip=self.tr("Align widgets to a grid."),
                     triggered=self.alignToGrid,
                     )
 
@@ -215,7 +215,7 @@ class SchemeEditWidget(QWidget):
         self.__newArrowAnnotationAction = \
             QAction(self.tr("Arrow"), self,
                     objectName="new-arrow-action",
-                    toolTip=self.tr("Add a arrow annotation to the workflow."),
+                    toolTip=self.tr("Add an arrow annotation to the workflow."),
                     checkable=True,
                     toggled=self.__toggleNewArrowAnnotation,
                     )
@@ -260,7 +260,7 @@ class SchemeEditWidget(QWidget):
         self.__redoAction.setObjectName("redo-action")
 
         self.__selectAllAction = \
-            QAction(self.tr("Select all"), self,
+            QAction(self.tr("Select All"), self,
                     objectName="select-all-action",
                     toolTip=self.tr("Select all items."),
                     triggered=self.selectAll,

--- a/Orange/widgets/classify/owadaboost.py
+++ b/Orange/widgets/classify/owadaboost.py
@@ -30,15 +30,15 @@ class OWAdaBoostClassification(OWBaseLearner):
         self.base_estimator = TreeLearner()
         self.base_label = gui.label(box, self, "Base estimator: " + self.base_estimator.name)
 
-        gui.spin(box, self, "n_estimators", 1, 100, label="Number of estimators",
+        gui.spin(box, self, "n_estimators", 1, 100, label="Number of estimators:",
                  alignment=Qt.AlignRight, callback=self.settings_changed)
         gui.doubleSpin(box, self, "learning_rate", 1e-5, 1.0, 1e-5,
-                       label="Learning rate", decimals=5, alignment=Qt.AlignRight,
+                       label="Learning rate:", decimals=5, alignment=Qt.AlignRight,
                        controlWidth=90, callback=self.settings_changed)
         self.add_specific_parameters(box)
 
     def add_specific_parameters(self, box):
-        gui.comboBox(box, self, "algorithm", label="Algorithm",
+        gui.comboBox(box, self, "algorithm", label="Algorithm:",
                      orientation=Qt.Horizontal, items=self.losses,
                      callback=self.settings_changed)
 

--- a/Orange/widgets/classify/owadaboost.py
+++ b/Orange/widgets/classify/owadaboost.py
@@ -11,7 +11,8 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWAdaBoostClassification(OWBaseLearner):
     name = "AdaBoost"
-    description = "An AdaBoost classifier."
+    description = "An ensemble meta-algorithm that combines weak learners " \
+                  "and adapts to the 'hardness' of each training sample. "
     icon = "icons/AdaBoost.svg"
     priority = 80
 

--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -27,20 +27,20 @@ class OWClassificationTree(OWBaseLearner):
 
     def add_main_layout(self):
         gui.comboBox(self.controlArea, self, "attribute_score",
-                     box='Feature selection',
+                     box='Feature Selection',
                      items=[name for name, _ in self.scores],
                      callback=self.settings_changed)
 
         box = gui.vBox(self.controlArea, 'Pruning')
         gui.spin(box, self, "min_leaf", 1, 1000,
-                 label="Min. instances in leaves ", checked="limit_min_leaf",
+                 label="Min. instances in leaves: ", checked="limit_min_leaf",
                  callback=self.settings_changed)
         gui.spin(box, self, "min_internal", 1, 1000,
-                 label="Stop splitting nodes with less instances than ",
+                 label="Stop splitting nodes with less instances than: ",
                  checked="limit_min_internal",
                  callback=self.settings_changed)
         gui.spin(box, self, "max_depth", 1, 1000,
-                 label="Limit the depth to ", checked="limit_depth",
+                 label="Limit the depth to: ", checked="limit_depth",
                  callback=self.settings_changed)
 
     def create_learner(self):

--- a/Orange/widgets/classify/owclassificationtreegraph.py
+++ b/Orange/widgets/classify/owclassificationtreegraph.py
@@ -453,7 +453,7 @@ class ClassificationTreeNode(TreeNode):
 
 class OWClassificationTreeGraph(OWTreeGraph):
     name = "Classification Tree Viewer"
-    description = "Graphical visualization of a classification tree."
+    description = "A graphical visualization of a classification tree."
     icon = "icons/ClassificationTreeGraph.svg"
 
     settingsHandler = ClassValuesContextHandler()
@@ -470,7 +470,7 @@ class OWClassificationTreeGraph(OWTreeGraph):
             addToLayout=False,
             sizePolicy=QSizePolicy(QSizePolicy.MinimumExpanding,
                                    QSizePolicy.Fixed))
-        self.display_box.layout().addRow("Target class ", self.target_combo)
+        self.display_box.layout().addRow("Target class: ", self.target_combo)
         gui.rubber(self.controlArea)
 
     def ctree(self, model=None):

--- a/Orange/widgets/classify/owknn.py
+++ b/Orange/widgets/classify/owknn.py
@@ -9,7 +9,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWKNNLearner(OWBaseLearner):
     name = "Nearest Neighbors"
-    description = "k-nearest neighbors classification algorithm."
+    description = "The k-nearest neighbors classification algorithm."
     icon = "icons/KNN.svg"
     priority = 20
 
@@ -25,13 +25,13 @@ class OWKNNLearner(OWBaseLearner):
 
     def add_main_layout(self):
         box = gui.vBox(self.controlArea, "Neighbors")
-        gui.spin(box, self, "n_neighbors", 1, 100, label="Number of neighbors",
+        gui.spin(box, self, "n_neighbors", 1, 100, label="Number of neighbors:",
                  alignment=Qt.AlignRight, callback=self.settings_changed)
-        gui.comboBox(box, self, "metric_index", label="Metric",
+        gui.comboBox(box, self, "metric_index", label="Metric:",
                      orientation=Qt.Horizontal,
                      items=[i.capitalize() for i in self.metrics],
                      callback=self.settings_changed)
-        gui.comboBox(box, self, "weight_type", label='Weight',
+        gui.comboBox(box, self, "weight_type", label="Weight:",
                      orientation=Qt.Horizontal,
                      items=[i.capitalize() for i in self.weights],
                      callback=self.settings_changed)

--- a/Orange/widgets/classify/owknn.py
+++ b/Orange/widgets/classify/owknn.py
@@ -9,7 +9,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWKNNLearner(OWBaseLearner):
     name = "Nearest Neighbors"
-    description = "The k-nearest neighbors classification algorithm."
+    description = "Predict according to the nearest training instances."
     icon = "icons/KNN.svg"
     priority = 20
 

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -11,7 +11,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWLogisticRegression(OWBaseLearner):
     name = "Logistic Regression"
-    description = "Logistic regression classification algorithm with " \
+    description = "The logistic regression classification algorithm with " \
                   "LASSO (L1) or ridge (L2) regularization."
     icon = "icons/LogisticRegression.svg"
     priority = 60

--- a/Orange/widgets/classify/ownaivebayes.py
+++ b/Orange/widgets/classify/ownaivebayes.py
@@ -8,7 +8,8 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWNaiveBayes(OWBaseLearner):
     name = "Naive Bayes"
-    description = "The Naive Bayesian classifier."
+    description = "A fast and simple probabilistic classifier based on " \
+                  "Bayes' theorem with the assumption of feature independence. "
     icon = "icons/NaiveBayes.svg"
     priority = 70
 

--- a/Orange/widgets/classify/ownaivebayes.py
+++ b/Orange/widgets/classify/ownaivebayes.py
@@ -8,7 +8,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWNaiveBayes(OWBaseLearner):
     name = "Naive Bayes"
-    description = "Naive Bayesian classifier."
+    description = "The Naive Bayesian classifier."
     icon = "icons/NaiveBayes.svg"
     priority = 70
 

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -11,7 +11,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWRandomForest(OWBaseLearner):
     name = "Random Forest Classification"
-    description = "The random forest classification algorithm."
+    description = "Predict using an ensemble of decision trees."
     icon = "icons/RandomForest.svg"
     priority = 40
 

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -11,7 +11,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWRandomForest(OWBaseLearner):
     name = "Random Forest Classification"
-    description = "Random forest classification algorithm."
+    description = "The random forest classification algorithm."
     icon = "icons/RandomForest.svg"
     priority = 40
 
@@ -31,9 +31,9 @@ class OWRandomForest(OWBaseLearner):
     def add_main_layout(self):
         form = QGridLayout()
         basic_box = gui.widgetBox(
-            self.controlArea, "Basic properties", orientation=form)
+            self.controlArea, "Basic Properties", orientation=form)
 
-        form.addWidget(QLabel(self.tr("Number of trees ")),
+        form.addWidget(QLabel(self.tr("Number of trees: ")),
                        0, 0, Qt.AlignLeft)
         spin = gui.spin(basic_box, self, "n_estimators", minv=1, maxv=1e4,
                         callback=self.settings_changed, addToLayout=False,
@@ -43,7 +43,7 @@ class OWRandomForest(OWBaseLearner):
         max_features_cb = gui.checkBox(
             basic_box, self, "use_max_features",
             callback=self.settings_changed, addToLayout=False,
-            label="Number of considered attributes at each split ")
+            label="Number of attributes considered at each split: ")
 
         max_features_spin = gui.spin(
             basic_box, self, "max_features", 2, 50, addToLayout=False,
@@ -54,7 +54,7 @@ class OWRandomForest(OWBaseLearner):
 
         random_state_cb = gui.checkBox(
             basic_box, self, "use_random_state", callback=self.settings_changed,
-            addToLayout=False, label="Fixed seed for random generator ")
+            addToLayout=False, label="Fixed seed for random generator: ")
         random_state_spin = gui.spin(
             basic_box, self, "random_state", 0, 2 ** 31 - 1, addToLayout=False,
             callback=self.settings_changed, controlWidth=50)
@@ -67,11 +67,11 @@ class OWRandomForest(OWBaseLearner):
         # Growth control
         form = QGridLayout()
         growth_box = gui.widgetBox(
-            self.controlArea, "Growth control", orientation=form)
+            self.controlArea, "Growth Control", orientation=form)
 
         max_depth_cb = gui.checkBox(
             growth_box, self, "use_max_depth",
-            label="Limit depth of individual trees",
+            label="Limit depth of individual trees: ",
             callback=self.settings_changed,
             addToLayout=False)
 
@@ -84,7 +84,7 @@ class OWRandomForest(OWBaseLearner):
 
         max_leaf_nodes_cb = gui.checkBox(
             growth_box, self, "use_max_leaf_nodes",
-            label="Do not split subsets smaller than ",
+            label="Do not split subsets smaller than: ",
             callback=self.settings_changed, addToLayout=False)
 
         max_leaf_nodes_spin = gui.spin(

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -65,10 +65,10 @@ class OWBaseSVM(OWBaseLearner):
 
     def _add_optimization_box(self):
         self.optimization_box = gui.vBox(
-            self.controlArea, "Optimization parameters")
+            self.controlArea, "Optimization Parameters")
         gui.doubleSpin(
             self.optimization_box, self, "tol", 1e-6, 1.0, 1e-5,
-            label="Numerical Tolerance",
+            label="Numerical tolerance:",
             decimals=6, alignment=Qt.AlignRight, controlWidth=100,
             callback=self.settings_changed
         )
@@ -115,7 +115,7 @@ class OWBaseSVM(OWBaseLearner):
 
 class OWSVMClassification(OWBaseSVM):
     name = "SVM"
-    description = "Support vector machines classifier with standard " \
+    description = "A support vector machine classifier with a standard " \
                   "selection of kernels."
     icon = "icons/SVM.svg"
     priority = 50
@@ -141,7 +141,7 @@ class OWSVMClassification(OWBaseSVM):
 
         form.addWidget(gui.appendRadioButton(box, "C-SVM", addToLayout=False),
                        0, 0, Qt.AlignLeft)
-        form.addWidget(QtGui.QLabel("Cost (C)"),
+        form.addWidget(QtGui.QLabel("Cost (C):"),
                        0, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "C", 1e-3, 1000.0, 0.1,
                                       decimals=3, alignment=Qt.AlignRight,
@@ -151,7 +151,7 @@ class OWSVMClassification(OWBaseSVM):
 
         form.addWidget(gui.appendRadioButton(box, "ν-SVM", addToLayout=False),
                        1, 0, Qt.AlignLeft)
-        form.addWidget(QtGui.QLabel("Complexity (ν)"),
+        form.addWidget(QtGui.QLabel("Complexity (ν):"),
                        1, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "nu", 0.05, 1.0, 0.05,
                                       decimals=2, alignment=Qt.AlignRight,
@@ -162,7 +162,7 @@ class OWSVMClassification(OWBaseSVM):
     def _add_optimization_box(self):
         super()._add_optimization_box()
         gui.spin(self.optimization_box, self, "max_iter", 50, 1e6, 50,
-                 label="Iteration Limit", checked="limit_iter",
+                 label="Iteration limit:", checked="limit_iter",
                  alignment=Qt.AlignRight, controlWidth=100,
                  callback=self.settings_changed)
 

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -115,8 +115,8 @@ class OWBaseSVM(OWBaseLearner):
 
 class OWSVMClassification(OWBaseSVM):
     name = "SVM"
-    description = "A support vector machine classifier with a standard " \
-                  "selection of kernels."
+    description = "Support Vector Machines map inputs to higher-dimensional " \
+                  "feature spaces that best separate different classes. "
     icon = "icons/SVM.svg"
     priority = 50
 

--- a/Orange/widgets/classify/owtreeviewer2d.py
+++ b/Orange/widgets/classify/owtreeviewer2d.py
@@ -381,27 +381,27 @@ class OWTreeViewer2D(OWWidget):
             gui.widgetBox(self.controlArea, "Display", addSpace=True,
                           orientation=layout)
         layout.addRow(
-            "Zoom ",
+            "Zoom: ",
             gui.hSlider(box, self, 'zoom',
                         minValue=1, maxValue=10, step=1, ticks=False,
                         callback=self.toggle_zoom_slider,
                         createLabel=False, addToLayout=False, addSpace=False))
         layout.addRow(
-            "Width ",
+            "Width: ",
             gui.hSlider(box, self, 'max_node_width',
                         minValue=50, maxValue=200, step=1, ticks=False,
                         callback=self.toggle_node_size,
                         createLabel=False, addToLayout=False, addSpace=False))
         policy = QSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
         layout.addRow(
-            "Depth ",
+            "Depth: ",
             gui.comboBox(box, self, 'max_tree_depth',
                          items=["Unlimited"] + [
                              "{} levels".format(x) for x in range(2, 10)],
                          addToLayout=False, sendSelectedValue=False,
                          callback=self.toggle_tree_depth, sizePolicy=policy))
         layout.addRow(
-            "Edge width ",
+            "Edge width: ",
             gui.comboBox(box, self, 'line_width_method',
                          items=['Fixed', 'Relative to root',
                                 'Relative to parent'],

--- a/Orange/widgets/data/__init__.py
+++ b/Orange/widgets/data/__init__.py
@@ -2,7 +2,7 @@ NAME = "Data"
 
 ID = "orange.widgets.data"
 
-DESCRIPTION = """Widgets for data manipulation"""
+DESCRIPTION = """Widgets for data manipulation."""
 
 LONG_DESRIPTION = """
 This category contains widgets for data manipulation. This includes

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -218,7 +218,7 @@ class ContinuousTable(ColorTable):
 
 class OWColor(widget.OWWidget):
     name = "Color"
-    description = "Set color legend for variables"
+    description = "Set color legend for variables."
     icon = "icons/Colors.svg"
 
     inputs = [("Data", Orange.data.Table, "set_data")]
@@ -240,21 +240,21 @@ class OWColor(widget.OWWidget):
         self.disc_colors = []
         self.cont_colors = []
 
-        box = gui.hBox(self.controlArea, "Discrete variables")
+        box = gui.hBox(self.controlArea, "Discrete Variables")
         self.disc_model = DiscColorTableModel()
         disc_view = self.disc_view = DiscreteTable(self.disc_model)
         disc_view.horizontalHeader().setResizeMode(QHeaderView.ResizeToContents)
         self.disc_model.dataChanged.connect(self._on_data_changed)
         box.layout().addWidget(disc_view)
 
-        box = gui.hBox(self.controlArea, "Numeric variables")
+        box = gui.hBox(self.controlArea, "Numeric Variables")
         self.cont_model = ContColorTableModel()
         cont_view = self.cont_view = ContinuousTable(self, self.cont_model)
         cont_view.setColumnWidth(1, 256)
         self.cont_model.dataChanged.connect(self._on_data_changed)
         box.layout().addWidget(cont_view)
 
-        box = gui.auto_commit(self.controlArea, self, "auto_apply", "Send data",
+        box = gui.auto_commit(self.controlArea, self, "auto_apply", "Send Data",
                               orientation=Qt.Horizontal,
                               checkbox_label="Resend data on every change")
         box.layout().insertSpacing(0, 20)

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -256,7 +256,7 @@ class OWColor(widget.OWWidget):
 
         box = gui.auto_commit(self.controlArea, self, "auto_apply", "Apply",
                               orientation=Qt.Horizontal,
-                              checkbox_label="Auto apply on change")
+                              checkbox_label="Apply automatically")
         box.layout().insertSpacing(0, 20)
         box.layout().insertWidget(0, self.report_button)
 

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -254,9 +254,9 @@ class OWColor(widget.OWWidget):
         self.cont_model.dataChanged.connect(self._on_data_changed)
         box.layout().addWidget(cont_view)
 
-        box = gui.auto_commit(self.controlArea, self, "auto_apply", "Send Data",
+        box = gui.auto_commit(self.controlArea, self, "auto_apply", "Apply",
                               orientation=Qt.Horizontal,
-                              checkbox_label="Resend data on every change")
+                              checkbox_label="Auto apply on change")
         box.layout().insertSpacing(0, 20)
         box.layout().insertWidget(0, self.report_button)
 

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -54,7 +54,7 @@ class OWConcatenate(widget.OWWidget):
     domain_opts = ("Union of attributes appearing in all tables",
                    "Intersection of attributes in all tables")
 
-    id_roles = ("Class Attribute", "Attribute", "Meta Attribute")
+    id_roles = ("Class attribute", "Attribute", "Meta attribute")
 
     auto_commit = Setting(True)
 

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -119,8 +119,7 @@ class OWConcatenate(widget.OWWidget):
         cb.makeConsistent()
 
         box = gui.auto_commit(
-            self.controlArea, self, "auto_commit", "Apply Changes",
-            "Apply on Change", commit=self.apply)
+            self.controlArea, self, "auto_commit", "Apply", commit=self.apply)
         box.layout().insertWidget(0, self.report_button)
         box.layout().insertSpacing(1, 20)
 

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -54,7 +54,7 @@ class OWConcatenate(widget.OWWidget):
     domain_opts = ("Union of attributes appearing in all tables",
                    "Intersection of attributes in all tables")
 
-    id_roles = ("Class attribute", "Attribute", "Meta attribute")
+    id_roles = ("Class Attribute", "Attribute", "Meta Attribute")
 
     auto_commit = Setting(True)
 
@@ -64,7 +64,7 @@ class OWConcatenate(widget.OWWidget):
         self.primary_data = None
         self.more_data = OrderedDict()
 
-        mergebox = gui.vBox(self.controlArea, "Domains merging")
+        mergebox = gui.vBox(self.controlArea, "Domain Merging")
         box = gui.radioButtons(
             mergebox, self, "merge_type",
             callback=self._merge_type_changed)
@@ -80,13 +80,13 @@ class OWConcatenate(widget.OWWidget):
 
         label = gui.widgetLabel(
             box,
-            self.tr("The resulting table will have class only if there " +
+            self.tr("The resulting table will have a class only if there " +
                     "is no conflict between input classes."))
         label.setWordWrap(True)
 
         ###
         box = gui.vBox(
-            self.controlArea, self.tr("Source identification"),
+            self.controlArea, self.tr("Source Identification"),
             addSpace=False)
 
         cb = gui.checkBox(
@@ -103,11 +103,11 @@ class OWConcatenate(widget.OWWidget):
         )
 
         form.addRow(
-            self.tr("Feature name"),
+            self.tr("Feature name:"),
             gui.lineEdit(ibox, self, "source_attr_name", valueType=str))
 
         form.addRow(
-            self.tr("Place"),
+            self.tr("Place:"),
             gui.comboBox(ibox, self, "source_column_role", items=self.id_roles)
         )
 
@@ -120,7 +120,7 @@ class OWConcatenate(widget.OWWidget):
 
         box = gui.auto_commit(
             self.controlArea, self, "auto_commit", "Apply Changes",
-            "Apply on change", commit=self.apply)
+            "Apply on Change", commit=self.apply)
         box.layout().insertWidget(0, self.report_button)
         box.layout().insertSpacing(1, 20)
 

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -55,30 +55,30 @@ class OWContinuize(widget.OWWidget):
         ("One class per value", Continuize.Indicators),
     )
 
-    value_ranges = ["from -1 to 1", "from 0 to 1"]
+    value_ranges = ["From -1 to 1", "From 0 to 1"]
 
     def __init__(self):
         super().__init__()
 
-        box = gui.vBox(self.controlArea, "Multinomial attributes")
+        box = gui.vBox(self.controlArea, "Multinomial Attributes")
         gui.radioButtonsInBox(
             box, self, "multinomial_treatment",
             btnLabels=[x[0] for x in self.multinomial_treats],
             callback=self.settings_changed)
 
-        box = gui.vBox(self.controlArea, "Continuous attributes")
+        box = gui.vBox(self.controlArea, "Continuous Attributes")
         gui.radioButtonsInBox(
             box, self, "continuous_treatment",
             btnLabels=[x[0] for x in self.continuous_treats],
             callback=self.settings_changed)
 
-        box = gui.vBox(self.controlArea, "Discrete class attribute")
+        box = gui.vBox(self.controlArea, "Discrete Class Attribute")
         gui.radioButtonsInBox(
             box, self, "class_treatment",
             btnLabels=[t[0] for t in self.class_treats],
             callback=self.settings_changed)
 
-        zbbox = gui.vBox(self.controlArea, "Value range")
+        zbbox = gui.vBox(self.controlArea, "Value Range")
 
         gui.radioButtonsInBox(
             zbbox, self, "zero_based",

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -15,8 +15,8 @@ except ImportError:
 class OWDataInfo(widget.OWWidget):
     name = "Data Info"
     id = "orange.widgets.data.info"
-    description = """Display the basic information about the data set, like
-    number and type of variables in columns and number of rows."""
+    description = """Display basic information about the data set, such
+    as the number and type of variables in the columns and the number of rows."""
     icon = "icons/DataInfo.svg"
     priority = 80
     category = "Data"

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -72,7 +72,7 @@ class OWDataSampler(widget.OWWidget):
             callback=set_sampling_type(self.FixedProportion),
             addSpace=12)
 
-        gui.appendRadioButton(sampling, "Fixed sample size:")
+        gui.appendRadioButton(sampling, "Fixed sample size")
         ibox = gui.indentedBox(sampling)
         self.sampleSizeSpin = gui.spin(
             ibox, self, "sampleSizeNumber", label="Instances: ",
@@ -83,13 +83,13 @@ class OWDataSampler(widget.OWWidget):
             callback=set_sampling_type(self.FixedSize),
             addSpace=12)
 
-        gui.appendRadioButton(sampling, "Cross Validation:")
+        gui.appendRadioButton(sampling, "Cross Validation")
         form = QtGui.QFormLayout(
             formAlignment=Qt.AlignLeft | Qt.AlignTop,
             labelAlignment=Qt.AlignLeft,
             fieldGrowthPolicy=QtGui.QFormLayout.AllNonFixedFieldsGrow)
         ibox = gui.indentedBox(sampling, addSpace=True, orientation=form)
-        form.addRow("Number of folds",
+        form.addRow("Number of folds:",
                     gui.spin(
                         ibox, self, "number_of_folds", 2, 100,
                         addToLayout=False,
@@ -97,7 +97,7 @@ class OWDataSampler(widget.OWWidget):
         self.selected_fold_spin = gui.spin(
             ibox, self, "selectedFold", 1, self.number_of_folds,
             addToLayout=False, callback=self.fold_changed)
-        form.addRow("Selected fold", self.selected_fold_spin)
+        form.addRow("Selected fold:", self.selected_fold_spin)
 
         gui.appendRadioButton(sampling, "Boostrap")
 

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -83,7 +83,7 @@ class OWDataSampler(widget.OWWidget):
             callback=set_sampling_type(self.FixedSize),
             addSpace=12)
 
-        gui.appendRadioButton(sampling, "Cross Validation")
+        gui.appendRadioButton(sampling, "Cross validation")
         form = QtGui.QFormLayout(
             formAlignment=Qt.AlignLeft | Qt.AlignTop,
             labelAlignment=Qt.AlignLeft,

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -223,7 +223,7 @@ class OWDiscretize(widget.OWWidget):
         box = gui.auto_commit(
             self.controlArea, self, "autosend", "Apply",
             orientation=Qt.Horizontal,
-            checkbox_label="Send data after every change")
+            checkbox_label="Auto apply on change")
         box.layout().insertSpacing(0, 20)
         box.layout().insertWidget(0, self.report_button)
 

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -223,7 +223,7 @@ class OWDiscretize(widget.OWWidget):
         box = gui.auto_commit(
             self.controlArea, self, "autosend", "Apply",
             orientation=Qt.Horizontal,
-            checkbox_label="Auto apply on change")
+            checkbox_label="Apply automatically")
         box.layout().insertSpacing(0, 20)
         box.layout().insertWidget(0, self.report_button)
 

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -133,7 +133,7 @@ class VariableEditor(QWidget):
 
     def _setup_gui_name(self):
         self.name_edit = QLineEdit()
-        self.main_form.addRow("Name", self.name_edit)
+        self.main_form.addRow("Name:", self.name_edit)
         self.name_edit.editingFinished.connect(self.on_name_changed)
 
     def _setup_gui_labels(self):
@@ -189,7 +189,7 @@ class VariableEditor(QWidget):
         hlayout.addStretch(10)
         vlayout.addLayout(hlayout)
 
-        self.main_form.addRow("Labels", vlayout)
+        self.main_form.addRow("Labels:", vlayout)
 
     def set_data(self, var):
         """Set the variable to edit.
@@ -300,7 +300,7 @@ class DiscreteVariableEditor(VariableEditor):
         self.values_edit.setModel(self.values_model)
 
         self.values_model.dataChanged.connect(self.on_values_changed)
-        self.main_form.addRow("Values", self.values_edit)
+        self.main_form.addRow("Values:", self.values_edit)
 
     def set_data(self, var):
         """Set the variable to edit
@@ -381,11 +381,11 @@ class OWEditDomain(widget.OWWidget):
         box.layout().addWidget(self.domain_view)
 
         box = gui.hBox(self.controlArea)
-        gui.button(box, self, "Reset selected", callback=self.reset_selected)
-        gui.button(box, self, "Reset all", callback=self.reset_all)
+        gui.button(box, self, "Reset Selected", callback=self.reset_selected)
+        gui.button(box, self, "Reset All", callback=self.reset_all)
 
         gui.auto_commit(self.controlArea, self, "autocommit", "Commit",
-                        "Commit on change is on")
+                        "Commit on Change is On")
 
         box = gui.vBox(self.mainArea, "Edit")
         self.editor_stack = QtGui.QStackedWidget()

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -384,8 +384,7 @@ class OWEditDomain(widget.OWWidget):
         gui.button(box, self, "Reset Selected", callback=self.reset_selected)
         gui.button(box, self, "Reset All", callback=self.reset_all)
 
-        gui.auto_commit(self.controlArea, self, "autocommit", "Commit",
-                        "Commit on Change is On")
+        gui.auto_commit(self.controlArea, self, "autocommit", "Apply")
 
         box = gui.vBox(self.mainArea, "Edit")
         self.editor_stack = QtGui.QStackedWidget()

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -165,7 +165,7 @@ class FeatureEditor(QtGui.QFrame):
         self.expressionedit.setText(data.expression)
         self.setModified(False)
         self.featureChanged.emit()
-        self.attrs_model[:] = ["Select feature"]
+        self.attrs_model[:] = ["Select Feature"]
         if domain:
             self.attrs_model[:] += chain(domain.attributes,
                                          domain.class_vars,

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -440,7 +440,7 @@ class OWFeatureConstructor(widget.OWWidget):
         box.layout().addWidget(self.report_button)
         self.report_button.setMinimumWidth(180)
         gui.rubber(box)
-        commit = gui.button(box, self, "Commit", callback=self.apply,
+        commit = gui.button(box, self, "Send", callback=self.apply,
                             default=True)
         commit.setMinimumWidth(180)
 

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -106,7 +106,7 @@ class FeatureEditor(QtGui.QFrame):
         )
 
         self.attrs_model = itemmodels.VariableListModel(
-            ["Select feature"], parent=self)
+            ["Select Feature"], parent=self)
         self.attributescb = QtGui.QComboBox(
             minimumContentsLength=16,
             sizeAdjustPolicy=QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon,
@@ -119,7 +119,7 @@ class FeatureEditor(QtGui.QFrame):
         self.funcs_model = itemmodels.PyListModelTooltip()
         self.funcs_model.setParent(self)
 
-        self.funcs_model[:] = chain(["Select function"], sorted_funcs)
+        self.funcs_model[:] = chain(["Select Function"], sorted_funcs)
         self.funcs_model.tooltips[:] = chain(
             [''],
             [self.FUNCTIONS[func].__doc__ for func in sorted_funcs])
@@ -397,7 +397,7 @@ class OWFeatureConstructor(widget.OWWidget):
                 StringDescriptor(generate_newname("S{}"), ""))
         )
         menu.addSeparator()
-        self.duplicateaction = menu.addAction("Duplicate selected variable")
+        self.duplicateaction = menu.addAction("Duplicate Selected Variable")
         self.duplicateaction.triggered.connect(self.duplicateFeature)
         self.duplicateaction.setEnabled(False)
         self.addbutton.setMenu(menu)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -176,7 +176,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         box = gui.hBox(self.controlArea)
         gui.button(
-            box, self, "Browse Documentation Data Sets",
+            box, self, "Browse documentation data sets",
             callback=lambda: self.browse_file(True), autoDefault=False)
         gui.rubber(box)
         box.layout().addWidget(self.report_button)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -62,7 +62,7 @@ class XlsContextHandler(ContextHandler):
 class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     name = "File"
     id = "orange.widgets.data.file"
-    description = "Read a data from an input file or network" \
+    description = "Read a data from an input file or network " \
                   "and send the data table to the output."
     icon = "icons/File.svg"
     priority = 10
@@ -112,7 +112,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         vbox = gui.radioButtons(None, self, "source", box=True, addSpace=True,
                                 callback=self.load_data, addToLayout=False)
 
-        rb_button = gui.appendRadioButton(vbox, "File", addToLayout=False)
+        rb_button = gui.appendRadioButton(vbox, "File:", addToLayout=False)
         layout.addWidget(rb_button, 0, 0, QtCore.Qt.AlignVCenter)
 
         box = gui.hBox(None, addToLayout=False, margin=0)
@@ -153,7 +153,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         layout.addWidget(self.sheet_box, 2, 1)
         self.sheet_box.hide()
 
-        rb_button = gui.appendRadioButton(vbox, "URL", addToLayout=False)
+        rb_button = gui.appendRadioButton(vbox, "URL:", addToLayout=False)
         layout.addWidget(rb_button, 3, 0, QtCore.Qt.AlignVCenter)
 
         self.url_combo = url_combo = QtGui.QComboBox()
@@ -176,7 +176,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         box = gui.hBox(self.controlArea)
         gui.button(
-            box, self, "Browse documentation data sets",
+            box, self, "Browse Documentation Data Sets",
             callback=lambda: self.browse_file(True), autoDefault=False)
         gui.rubber(box)
         box.layout().addWidget(self.report_button)

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -372,8 +372,7 @@ class OWImageViewer(widget.OWWidget):
         )
         gui.rubber(self.controlArea)
 
-        gui.auto_commit(self.buttonsArea, self, "autoCommit",
-                        "Commit", "Auto Commit", box=False)
+        gui.auto_commit(self.buttonsArea, self, "autoCommit", "Send", box=False)
 
         self.scene = GraphicsScene()
         self.sceneView = QGraphicsView(self.scene, self)

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -373,7 +373,7 @@ class OWImageViewer(widget.OWWidget):
         gui.rubber(self.controlArea)
 
         gui.auto_commit(self.buttonsArea, self, "autoCommit",
-                        "Commit", "Auto commit", box=False)
+                        "Commit", "Auto Commit", box=False)
 
         self.scene = GraphicsScene()
         self.sceneView = QGraphicsView(self.scene, self)
@@ -435,7 +435,7 @@ class OWImageViewer(widget.OWWidget):
             if self.stringAttrs:
                 self.setupScene()
         else:
-            self.info.setText("Waiting for input\n")
+            self.info.setText("Waiting for input.\n")
 
     def clear(self):
         self.data = None

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -343,7 +343,7 @@ class OWImageViewer(widget.OWWidget):
 
         self.info = gui.widgetLabel(
             gui.vBox(self.controlArea, "Info"),
-            "Waiting for input\n"
+            "Waiting for input.\n"
         )
 
         self.imageAttrCB = gui.comboBox(

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -155,8 +155,8 @@ class OWImpute(OWWidget):
         self.variable_button_group = button_group
 
         box = gui.auto_commit(
-            self.controlArea, self, "autocommit", "Commit",
-            orientation=Qt.Horizontal, checkbox_label="Commit on any change")
+            self.controlArea, self, "autocommit", "Apply",
+            orientation=Qt.Horizontal, checkbox_label="Apply on any change")
         box.layout().insertSpacing(0, 80)
         box.layout().insertWidget(0, self.report_button)
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -156,7 +156,7 @@ class OWImpute(OWWidget):
 
         box = gui.auto_commit(
             self.controlArea, self, "autocommit", "Apply",
-            orientation=Qt.Horizontal, checkbox_label="Apply on any change")
+            orientation=Qt.Horizontal, checkbox_label="Apply automatically")
         box.layout().insertSpacing(0, 80)
         box.layout().insertWidget(0, self.report_button)
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -80,7 +80,7 @@ class OWImpute(OWWidget):
         main_layout.setMargin(10)
         self.controlArea.layout().addLayout(main_layout)
 
-        box = QtGui.QGroupBox(title=self.tr("Default method"), flat=False)
+        box = QtGui.QGroupBox(title=self.tr("Default Method"), flat=False)
         box_layout = QtGui.QVBoxLayout(box)
         main_layout.addWidget(box)
 
@@ -95,7 +95,7 @@ class OWImpute(OWWidget):
 
         self.default_button_group = button_group
 
-        box = QtGui.QGroupBox(title=self.tr("Individual attribute settings"),
+        box = QtGui.QGroupBox(title=self.tr("Individual Attribute Settings"),
                               flat=False)
         main_layout.addWidget(box)
 
@@ -147,7 +147,7 @@ class OWImpute(OWWidget):
         method_layout.addStretch(2)
 
         reset_button = QtGui.QPushButton(
-                "Restore all to default", checked=False, checkable=False,
+                "Restore All to Default", checked=False, checkable=False,
                 clicked=self.reset_variable_methods, default=False,
                 autoDefault=False)
         method_layout.addWidget(reset_button)

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -17,7 +17,7 @@ INDEX = "Index"
 
 class OWMergeData(widget.OWWidget):
     name = "Merge Data"
-    description = "Merge data sets based on values of selected data feature."
+    description = "Merge data sets based on the values of selected data features."
     icon = "icons/MergeData.svg"
     priority = 1110
 

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -13,7 +13,7 @@ from Orange.widgets.utils.sql import check_sql_input
 
 class OWOutliers(widget.OWWidget):
     name = "Outliers"
-    description = "Detects outliers."
+    description = "Detect outliers."
     icon = "icons/Outliers.svg"
     priority = 3000
     category = "Data"
@@ -46,11 +46,11 @@ class OWOutliers(widget.OWWidget):
         self.in_out_info_label = gui.widgetLabel(box,
                                                  self.in_out_info_default)
 
-        box = gui.vBox(self.controlArea, "Outlier detection method")
+        box = gui.vBox(self.controlArea, "Outlier Detection Method")
         detection = gui.radioButtons(box, self, "outlier_method")
 
         gui.appendRadioButton(detection,
-                              "One class SVM with non-linear kernel (RBF):")
+                              "One class SVM with non-linear kernel (RBF)")
         ibox = gui.indentedBox(detection)
         tooltip = "An upper bound on the fraction of training errors and a " \
                   "lower bound of the fraction of support vectors"
@@ -63,7 +63,7 @@ class OWOutliers(widget.OWWidget):
             spinType=float, minv=0.01, maxv=10, callback=self.gamma_changed)
         gui.separator(detection, 12)
 
-        self.rb_cov = gui.appendRadioButton(detection, "Covariance estimator:")
+        self.rb_cov = gui.appendRadioButton(detection, "Covariance estimator")
         ibox = gui.indentedBox(detection)
         self.l_cov = gui.widgetLabel(ibox, 'Contamination:')
         self.cont_slider = gui.hSlider(

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -916,7 +916,7 @@ class OWPaintData(widget.OWWidget):
 
         gui.rubber(self.controlArea)
         gui.auto_commit(self.left_side, self, "autocommit",
-                        "Send", "Send on change")
+                        "Send")
 
         # main area GUI
         viewbox = PaintViewBox(enableMouse=False)

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -757,7 +757,7 @@ class OWPaintData(widget.OWWidget):
     ]
 
     name = "Paint Data"
-    description = "Create data by painting data points in the plane."
+    description = "Create data by painting data points on a plane."
     long_description = ""
     icon = "icons/PaintData.svg"
     priority = 10
@@ -809,12 +809,12 @@ class OWPaintData(widget.OWWidget):
         namesBox = gui.vBox(self.controlArea, "Names")
 
         hbox = gui.hBox(namesBox, margin=0, spacing=0)
-        gui.lineEdit(hbox, self, "attr1", "Variable X ",
+        gui.lineEdit(hbox, self, "attr1", "Variable X: ",
                      controlWidth=80, orientation=Qt.Horizontal,
                      enterPlaceholder=True, callback=self._attr_name_changed)
         gui.separator(hbox, 18)
         hbox = gui.hBox(namesBox, margin=0, spacing=0)
-        attr2 = gui.lineEdit(hbox, self, "attr2", "Variable Y ",
+        attr2 = gui.lineEdit(hbox, self, "attr2", "Variable Y: ",
                              controlWidth=80, orientation=Qt.Horizontal,
                              enterPlaceholder=True,
                              callback=self._attr_name_changed)
@@ -905,14 +905,14 @@ class OWPaintData(widget.OWWidget):
             indBox, self, "brushRadius", minValue=1, maxValue=100,
             createLabel=False
         )
-        form.addRow("Radius", slider)
+        form.addRow("Radius:", slider)
 
         slider = gui.hSlider(
             indBox, self, "density", None, minValue=1, maxValue=100,
             createLabel=False
         )
 
-        form.addRow("Intensity", slider)
+        form.addRow("Intensity:", slider)
 
         gui.rubber(self.controlArea)
         gui.auto_commit(self.left_side, self, "autocommit",

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -394,7 +394,7 @@ class UnivariateFeatureSelect(QWidget):
         self.__spins = {}
 
         form = QFormLayout()
-        fixedrb = QRadioButton("Fixed", checked=True)
+        fixedrb = QRadioButton("Fixed:", checked=True)
         group.addButton(fixedrb, UnivariateFeatureSelect.Fixed)
         kspin = QSpinBox(
             minimum=1, value=self.__k,
@@ -405,7 +405,7 @@ class UnivariateFeatureSelect(QWidget):
         self.__spins[UnivariateFeatureSelect.Fixed] = kspin
         form.addRow(fixedrb, kspin)
 
-        percrb = QRadioButton("Percentile")
+        percrb = QRadioButton("Percentile:")
         group.addButton(percrb, UnivariateFeatureSelect.Percentile)
         pspin = QDoubleSpinBox(
             minimum=0.0, maximum=100.0, singleStep=0.5,
@@ -511,9 +511,9 @@ class FeatureSelectEditor(BaseEditor):
 
         self.__uni_fs = UnivariateFeatureSelect()
         self.__uni_fs.setItems(
-            [{"text": "Information gain", "tooltip": ""},
-             {"text": "Gain ratio"},
-             {"text": "Gini index"},
+            [{"text": "Information Gain", "tooltip": ""},
+             {"text": "Gain Ratio"},
+             {"text": "Gini Index"},
              {"text": "ReliefF"},
              {"text": "Fast Correlation Based Filter"}
             ]
@@ -623,15 +623,15 @@ class Scale(BaseEditor):
 
         form = QFormLayout()
         self.__centercb = QComboBox()
-        self.__centercb.addItems(["No centering", "Center by mean",
-                                  "Center by median"])
+        self.__centercb.addItems(["No Centering", "Center by Mean",
+                                  "Center by Median"])
 
         self.__scalecb = QComboBox()
-        self.__scalecb.addItems(["No scaling", "Scale by std",
-                                 "Scale by span"])
+        self.__scalecb.addItems(["No scaling", "Scale by SD",
+                                 "Scale by Span"])
 
-        form.addRow("Center", self.__centercb)
-        form.addRow("Scale", self.__scalecb)
+        form.addRow("Center:", self.__centercb)
+        form.addRow("Scale:", self.__scalecb)
         self.layout().addLayout(form)
         self.__centercb.currentIndexChanged.connect(self.changed)
         self.__scalecb.currentIndexChanged.connect(self.changed)
@@ -700,7 +700,7 @@ class Randomize(BaseEditor):
                                       "Features",
                                       "Meta data"])
 
-        form.addRow("Randomize", self.__rand_type_cb)
+        form.addRow("Randomize:", self.__rand_type_cb)
         self.layout().addLayout(form)
         self.__rand_type_cb.currentIndexChanged.connect(self.changed)
         self.__rand_type_cb.activated.connect(self.edited)
@@ -731,7 +731,7 @@ class PCA(BaseEditor):
         self.cspin.valueChanged[int].connect(self.setC)
         self.cspin.editingFinished.connect(self.edited)
 
-        form.addRow("Components", self.cspin)
+        form.addRow("Components:", self.cspin)
         self.layout().addLayout(form)
 
     def setParameters(self, params):
@@ -771,8 +771,8 @@ class CUR(BaseEditor):
         self.espin.valueChanged[float].connect(self.setE)
         self.espin.editingFinished.connect(self.edited)
 
-        form.addRow("Rank", self.rspin)
-        form.addRow("Relative error", self.espin)
+        form.addRow("Rank:", self.rspin)
+        form.addRow("Relative error:", self.espin)
         self.layout().addLayout(form)
 
     def setParameters(self, params):

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -628,7 +628,7 @@ class Scale(BaseEditor):
 
         self.__scalecb = QComboBox()
         self.__scalecb.addItems(["No scaling", "Scale by SD",
-                                 "Scale by Span"])
+                                 "Scale by span"])
 
         form.addRow("Center:", self.__centercb)
         form.addRow("Scale:", self.__scalecb)

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1693,7 +1693,7 @@ class OWPreprocess(widget.OWWidget):
         self.flow_view.installEventFilter(self)
 
         box = gui.vBox(self.controlArea, "Output")
-        gui.auto_commit(box, self, "autocommit", "Commit", box=False)
+        gui.auto_commit(box, self, "autocommit", "Send", box=False)
 
         self._initialize()
 

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -94,8 +94,7 @@ class OWPurgeDomain(widget.OWWidget):
                 gui.separator(box3, 2)
             gui.label(box3, self, "{}: %({})s".format(label, value))
 
-        gui.auto_commit(self.buttonsArea, self, "autoSend", "Send Data",
-                        checkbox_label="Send automatically",
+        gui.auto_commit(self.buttonsArea, self, "autoSend", "Apply",
                         orientation=Qt.Horizontal)
         gui.rubber(self.controlArea)
 

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -11,7 +11,7 @@ from Orange.widgets.utils.sql import check_sql_input
 class OWPurgeDomain(widget.OWWidget):
     name = "Purge Domain"
     description = "Remove redundant values and features from the data set. " \
-                  "Sorts values."
+                  "Sort values."
     icon = "icons/PurgeDomain.svg"
     category = "Data"
     keywords = ["data", "purge", "domain"]

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -460,7 +460,8 @@ class OWPythonScript(widget.OWWidget):
 
         self.controlBox.layout().addWidget(w)
 
-        gui.auto_commit(self.controlArea, self, "auto_execute", "Execute")
+        gui.auto_commit(self.controlArea, self, "auto_execute", "Execute",
+                        auto_label="Auto Execute")
 
         self.splitCanvas = QSplitter(Qt.Vertical, self.mainArea)
         self.mainArea.layout().addWidget(self.splitCanvas)

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -442,8 +442,8 @@ class OWPythonScript(widget.OWWidget):
 
         action = QAction("More", self, toolTip="More actions")
 
-        new_from_file = QAction("Import a script from a file", self)
-        save_to_file = QAction("Save selected script to a file", self)
+        new_from_file = QAction("Import Script from File", self)
+        save_to_file = QAction("Save Selected Script to File", self)
         save_to_file.setShortcut(QKeySequence(QKeySequence.SaveAs))
 
         new_from_file.triggered.connect(self.onAddScriptFromFile)
@@ -468,7 +468,7 @@ class OWPythonScript(widget.OWWidget):
         self.defaultFont = defaultFont = \
             "Monaco" if sys.platform == "darwin" else "Courier"
 
-        self.textBox = gui.vBox(self, 'Python script')
+        self.textBox = gui.vBox(self, 'Python Script')
         self.splitCanvas.addWidget(self.textBox)
         self.text = PythonScriptEditor(self)
         self.textBox.layout().addWidget(self.text)

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -95,7 +95,7 @@ class OWRank(widget.OWWidget):
                              if issubclass(ContinuousVariable, m.score.class_type)]
 
         selMethBox = gui.vBox(
-                self.controlArea, "Select attributes", addSpace=True)
+                self.controlArea, "Select Attributes", addSpace=True)
 
         grid = QtGui.QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
@@ -128,7 +128,7 @@ class OWRank(widget.OWWidget):
         selMethBox.layout().addLayout(grid)
 
         gui.auto_commit(self.buttonsArea, self, "auto_apply", "Commit",
-                        auto_label="Commit on change", box=False)
+                        auto_label="Commit on Change", box=False)
 
         gui.rubber(self.controlArea)
 

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -98,7 +98,7 @@ class OWRank(widget.OWWidget):
                 self.controlArea, "Select Attributes", addSpace=True)
 
         grid = QtGui.QGridLayout()
-        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setContentsMargins(6, 0, 6, 0)
         self.selectButtons = QtGui.QButtonGroup()
         self.selectButtons.buttonClicked[int].connect(self.setSelectMethod)
 
@@ -112,7 +112,7 @@ class OWRank(widget.OWWidget):
         b1 = button(self.tr("None"), OWRank.SelectNone)
         b2 = button(self.tr("All"), OWRank.SelectAll)
         b3 = button(self.tr("Manual"), OWRank.SelectManual)
-        b4 = button(self.tr("Best ranked"), OWRank.SelectNBest)
+        b4 = button(self.tr("Best ranked:"), OWRank.SelectNBest)
 
         s = gui.spin(selMethBox, self, "nSelected", 1, 100,
                      callback=self.nSelectedChanged)

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -127,8 +127,7 @@ class OWRank(widget.OWWidget):
 
         selMethBox.layout().addLayout(grid)
 
-        gui.auto_commit(self.buttonsArea, self, "auto_apply", "Commit",
-                        auto_label="Commit on Change", box=False)
+        gui.auto_commit(self.buttonsArea, self, "auto_apply", "Send", box=False)
 
         gui.rubber(self.controlArea)
 

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -42,7 +42,7 @@ class OWSave(widget.OWWidget):
             commit=self.save_file, callback=self.adjust_label,
             disabled=True, addSpace=True)
         self.saveAs = gui.button(
-            self.controlArea, self, "Save as ...",
+            self.controlArea, self, "Save As...",
             callback=self.save_file_as, disabled=True)
         self.saveAs.setMinimumWidth(220)
         self.adjustSize()

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -412,13 +412,12 @@ class OWSelectAttributes(widget.OWWidget):
         self.down_meta_button = gui.button(bbox, self, "Down",
             callback=partial(self.move_down, self.meta_attrs_view))
 
-        autobox = gui.auto_commit(None, self, "auto_commit", "Send Selected",
-                                  "Auto Send")
+        autobox = gui.auto_commit(None, self, "auto_commit", "Send")
         layout.addWidget(autobox, 3, 0, 1, 3)
         reset = gui.button(None, self, "Reset", callback=self.reset)
         autobox.layout().insertWidget(0, self.report_button)
         autobox.layout().insertWidget(1, reset)
-        autobox.layout().insertSpacing(2, 40)
+        autobox.layout().insertSpacing(2, 10)
         reset.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Preferred)
         self.report_button.setSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Preferred)
 

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -412,7 +412,8 @@ class OWSelectAttributes(widget.OWWidget):
         self.down_meta_button = gui.button(bbox, self, "Down",
             callback=partial(self.move_down, self.meta_attrs_view))
 
-        autobox = gui.auto_commit(None, self, "auto_commit", "Apply", "Auto Apply")
+        autobox = gui.auto_commit(None, self, "auto_commit", "Send Selected",
+                                  "Auto Send")
         layout.addWidget(autobox, 3, 0, 1, 3)
         reset = gui.button(None, self, "Reset", callback=self.reset)
         autobox.layout().insertWidget(0, self.report_button)

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -412,7 +412,7 @@ class OWSelectAttributes(widget.OWWidget):
         self.down_meta_button = gui.button(bbox, self, "Down",
             callback=partial(self.move_down, self.meta_attrs_view))
 
-        autobox = gui.auto_commit(None, self, "auto_commit", "Apply", "Auto apply")
+        autobox = gui.auto_commit(None, self, "auto_commit", "Apply", "Auto Apply")
         layout.addWidget(autobox, 3, 0, 1, 3)
         reset = gui.button(None, self, "Reset", callback=self.reset)
         autobox.layout().insertWidget(0, self.report_button)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -82,11 +82,11 @@ class OWSelectRows(widget.OWWidget):
         self.cond_list.viewport().setBackgroundRole(QtGui.QPalette.Window)
 
         box2 = gui.hBox(box)
-        self.add_button = gui.button(box2, self, "Add condition",
+        self.add_button = gui.button(box2, self, "Add Condition",
                                      callback=self.add_row)
-        self.add_all_button = gui.button(box2, self, "Add all variables",
+        self.add_all_button = gui.button(box2, self, "Add All Variables",
                                          callback=self.add_all)
-        self.remove_all_button = gui.button(box2, self, "Remove all",
+        self.remove_all_button = gui.button(box2, self, "Remove All",
                                             callback=self.remove_all)
         gui.rubber(box2)
 

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -111,7 +111,7 @@ class OWSelectRows(widget.OWWidget):
             box_setting, self, "purge_classes", "Remove unused classes",
             callback=self.conditions_changed)
         gui.auto_commit(box, self, "auto_commit", label="Send",
-                        checkbox_label="Auto send on change")
+                        checkbox_label="Send automatically")
         self.set_data(None)
         self.resize(600, 400)
 

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -110,8 +110,8 @@ class OWSelectRows(widget.OWWidget):
         self.cb_pc = gui.checkBox(
             box_setting, self, "purge_classes", "Remove unused classes",
             callback=self.conditions_changed)
-        gui.auto_commit(box, self, "auto_commit", label="Commit",
-                        checkbox_label="Commit on change")
+        gui.auto_commit(box, self, "auto_commit", label="Send",
+                        checkbox_label="Auto send on change")
         self.set_data(None)
         self.resize(600, 400)
 

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -353,7 +353,7 @@ TableSlot = namedtuple("TableSlot", ["input_id", "table", "summary", "view"])
 
 class OWDataTable(widget.OWWidget):
     name = "Data Table"
-    description = "View data set in a spreadsheet."
+    description = "View the data set in a spreadsheet."
     icon = "icons/Table.svg"
     priority = 100
 
@@ -418,7 +418,7 @@ class OWDataTable(widget.OWWidget):
             tooltip="Show rows in the original order", autoDefault=False)
         self.buttonsArea.layout().insertWidget(0, reset)
         gui.auto_commit(self.buttonsArea, self, "auto_commit",
-                        "Send Selected Rows", "Auto send is on")
+                        "Send Selected Rows", "Auto Send is On")
 
         # GUI with tabs
         self.tabs = gui.tabWidget(self.mainArea)

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -418,7 +418,7 @@ class OWDataTable(widget.OWWidget):
             tooltip="Show rows in the original order", autoDefault=False)
         self.buttonsArea.layout().insertWidget(0, reset)
         gui.auto_commit(self.buttonsArea, self, "auto_commit",
-                        "Send Selected Rows", "Auto Send is On")
+                        "Send Selected Rows", "Send Automatically")
 
         # GUI with tabs
         self.tabs = gui.tabWidget(self.mainArea)

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -80,9 +80,9 @@ class OWConfusionMatrix(widget.OWWidget):
     inputs = [("Evaluation Results", Orange.evaluation.Results, "set_results")]
     outputs = [("Selected Data", Orange.data.Table)]
 
-    quantities = ["Number of Instances",
-                  "Proportion of Predicted",
-                  "Proportion of Actual"]
+    quantities = ["Number of instances",
+                  "Proportion of predicted",
+                  "Proportion of actual"]
 
     settingsHandler = settings.ClassValuesContextHandler()
 
@@ -137,7 +137,7 @@ class OWConfusionMatrix(widget.OWWidget):
                      callback=self._invalidate)
 
         gui.auto_commit(self.controlArea, self, "autocommit",
-                        "Send Selected", "Auto Send is On")
+                        "Send Selected", "Send Automatically")
 
         grid = QGridLayout()
 

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -137,7 +137,7 @@ class OWConfusionMatrix(widget.OWWidget):
                      callback=self._invalidate)
 
         gui.auto_commit(self.controlArea, self, "autocommit",
-                        "Send Data", "Auto send is on")
+                        "Send Selected", "Auto Send is On")
 
         grid = QGridLayout()
 

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -72,17 +72,17 @@ class OWConfusionMatrix(widget.OWWidget):
     """Confusion matrix widget"""
 
     name = "Confusion Matrix"
-    description = "Display confusion matrix constructed from results " \
-                  "of evaluation of classifiers."
+    description = "Display a confusion matrix constructed from " \
+                  "the results of classifier evaluations."
     icon = "icons/ConfusionMatrix.svg"
     priority = 1001
 
     inputs = [("Evaluation Results", Orange.evaluation.Results, "set_results")]
     outputs = [("Selected Data", Orange.data.Table)]
 
-    quantities = ["Number of instances",
-                  "Proportion of predicted",
-                  "Proportion of actual"]
+    quantities = ["Number of Instances",
+                  "Proportion of Predicted",
+                  "Proportion of Actual"]
 
     settingsHandler = settings.ClassValuesContextHandler()
 
@@ -126,7 +126,7 @@ class OWConfusionMatrix(widget.OWWidget):
                    callback=self.select_correct, autoDefault=False)
         gui.button(box, self, "Select Misclassified",
                    callback=self.select_wrong, autoDefault=False)
-        gui.button(box, self, "Clear selection",
+        gui.button(box, self, "Clear Selection",
                    callback=self.select_none, autoDefault=False)
 
         self.outputbox = box = gui.vBox(self.controlArea, "Output")

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -35,7 +35,7 @@ class OWPredictions(widget.OWWidget):
     name = "Predictions"
     icon = "icons/Predictions.svg"
     priority = 200
-    description = "Display predictions of models for an input data set."
+    description = "Display the predictions of models for an input data set."
     inputs = [("Data", Orange.data.Table, "set_data"),
               ("Predictors", Model,
                "set_predictor", widget.Multiple)]
@@ -73,7 +73,7 @@ class OWPredictions(widget.OWWidget):
 
         box = gui.vBox(self.controlArea, "Info")
         self.infolabel = gui.widgetLabel(
-            box, "No data on input\nPredictors: 0\nTask: N/A")
+            box, "No data on input.\nPredictors: 0\nTask: N/A")
         self.infolabel.setMinimumWidth(150)
         gui.button(box, self, "Restore Original Order",
                    callback=self._reset_order,
@@ -97,7 +97,7 @@ class OWPredictions(widget.OWWidget):
         gui.checkBox(box, self, "draw_dist", "Draw distribution bars",
                      callback=self._update_prediction_delegate)
 
-        box = gui.vBox(self.controlArea, "Data view")
+        box = gui.vBox(self.controlArea, "Data View")
         gui.checkBox(box, self, "show_attrs", "Show full data set",
                      callback=self._update_column_visibility)
 

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -274,8 +274,8 @@ class InfiniteLine(pg.InfiniteLine):
 
 class OWROCAnalysis(widget.OWWidget):
     name = "ROC Analysis"
-    description = "Display Receiver Operating Characteristics curve " \
-                  "based on evaluation of classifiers."
+    description = "Display the Receiver Operating Characteristics curve " \
+                  "based on the evaluation of classifiers."
     icon = "icons/ROCAnalysis.svg"
     priority = 1010
     inputs = [("Evaluation Results", Orange.evaluation.Results, "set_results")]
@@ -329,8 +329,8 @@ class OWROCAnalysis(widget.OWWidget):
         abox = gui.vBox(box, "Combine ROC Curves From Folds")
         abox.setFlat(True)
         gui.comboBox(abox, self, "roc_averaging",
-                     items=["Merge predictions from folds", "Mean TP rate",
-                            "Mean TP and FP at threshold", "Show individual curves"],
+                     items=["Merge Predictions from Folds", "Mean TP Rate",
+                            "Mean TP and FP at Threshold", "Show Individual Curves"],
                      callback=self._replot)
 
         hbox = gui.vBox(box, "ROC Convex Hull")
@@ -353,18 +353,18 @@ class OWROCAnalysis(widget.OWWidget):
 
         sp = gui.spin(box, self, "fp_cost", 1, 1000, 10,
                       callback=self._on_display_perf_line_changed)
-        grid.addWidget(QtGui.QLabel("FP Cost"), 0, 0)
+        grid.addWidget(QtGui.QLabel("FP Cost:"), 0, 0)
         grid.addWidget(sp, 0, 1)
 
         sp = gui.spin(box, self, "fn_cost", 1, 1000, 10,
                       callback=self._on_display_perf_line_changed)
-        grid.addWidget(QtGui.QLabel("FN Cost"))
+        grid.addWidget(QtGui.QLabel("FN Cost:"))
         grid.addWidget(sp, 1, 1)
         sp = gui.spin(box, self, "target_prior", 1, 99,
                       callback=self._on_display_perf_line_changed)
         sp.setSuffix("%")
         sp.addAction(QtGui.QAction("Auto", sp))
-        grid.addWidget(QtGui.QLabel("Prior target class probability"))
+        grid.addWidget(QtGui.QLabel("Prior target class probability:"))
         grid.addWidget(sp, 2, 1)
 
         self.plotview = pg.GraphicsView(background="w")

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -184,7 +184,7 @@ class OWTestLearners(widget.OWWidget):
 
         gui.appendRadioButton(rbox, "Random sampling")
         ibox = gui.indentedBox(rbox)
-        gui.spin(ibox, self, "n_repeat", 2, 50, label="Repeat train/test",
+        gui.spin(ibox, self, "n_repeat", 2, 50, label="Repeat train/test:",
                  callback=self.shuffle_split_changed)
         gui.widgetLabel(ibox, "Relative training set size:")
         gui.hSlider(ibox, self, "sample_p", minValue=1, maxValue=99,
@@ -202,7 +202,7 @@ class OWTestLearners(widget.OWWidget):
         self.apply_button = gui.button(
             rbox, self, "&Apply", callback=self.apply, default=True)
 
-        self.cbox = gui.vBox(self.controlArea, "Target class")
+        self.cbox = gui.vBox(self.controlArea, "Target Class")
         self.class_selection_combo = gui.comboBox(
             self.cbox, self, "class_selection", items=[],
             sendSelectedValue=True, valueType=str,

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2202,7 +2202,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
         if checkbox_label:
             auto_label = label
         else:
-            auto_label = "Auto " + label.title() + " is On"
+            auto_label = label.title() + " Automatically"
     if isinstance(box, QtGui.QWidget):
         b = box
     else:

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2202,7 +2202,7 @@ def auto_commit(widget, master, value, label, auto_label=None, box=True,
         if checkbox_label:
             auto_label = label
         else:
-            auto_label = "Auto " + label.lower() + " is on"
+            auto_label = "Auto " + label.title() + " is On"
     if isinstance(box, QtGui.QWidget):
         b = box
     else:

--- a/Orange/widgets/regression/owadaboostregression.py
+++ b/Orange/widgets/regression/owadaboostregression.py
@@ -10,7 +10,8 @@ from Orange.widgets.settings import Setting
 
 class OWAdaBoostRegression(owadaboost.OWAdaBoostClassification):
     name = "AdaBoost"
-    description = "An AdaBoost regression algorithm."
+    description = "An ensemble meta-algorithm that combines weak learners " \
+                  "and adapts to the 'hardness' of each training sample. "
     icon = "icons/AdaBoost.svg"
     priority = 80
 

--- a/Orange/widgets/regression/owadaboostregression.py
+++ b/Orange/widgets/regression/owadaboostregression.py
@@ -18,11 +18,11 @@ class OWAdaBoostRegression(owadaboost.OWAdaBoostClassification):
 
     inputs = [("Learner", LearnerRegression, "set_base_learner")]
 
-    losses = ["linear", "square", "exponential"]
+    losses = ["Linear", "Square", "Exponential"]
     loss = Setting(0)
 
     def add_specific_parameters(self, box):
-        gui.comboBox(box, self, "loss", label="Loss",
+        gui.comboBox(box, self, "loss", label="Loss:",
                      orientation=Qt.Horizontal, items=self.losses,
                      callback=self.settings_changed)
 

--- a/Orange/widgets/regression/owknnregression.py
+++ b/Orange/widgets/regression/owknnregression.py
@@ -4,7 +4,7 @@ from Orange.regression.knn import KNNRegressionLearner
 
 class OWKNNRegression(owknn.OWKNNLearner):
     name = "Nearest Neighbors"
-    description = "k-nearest neighbours regression algorithm."
+    description = "Predict according to the nearest training instances."
     icon = "icons/kNearestNeighbours.svg"
     priority = 20
 

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -12,8 +12,8 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWLinearRegression(OWBaseLearner):
     name = "Linear Regression"
-    description = "A linear regression algorithm with optional L1 and L2 " \
-                  "regularization."
+    description = "A linear regression algorithm with optional L1 (LASSO), " \
+                  "L2 (ridge) or L1L2 (elastic net) regularization."
     icon = "icons/LinearRegression.svg"
     priority = 60
 
@@ -50,7 +50,7 @@ class OWLinearRegression(OWBaseLearner):
 
         gui.separator(box, 20, 20)
         self.alpha_box = box2 = gui.vBox(box, margin=0)
-        gui.widgetLabel(box2, "Regularization strength")
+        gui.widgetLabel(box2, "Regularization strength:")
         self.alpha_slider = gui.hSlider(
             box2, self, "alpha_index",
             minValue=0, maxValue=len(self.alphas) - 1,
@@ -62,7 +62,7 @@ class OWLinearRegression(OWBaseLearner):
 
         gui.separator(box2, 10, 10)
         box4 = gui.vBox(box2, margin=0)
-        gui.widgetLabel(box4, "Elastic net mixing")
+        gui.widgetLabel(box4, "Elastic net mixing:")
         box5 = gui.hBox(box4)
         gui.widgetLabel(box5, "L1")
         self.l1_ratio_slider = gui.hSlider(

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -78,8 +78,7 @@ class OWLinearRegression(OWBaseLearner):
         self._set_l1_ratio_label()
 
         auto_commit = gui.auto_commit(
-                self.controlArea, self, "autosend",
-                "Apply", auto_label="Apply on change")
+                self.controlArea, self, "autosend", "Apply")
         auto_commit.layout().insertWidget(0, self.report_button)
         auto_commit.layout().insertSpacing(1, 20)
         self.report_button.setMinimumWidth(150)

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -49,7 +49,7 @@ class OWLinearRegression(OWBaseLearner):
                          callback=self._reg_type_changed)
 
         gui.separator(box, 20, 20)
-        self.alpha_box = box2 = gui.vBox(box, margin=0)
+        self.alpha_box = box2 = gui.vBox(box, margin=10)
         gui.widgetLabel(box2, "Regularization strength:")
         self.alpha_slider = gui.hSlider(
             box2, self, "alpha_index",

--- a/Orange/widgets/regression/owrandomforestregression.py
+++ b/Orange/widgets/regression/owrandomforestregression.py
@@ -5,7 +5,7 @@ from Orange.widgets import settings
 
 class OWRandomForestRegression(owrandomforest.OWRandomForest):
     name = "Random Forest Regression"
-    description = "The random forest regression algorithm."
+    description = "Predict using an ensemble of regression trees."
     icon = "icons/RandomForest.svg"
     priority = 40
 

--- a/Orange/widgets/regression/owrandomforestregression.py
+++ b/Orange/widgets/regression/owrandomforestregression.py
@@ -5,7 +5,7 @@ from Orange.widgets import settings
 
 class OWRandomForestRegression(owrandomforest.OWRandomForest):
     name = "Random Forest Regression"
-    description = "Random forest regression algorithm."
+    description = "The random forest regression algorithm."
     icon = "icons/RandomForest.svg"
     priority = 40
 

--- a/Orange/widgets/regression/owregressiontree.py
+++ b/Orange/widgets/regression/owregressiontree.py
@@ -5,7 +5,7 @@ from Orange.widgets.classify import owclassificationtree
 
 class OWRegressionTree(owclassificationtree.OWClassificationTree):
     name = "Regression Tree"
-    description = "Regression tree algorithm with forward pruning."
+    description = "A regression tree algorithm with forward pruning."
     icon = "icons/RegressionTree.svg"
     priority = 30
 

--- a/Orange/widgets/regression/owregressiontreegraph.py
+++ b/Orange/widgets/regression/owregressiontreegraph.py
@@ -25,7 +25,7 @@ class RegressionTreeNode(TreeNode):
 
 class OWRegressionTreeGraph(OWTreeGraph):
     name = "Regression Tree Viewer"
-    description = "Graphical visualization of a regression tree."
+    description = "A graphical visualization of a regression tree."
     icon = "icons/RegressionTreeGraph.svg"
     priority = 35
 

--- a/Orange/widgets/regression/owsgdregression.py
+++ b/Orange/widgets/regression/owsgdregression.py
@@ -12,7 +12,8 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWSGDRegression(OWBaseLearner):
     name = "Stochastic Gradient Descent"
-    description = "A stochastic gradient descent algorithm for regression."
+    description = "Minimize an objective function using a stochastic " \
+                  "approximation of gradient descent. "
     icon = "icons/SGDRegression.svg"
     priority = 90
     LEARNER = SGDRegressionLearner

--- a/Orange/widgets/regression/owsgdregression.py
+++ b/Orange/widgets/regression/owsgdregression.py
@@ -12,7 +12,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 class OWSGDRegression(OWBaseLearner):
     name = "Stochastic Gradient Descent"
-    description = "Stochastic gradient descent algorithm for regression."
+    description = "A stochastic gradient descent algorithm for regression."
     icon = "icons/SGDRegression.svg"
     priority = 90
     LEARNER = SGDRegressionLearner
@@ -52,7 +52,7 @@ class OWSGDRegression(OWBaseLearner):
             return form
 
         box = gui.radioButtons(
-            self.controlArea, self, "loss_function", box="Loss function",
+            self.controlArea, self, "loss_function", box="Loss Function",
             btnLabels=self.LOSS_FUNCTIONS, callback=self._on_func_changed,
             orientation=Qt.Vertical)
         form = add_form(box)
@@ -77,7 +77,7 @@ class OWSGDRegression(OWBaseLearner):
         self._on_penalty_changed()
 
         box = gui.radioButtons(
-            self.controlArea, self, "learning_rate", box="Learning rate",
+            self.controlArea, self, "learning_rate", box="Learning Rate",
             btnLabels=self.LEARNING_RATES, callback=self._on_lrate_changed,
             orientation=Qt.Vertical)
         form = add_form(box)

--- a/Orange/widgets/regression/owsvmregression.py
+++ b/Orange/widgets/regression/owsvmregression.py
@@ -12,7 +12,7 @@ from Orange.widgets.classify.owsvmclassification import OWBaseSVM
 
 class OWSVMRegression(OWBaseSVM):
     name = "SVM Regression"
-    description = "Support vector machine regression algorithm."
+    description = "A support vector machine regression algorithm."
     icon = "icons/SVMRegression.svg"
     priority = 50
 
@@ -41,12 +41,12 @@ class OWSVMRegression(OWBaseSVM):
 
         form.addWidget(gui.appendRadioButton(box, "ε-SVR", addToLayout=False),
                        0, 0, Qt.AlignLeft)
-        form.addWidget(QtGui.QLabel("Cost (C)"),
+        form.addWidget(QtGui.QLabel("Cost (C):"),
                        0, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "epsilon_C", 0.1, 512.0, 0.1,
                                       decimals=2, addToLayout=False),
                        0, 2)
-        form.addWidget(QLabel("Loss Epsilon (ε)"),
+        form.addWidget(QLabel("Loss epsilon (ε):"),
                        1, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "epsilon", 0.1, 512.0, 0.1,
                                       decimals=2, addToLayout=False),
@@ -54,12 +54,12 @@ class OWSVMRegression(OWBaseSVM):
 
         form.addWidget(gui.appendRadioButton(box, "ν-SVR", addToLayout=False),
                        2, 0, Qt.AlignLeft)
-        form.addWidget(QLabel("Cost (C)"),
+        form.addWidget(QLabel("Cost (C):"),
                        2, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "nu_C", 0.1, 512.0, 0.1,
                                       decimals=2, addToLayout=False),
                        2, 2)
-        form.addWidget(QLabel("Complexity bound (ν)"),
+        form.addWidget(QLabel("Complexity bound (ν):"),
                        3, 1, Qt.AlignRight)
         form.addWidget(gui.doubleSpin(box, self, "nu", 0.05, 1.0, 0.05,
                                       decimals=2, addToLayout=False),

--- a/Orange/widgets/regression/owsvmregression.py
+++ b/Orange/widgets/regression/owsvmregression.py
@@ -12,7 +12,8 @@ from Orange.widgets.classify.owsvmclassification import OWBaseSVM
 
 class OWSVMRegression(OWBaseSVM):
     name = "SVM Regression"
-    description = "A support vector machine regression algorithm."
+    description = "Support Vector Machines map inputs to higher-dimensional " \
+                  "feature spaces that best map instances to a linear function.  "
     icon = "icons/SVMRegression.svg"
     priority = 50
 

--- a/Orange/widgets/regression/owunivariateregression.py
+++ b/Orange/widgets/regression/owunivariateregression.py
@@ -44,7 +44,7 @@ class OWUnivariateRegression(OWBaseLearner):
 
         self.x_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesX = gui.comboBox(
-            box, self, value='x_var_index', label="Input ",
+            box, self, value='x_var_index', label="Input: ",
             orientation=Qt.Horizontal, callback=self.apply, contentsLength=12)
         self.comboBoxAttributesX.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
@@ -57,7 +57,7 @@ class OWUnivariateRegression(OWBaseLearner):
         gui.separator(box, height=8)
         self.y_var_model = itemmodels.VariableListModel()
         self.comboBoxAttributesY = gui.comboBox(
-            box, self, value='y_var_index', label='Target',
+            box, self, value="y_var_index", label="Target: ",
             orientation=Qt.Horizontal, callback=self.apply, contentsLength=12)
         self.comboBoxAttributesY.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -11,7 +11,7 @@ from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
 class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
     name = "Distance File"
     id = "orange.widgets.unsupervised.distancefile"
-    description = "Read distances from file"
+    description = "Read distances from a file."
     icon = "icons/DistanceFile.svg"
     priority = 10
     category = "Data"
@@ -55,7 +55,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
 
     def set_file_list(self):
         super().set_file_list()
-        self.file_combo.addItem("Browse documentation data sets...")
+        self.file_combo.addItem("Browse Documentation Data Sets...")
 
     def reload(self):
         return self.open_file()

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -55,7 +55,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
 
     def set_file_list(self):
         super().set_file_list()
-        self.file_combo.addItem("Browse Documentation Data Sets...")
+        self.file_combo.addItem("Browse documentation data sets...")
 
     def reload(self):
         return self.open_file()

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -324,7 +324,7 @@ class OWDistanceMap(widget.OWWidget):
         self.controlArea.layout().addStretch()
 
         gui.auto_commit(self.controlArea, self, "autocommit",
-                        "Send data", "Auto send is on")
+                        "Send Selected")
 
         self.view = pg.GraphicsView(background="w")
         self.mainArea.layout().addWidget(self.view)

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -278,7 +278,7 @@ class OWDistanceMap(widget.OWWidget):
         self._selection = None
 
         self.sorting_cb = gui.comboBox(
-            self.controlArea, self, "sorting", box="Element sorting",
+            self.controlArea, self, "sorting", box="Element Sorting",
             items=["None", "Clustering", "Clustering with ordered leaves"],
             callback=self._invalidate_ordering)
 
@@ -303,13 +303,13 @@ class OWDistanceMap(widget.OWWidget):
 #                         createLabel=False, callback=self._update_color)
 #         )
         form.addRow(
-            "Low",
+            "Low:",
             gui.hSlider(box, self, "color_low", minValue=0.0, maxValue=1.0,
                         step=0.05, ticks=True, intOnly=False,
                         createLabel=False, callback=self._update_color)
         )
         form.addRow(
-            "High",
+            "High:",
             gui.hSlider(box, self, "color_high", minValue=0.0, maxValue=1.0,
                         step=0.05, ticks=True, intOnly=False,
                         createLabel=False, callback=self._update_color)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -196,7 +196,7 @@ class DistanceMatrixContextHandler(ContextHandler):
 
 class OWDistanceMatrix(widget.OWWidget):
     name = "Distance Matrix"
-    description = "View distance matrix"
+    description = "View distance matrix."
     icon = "icons/DistanceMatrix.svg"
     priority = 200
 

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -244,8 +244,9 @@ class OWDistanceMatrix(widget.OWWidget):
         gui.rubber(settings_box)
         settings_box.layout().addWidget(self.report_button)
         gui.separator(settings_box, 40)
-        gui.auto_commit(settings_box, self, "auto_commit",
-                        "Send Selected", "Auto Send is On", box=None)
+        acb = gui.auto_commit(settings_box, self, "auto_commit",
+                              "Send Selected", "Send Automatically", box=None)
+        acb.setFixedWidth(200)
         # Signal must be connected after self.commit is redirected
         selmodel.selectionChanged.connect(self.commit)
 

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -244,9 +244,8 @@ class OWDistanceMatrix(widget.OWWidget):
         gui.rubber(settings_box)
         settings_box.layout().addWidget(self.report_button)
         gui.separator(settings_box, 40)
-        gui.auto_commit(
-            settings_box, self, "auto_commit",
-            "Send Selected Data", "Auto send is on", box=None)
+        gui.auto_commit(settings_box, self, "auto_commit",
+                        "Send Selected", "Auto Send is On", box=None)
         # Signal must be connected after self.commit is redirected
         selmodel.selectionChanged.connect(self.commit)
 

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -14,9 +14,9 @@ _METRICS = [
     ("Cosine", distance.Cosine),
     ("Jaccard", distance.Jaccard),
     ("Spearman", distance.SpearmanR),
-    ("Spearman Absolute", distance.SpearmanRAbsolute),
+    ("Spearman absolute", distance.SpearmanRAbsolute),
     ("Pearson", distance.PearsonR),
-    ("Pearson Absolute", distance.PearsonRAbsolute),
+    ("Pearson absolute", distance.PearsonRAbsolute),
 ]
 
 
@@ -48,7 +48,7 @@ class OWDistances(widget.OWWidget):
                      callback=self._invalidate
         )
         box = gui.auto_commit(self.buttonsArea, self, "autocommit", "Apply",
-                              box=False, checkbox_label="Auto apply on change")
+                              box=False, checkbox_label="Apply automatically")
         box.layout().insertWidget(0, self.report_button)
         box.layout().insertSpacing(1, 8)
 

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -48,7 +48,7 @@ class OWDistances(widget.OWWidget):
                      callback=self._invalidate
         )
         box = gui.auto_commit(self.buttonsArea, self, "autocommit", "Apply",
-                              box=False, checkbox_label="Apply on any change")
+                              box=False, checkbox_label="Auto apply on change")
         box.layout().insertWidget(0, self.report_button)
         box.layout().insertSpacing(1, 8)
 

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -14,9 +14,9 @@ _METRICS = [
     ("Cosine", distance.Cosine),
     ("Jaccard", distance.Jaccard),
     ("Spearman", distance.SpearmanR),
-    ("Spearman absolute", distance.SpearmanRAbsolute),
+    ("Spearman Absolute", distance.SpearmanRAbsolute),
     ("Pearson", distance.PearsonR),
-    ("Pearson absolute", distance.PearsonRAbsolute),
+    ("Pearson Absolute", distance.PearsonRAbsolute),
 ]
 
 
@@ -40,7 +40,7 @@ class OWDistances(widget.OWWidget):
 
         self.data = None
 
-        gui.radioButtons(self.controlArea, self, "axis", ["rows", "columns"],
+        gui.radioButtons(self.controlArea, self, "axis", ["Rows", "Columns"],
                          box="Distances between", callback=self._invalidate
         )
         gui.comboBox(self.controlArea, self, "metric_idx",
@@ -91,6 +91,6 @@ class OWDistances(widget.OWWidget):
 
     def send_report(self):
         self.report_items((
-            ("Distances between", ["rows", "columns"][self.axis]),
+            ("Distances Between", ["Rows", "Columns"][self.axis]),
             ("Metric", _METRICS[self.metric_idx][0])
         ))

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -53,7 +53,7 @@ class OWDistanceTransformation(widget.OWWidget):
                          callback=self._invalidate)
 
         box = gui.auto_commit(self.buttonsArea, self, "autocommit", "Apply",
-                              checkbox_label="Auto apply on change", box=None)
+                              checkbox_label="Apply automatically", box=None)
         box.layout().insertWidget(0, self.report_button)
         box.layout().insertSpacing(1, 8)
 

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -53,7 +53,7 @@ class OWDistanceTransformation(widget.OWWidget):
                          callback=self._invalidate)
 
         box = gui.auto_commit(self.buttonsArea, self, "autocommit", "Apply",
-                              checkbox_label="Apply on change", box=None)
+                              checkbox_label="Auto apply on change", box=None)
         box.layout().insertWidget(0, self.report_button)
         box.layout().insertSpacing(1, 8)
 

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -740,7 +740,7 @@ class OWHierarchicalClustering(widget.OWWidget):
     #: Cluster variable domain role
     AttributeRole, ClassRole, MetaRole = 0, 1, 2
 
-    cluster_roles = ["Attribute", "Class Variable", "Meta Variable"]
+    cluster_roles = ["Attribute", "Class variable", "Meta variable"]
 
     def __init__(self):
         super().__init__()
@@ -860,7 +860,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         ibox.layout().addLayout(form)
         ibox.layout().addSpacing(5)
 
-        gui.auto_commit(box, self, "autocommit", "Send Selected", "Auto Send is On",
+        gui.auto_commit(box, self, "autocommit", "Send Selected", "Send Automatically",
                         box=False)
 
         self.scene = QGraphicsScene()

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -860,7 +860,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         ibox.layout().addLayout(form)
         ibox.layout().addSpacing(5)
 
-        gui.auto_commit(box, self, "autocommit", "Send Data", "Auto Send is On",
+        gui.auto_commit(box, self, "autocommit", "Send Selected", "Auto Send is On",
                         box=False)
 
         self.scene = QGraphicsScene()

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -740,7 +740,7 @@ class OWHierarchicalClustering(widget.OWWidget):
     #: Cluster variable domain role
     AttributeRole, ClassRole, MetaRole = 0, 1, 2
 
-    cluster_roles = ["Attribute", "Class variable", "Meta variable"]
+    cluster_roles = ["Attribute", "Class Variable", "Meta Variable"]
 
     def __init__(self):
         super().__init__()
@@ -778,7 +778,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         )
 
         grid.addWidget(
-            gui.appendRadioButton(box, "Max depth", addToLayout=False),
+            gui.appendRadioButton(box, "Max depth:", addToLayout=False),
             1, 0)
         grid.addWidget(self.max_depth_spin, 1, 1)
 
@@ -794,7 +794,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             0, 0
         )
         grid.addWidget(
-            gui.appendRadioButton(box, "Height ratio", addToLayout=False),
+            gui.appendRadioButton(box, "Height ratio:", addToLayout=False),
             1, 0
         )
         self.cut_ratio_spin = gui.spin(
@@ -806,7 +806,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         grid.addWidget(self.cut_ratio_spin, 1, 1)
 
         grid.addWidget(
-            gui.appendRadioButton(box, "Top N", addToLayout=False),
+            gui.appendRadioButton(box, "Top N:", addToLayout=False),
             2, 0
         )
         self.top_n_spin = gui.spin(box, self, "top_n", 1, 20,
@@ -853,14 +853,14 @@ class OWHierarchicalClustering(widget.OWWidget):
             labelAlignment=Qt.AlignLeft,
             spacing=8
         )
-        form.addRow("Name", name_edit)
-        form.addRow("Place", cb)
+        form.addRow("Name:", name_edit)
+        form.addRow("Place:", cb)
 
         ibox.layout().addSpacing(5)
         ibox.layout().addLayout(form)
         ibox.layout().addSpacing(5)
 
-        gui.auto_commit(box, self, "autocommit", "Send data", "Auto send is on",
+        gui.auto_commit(box, self, "autocommit", "Send Data", "Auto Send is On",
                         box=False)
 
         self.scene = QGraphicsScene()

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -13,7 +13,7 @@ from Orange.widgets.utils.sql import check_sql_input
 
 
 class OWKMeans(widget.OWWidget):
-    name = "k-Means"
+    name = "k-means"
     description = "k-means clustering algorithm with silhouette-based " \
                   "quality estimation."
     icon = "icons/KMeans.svg"
@@ -25,13 +25,13 @@ class OWKMeans(widget.OWWidget):
                ("Centroids", Table)]
 
     INIT_KMEANS, INIT_RANDOM = range(2)
-    INIT_METHODS = "Initialize with KMeans++", "Random initialization"
+    INIT_METHODS = "Initialize with KMeans++", "Random Initialization"
 
     SILHOUETTE, INTERCLUSTER, DISTANCES = range(3)
     SCORING_METHODS = [("Silhouette", lambda km: km.silhouette, False),
-                       ("Inter-cluster distance",
+                       ("Inter-cluster Distance",
                         lambda km: km.inter_cluster, True),
-                       ("Distance to centroids",
+                       ("Distance to Centroids",
                         lambda km: km.inertia, True)]
 
     OUTPUT_CLASS, OUTPUT_ATTRIBUTE, OUTPUT_META = range(3)
@@ -65,7 +65,7 @@ class OWKMeans(widget.OWWidget):
             box, self, "optimize_k", [], orientation=layout,
             callback=self.update)
         layout.addWidget(
-            gui.appendRadioButton(bg, "Fixed", addToLayout=False),
+            gui.appendRadioButton(bg, "Fixed:", addToLayout=False),
             1, 1)
         sb = gui.hBox(None, margin=0)
         self.fixedSpinBox = gui.spin(
@@ -75,7 +75,7 @@ class OWKMeans(widget.OWWidget):
         layout.addWidget(sb, 1, 2)
 
         layout.addWidget(
-            gui.appendRadioButton(bg, "Optimized", addToLayout=False), 2, 1)
+            gui.appendRadioButton(bg, "Optimized from", addToLayout=False), 2, 1)
         ftobox = gui.hBox(None)
         ftobox.layout().setContentsMargins(0, 0, 0, 0)
         layout.addWidget(ftobox)
@@ -83,7 +83,7 @@ class OWKMeans(widget.OWWidget):
             ftobox, self, "k_from", minv=2, maxv=29,
             controlWidth=60, alignment=Qt.AlignRight,
             callback=self.update_from)
-        gui.widgetLabel(ftobox, "  To: ")
+        gui.widgetLabel(ftobox, "to")
         self.fixedSpinBox = gui.spin(
             ftobox, self, "k_to", minv=3, maxv=30,
             controlWidth=60, alignment=Qt.AlignRight,
@@ -125,10 +125,10 @@ class OWKMeans(widget.OWWidget):
 
         box = gui.vBox(self.controlArea, "Output")
         gui.comboBox(box, self, "place_cluster_ids",
-                     label="Append cluster id as ", orientation=Qt.Horizontal,
+                     label="Append cluster ID as", orientation=Qt.Horizontal,
                      callback=self.send_data, items=self.OUTPUT_METHODS)
         gui.lineEdit(box, self, "output_name",
-                     label="Name ", orientation=Qt.Horizontal,
+                     label="Name:", orientation=Qt.Horizontal,
                      callback=self.send_data)
 
         gui.separator(self.buttonsArea, 30)

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -132,8 +132,7 @@ class OWKMeans(widget.OWWidget):
                      callback=self.send_data)
 
         gui.separator(self.buttonsArea, 30)
-        gui.auto_commit(self.buttonsArea, self, "auto_run", "Run",
-                        "Run on change", box=None)
+        gui.auto_commit(self.buttonsArea, self, "auto_run", "Apply", box=None)
         gui.rubber(self.controlArea)
 
         self.table_model = QStandardItemModel(self)

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -25,13 +25,13 @@ class OWKMeans(widget.OWWidget):
                ("Centroids", Table)]
 
     INIT_KMEANS, INIT_RANDOM = range(2)
-    INIT_METHODS = "Initialize with KMeans++", "Random Initialization"
+    INIT_METHODS = "Initialize with KMeans++", "Random initialization"
 
     SILHOUETTE, INTERCLUSTER, DISTANCES = range(3)
     SCORING_METHODS = [("Silhouette", lambda km: km.silhouette, False),
-                       ("Inter-cluster Distance",
+                       ("Inter-cluster distance",
                         lambda km: km.inter_cluster, True),
-                       ("Distance to Centroids",
+                       ("Distance to centroids",
                         lambda km: km.inertia, True)]
 
     OUTPUT_CLASS, OUTPUT_ATTRIBUTE, OUTPUT_META = range(3)
@@ -125,7 +125,7 @@ class OWKMeans(widget.OWWidget):
 
         box = gui.vBox(self.controlArea, "Output")
         gui.comboBox(box, self, "place_cluster_ids",
-                     label="Append cluster ID as", orientation=Qt.Horizontal,
+                     label="Append cluster ID as:", orientation=Qt.Horizontal,
                      callback=self.send_data, items=self.OUTPUT_METHODS)
         gui.lineEdit(box, self, "output_name",
                      label="Name:", orientation=Qt.Horizontal,

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -107,20 +107,20 @@ class OWMDS(widget.OWWidget):
 
     #: Refresh rate
     RefreshRate = [
-        ("Every iteration", 1),
-        ("Every 5 steps", 5),
-        ("Every 10 steps", 10),
-        ("Every 25 steps", 25),
-        ("Every 50 steps", 50),
+        ("Every Iteration", 1),
+        ("Every 5 Steps", 5),
+        ("Every 10 Steps", 10),
+        ("Every 25 Steps", 25),
+        ("Every 50 Steps", 50),
         ("None", -1)
     ]
 
     JitterAmount = [
         ("None", 0),
-        ("0.1%", 0.1),
-        ("0.5%", 0.5),
-        ("1%", 1.0),
-        ("2%", 2.0)
+        ("0.1 %", 0.1),
+        ("0.5 %", 0.5),
+        ("1 %", 1.0),
+        ("2 %", 2.0)
     ]
     #: Runtime state
     Running, Finished, Waiting = 1, 2, 3
@@ -188,13 +188,13 @@ class OWMDS(widget.OWWidget):
         form.addRow("Max iterations:",
                     gui.spin(box, self, "max_iter", 10, 10 ** 4, step=1))
 
-        form.addRow("Initialization",
+        form.addRow("Initialization:",
                     gui.comboBox(box, self, "initialization",
                                  items=["PCA (Torgerson)", "Random"],
                                  callback=self.__invalidate_embedding))
 
         box.layout().addLayout(form)
-        form.addRow("Refresh",
+        form.addRow("Refresh:",
                     gui.comboBox(
                         box, self, "refresh_rate",
                         items=[t for t, _ in OWMDS.RefreshRate],
@@ -211,25 +211,25 @@ class OWMDS(widget.OWWidget):
             labelWidth=50, contentsLength=12)
 
         self.cb_color_value = gui.comboBox(
-            box, self, "color_value", label="Color",
+            box, self, "color_value", label="Color:",
             callback=self._on_color_index_changed, **common_options)
         self.cb_color_value.setModel(self.colorvar_model)
 
         self.shapevar_model = itemmodels.VariableListModel()
         self.cb_shape_value = gui.comboBox(
-            box, self, "shape_value", label="Shape",
+            box, self, "shape_value", label="Shape:",
             callback=self._on_shape_index_changed, **common_options)
         self.cb_shape_value.setModel(self.shapevar_model)
 
         self.sizevar_model = itemmodels.VariableListModel()
         self.cb_size_value = gui.comboBox(
-            box, self, "size_value", label="Size",
+            box, self, "size_value", label="Size:",
             callback=self._on_size_index_changed, **common_options)
         self.cb_size_value.setModel(self.sizevar_model)
 
         self.labelvar_model = itemmodels.VariableListModel()
         self.cb_label_value = gui.comboBox(
-            box, self, "label_value", label="Label",
+            box, self, "label_value", label="Label.",
             callback=self._on_label_index_changed, **common_options)
         self.cb_label_value.setModel(self.labelvar_model)
 
@@ -239,23 +239,23 @@ class OWMDS(widget.OWWidget):
             fieldGrowthPolicy=QtGui.QFormLayout.AllNonFixedFieldsGrow,
             verticalSpacing=10
         )
-        form.addRow("Symbol size",
+        form.addRow("Symbol size:",
                     gui.hSlider(box, self, "symbol_size",
                                 minValue=1, maxValue=20,
                                 callback=self._on_size_index_changed,
                                 createLabel=False))
-        form.addRow("Symbol opacity",
+        form.addRow("Symbol opacity:",
                     gui.hSlider(box, self, "symbol_opacity",
                                 minValue=100, maxValue=255, step=100,
                                 callback=self._on_color_index_changed,
                                 createLabel=False))
-        form.addRow("Show similar pairs",
+        form.addRow("Show similar pairs:",
                     gui.hSlider(
                         gui.hBox(self.controlArea),
                         self, "connected_pairs", minValue=0, maxValue=20,
                         createLabel=False,
                         callback=self._on_connected_changed))
-        form.addRow("Jitter",
+        form.addRow("Jitter:",
                     gui.comboBox(
                         box, self, "jitter",
                         items=[text for text, _ in self.JitterAmount],
@@ -316,13 +316,13 @@ class OWMDS(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Output")
         self.output_combo = gui.comboBox(
             box, self, "output_embedding_role",
-            items=["Original features only",
-                   "Coordinates only",
-                   "Coordinates as features",
-                   "Coordinates as meta attributes"],
+            items=["Original Features Only",
+                   "Coordinates Only",
+                   "Coordinates as Features",
+                   "Coordinates as Meta Attributes"],
             callback=self._invalidate_output, addSpace=4)
-        gui.auto_commit(box, self, "autocommit", "Send data",
-                        checkbox_label="Send after any change",
+        gui.auto_commit(box, self, "autocommit", "Send Data",
+                        checkbox_label="Send After Any Change",
                         box=None)
 
         self.plot = pg.PlotWidget(background="w", enableMenu=False)
@@ -413,10 +413,10 @@ class OWMDS(widget.OWWidget):
         self._label_data = None
         self._similar_pairs = None
 
-        self.colorvar_model[:] = ["Same color"]
-        self.shapevar_model[:] = ["Same shape"]
-        self.sizevar_model[:] = ["Same size"]
-        self.labelvar_model[:] = ["No labels"]
+        self.colorvar_model[:] = ["Same Color"]
+        self.shapevar_model[:] = ["Same Shape"]
+        self.sizevar_model[:] = ["Same Size"]
+        self.labelvar_model[:] = ["No Labels"]
 
         self.color_value = self.colorvar_model[0]
         self.shape_value = self.shapevar_model[0]
@@ -441,9 +441,9 @@ class OWMDS(widget.OWWidget):
         if self.data is None and getattr(self.matrix, 'axis', 1) == 0:
             # Column-wise distances
             attr = "Attribute names"
-            self.labelvar_model[:] = ["No labels", attr]
-            self.shapevar_model[:] = ["Same shape", attr]
-            self.colorvar_model[:] = ["Same color", attr]
+            self.labelvar_model[:] = ["No Labels", attr]
+            self.shapevar_model[:] = ["Same Shape", attr]
+            self.colorvar_model[:] = ["Same Color", attr]
 
             self.color_value = attr
             self.shape_value = attr
@@ -456,16 +456,16 @@ class OWMDS(widget.OWWidget):
             cont_vars = [var for var in all_vars if var.is_continuous]
             shape_vars = [var for var in disc_vars
                           if len(var.values) <= len(ScatterPlotItem.Symbols) - 1]
-            self.colorvar_model[:] = chain(["Same color"],
+            self.colorvar_model[:] = chain(["Same Color"],
                                            [self.colorvar_model.Separator],
                                            cd_vars)
-            self.shapevar_model[:] = chain(["Same shape"],
+            self.shapevar_model[:] = chain(["Same Shape"],
                                            [self.shapevar_model.Separator],
                                            shape_vars)
-            self.sizevar_model[:] = chain(["Same size", "Stress"],
+            self.sizevar_model[:] = chain(["Same Size", "Stress"],
                                           [self.sizevar_model.Separator],
                                           cont_vars)
-            self.labelvar_model[:] = chain(["No labels"],
+            self.labelvar_model[:] = chain(["No Labels"],
                                            [self.labelvar_model.Separator],
                                            all_vars)
 
@@ -1053,10 +1053,10 @@ class OWMDS(widget.OWWidget):
             return
         self.report_plot()
         caption = report.render_items_vert((
-            ("Color", self.color_value != "Same color" and self.color_value),
-            ("Shape", self.shape_value != "Same shape" and self.shape_value),
-            ("Size", self.size_value != "Same size" and self.size_value),
-            ("Labels", self.label_value != "No labels" and self.label_value)))
+            ("Color", self.color_value != "Same Color" and self.color_value),
+            ("Shape", self.shape_value != "Same Shape" and self.shape_value),
+            ("Size", self.size_value != "Same Size" and self.size_value),
+            ("Labels", self.label_value != "No Labels" and self.label_value)))
         if caption:
             self.report_caption(caption)
         self.report_items((("Output", self.output_combo.currentText()),))

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -321,8 +321,8 @@ class OWMDS(widget.OWWidget):
                    "Coordinates as Features",
                    "Coordinates as Meta Attributes"],
             callback=self._invalidate_output, addSpace=4)
-        gui.auto_commit(box, self, "autocommit", "Send Data",
-                        checkbox_label="Send After Any Change",
+        gui.auto_commit(box, self, "autocommit", "Send Selected",
+                        checkbox_label="Auto send selected on change",
                         box=None)
 
         self.plot = pg.PlotWidget(background="w", enableMenu=False)

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -107,11 +107,11 @@ class OWMDS(widget.OWWidget):
 
     #: Refresh rate
     RefreshRate = [
-        ("Every Iteration", 1),
-        ("Every 5 Steps", 5),
-        ("Every 10 Steps", 10),
-        ("Every 25 Steps", 25),
-        ("Every 50 Steps", 50),
+        ("Every iteration", 1),
+        ("Every 5 steps", 5),
+        ("Every 10 steps", 10),
+        ("Every 25 steps", 25),
+        ("Every 50 steps", 50),
         ("None", -1)
     ]
 
@@ -229,7 +229,7 @@ class OWMDS(widget.OWWidget):
 
         self.labelvar_model = itemmodels.VariableListModel()
         self.cb_label_value = gui.comboBox(
-            box, self, "label_value", label="Label.",
+            box, self, "label_value", label="Label:",
             callback=self._on_label_index_changed, **common_options)
         self.cb_label_value.setModel(self.labelvar_model)
 
@@ -316,13 +316,13 @@ class OWMDS(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Output")
         self.output_combo = gui.comboBox(
             box, self, "output_embedding_role",
-            items=["Original Features Only",
-                   "Coordinates Only",
-                   "Coordinates as Features",
-                   "Coordinates as Meta Attributes"],
+            items=["Original features only",
+                   "Coordinates only",
+                   "Coordinates as features",
+                   "Coordinates as meta attributes"],
             callback=self._invalidate_output, addSpace=4)
         gui.auto_commit(box, self, "autocommit", "Send Selected",
-                        checkbox_label="Auto send selected on change",
+                        checkbox_label="Send selected automatically",
                         box=None)
 
         self.plot = pg.PlotWidget(background="w", enableMenu=False)
@@ -413,10 +413,10 @@ class OWMDS(widget.OWWidget):
         self._label_data = None
         self._similar_pairs = None
 
-        self.colorvar_model[:] = ["Same Color"]
-        self.shapevar_model[:] = ["Same Shape"]
-        self.sizevar_model[:] = ["Same Size"]
-        self.labelvar_model[:] = ["No Labels"]
+        self.colorvar_model[:] = ["Same color"]
+        self.shapevar_model[:] = ["Same shape"]
+        self.sizevar_model[:] = ["Same size"]
+        self.labelvar_model[:] = ["No labels"]
 
         self.color_value = self.colorvar_model[0]
         self.shape_value = self.shapevar_model[0]
@@ -441,9 +441,9 @@ class OWMDS(widget.OWWidget):
         if self.data is None and getattr(self.matrix, 'axis', 1) == 0:
             # Column-wise distances
             attr = "Attribute names"
-            self.labelvar_model[:] = ["No Labels", attr]
-            self.shapevar_model[:] = ["Same Shape", attr]
-            self.colorvar_model[:] = ["Same Color", attr]
+            self.labelvar_model[:] = ["No labels", attr]
+            self.shapevar_model[:] = ["Same shape", attr]
+            self.colorvar_model[:] = ["Same solor", attr]
 
             self.color_value = attr
             self.shape_value = attr
@@ -456,16 +456,16 @@ class OWMDS(widget.OWWidget):
             cont_vars = [var for var in all_vars if var.is_continuous]
             shape_vars = [var for var in disc_vars
                           if len(var.values) <= len(ScatterPlotItem.Symbols) - 1]
-            self.colorvar_model[:] = chain(["Same Color"],
+            self.colorvar_model[:] = chain(["Same color"],
                                            [self.colorvar_model.Separator],
                                            cd_vars)
-            self.shapevar_model[:] = chain(["Same Shape"],
+            self.shapevar_model[:] = chain(["Same shape"],
                                            [self.shapevar_model.Separator],
                                            shape_vars)
-            self.sizevar_model[:] = chain(["Same Size", "Stress"],
+            self.sizevar_model[:] = chain(["Same size", "Stress"],
                                           [self.sizevar_model.Separator],
                                           cont_vars)
-            self.labelvar_model[:] = chain(["No Labels"],
+            self.labelvar_model[:] = chain(["No labels"],
                                            [self.labelvar_model.Separator],
                                            all_vars)
 
@@ -1053,10 +1053,10 @@ class OWMDS(widget.OWWidget):
             return
         self.report_plot()
         caption = report.render_items_vert((
-            ("Color", self.color_value != "Same Color" and self.color_value),
-            ("Shape", self.shape_value != "Same Shape" and self.shape_value),
-            ("Size", self.size_value != "Same Size" and self.size_value),
-            ("Labels", self.label_value != "No Labels" and self.label_value)))
+            ("Color", self.color_value != "Same color" and self.color_value),
+            ("Shape", self.shape_value != "Same shape" and self.shape_value),
+            ("Size", self.size_value != "Same size" and self.size_value),
+            ("Labels", self.label_value != "No labels" and self.label_value)))
         if caption:
             self.report_caption(caption)
         self.report_items((("Output", self.output_combo.currentText()),))

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -73,8 +73,8 @@ class OWPCA(widget.OWWidget):
         )
         self.variance_spin.setSuffix("%")
 
-        form.addRow("Components", self.components_spin)
-        form.addRow("Variance covered", self.variance_spin)
+        form.addRow("Components:", self.components_spin)
+        form.addRow("Variance covered:", self.variance_spin)
 
         # Incremental learning
         self.sampling_box = gui.vBox(self.controlArea, "Incremental learning")
@@ -116,8 +116,8 @@ class OWPCA(widget.OWWidget):
 
         self.controlArea.layout().addStretch()
 
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Send data",
-                        checkbox_label="Auto send on change")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Data",
+                        checkbox_label="Auto Send on Change")
 
         self.plot = pg.PlotWidget(background="w")
 

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -116,8 +116,8 @@ class OWPCA(widget.OWWidget):
 
         self.controlArea.layout().addStretch()
 
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Data",
-                        checkbox_label="Auto Send on Change")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Apply",
+                        checkbox_label="Auto Apply on Change")
 
         self.plot = pg.PlotWidget(background="w")
 

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -117,7 +117,7 @@ class OWPCA(widget.OWWidget):
         self.controlArea.layout().addStretch()
 
         gui.auto_commit(self.controlArea, self, "auto_commit", "Apply",
-                        checkbox_label="Auto Apply on Change")
+                        checkbox_label="Apply automatically")
 
         self.plot = pg.PlotWidget(background="w")
 

--- a/Orange/widgets/unsupervised/owsavedistances.py
+++ b/Orange/widgets/unsupervised/owsavedistances.py
@@ -32,7 +32,7 @@ class OWSaveDistances(widget.OWWidget):
             commit=self.save_file, callback=self.adjust_label,
             disabled=True, addSpace=True)
         self.saveAs = gui.button(
-            self.controlArea, self, "Save as ...",
+            self.controlArea, self, "Save As...",
             callback=self.save_file_as, disabled=True)
         self.saveAs.setMinimumWidth(300)
         self.adjustSize()

--- a/Orange/widgets/unsupervised/owsilhouetteplot.py
+++ b/Orange/widgets/unsupervised/owsilhouetteplot.py
@@ -92,8 +92,8 @@ class OWSilhouettePlot(widget.OWWidget):
 
         box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "add_scores", "Add silhouette scores",)
-        gui.auto_commit(box, self, "auto_commit", "Commit",
-                        auto_label="Auto Commit", box=False)
+        gui.auto_commit(box, self, "auto_commit", "Apply",
+                        auto_label="Auto Apply", box=False)
 
         self.scene = QtGui.QGraphicsScene()
         self.view = QtGui.QGraphicsView(self.scene)

--- a/Orange/widgets/unsupervised/owsilhouetteplot.py
+++ b/Orange/widgets/unsupervised/owsilhouetteplot.py
@@ -91,9 +91,9 @@ class OWSilhouettePlot(widget.OWWidget):
         gui.rubber(self.controlArea)
 
         box = gui.vBox(self.controlArea, "Output")
+        box.setFixedWidth(190)
         gui.checkBox(box, self, "add_scores", "Add silhouette scores",)
-        gui.auto_commit(box, self, "auto_commit", "Apply",
-                        auto_label="Auto Apply", box=False)
+        gui.auto_commit(box, self, "auto_commit", "Apply", box=False)
 
         self.scene = QtGui.QGraphicsScene()
         self.view = QtGui.QGraphicsView(self.scene)

--- a/Orange/widgets/unsupervised/owsilhouetteplot.py
+++ b/Orange/widgets/unsupervised/owsilhouetteplot.py
@@ -26,7 +26,7 @@ from Orange.widgets.unsupervised.owhierarchicalclustering import \
 
 class OWSilhouettePlot(widget.OWWidget):
     name = "Silhouette Plot"
-    description = "Silhouette Plot"
+    description = "Show a silhouette plot. "
 
     icon = "icons/Silhouette.svg"
 
@@ -66,23 +66,23 @@ class OWSilhouettePlot(widget.OWWidget):
         self._silplot = None
 
         box = gui.vBox(self.controlArea, "Settings",)
-        gui.comboBox(box, self, "distance_idx", label="Distance",
+        gui.comboBox(box, self, "distance_idx", label="Distance:",
                      items=[name for name, _ in OWSilhouettePlot.Distances],
                      callback=self._invalidate_distances)
         self.cluster_var_cb = gui.comboBox(
-            box, self, "cluster_var_idx", label="Cluster",
+            box, self, "cluster_var_idx", label="Cluster:",
             callback=self._invalidate_scores)
         self.cluster_var_model = itemmodels.VariableListModel(parent=self)
         self.cluster_var_cb.setModel(self.cluster_var_model)
 
-        gui.spin(box, self, "bar_size", minv=1, maxv=10, label="Bar Size",
+        gui.spin(box, self, "bar_size", minv=1, maxv=10, label="Bar size:",
                  callback=self._update_bar_size)
 
         gui.checkBox(box, self, "group_by_cluster", "Group by cluster",
                      callback=self._replot)
 
         self.annotation_cb = gui.comboBox(
-            box, self, "annotation_var_idx", label="Annotations",
+            box, self, "annotation_var_idx", label="Annotations:",
             callback=self._update_annotations)
         self.annotation_var_model = itemmodels.VariableListModel(parent=self)
         self.annotation_var_model[:] = ["None"]
@@ -93,7 +93,7 @@ class OWSilhouettePlot(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "add_scores", "Add silhouette scores",)
         gui.auto_commit(box, self, "auto_commit", "Commit",
-                        auto_label="Auto commit", box=False)
+                        auto_label="Auto Commit", box=False)
 
         self.scene = QtGui.QGraphicsScene()
         self.view = QtGui.QGraphicsView(self.scene)

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -66,7 +66,7 @@ def get_file_name(start_dir, start_filter, file_formats):
 
     while True:
         filename, filter = QFileDialog.getSaveFileNameAndFilter(
-            None, 'Save as ...', start_dir, ';;'.join(filters), start_filter)
+            None, 'Save As...', start_dir, ';;'.join(filters), start_filter)
         if not filename:
             return None, None, None
 

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -91,7 +91,7 @@ class OWBoxPlot(widget.OWWidget):
     display_changed call display_changed_disc that draws everything.
     """
     name = "Box Plot"
-    description = "Visualize distribution of feature values in a box plots."
+    description = "Visualize the distribution of feature values in a box plot."
     icon = "icons/BoxPlot.svg"
     priority = 100
     inputs = [("Data", Orange.data.Table, "set_data")]

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -157,7 +157,7 @@ class OWDistributions(widget.OWWidget):
             tooltip="Normalize probabilities so that probabilities for each group-by value sum to 1.")
         gui.separator(box2)
         self.cb_prob = gui.comboBox(
-            box2, self, "show_prob", label="Show probabilities",
+            box2, self, "show_prob", label="Show probabilities:",
             orientation=Qt.Horizontal,
             callback=self._on_relative_freq_changed,
             tooltip="Show probabilities for a chosen group-by value (at each point probabilities for all group-by values sum to 1).")

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -373,7 +373,7 @@ _default_palette_index = \
 
 class OWHeatMap(widget.OWWidget):
     name = "Heat Map"
-    description = "Heatmap visualization."
+    description = "Plot a heat map for a pair of attributes."
     icon = "icons/Heatmap.svg"
     priority = 1040
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1501,8 +1501,8 @@ class OWHeatMap(widget.OWWidget):
 
     def send_report(self):
         self.report_items((
-            ("Columns", self.ColumnOrdering[self.sort_columns_idx][1].lower()),
-            ("Rows", self.RowOrdering[self.sort_rows_idx][1].lower()),
+            ("Columns:", self.ColumnOrdering[self.sort_columns_idx][1].lower()),
+            ("Rows:", self.RowOrdering[self.sort_rows_idx][1].lower()),
             ("Row annotation",
              self.annotation_index > 0 and
              self.annotation_vars[self.annotation_index])

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -572,7 +572,7 @@ class OWHeatMap(widget.OWWidget):
                      callback=self.__aspect_mode_changed)
 
         gui.rubber(self.controlArea)
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Selection")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Selection", "Send Automatically")
 
         # Scene with heatmap
         self.heatmap_scene = self.scene = HeatmapScene(parent=self)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -572,7 +572,7 @@ class OWHeatMap(widget.OWWidget):
                      callback=self.__aspect_mode_changed)
 
         gui.rubber(self.controlArea)
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Commit")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Selection")
 
         # Scene with heatmap
         self.heatmap_scene = self.scene = HeatmapScene(parent=self)

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -214,7 +214,7 @@ class LegendItem(LegendItem):
 
 class OWLinearProjection(widget.OWWidget):
     name = "Linear Projection"
-    description = "A multi-axes projection of data to a two-dimension plane."
+    description = "A multi-axis projection of data onto a two-dimensional plane."
     icon = "icons/LinearProjection.svg"
     priority = 2000
 
@@ -339,27 +339,27 @@ class OWLinearProjection(widget.OWWidget):
                           callback=self._on_color_change,
                           contentsLength=12)
         cb.setModel(self.colorvar_model)
-        form.addRow("Colors", cb)
+        form.addRow("Colors:", cb)
 
         alpha_slider = QSlider(
             Qt.Horizontal, minimum=10, maximum=255, pageStep=25,
             tickPosition=QSlider.TicksBelow, value=self.alpha_value)
         alpha_slider.valueChanged.connect(self._set_alpha)
-        form.addRow("Opacity", alpha_slider)
+        form.addRow("Opacity:", alpha_slider)
 
         cb = gui.comboBox(box, self, "shape_index",
                           callback=self._on_shape_change,
                           contentsLength=12)
 
         cb.setModel(self.shapevar_model)
-        form.addRow("Shape", cb)
+        form.addRow("Shape:", cb)
 
         cb = gui.comboBox(box, self, "size_index",
                           callback=self._on_size_change,
                           contentsLength=12)
 
         cb.setModel(self.sizevar_model)
-        form.addRow("Size", cb)
+        form.addRow("Size:", cb)
 
         size_slider = QSlider(
             Qt.Horizontal,  minimum=3, maximum=30, value=self.point_size,
@@ -370,13 +370,13 @@ class OWLinearProjection(widget.OWWidget):
 
         cb = self.jitter_combo = gui.comboBox(
             box, self, "jitter_value",
-            items=["None", "0.01%", "0.1%", "0.5%", "1%", "2%"],
+            items=["None", "0.01 %", "0.1 %", "0.5 %", "1 %", "2 %"],
             callback=self._invalidate_plot)
-        form.addRow("Jittering", cb)
+        form.addRow("Jittering:", cb)
 
         self.cb_class_density = gui.checkBox(box, self, "class_density", label="",
                                              callback=self._update_density)
-        form.addRow("Class density", self.cb_class_density)
+        form.addRow("Class density:", self.cb_class_density)
 
         toolbox = gui.vBox(self.controlArea, "Zoom/Select")
         toollayout = QtGui.QHBoxLayout()

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -382,7 +382,7 @@ class OWLinearProjection(widget.OWWidget):
         toollayout = QtGui.QHBoxLayout()
         toolbox.layout().addLayout(toollayout)
 
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Commit")
+        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Selection")
 
         self.controlArea.setSizePolicy(
             QSizePolicy.Preferred, QSizePolicy.Expanding)

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -83,7 +83,7 @@ class OWMosaicDisplay(OWWidget):
             for i in range(1, 5)]
         self.rb_colors = gui.radioButtonsInBox(
                 self.controlArea, self, "interior_coloring",
-                self.interior_coloring_opts, box="Interior coloring",
+                self.interior_coloring_opts, box="Interior Coloring",
                 callback=self.update_graph)
         self.bar_button = gui.checkBox(
                 gui.indentedBox(self.rb_colors),

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -524,7 +524,7 @@ class OWScatterMap(widget.OWWidget):
         )
         gui.comboBox(box, self, "color_scale", label="Scale: ",
                      orientation=Qt.Horizontal,
-                     items=["Linear", "Square Root", "Logarithmic"],
+                     items=["Linear", "Square root", "Logarithmic"],
                      callback=self._on_color_scale_changed)
 
         self.sampling_box = gui.vBox(self.controlArea, "Sampling")

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -472,7 +472,7 @@ class OWScatterMap(widget.OWWidget):
     sample_percentages = []
     sample_percentages_captions = []
     sample_times = [0.5, 3, 5, 20, 40, 80]
-    sample_times_captions = ['1s', '5s', '10s', '30s', '1min', '2min']
+    sample_times_captions = ['1 s', '5 s', '10 s', '30 s', '1 min', '2 min']
 
     use_cache = settings.Setting(True)
 
@@ -524,7 +524,7 @@ class OWScatterMap(widget.OWWidget):
         )
         gui.comboBox(box, self, "color_scale", label="Scale: ",
                      orientation=Qt.Horizontal,
-                     items=["Linear", "Square root", "Logarithmic"],
+                     items=["Linear", "Square Root", "Logarithmic"],
                      callback=self._on_color_scale_changed)
 
         self.sampling_box = gui.vBox(self.controlArea, "Sampling")

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -38,7 +38,7 @@ def font_resize(font, factor, minsize=None, maxsize=None):
 
 class OWScatterPlot(OWWidget):
     name = 'Scatter Plot'
-    description = 'Scatter plot visualization.'
+    description = 'Scatterplot visualization with explorative analysis and intelligent data visualization enhancements.'
     icon = "icons/ScatterPlot.svg"
 
     inputs = [("Data", Table, "set_data", Default),

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -102,7 +102,7 @@ class OWScatterPlot(OWWidget):
         vizrank_box = gui.hBox(box)
         gui.separator(vizrank_box, width=common_options["labelWidth"])
         self.vizrank_button = gui.button(
-            vizrank_box, self, "Rank projections:", callback=self.vizrank.reshow,
+            vizrank_box, self, "Rank Projections", callback=self.vizrank.reshow,
             tooltip="Find projections with good class separation")
         self.vizrank_button.setEnabled(False)
         gui.separator(box)
@@ -167,7 +167,7 @@ class OWScatterPlot(OWWidget):
         self.graph.set_palette(p)
 
         gui.auto_commit(self.controlArea, self, "auto_send_selection",
-                        "Send Selection")
+                        "Send Selection", "Send Automatically")
 
         def zoom(s):
             """Zoom in/out by factor `s`."""

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -102,7 +102,7 @@ class OWScatterPlot(OWWidget):
         vizrank_box = gui.hBox(box)
         gui.separator(vizrank_box, width=common_options["labelWidth"])
         self.vizrank_button = gui.button(
-            vizrank_box, self, "Rank projections", callback=self.vizrank.reshow,
+            vizrank_box, self, "Rank projections:", callback=self.vizrank.reshow,
             tooltip="Find projections with good class separation")
         self.vizrank_button.setEnabled(False)
         gui.separator(box)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -19,9 +19,9 @@ from Orange.widgets.widget import OWWidget, Default, AttributeList
 
 class OWSieveDiagram(OWWidget):
     name = "Sieve Diagram"
-    description = "A two-way contingency table providing information in " \
-                  "relation to expected frequency of combination of feature " \
-                  "values under independence."
+    description = "A two-way contingency table providing information on the " \
+                  "relation between the observed and expected frequencies " \
+                  "of a combination of feature values under the assumption of independence."
     icon = "icons/SieveDiagram.svg"
     priority = 4200
 

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -34,7 +34,7 @@ _ItemSet = namedtuple("_ItemSet", ["key", "name", "title", "items"])
 
 class OWVennDiagram(widget.OWWidget):
     name = "Venn Diagram"
-    description = "A graphical visualization of an overlap of data instances " \
+    description = "A graphical visualization of the overlap of data instances " \
                   "from a collection of input data sets."
     icon = "icons/VennDiagram.svg"
 
@@ -72,7 +72,7 @@ class OWVennDiagram(widget.OWWidget):
 
         # GUI
         box = gui.vBox(self.controlArea, "Info")
-        self.info = gui.widgetLabel(box, "No data on input\n")
+        self.info = gui.widgetLabel(box, "No data on input.\n")
 
         self.identifiersBox = gui.radioButtonsInBox(
             self.controlArea, self, "useidentifiers", [],

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -110,7 +110,7 @@ class OWVennDiagram(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "output_duplicates", "Output duplicates",
                      callback=lambda: self.commit())
-        gui.auto_commit(box, self, "autocommit", "Commit", box=False)
+        gui.auto_commit(box, self, "autocommit", "Send Selection", box=False)
 
         # Main area view
         self.scene = QGraphicsScene()

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -110,7 +110,7 @@ class OWVennDiagram(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "output_duplicates", "Output duplicates",
                      callback=lambda: self.commit())
-        gui.auto_commit(box, self, "autocommit", "Send Selection", box=False)
+        gui.auto_commit(box, self, "autocommit", "Send Selection", "Send Automatically", box=False)
 
         # Main area view
         self.scene = QGraphicsScene()


### PR DESCRIPTION
The pull request fixes a few issues with spelling, phrasing, typos and such, all inside the Orange GUI. This is some low-hanging fruit for polishing the application. 

Fixes and improvements:
- spelling (plurals etc)
- proper articles
- consIstenT cApitalIzation
- three-dots are now attached to the last word, as is the norm (Save As ... -> Save As...)
- consistent usage of active/passive verbs. 

There are some changes I'm not completely sure about (the ones where I changed more than two letters) and I'd appreciate a review of them, so the meaning stays what it should be. 