### PR TITLE
TableModel: Change columns order to class, metas, attrs

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -174,8 +174,6 @@ class OWPredictions(widget.OWWidget):
             modelproxy.setSourceModel(model)
             self.dataview.setModel(modelproxy)
             self._update_column_visibility()
-            self.dataview.scrollTo(
-                modelproxy.index(0, len(data.domain.attributes)))
 
         self.invalidate_predictions()
 
@@ -300,12 +298,13 @@ class OWPredictions(widget.OWWidget):
 
     def _update_column_visibility(self):
         """Update data column visibility."""
+        domain = self.data.domain
+        first_attr = len(domain.class_vars) + len(domain.metas)
         if self.data is not None:
-            for i in range(len(self.data.domain.attributes)):
+            for i in range(first_attr, first_attr + len(domain.attributes)):
                 self.dataview.setColumnHidden(i, not self.show_attrs)
-            if self.data.domain.class_var:
-                self.dataview.setColumnHidden(
-                    len(self.data.domain.attributes), False)
+            if domain.class_var:
+                self.dataview.setColumnHidden(0, False)
             self._update_spliter()
 
     def _update_data_sort_order(self):
@@ -426,8 +425,6 @@ class OWPredictions(widget.OWWidget):
             self.dataview.setMaximumWidth(QWIDGETSIZE_MAX)
 
             self.spliter_restore_state = 0, w
-            self.dataview.horizontalScrollBar().triggerAction(
-                QtGui.QScrollBar.SliderToMaximum)
 
     def commit(self):
         if self.data is None or not self.predictors:

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -658,13 +658,13 @@ class TableModel(QAbstractTableModel):
     DomainRole = next(gui.OrangeUserRole)
 
     #: Column domain roles
-    Attribute, ClassVar, Meta = range(3)
+    ClassVar, Meta, Attribute = range(3)
 
     #: Default background color for domain roles
     ColorForRole = {
-        Attribute: None,
         ClassVar: QColor(160, 160, 160),
-        Meta: QColor(220, 220, 200)
+        Meta: QColor(220, 220, 200),
+        Attribute: None,
     }
 
     #: Standard column descriptor
@@ -721,14 +721,6 @@ class TableModel(QAbstractTableModel):
 
         columns = []
 
-        if self.X_density != Storage.DENSE:
-            coldesc = make_basket(domain.attributes, self.X_density,
-                                  TableModel.Attribute)
-            columns.append(coldesc)
-        else:
-            columns += [make_column(var, TableModel.Attribute)
-                        for var in domain.attributes]
-
         if self.Y_density != Storage.DENSE:
             coldesc = make_basket(domain.class_vars, self.Y_density,
                                   TableModel.ClassVar)
@@ -745,8 +737,16 @@ class TableModel(QAbstractTableModel):
             columns += [make_column(var, TableModel.Meta)
                         for var in domain.metas]
 
-        #: list of all domain variables (attrs + class_vars + metas)
-        self.vars = domain.attributes + domain.class_vars + domain.metas
+        if self.X_density != Storage.DENSE:
+            coldesc = make_basket(domain.attributes, self.X_density,
+                                  TableModel.Attribute)
+            columns.append(coldesc)
+        else:
+            columns += [make_column(var, TableModel.Attribute)
+                        for var in domain.attributes]
+
+        #: list of all domain variables (class_vars + metas + attrs)
+        self.vars = domain.class_vars + domain.metas + domain.attributes
         self.columns = columns
 
         #: A list of all unique attribute labels (in all variables)


### PR DESCRIPTION
Changed the column's order in `Data Table` and `Predictions` widgets. Class attributes are displayed first, followed by metas and attributes. Consequently, the scrolling to maximum (right) in `Predictions` was also disabled.