### PR TITLE
[FIX] Invalid number format in KMeans widget

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -265,7 +265,7 @@ class OWKMeans(widget.OWWidget):
         best_run = scores.index(best_score)
         score_span = (best_score - worst_score) or 1
         max_score = max(scores)
-        nplaces = min(5, np.floor(abs(math.log(max(max_score, 1e-10)))) + 2)
+        nplaces = min(5, int(abs(math.log(max(max_score, 1e-10)))) + 2)
         fmt = "{{:.{}f}}".format(int(nplaces))
         model = self.table_model
         model.setRowCount(len(k_scores))


### PR DESCRIPTION
The format string was, for instance, `{:.2.0f}` instead of `{:.2f}`.