### PR TITLE
[FIX] OWBaseLearner: Learner name is changed on output when user changes it and auto apply selected 

### DIFF
--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -1,5 +1,5 @@
 import numpy as np
-from PyQt4.QtCore import QTimer
+from PyQt4.QtCore import QTimer, Qt
 
 from Orange.classification.base_classification import LearnerClassification
 from Orange.data import Table
@@ -225,7 +225,9 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
 
     def add_learner_name_widget(self):
         gui.lineEdit(self.controlArea, self, 'learner_name', box='Name',
-                     tooltip='The name will identify this model in other widgets')
+                     tooltip='The name will identify this model in other widgets',
+                     orientation=Qt.Horizontal,
+                     callback=lambda: self.apply())
 
     def add_bottom_buttons(self):
         box = gui.hBox(self.controlArea, True)


### PR DESCRIPTION
Learner name field didn't have callback when it is changed. Problem was when user changed name and auto apply was on, because name haven't changed on output. It is fixed with this PR. 