### PR TITLE
[FIX] Remove '(from Orange3)' from widget names in canvas

### DIFF
--- a/Orange/canvas/registry/qt.py
+++ b/Orange/canvas/registry/qt.py
@@ -296,7 +296,7 @@ def tooltip_helper(desc):
     tooltip = []
     tooltip.append("<b>{name}</b>".format(name=escape(desc.name)))
 
-    if desc.project_name and desc.project_name != "Orange":
+    if desc.project_name:
         tooltip[0] += " (from {0})".format(desc.project_name)
 
     if desc.description:


### PR DESCRIPTION
Tooltips on widget toolbars showed "(from Orange3)" after the name of each widget due to mismatching project name.

@ales-erjavec, @astaric, is there a better, long-term solution? Comparing with `Orange.setup.NAME` doesn't seem appropriate - or is it?