### PR TITLE
[ENH] Scatter plot and MDS: Show labels only for selected points

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -141,6 +141,7 @@ class OWMDS(widget.OWWidget):
     shape_value = settings.ContextSetting("")
     size_value = settings.ContextSetting("")
     label_value = settings.ContextSetting("")
+    label_only_selected = settings.Setting(False)
 
     symbol_size = settings.Setting(8)
     symbol_opacity = settings.Setting(230)
@@ -232,6 +233,9 @@ class OWMDS(widget.OWWidget):
             box, self, "label_value", label="Label:",
             callback=self._on_label_index_changed, **common_options)
         self.cb_label_value.setModel(self.labelvar_model)
+        gui.checkBox(
+            gui.indentedBox(box), self, 'label_only_selected',
+            'Label only selected points', callback=self._on_label_index_changed)
 
         form = QtGui.QFormLayout(
             labelAlignment=Qt.AlignLeft,
@@ -930,9 +934,18 @@ class OWMDS(widget.OWWidget):
         self.plot.addItem(item)
 
         if self._label_data is not None:
-            for (x, y), text_item in zip(self.embedding, self._label_data):
-                self.plot.addItem(text_item)
-                text_item.setPos(x, y)
+            if self.label_only_selected:
+                if self._selection_mask is not None:
+                    for (x, y), text_item, selected \
+                            in zip(self.embedding, self._label_data,
+                                   self._selection_mask):
+                        if selected:
+                            self.plot.addItem(text_item)
+                            text_item.setPos(x, y)
+            else:
+                for (x, y), text_item in zip(self.embedding, self._label_data):
+                    self.plot.addItem(text_item)
+                    text_item.setPos(x, y)
 
         self._legend_item = LegendItem()
         viewbox = self.plot.getViewBox()

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -373,8 +373,11 @@ class OWPlotGUI:
         '''
         self._check_box(widget, 'use_animations', 'Use animations', 'update_animations')
 
-    def _slider(self, widget, value, label, min_value, max_value, step, cb_name):
-        gui.hSlider(widget, self._plot, value, label=label, minValue=min_value, maxValue=max_value, step=step, callback=self._get_callback(cb_name))
+    def _slider(self, widget, value, label, min_value, max_value, step, cb_name,
+                show_number=False):
+        gui.hSlider(widget, self._plot, value, label=label, minValue=min_value,
+                    maxValue=max_value, step=step, createLabel=show_number,
+                    callback=self._get_callback(cb_name))
 
     def point_size_slider(self, widget):
         '''

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -130,6 +130,9 @@ class OWScatterPlot(OWWidget):
             box, self, "graph.attr_label", label="Label:",
             emptyString="(No labels)", callback=self.graph.update_labels,
             **common_options)
+        gui.checkBox(
+            gui.indentedBox(box), self, 'graph.label_only_selected',
+            'Label only selected points', callback=self.graph.update_labels)
         self.cb_attr_shape = gui.comboBox(
             box, self, "graph.attr_shape", label="Shape:",
             emptyString="(Same shape)", callback=self.graph.update_shapes,

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -102,8 +102,8 @@ class OWScatterPlot(OWWidget):
         vizrank_box = gui.hBox(box)
         gui.separator(vizrank_box, width=common_options["labelWidth"])
         self.vizrank_button = gui.button(
-            vizrank_box, self, "Rank Projections", callback=self.vizrank.reshow,
-            tooltip="Find projections with good class separation")
+            vizrank_box, self, "Score Plots", callback=self.vizrank.reshow,
+            tooltip="Find plots with good class separation")
         self.vizrank_button.setEnabled(False)
         gui.separator(box)
 
@@ -130,9 +130,6 @@ class OWScatterPlot(OWWidget):
             box, self, "graph.attr_label", label="Label:",
             emptyString="(No labels)", callback=self.graph.update_labels,
             **common_options)
-        gui.checkBox(
-            gui.indentedBox(box), self, 'graph.label_only_selected',
-            'Label only selected points', callback=self.graph.update_labels)
         self.cb_attr_shape = gui.comboBox(
             box, self, "graph.attr_shape", label="Shape:",
             emptyString="(Same shape)", callback=self.graph.update_shapes,
@@ -147,11 +144,15 @@ class OWScatterPlot(OWWidget):
 
         box = gui.vBox(self.controlArea, "Plot Properties")
         g.add_widgets([g.ShowLegend, g.ShowGridLines], box)
-        gui.checkBox(box, self, value='graph.tooltip_shows_all',
-                     label='Show all data on mouse hover')
+        gui.checkBox(
+            box, self, value='graph.tooltip_shows_all',
+            label='Show all data on mouse hover')
         self.cb_class_density = gui.checkBox(
             box, self, value='graph.class_density', label='Show class density',
             callback=self.update_density)
+        gui.checkBox(
+            box, self, 'graph.label_only_selected',
+            'Label only selected points', callback=self.graph.update_labels)
 
         self.zoom_select_toolbar = g.zoom_select_toolbar(
             gui.vBox(self.controlArea, "Zoom/Select"), nomargin=True,

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -455,6 +455,7 @@ _define_symbols()
 class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
     attr_color = ContextSetting("", ContextSetting.OPTIONAL)
     attr_label = ContextSetting("", ContextSetting.OPTIONAL)
+    label_only_selected = Setting(False)
     attr_shape = ContextSetting("", ContextSetting.OPTIONAL)
     attr_size = ContextSetting("", ContextSetting.OPTIONAL)
 
@@ -842,7 +843,8 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
             self.labels.append(ti)
 
     def update_labels(self):
-        if not self.attr_label:
+        if not self.attr_label or \
+                self.label_only_selected and self.selection is None:
             for label in self.labels:
                 label.setText("")
             return
@@ -852,8 +854,13 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         formatter = self.raw_data.domain[self.attr_label].str_val
         label_data = map(formatter, label_column)
         black = pg.mkColor(0, 0, 0)
-        for label, text in zip(self.labels, label_data):
-            label.setText(text, black)
+        if self.label_only_selected:
+            for label, text, selected \
+                    in zip(self.labels, label_data, self.selection):
+                label.setText(text if selected else "", black)
+        else:
+            for label, text in zip(self.labels, label_data):
+                label.setText(text, black)
 
     def get_shape_index(self):
         shape_index = -1
@@ -991,6 +998,8 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
     def unselect_all(self):
         self.selection = None
         self.update_colors(keep_colors=True)
+        if self.label_only_selected:
+            self.update_labels()
         self.master.selection_changed()
 
     def select(self, points):
@@ -1009,6 +1018,8 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         else:  # Handle shift and no modifiers
             self.selection[indices] = True
         self.update_colors(keep_colors=True)
+        if self.label_only_selected:
+            self.update_labels()
         self.master.selection_changed()
 
     def get_selection(self):


### PR DESCRIPTION
The ticket was about doing this for all widgets. I found only these two.

The first and the thirs commit implement the option for the two widgets.

The second commit reorganizes the Scatter plot GUI. The original layout had separate boxes for combos and for checkboxes. The new checkbox so obviously belongs to the label combo that I've put it there. By the same logic, other checkboxes belong to different places in the widget. I'm not totally satisfied with the result; I think it's better than the original (cleaner and smaller), but I can revert it if you dislike it.

Original:
<img width="816" alt="screen shot 2016-06-22 at 17 48 44" src="https://cloud.githubusercontent.com/assets/2387315/16273558/61be9122-38a2-11e6-8dcc-c555c51282d5.png">

Changed:
<img width="788" alt="screen shot 2016-06-22 at 17 48 47" src="https://cloud.githubusercontent.com/assets/2387315/16273561/64f0f3c6-38a2-11e6-9db2-739de0026563.png">
