### PR TITLE
[FIX] Table: Fix ensure_copy for sparse matrices

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -912,15 +912,20 @@ class Table(MutableSequence, Storage):
 
     def ensure_copy(self):
         """
-        Ensure that the table owns its data; copy arrays when necessary
+        Ensure that the table owns its data; copy arrays when necessary.
         """
-        if self.X.base is not None:
+        def is_view(x):
+            # Sparse matrices don't have views like numpy arrays. Since indexing on
+            # them creates copies in constructor we can skip this check here.
+            return not sp.issparse(x) and x.base is not None
+
+        if is_view(self.X):
             self.X = self.X.copy()
-        if self._Y.base is not None:
+        if is_view(self._Y):
             self._Y = self._Y.copy()
-        if self.metas.base is not None:
+        if is_view(self.metas):
             self.metas = self.metas.copy()
-        if self.W.base is not None:
+        if is_view(self.W):
             self.W = self.W.copy()
 
     def copy(self):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -649,6 +649,19 @@ class TableTestCase(unittest.TestCase):
         self.assertFalse(np.all(t.Y == copy.Y))
         self.assertFalse(np.all(t.metas == copy.metas))
 
+    def test_copy_sparse(self):
+        t = data.Table('iris')
+        t.X = csr_matrix(t.X)
+        copy = t.copy()
+
+        self.assertEqual((t.X != copy.X).nnz, 0)      # sparse matrices match by content
+        np.testing.assert_equal(t.Y, copy.Y)
+        np.testing.assert_equal(t.metas, copy.metas)
+
+        self.assertNotEqual(id(t.X), id(copy.X))
+        self.assertNotEqual(id(t._Y), id(copy._Y))
+        self.assertNotEqual(id(t.metas), id(copy.metas))
+
     def test_concatenate(self):
         d1 = data.Domain([data.ContinuousVariable('a1')])
         t1 = data.Table.from_numpy(d1, [[1],


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

`ensure_copy` is checking whether an array is a view through the `.base` argument which doesn't exist on `scipy.sparse` matrices. Since `scipy.sparse` don't work with views (e.g. indexing returns a copy of the matrix) the check should only be performed for dense matrices.