### PR TITLE
[FIX] Select Rows: skip undefined TimeVariable filters

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -936,7 +936,8 @@ class TimeVariable(ContinuousVariable):
             return Unknown
         datestr = datestr.strip().rstrip('Z')
 
-        ERROR = ValueError('Invalid datetime format. Only ISO 8601 supported.')
+        ERROR = ValueError("Invalid datetime format '{}'. "
+                           "Only ISO 8601 supported.".format(datestr))
         if not self._matches_iso_format(datestr):
             try:
                 # If it is a number, assume it is a unix timestamp

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -352,17 +352,18 @@ class OWSelectRows(widget.OWWidget):
                 attr_index = domain.index(attr_name)
                 attr = domain[attr_index]
 
-                # Parse datetime strings into floats
-                if isinstance(attr, TimeVariable):
-                    try:
-                        values = [attr.parse(v) for v in values]
-                    except ValueError as e:
-                        self.error(21, e.args[0])
-                        return
-
                 if attr.is_continuous:
                     if any(not v for v in values):
                         continue
+
+                    # Parse datetime strings into floats
+                    if isinstance(attr, TimeVariable):
+                        try:
+                            values = [attr.parse(v) for v in values]
+                        except ValueError as e:
+                            self.error(21, e.args[0])
+                            return
+
                     filter = data_filter.FilterContinuous(
                         attr_index, oper, *[float(v) for v in values])
                 elif attr.is_string:


### PR DESCRIPTION
... as they are skipped for ordinary ContinuousVariables.
Previous implementation parsed empty strings first into nan objects which were not skipped over later.
