### PR TITLE
[FIX] Scatterplot: Score plots crashed if multiple attributes have the same…

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -82,7 +82,8 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         relief = ReliefF if isinstance(dom.class_var, DiscreteVariable) \
             else RReliefF
         weights = relief(n_iterations=100, k_nearest=self.K)(data)
-        attrs = sorted(zip(weights, mdomain.attributes), reverse=True)
+        attrs = sorted(zip(weights, mdomain.attributes),
+                       key=lambda x: (-x[0], x[1].name))
         return [a for _, a in attrs]
 
 

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -2,9 +2,10 @@
 # pylint: disable=missing-docstring
 import numpy as np
 
-from Orange.data import Table
+from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.widgets.tests.base import WidgetTest
-from Orange.widgets.visualize.owscatterplot import OWScatterPlot
+from Orange.widgets.visualize.owscatterplot import \
+    OWScatterPlot, ScatterPlotVizRank
 
 
 class TestOWScatterPlot(WidgetTest):
@@ -45,3 +46,13 @@ class TestOWScatterPlot(WidgetTest):
 
         self.assertEqual(self.widget.attr_x, self.iris.domain[2].name)
         self.assertEqual(self.widget.attr_y, self.iris.domain[3].name)
+
+    def test_score_heuristics(self):
+        domain = Domain([ContinuousVariable(c) for c in "abcd"],
+                        DiscreteVariable("c", values="ab"))
+        a = np.arange(10).reshape((10, 1))
+        data = Table(domain, np.hstack([a, a, a, a]), a >= 5)
+        self.send_signal("Data", data)
+        vizrank = ScatterPlotVizRank(self.widget)
+        self.assertEqual([x.name for x in vizrank.score_heuristic()],
+                         list("abcd"))


### PR DESCRIPTION
Sort tried to compare two instances of ContinuousVariable.