### PR TITLE
k-Means: Renamed k-means widget to k-Means

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -13,8 +13,8 @@ from Orange.widgets.utils.sql import check_sql_input
 
 
 class OWKMeans(widget.OWWidget):
-    name = "k-means"
-    description = "k-means clustering algorithm with silhouette-based " \
+    name = "k-Means"
+    description = "k-Means clustering algorithm with silhouette-based " \
                   "quality estimation."
     icon = "icons/KMeans.svg"
     priority = 2100


### PR DESCRIPTION
After some consultation with Google I notice that the name of the widget should be k-Means, as this is the name of the algorithm and as we are using camel case for widget names.