### PR TITLE
[RFC] Constants for status messages

### DIFF
--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -302,14 +302,14 @@ class OWSql(widget.OWWidget):
             elif confirm.clickedButton() == sample_button:
                 sample = True
 
-        self.information(1)
+        self.information()
         if self.guess_values:
             QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
             if sample:
                 s = table.sample_time(1)
                 domain = s.get_domain(guess_values=True)
                 self.information(
-                    1, "Domain was generated from a sample of the table.")
+                    "Domain was generated from a sample of the table.")
             else:
                 domain = table.get_domain(guess_values=True)
             QApplication.restoreOverrideCursor()

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -166,6 +166,21 @@ class OWTestLearners(widget.OWWidget):
     TARGET_AVERAGE = "(Average over classes)"
     class_selection = settings.ContextSetting(TARGET_AVERAGE)
 
+    ERR_CLASS_REQUIRED = widget.OWWidget.status_id()
+    ERR_CLASS_REQUIRED_IN_TEST = widget.OWWidget.status_id()
+    ERR_CLASS_INCONSISTENT = widget.OWWidget.status_id()
+    ERR_TOO_MANY_FOLDS = widget.OWWidget.status_id()
+    ERR_GENERAL = widget.OWWidget.status_id()
+
+    WARN_MISSING_DATA = widget.OWWidget.status_id()
+    WARN_TEST_DATA_MISSING = widget.OWWidget.status_id()
+    WARN_TEST_DATA_UNUSED = widget.OWWidget.status_id()
+    WARN_SCORES_NOT_COMPUTED = widget.OWWidget.status_id()
+    WARN_GENERAL = widget.OWWidget.status_id()
+
+    INF_DATA_SAMPLED = widget.OWWidget.status_id()
+    INF_TEST_DATA_SAMPLED = widget.OWWidget.status_id()
+
     def __init__(self):
         super().__init__()
 
@@ -258,28 +273,31 @@ class OWTestLearners(widget.OWWidget):
         """
         Set the input training dataset.
         """
-        self.error(0)
-        self.information(0)
+        self.error(self.ERR_CLASS_REQUIRED)
+        self.information(self.INF_DATA_SAMPLED)
         if data and not data.domain.class_var:
-            self.error(0, "Train data input requires a class variable")
+            self.error(self.ERR_CLASS_REQUIRED,
+                       "Train data input requires a class variable")
             data = None
 
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:
                 data = Table(data)
             else:
-                self.information(0, "Train data has been sampled")
+                self.information(self.INF_DATA_SAMPLED,
+                                 "Train data has been sampled")
                 data_sample = data.sample_time(1, no_cache=True)
                 data_sample.download_data(AUTO_DL_LIMIT, partial=True)
                 data = Table(data_sample)
 
-        self.warning(4)
+        self.warning(self.WARN_MISSING_DATA)
         self.train_data_missing_vals = data is not None and \
                                        np.isnan(data.Y).any()
         if self.train_data_missing_vals or self.test_data_missing_vals:
-            self.warning(4, self._get_missing_data_warning(
-                self.train_data_missing_vals, self.test_data_missing_vals
-            ))
+            self.warning(
+                self.WARN_MISSING_DATA,
+                self._get_missing_data_warning(
+                    self.train_data_missing_vals, self.test_data_missing_vals))
             if data:
                 data = RemoveNaNClasses(data)
 
@@ -294,29 +312,32 @@ class OWTestLearners(widget.OWWidget):
         """
         Set the input separate testing dataset.
         """
-        self.error(1)
-        self.information(1)
+        self.error(self.ERR_CLASS_REQUIRED_IN_TEST)
+        self.information(self.INF_TEST_DATA_SAMPLED)
         if data and not data.domain.class_var:
-            self.error(1, "Test data input requires a class variable")
+            self.error(self.ERR_CLASS_REQUIRED_IN_TEST,
+                       "Test data input requires a class variable")
             data = None
 
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:
                 data = Table(data)
             else:
-                self.information(1, "Test data has been sampled")
+                self.information(self.INF_TEST_DATA_SAMPLED,
+                                 "Test data has been sampled")
                 data_sample = data.sample_time(1, no_cache=True)
                 data_sample.download_data(AUTO_DL_LIMIT, partial=True)
                 data = Table(data_sample)
 
-        self.warning(4)
+        self.warning(self.WARN_MISSING_DATA)
         self.test_data_missing_vals = data is not None and \
                                       np.isnan(data.Y).any()
 
         if self.train_data_missing_vals or self.test_data_missing_vals:
-            self.warning(4, self._get_missing_data_warning(
-                self.train_data_missing_vals, self.test_data_missing_vals
-            ))
+            self.warning(
+                self.WARN_MISSING_DATA,
+                self._get_missing_data_warning(
+                    self.train_data_missing_vals, self.test_data_missing_vals))
             if data:
                 data = RemoveNaNClasses(data)
 
@@ -356,8 +377,8 @@ class OWTestLearners(widget.OWWidget):
         """
         Run/evaluate the learners.
         """
-        self.warning([1, 2])
-        self.error([2, 4])
+        self.warning([self.WARN_TEST_DATA_UNUSED, self.WARN_TEST_DATA_MISSING])
+        self.error([self.ERR_CLASS_INCONSISTENT, self.ERR_TOO_MANY_FOLDS])
         if self.data is None:
             return
 
@@ -365,11 +386,13 @@ class OWTestLearners(widget.OWWidget):
 
         if self.resampling == OWTestLearners.TestOnTest:
             if self.test_data is None:
-                self.warning(2, "Missing separate test data input")
+                self.warning(self.WARN_TEST_DATA_MISSING,
+                             "Missing separate test data input")
                 return
             elif self.test_data.domain.class_var != class_var:
-                self.error(2, ("Inconsistent class variable between test " +
-                               "and train data sets"))
+                self.error(self.ERR_CLASS_INCONSISTENT,
+                           "Inconsistent class variable between test "
+                           "and train data sets")
                 return
 
         # items in need of an update
@@ -381,8 +404,9 @@ class OWTestLearners(widget.OWWidget):
 
         if self.test_data is not None and \
                 self.resampling != OWTestLearners.TestOnTest:
-            self.warning(1, "Test data is present but unused. "
-                            "Select 'Test on test data' to use it.")
+            self.warning(self.WARN_TEST_DATA_UNUSED,
+                         "Test data is present but unused. "
+                         "Select 'Test on test data' to use it.")
 
         rstate = 42
         def update_progress(finished):
@@ -400,14 +424,15 @@ class OWTestLearners(widget.OWWidget):
                 folds = self.NFolds[self.n_folds]
                 if self.resampling == OWTestLearners.KFold:
                     if len(self.data) < folds:
-                        self.error(4, "Number of folds exceeds the data size")
+                        self.error(self.ERR_TOO_MANY_FOLDS,
+                                   "Number of folds exceeds the data size")
                         return
                     warnings = []
                     results = Orange.evaluation.CrossValidation(
                         self.data, learners, k=folds,
                         random_state=rstate, warnings=warnings, **common_args)
                     if warnings:
-                        self.warning(2, warnings[0])
+                        self.warning(self.WARN_GENERAL, warnings[0])
                 elif self.resampling == OWTestLearners.LeaveOneOut:
                     results = Orange.evaluation.LeaveOneOut(
                         self.data, learners, **common_args)
@@ -428,7 +453,7 @@ class OWTestLearners(widget.OWWidget):
                 else:
                     assert False
             except (RuntimeError, ValueError) as e:
-                self.error(2, str(e))
+                self.error(self.ERR_CLASS_INCONSISTENT, str(e))
                 self.setStatusMessage("")
                 return
 
@@ -532,14 +557,15 @@ class OWTestLearners(widget.OWWidget):
             model.appendRow(row)
 
         if errors:
-            self.error(3, "\n".join(errors))
+            self.error(self.ERR_GENERAL, "\n".join(errors))
         else:
-            self.error(3)
+            self.error(self.ERR_GENERAL)
 
         if has_missing_scores:
-            self.warning(3, "Some scores could not be computed")
+            self.warning(self.WARN_SCORES_NOT_COMPUTED,
+                         "Some scores could not be computed")
         else:
-            self.warning(3)
+            self.warning(self.WARN_SCORES_NOT_COMPUTED)
 
     def _update_class_selection(self):
         self.class_selection_combo.setCurrentIndex(-1)

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -67,8 +67,8 @@ class OWDistances(widget.OWWidget):
             self.metrics_combo.addItem(m.name)
 
     def commit(self):
-        self.warning(1)
-        self.error(1)
+        self.warning()
+        self.error()
 
         data = distances = None
         if self.data is not None:
@@ -77,20 +77,20 @@ class OWDistances(widget.OWWidget):
                 metric.fit(self.data, axis=1-self.axis)
 
             if not any(a.is_continuous for a in self.data.domain.attributes):
-                self.error(1, "No continuous features")
+                self.error("No continuous features")
                 data = None
             elif any(a.is_discrete for a in self.data.domain.attributes) or \
                     (not issparse(self.data.X) and numpy.any(numpy.isnan(self.data.X))):
                 data = distance._preprocess(self.data)
                 if len(self.data.domain.attributes) - len(data.domain.attributes) > 0:
-                    self.warning(1, "Ignoring discrete features")
+                    self.warning("Ignoring discrete features")
             else:
                 data = self.data
 
         if data is not None:
             shape = (len(data), len(data.domain.attributes))
             if numpy.product(shape) == 0:
-                self.error(1, "Empty data (shape == {})".format(shape))
+                self.error("Empty data (shape == {})".format(shape))
             else:
                 distances = metric(data, data, 1 - self.axis, impute=True)
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -452,6 +452,11 @@ class OWHeatMap(widget.OWWidget):
 
     graph_name = "scene"
 
+    INFO_SAMPLED = widget.OWWidget.status_id()
+    INFO_DISCRETE_IGNORED = widget.OWWidget.status_id()
+    INFO_ROW_CLUST = widget.OWWidget.status_id()
+    INFO_COL_CLUST = widget.OWWidget.status_id()
+
     def __init__(self):
         super().__init__()
 
@@ -656,13 +661,13 @@ class OWHeatMap(widget.OWWidget):
         self.closeContext()
         self.clear()
         self.error(0)
-        self.information([0, 1])
+        self.information([self.INFO_SAMPLED, self.INFO_DISCRETE_IGNORED])
 
         if isinstance(data, SqlTable):
             if data.approx_len() < 4000:
                 data = Table(data)
             else:
-                self.information(0, "Data has been sampled")
+                self.information(self.INFO_SAMPLED, "Data has been sampled")
                 data_sample = data.sample_time(1, no_cache=True)
                 data_sample.download_data(2000, partial=True)
                 data = Table(data_sample)
@@ -681,7 +686,8 @@ class OWHeatMap(widget.OWWidget):
                 self.error(0, "No continuous feature columns")
                 input_data = data = None
             else:
-                self.information(1, "{} discrete column{} ignored"
+                self.information(self.INFO_DISCRETE_IGNORED,
+                                 "{} discrete column{} ignored"
                                 .format(ndisc, "s" if ndisc > 1 else ""))
 
         self.data = data
@@ -1286,8 +1292,8 @@ class OWHeatMap(widget.OWWidget):
             col_clust_msg = "Column clustering was disabled due to the " \
                             "input matrix being to big"
 
-        self.information(3, row_clust_msg)
-        self.information(4, col_clust_msg)
+        self.information(self.INFO_ROW_CLUST, row_clust_msg)
+        self.information(self.INFO_COL_CLUST, col_clust_msg)
 
         self.sort_rows = sort_rows
         self.sort_columns = sort_cols


### PR DESCRIPTION
When implementing a widget which issues multiple error, warning or information messages, we have to keep track of the used id's or pick random numbers and hope for the best to avoid collisions.

This PR adds id generator `status_id` to the `OWWidget` class, and shows its use on several widgets. Most widgets have only a single type of error, hence they won't need to use these constants (see owsql and owdistances, below). For those with multiple statuses, constants will clean the mess (see owtestlearners and owheatmap).

Current `int` constants are allowed but deprecated.