### PR TITLE
[FIX] Support Sparse Matrices

### DIFF
--- a/Orange/classification/majority.py
+++ b/Orange/classification/majority.py
@@ -74,9 +74,9 @@ class ConstantModel(Model):
         :return: predicted value
         :rtype: vector of majority values
         """
-        probs = np.tile(self.dist, (len(X), 1))
+        probs = np.tile(self.dist, (X.shape[0], 1))
         if self.unif_maj is not None:
-            value = np.tile(self.unif_maj, (len(X), ))
+            value = np.tile(self.unif_maj, (X.shape[0], ))
             return value, probs
         return probs
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -311,7 +311,7 @@ class Table(MutableSequence, Storage):
                 if n_rows < 0:
                     n_rows = 0
             elif row_indices is ...:
-                n_rows = len(source.X)
+                n_rows = len(source)
             else:
                 n_rows = len(row_indices)
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -259,6 +259,11 @@ class Table(MutableSequence, Storage):
         """
 
         def get_columns(row_indices, src_cols, n_rows, dtype=np.float64):
+            def sparse_to_flat(x):
+                if sp.issparse(x):
+                    x = np.ravel(x.toarray())
+                return x
+
             if not len(src_cols):
                 return np.zeros((n_rows, 0), dtype=source.X.dtype)
 
@@ -289,7 +294,7 @@ class Table(MutableSequence, Storage):
                 elif col < 0:
                     a[:, i] = source.metas[row_indices, -1 - col]
                 elif col < n_src_attrs:
-                    a[:, i] = source.X[row_indices, col]
+                    a[:, i] = sparse_to_flat(source.X[row_indices, col])
                 else:
                     a[:, i] = source._Y[row_indices, col - n_src_attrs]
             return a

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -1,6 +1,7 @@
 import random
 import Orange
 import numpy as np
+from scipy.sparse import issparse
 
 from itertools import takewhile
 from operator import itemgetter
@@ -139,6 +140,10 @@ class RemoveNaNColumns(Preprocess):
         self.threshold = threshold
 
     def __call__(self, data, threshold=None):
+        # missing entries in sparse data are treated as zeros so we skip removing NaNs
+        if issparse(data.X):
+            return data
+
         if threshold is None:
             threshold = data.X.shape[0] if self.threshold is None else \
                         self.threshold

--- a/Orange/tests/test_fss.py
+++ b/Orange/tests/test_fss.py
@@ -4,6 +4,7 @@
 import unittest
 
 import numpy as np
+from scipy.sparse import csr_matrix
 
 from Orange.data import Table, Variable
 from Orange.preprocess.score import ANOVA, Gini, UnivariateLinearRegression, \
@@ -86,6 +87,13 @@ class TestRemoveNaNColumns(unittest.TestCase):
         new_data = RemoveNaNColumns(data)
         self.assertEqual(len(new_data.domain.attributes),
                          len(data.domain.attributes))
+
+    def test_column_filtering_sparse(self):
+        data = Table("iris")
+        data.X = csr_matrix(data.X)
+
+        new_data = RemoveNaNColumns(data)
+        self.assertEqual(data, new_data)
 
 
 class TestSelectRandomFeatures(unittest.TestCase):


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
* Modified RemoveNaNColumns to skip sparse data sets so most classifiers (except Naive Bayes) can work on sparse data.
* Modified `Table.from_table` to work if `table.X` is sparse.
* Changed a few `len(data.X)` to `data.X.shape[0]` since len does not work on scipy sparse matrices.