### PR TITLE
[FIX] Bump scikit-learn version

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,6 +1,6 @@
 numpy>=1.9.0
 scipy>=0.11.0
-scikit-learn>=0.16
+scikit-learn>=0.17
 bottlechest>=0.7.1
 # Reading Excel files
 xlrd>=0.9.2


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

`scikit-learn==0.16` did not yet have `gamma="auto"` option for SVM (`svm.py`, line 30) and hence the defualt SVM on Iris failed.