### PR TITLE
Test score - Changes in GUI

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -64,9 +64,10 @@ class ItemDelegate(QStyledItemDelegate):
 
 
 class Try(abc.ABC):
-    # Try to walk in a Turing tar pit.
+    """Try to walk in a Turing tar pit."""
 
     class Success:
+        """Data type for instance constructed on success"""
         __slots__ = ("__value",)
 #         __bool__ = lambda self: True
         success = property(lambda self: True)
@@ -86,6 +87,7 @@ class Try(abc.ABC):
             return Try(lambda: fn(self.value))
 
     class Fail:
+        """Data type for instance constructed on fail"""
         __slots__ = ("__exception", )
 #         __bool__ = lambda self: False
         success = property(lambda self: False)
@@ -593,6 +595,7 @@ class OWTestLearners(widget.OWWidget):
         self.commit()
 
     def commit(self):
+        """Recompute and output the results"""
         self._update_header()
         # Update the view to display the model names
         self._update_stats_model()
@@ -615,6 +618,7 @@ class OWTestLearners(widget.OWWidget):
         self.send("Predictions", predictions)
 
     def send_report(self):
+        """Report on the testing schema and results"""
         if not self.data or not self.learners:
             return
         if self.resampling == self.KFold:
@@ -643,6 +647,8 @@ class OWTestLearners(widget.OWWidget):
 
 
 def learner_name(learner):
+    """Return the value of `learner.name` if it exists, or the learner's type
+    name otherwise"""
     return getattr(learner, "name", type(learner).__name__)
 
 
@@ -689,6 +695,7 @@ def results_one_vs_rest(results, pos_index):
 
 
 def main(argv=None):
+    """Show and test the widget"""
     if argv is None:
         argv = sys.argv
     argv = list(argv)

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -186,7 +186,7 @@ class OWComponent:
 
 def miscellanea(control, box, parent,
                 addToLayout=True, stretch=0, sizePolicy=None, addSpace=False,
-                disabled=False, tooltip=None):
+                disabled=False, tooltip=None, **kwargs):
     """
     Helper function that sets various properties of the widget using a common
     set of arguments.
@@ -206,6 +206,11 @@ def miscellanea(control, box, parent,
 
     If `box` is the same as `parent` it is set to `None`; this is convenient
     because of the way complex controls are inserted.
+
+    Unused keyword arguments are assumed to be properties; with this `gui`
+    function mimic the behaviour of PyQt's constructors. For instance, if
+    `gui.lineEdit` is called with keyword argument `sizePolicy=some_policy`,
+    `miscallenea` will call `control.setSizePolicy(some_policy)`.
 
     :param control: the control, e.g. a `QCheckBox`
     :type control: PyQt4.QtGui.QWidget
@@ -228,6 +233,8 @@ def miscellanea(control, box, parent,
     :param sizePolicy: the size policy for the box or the control
     :type sizePolicy: PyQt4.QtQui.QSizePolicy
     """
+    for prop, val in kwargs.items():
+        getattr(control, "set" + prop[0].upper() + prop[1:])(val)
     if disabled:
         # if disabled==False, do nothing; it can be already disabled
         control.setDisabled(disabled)

--- a/doc/development/source/gui.rst
+++ b/doc/development/source/gui.rst
@@ -102,6 +102,23 @@ Many functions share common arguments.
     of :obj:`~PyQt4.QtGui.QLayout`.
 
 
+**********
+Properties
+**********
+
+PyQt support settings of properties using keyword arguments. Functions in this
+module mimic this functionality. For instance, calling
+
+    cb = gui.comboBox(..., editable=True)
+
+has the same effect as
+
+    cb = gui.comboBox(...)
+    cb.setEditable(True)
+
+Any properties that have the corresponding setter in the underlying Qt control
+can be set by using keyword arguments.
+
 *****************
 Common Attributes
 *****************


### PR DESCRIPTION
Continues from #1352 -- see the discussion there.

In a nutshell, we would like to have auto-apply as default, but for this we need to disable tracking and change spins into combos.

Class attributes were renamed to avoid compatibility problems with older saved settings.

@kernc, please comment on 820d34c8bd1072f98978fb7209d3b6e7f91287d1. I think we need something like this; the implementation is a bit of a hack, but this is easier than passing arguments to constructor. Besides, it fixes all controls in `gui` with a single change.