### PR TITLE
bottlechest.stats: return zeros for empty tables

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -165,7 +165,7 @@ def stats(X, weights=None, compute_variance=False):
     is_numeric = np.issubdtype(X.dtype, np.number)
     is_sparse = issparse(X)
 
-    if is_numeric and not is_sparse:
+    if X.size and is_numeric and not is_sparse:
         nans = np.isnan(X).sum(axis=0)
         return np.column_stack((
             np.nanmin(X, axis=0),
@@ -188,7 +188,7 @@ def stats(X, weights=None, compute_variance=False):
             X.shape[1] - non_zero,
             non_zero))
     else:
-        nans = ~X.astype(bool).sum(axis=0)
+        nans = ~X.astype(bool).sum(axis=0) if X.size else np.zeros(X.shape[1])
         return np.column_stack((
             np.tile(np.inf, X.shape[1]),
             np.tile(-np.inf, X.shape[1]),

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -33,6 +33,10 @@ class TestUtil(unittest.TestCase):
         X[1, 1] = np.nan
         np.testing.assert_equal(stats(X), [[0, 2, 1, 0, 0, 2],
                                            [1, 1, 1, 0, 1, 1]])
+        # empty table should return ~like metas
+        X = X[:0]
+        np.testing.assert_equal(stats(X), [[np.inf, -np.inf, 0, 0, 0, 0],
+                                           [np.inf, -np.inf, 0, 0, 0, 0]])
 
     def test_stats_sparse(self):
         X = csr_matrix(np.identity(5))


### PR DESCRIPTION
Should supposedly help in preventing the need for further PRs like https://github.com/biolab/orange3/pull/1425, https://github.com/biolab/orange3/pull/1428, https://github.com/biolab/orange3/pull/1431.  