### PR TITLE
Remove Orange.egg-info dir from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Build files
 build
 dist
-Orange.egg-info/*
-Orange.egg-info
 Orange3.egg-info
 Orange/version.py
 doc/build


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

pip collects package metadata by invoking `python setup.py egg_info` and
reading information from the generated *.egg-info/ under the assumption
that there is only one such directory. This can cause problems for
developers who might have remaining Orange.egg-info directories in their
git checkouts, causing pip install -e . to pick up obsolete
dependencies, version, ...

This does not solve the problem, but at least `git status` will indicate
there are untracked files in the checkout and that `git clean` is in
order.