### PR TITLE
[FIX] Fix an logging error on windows

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -77,10 +77,10 @@ def fix_win_pythonw_std_stream():
     """
     if sys.platform == "win32" and \
             os.path.basename(sys.executable) == "pythonw.exe":
-        if sys.stdout is not None and sys.stdout.fileno() < 0:
-            sys.stdout = open(os.devnull, "wb")
-        if sys.stdout is not None and sys.stderr.fileno() < 0:
-            sys.stderr = open(os.devnull, "wb")
+        if sys.stdout is None:
+            sys.stdout = open(os.devnull, "w")
+        if sys.stderr is None:
+            sys.stderr = open(os.devnull, "w")
 
 
 def make_sql_logger(level=logging.INFO):


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

An error in `fix_win_pythonw_std_stream` prevented it from setting a
valid stream to stderr/stdout. Without a valid stderr stream the logging
module raises errors when attempting to write to stderr.