### PR TITLE
[FIX] io: Safer check for attributes when storing

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -279,7 +279,7 @@ class FileFormat(metaclass=FileFormatMeta):
 
     @classmethod
     def write_table_metadata(cls, filename, data):
-        if isinstance(filename, str) and data.attributes:
+        if isinstance(filename, str) and getattr(data, 'attributes', {}):
             with open(filename + '.metadata', 'wb') as f:
                 pickle.dump(data.attributes, f, pickle.HIGHEST_PROTOCOL)
 


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
Some classes that extend Table (like Corpus) did not yet have attribute `attributes` which prevented storing them using Save Data widget. I fixed it for Corpus but this I think this is a safer way to check for attributes.


