### PR TITLE
Discretize: Improve gui

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -448,6 +448,7 @@ def indentedBox(widget, sep=20, orientation=Qt.Vertical, **misc):
     separator(outer, sep, 0)
     indented = widgetBox(outer, orientation=orientation)
     miscellanea(indented, outer, widget, **misc)
+    indented.box = outer
     return indented
 
 


### PR DESCRIPTION
To consider: the orders of options for general and individual setting are no longer the same. We can

- keep them different
- reorder them and disregard the compatibility with saved settings
- reorder them and keep the compatibility, which would require having some trivial, but annoying code for reshuffling.

Before:
<img width="643" alt="screen shot 2016-06-10 at 12 38 28" src="https://cloud.githubusercontent.com/assets/2387315/15961991/581dd838-2f08-11e6-85e2-b2fbe96b27cd.png">

After:
<img width="609" alt="screen shot 2016-06-10 at 12 36 19" src="https://cloud.githubusercontent.com/assets/2387315/15961996/5ce18ba8-2f08-11e6-980f-85e5baec6f29.png">
