### PR TITLE
[FIX] Fix a RuntimeError in 'Image Viewer' when clearing the scene

### DIFF
--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -550,12 +550,12 @@ class OWImageViewer(widget.OWWidget):
     def clearScene(self):
         self._cancelAllFutures()
 
-        self.scene.clear()
         self.items = []
-        self._errcount = 0
-        self._successcount = 0
         self.thumbnailWidget = None
         self.sceneLayout = None
+        self.scene.clear()
+        self._errcount = 0
+        self._successcount = 0
 
     def thumbnailItems(self):
         return [item.widget for item in self.items]


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Calling QGraphicsScene.clear when the scene has selected items will
trigger a selectionChanged signal, however the containing items will
have already been deleted (C++ side).

Avoid this by removing all python references to the graphics items
before calling scene.clear()