### PR TITLE
Error/Information/Warning using strings as id's

### DIFF
--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -817,7 +817,7 @@ def mock_error_owwidget(node, message):
 
         def setErrorMessage(self, message):
             self.errorLabel.setText(message)
-            self.error(0, message)
+            self.error(message)
 
     widget = DummyOWWidget()
     widget._settings = node.properties

--- a/Orange/widgets/classify/owrandomforest.py
+++ b/Orange/widgets/classify/owrandomforest.py
@@ -5,6 +5,7 @@ from Orange.data import Table
 from Orange.classification.random_forest import RandomForestLearner
 from Orange.widgets import settings, gui
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
+from Orange.widgets.widget import Msg
 
 
 class OWRandomForest(OWBaseLearner):
@@ -25,6 +26,9 @@ class OWRandomForest(OWBaseLearner):
     min_samples_split = settings.Setting(5)
     use_min_samples_split = settings.Setting(True)
     index_output = settings.Setting(0)
+
+    class Error(OWBaseLearner.Error):
+        not_enough_features = Msg("Insufficient number of attributes ({})")
 
     def add_main_layout(self):
         box = gui.vBox(self.controlArea, 'Basic Properties')
@@ -75,9 +79,7 @@ class OWRandomForest(OWBaseLearner):
         if super().check_data():
             n_features = len(self.data.domain.attributes)
             if self.use_max_features and self.max_features > n_features:
-                self.error(self.DATA_ERROR_ID,
-                           "Number of splitting attributes should "
-                           "be smaller than number of features.")
+                self.Error.data_error(n_features)
                 self.valid_data = False
         return self.valid_data
 

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -11,10 +11,10 @@ from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
 from Orange.data import Table
 from Orange.data.sql.table import SqlTable
-from Orange.widgets.widget import Msg
+from Orange.widgets.widget import Msg, OWWidget
 
 
-class OWDataSampler(widget.OWWidget):
+class OWDataSampler(OWWidget):
     name = "Data Sampler"
     description = "Randomly draw a subset of data points " \
                   "from the input data set."
@@ -45,10 +45,10 @@ class OWDataSampler(widget.OWWidget):
     number_of_folds = Setting(10)
     selectedFold = Setting(1)
 
-    class Error(widget.OWWidget.Error):
-        too_many_folds = Msg("Number of folds exceeds the data size")
+    class Error(OWWidget.Error):
+        too_many_folds = Msg("Number of folds exceeds data size")
         sample_larger_than_data = Msg("Sample must be smaller than data")
-        not_enough_to_stratify = Msg("Not enough data for stratified sampling")
+        not_enough_to_stratify = Msg("Data is too small to stratify")
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -11,6 +11,7 @@ from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
 from Orange.data import Table
 from Orange.data.sql.table import SqlTable
+from Orange.widgets.widget import Msg
 
 
 class OWDataSampler(widget.OWWidget):
@@ -43,6 +44,11 @@ class OWDataSampler(widget.OWWidget):
     sampleSizeSqlPercentage = Setting(0.1)
     number_of_folds = Setting(10)
     selectedFold = Setting(1)
+
+    class Error(widget.OWWidget.Error):
+        too_many_folds = Msg("Number of folds exceeds the data size")
+        sample_larger_than_data = Msg("Sample must be smaller than data")
+        not_enough_to_stratify = Msg("Not enough data for stratified sampling")
 
     def __init__(self):
         super().__init__()
@@ -213,7 +219,7 @@ class OWDataSampler(widget.OWWidget):
         self.send("Remaining Data", other)
 
     def updateindices(self):
-        err_msg = ""
+        self.Error.clear()
         repl = True
         data_length = len(self.data)
         num_classes = len(self.data.domain.class_var.values) \
@@ -228,18 +234,16 @@ class OWDataSampler(widget.OWWidget):
             repl = False
         elif self.sampling_type == self.CrossValidation:
             if data_length < self.number_of_folds:
-                err_msg = "Number of folds exceeds the data size"
+                self.Error.too_many_folds()
         else:
             assert self.sampling_type == self.Bootstrap
 
         if not repl and size is not None and (data_length <= size):
-            err_msg = "Sample must be smaller than data"
+            self.Error.sample_larger_than_data()
         if not repl and data_length <= num_classes and self.stratify:
-            err_msg = "Not enough data for stratified sampling"
+            self.Error.not_enough_to_stratify()
 
-        self.error(0)
-        if err_msg:
-            self.error(err_msg)
+        if self.Error.active:
             self.indices = None
             return
 

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -260,8 +260,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
                 errors.append(str(ex))
                 data = None
                 self.editor_model.reset()
-            self.warning(
-                33, warnings[-1].message.args[0] if warnings else '')
+            self.warning(warnings[-1].message.args[0] if warnings else '')
 
         if data is None:
             self.send("Data", None)

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -980,15 +980,13 @@ class OWImageViewer(widget.OWWidget):
 
     def clear(self):
         self.data = None
-        self.information(0)
-        self.error(0)
+        self.error()
         self.imageAttrCB.clear()
         self.titleAttrCB.clear()
         self.clearScene()
 
     def setupScene(self):
-        self.information(0)
-        self.error(0)
+        self.error()
         if self.data:
             attr = self.stringAttrs[self.imageAttr]
             titleAttr = self.allAttrs[self.titleAttr]
@@ -1128,9 +1126,8 @@ class OWImageViewer(widget.OWWidget):
                     "{} images".format(count)
                 )
             attr = self.stringAttrs[self.imageAttr]
-            if self._errcount == count and not "type" in attr.attributes:
-                self.error(0,
-                           "No images found! Make sure the '%s' attribute "
+            if self._errcount == count and "type" not in attr.attributes:
+                self.error("No images found! Make sure the '%s' attribute "
                            "is tagged with 'type=image'" % attr.name)
 
     def onDeleteWidget(self):

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -242,14 +242,14 @@ class OWImpute(OWWidget):
             attributes = []
             class_vars = []
 
-            self.warning(1)
+            self.warning()
             with self.progressBar(len(self.varmodel)) as progress:
                 for i, var in enumerate(self.varmodel):
                     method = self.variable_methods.get(i, self.default_method)
 
                     if not method.supports_variable(var):
-                        self.warning(1, "Default method could not impute some "
-                                        "of the variables.")
+                        self.warning("Default method can not handle '{}'".
+                                     format(var.name))
                     elif isinstance(method, impute.DropInstances):
                         drop_mask |= method(self.data, var)
                     else:

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -106,7 +106,7 @@ class OWOutliers(widget.OWWidget):
         self.cont_slider.setDisabled(True)
         self.cb_emp_cov.setDisabled(True)
         self.support_fraction_spin.setDisabled(True)
-        self.warning(0, 'Too many features for covariance estimation.')
+        self.warning('Too many features for covariance estimation.')
 
     def enable_covariance(self):
         self.rb_cov.setDisabled(False)
@@ -114,7 +114,7 @@ class OWOutliers(widget.OWWidget):
         self.cont_slider.setDisabled(False)
         self.cb_emp_cov.setDisabled(False)
         self.support_fraction_spin.setDisabled(False)
-        self.warning(0)
+        self.warning()
 
     @check_sql_input
     def set_data(self, dataset):
@@ -140,7 +140,7 @@ class OWOutliers(widget.OWWidget):
             try:
                 y_pred = self.detect_outliers()
             except ValueError:
-                self.error(0, "Singular covariance matrix.")
+                self.error("Singular covariance matrix.")
                 self.in_out_info_label.setText(self.in_out_info_default)
             else:
                 inliers_ind = np.where(y_pred == 1)[0]

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1989,11 +1989,11 @@ class OWPreprocess(widget.OWWidget):
         preprocessor = self.buildpreproc()
 
         if self.data is not None:
-            self.error(0)
+            self.error()
             try:
                 data = preprocessor(self.data)
             except ValueError as e:
-                self.error(0, str(e))
+                self.error(str(e))
                 return
         else:
             data = None

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -83,9 +83,10 @@ class OWSave(widget.OWWidget):
         else:
             try:
                 self.writer.write(self.filename, self.data)
-                self.error()
             except Exception as errValue:
                 self.error(str(errValue))
+            else:
+                self.error()
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -344,7 +344,7 @@ class OWSelectRows(widget.OWWidget):
     def commit(self):
         matching_output = self.data
         non_matching_output = None
-        self.error(21)
+        self.error()
         if self.data:
             domain = self.data.domain
             conditions = []
@@ -361,7 +361,7 @@ class OWSelectRows(widget.OWWidget):
                         try:
                             values = [attr.parse(v) for v in values]
                         except ValueError as e:
-                            self.error(21, e.args[0])
+                            self.error(e.args[0])
                             return
 
                     filter = data_filter.FilterContinuous(

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -8,9 +8,9 @@ from PyQt4.QtGui import QApplication, QCursor, QMessageBox
 
 from Orange.data import Table
 from Orange.data.sql.table import SqlTable, LARGE_TABLE, AUTO_DL_LIMIT
-from Orange.widgets import widget, gui
+from Orange.widgets import gui
 from Orange.widgets.settings import Setting
-from Orange.widgets.widget import OutputSignal, Msg
+from Orange.widgets.widget import OWWidget, OutputSignal, Msg
 from Orange.canvas import report
 
 
@@ -18,7 +18,7 @@ MAX_DL_LIMIT = 1000000
 EXTENSIONS = ('tsm_system_time', 'quantile')
 
 
-class OWSql(widget.OWWidget):
+class OWSql(OWWidget):
     name = "SQL Table"
     id = "orange.widgets.data.sql"
     description = """
@@ -50,8 +50,12 @@ class OWSql(widget.OWWidget):
     materialize = Setting(False)
     materialize_table_name = Setting("")
 
-    class Information(widget.OWWidget.Information):
+    class Information(OWWidget.Information):
         data_sampled = Msg("Data description was generated from a sample.")
+
+    class Error(OWWidget.Error):
+        connection = Msg("{}")
+        missing_extension = Msg("Database is missing extension{}: {}")
 
     def __init__(self):
         super().__init__()
@@ -165,7 +169,7 @@ class OWSql(widget.OWWidget):
                 user=self.username,
                 password=self.password
             )
-            self.error(0)
+            self.Error.connection.clear()
             self.database_desc = OrderedDict((
                 ("Host", self.host), ("Port", self.port),
                 ("Database", self.database), ("User name", self.username)
@@ -173,13 +177,13 @@ class OWSql(widget.OWWidget):
             self.refresh_tables()
             self.select_table()
         except psycopg2.Error as err:
-            self.error(0, str(err).split('\n')[0])
+            self.Error.connection(str(err).split('\n')[0])
             self.database_desc = self.data_desc_table = None
             self.tablecombo.clear()
 
     def refresh_tables(self):
         self.tablecombo.clear()
-        self.error(1)
+        self.Error.missing_extension.clear()
         if self._connection is None:
             self.data_desc_table = None
             return
@@ -229,12 +233,10 @@ class OWSql(widget.OWWidget):
                 missing.append(ext)
             finally:
                 self._connection.commit()
-        if missing:
-            self.error(1, 'Database missing extension{}: {}'.format(
-                's' if len(missing) > 1 else '',
-                ', '.join(missing)))
-        else:
-            self.error(1)
+        self.Error.missing_extension(
+            's' if len(missing) > 1 else '',
+            ', '.join(missing),
+            shown=missing)
 
     def open_table(self):
         self.create_extensions()
@@ -258,8 +260,8 @@ class OWSql(widget.OWWidget):
             self.sql = self.table = self.sqltext.toPlainText()
             if self.materialize:
                 if not self.materialize_table_name:
-                    self.error(
-                        0, "Specify a table name to materialize the query")
+                    self.Error.connection(
+                        "Specify a table name to materialize the query")
                     return
                 try:
                     cur = self._connection.cursor()
@@ -268,7 +270,7 @@ class OWSql(widget.OWWidget):
                     cur.execute("ANALYZE " + self.materialize_table_name)
                     self.table = self.materialize_table_name
                 except psycopg2.ProgrammingError as ex:
-                    self.error(0, str(ex))
+                    self.Error.connection(str(ex))
                     return
                 finally:
                     self._connection.commit()
@@ -282,10 +284,10 @@ class OWSql(widget.OWWidget):
                              self.table,
                              inspect_values=False)
         except psycopg2.ProgrammingError as ex:
-            self.error(0, str(ex))
+            self.Error.connection(str(ex))
             return
 
-        self.error(0)
+        self.Error.connection.clear()
 
 
         sample = False

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -10,7 +10,7 @@ from Orange.data import Table
 from Orange.data.sql.table import SqlTable, LARGE_TABLE, AUTO_DL_LIMIT
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
-from Orange.widgets.widget import OutputSignal
+from Orange.widgets.widget import OutputSignal, Msg
 from Orange.canvas import report
 
 
@@ -49,6 +49,9 @@ class OWSql(widget.OWWidget):
 
     materialize = Setting(False)
     materialize_table_name = Setting("")
+
+    class Information(widget.OWWidget.Information):
+        data_sampled = Msg("Data description was generated from a sample.")
 
     def __init__(self):
         super().__init__()
@@ -302,14 +305,13 @@ class OWSql(widget.OWWidget):
             elif confirm.clickedButton() == sample_button:
                 sample = True
 
-        self.information(1)
+        self.Information.clear()
         if self.guess_values:
             QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
             if sample:
                 s = table.sample_time(1)
                 domain = s.get_domain(guess_values=True)
-                self.information(
-                    1, "Domain was generated from a sample of the table.")
+                self.Information.data_sampled()
             else:
                 domain = table.get_domain(guess_values=True)
             QApplication.restoreOverrideCursor()

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -11,6 +11,7 @@ import pyqtgraph as pg
 
 import Orange
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.evaluate.utils import check_results_adequacy
 from Orange.widgets.utils import colorpalette, colorbrewer
 from Orange.widgets.io import FileFormat
 from Orange.canvas import report
@@ -83,18 +84,8 @@ class OWCalibrationPlot(widget.OWWidget):
 
     def set_results(self, results):
         self.clear()
-        self.results = results
-
-        if results is not None:
-            if results.data is None:
-                self.error(0, "Evaluation results require"
-                              " information on test data")
-                results = None
-            elif not results.data.domain.has_discrete_class:
-                self.error(0, "Need discrete class variable")
-                results = None
-
-        if results is not None:
+        self.results = check_results_adequacy(results, self.Error)
+        if self.results is not None:
             self._initialize(results)
             self._replot()
 

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -216,7 +216,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
         prev_sel_learner = self.selected_learner
         self.clear()
-        self.warning([0, 1])
+        self.warning()
         self.closeContext()
 
         data = None
@@ -224,8 +224,7 @@ class OWConfusionMatrix(widget.OWWidget):
             data = results.data
 
         if data is not None and not data.domain.has_discrete_class:
-            self.warning(
-                0, "Confusion Matrix cannot be used for regression results.")
+            self.warning("Confusion Matrix cannot show regression results.")
 
         self.results = results
         self.data = data

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -16,6 +16,7 @@ import pyqtgraph as pg
 
 import Orange
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.evaluate.utils import check_results_adequacy
 from Orange.widgets.utils import colorpalette, colorbrewer
 from Orange.widgets.evaluate.owrocanalysis import convex_hull
 from Orange.widgets.io import FileFormat
@@ -127,20 +128,8 @@ class OWLiftCurve(widget.OWWidget):
     def set_results(self, results):
         """Set the input evaluation results."""
         self.clear()
-        self.error(0)
-
-        if results is not None:
-            if results.data is None:
-                self.error(0, "Evaluation results require"
-                              " information on test data")
-                results = None
-            elif not results.data.domain.has_discrete_class:
-                self.error(0, "Need discrete class variable")
-                results = None
-
-        self.results = results
-
-        if results is not None:
+        self.results = check_results_adequacy(results, self.Error)
+        if self.results is not None:
             self._initialize(results)
             self._setup_plot()
 

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -191,7 +191,7 @@ class OWPredictions(widget.OWWidget):
             self.class_var = predictor.domain.class_var
 
     def handleNewSignals(self):
-        self.error(0)
+        self.clear_messages()
         if self.data is not None:
             for inputid, pred in list(self.predictors.items()):
                 if pred.results is None or numpy.isnan(pred.results[0]).all():
@@ -200,7 +200,7 @@ class OWPredictions(widget.OWWidget):
                     except ValueError as err:
                         err_msg = '{}:\n'.format(pred.predictor.name) + \
                                   str(err)
-                        self.error(0, err_msg)
+                        self.error(err_msg)
                         n, m = len(self.data), 1
                         if self.data.domain.has_discrete_class:
                             m = len(self.data.domain.class_var.values)
@@ -228,11 +228,7 @@ class OWPredictions(widget.OWWidget):
         # Check for prediction target consistency
         target_vars = set([p.predictor.domain.class_var
                            for p in self.predictors.values()])
-
-        if len(target_vars) > 1:
-            self.warning(0, "Inconsistent class variables")
-        else:
-            self.warning(0)
+        self.warning("Mismatching class variables", shown=len(target_vars) > 1)
 
         # Update the Info box text.
         info = []

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -16,6 +16,7 @@ import pyqtgraph as pg
 
 import Orange
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.evaluate.utils import check_results_adequacy
 from Orange.widgets.utils import colorpalette, colorbrewer
 from Orange.widgets.io import FileFormat
 from Orange.canvas import report
@@ -398,20 +399,8 @@ class OWROCAnalysis(widget.OWWidget):
     def set_results(self, results):
         """Set the input evaluation results."""
         self.clear()
-        self.error(0)
-
-        if results is not None:
-            if results.data is None:
-                self.error(0, "Evaluation results require"
-                              " information on test data")
-                results = None
-            elif not results.data.domain.has_discrete_class:
-                self.error(0, "Need discrete class variable")
-                results = None
-
-        self.results = results
-
-        if results is not None:
+        self.results = check_results_adequacy(results, self.Error)
+        if self.results is not None:
             self._initialize(results)
             self._setup_plot()
 

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -1,0 +1,13 @@
+def check_results_adequacy(results, error_group):
+    error_group.add_message("invalid_results")
+    error_group.invalid_results.clear()
+    if results is None:
+        return None
+    if results.data is None:
+        error_group.invalid_results(
+            "Results do not include information on test data")
+    elif not results.data.domain.has_discrete_class:
+        error_group.invalid_results(
+            "Discrete outcome variable is required")
+    else:
+        return results

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -300,5 +300,4 @@ class WidgetLearnerTestMixin:
                 if model is not None:
                     self.assertEqual(model.params.get(element.name), val)
                 else:
-                    self.assertIn(self.widget.DATA_ERROR_ID,
-                                  self.widget.widgetState.get("Error"))
+                    self.assertTrue(self.widget.Error.active)

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -11,6 +11,7 @@ from Orange.classification.base_classification import (LearnerClassification,
                                                        ModelClassification)
 from Orange.regression.base_regression import LearnerRegression, ModelRegression
 from Orange.canvas.report.owreport import OWReport
+from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 app = None
 
@@ -168,6 +169,9 @@ class WidgetLearnerTestMixin:
     widget, should override self.gui_to_params list in the setUp method. The
     list should contain mapping: learner parameter - gui component.
     """
+
+    widget = None  # type: OWBaseLearner
+
     def init(self):
         self.iris = Table("iris")
         self.housing = Table("housing")
@@ -202,14 +206,12 @@ class WidgetLearnerTestMixin:
 
     def test_input_data_learner_adequacy(self):
         """Check if error message is shown with inadequate data on input"""
-        err_id = self.widget.DATA_ERROR_ID
+        error = self.widget.Error.data_error
         self.send_signal("Data", self.inadequate_data)
         self.widget.apply_button.button.click()
-        self.assertIn(err_id, self.widget.widgetState.get("Error"))
-        self.assertEqual(self.widget.widgetState.get("Error").get(err_id),
-                         self.learner_class.learner_adequacy_err_msg)
+        self.assertTrue(self.widget.Error.data_error.is_shown())
         self.send_signal("Data", self.data)
-        self.assertNotIn(err_id, self.widget.widgetState.get("Error"))
+        self.assertFalse(self.widget.Error.data_error.is_shown())
 
     def test_input_preprocessor(self):
         """Check learner's preprocessors with an extra pp on input"""

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -97,7 +97,6 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     def set_data(self, data):
         self.closeContext()
         self.clear()
-        self.warning(0)
         self.data = data
 
         if data is not None:

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -92,10 +92,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
 
     # Open a file, create data from it and send it over the data channel
     def open_file(self):
-        self.error()
-        self.warning()
-        self.information()
-
+        self.clear_messages()
         fn = self.last_path()
         if not fn:
             return

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -382,11 +382,11 @@ class OWDistanceMap(widget.OWWidget):
     def set_distances(self, matrix):
         self.closeContext()
         self.clear()
-        self.error(0)
+        self.error()
         if matrix is not None:
             N, _ = matrix.shape
             if N < 2:
-                self.error(0, "Empty distance matrix.")
+                self.error("Empty distance matrix.")
                 matrix = None
 
         self.matrix = matrix
@@ -423,7 +423,7 @@ class OWDistanceMap(widget.OWWidget):
         else:
             item.setFlags(item.flags() | Qt.ItemIsEnabled)
 
-        self.information(1, msg)
+        self.information(msg)
 
     def set_items(self, items, axis=1):
         self.items = items

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -938,12 +938,12 @@ class OWHierarchicalClustering(widget.OWWidget):
         self._set_cut_line_visible(self.selection_method == 1)
 
     def set_distances(self, matrix):
-        self.error(0)
+        self.error()
         self._set_items(None)
         if matrix is not None:
             N, _ = matrix.shape
             if N < 2:
-                self.error(0, "Empty distance matrix")
+                self.error("Empty distance matrix")
                 matrix = None
 
         self.matrix = matrix

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -199,12 +199,16 @@ class OWKMeans(widget.OWWidget):
         self.updateOptimizationGui()
         self.update()
 
-    def check_data_size(self, n, msg_func):
+    def check_data_size(self, n, msg_group):
+        msg_group.add_message(
+            "not_enough_data",
+            "Too few ({}) unique data instances for {} clusters")
         if n > len(self.data):
-            msg_func("Too few unique data instances ({}) for {} clusters".
-                     format(len(self.data), n))
+            msg_group.not_enough_data(len(self.data), n)
             return False
-        return True
+        else:
+            msg_group.not_enough_data.clear()
+            return True
 
     def run_optimization(self):
         # Disabling is needed since this function is not reentrant
@@ -212,9 +216,9 @@ class OWKMeans(widget.OWWidget):
         try:
             self.controlArea.setDisabled(True)
             self.optimization_runs = []
-            if not self.check_data_size(self.k_from, self.error):
+            if not self.check_data_size(self.k_from, self.Error):
                 return
-            self.check_data_size(self.k_to, self.warning)
+            self.check_data_size(self.k_to, self.Warning)
             k_to = min(self.k_to, len(self.data))
             kmeans = KMeans(
                 init=['random', 'k-means++'][self.smart_init],
@@ -231,7 +235,7 @@ class OWKMeans(widget.OWWidget):
         self.send_data()
 
     def cluster(self):
-        if not self.check_data_size(self.k, self.error):
+        if not self.check_data_size(self.k, self.Error):
             return
         self.km = KMeans(
             n_clusters=self.k,
@@ -241,8 +245,7 @@ class OWKMeans(widget.OWWidget):
         self.send_data()
 
     def run(self):
-        self.error()
-        self.warning()
+        self.clear_messages()
         if not self.data:
             return
         if self.optimize_k:

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -157,12 +157,12 @@ class OWPCA(widget.OWWidget):
             self.start_button.setText("Abort remote computation")
 
     def set_data(self, data):
-        self.information(0)
+        self.information()
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:
                 data = Table(data)
             elif not remotely:
-                self.information(0, "Data has been sampled")
+                self.information("Data has been sampled")
                 data_sample = data.sample_time(1, no_cache=True)
                 data_sample.download_data(2000, partial=True)
                 data = Table(data_sample)

--- a/Orange/widgets/utils/messages.py
+++ b/Orange/widgets/utils/messages.py
@@ -1,0 +1,397 @@
+"""Mixin class for errors, warnings and information
+
+A class derived from `OWWidget` can include member classes `Error`, `Warning`
+and `Information`, derived from the same-named `OWWidget` classes. Each of
+those contains members that are instances of `UnboundMsg`, which is, for
+convenience, also exposed as `Orange.widgets.widget.Msg`. These members
+represent all possible errors, like `Error.no_discrete_vars`, with exception
+of the deprecated old-style errors.
+
+When the widget is instantiated, classes `Error`, `Warning` and `Information`
+are instantiated and bound to the widget: their attribute `widget` is the link
+to the widget that instantiated them. Their member messages are replaced with
+instances of `_BoundMsg`, which are bound to the group through the `group`
+attribute.
+
+A message is shown by calling, e.g. `self.Error.no_discrete_vars()`. The call
+formats the message and tells the group to activate it::
+
+    self.formatted = self.format(*args, **kwargs)
+    self.group.activate_msg(self)
+
+The group adds it to the dictionary of active messages (attribute `active`)
+and emits the signal `messageActivated`. The signal is connected to the
+widget's method `update_widget_state`, which shows the message in the bar, and
+`WidgetManager`'s `__on_widget_state_changed`, which manages the icons on the
+canvas.
+
+Clearing messages work analogously.
+"""
+
+from operator import attrgetter
+from warnings import warn
+
+from PyQt4.QtGui import QApplication, QStyle, QSizePolicy
+
+from Orange.widgets import gui
+
+
+class UnboundMsg(str):
+    """
+    The class used for declaring messages in classes derived from
+    MessageGroup. When instantiating the message group, instances of this
+    class are replaced by instances of `_BoundMsg` that are bound to the group.
+
+    Note: this class is aliased to `Orange.widgets.widget.Msg`.
+    """
+    def __new__(cls, msg):
+        return str.__new__(cls, msg)
+
+    def bind(self, group):
+        return _BoundMsg(self, group)
+
+    # The method is implemented in _BoundMsg
+    # pylint: disable=unused-variable
+    def __call__(self, *args, shown=True, **kwargs):
+        """
+        Show the message, or hide it if `show` is set `False`
+        `*args` and `**kwargs` are passed to the `format` method.
+
+        Args:
+            shown (bool): keyword-only argument that can be set to `False` to
+                hide the message
+            *args: arguments for `format`
+            **kwargs: keyword arguments for `format`
+        """
+        raise RuntimeError("Message is not bound")
+
+    # The method is implemented in _BoundMsg
+    def clear(self):
+        """Remove the message."""
+        raise RuntimeError("Message is not bound")
+
+    # Ensure that two instance of message are always different
+    # In particular, there may be multiple messages "{}".
+    def __hash__(self):
+        return id(self)
+
+    def __eq__(self, other):
+        return self is other
+
+
+class _BoundMsg(UnboundMsg):
+    """
+    A message that is bound to the group.
+
+    Instances of this class provide the call operator for raising the message,
+    and method `clear` for removing it.
+
+    When the message is called, the arguments are passed to the message's
+    format` method and the resulting string is stored in the attribute
+    `formatted`.
+
+    Attributes:
+        group (MessageGroup): the group to which this message belongs
+        formatted (str): formatted message
+
+    """
+    def __new__(cls, unbound_msg, group):
+        self = UnboundMsg.__new__(cls, unbound_msg)
+        self.group = group
+        self.formatted = ""
+        return self
+
+    def __call__(self, *args, shown=True, **kwargs):
+        if not shown:
+            self.clear()
+        else:
+            self.formatted = self.format(*args, **kwargs)
+            self.group.activate_msg(self)
+
+    def clear(self):
+        self.group.deactivate_msg(self)
+
+    def __str__(self):
+        return self.formatted
+
+
+class _OldStyleMsg(_BoundMsg):
+    """
+    Class for handling the old-style messages.
+
+    Instances of this class are instantiated by the old methods `error`,
+    `warning` and `information` and added to the list of active messages,
+    with their old-style id's as keys. Instance of `_OldStyleMsg` are not
+    members of message groups.
+    """
+    def __new__(cls, text, group):
+        self = _BoundMsg.__new__(cls, text, group)
+        self.formatted = text
+        return self
+
+
+class MessageGroup:
+    """
+    A groups of messages, e.g. errors, warnings, information messages
+
+    Widget's `__init__` searches for instances of this class among the widget's
+    class member and instantiates them.
+
+    Attributes:
+        widget (widget.OWWidget): the widget instance to which the group belongs
+        active (dict): active messages
+
+    Note: active messages are stored in the dictionary, in which the key and
+    the corresponding value are one and the same object, except for old-style
+    classes, for which the key is an (old-style) id. When we remove support for
+    old-style messages, this dictionary can be replaced with a set.
+    """
+    def __init__(self, widget):
+        self.widget = widget
+        self.active = {}
+        self._general = UnboundMsg("{}")
+        self._bind_messages()
+
+    def _bind_messages(self):
+        # type(self).__dict__ wouldn't return inherited messages, hence dir
+        for name in dir(self):
+            msg = getattr(self, name)
+            if isinstance(msg, UnboundMsg):
+                msg = msg.bind(self)
+                self.__dict__[name] = msg
+
+    def add_message(self, name, msg="{}"):
+        """Add and bind message to a group that is already instantiated
+        and bound.
+
+        If the message with that name already exists, the method does nothing.
+        The method is used by helpers like this (simplified) one::
+
+            def check_results(results, msg_group):
+                msg_group.add_message("invalid_results",
+                                      "Results do not include any data")
+                msg_group.invalid_results.clear()
+                if results.data is None:
+                    msg_group.invalid_results()
+
+        The helper is called from several widgets with
+        `check_results(results, self.Error)`
+
+        Args:
+            name (str): the name of the member with the message
+            msg (str or UnboundMsg): message text or instance (default `"{}"`)
+        """
+        if not isinstance(msg, UnboundMsg):
+            msg = UnboundMsg(msg)
+        if name not in self.__dict__:
+            self.__dict__[name] = msg.bind(self)
+
+    def activate_msg(self, msg, msg_id=None):
+        """Activate a message and emit the signal messageActivated
+
+        Args:
+            msg (_BoundMsg): the message to activate
+            msg_id (int): id for old-style message (to be removed in the future)
+        """
+        key = msg if msg_id is None else msg_id
+        if self.active.get(key) == msg:
+            return
+        self.active[key] = msg
+        self.widget.messageActivated.emit(msg)
+
+    def deactivate_msg(self, msg):
+        """Deactivate a message and emit the signal messageDeactivated.
+
+        Args:
+            msg (_BoundMsg): the message to deactivate
+        """
+        if msg not in self.active:
+            return
+        inst_msg = self.active.pop(msg)
+        self.widget.messageDeactivated.emit(
+            inst_msg if isinstance(msg, int) else msg)
+
+        # When when we no longer support old-style messages, replace with:
+        # if msg not in self.active:
+        #     return
+        # del self.active[msg]
+        # self.widget.messageDeactivated.emit(msg)
+
+    # self has default value to avoid PyCharm warnings when calling
+    # self.Error.clear(): PyCharm doesn't know that Error is instantiated
+    def clear(self=None):
+        """Deactivate all active message from this group."""
+        for msg in list(self.active):
+            self.deactivate_msg(msg)
+
+    def _add_general(self, id_or_text, text, shown):
+        """Handler for methods `error`, `warning` and `information`;
+        do not call directly.
+
+        The message is shown as general message. This method also
+        handles deprecated messages with id's."""
+        if id_or_text is None or id_or_text == "":
+            self._general.clear()
+        elif isinstance(id_or_text, str):
+            self._general(id_or_text, shown=shown)
+        # remaining cases handle deprecated messages with id's
+        elif text:
+            self.activate_msg(_OldStyleMsg(text, self), id_or_text)
+        elif isinstance(id_or_text, list):
+            for msg_id in id_or_text:
+                self.deactivate_msg(msg_id)
+        else:
+            self.deactivate_msg(id_or_text)
+
+
+class MessagesMixin:
+    """
+    Base class for message mixins. The class provides a constructor for
+    instantiating and binding message groups.
+
+    Widgets should use `WidgetMessageMixin rather than this class.
+    """
+    def __init__(self):
+        # type(self).__dict__ wouldn't return inherited messages, hence dir
+        self.message_groups = []
+        for name in dir(self):
+            group_class = getattr(self, name)
+            if isinstance(group_class, type) and \
+                    issubclass(group_class, MessageGroup) and \
+                    group_class is not MessageGroup:
+                bound_group = group_class(self)
+                setattr(self, name, bound_group)
+                self.message_groups.append(bound_group)
+        self.message_groups.sort(key=attrgetter("severity"), reverse=True)
+
+
+class WidgetMessagesMixin(MessagesMixin):
+    """
+    Provide the necessary methods for handling messages in widgets.
+
+    The class defines member classes `Error`, `Warning` and `Information` that
+    serve as base classes for these message groups.
+    """
+    class Error(MessageGroup):
+        """Base class for groups of error messages in widgets"""
+        severity = 3
+        icon_path = gui.resource_filename("icons/error.png")
+        bar_background = "#ffc6c6"
+        bar_icon = QStyle.SP_MessageBoxCritical
+
+    class Warning(MessageGroup):
+        """Base class for groups of warning messages in widgets"""
+        severity = 2
+        icon_path = gui.resource_filename("icons/warning.png")
+        bar_background = "#ffffc9"
+        bar_icon = QStyle.SP_MessageBoxWarning
+
+    class Information(MessageGroup):
+        """Base class for groups of information messages in widgets"""
+        severity = 1
+        icon_path = gui.resource_filename("icons/information.png")
+        bar_background = "#ceceff"
+        bar_icon = QStyle.SP_MessageBoxInformation
+
+    def __init__(self):
+        super().__init__()
+        self.message_bar = self.message_label = self.message_icon = None
+        self.messageActivated.connect(self.update_message_state)
+        self.messageDeactivated.connect(self.update_message_state)
+
+    def clear_messages(self):
+        """Clear all messages"""
+        for group in self.message_groups:
+            group.clear()
+
+    def update_message_state(self):
+        """Show and update (or hide) the content of the widget's message bar.
+
+        The method is connected to widget's signals `messageActivated` and
+        `messageDeactivated`.
+        """
+        messages = [msg
+                    for group in self.message_groups
+                    for msg in group.active.values()]
+        if not messages:
+            self._hide_message_bar()
+            return
+        else:
+            group = messages[0].group
+            text = str(messages[0]) if len(messages) == 1 \
+                else "{} problems during execution".format(len(messages))
+            # TODO: fix tooltip background color - it is not white
+            tooltip = '<div style="background-color: #ffffff;">{}</div>'.format(
+                ''.join(
+                    '<p style="background-color: {}; padding: 5">'
+                    '<nobr>{}</nobr></p>'.format(
+                        msg.group.bar_background, str(msg))
+                    for msg in messages))
+            self._set_message_bar(group, text, tooltip)
+
+    def insert_message_bar(self):
+        """Insert message bar into the widget.
+
+        This method must be called at the appropriate place in the widget
+        layout setup by any widget that is using this mixin."""
+        self.message_bar = gui.hBox(self, spacing=0)
+        self.message_icon = gui.widgetLabel(self.message_bar, "")
+        self.message_label = gui.widgetLabel(self.message_bar, "")
+        self.message_label.setStyleSheet("padding-top: 5px")
+        self.message_bar.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Maximum)
+        gui.rubber(self.message_bar)
+        self.message_bar.setVisible(False)
+
+    def _check_has_message_bar(self):
+        if self.message_bar is None:
+            raise RuntimeError(
+                "Did you forget to call WidgetMessagesMixin.insert_message_bar "
+                "for {} (or one of its parent classes)?".
+                format(type(self).__name__))
+
+    def _hide_message_bar(self):
+        self._check_has_message_bar()
+        if not self.message_bar.isHidden():
+            new_height = self.height() - self.message_bar.height()
+            self.message_bar.setVisible(False)
+            self.resize(self.width(), new_height)
+
+    def _set_message_bar(self, group, text=None, tooltip=None):
+        self._check_has_message_bar()
+        current_height = self.height()
+        style = QApplication.instance().style()
+        self.message_icon.setPixmap(
+            style.standardIcon(group.bar_icon).pixmap(14, 14))
+        self.message_bar.setStyleSheet(
+            "background-color: {}; color: black;"
+            "padding: 3px; padding-left: 6px; vertical-align: center".
+            format(group.bar_background))
+        self.message_label.setText(text)
+        self.message_bar.setToolTip(tooltip)
+        if self.message_bar.isHidden():
+            self.message_bar.setVisible(True)
+            new_height = current_height + self.message_bar.height()
+            self.resize(self.width(), new_height)
+
+    # pylint doesn't know that Information, Error and Warning are instantiated
+    # and thus the methods are bound
+    # pylint: disable=no-value-for-parameter
+    # This class and classes Information, Error and Warning are friends
+    # pylint: disable=protected-access
+    @staticmethod
+    def _warn_obsolete(text_or_id, what):
+        if not isinstance(text_or_id, str) and text_or_id is not None:
+            warn("'{}' with id is deprecated; use {} class".
+                 format(what, what.title()), stacklevel=3)
+
+    def information(self, text_or_id=None, text=None, shown=True):
+        self._warn_obsolete(text_or_id, "information")
+        self.Information._add_general(text_or_id, text, shown)
+
+    def warning(self, text_or_id=None, text=None, shown=True):
+        self._warn_obsolete(text_or_id, "warning")
+        self.Warning._add_general(text_or_id, text, shown)
+
+    def error(self, text_or_id=None, text=None, shown=True):
+        self._warn_obsolete(text_or_id, "error")
+        self.Error._add_general(text_or_id, text, shown)

--- a/Orange/widgets/utils/messages.py
+++ b/Orange/widgets/utils/messages.py
@@ -70,6 +70,11 @@ class UnboundMsg(str):
         """Remove the message."""
         raise RuntimeError("Message is not bound")
 
+    # The method is implemented in _BoundMsg
+    def is_shown(self):
+        """Return True if message is currently displayed."""
+        raise RuntimeError("Message is not bound")
+
     # Ensure that two instance of message are always different
     # In particular, there may be multiple messages "{}".
     def __hash__(self):
@@ -110,6 +115,9 @@ class _BoundMsg(UnboundMsg):
 
     def clear(self):
         self.group.deactivate_msg(self)
+
+    def is_shown(self):
+        return self in self.group.active
 
     def __str__(self):
         return self.formatted

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -187,8 +187,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
             if not self.learner.check_learner_adequacy(self.data.domain):
                 self.Error.data_error(self.learner.learner_adequacy_err_msg)
             elif len(np.unique(self.data.Y)) < 2:
-                self.Error.data_error("Data contains a single target value. "
-                                      "There is nothing to learn.")
+                self.Error.data_error("Data contains a single target value.")
             elif self.data.X.size == 0:
                 self.Error.data_error("Data has no features to learn from.")
             else:

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -7,7 +7,7 @@ from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.sql import check_sql_input
-from Orange.widgets.widget import OWWidget, WidgetMetaClass
+from Orange.widgets.widget import OWWidget, WidgetMetaClass, Msg
 
 
 class DefaultWidgetChannelsMetaClass(WidgetMetaClass):
@@ -108,8 +108,11 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
     resizing_enabled = False
     auto_apply = Setting(True)
 
-    DATA_ERROR_ID = 1
-    OUTDATED_LEARNER_WARNING_ID = 2
+    class Error(OWWidget.Error):
+        data_error = Msg("{}")
+
+    class Warning(OWWidget.Warning):
+        outdated_learner = Msg("Press Apply to submit changes.")
 
     def __init__(self):
         super().__init__()
@@ -147,10 +150,10 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
     @check_sql_input
     def set_data(self, data):
         """Set the input train data set."""
-        self.error(self.DATA_ERROR_ID)
+        self.Error.data_error.clear()
         self.data = data
         if data is not None and data.domain.class_var is None:
-            self.error(self.DATA_ERROR_ID, "Data has no target variable")
+            self.Error.data_error("Data has no target variable.")
             self.data = None
 
         self.update_model()
@@ -165,7 +168,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
         self.learner.name = self.learner_name
         self.send("Learner", self.learner)
         self.outdated_settings = False
-        self.warning(self.OUTDATED_LEARNER_WARNING_ID)
+        self.Warning.outdated_learner.clear()
 
     def update_model(self):
         if self.check_data():
@@ -180,24 +183,21 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
     def check_data(self):
         self.valid_data = False
         if self.data is not None and self.learner is not None:
-            self.error(self.DATA_ERROR_ID)
+            self.Error.data_error.clear()
             if not self.learner.check_learner_adequacy(self.data.domain):
-                self.error(self.DATA_ERROR_ID, self.learner.learner_adequacy_err_msg)
+                self.Error.data_error(self.learner.learner_adequacy_err_msg)
             elif len(np.unique(self.data.Y)) < 2:
-                self.error(self.DATA_ERROR_ID,
-                           "Data contains a single target value. "
-                           "There is nothing to learn.")
+                self.Error.data_error("Data contains a single target value. "
+                                      "There is nothing to learn.")
             elif self.data.X.size == 0:
-                self.error(self.DATA_ERROR_ID,
-                           "Data has no features to learn from.")
+                self.Error.data_error("Data has no features to learn from.")
             else:
                 self.valid_data = True
         return self.valid_data
 
     def settings_changed(self, *args, **kwargs):
         self.outdated_settings = True
-        self.warning(self.OUTDATED_LEARNER_WARNING_ID,
-                     None if self.auto_apply else "Press Apply to submit changes.")
+        self.Warning.outdated_learner(shown=not self.auto_apply)
         self.apply()
 
     def send_report(self):

--- a/Orange/widgets/utils/sql.py
+++ b/Orange/widgets/utils/sql.py
@@ -1,5 +1,9 @@
+from Orange.widgets.utils.messages import UnboundMsg
 from Orange.data import Table
 from Orange.data.sql.table import SqlTable, AUTO_DL_LIMIT
+
+_download_sql_data = UnboundMsg(
+    "Download (and sample if necessary) the SQL data first")
 
 
 def check_sql_input(f):
@@ -12,15 +16,15 @@ def check_sql_input(f):
     :param f: widget's `set_data` method to wrap
     :return: wrapped method that handles SQL data inputs
     """
-    def new_f(self, data, *args, **kwargs):
-        self.error(219)
+    def new_f(widget, data, *args, **kwargs):
+        widget.Error.add_message("download_sql_data", _download_sql_data)
+        widget.Error.download_sql_data.clear()
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:
                 data = Table(data)
             else:
-                self.error(219, "Download (and sample if necessary) "
-                                "the SQL data first")
+                widget.Error.download_sql_data()
                 data = None
-        return f(self, data, *args, **kwargs)
+        return f(widget, data, *args, **kwargs)
 
     return new_f

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -211,11 +211,11 @@ class OWDistributions(widget.OWWidget):
     def set_data(self, data):
         self.closeContext()
         self.clear()
-        self.warning(0)
+        self.warning()
         self.data = data
         if self.data is not None:
             if not self.data:
-                self.warning(0, "Empty input data cannot be visualized")
+                self.warning("Empty input data cannot be visualized")
                 return
             domain = self.data.domain
             self.varmodel[:] = list(domain)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -456,8 +456,8 @@ class OWHeatMap(widget.OWWidget):
     class Information(widget.OWWidget.Information):
         sampled = Msg("Data has been sampled")
         discrete_ignored = Msg("{} discrete column{} ignored")
-        row_clust = Msg()
-        col_clust = Msg()
+        row_clust = Msg("{}")
+        col_clust = Msg("{}")
 
     def __init__(self):
         super().__init__()
@@ -662,8 +662,7 @@ class OWHeatMap(widget.OWWidget):
         """Set the input dataset to display."""
         self.closeContext()
         self.clear()
-        self.error(0)
-        self.Information.clear()
+        self.clear_messages()
 
         if isinstance(data, SqlTable):
             if data.approx_len() < 4000:
@@ -685,7 +684,7 @@ class OWHeatMap(widget.OWWidget):
                        data.domain.metas),
                 data)
             if not data.domain.attributes:
-                self.error(0, "No continuous feature columns")
+                self.error("No continuous feature columns")
                 input_data = data = None
             else:
                 self.Information.discrete_ignored(

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -27,6 +27,7 @@ from Orange.widgets.io import FileFormat
 
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
     DendrogramWidget
+from Orange.widgets.widget import Msg
 
 
 def split_domain(domain, split_label):
@@ -452,6 +453,12 @@ class OWHeatMap(widget.OWWidget):
 
     graph_name = "scene"
 
+    class Information(widget.OWWidget.Information):
+        sampled = Msg("Data has been sampled")
+        discrete_ignored = Msg("{} discrete column{} ignored")
+        row_clust = Msg()
+        col_clust = Msg()
+
     def __init__(self):
         super().__init__()
 
@@ -656,13 +663,13 @@ class OWHeatMap(widget.OWWidget):
         self.closeContext()
         self.clear()
         self.error(0)
-        self.information([0, 1])
+        self.Information.clear()
 
         if isinstance(data, SqlTable):
             if data.approx_len() < 4000:
                 data = Table(data)
             else:
-                self.information(0, "Data has been sampled")
+                self.Information.sampled()
                 data_sample = data.sample_time(1, no_cache=True)
                 data_sample.download_data(2000, partial=True)
                 data = Table(data_sample)
@@ -681,8 +688,8 @@ class OWHeatMap(widget.OWWidget):
                 self.error(0, "No continuous feature columns")
                 input_data = data = None
             else:
-                self.information(1, "{} discrete column{} ignored"
-                                .format(ndisc, "s" if ndisc > 1 else ""))
+                self.Information.discrete_ignored(
+                    ndisc, "s" if ndisc > 1 else "")
 
         self.data = data
         self.input_data = input_data
@@ -1263,8 +1270,8 @@ class OWHeatMap(widget.OWWidget):
         cco_enabled = M <= OWHeatMap._MaxOrderedClustering
         sort_rows, sort_cols = self.sort_rows, self.sort_columns
 
-        row_clust_msg = None
-        col_clust_msg = None
+        row_clust_msg = ""
+        col_clust_msg = ""
 
         if not rco_enabled and sort_rows == OWHeatMap.OrderedClustering:
             sort_rows = OWHeatMap.Clustering
@@ -1286,8 +1293,8 @@ class OWHeatMap(widget.OWWidget):
             col_clust_msg = "Column clustering was disabled due to the " \
                             "input matrix being to big"
 
-        self.information(3, row_clust_msg)
-        self.information(4, col_clust_msg)
+        self.Information.row_clust(row_clust_msg)
+        self.Information.col_clust(col_clust_msg)
 
         self.sort_rows = sort_rows
         self.sort_columns = sort_cols

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -552,12 +552,12 @@ class OWLinearProjection(widget.OWWidget):
         """
         self.closeContext()
         self.clear()
-        self.information(0)
+        self.information()
         if isinstance(data, SqlTable):
             if data.approx_len() < 4000:
                 data = Table(data)
             else:
-                self.information(0, "Data has been sampled")
+                self.information("Data has been sampled")
                 data_sample = data.sample_time(1, no_cache=True)
                 data_sample.download_data(2000, partial=True)
                 data = Table(data_sample)
@@ -693,10 +693,8 @@ class OWLinearProjection(widget.OWWidget):
         shape_vars = [var for var in disc_vars
                       if len(var.values) <= len(ScatterPlotItem.Symbols) - 1]
 
-        self.warning(0)
-        if not len(cont_vars):
-            self.warning(
-                "Need at least one continuous feature to plot the data.")
+        self.warning("Plotting requires continuous features.",
+                     shown=not len(cont_vars))
 
         self.all_vars = data.domain.variables
         self.varmodel_selected[:] = cont_vars[:3]

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -21,7 +21,7 @@ from Orange.widgets.utils import to_html
 from Orange.widgets.utils.scaling import get_variable_values_sorted
 from Orange.widgets.visualize.utils import (
     CanvasText, CanvasRectangle, ViewWithPress)
-from Orange.widgets.widget import OWWidget, Default
+from Orange.widgets.widget import OWWidget, Default, Msg
 
 
 class OWMosaicDisplay(OWWidget):
@@ -58,6 +58,12 @@ class OWMosaicDisplay(OWWidget):
                   QColor(255, 100, 100), QColor(255, 0, 0)]
 
     graph_name = "canvas"
+
+    class Warning(OWWidget.Warning):
+        incompatible_subset = Msg("Data subset is incompatible with Data")
+        no_valid_data = Msg("No valid data")
+        no_cont_selection_sql = \
+            Msg("Selection of continuous variables on SQL is not supported")
 
     def __init__(self):
         super().__init__()
@@ -145,14 +151,9 @@ class OWMosaicDisplay(OWWidget):
         self.closeContext()
         self.data = data
         self.init_combos(self.data)
-        self.information([0, 1, 2])
         if not self.data:
             self.discrete_data = None
             return
-        """ TODO: check
-        if data.has_missing_class():
-            self.information(1, "Examples with missing classes were removed.")
-        """
         if any(attr.is_continuous for attr in data.domain):
             self.discrete_data = Discretize(method=EqualFreq(n=4))(data)
         else:
@@ -175,19 +176,15 @@ class OWMosaicDisplay(OWWidget):
             self.unprocessed_subset_data = None
 
     def set_subset_data(self, data):
+        self.Warning.incompatible_subset.clear()
         if self.data is None:
             self.unprocessed_subset_data = data
-            self.warning(10)
             return
         try:
             self.subset_data = data.from_table(self.data.domain, data)
-            self.warning(10)
         except:
             self.subset_data = None
-            self.warning(
-                10,
-                "'Data' and 'Data Subset' are incompatible" if data is not None
-                else "")
+            self.Warning.incompatible_subset(shown=data is not None)
 
     # this is called by widget after setData and setSubsetData are called.
     # this way the graph is updated only once
@@ -225,12 +222,10 @@ class OWMosaicDisplay(OWWidget):
             self.send("Selected Data", None)
             return
         filters = []
-        self.warning(6)
+        self.Warning.no_cont_selection_sql.clear()
         if self.discrete_data is not self.data:
             if isinstance(self.data, SqlTable):
-                self.warning(
-                    6,
-                    "Selection of continuous variables on SQL is not supported")
+                self.Warning.no_cont_selection_sql()
         for i in self.selection:
             cols, vals, area = self.areas[i]
             filters.append(
@@ -643,10 +638,10 @@ class OWMosaicDisplay(OWWidget):
         # TODO: check this
         # data = Preprocessor_dropMissing(data)
         if len(data) == 0:
-            self.warning(5, "No valid data for current attributes.")
+            self.Warning.no_valid_data()
             return
         else:
-            self.warning(5)
+            self.Warning.no_valid_data.clear()
 
         if self.interior_coloring == self.PEARSON:
             apriori_dists = [get_distribution(data, attr) for attr in attr_list]

--- a/Orange/widgets/visualize/owparallelcoordinates.py
+++ b/Orange/widgets/visualize/owparallelcoordinates.py
@@ -110,10 +110,10 @@ class OWParallelCoordinates(OWVisWidget):
     def flip_attribute(self, item):
         if self.graph.flip_attribute(str(item.text())):
             self.update_graph()
-            self.information(0)
+            self.information()
         else:
-            self.information(0, "Didn't flip the attribute. To flip a continuous "
-                                "attribute uncheck 'Global value scaling' checkbox.")
+            self.information("To flip a numeric feature, disable"
+                             "'Global value scaling'")
 
     def update_graph(self):
         self.graph.update_data(self.shown_attributes)

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -638,11 +638,7 @@ class OWScatterMap(widget.OWWidget):
                 item = self.z_values_view.item(i)
                 item.setIcon(colorpalette.ColorPixmap(self.colors[i]))
 
-        if not cvars:
-            self.error(1, "Data contains no continuous features")
-        else:
-            self.error(1)
-
+        self.error("Data contains no continuous features", shown=not cvars)
         self.setup_plot()
 
     def clear(self):

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -213,14 +213,14 @@ class OWSieveDiagram(OWWidget):
         and at least two attributes appear in the domain. If there are
         multiple, use the first two. Combos are disabled if inputs are used.
         """
-        self.warning(1)
+        self.warning()
         self.attr_box.setEnabled(True)
         if not self.input_features:  # None or empty
             return
         features = [f for f in self.input_features if f in self.attrs]
         if not features:
-            self.warning(1, "Features from the input signal "
-                            "are not present in the data")
+            self.warning(
+                "Features from the input signal are not present in the data")
             return
         old_attrs = self.attrX, self.attrY
         self.attrX, self.attrY = [f.name for f in (features * 2)[:2]]

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -21,6 +21,7 @@ from Orange.widgets.utils import itemmodels
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
     WrapperLayoutItem
+from Orange.widgets.widget import Msg
 
 
 class OWSilhouettePlot(widget.OWWidget):
@@ -60,6 +61,9 @@ class OWSilhouettePlot(widget.OWWidget):
 
     graph_name = "scene"
     buttons_area_orientation = Qt.Vertical
+
+    class Error(widget.OWWidget.Error):
+        need_two_clusters = Msg("Need at least two non-empty clusters")
 
     def __init__(self):
         super().__init__()
@@ -167,8 +171,8 @@ class OWSilhouettePlot(widget.OWWidget):
             self._effective_data = Orange.distance._preprocess(data)
             self.openContext(Orange.data.Domain(candidatevars))
 
-        self.error(0, error_msg)
-        self.warning(0, warning_msg)
+        self.error(error_msg)
+        self.warning(warning_msg)
 
     def handleNewSignals(self):
         if self._effective_data is not None:
@@ -227,11 +231,11 @@ class OWSilhouettePlot(widget.OWWidget):
         labels = labels.astype(int)
         _, counts = numpy.unique(labels, return_counts=True)
         if numpy.count_nonzero(counts) >= 2:
-            self.error(1, "")
+            self.Error.need_two_clusters.clear()
             silhouette = sklearn.metrics.silhouette_samples(
                 self._matrix, labels, metric="precomputed")
         else:
-            self.error(1, "Need at least 2 clusters with non zero counts")
+            self.Error.need_two_clusters()
             labels = silhouette = None
 
         self._labels = labels

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -135,7 +135,7 @@ class OWVennDiagram(widget.OWWidget):
 
     @check_sql_input
     def setData(self, data, key=None):
-        self.error(0)
+        self.error()
         if not self._inputUpdate:
             # Store hints only on the first setData call.
             self._storeHints()
@@ -152,7 +152,7 @@ class OWVennDiagram(widget.OWWidget):
             # TODO: Allow setting more them 5 inputs and let the user
             # select the 5 to display.
             if len(self.data) == 5:
-                self.error(0, "Can only take 5 inputs.")
+                self.error("Venn diagram accepts at most five data sets.")
                 return
             # Add a new input
             self._add(key, data)
@@ -259,7 +259,7 @@ class OWVennDiagram(widget.OWWidget):
         index = list(self.data.keys()).index(key)
 
         # Clear possible warnings.
-        self.warning(index)
+        self.warning()
 
         self._setAttributes(index, None)
 
@@ -437,7 +437,7 @@ class OWVennDiagram(widget.OWWidget):
 
     def _updateInfo(self):
         # Clear all warnings
-        self.warning(list(range(5)))
+        self.warning()
 
         if not len(self.data):
             self.info.setText("No data on input\n")
@@ -446,10 +446,15 @@ class OWVennDiagram(widget.OWWidget):
                 "{0} data sets on input\n".format(len(self.data)))
 
         if self.useidentifiers:
-            for i, key in enumerate(self.data):
-                if not source_attributes(self.data[key].table.domain):
-                    self.warning(i, "Data set #{} has no suitable identifiers."
-                                 .format(i + 1))
+            no_idx = ["#{}".format(i + 1)
+                      for i, key in enumerate(self.data)
+                      if not source_attributes(self.data[key].table.domain)]
+            if len(no_idx) == 1:
+                self.warning("Data set {} has no suitable identifiers."
+                             .format(no_idx[0]))
+            elif len(no_idx) > 1:
+                self.warning("Data sets {} and {} have no suitable identifiers."
+                             .format(", ".join(no_idx[:-1]), no_idx[-1]))
 
     def _on_selectionChanged(self):
         if self._updating:

--- a/doc/development/source/tutorial-utilities.rst
+++ b/doc/development/source/tutorial-utilities.rst
@@ -92,38 +92,83 @@ displayed in the top row of the widget and also indicated in the schema.
 
 .. image:: images/warningmessage.png
 
-Messages, warning and errors are issued by methods
+Simple messages
+...............
+
+If the widget only issues a single error, warning and/or information at a time,
+it can do so by calling `self.error(text, shown=True)`,
+`self.warning(text, shown=True)` or `self.information(text, shown=True)`.
+Multiple messages - but just one of each kind - can be present at the same
+time::
+
+    self.warning("Discrete features are ignored.")
+    self.error("Fitting failed due to missing data.")
+
+At this point, the widget has a warning and an error message.
+
+    self.error("Fitting failed due to weird data.")
+
+This replaces the old error message, but the warning remains.
+
+The message is removed by setting an empty message, e.g. `self.error()`.
+To remove all messages, call `self.clear_messages()`.
+
+If the argument `shown` is set to `False`, the message is removed::
+
+    self.error("No suitable features", shown=not self.suitable_features)
+
+"Not showing" a message in this way also remove any existing messages.
+
+Multiple messages
+.................
+
+Widget that issue multiple independent messages that can appear simultaneously,
+need to declare them within local classes within the widget class, and derive
+them from the corresponding `OWWidget` classes for a particular kind of a
+message. For instance, a widget class can contain the following classes::
+
+    class Error(OWWidget.Error):
+        no_continuous_features = Msg("No continuous features")
+
+    class Warning(OWWidget.Error):
+        empty_data = Msg("Comtrongling does not work on meta data")
+        no_scissors_run = Msg("Do not run with scissors")
+        ignoring_discrete = Msg("Ignoring {n} discrete features: {}")
+
+Within the widget, errors are raised via calls like::
+
+    self.Error.no_continuous_features()
+    self.Warning.no_scissors_run()
+
+As for the simpler messages, the `shown` argument can be added::
+
+    self.Warning.no_scissors_run(shown=self.scissors_are_available)
+
+If the message includes formatting, the call must include the necessary data
+for the `format` method::
+
+    self.Warning.ignoring_discrete(", ".join(attrs), n=len(attr))
+
+Message is cleared by::
+
+    self.Warning.ignoring_discrete.clear()
+
+Multiple messages can be removed as in the simpler schema, with::
+
+    self.Warning.clear()
+
+or::
+
+    self.clear_messages()
+
+Messages of both kinds - those from messages classes and those issued by,
+for instance, `self.error` - can coexist. Note, though, that methods for
+removing all messages of certain type (e.g. `self.Error.clear()`) or all
+messags (`self.clear_message()`) apply to all messages of this type.
+
+**Note**: handling multiple messages through ids, that is, using
 `self.information(id, text)`, `self.warning(id, text)` and
-`self.error(id, text)`, respectively. A warning like the one above is
-issued by ::
-
-    self.warning(42, "Data contains continuous variables. "
-                 "Discretize the data to use them.")
-
-and removed by ::
-
-    self.warning(42)
-
-A widget can have multiple such messages at the same time. They are
-distinguished by different id's, like `42` above. The id numbers are
-arbitrary and are assigned by the programmer. They need to be unique
-for a widget.
-
-Multiple error messages can be removed by calling the function with a
-list of id's, `self.warning([1, 13, 42])`.
-
-Since most widgets have only a single error message, the id can be omitted
-(in which case it defaults to 0). In this case, ::
-
-    self.warning("Data contains continuous variables. "
-                 "Discretize the data to use them.")
-
-issues the warning, and ::
-
-    self.warning()
-
-removes it.
-
+`self.error(id, text)` is deprecated and will be removed in the future.
 
 Tips
 ----

--- a/doc/development/source/tutorial-utilities.rst
+++ b/doc/development/source/tutorial-utilities.rst
@@ -130,7 +130,7 @@ message. For instance, a widget class can contain the following classes::
     class Error(OWWidget.Error):
         no_continuous_features = Msg("No continuous features")
 
-    class Warning(OWWidget.Error):
+    class Warning(OWWidget.Warning):
         empty_data = Msg("Comtrongling does not work on meta data")
         no_scissors_run = Msg("Do not run with scissors")
         ignoring_discrete = Msg("Ignoring {n} discrete features: {}")


### PR DESCRIPTION
When implementing a widget which issues multiple error, warning or information messages, we have to keep track of the used id's or pick random numbers and hope for the best to avoid collisions.

This PR proposes the use of Msg instances as id's.

The `OWWidget` class has local classes `Error`, `Warning`, `Information` that contains message instances that can be triggered or cleared.

The old methods `error`, `warning` and `information` can trigger a specific (protected) message instance. Using the old methods with id's is deprecated and triggers a warning.

Most widgets will require no other changes than removing the first argument in the call of `error`, `warning` or `information`. If they didn't use the id argument, no change is required. 