### PR TITLE
[FIX] statistics.util: Fix applying weights

### DIFF
--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -53,3 +53,19 @@ class TestUtil(unittest.TestCase):
                                            [0, 1, 1/3, 0, 4, 1],
                                            [0, 0,   0, 0, 5, 0],
                                            [0, 0,   0, 0, 5, 0]])
+
+    def test_stats_weights(self):
+        X = np.arange(4).reshape(2, 2).astype(float)
+        weights = np.array([1, 3])
+        np.testing.assert_equal(stats(X, weights), [[0, 2, 1.5, 0, 0, 2],
+                                                    [1, 3, 2.5, 0, 0, 2]])
+
+        X = np.arange(4).reshape(2, 2).astype(object)
+        np.testing.assert_equal(stats(X, weights), stats(X))
+
+    def test_stats_weights_sparse(self):
+        X = np.arange(4).reshape(2, 2).astype(float)
+        X = csr_matrix(X)
+        weights = np.array([1, 3])
+        np.testing.assert_equal(stats(X, weights), [[0, 2, 1.5, 0, 1, 1],
+                                                    [1, 3, 2.5, 0, 0, 2]])


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

This commit fixes three issues about weights. First, multiplication does work since X is 2d and weights are 1d (e.g. `operands could not be broadcast together with shapes (1000,2) (1000,)`). This is fixed by transforming weights to 2d. Further, weights should only be used for calculating mean. Third, we should not apply weights if X contains objects (like StringVariable).