### PR TITLE
[FIX] Revert PyListModel display role change

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -273,14 +273,16 @@ def variable_icon(dtype):
         return QtGui.QIcon()
 
 
+class FeatureItemDelegate(QtGui.QStyledItemDelegate):
+    def displayText(self, value, locale):
+        return value.name + " := " + value.expression
+
+
 class DescriptorModel(itemmodels.PyListModel):
     def data(self, index, role=Qt.DisplayRole):
         if role == Qt.DecorationRole:
             value = self[index.row()]
             return variable_icon(type(value))
-        elif role == Qt.DisplayRole:
-            value = self[index.row()]
-            return value.name + " := " + value.expression
         else:
             return super().data(index, role)
 
@@ -424,6 +426,7 @@ class OWFeatureConstructor(widget.OWWidget):
                                    QSizePolicy.MinimumExpanding)
         )
 
+        self.featureview.setItemDelegate(FeatureItemDelegate(self))
         self.featureview.setModel(self.featuremodel)
         self.featureview.selectionModel().selectionChanged.connect(
             self._on_selectedVariableChanged

--- a/Orange/widgets/tests/test_itemmodels.py
+++ b/Orange/widgets/tests/test_itemmodels.py
@@ -109,5 +109,5 @@ class TestPyListModel(TestCase):
 
     def test_data(self):
         mi = self.model.index(2)
-        self.assertEqual(self.model.data(mi), '3')
+        self.assertEqual(self.model.data(mi), 3)
         self.assertEqual(self.model.data(mi, Qt.EditRole), 3)

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -345,7 +345,7 @@ class PyListModel(QAbstractListModel):
         row = index.row()
         if role in [self.list_item_role, Qt.EditRole] \
                 and self._is_index_valid_for(index, self):
-            return str(self[row]) if role == Qt.DisplayRole else self[row]
+            return self[row]
         elif self._is_index_valid_for(row, self._other_data):
             return self._other_data[row].get(role, None)
 


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Granted the Qt documentation can be a bit misleading at times, however the Qt's item view framework does not impose the restriction that the data associated with a DisplayRole be a string. After all a MVC abstraction is intended to separate the data from its presentation.

For instance there are many situations where preserving the type of the item intended for display is beneficial (when displaying numerical data, dates, ...), as the view can then benefit from the default behavior of QSortFilterProxyModel model and have proper sorting with the default configuration out of the box (i.e. no `setSortRole` necessary, as the item to be displayed is also the one defining the ordering), locale specific date formating, decimal separator, .... (courtesy of `QStyleItemDelegate.displayText`). 
In extreme cases the data presentation is not even textual (https://doc.qt.io/qt-4.8/qt-itemviews-pixelator-example.html, https://doc.qt.io/qt-4.8/qt-itemviews-chart-example.html)
