### PR TITLE
[FIX] Scatterplot: Sends none in no instance selected

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -447,12 +447,19 @@ class OWScatterPlot(OWWidget):
             selected = unselected = self.data
         elif self.data is not None:
             selection = self.graph.get_selection()
+            if len(selection) == 0:
+                self.send("Selected Data", None)
+                self.send("Other Data", self.data)
+                return
             selected = self.data[selection]
             unselection = np.full(len(self.data), True, dtype=bool)
             unselection[selection] = False
             unselected = self.data[unselection]
         self.send("Selected Data", selected)
-        self.send("Other Data", unselected)
+        if len(unselected) == 0:
+            self.send("Other Data", None)
+        else:
+            self.send("Other Data", unselected)
 
     def send_features(self):
         features = None


### PR DESCRIPTION
In the previous version ScatterPlot would send the data table with no instances, which would crash some widgets. This has been fixed now, such that if no instances are selected, None is send. Similar for sending out un-selected instances.