### PR TITLE
Changes to widget descriptions.

### DIFF
--- a/Orange/canvas/registry/description.py
+++ b/Orange/canvas/registry/description.py
@@ -198,9 +198,6 @@ class WidgetDescription(object):
         version.
     description : str, optional
         A short description of the widget, suitable for a tool tip.
-    long_description : str, optional
-        A longer description of the widget, suitable for a 'what's this?'
-        role.
     qualified_name : str
         A qualified name (import name) of the class implementing the widget.
     package : str, optional
@@ -229,7 +226,7 @@ class WidgetDescription(object):
 
     """
     def __init__(self, name, id, category=None, version=None,
-                 description=None, long_description=None,
+                 description=None,
                  qualified_name=None, package=None, project_name=None,
                  inputs=[], outputs=[],
                  help=None, help_ref=None, url=None, keywords=None,
@@ -247,7 +244,6 @@ class WidgetDescription(object):
         self.category = category
         self.version = version
         self.description = description
-        self.long_description = long_description
         self.qualified_name = qualified_name
         self.package = package
         self.project_name = project_name
@@ -307,14 +303,7 @@ class WidgetDescription(object):
             raise WidgetSpecificationError
 
         qualified_name = "%s.%s" % (module.__name__, widget_cls_name)
-        long_description = (
-            widget_class.long_description or
-            widget_class.__doc__ or
-            "").strip()
-        description = (
-            widget_class.description or
-            long_description and long_description.split("\n\n")[0]).strip()
-
+        description = widget_class.description
         inputs = [input_channel_from_args(input_) for input_ in
                   widget_class.inputs]
         outputs = [output_channel_from_args(output) for output in
@@ -333,7 +322,6 @@ class WidgetDescription(object):
             category=widget_class.category or default_cat_name,
             version=widget_class.version,
             description=description,
-            long_description=long_description,
             qualified_name=qualified_name,
             package=module.__package__,
             inputs=inputs,

--- a/Orange/canvas/registry/qt.py
+++ b/Orange/canvas/registry/qt.py
@@ -335,15 +335,11 @@ def whats_this_helper(desc, include_more_link=False):
         help_url = "help://search?" + urlencode({"id": desc.qualified_name})
 
     description = desc.description
-    long_description = desc.long_description
 
     template = ["<h3>{0}</h3>".format(escape(title))]
 
     if description:
         template.append("<p>{0}</p>".format(escape(description)))
-
-    if long_description:
-        template.append("<p>{0}</p>".format(escape(long_description[:100])))
 
     if help_url and include_more_link:
         template.append("<a href='{0}'>more...</a>".format(escape(help_url)))

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -275,14 +275,8 @@ class ContinuousTable(ColorTable):
 
 
 class OWColor(widget.OWWidget):
-    """
-    Set color legend for variables
-
-    Widget for defining specific color palettes for discrete and continuous
-    features
-    """
-
     name = "Color"
+    description = "Set color legend for variables."
     icon = "icons/Colors.svg"
     inputs = [("Data", Orange.data.Table, "set_data")]
     outputs = [("Data", Orange.data.Table)]

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -68,8 +68,8 @@ class XlsContextHandler(ContextHandler):
 class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     name = "File"
     id = "orange.widgets.data.file"
-    description = "Read a data from an input file or network " \
-                  "and send the data table to the output."
+    description = "Read data from an input file or network " \
+                  "and send a data table to the output."
     icon = "icons/File.svg"
     priority = 10
     category = "Data"

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -758,7 +758,6 @@ class OWPaintData(OWWidget):
 
     name = "Paint Data"
     description = "Create data by painting data points on a plane."
-    long_description = ""
     icon = "icons/PaintData.svg"
     priority = 15
     keywords = ["data", "paint", "create"]

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -21,10 +21,7 @@ EXTENSIONS = ('tsm_system_time', 'quantile')
 class OWSql(OWWidget):
     name = "SQL Table"
     id = "orange.widgets.data.sql"
-    description = """
-    Load dataset from SQL."""
-    long_description = """
-    Sql widget connects to server and opens data from there. """
+    description = "Load data set from SQL."
     icon = "icons/SQLTable.svg"
     priority = 10
     category = "Data"

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -52,11 +52,9 @@ class SieveRank(VizRankDialogAttrPair):
 
 
 class OWSieveDiagram(OWWidget):
-    """
-    A two-way contingency table providing information on the relation
-    between the observed and expected frequencies of a combination of values
-    """
     name = "Sieve Diagram"
+    description = "Visualize the observed and expected frequencies " \
+                  "for a combination of values."
     icon = "icons/SieveDiagram.svg"
     priority = 310
 

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -26,7 +26,8 @@ from Orange.widgets.widget import Msg
 
 class OWSilhouettePlot(widget.OWWidget):
     name = "Silhouette Plot"
-    description = "Silhouette Plot"
+    description = "Visually assess cluster quality and " \
+                  "the degree of cluster membership."
 
     icon = "icons/SilhouettePlot.svg"
     priority = 510

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -88,8 +88,6 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
     #: Short widget description (:class:`str` optional), displayed in
     #: canvas help tooltips.
     description = None
-    #: A longer widget description (:class:`str` optional)
-    long_description = None
     #: Widget icon path relative to the defining module
     icon = "icons/Unknown.png"
     #: Widget priority used for sorting within a category


### PR DESCRIPTION
As discussed with @janezd, I'm introducing standard widget descriptions that get displayed in canvas. Now only `description `variable gets displayed - it needs to be short and telling. `long_description `is no longer displayed but remains in the code. This also somehow prevents showing docstrings, which is good. 