### PR TITLE
[FIX] Compute distances between constructed Instances.

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -23,7 +23,7 @@ def _orange_to_numpy(x):
     """Convert :class:`Orange.data.Table` and :class:`Orange.data.RowInstance` to :class:`numpy.ndarray`."""
     if isinstance(x, data.Table):
         return x.X
-    elif isinstance(x, data.RowInstance):
+    elif isinstance(x, data.Instance):
         return np.atleast_2d(x.x)
     elif isinstance(x, np.ndarray):
         return np.atleast_2d(x)

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 from Orange.data import (Table, Domain, ContinuousVariable,
-                         DiscreteVariable, StringVariable)
+                         DiscreteVariable, StringVariable, Instance)
 from Orange.distance import (Euclidean, SpearmanR, SpearmanRAbsolute,
                              PearsonR, PearsonRAbsolute, Manhattan, Cosine,
                              Jaccard, _preprocess)
@@ -769,3 +769,8 @@ class TestDistances(TestCase):
     def test_preprocess_impute(self):
         new_table = _preprocess(self.test5)
         self.assertFalse(np.isnan(new_table.X).any())
+
+    def test_distance_to_instance(self):
+        iris = Table('iris')
+        inst = Instance(iris.domain, np.concatenate((iris[1].x, iris[1].y)))
+        self.assertEqual(Euclidean(iris[1], inst), 0)


### PR DESCRIPTION
```
import numpy as np
from Orange.data import Table, Instance
from Orange.distance import Euclidean

iris = Table('iris')
inst = Instance(iris.domain, np.concatenate((iris[0].x, [2])))

Euclidean(iris[0], iris[1])  # works
Euclidean(iris[0], inst)  # fails
```