### PR TITLE
[FIX] statistics.utils: Fix stats for sparse when last column missing

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -178,7 +178,7 @@ def stats(X, weights=None, compute_variance=False):
         if compute_variance:
             raise NotImplementedError
 
-        non_zero = np.bincount(X.nonzero()[1])
+        non_zero = np.bincount(X.nonzero()[1], minlength=X.shape[1])
         X = X.tocsc()
         return np.column_stack((
             X.min(axis=0).toarray().ravel(),

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -41,3 +41,11 @@ class TestUtil(unittest.TestCase):
                                            [0, 1, .2, 0, 4, 1],
                                            [0, 1, .2, 0, 4, 1],
                                            [0, 1, .2, 0, 4, 1]])
+
+        # assure last two columns have just zero elements
+        X = X[:3]
+        np.testing.assert_equal(stats(X), [[0, 1, 1/3, 0, 4, 1],
+                                           [0, 1, 1/3, 0, 4, 1],
+                                           [0, 1, 1/3, 0, 4, 1],
+                                           [0, 0,   0, 0, 5, 0],
+                                           [0, 0,   0, 0, 5, 0]])


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

`np.bincount` has a length of the maximal element and can hence be shorter than the number of columns (e.g. when some of the last columns have all zeros). This forces it to count non zero elements for all columns.