### PR TITLE
[FIX] overlay: Auto disconnect when the overlay widget is deleted

### DIFF
--- a/Orange/widgets/utils/overlay.py
+++ b/Orange/widgets/utils/overlay.py
@@ -18,7 +18,7 @@ from PyQt4.QtGui import (
     QWidget, QPixmap, QStyleOption, QPainter
 )
 from PyQt4.QtCore import Qt, QSize, QRect, QPoint, QEvent, QTimer
-from PyQt4.QtCore import pyqtSignal as Signal
+from PyQt4.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 
 class OverlayWidget(QWidget):
@@ -172,6 +172,7 @@ class OverlayWidget(QWidget):
         geom = QRect(QPoint(x, y), size)
         self.setGeometry(geom)
 
+    @Slot()
     def __on_destroyed(self):
         self.__widget = None
         if self.isVisible():


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Register `__on_destroyed` as a Qt slot so it can be automatically
disconnected when the overlay widget is deleted/destroyed.
This fixes a possible 'RuntimeError C/C++ object was deleted ...' error
when the overlay is deleted before the target widget.