### PR TITLE
[FIX] Tree preprocessor order.

### DIFF
--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -2,8 +2,6 @@ import sklearn.tree as skl_tree
 
 from Orange.base import Tree
 from Orange.classification import SklLearner, SklModel
-from Orange.preprocess import (RemoveNaNClasses, Continuize,
-                               RemoveNaNColumns, SklImpute)
 
 __all__ = ["TreeLearner"]
 
@@ -18,10 +16,6 @@ class TreeLearner(SklLearner):
     __wraps__ = skl_tree.DecisionTreeClassifier
     __returns__ = TreeClassifier
     name = 'tree'
-    preprocessors = [RemoveNaNClasses(),
-                     RemoveNaNColumns(),
-                     SklImpute(),
-                     Continuize()]
 
     def __init__(self, criterion="gini", splitter="best", max_depth=None,
                  min_samples_split=2, min_samples_leaf=1,

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -2,7 +2,6 @@ import sklearn.tree as skl_tree
 
 from Orange.base import Tree
 from Orange.regression import SklLearner, SklModel
-from Orange.preprocess import Continuize, RemoveNaNColumns, SklImpute
 
 __all__ = ["TreeRegressionLearner"]
 
@@ -17,9 +16,6 @@ class TreeRegressionLearner(SklLearner):
     __wraps__ = skl_tree.DecisionTreeRegressor
     __returns__ = TreeRegressor
     name = 'regression tree'
-    preprocessors = [RemoveNaNColumns(),
-                     SklImpute(),
-                     Continuize()]
 
     def __init__(self, criterion="mse", splitter="best", max_depth=None,
                  min_samples_split=2, min_samples_leaf=1,


### PR DESCRIPTION
The preprocessors in tree.py were in the incorrect order (continuize must be in front of impute). Revert to the inherited order. 