### PR TITLE
[ENH] Enable Ward clustering in Hierarchical clustering widget 

### DIFF
--- a/Orange/clustering/hierarchical.py
+++ b/Orange/clustering/hierarchical.py
@@ -392,12 +392,11 @@ def top_clusters(tree, k):
     heap = [item(tree)]
 
     while len(heap) < k:
-        key, cl = heapq.heappop(heap)
+        _, cl = heap[0]  # peek
         if cl.is_leaf:
             assert all(n.is_leaf for _, n in heap)
-            heapq.heappush(heap, (key, cl))
             break
-
+        key, cl = heapq.heappop(heap)
         left, right = cl.left, cl.right
         heapq.heappush(heap, item(left))
         heapq.heappush(heap, item(right))

--- a/Orange/clustering/hierarchical.py
+++ b/Orange/clustering/hierarchical.py
@@ -1,10 +1,14 @@
 from collections import namedtuple, deque
 from operator import attrgetter
 from itertools import chain, count
+from distutils.version import LooseVersion as _LooseVersion
+
 import heapq
 import numpy
 
 import scipy.cluster.hierarchy
+import scipy.spatial.distance
+
 from Orange.distance import Euclidean, PearsonR
 
 __all__ = ['HierarchicalClustering']
@@ -14,6 +18,15 @@ AVERAGE = "average"
 COMPLETE = "complete"
 WEIGHTED = "weighted"
 WARD = "ward"
+
+
+# Prior to 0.18 scipy.cluster.hierarchical's python interface disallowed
+# ward clustering from a precomputed distance matrix even though it's cython
+# implementation allowed it and was documented to support it (scipy issue 5220)
+_HAS_WARD_LINKAGE_FROM_DIST = \
+    _LooseVersion(scipy.__version__) >= _LooseVersion("0.18") and \
+    hasattr(scipy.cluster.hierarchy, "_hierarchy") and \
+    hasattr(scipy.cluster.hierarchy._hierarchy, "nn_chain")
 
 
 def condensedform(X, mode="upper"):
@@ -86,7 +99,23 @@ def dist_matrix_linkage(matrix, linkage=AVERAGE):
     """
     # Extract compressed upper triangular distance matrix.
     distances = condensedform(matrix)
-    return scipy.cluster.hierarchy.linkage(distances, method=linkage)
+    if linkage == WARD and not _HAS_WARD_LINKAGE_FROM_DIST:
+        # Avoid `scipy.cluster.hierarchy.linkage` and dispatch to it's
+        # cython implementation directly.
+        # This the core of the scipy.cluster.hierarchy.linkage in
+        # scipy 0.16, 0.17. Assuming the branches are in bug fix mode
+        # only so this interface will not change.
+        y = numpy.asarray(distances, dtype=float)
+        scipy.spatial.distance.is_valid_y(y, throw=True)
+        N = scipy.spatial.distance.num_obs_y(y)
+        # allocate the output linkage matrix
+        Z = numpy.zeros((N - 1, 4))
+        # retrieve the correct method flag
+        method = scipy.cluster.hierarchy._cpy_euclid_methods["ward"]
+        scipy.cluster.hierarchy._hierarchy.linkage(y, Z, int(N), int(method))
+        return Z
+    else:
+        return scipy.cluster.hierarchy.linkage(distances, method=linkage)
 
 
 def dist_matrix_clustering(matrix, linkage=AVERAGE):
@@ -96,9 +125,7 @@ def dist_matrix_clustering(matrix, linkage=AVERAGE):
     :param Orange.misc.DistMatrix matrix:
     :param str linkage:
     """
-    # Extract compressed upper triangular distance matrix.
-    distances = condensedform(matrix)
-    Z = scipy.cluster.hierarchy.linkage(distances, method=linkage)
+    Z = dist_matrix_linkage(matrix, linkage=linkage)
     return tree_from_linkage(Z)
 
 

--- a/Orange/clustering/hierarchical.py
+++ b/Orange/clustering/hierarchical.py
@@ -19,14 +19,16 @@ COMPLETE = "complete"
 WEIGHTED = "weighted"
 WARD = "ward"
 
+# Does scipy implement a O(n**2) NN chain algorithm?
+_HAS_NN_CHAIN = hasattr(scipy.cluster.hierarchy, "_hierarchy") and \
+                hasattr(scipy.cluster.hierarchy._hierarchy, "nn_chain")
 
 # Prior to 0.18 scipy.cluster.hierarchical's python interface disallowed
 # ward clustering from a precomputed distance matrix even though it's cython
 # implementation allowed it and was documented to support it (scipy issue 5220)
 _HAS_WARD_LINKAGE_FROM_DIST = \
     _LooseVersion(scipy.__version__) >= _LooseVersion("0.18") and \
-    hasattr(scipy.cluster.hierarchy, "_hierarchy") and \
-    hasattr(scipy.cluster.hierarchy._hierarchy, "nn_chain")
+    _HAS_NN_CHAIN
 
 
 def condensedform(X, mode="upper"):

--- a/Orange/tests/test_clustering_hierarchical.py
+++ b/Orange/tests/test_clustering_hierarchical.py
@@ -77,6 +77,9 @@ class TestHierarchical(unittest.TestCase):
         self.assertEqual(len(top), len(self.matrix))
         self.assertTrue(all(n.is_leaf for n in top))
 
+        top1 = hierarchical.top_clusters(self.cluster, len(self.matrix) + 1)
+        self.assertEqual(top1, top)
+
     def test_form(self):
         m = [[0, 2, 3, 4],
              [2, 0, 6, 7],

--- a/Orange/tests/test_clustering_hierarchical.py
+++ b/Orange/tests/test_clustering_hierarchical.py
@@ -70,6 +70,13 @@ class TestHierarchical(unittest.TestCase):
         pruned = hierarchical.prune(self.cluster, height=10)
         self.assertTrue(c.height >= 10 for c in hierarchical.preorder(pruned))
 
+        top = hierarchical.top_clusters(self.cluster, 3)
+        self.assertEqual(len(top), 3)
+
+        top = hierarchical.top_clusters(self.cluster, len(self.matrix))
+        self.assertEqual(len(top), len(self.matrix))
+        self.assertTrue(all(n.is_leaf for n in top))
+
     def test_form(self):
         m = [[0, 2, 3, 4],
              [2, 0, 6, 7],
@@ -116,6 +123,14 @@ class TestHierarchical(unittest.TestCase):
         score_ordered = score(ordered)
         self.assertGreater(score_unordered, score_ordered)
         self.assertEqual(score_ordered, 21.0)
+
+    def test_table_clustering(self):
+        table = Orange.data.Table(numpy.eye(3))
+        tree = hierarchical.data_clustering(table, linkage="single")
+        numpy.testing.assert_almost_equal(tree.value.height, numpy.sqrt(2))
+
+        tree = hierarchical.feature_clustering(table)
+        numpy.testing.assert_almost_equal(tree.value.height, 0.75)
 
 
 class TestTree(unittest.TestCase):

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -263,7 +263,10 @@ class OWDistanceMap(widget.OWWidget):
     graph_name = "grid_widget"
 
     # Disable clustering for inputs bigger than this
-    _MaxClustering = 3000
+    if hierarchical._HAS_NN_CHAIN:
+        _MaxClustering = 25000
+    else:
+        _MaxClustering = 3000
 
     # Disable cluster leaf ordering for inputs bigger than this
     _MaxOrderedClustering = 1000

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -3,11 +3,9 @@ import sys
 
 from collections import namedtuple, OrderedDict
 from itertools import chain
-from functools import reduce
 from contextlib import contextmanager
 
 import numpy
-import scipy.cluster.hierarchy
 
 from PyQt4.QtGui import (
     QGraphicsWidget, QGraphicsObject, QGraphicsLinearLayout, QGraphicsPathItem,
@@ -26,7 +24,8 @@ import Orange.data
 from Orange.data.domain import filter_visible
 import Orange.misc
 from Orange.clustering.hierarchical import \
-    postorder, preorder, Tree, tree_from_linkage, leaves, prune, top_clusters
+    postorder, preorder, Tree, tree_from_linkage, dist_matrix_linkage, \
+    leaves, prune, top_clusters
 
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils import colorpalette, itemmodels
@@ -34,11 +33,8 @@ from Orange.widgets.io import FileFormat
 
 __all__ = ["OWHierarchicalClustering"]
 
-# In scipy 0.14 ward linkage cannot be computed from the distance
-# matrix alone, it requires the full data matrix (in 0.15 the whole
-# hierarchical clustering is/will be reimplemented and from the
-# looks of it will support ward from dist matrix).
-LINKAGE = ["Single", "Average", "Weighted", "Complete"]
+
+LINKAGE = ["Single", "Average", "Weighted", "Complete", "Ward"]
 
 
 def dendrogram_layout(tree, expand_leaves=False):
@@ -1003,14 +999,9 @@ class OWHierarchicalClustering(widget.OWWidget):
         distances = self.matrix
 
         if distances is not None:
-            # Convert to flat upper triangular distances
-            i, j = numpy.triu_indices(distances.shape[0], k=1)
-            distances = numpy.asarray(distances[i, j])
-
             method = LINKAGE[self.linkage].lower()
-            Z = scipy.cluster.hierarchy.linkage(
-                distances, method=method
-            )
+            Z = dist_matrix_linkage(distances, linkage=method)
+
             tree = tree_from_linkage(Z)
             self.linkmatrix = Z
             self.root = tree

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -27,6 +27,7 @@ from Orange.widgets.io import FileFormat
 
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
     DendrogramWidget
+
 from Orange.widgets.widget import Msg
 
 
@@ -398,7 +399,10 @@ class OWHeatMap(widget.OWWidget):
         (OrderedClustering, "Clustering with leaf ordering")
     ]
     # Disable clustering for inputs bigger than this
-    _MaxClustering = 3000
+    if hierarchical._HAS_NN_CHAIN:
+        _MaxClustering = 25000
+    else:
+        _MaxClustering = 3000
 
     # Disable cluster leaf ordering for inputs bigger than this
     _MaxOrderedClustering = 1000


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
* Enable ward clustering in Hierarchical clustering widget
* Implement a workaround for scipy's input checking in scipy.cluster.hierarchy.linkage in scipy 0.16 and 0.17 (scipy issue 5220)
* Adjust limits for clustering in 'Distance map' and 'Heatmap' widgets.