### PR TITLE
[FIX] Table names set by readers

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -669,8 +669,14 @@ class CSVReader(FileFormat):
                 try:
                     reader = csv.reader(file, dialect=dialect)
                     data = self.data_table(reader)
-                    data.name = os.path.splitext(
-                        os.path.split(self.filename)[-1])[0]
+
+                    # TODO: Name can be set unconditionally when/if
+                    # self.filename will always be a string with the file name.
+                    # Currently, some tests pass StringIO instead of
+                    # the file name to a reader.
+                    if isinstance(self.filename, str):
+                        data.name = os.path.splitext(
+                            os.path.split(self.filename)[-1])[0]
                     if error and isinstance(error, UnicodeDecodeError):
                         pos, endpos = error.args[2], error.args[3]
                         warning = ('Skipped invalid byte(s) in position '

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -1,6 +1,7 @@
 import contextlib
 import csv
 import locale
+import os
 import pickle
 import re
 import subprocess
@@ -668,6 +669,8 @@ class CSVReader(FileFormat):
                 try:
                     reader = csv.reader(file, dialect=dialect)
                     data = self.data_table(reader)
+                    data.name = os.path.splitext(
+                        os.path.split(self.filename)[-1])[0]
                     if error and isinstance(error, UnicodeDecodeError):
                         pos, endpos = error.args[2], error.args[3]
                         warning = ('Skipped invalid byte(s) in position '
@@ -731,8 +734,10 @@ class BasketReader(FileFormat):
         classes = constr_vars(class_indices)
         meta_attrs = constr_vars(meta_indices)
         domain = Domain(attrs, classes, meta_attrs)
-        return Table.from_numpy(
+        table = Table.from_numpy(
             domain, attrs and X, classes and Y, metas and meta_attrs)
+        table.name = os.path.splitext(os.path.split(self.filename)[-1])[0]
+        return table
 
 
 class ExcelReader(FileFormat):
@@ -767,6 +772,9 @@ class ExcelReader(FileFormat):
                              for col in range(first_col, row_len)]
                             for row in range(first_row, ss.nrows)])
             table = self.data_table(cells)
+            table.name = os.path.splitext(os.path.split(self.filename)[-1])[0]
+            if self.sheet:
+                table.name = '-'.join((table.name, self.sheet))
         except Exception:
             raise IOError("Couldn't load spreadsheet from " + self.filename)
         return table

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -525,7 +525,6 @@ class Table(MutableSequence, Storage):
         if cls != data.__class__:
             data = cls(data)
 
-        data.name = os.path.splitext(os.path.split(filename)[-1])[0]
         # no need to call _init_ids as fuctions from .io already
         # construct a table with .ids
 

--- a/Orange/tests/test_basket_reader.py
+++ b/Orange/tests/test_basket_reader.py
@@ -89,6 +89,10 @@ class TestBasketReader(unittest.TestCase):
         table = read_basket(fname)
         self.assertEqual(len(table.domain.variables), 4)
 
+    def test_data_name(self):
+        filename = os.path.join(os.path.dirname(__file__), 'iris_basket.basket')
+        self.assertEqual(read_basket(filename).name, 'iris_basket')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -9,8 +9,9 @@ import shutil
 
 import numpy as np
 
-from Orange.data import Table, ContinuousVariable, DiscreteVariable
+from Orange.data import Table, DiscreteVariable
 from Orange.data.io import TabReader
+
 
 def read_tab_file(filename):
     return TabReader(filename).read()
@@ -152,3 +153,9 @@ class TestTabReader(unittest.TestCase):
         table = Table(path.join(tempdir, "out.tab"))
         self.assertEqual(table.attributes[1], "test")
         shutil.rmtree(tempdir)
+
+    def test_data_name(self):
+        table1 = Table('iris')
+        table2 = TabReader(table1.__file__).read()
+        self.assertEqual(table1.name, 'iris')
+        self.assertEqual(table2.name, 'iris')

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -6,7 +6,7 @@ import os
 
 import numpy as np
 
-from Orange.data import io, ContinuousVariable, DiscreteVariable, StringVariable
+from Orange.data import io, ContinuousVariable, DiscreteVariable
 
 
 def get_dataset(name):
@@ -31,6 +31,7 @@ class TestExcelHeader0(unittest.TestCase):
                                        np.array([[0.1, 0.5, 0.1, 21],
                                                  [0.2, 0.1, 2.5, 123],
                                                  [0, 0, 0, 0]]))
+        self.assertEqual(table.name, 'header_0')
 
 
 class TextExcelSheets(unittest.TestCase):
@@ -45,6 +46,7 @@ class TextExcelSheets(unittest.TestCase):
         self.reader.select_sheet("my_sheet")
         table = self.reader.read()
         self.assertEqual(len(table.domain.attributes), 4)
+        self.assertEqual(table.name, 'header_0_sheet-my_sheet')
 
 
 class TestExcelHeader1(unittest.TestCase):
@@ -94,6 +96,7 @@ class TestExcelHeader1(unittest.TestCase):
         np.testing.assert_almost_equal(
             table.metas[:, 1], np.array([0, 1, 2, 3] * 5 + [0, 1, 2]))
 
+
 class TestExcelHeader3(unittest.TestCase):
     def test_read(self):
         table = read_file("header_3.xlsx")
@@ -129,6 +132,7 @@ class TestExcelHeader3(unittest.TestCase):
             table.metas[:, 1], np.array([0, 1, 2, 3] * 5 + [0, 1, 2]))
         np.testing.assert_equal(
             table.metas[:, 2], np.array(list("abcdefghijklmnopqrstuvw")))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -256,7 +256,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             try:
                 data = self.reader.read()
             except Exception as ex:
-                errors.append("An error occured:")
+                errors.append("An error occurred:")
                 errors.append(str(ex))
                 data = None
                 self.editor_model.reset()


### PR DESCRIPTION
Although Tables should ideally be constructed using Table methods (e.g. from_file), sometimes readers are used directly (as in owfile.py). Currently names are not set properly in that case, leading to 'untitled' datasets.
This changes readers (csv,tab,excel) to return more complete data Tables with names set.



<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
