### PR TITLE
[FIX] Confusion matrix: fix selected_learner setting

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -250,7 +250,6 @@ class OWConfusionMatrix(widget.OWWidget):
 
             self._init_table(len(class_values))
             self.openContext(data.domain.class_var)
-            print("ZZZ", prev_sel_learner)
             if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
                 self.selected_learner[:] = [0]
             else:

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -86,7 +86,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
     settingsHandler = settings.ClassValuesContextHandler()
 
-    selected_learner = settings.Setting(0)
+    selected_learner = settings.Setting([0], schema_only=True)
     selection = settings.ContextSetting(set())
     selected_quantity = settings.Setting(0)
     append_predictions = settings.Setting(True)
@@ -101,8 +101,6 @@ class OWConfusionMatrix(widget.OWWidget):
 
     def __init__(self):
         super().__init__()
-        if isinstance(self.selected_learner, list):
-            self.selected_learner = (self.selected_learner + [0])[0]
 
         self.data = None
         self.results = None
@@ -214,7 +212,7 @@ class OWConfusionMatrix(widget.OWWidget):
     def set_results(self, results):
         """Set the input results."""
 
-        prev_sel_learner = self.selected_learner
+        prev_sel_learner = self.selected_learner.copy()
         self.clear()
         self.warning()
         self.closeContext()
@@ -252,11 +250,11 @@ class OWConfusionMatrix(widget.OWWidget):
 
             self._init_table(len(class_values))
             self.openContext(data.domain.class_var)
-            if prev_sel_learner is None or \
-                    prev_sel_learner >= len(self.learners):
-                self.selected_learner = 0
+            print("ZZZ", prev_sel_learner)
+            if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
+                self.selected_learner[:] = [0]
             else:
-                self.selected_learner = prev_sel_learner
+                self.selected_learner[:] = prev_sel_learner
             self._update()
             self._set_selection()
             self.unconditional_commit()
@@ -319,12 +317,12 @@ class OWConfusionMatrix(widget.OWWidget):
     def commit(self):
         """Output data instances corresponding to selected cells"""
         if self.results is not None and self.data is not None \
-                and self.selected_learner is not None:
+                and self.selected_learner:
             indices = self.tableview.selectedIndexes()
             indices = {(ind.row() - 2, ind.column() - 2) for ind in indices}
             actual = self.results.actual
-            learner_name = self.learners[self.selected_learner]
-            predicted = self.results.predicted[self.selected_learner]
+            learner_name = self.learners[self.selected_learner[0]]
+            predicted = self.results.predicted[self.selected_learner[0]]
             selected = [i for i, t in enumerate(zip(actual, predicted))
                         if t in indices]
             row_indices = self.results.row_indices[selected]
@@ -344,7 +342,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
             if self.append_probabilities and \
                     self.results.probabilities is not None:
-                probs = self.results.probabilities[self.selected_learner,
+                probs = self.results.probabilities[self.selected_learner[0],
                                                    selected]
                 extra.append(numpy.array(probs, dtype=object))
                 pvars = [Orange.data.ContinuousVariable("p({})".format(value))
@@ -395,8 +393,8 @@ class OWConfusionMatrix(widget.OWWidget):
             return isnan(x) or isinf(x)
 
         # Update the displayed confusion matrix
-        if self.results is not None and self.selected_learner is not None:
-            cmatrix = confusion_matrix(self.results, self.selected_learner)
+        if self.results is not None and self.selected_learner:
+            cmatrix = confusion_matrix(self.results, self.selected_learner[0])
             colsum = cmatrix.sum(axis=0)
             rowsum = cmatrix.sum(axis=1)
             n = len(cmatrix)
@@ -459,10 +457,10 @@ class OWConfusionMatrix(widget.OWWidget):
 
     def send_report(self):
         """Send report"""
-        if self.results is not None and self.selected_learner is not None:
+        if self.results is not None and self.selected_learner:
             self.report_table(
                 "Confusion matrix for {} (showing {})".
-                format(self.learners[self.selected_learner],
+                format(self.learners[self.selected_learner[0]],
                        self.quantities[self.selected_quantity].lower()),
                 self.tableview)
 

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -1,0 +1,41 @@
+# pylint: disable=missing-docstring
+
+from Orange.data import Table
+from Orange.classification import NaiveBayesLearner, TreeLearner
+from Orange.evaluation.testing import CrossValidation
+from Orange.widgets.evaluate.owconfusionmatrix import OWConfusionMatrix
+from Orange.widgets.tests.base import WidgetTest
+
+class TestOWClassificationTree(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        bayes = NaiveBayesLearner()
+        tree = TreeLearner()
+        iris = Table("iris")
+        titanic = Table("titanic")
+        common = dict(k=3, store_data=True)
+        cls.results_1_iris = CrossValidation(iris, [bayes], **common)
+        cls.results_2_iris = CrossValidation(iris, [bayes, tree], **common)
+        cls.results_2_titanic = CrossValidation(titanic, [bayes, tree],
+                                                **common)
+
+    def setUp(self):
+        self.widget = self.create_widget(OWConfusionMatrix,
+                                         stored_settings={"auto_apply": False})
+
+    def test_selected_learner(self):
+        """Check learner and model for various values of all parameters
+        when pruning parameters are not checked
+        """
+        self.widget.set_results(self.results_2_iris)
+        self.assertEqual(self.widget.selected_learner, [0])
+        self.widget.selected_learner[:] = [1]
+        self.widget.set_results(self.results_2_titanic)
+        self.widget.selected_learner[:] = [1]
+        self.widget.set_results(self.results_1_iris)
+        self.widget.selected_learner[:] = [0]
+        self.widget.set_results(None)
+        self.widget.set_results(self.results_1_iris)
+        self.widget.selected_learner[:] = [0]
+

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2251,7 +2251,7 @@ class ControlledList(list):
     selection in the list box.
     """
     def __init__(self, content, listBox=None):
-        super().__init__(content)
+        super().__init__(content if content is not None else [])
         self.listBox = listBox
 
     def __reduce__(self):


### PR DESCRIPTION
Fixes #1505.

The actual fix is in `gui.py`, in the constructor for `ControlledList`. The remainder of the PR deals with another related error: the widget wanted to store the `selected_learner` as an `int`, but since it represents the selection in `gui.listBox`, it kept changing to `list` at various places. It's simpler/safer to have a single-element list.