### PR TITLE
Performance improvement with many discrete values in File widget

### DIFF
--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -48,10 +48,16 @@ class VarTableModel(QtCore.QAbstractTableModel):
                     return False
             return False
 
+        def discrete_value_display(value_list):
+            result = ", ".join(str(v) for v in value_list[:VarTableModel.DISCRETE_VALUE_DISPLAY_LIMIT])
+            if len(value_list) > VarTableModel.DISCRETE_VALUE_DISPLAY_LIMIT:
+                result += ", ..."
+            return result
+
         self.modelAboutToBeReset.emit()
         self.variables[:] = self.original = [
             [var.name, type(var), place,
-             ", ".join(var.values[:self.DISCRETE_VALUE_DISPLAY_LIMIT]) if var.is_discrete else "",
+             discrete_value_display(var.values) if var.is_discrete else "",
              may_be_numeric(var)]
             for place, vars in enumerate(
                 (domain.attributes, domain.class_vars, domain.metas))

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -24,6 +24,8 @@ class Place:
 
 
 class VarTableModel(QtCore.QAbstractTableModel):
+    DISCRETE_VALUE_DISPLAY_LIMIT = 20
+
     places = "feature", "target", "meta", "skip"
     typenames = "nominal", "numeric", "string", "datetime"
     vartypes = DiscreteVariable, ContinuousVariable, StringVariable, TimeVariable
@@ -49,7 +51,7 @@ class VarTableModel(QtCore.QAbstractTableModel):
         self.modelAboutToBeReset.emit()
         self.variables[:] = self.original = [
             [var.name, type(var), place,
-             ", ".join(var.values) if var.is_discrete else "",
+             ", ".join(var.values[:self.DISCRETE_VALUE_DISPLAY_LIMIT]) if var.is_discrete else "",
              may_be_numeric(var)]
             for place, vars in enumerate(
                 (domain.attributes, domain.class_vars, domain.metas))


### PR DESCRIPTION
When trying to display many (as in 100k) values in a discrete attribute in the File widget, there is a significant performance hit. This PR solves this issue by limiting display to 20 values, instead of trying to display all of them and then ellipsizing the grossly long text.