### PR TITLE
[FIX] PaintData: Sends None when the paint includes no data points

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1226,6 +1226,9 @@ class OWPaintData(widget.OWWidget):
         self.commit()
 
     def commit(self):
+        if len(self.data) == 0:
+            self.send("Data", None)
+            return
         if self.hasAttr2:
             X, Y = self.data[:, :2], self.data[:, 2]
             attrs = (Orange.data.ContinuousVariable(self.attr1),


### PR DESCRIPTION
Before, the widget would send out the data table despite not including any data instances. This happens, for example, when sending the data is set to automatic (every change is committed) and the user removes all the data. With the empty data sets, some of Orange's widget crash (a problem on its own), so it is safer and according to convention in Orange to send None if the data set is empty.