### PR TITLE
Use widget class docstrings as descriptions

### DIFF
--- a/Orange/canvas/registry/description.py
+++ b/Orange/canvas/registry/description.py
@@ -271,6 +271,9 @@ class WidgetDescription(object):
 
     @classmethod
     def from_module(cls, module):
+        # False positive for widget_class: undefined var is prevented by
+        # raising exception in else after the for
+        # pylint: disable=undefined-loop-variable
         """
         Get the widget description from a module.
 
@@ -304,6 +307,12 @@ class WidgetDescription(object):
             raise WidgetSpecificationError
 
         qualified_name = "%s.%s" % (module.__name__, widget_cls_name)
+        long_description = (
+            widget_class.long_description or
+            widget_class.__doc__).strip()
+        description = (
+            widget_class.description or
+            long_description and long_description.split("\n\n")[0]).strip()
 
         inputs = [input_channel_from_args(input_) for input_ in
                   widget_class.inputs]
@@ -322,8 +331,8 @@ class WidgetDescription(object):
             id=widget_class.id or module_name,
             category=widget_class.category or default_cat_name,
             version=widget_class.version,
-            description=widget_class.description,
-            long_description=widget_class.long_description,
+            description=description,
+            long_description=long_description,
             qualified_name=qualified_name,
             package=module.__package__,
             inputs=inputs,

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -288,12 +288,15 @@ class ContinuousTable(ColorTable):
 
 
 class OWColor(widget.OWWidget):
-    """Widget for assigning color palettes to variable"""
+    """
+    Set color legend for variables
+
+    Widget for defining specific color palettes for discrete and continuous
+    features
+    """
 
     name = "Color"
-    description = "Set color legend for variables."
     icon = "icons/Colors.svg"
-
     inputs = [("Data", Orange.data.Table, "set_data")]
     outputs = [("Data", Orange.data.Table)]
 


### PR DESCRIPTION
Widget docstrings (required by lint) give the same information as descriptions. I recommend preferring docstrings. With this PR, if the widget class does not have `description` and/or `long_description`,

- the docstring is used for `long_description` and/or
- the `long_description` up to the first `\n\n` is used for `description`.

Usage is demonstrated on widget `OWColor`.

If the docstring actually contains technical info (e.g. a real Napoleon-style docstring), the widget must use `long_description` (and `short_description`, if necessary).