### PR TITLE
[FIX] Gini impurity: formula and docstring fixed.

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -205,9 +205,9 @@ def _entropy(D):
 
 def _gini(D):
     """Gini index of class-distribution matrix"""
-    P = D / np.sum(D, axis=0)
-    return sum((np.ones(1 if len(D.shape) == 1 else D.shape[1]) - np.sum(np.square(P), axis=0))
-               * 0.5 * np.sum(D, axis=0) / np.sum(D))
+    P = np.asarray(D / np.sum(D, axis=0))
+    return np.sum((1 - np.sum(P ** 2, axis=0)) *
+                  np.sum(D, axis=0) / np.sum(D))
 
 
 def _symmetrical_uncertainty(X, Y):
@@ -287,8 +287,9 @@ class GainRatio(ClassificationScorer):
 
 class Gini(ClassificationScorer):
     """
-    Gini index is the probability that two randomly chosen instances will have different
-    classes. See `Wikipedia entry on gini index <http://en.wikipedia.org/wiki/Gini_coefficient>`_.
+    Gini impurity is the probability that two randomly chosen instances will have different
+    classes. See `Wikipedia entry on Gini impurity
+    <https://en.wikipedia.org/wiki/Decision_tree_learning#Gini_impurity>`_.
     """
     def from_contingency(self, cont, nan_adjustment):
         return (_gini(np.sum(cont, axis=1)) - _gini(cont)) * nan_adjustment

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -34,7 +34,7 @@ class FeatureScoringTest(unittest.TestCase):
 
     def test_gini(self):
         scorer = Gini()
-        correct = [0.11893, 0.10427, 0.13117, 0.14650, 0.05973]
+        correct = [0.23786, 0.20855, 0.26235, 0.29300, 0.11946]
         np.testing.assert_almost_equal([scorer(self.zoo, a) for a in range(5)],
                                        correct, decimal=5)
 

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -41,7 +41,7 @@ score_meta = namedtuple(
 SCORES = [
     score_meta("Information Gain", "Inf. gain", score.InfoGain),
     score_meta("Gain Ratio", "Gain Ratio", score.GainRatio),
-    score_meta("Gini Gain", "Gini", score.Gini),
+    score_meta("Gini Decrease", "Gini", score.Gini),
     score_meta("ANOVA", "ANOVA", score.ANOVA),
     score_meta("Chi2", "Chi2", score.Chi2),
     score_meta("Univariate Linear Regression", "Univar. Lin. Reg.", score.UnivariateLinearRegression),


### PR DESCRIPTION
Gini coefficient and Gini impurity are not the same. Docstring fixed to proper Wikipedia source.

As observed in many [sources](https://en.wikipedia.org/wiki/Decision_tree_learning#Gini_impurity), the formula for Gini impurity never contains division by 2. @BlazZupan, please check whether this is the right formula or not.

Also, "Gini" was a misleading attribute name in Rank widget. Here we're actually measuring Gini decrease. So even perhaps "Gini Gain" might not be the right name for this. Comments? @lanzagar @astaric 

Probably some fixes to names should be made elsewhere, too.
