### PR TITLE
[FIX] Stop advertising support for weights in LogisticRegression.

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -41,3 +41,8 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
                  random_state=None, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
+
+    @property
+    def supports_weights(self):
+        # liblinear (default) cannot handle weights
+        return False

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -4,6 +4,10 @@ import unittest
 
 from Orange.base import SklLearner
 from Orange.regression import LinearRegressionLearner
+from Orange.classification import LogisticRegressionLearner
+from Orange.data import Table
+
+from sklearn.linear_model import LogisticRegression
 
 
 class TestSklLearner(unittest.TestCase):
@@ -26,7 +30,19 @@ class TestSklLearner(unittest.TestCase):
 
         self.assertFalse(DummyLearner().supports_weights)
 
-    def test_logreg(self):
+    def test_linreg(self):
         self.assertTrue(LinearRegressionLearner().supports_weights,
                         "Either LinearRegression no longer supports weighted tables "
                         "or SklLearner.supports_weights is out-of-date.")
+
+    def test_logreg(self):
+        self.assertFalse(LogisticRegressionLearner().supports_weights,
+                         "Logistic regression has its supports_weights overridden because "
+                         "liblinear doesn't support them (even though the parameter exists)")
+
+    def test_assert_liblinear_doesnt_accept_weights(self):
+        data = Table('iris')
+        data.set_weights(1.2)
+        with self.assertRaises(ValueError):
+            skl = LogisticRegression(solver='liblinear')
+            skl.fit(data.X, data.Y, data.W)

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -3,7 +3,7 @@
 import unittest
 
 from Orange.base import SklLearner
-from Orange.classification import LogisticRegressionLearner
+from Orange.regression import LinearRegressionLearner
 
 
 class TestSklLearner(unittest.TestCase):
@@ -27,6 +27,6 @@ class TestSklLearner(unittest.TestCase):
         self.assertFalse(DummyLearner().supports_weights)
 
     def test_logreg(self):
-        self.assertTrue(LogisticRegressionLearner().supports_weights,
-                        "Either LogisticRegression no longer supports weighted tables"
+        self.assertTrue(LinearRegressionLearner().supports_weights,
+                        "Either LinearRegression no longer supports weighted tables "
                         "or SklLearner.supports_weights is out-of-date.")


### PR DESCRIPTION
The liblinear solver does not support weights in SKL, even though the parameter is there. Override the property to prevent errors. 