### PR TITLE
[ENH] Implement copying graph to clipboard using Ctrl-C (Cmd-C)

### DIFF
--- a/Orange/widgets/classify/owtreeviewer2d.py
+++ b/Orange/widgets/classify/owtreeviewer2d.py
@@ -361,7 +361,7 @@ class OWTreeViewer2D(OWWidget):
     _DEF_NODE_WIDTH = 24
     _DEF_NODE_HEIGHT = 20
 
-    graph_name = True
+    graph_name = "scene"
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/io.py
+++ b/Orange/widgets/io.py
@@ -1,5 +1,6 @@
 from PyQt4 import QtGui, QtCore, QtSvg
-from PyQt4.QtGui import QGraphicsScene, QGraphicsView, QWidget
+from PyQt4.QtCore import QMimeData
+from PyQt4.QtGui import QGraphicsScene, QGraphicsView, QWidget, QApplication
 
 from Orange.data.io import FileFormat
 
@@ -98,6 +99,23 @@ class PngFormat(ImgFormat):
     def _export(exporter, filename):
         buffer = exporter.export(toBytes=True)
         buffer.save(filename, "png")
+
+
+class ClipboardFormat(PngFormat):
+    EXTENSIONS = ()
+    DESCRIPTION = 'System Clipboard'
+    PRIORITY = 50
+
+    @staticmethod
+    def _save_buffer(buffer, _):
+        QApplication.clipboard().setPixmap(buffer)
+
+    @staticmethod
+    def _export(exporter, _):
+        buffer = exporter.export(toBytes=True)
+        mimedata = QMimeData()
+        mimedata.setData("image/png", buffer)
+        QApplication.clipboard().setMimeData(mimedata)
 
 
 class SvgFormat(ImgFormat):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -18,6 +18,7 @@ from Orange.widgets import settings, gui
 from Orange.canvas.registry import description as widget_description
 from Orange.canvas.report import Report
 from Orange.widgets.gui import ControlledAttributesDict, notify_changed
+from Orange.widgets.io import ClipboardFormat
 from Orange.widgets.settings import SettingsHandler
 from Orange.widgets.utils import saveplot, getdeepattr
 from .utils.overlay import MessageOverlayWidget
@@ -198,6 +199,9 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
         sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
         sc.activated.connect(self.__quicktip)
 
+        sc = QShortcut(QKeySequence.Copy, self)
+        sc.activated.connect(self.copy_to_clipboard)
+
         return self
 
     def __init__(self, *args, **kwargs):
@@ -315,6 +319,12 @@ class OWWidget(QDialog, Report, metaclass=WidgetMetaClass):
         if graph_obj is None:
             return
         saveplot.save_plot(graph_obj, self.graph_writers)
+
+    def copy_to_clipboard(self):
+        graph_obj = getdeepattr(self, self.graph_name, None)
+        if graph_obj is None:
+            return
+        ClipboardFormat.write_image(None, graph_obj)
 
     def __restoreWidgetGeometry(self):
 


### PR DESCRIPTION
This should work for all widgets that have `graph_name` attribute (~ the Save Image button).

Can somebody check it on Linux and Windows? Scatter plot and Box plot, for instance.

@VesnaT, you're an expert for Linear Projection - and saving graphs in general. Can you check why it copying doesn't work for Linear Projection and Distributions?