### PR TITLE
WidgetTests: Create widgets with default settings

### DIFF
--- a/Orange/widgets/classify/tests/test_owrandomforest.py
+++ b/Orange/widgets/classify/tests/test_owrandomforest.py
@@ -43,10 +43,6 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
                 el.name, el.gui_el, lambda x: x.value(),
                 lambda i, x: x.setValue(i), el_min_max, el_min_max)
         self.test_parameters()
-        # FIXME: checkboxes are reset to default, since the widget settings were saved
-        self.widget.max_features_spin[0].setCheckState(False)
-        self.widget.random_state_spin[0].setCheckState(False)
-        self.widget.max_depth_spin[0].setCheckState(False)
 
     def test_parameters_unchecked(self):
         """Check learner and model for various values of all parameters
@@ -57,5 +53,3 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
         self.gui_to_params[4] = GuiToParam(el.name, el.gui_el, lambda x: 2,
                                            lambda i, x: x.setValue(i), [2], [0])
         self.test_parameters()
-        # FIXME: checkboxes are reset to default, since the widget settings were saved
-        self.widget.min_samples_split_spin[0].setCheckState(True)

--- a/Orange/widgets/regression/tests/test_owrandomforestregression.py
+++ b/Orange/widgets/regression/tests/test_owrandomforestregression.py
@@ -44,10 +44,6 @@ class TestOWRandomForestRegression(WidgetTest, WidgetLearnerTestMixin):
                 el.name, el.gui_el, lambda x: x.value(),
                 lambda i, x: x.setValue(i), el_min_max, el_min_max)
         self.test_parameters()
-        # FIXME: checkboxes are reset to default, since the widget settings were saved
-        self.widget.max_features_spin[0].setCheckState(False)
-        self.widget.random_state_spin[0].setCheckState(False)
-        self.widget.max_depth_spin[0].setCheckState(False)
 
     def test_parameters_unchecked(self):
         """Check learner and model for various values of all parameters
@@ -58,5 +54,3 @@ class TestOWRandomForestRegression(WidgetTest, WidgetLearnerTestMixin):
         self.gui_to_params[4] = GuiToParam(el.name, el.gui_el, lambda x: 2,
                                            lambda i, x: x.setValue(i), [2], [0])
         self.test_parameters()
-        # FIXME: checkboxes are reset to default, since the widget settings were saved
-        self.widget.min_samples_split_spin[0].setCheckState(True)

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -102,12 +102,32 @@ class WidgetTest(GuiTest):
         -------
         Widget instance : cls
         """
+        self.reset_default_settings(cls)
         widget = cls.__new__(cls, signal_manager=self.signal_manager,
                              stored_settings=stored_settings)
         widget.__init__()
         self.process_events()
         self.widgets.append(widget)
         return widget
+
+    @staticmethod
+    def reset_default_settings(cls):
+        """Reset default setting values for widget
+
+        Discards settings read from disk and changes stored by fast_save
+
+        Parameters
+        ----------
+        cls : OWWidget
+            widget to reset settings for
+        """
+        settings_handler = getattr(cls, "settingsHandler", None)
+        if settings_handler:
+            # Rebind settings handler to get fresh copies of settings
+            # in known_settings
+            settings_handler.bind(cls)
+            # Reset defaults read from disk
+            settings_handler.defaults = {}
 
     @staticmethod
     def process_events():

--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from Orange.widgets.gui import CONTROLLED_ATTRIBUTES, OWComponent
+from Orange.widgets.settings import Setting
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.widget import OWWidget
 
@@ -10,10 +11,13 @@ class DummyComponent(OWComponent):
 
 
 class MyWidget(OWWidget):
+    name = "Dummy"
+
+    field = Setting(42)
+
     def __init__(self):
         super().__init__()
 
-        self.field = 42
         self.component = DummyComponent(self)
         self.widget = None
 
@@ -69,5 +73,11 @@ class WidgetTestCase(WidgetTest):
 
         self.assertEqual(len(calls), 5)
 
+    def test_widget_tests_do_not_use_stored_settings(self):
+        widget = self.create_widget(MyWidget)
 
+        widget.field = 5
+        widget.saveSettings()
 
+        widget2 = self.create_widget(MyWidget)
+        self.assertEqual(widget2.field, 42)


### PR DESCRIPTION
Reset widget settings to defaults defined in code. This ensures that a
test always gets a widget with (same) default values, regardless of the
order in which the tests are run.