### PR TITLE
[FIX] OWHeatMap: Fix crash when creating an instance of the widget

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1295,8 +1295,12 @@ class OWHeatMap(widget.OWWidget):
             col_clust_msg = "Column clustering was disabled due to the " \
                             "input matrix being to big"
 
-        self.Information.row_clust(row_clust_msg)
-        self.Information.col_clust(col_clust_msg)
+        self.Information.row_clust.clear()
+        self.Information.col_clust.clear()
+        if row_clust_msg:
+            self.Information.row_clust(row_clust_msg)
+        if col_clust_msg:
+            self.Information.col_clust(col_clust_msg)
 
         self.sort_rows = sort_rows
         self.sort_columns = sort_cols

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -459,6 +459,9 @@ class OWHeatMap(widget.OWWidget):
         row_clust = Msg("{}")
         col_clust = Msg("{}")
 
+    class Error(widget.OWWidget.Error):
+        no_continuous = Msg("No continuous feature columns")
+
     def __init__(self):
         super().__init__()
 
@@ -684,7 +687,7 @@ class OWHeatMap(widget.OWWidget):
                        data.domain.metas),
                 data)
             if not data.domain.attributes:
-                self.error("No continuous feature columns")
+                self.Error.no_continuous()
                 input_data = data = None
             else:
                 self.Information.discrete_ignored(

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -17,4 +17,13 @@ class TestOWHeatMap(WidgetTest):
             self.assertEqual(self.widget.data, None)
             self.send_signal("Data", data)
             self.assertEqual(self.widget.data, data)
+            self.assertFalse(self.widget.Error.active)
+            self.assertFalse(self.widget.Warning.active)
+            self.assertFalse(self.widget.Information.active)
             self.send_signal("Data", None)
+
+    def test_error_message(self):
+        self.send_signal("Data", self.titanic)
+        self.assertTrue(self.widget.Error.active)
+        self.send_signal("Data", self.iris)
+        self.assertFalse(self.widget.Error.active)

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -1,0 +1,20 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table
+from Orange.widgets.visualize.owheatmap import OWHeatMap
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWHeatMap(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWHeatMap)
+        self.iris = Table("iris")
+        self.housing = Table("housing")
+
+    def test_input_data(self):
+        """Check widget's data with data on the input"""
+        for data in (self.iris, self.housing):
+            self.assertEqual(self.widget.data, None)
+            self.send_signal("Data", data)
+            self.assertEqual(self.widget.data, data)
+            self.send_signal("Data", None)

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from Orange.data import Table
+from Orange.preprocess import Continuize
 from Orange.widgets.visualize.owheatmap import OWHeatMap
 from Orange.widgets.tests.base import WidgetTest
 
@@ -10,6 +11,7 @@ class TestOWHeatMap(WidgetTest):
         self.widget = self.create_widget(OWHeatMap)
         self.iris = Table("iris")
         self.housing = Table("housing")
+        self.titanic = Table("titanic")
 
     def test_input_data(self):
         """Check widget's data with data on the input"""
@@ -27,3 +29,12 @@ class TestOWHeatMap(WidgetTest):
         self.assertTrue(self.widget.Error.active)
         self.send_signal("Data", self.iris)
         self.assertFalse(self.widget.Error.active)
+
+    def test_information_message(self):
+        self.widget.sort_rows = self.widget.OrderedClustering
+        continuizer = Continuize()
+        cont_titanic = continuizer(self.titanic)
+        self.send_signal("Data", cont_titanic)
+        self.assertTrue(self.widget.Information.active)
+        self.send_signal("Data", self.iris)
+        self.assertFalse(self.widget.Information.active)

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -162,11 +162,12 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, None, cls.get_flags())
         QDialog.__init__(self, None, self.get_flags())
-        WidgetMessagesMixin.__init__(self)
 
         stored_settings = kwargs.get('stored_settings', None)
         if self.settingsHandler:
             self.settingsHandler.initialize(self, stored_settings)
+
+        WidgetMessagesMixin.__init__(self)
 
         self.signalManager = kwargs.get('signal_manager', None)
         self.__env = _asmappingproxy(kwargs.get("env", {}))


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
The widget crashed, because its properties (which use settings) were accessed before the settings were initialized.