### PR TITLE
[FIX] DataTable: Sends None when no data is selected

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -797,6 +797,12 @@ class OWDataTable(widget.OWWidget):
             rowsel, colsel = self.get_selection(view)
             self.selected_rows, self.selected_cols = rowsel, colsel
 
+            # Handle case when nothing is selected
+            if len(rowsel) == 0:
+                self.send("Selected Data", None)
+                self.send("Other Data", table)
+                return
+
             def select(data, rows, domain):
                 """
                 Select the data subset with specified rows and domain subsets.


### PR DESCRIPTION
Fixed a bug where Data Table send an empty data table (table with no instances) when no data was selected. No sends None.