### PR TITLE
[FIX] Image viewer runtime error

### DIFF
--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -309,9 +309,9 @@ class GraphicsScene(QGraphicsScene):
 
 _ImageItem = namedtuple(
     "_ImageItem",
-    ["index",  # Row index in the input data table
-     "widget",  # GraphicsThumbnailWidget belonging to this item.
-     "url",  # Composed final url.
+    ["index",   # Row index in the input data table
+     "widget",  # GraphicsThumbnailWidget displaying the image.
+     "url",     # Composed final image url.
      "future"]  # Future instance yielding an QImage
 )
 
@@ -542,7 +542,10 @@ class OWImageViewer(widget.OWWidget):
         for item in self.items:
             if item.future is not None:
                 item.future.cancel()
-                item.future._reply.close()
+                if item.future._reply is not None:
+                    item.future._reply.close()
+                    item.future._reply.deleteLater()
+                    item.future._reply = None
 
     def clearScene(self):
         self._cancelAllFutures()
@@ -668,7 +671,7 @@ class ImageLoader(QObject):
 
     def get(self, url):
         future = Future()
-        url = url = QUrl(url)
+        url = QUrl(url)
         request = QNetworkRequest(url)
         request.setRawHeader(b"User-Agent", b"OWImageViewer/1.0")
         request.setAttribute(
@@ -679,12 +682,24 @@ class ImageLoader(QObject):
         # Future yielding a QNetworkReply when finished.
         reply = self._netmanager.get(request)
         future._reply = reply
+
+        @future.add_done_callback
+        def abort_on_cancel(f):
+            # abort the network request on future.cancel()
+            if f.cancelled() and f._reply is not None:
+                f._reply.abort()
+
         n_redir = 0
 
         def on_reply_ready(reply, future):
             nonlocal n_redir
+            # schedule deferred delete to ensure the reply is closed
+            # otherwise we will leak file/socket descriptors
+            reply.deleteLater()
+            future._reply = None
             if reply.error() == QNetworkReply.OperationCanceledError:
-                # The network request itself was canceled
+                # The network request was cancelled
+                reply.close()
                 future.cancel()
                 return
 
@@ -692,6 +707,7 @@ class ImageLoader(QObject):
                 # XXX Maybe convert the error into standard
                 # http and urllib exceptions.
                 future.set_exception(Exception(reply.errorString()))
+                reply.close()
                 return
 
             # Handle a possible redirection
@@ -708,10 +724,12 @@ class ImageLoader(QObject):
                 future._reply = newreply
                 newreply.finished.connect(
                     partial(on_reply_ready, newreply, future))
+                reply.close()
                 return
 
             reader = QImageReader(reply)
             image = reader.read()
+            reply.close()
 
             if image.isNull():
                 future.set_exception(Exception(reader.errorString()))

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -654,7 +654,7 @@ class ImageLoader(QObject):
     _NETMANAGER_REF = None
 
     def __init__(self, parent=None):
-        QObject.__init__(self, parent=None)
+        QObject.__init__(self, parent)
         assert QThread.currentThread() is QApplication.instance().thread()
 
         netmanager = self._NETMANAGER_REF and self._NETMANAGER_REF()


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Do not use (Qt's) queued connection to set the retrieved image.
When a scene is cleared all the pending tasks are cancelled and target
widgets deleted, however if the signal is already enqueued, when the
scene is cleared, the signal handler would attempt to set the pixmap on
an already deleted widget.

Also fix an file/socket descriptor leak.

