### PR TITLE
[FIX] Lin and Log Regression: Prevent double commit

### DIFF
--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -347,7 +347,9 @@ class Results:
             # multiprocessing (otherwise it shits itself at least on Windos)
             mp_queue = mp_ctx.Manager().Queue() if n_jobs > 1 else mp.Queue()
         except (EOFError, RuntimeError):
-            raise RuntimeError('''
+            mp_queue = mp.Queue()
+            n_jobs = 1
+            warnings.warn('''
 
         Can't run multiprocessing code without a __main__ guard.
 
@@ -365,8 +367,8 @@ class Results:
         recursion ensues.
 
         Guard your executed code with above Python idiom, or pass n_jobs=1
-        to evaluation methods, i.e. {}(..., n_jobs=1).
-            '''.format(self.__class__.__name__)) from None
+        to evaluation methods, i.e. {}(..., n_jobs=1). Setting n_jobs to 1.
+            '''.format(self.__class__.__name__), OrangeWarning)
 
         data_splits = (
             (fold_i, self.preprocessor(train_data[train_i]), test_data[test_i])

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -47,7 +47,8 @@ class OWLogisticRegression(OWBaseLearner):
         gui.widgetLabel(box2, "Weak").setStyleSheet("margin-top:6px")
         gui.hSlider(box2, self, "C_index",
                     minValue=0, maxValue=len(self.C_s) - 1,
-                    callback=self.set_c, createLabel=False)
+                    callback=lambda: (self.set_c(), self.settings_changed()),
+                    createLabel=False)
         gui.widgetLabel(box2, "Strong").setStyleSheet("margin-top:6px")
         box2 = gui.hBox(box)
         box2.layout().setAlignment(Qt.AlignCenter)
@@ -58,7 +59,6 @@ class OWLogisticRegression(OWBaseLearner):
         self.C = self.C_s[self.C_index]
         fmt = "C={}" if self.C >= 1 else "C={:.3f}"
         self.c_label.setText(fmt.format(self.C))
-        self.settings_changed()
 
     def create_learner(self):
         penalty = ["l1", "l2"][self.penalty_type]

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -86,7 +86,6 @@ class OWLinearRegression(OWBaseLearner):
         self.layout().setSizeConstraint(QLayout.SetFixedSize)
         self.alpha_slider.setEnabled(self.reg_type != self.OLS)
         self.l1_ratio_slider.setEnabled(self.reg_type == self.Elastic)
-        self.commit()
 
     def handleNewSignals(self):
         self.commit()


### PR DESCRIPTION
Both linear and logistic regression committed the learner twice upon initialization. The first time when setting (changing) the attributes for initial setup, and the second time once the initialization was over and when the auto commit was set to True. If the widgets were connected to Test & Score, this resulted in running the testing (e.g. cross validation) twice.

Debugging of these widget lead to discovery a bug of crashing the parallel execution of cross-validation, but only when in debug mode and running through PyCharm on OS X. The fix is to change to sequential execution  (`n_jobs = 1`) but issuing a warning instead of raising an error.