### PR TITLE
ScatterPlot: Filter metas in Shape, Size, ...

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -531,6 +531,7 @@ class ContextSetting(Setting):
     # something with the attributes. Large majority does, so this greatly
     # simplifies the declaration of settings in widget at no (visible)
     # cost to those settings that don't need it
+    # TODO: exclude_metas should be disabled by default
     def __init__(self, default, not_attribute=False, required=0,
                  exclude_attributes=False, exclude_metas=True, **data):
         super().__init__(default, **data)

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -453,11 +453,11 @@ _define_symbols()
 
 
 class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
-    attr_color = ContextSetting("", ContextSetting.OPTIONAL)
-    attr_label = ContextSetting("", ContextSetting.OPTIONAL)
+    attr_color = ContextSetting("", ContextSetting.OPTIONAL, exclude_metas=False)
+    attr_label = ContextSetting("", ContextSetting.OPTIONAL, exclude_metas=False)
     label_only_selected = Setting(False)
-    attr_shape = ContextSetting("", ContextSetting.OPTIONAL)
-    attr_size = ContextSetting("", ContextSetting.OPTIONAL)
+    attr_shape = ContextSetting("", ContextSetting.OPTIONAL, exclude_metas=False)
+    attr_size = ContextSetting("", ContextSetting.OPTIONAL, exclude_metas=False)
 
     point_width = Setting(10)
     alpha_value = Setting(128)

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -56,3 +56,16 @@ class TestOWScatterPlot(WidgetTest):
         vizrank = ScatterPlotVizRank(self.widget)
         self.assertEqual([x.name for x in vizrank.score_heuristic()],
                          list("abcd"))
+
+    def test_optional_combos(self):
+        domain = self.iris.domain
+        d1 = Domain(domain.attributes[:2], domain.class_var,
+                   [domain.attributes[2]])
+        t1 = Table(d1, self.iris)
+        self.send_signal("Data", t1)
+        self.widget.graph.attr_size = domain.attributes[2].name
+
+        d2 = Domain(domain.attributes[:2], domain.class_var,
+                    [domain.attributes[3]])
+        t2 = Table(d2, self.iris)
+        self.send_signal("Data", t2)


### PR DESCRIPTION
Once upon a time, metas were treated as inferior and were ignored by the ContextSettings unless explicitly told not to.

This PR fixes ScatterPlot, but in general, if we are going to treat metas as first class citizens (like we already do in many widgets), it makes sense to allow them to be used in all ContextSettings. This can be done by changing the default (see the TODO).