### PR TITLE
[FIX] Mosaic: Output original data, not discretized

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -241,7 +241,7 @@ class OWMosaicDisplay(OWWidget):
         if self.discrete_data is not self.data:
             idset = set(selection.ids)
             sel_idx = [i for i, id in enumerate(self.data.ids) if id in idset]
-            selection = self.discrete_data[sel_idx]
+            selection = self.data[sel_idx]
         self.send("Selected Data", selection)
 
 


### PR DESCRIPTION
After all the fuss needed to get the example indices for the original data, Mosaic output discretized data. :)