### PR TITLE
[FIX] SelectRows: Index attrs only by visible in set_data

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -319,7 +319,7 @@ class OWSelectRows(widget.OWWidget):
         self.update_info(data, self.data_in_variables, "In: ")
         for attr, cond_type, cond_value in self.conditions:
             attrs = [a.name for a in
-                     data.domain.variables + data.domain.metas]
+                     filter_visible(chain(data.domain.variables, data.domain.metas))]
             if attr in attrs:
                 self.add_row(attrs.index(attr), cond_type, cond_value)
         self.unconditional_commit()


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

In `set_data` we calculate the index of an attribute that is passed to `add_rows`. Since `add_rows` only consider visible attributes the index has to be calculated only on visible as well.

Otherwise this caused `attr_combo.setCurrentIndex` to be set to values larger than the number of items inside it. Strangely this works but causes `attr_combo.currentText()` to returns an empty string which of course breaks indexing on domain.