### PR TITLE
[FIX] OWBaseLearner: Add name attribute to learner

### DIFF
--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -162,6 +162,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
 
     def update_learner(self):
         self.learner = self.create_learner()
+        self.learner.name = self.learner_name
         self.send("Learner", self.learner)
         self.outdated_settings = False
         self.warning(self.OUTDATED_LEARNER_WARNING_ID)


### PR DESCRIPTION
`OWBaseLearner` assigned `learner_name` to `model.name` but not to `learner.name`. Widgets like Test & Score or Confusion Matrix thus showed the type of the model (e.g. "naive bayes") instead of the name specified in the widget (e.g. "Naive Bayes", as is the default in Naive Bayes widget).

The fix is roughly nine times shorter than this message. :)