### PR TITLE
[FIX] Pass data attributes after preprocess.

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -168,7 +168,9 @@ class SklImpute(Preprocess):
         assert X.shape[1] == len(features)
         domain = Orange.data.Domain(features, data.domain.class_vars,
                                     data.domain.metas)
-        return Orange.data.Table(domain, X, data.Y, data.metas, W=data.W)
+        new_data = Orange.data.Table(domain, X, data.Y, data.metas, W=data.W)
+        new_data.attributes = getattr(data, 'attributes', {})
+        return new_data
 
 
 class RemoveConstant(Preprocess):


### PR DESCRIPTION
Data table can include "attributes" attribute that stores object to be passed along with the data. SklImpute created a new data set from numpy objects, thus not storing the "attributes" from original data table. This has now been fixed. 

I was not able to find a better, general fix that would modify Preprocess class to do so for any kind of preprocessing.

The unwanted behavior fixed in this pull request was found through combination of Distance -> MDS widgets where the "attributes" attribute of the incoming data was lost when selecting data from MDS, and the loss was contributed to management of the data in Distance widget.