### PR TITLE
Reorder visualisation widgets

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -81,7 +81,7 @@ class OWDistributions(widget.OWWidget):
     name = "Distributions"
     description = "Display value distributions of a data feature in a graph."
     icon = "icons/Distribution.svg"
-    priority = 100
+    priority = 120
     inputs = [InputSignal("Data", Orange.data.Table, "set_data",
                           doc="Set the input data set")]
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -375,7 +375,7 @@ class OWHeatMap(widget.OWWidget):
     name = "Heat Map"
     description = "Plot a heat map for a pair of attributes."
     icon = "icons/Heatmap.svg"
-    priority = 1040
+    priority = 330
 
     inputs = [("Data", Table, "set_dataset")]
     outputs = [("Selected Data", Table, widget.Default)]

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -218,7 +218,7 @@ class OWLinearProjection(widget.OWWidget):
     description = "A multi-axis projection of data onto " \
                   "a two-dimensional plane."
     icon = "icons/LinearProjection.svg"
-    priority = 2000
+    priority = 420
 
     inputs = [("Data", Table, "set_data", widget.Default),
               ("Data Subset", Table, "set_subset_data")]

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -28,6 +28,7 @@ class OWMosaicDisplay(OWWidget):
     name = "Mosaic Display"
     description = "Display data in a mosaic plot."
     icon = "icons/MosaicDisplay.svg"
+    priority = 320
 
     inputs = [("Data", Table, "set_data", Default),
               ("Data Subset", Table, "set_subset_data")]

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -455,7 +455,7 @@ class OWScatterMap(widget.OWWidget):
     name = "Scatter Map"
     description = "Draw a two dimensional rectangular bin density plot."
     icon = "icons/Scattermap.svg"
-    priority = 100
+    priority = 500
 
     inputs = [("Data", Orange.data.Table, "set_data")]
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -86,8 +86,10 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
 
 class OWScatterPlot(OWWidget):
     name = 'Scatter Plot'
-    description = 'Scatterplot visualization with explorative analysis and intelligent data visualization enhancements.'
+    description = "Interactive scatter plot visualization with " \
+                  "intelligent data visualization enhancements."
     icon = "icons/ScatterPlot.svg"
+    priority = 210
 
     inputs = [("Data", Table, "set_data", Default),
               ("Data Subset", Table, "set_subset_data"),

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -58,7 +58,7 @@ class OWSieveDiagram(OWWidget):
     """
     name = "Sieve Diagram"
     icon = "icons/SieveDiagram.svg"
-    priority = 4200
+    priority = 310
 
     inputs = [("Data", Table, "set_data", Default),
               ("Features", AttributeList, "set_input_features")]

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -37,6 +37,7 @@ class OWVennDiagram(widget.OWWidget):
     description = "A graphical visualization of the overlap of data instances " \
                   "from a collection of input data sets."
     icon = "icons/VennDiagram.svg"
+    priority = 410
 
     inputs = [("Data", Orange.data.Table, "setData", widget.Multiple)]
     outputs = [("Selected Data", Orange.data.Table)]


### PR DESCRIPTION
Widget priority determines the order in which widgets are displayed in the Orange toolbox. I have updated this order for widgets in Visualization pane as the previous order was not consistent with the order in which these widgets are normally used. For some of the widgets the priority (=100) was wrong, and for some it was not defined - both is now fixed.