### PR TITLE
[ENH] Support unix timestamps in TimeVariable

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -936,7 +936,11 @@ class TimeVariable(ContinuousVariable):
 
         ERROR = ValueError('Invalid datetime format. Only ISO 8601 supported.')
         if not self._matches_iso_format(datestr):
-            raise ERROR
+            try:
+                # If it is a number, assume it is a unix timestamp
+                return float(datestr)
+            except ValueError:
+                raise ERROR
 
         for i, (have_date, have_time, fmt) in enumerate(self._ISO_FORMATS):
             try:

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -6,6 +6,7 @@ import math
 import unittest
 import pickle
 import pkgutil
+from datetime import datetime, timezone
 
 from io import StringIO
 
@@ -328,6 +329,12 @@ class TimeVariableTest(VariableTest):
         ts2 = var.parse(datestr)
         self.assertEqual(var.repr_val(ts2), datestr)
         self.assertEqual(var.repr_val(ts1), '2015-10-18 20:48:20')
+
+    def test_parse_timestamp(self):
+        var = TimeVariable("time")
+        datestr = str(datetime(2016, 6, 14, 23, 8, tzinfo=timezone.utc).timestamp())
+        ts1 = var.parse(datestr)
+        self.assertEqual(var.repr_val(ts1), '2016-06-14 23:08:00')
 
     def test_parse_invalid(self):
         var = TimeVariable('var')


### PR DESCRIPTION
Time information might be specified as a unix timestamp. Currently such values are not compatible with TimeVariable, as it assumes data in one of the ISO (human-readable) formats.

Numeric values between 1 and 9999 could be either timestamp or year (iso format "%Y"). For those cases, the values is assumed to be in iso format and parsed accordingly (the existing behaviour).