### PR TITLE
Changed defaults in Test&Score

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -158,7 +158,7 @@ class OWTestLearners(widget.OWWidget):
     TARGET_AVERAGE = "(Average over classes)"
     class_selection = settings.ContextSetting(TARGET_AVERAGE)
 
-    auto_apply = settings.Setting(False)
+    auto_apply = settings.Setting(True)
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Probably we want to keep all the defaults to `auto_apply = True`. No?