### PR TITLE
VizRank: Add convenience method for construction

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -154,14 +154,10 @@ class OWScatterPlot(OWWidget):
                                       callback=self.update_attr,
                                       **common_options)
 
-        self.vizrank = ScatterPlotVizRank(self)
         vizrank_box = gui.hBox(box)
         gui.separator(vizrank_box, width=common_options["labelWidth"])
-        self.vizrank_button_tooltip = "Find informative projections"
-        self.vizrank_button = gui.button(
-            vizrank_box, self, "Score Plots", callback=self.vizrank.reshow,
-            tooltip=self.vizrank_button_tooltip, enabled=False)
-        self.vizrank.pairSelected.connect(self.set_attr)
+        self.vizrank, self.vizrank_button = ScatterPlotVizRank.add_vizrank(
+            vizrank_box, self, "Find Informative Projections", self.set_attr)
 
         gui.separator(box)
 
@@ -316,7 +312,7 @@ class OWScatterPlot(OWWidget):
             self.vizrank_button.setToolTip(
                 "Data with a class variable is required.")
         else:
-            self.vizrank_button.setToolTip(self.vizrank_button_tooltip)
+            self.vizrank_button.setToolTip("")
         self.openContext(self.data)
 
     def add_data(self, time=0.4):
@@ -491,14 +487,6 @@ class OWScatterPlot(OWWidget):
     def commit(self):
         self.send_data()
         self.send_features()
-
-    def closeEvent(self, ce):
-        self.vizrank.close()
-        super().closeEvent(ce)
-
-    def hideEvent(self, he):
-        self.vizrank.hide()
-        super().hideEvent(he)
 
     def get_widget_name_extension(self):
         if self.data is not None:

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -88,6 +88,9 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
 
 
 class OWScatterPlot(OWWidget):
+    """Scatterplot visualization with explorative analysis and intelligent
+    data visualization enhancements."""
+
     name = 'Scatter Plot'
     description = "Interactive scatter plot visualization with " \
                   "intelligent data visualization enhancements."
@@ -162,7 +165,7 @@ class OWScatterPlot(OWWidget):
         gui.separator(box)
 
         gui.valueSlider(
-            box, self, value='graph.jitter_size',  label='Jittering: ',
+            box, self, value='graph.jitter_size', label='Jittering: ',
             values=self.jitter_sizes, callback=self.reset_graph_data,
             labelFormat=lambda x:
             "None" if x == 0 else ("%.1f %%" if x < 1 else "%d %%") % x)
@@ -194,8 +197,6 @@ class OWScatterPlot(OWWidget):
             **common_options)
 
         g = self.graph.gui
-        box2 = g.point_properties_box(self.controlArea, box)
-
         box = gui.vBox(self.controlArea, "Plot Properties")
         g.add_widgets([g.ShowLegend, g.ShowGridLines], box)
         gui.checkBox(
@@ -500,12 +501,12 @@ class OWScatterPlot(OWWidget):
             disc_attr = domain[self.attr_x].is_discrete or \
                         domain[self.attr_y].is_discrete
         caption = report.render_items_vert((
-             ("Color", self.combo_value(self.cb_attr_color)),
-             ("Label", self.combo_value(self.cb_attr_label)),
-             ("Shape", self.combo_value(self.cb_attr_shape)),
-             ("Size", self.combo_value(self.cb_attr_size)),
-             ("Jittering", (self.graph.jitter_continuous or disc_attr) and
-              self.graph.jitter_size)))
+            ("Color", self.combo_value(self.cb_attr_color)),
+            ("Label", self.combo_value(self.cb_attr_label)),
+            ("Shape", self.combo_value(self.cb_attr_shape)),
+            ("Size", self.combo_value(self.cb_attr_size)),
+            ("Jittering", (self.graph.jitter_continuous or disc_attr) and
+             self.graph.jitter_size)))
         self.report_plot()
         if caption:
             self.report_caption(caption)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -92,11 +92,9 @@ class OWSieveDiagram(OWWidget):
         self.attrXCombo = gui.comboBox(value="attrX", **combo_args)
         gui.widgetLabel(self.attr_box, "\u2715", sizePolicy=fixed_size)
         self.attrYCombo = gui.comboBox(value="attrY", **combo_args)
-        self.vizrank = SieveRank(self)
-        self.vizrank_button = gui.button(
-            self.attr_box, self, "Score Combinations", sizePolicy=fixed_size,
-            callback=self.vizrank.reshow, enabled=False)
-        self.vizrank.pairSelected.connect(self.set_attr)
+        self.vizrank, self.vizrank_button = SieveRank.add_vizrank(
+            self.attr_box, self, "Score Combinations", self.set_attr)
+        self.vizrank_button.setSizePolicy(*fixed_size)
 
         self.canvas = QGraphicsScene()
         self.canvasView = ViewWithPress(
@@ -119,14 +117,6 @@ class OWSieveDiagram(OWWidget):
     def showEvent(self, event):
         super().showEvent(event)
         self.update_graph()
-
-    def closeEvent(self, event):
-        self.vizrank.close()
-        super().closeEvent(event)
-
-    def hideEvent(self, event):
-        self.vizrank.hide()
-        super().hideEvent(event)
 
     def set_data(self, data):
         """

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -1,3 +1,7 @@
+"""
+Utility classes for visualization widgets
+"""
+
 from bisect import bisect_left
 from operator import attrgetter
 
@@ -327,9 +331,28 @@ class VizRankDialogAttrPair(VizRankDialog):
 
 
 class CanvasText(QGraphicsTextItem):
-    def __init__(self, canvas, text="", x=0, y=0,
-                 alignment=Qt.AlignLeft | Qt.AlignTop, bold=0, font=None, z=0,
-                 html_text=None, tooltip=None, show=1, vertical=False):
+    """QGraphicsTextItem with more convenient constructor
+
+       Args:
+           scene (QGraphicsScene): scene into which the text is placed
+           text (str): text; see also argument `html_text` (default: `""`)
+           x (int): x-coordinate (default: 0)
+           y (int): y-coordinate (default: 0)
+           alignment (Qt.Alignment): text alignment
+               (default: Qt.AlignLeft | Qt.AlignTop)
+           bold (bool): if `True`, font is set to bold (default: `False`)
+           font (QFont): text font
+           z (int): text layer
+           html_text (str): text as html; if present (default is `None`),
+               it overrides the `text` argument
+           tooltip (str): text tooltip
+           show (bool): if `False`, the text is hidden (default: `True`)
+           vertical (bool): if `True`, the text is rotated by 90 degrees
+               (default: `False`)
+    """
+    def __init__(self, scene, text="", x=0, y=0,
+                 alignment=Qt.AlignLeft | Qt.AlignTop, bold=False, font=None,
+                 z=0, html_text=None, tooltip=None, show=True, vertical=False):
         QGraphicsTextItem.__init__(self, text, None)
 
         if font:
@@ -356,10 +379,11 @@ class CanvasText(QGraphicsTextItem):
         else:
             self.hide()
 
-        if canvas is not None:
-            canvas.addItem(self)
+        if scene is not None:
+            scene.addItem(self)
 
     def setPos(self, x, y):
+        """setPos with adjustment for alignment"""
         self.x, self.y = x, y
         rect = QGraphicsTextItem.boundingRect(self)
         if self.vertical:
@@ -378,9 +402,30 @@ class CanvasText(QGraphicsTextItem):
 
 
 class CanvasRectangle(QGraphicsRectItem):
-    def __init__(self, canvas, x=0, y=0, width=0, height=0,
+    """QGraphicsRectItem with more convenient constructor
+
+    Args:
+        scene (QGraphicsScene): scene into which the rectangle is placed
+        x (int): x-coordinate (default: 0)
+        y (int): y-coordinate (default: 0)
+        width (int): rectangle's width (default: 0)
+        height (int): rectangle's height (default: 0)
+        z (int): z-layer
+        pen (QPen): pen for the border; if present, it overrides the separate
+            arguments for color, width and style
+        pen_color (QColor or QPen): the (color of) the pen
+            (default: `QColor(128, 128, 128)`)
+        pen_width (int): pen width
+        pen_style (PenStyle): pen style (default: `Qt.SolidLine`)
+        brush_color (QColor): the color for the interior (default: same as pen)
+        tooltip (str): tooltip
+        show (bool): if `False`, the text is hidden (default: `True`)
+        onclick (callable): callback for mouse click event
+    """
+
+    def __init__(self, scene, x=0, y=0, width=0, height=0,
                  pen_color=QColor(128, 128, 128), brush_color=None, pen_width=1,
-                 z=0, pen_style=Qt.SolidLine, pen=None, tooltip=None, show=1,
+                 z=0, pen_style=Qt.SolidLine, pen=None, tooltip=None, show=True,
                  onclick=None):
         super().__init__(x, y, width, height, None)
         self.onclick = onclick
@@ -398,22 +443,25 @@ class CanvasRectangle(QGraphicsRectItem):
         else:
             self.hide()
 
-        if canvas is not None:
-            canvas.addItem(self)
+        if scene is not None:
+            scene.addItem(self)
 
-    def mousePressEvent(self, ev):
+    def mousePressEvent(self, event):
         if self.onclick:
-            self.onclick(self, ev)
+            self.onclick(self, event)
 
 
 class ViewWithPress(QGraphicsView):
+    """QGraphicsView with a callback for mouse press event. The callback
+    is given as keyword argument `handler`.
+    """
     def __init__(self, *args, **kwargs):
         self.handler = kwargs.pop("handler")
         super().__init__(*args)
 
-    def mousePressEvent(self, ev):
-        super().mousePressEvent(ev)
-        if not ev.isAccepted():
+    def mousePressEvent(self, event):
+        super().mousePressEvent(event)
+        if not event.isAccepted():
             self.handler()
 
 


### PR DESCRIPTION
Add VizRank to a widget requires setting up the class and the button and overloading methods for closing and hiding the widget. This PR provides a convenience function that constructs everything needed and monkey patches the `closeEvent` and `hideEvent` methods.