### PR TITLE
[FIX] File: Stores filenames to image attributes

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -270,7 +270,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         self.info.setText(self._describe(data))
 
-        add_origin(data, self.loaded_file)
+        add_origin(data, self.loaded_file or self.last_path())
         self.send("Data", data)
         self.editor_model.set_domain(data.domain)
         self.data = data


### PR DESCRIPTION
Widgets that deal with images use `origin` attribute of the string feature with file names that stores the original location of the data file. This is used when image files are referred to with relative location. Initially, `self.loaded_file` stored this location, but this has been broken and only works when file is chosen from the file browser, and not when the file is selected from the combo box with history. To be on the safe side, I keep this variable but if empty add the filename from `self.last_path()`. Ideally, only `self.last_path()` would be sufficient, I guess.