### PR TITLE
gui: Fix crash in doubleSpin when checked parameters is set

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -734,7 +734,7 @@ def spin(widget, master, value, minv, maxv, step=1, box=None, label=None,
         widgetLabel(bi, posttext)
 
     isDouble = spinType == float
-    sbox = bi.control = \
+    sbox = bi.control = b.control = \
         (SpinBoxWFocusOut, DoubleSpinBoxWFocusOut)[isDouble](minv, maxv,
                                                              step, bi)
     if bi is not widget:

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -1,0 +1,15 @@
+from Orange.widgets import gui
+from Orange.widgets.tests.base import GuiTest
+from Orange.widgets.widget import OWWidget
+
+
+class OWTestDoubleSpin(GuiTest):
+    some_param = 0
+    some_option = False
+
+    # make sure that the gui element does not crash when
+    # 'checked' parameter is forwarded, ie. is not None
+    def test_checked_extension(self):
+        widget = OWWidget()
+        gui.doubleSpin(widget=widget, master=self, value="some_param",
+                       minv=1, maxv=10, checked="some_option")


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

The fix prevents the gui element to crash when 'checked' parameter is forwarded, ie. is not None.