### PR TITLE
[FIX] Predictions: column size hint

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -286,7 +286,13 @@ class OWPredictions(widget.OWWidget):
         predmodel.setDynamicSortFilter(True)
         self.predictionsview.setItemDelegate(PredictionsItemDelegate())
         self.predictionsview.setModel(predmodel)
-        self.predictionsview.horizontalHeader().setSortIndicatorShown(False)
+        hheader = self.predictionsview.horizontalHeader()
+        hheader.setSortIndicatorShown(False)
+        # SortFilterProxyModel is slow due to large abstraction overhead
+        # (every comparison triggers multiple `model.index(...)`,
+        # model.rowCount(...), `model.parent`, ... calls)
+        hheader.setClickable(predmodel.rowCount() < 20000)
+
         predmodel.layoutChanged.connect(self._update_data_sort_order)
         self._update_data_sort_order()
         self.predictionsview.resizeColumnsToContents()


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Reimplement sizeHintForColumn

The default QTableView.sizeHintForColumn can iterate over the entire
model's contents, which can be unforgivingly slow for large models.
In particular this happens when the `sizeHintForColumn` is called while
the view is not visible.
