### PR TITLE
Setup: Remove invalid classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ CLASSIFIERS = (
     'Environment :: Console',
     'Environment :: Plugins',
     'Programming Language :: Python',
-    'Framework :: Orange',
     'License :: OSI Approved :: '
     'GNU General Public License v3 or later (GPLv3+)',
     'Operating System :: POSIX',


### PR DESCRIPTION
While nice in theory, 'Framework :: Orange' is not a valid pypi identifier and needs to be removed in order to make setup.py upload work.