### PR TITLE
[FIX] PyTableModel: DisplayRole value presentation

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -149,7 +149,10 @@ class PyTableModel(QAbstractTableModel):
                                           1 if strlen < 5 else
                                           0 if strlen < 6 else
                                           3,
-                                          'f' if strlen < 6 and absval >= .001 else 'e')
+                                          'f' if (absval == 0 or
+                                                  absval >= .001 and
+                                                  strlen < 6)
+                                          else 'e')
             return str(value)
         if role == Qt.TextAlignmentRole and isinstance(value, Number):
             return Qt.AlignRight | Qt.AlignVCenter


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

When data is requested (and DisplayRole forwarded), value presentation is now correct & consistent, even if abs(value) equals to 0. This handles a display bug (consequently, no tests are included).