### PR TITLE
Created `__repr__` functions for some preprocessors

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -210,10 +210,11 @@ class SklLearner(Learner, metaclass=WrapperMeta):
     _params = {}
 
     name = 'skl learner'
-    preprocessors = [RemoveNaNClasses(),
-                     Continuize(),
-                     RemoveNaNColumns(),
-                     SklImpute()]
+    preprocessors = default_preprocessors = [
+        RemoveNaNClasses(),
+        Continuize(),
+        RemoveNaNColumns(),
+        SklImpute()]
 
     @property
     def params(self):
@@ -262,9 +263,14 @@ class SklLearner(Learner, metaclass=WrapperMeta):
         return '{} {}'.format(self.name, self.params)
 
     def __repr__(self):
-        return '{}({})'.format(type(self).__name__,
-                               ", ".join("{}={}".format(k, v)
-                                         for k, v in self.params.items()))
+        return '{}({}{})'.format(type(self).__name__,
+                               ", ".join("{}={}".format(k, repr(v))
+                                         for k, v in self.params.items()),
+                                "{}preprocessors={}".format(
+                                    ", " if len(self.params.items()) > 0
+                                        else "",
+                                    repr(self.preprocessors)
+                                ))
 
     @property
     def supports_weights(self):

--- a/Orange/data/filter.py
+++ b/Orange/data/filter.py
@@ -24,6 +24,14 @@ class Filter:
     def __call__(self, data):
         return
 
+    def __repr__(self):
+        args = self.__class__.__init__.__code__.co_varnames
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join("{}={}".format(arg, repr(getattr(self, arg))) for i, arg in enumerate(args) if
+                arg != "self" and self.__class__.__init__.__defaults__[i-1] != getattr(self, arg))
+        )
+
 
 class IsDefined(Filter):
     """
@@ -376,8 +384,6 @@ class FilterContinuous(ValueFilter):
         if self.oper == self.IsDefined:
             return "{} is defined".format(column)
         return "invalid operator"
-
-    __repr__ = __str__
 
 
     # For PyCharm:

--- a/Orange/preprocess/__init__.py
+++ b/Orange/preprocess/__init__.py
@@ -1,5 +1,5 @@
 from .continuize import *
-from .discretize import DomainDiscretizer
+from .discretize import *
 from .fss import *
 from .impute import *
 from .normalize import *

--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -98,6 +98,14 @@ class Discretization:
             "Subclasses of 'Discretization' need to implement "
             "the call operator")
 
+    def __repr__(self):
+        args = self.__class__.__init__.__code__.co_varnames
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join("{}={}".format(arg, repr(getattr(self, arg))) for i, arg in enumerate(args) if
+                arg != "self" and self.__class__.__init__.__defaults__[i-1] != getattr(self, arg))
+        )
+
 
 class EqualFreq(Discretization):
     """Discretization into bins with approximately equal number of data
@@ -126,7 +134,6 @@ class EqualFreq(Discretization):
             points = _discretize.split_eq_freq(d, self.n)
         return Discretizer.create_discretized_var(
             data.domain[attribute], points)
-
 
 class EqualWidth(Discretization):
     """Discretization into a fixed number of bins with equal widths.

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -8,7 +8,6 @@ from operator import itemgetter
 
 from Orange.preprocess.preprocess import Preprocess
 from Orange.preprocess.score import ANOVA, GainRatio, UnivariateLinearRegression
-from Orange.data import Domain
 
 __all__ = ["SelectBestFeatures", "RemoveNaNColumns", "SelectRandomFeatures"]
 
@@ -89,6 +88,15 @@ class SelectBestFeatures:
                                     data.domain.class_vars, data.domain.metas)
         return data.from_table(domain, data)
 
+    def __repr__(self):
+        args = self.__class__.__init__.__code__.co_varnames
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join("{}={}".format(arg, repr(getattr(self, arg))) for i, arg in enumerate(args) if
+                arg != "self" and self.__class__.__init__.__defaults__[i-1] != getattr(self, arg))
+        )
+
+
     def score_only_nice_features(self, data, method):
         mask = np.array([isinstance(a, method.feature_type)
                          for a in data.domain.attributes])
@@ -127,6 +135,8 @@ class SelectRandomFeatures:
             data.domain.class_vars, data.domain.metas)
         return data.from_table(domain, data)
 
+    __repr__ = SelectBestFeatures.__repr__
+
 
 class RemoveNaNColumns(Preprocess):
     """
@@ -155,3 +165,5 @@ class RemoveNaNColumns(Preprocess):
         domain = Orange.data.Domain(att, data.domain.class_vars,
                                     data.domain.metas)
         return Orange.data.Table(domain, data)
+
+    __repr__ = SelectBestFeatures.__repr__

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -4,7 +4,7 @@ import Orange.data
 from Orange.statistics import distribution, basic_stats
 from .transformation import Transformation, Lookup
 
-__all__ = ["ReplaceUnknowns", "Average", "DoNotImpute", 'DropInstances',
+__all__ = ["ReplaceUnknowns", "Average", "DoNotImpute", "DropInstances",
            "Model", "AsValue", "Random", "Default"]
 
 
@@ -69,6 +69,9 @@ class DoNotImpute(BaseImputeMethod):
     def __call__(self, data, variable):
         return variable
 
+    def __repr__(self):
+        return "DoNotImpute()"
+
 
 class DropInstances(BaseImputeMethod):
     name = "Remove instances with unknown values"
@@ -78,6 +81,9 @@ class DropInstances(BaseImputeMethod):
     def __call__(self, data, variable):
         index = data.domain.index(variable)
         return numpy.isnan(data[:, index]).reshape(-1)
+
+    def __repr__(self):
+        return "DropInstances()"
 
 
 class Average(BaseImputeMethod):
@@ -101,6 +107,9 @@ class Average(BaseImputeMethod):
         a.to_sql = ImputeSql(variable, value)
         return a
 
+    def __repr__(self):
+        return "Average()"
+
 
 class ImputeSql:
     def __init__(self, var, default):
@@ -109,6 +118,9 @@ class ImputeSql:
 
     def __call__(self):
         return 'coalesce(%s, %s)' % (self.var.to_sql(), str(self.default))
+
+    def __repr__(self):
+        return "ImputeSql()"
 
 
 class Default(BaseImputeMethod):
@@ -128,6 +140,9 @@ class Default(BaseImputeMethod):
 
     def copy(self):
         return Default(self.default)
+
+    def __repr__(self):
+        return "Default()"
 
 
 class ReplaceUnknownsModel:
@@ -163,6 +178,9 @@ class ReplaceUnknownsModel:
             predicted = self.model(data[mask])
         column[mask] = predicted
         return column
+
+    def __repr__(self):
+        return "ReplaceUnknownsModel()"
 
 
 class Model(BaseImputeMethod):

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -9,12 +9,14 @@ import bottleneck as bn
 
 import Orange.data
 from Orange.data import Table
-from . import impute, discretize
+from Orange.statistics import distribution
+from . import impute, discretize, transformation
 from ..misc.enum import Enum
+
 
 __all__ = ["Continuize", "Discretize", "Impute", "SklImpute",
            "Normalize", "Randomize", "RemoveNaNClasses",
-           "ProjectPCA", "ProjectCUR"]
+           "ProjectPCA", "ProjectCUR", "Scaling"]
 
 
 class Preprocess:
@@ -40,6 +42,14 @@ class Preprocess:
 
     def __call__(self, data):
         raise NotImplementedError("Subclasses need to implement __call__")
+
+    def __repr__(self):
+        args = self.__class__.__init__.__code__.co_varnames
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join("{}={}".format(arg, repr(getattr(self, arg))) for i, arg in enumerate(args) if
+                arg != "self" and self.__class__.__init__.__defaults__[i-1] != getattr(self, arg))
+        )
 
 
 class Continuize(Preprocess):
@@ -395,6 +405,73 @@ class ProjectCUR(Preprocess):
         )(data)
         return cur(data)
 
+class Scaling(Preprocess):
+    """
+    Scale data preprocessor.
+    """
+    @staticmethod
+    def mean(dist):
+        values, counts = np.array(dist)
+        return np.average(values, weights=counts)
+
+    @staticmethod
+    def median(dist):
+        values, counts = np.array(dist)
+        cumdist = np.cumsum(counts)
+        if cumdist[-1] > 0:
+            cumdist /= cumdist[-1]
+
+        return np.interp(0.5, cumdist, values)
+
+    @staticmethod
+    def span(dist):
+        values = np.array(dist[0])
+        minval = np.min(values)
+        maxval = np.max(values)
+        return maxval - minval
+
+    @staticmethod
+    def std(dist):
+        values, counts = np.array(dist)
+        mean = np.average(values, weights=counts)
+        diff = values - mean
+        return np.sqrt(np.average(diff ** 2, weights=counts))
+
+    def __init__(self, center=mean.__func__, scale=std.__func__):
+        self.center = center
+        self.scale = scale
+
+    def __call__(self, data):
+        if self.center is None and self.scale is None:
+            return data
+
+        def transform(var):
+            dist = distribution.get_distribution(data, var)
+            if self.center:
+                c = self.center(dist)
+                dist[0, :] -= c
+            else:
+                c = 0
+
+            if self.scale:
+                s = self.scale(dist)
+                if s < 1e-15:
+                    s = 1
+            else:
+                s = 1
+            factor = 1 / s
+            return var.copy(compute_value=transformation.Normalizer(var, c, factor))
+
+        newvars = []
+        for var in data.domain.attributes:
+            if var.is_continuous:
+                newvars.append(transform(var))
+            else:
+                newvars.append(var)
+        domain = Orange.data.Domain(newvars, data.domain.class_vars,
+                                    data.domain.metas)
+        return data.from_table(domain, data)
+
 
 class PreprocessorList:
     """
@@ -422,3 +499,9 @@ class PreprocessorList:
             data = pp(data)
         return data
 
+    def __repr__(self):
+        repstr = "PreprocessorList(["
+        for preproc in self.preprocessors:
+            repstr +=  repr(preproc) + ", "
+        repstr += "])"
+        return repstr

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -58,6 +58,14 @@ class Scorer:
 
         return self.score_data(data, feature)
 
+    def __repr__(self):
+        args = self.__class__.__init__.__code__.co_varnames
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join("{}={}".format(arg, repr(getattr(self, arg))) for i, arg in enumerate(args) if
+                arg != "self" and self.__class__.__init__.__defaults__[i-1] != getattr(self, arg))
+        )
+
     def score_data(self, data, feature):
         raise NotImplementedError
 

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -378,6 +378,18 @@ class DomainContinuizer:
         )
         return newdomain
 
+    def __repr__(self):
+        return "DomainContinuizer({}{}{}{})".format(
+            "zero_based=False, ".format(self.zero_based) if not
+                self.zero_based else "",
+            "multinomial_treatment=Continuize.{}, ".format(repr(self.multinomial_treatment)) if
+                self.multinomial_treatment != Continuize.Indicators else "",
+            "continuous_treatment=Continuize.{}, ".format(repr(self.continuous_treatment)) if
+                self.continuous_treatment != Continuize.Leave else "",
+            "class_treatment=Continuize.{}, ".format(repr(self.class_treatment)) if
+                self.class_treatment != Continuize.Leave else ""
+        )
+
 
 if __name__ == "__main__":
     import sys

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -212,6 +212,7 @@ class OWDataSampler(widget.OWWidget):
         self.send("Data Sample", sample)
         self.send("Remaining Data", other)
 
+
     def updateindices(self):
         err_msg = ""
         repl = True
@@ -248,20 +249,18 @@ class OWDataSampler(widget.OWWidget):
                       type(self.data) == Table and
                       self.data.domain.has_discrete_class)
         if self.sampling_type == self.FixedSize:
-            self.indices = sample_random_n(
-                self.data, size,
-                stratified=stratified, replace=self.replacement,
+            self.indice_gen = sample_random_n(
+                size, stratified=stratified, replace=self.replacement,
                 random_state=rnd)
         elif self.sampling_type == self.FixedProportion:
-            self.indices = sample_random_p(
-                self.data, self.sampleSizePercentage / 100,
-                stratified=stratified, random_state=rnd)
+            self.indice_gen = sample_random_p(
+                self.sampleSizePercentage / 100, stratified=stratified, random_state=rnd)
         elif self.sampling_type == self.Bootstrap:
-            self.indices = sample_bootstrap(data_length, random_state=rnd)
+            self.indice_gen = sample_bootstrap(data_length, random_state=rnd)
         else:
-            self.indices = sample_fold_indices(
-                self.data, self.number_of_folds, stratified=stratified,
-                random_state=rnd)
+            self.indice_gen = sample_fold_indices(
+                self.number_of_folds, stratified=stratified, random_state=rnd)
+        self.indices = self.indice_gen(self.data)
 
     def send_report(self):
         if self.sampling_type == self.FixedProportion:
@@ -294,62 +293,101 @@ class OWDataSampler(widget.OWWidget):
         self.report_items(items)
 
 
-def sample_fold_indices(table, folds=10, stratified=False, random_state=None):
-    """
-    :param Orange.data.Table table:
-    :param int folds: Number of folds
-    :param bool stratified: Return stratified indices (if applicable).
-    :param Random random_state:
-    :rval tuple-of-arrays: A tuple of array indices one for each fold.
-    """
-    if stratified and table.domain.has_discrete_class:
-        # XXX: StratifiedKFold does not support random_state
-        ind = skl_cross_validation.StratifiedKFold(
-            table.Y.ravel(), folds, random_state=random_state)
-    else:
-        ind = skl_cross_validation.KFold(
-            len(table), folds, shuffle=True, random_state=random_state)
-    return tuple(ind)
+class sample_fold_indices():
+    def __init__(self, folds=10, stratified=False, random_state=None):
+        """
+        :param int folds: Number of folds
+        :param bool stratified: Return stratified indices (if applicable).
+        :param Random random_state:
+        :rval tuple-of-arrays: A tuple of array indices one for each fold.
+        """
+        self.folds = folds
+        self.stratified = stratified
+        self.random_state = random_state
 
-
-def sample_random_n(table, n, stratified=False, replace=False,
-                    random_state=None):
-    if replace:
-        if random_state is None:
-            rgen = np.random
+    def __call__(self, table):
+        if self.stratified and table.domain.has_discrete_class:
+            # XXX: StratifiedKFold does not support random_state
+            ind = skl_cross_validation.StratifiedKFold(
+                table.Y.ravel(), self.folds, random_state=self.random_state)
         else:
-            rgen = np.random.mtrand.RandomState(random_state)
-        sample = rgen.random_integers(0, len(table) - 1, n)
-        o = np.ones(len(table))
-        o[sample] = 0
-        others = np.nonzero(o)[0]
-        return others, sample
-    if stratified and table.domain.has_discrete_class:
-        test_size = max(len(table.domain.class_var.values), n)
-        ind = skl_cross_validation.StratifiedShuffleSplit(
-            table.Y.ravel(), n_iter=1,
-            test_size=test_size, train_size=len(table) - test_size,
-            random_state=random_state)
-    else:
-        ind = skl_cross_validation.ShuffleSplit(
-            len(table), n_iter=1,
-            test_size=n, random_state=random_state)
-    return next(iter(ind))
+            ind = skl_cross_validation.KFold(
+                len(table), self.folds, shuffle=True, random_state=self.random_state)
+        return tuple(ind)
+
+    def __repr__(self):
+        args = self.__class__.__init__.__code__.co_varnames
+        return "{}({})".format(
+            self.__class__.__name__,
+            ", ".join("{}={}".format(arg, repr(getattr(self, arg))) for i, arg in enumerate(args) if
+                arg != "self" and self.__class__.__init__.__defaults__[i-1] != getattr(self, arg))
+        )
 
 
-def sample_random_p(table, p, stratified=False, random_state=None):
-    n = int(math.ceil(len(table) * p))
-    return sample_random_n(table, n, stratified, False, random_state)
+class sample_random_n():
+    def __init__(self, n, stratified=False, replace=False,
+                    random_state=None):
+        self.n = n
+        self.stratified = stratified
+        self.replace = replace
+        self.random_state = random_state
+
+    def __call__(self, table):
+        if self.replace:
+            if self.random_state is None:
+                rgen = np.random
+            else:
+                rgen = np.random.mtrand.RandomState(random_state)
+            sample = rgen.random_integers(0, len(table) - 1, self.n)
+            o = np.ones(len(table))
+            o[sample] = 0
+            others = np.nonzero(o)[0]
+            return others, sample
+        if self.stratified and table.domain.has_discrete_class:
+            test_size = max(len(table.domain.class_var.values), self.n)
+            ind = skl_cross_validation.StratifiedShuffleSplit(
+                table.Y.ravel(), n_iter=1,
+                test_size=test_size, train_size=len(table) - test_size,
+                random_state=self.random_state)
+        else:
+            ind = skl_cross_validation.ShuffleSplit(
+                len(table), n_iter=1,
+                test_size=self.n, random_state=self.random_state)
+
+        return next(iter(ind))
+
+    __repr__ =  sample_fold_indices.__repr__
 
 
-def sample_bootstrap(size, random_state=None):
-    rgen = np.random.RandomState(random_state)
-    sample = rgen.randint(0, size, size)
-    sample.sort()  # not needed for the code below, just for the user
-    insample = np.ones((size,), dtype=np.bool)
-    insample[sample] = False
-    remaining = np.flatnonzero(insample)
-    return remaining, sample
+class sample_random_p():
+    def __init__(self, p, stratified=False, random_state=None):
+        self.p = p
+        self.stratified = stratified
+        self.random_state = random_state
+
+    def __call__(self, table):
+        n = int(math.ceil(len(table) * self.p))
+        return sample_random_n(self.table, self.n,
+            self.stratified, False, self.random_state)
+
+    __repr__ = sample_fold_indices.__repr__
+
+
+def sample_bootstrap():
+    def __init__(self, size, random_state=None):
+        self.size = size
+        self.random_state = random_state
+
+    def __call__(self):
+        rgen = np.random.RandomState(self.random_state)
+        sample = rgen.randint(0, self.size, self.size)
+        sample.sort()  # not needed for the code below, just for the user
+        insample = np.ones((self.size,), dtype=np.bool)
+        insample[sample] = False
+        remaining = np.flatnonzero(insample)
+        return remaining, sample
+
+    __repr__ = sample_fold_indices.__repr__
 
 
 def test_main():

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -389,10 +389,10 @@ class OWSelectRows(widget.OWWidget):
                 conditions.append(filter)
 
             if conditions:
-                filters = data_filter.Values(conditions)
-                matching_output = filters(self.data)
-                filters.negate = True
-                non_matching_output = filters(self.data)
+                self.filters = data_filter.Values(conditions)
+                matching_output = self.filters(self.data)
+                self.filters.negate = True
+                non_matching_output = self.filters(self.data)
 
             # if hasattr(self.data, "name"):
             #     matching_output.name = self.data.name

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -193,6 +193,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
                 self.valid_data = True
         return self.valid_data
 
+
     def settings_changed(self, *args, **kwargs):
         self.outdated_settings = True
         self.warning(self.OUTDATED_LEARNER_WARNING_ID,


### PR DESCRIPTION
This commit creates `__repr__` functions for the majority of Orange's learner and preprocessor classes.  It uses standardized and generic functions wherever possible.  These changes pave the way for my code generator (PR upcoming), which makes extensive use of these functions to create runnable Python scripts based on the contents of the workflow.

I moved some data processing functions out of widget code and into more appropriate directories, updating the widget code as appropriate.  I converted some functions to classes in order to make them more similar to others and created __repr__ functions for them as well.  Their usages were updated accordingly.  I then squashed all commits into a single commit.

All tests are passing (except those that weren't passing before) and the linter doesn't show anything significant caused by this commit.  As far as I can tell, this commit is ready to merge and completely working.  If any changes need to be made, please let me know.