### PR TITLE
[FIX] kmeans: Compute silhouette only when possible

### DIFF
--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -21,11 +21,12 @@ class KMeans(SklProjector):
     def fit(self, X, Y=None):
         proj = skl_cluster.KMeans(**self.params)
         if isinstance(X, Table):
-            proj = proj.fit(X.X, Y)
-            proj.silhouette = silhouette_score(X.X, proj.labels_)
-        else:
-            proj = proj.fit(X, Y)
+            X = X.X
+        proj = proj.fit(X, Y)
+        if 2 <= proj.n_clusters < len(X):
             proj.silhouette = silhouette_score(X, proj.labels_)
+        else:
+            proj.silhouette = 0
         proj.inertia = proj.inertia_ / len(X)
         cluster_dist = Euclidean(proj.cluster_centers_)
         proj.inter_cluster = np.mean(cluster_dist[np.triu_indices_from(cluster_dist, 1)])

--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -20,8 +20,6 @@ class KMeans(SklProjector):
 
     def fit(self, X, Y=None):
         proj = skl_cluster.KMeans(**self.params)
-        if isinstance(X, Table):
-            X = X.X
         proj = proj.fit(X, Y)
         if 2 <= proj.n_clusters < len(X):
             proj.silhouette = silhouette_score(X, proj.labels_)

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -229,7 +229,6 @@ class OWKMeans(widget.OWWidget):
         self.show_results()
         self.send_data()
 
-
     def cluster(self):
         if not self.check_data_size(self.k):
             return

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -264,7 +264,7 @@ class OWKMeans(widget.OWWidget):
         score_span = (best_score - worst_score) or 1
         max_score = max(scores)
         nplaces = min(5, int(abs(math.log(max(max_score, 1e-10)))) + 2)
-        fmt = "{{:.{}}}".format(nplaces)
+        fmt = "{{:.{}f}}".format(nplaces)
         model = self.table_model
         model.setRowCount(len(k_scores))
         for i, (k, score) in enumerate(k_scores):

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -213,17 +213,17 @@ class OWKMeans(widget.OWWidget):
         try:
             self.controlArea.setDisabled(True)
             self.optimization_runs = []
-            if self.check_data_size(self.k_to):
-                self.optimization_runs = []
-                kmeans = KMeans(
-                    init=['random', 'k-means++'][self.smart_init],
-                    n_init=self.n_init,
-                    max_iter=self.max_iterations)
-                with self.progressBar(self.k_to - self.k_from + 1) as progress:
-                    for k in range(self.k_from, self.k_to + 1):
-                        progress.advance()
-                        kmeans.params["n_clusters"] = k
-                        self.optimization_runs.append((k, kmeans(self.data)))
+            if not self.check_data_size(self.k_to):
+                return
+            kmeans = KMeans(
+                init=['random', 'k-means++'][self.smart_init],
+                n_init=self.n_init,
+                max_iter=self.max_iterations)
+            with self.progressBar(self.k_to - self.k_from + 1) as progress:
+                for k in range(self.k_from, self.k_to + 1):
+                    progress.advance()
+                    kmeans.params["n_clusters"] = k
+                    self.optimization_runs.append((k, kmeans(self.data)))
         finally:
             self.controlArea.setDisabled(False)
         self.show_results()


### PR DESCRIPTION
Silhouette score can be computed only for 2 <= k < n. Prevent its call in other cases.
Reproduce the bug by e.g. setting k=n in the kmeans widget.

Side note: I do not like the fact that this and other scores are computed automatically after every clustering run. Currently, other code depends on the scores being there, but a future PR could address this and at least make it optional, but preferably separate the scoring methods into individual functions, which can be called after clustering.

<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

