### PR TITLE
[FIX] Context attributes with metas in Sieve and Mosaic

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -36,11 +36,11 @@ class OWMosaicDisplay(OWWidget):
 
     settingsHandler = DomainContextHandler()
     use_boxes = Setting(True)
-    variable1 = ContextSetting("")
-    variable2 = ContextSetting("")
-    variable3 = ContextSetting("")
-    variable4 = ContextSetting("")
-    selection = ContextSetting({})
+    variable1 = ContextSetting("", exclude_metas=False)
+    variable2 = ContextSetting("", exclude_metas=False)
+    variable3 = ContextSetting("", exclude_metas=False)
+    variable4 = ContextSetting("", exclude_metas=False)
+    selection = ContextSetting(set())
     # interior_coloring is context setting to properly reset it
     # if the widget switches to regression and back (set setData)
     interior_coloring = ContextSetting(1)
@@ -192,7 +192,7 @@ class OWMosaicDisplay(OWWidget):
         self.reset_graph()
 
     def clear_selection(self):
-        self.selection = {}
+        self.selection = set()
         self.update_selection_rects()
         self.send_selection()
 

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -69,8 +69,8 @@ class OWSieveDiagram(OWWidget):
     want_control_area = False
 
     settingsHandler = DomainContextHandler()
-    attrX = ContextSetting("")
-    attrY = ContextSetting("")
+    attrX = ContextSetting("", exclude_metas=False)
+    attrY = ContextSetting("", exclude_metas=False)
     selection = ContextSetting(set())
 
     def __init__(self):


### PR DESCRIPTION
Fixes a similar problem as #1538, but for Sieve and Mosaic.

The fix for Mosaic has no effect since context settings in Mosaic do not work. @astaric, can you check why?

We can modify Mosaic to use models (like Sieve), which would make the problem go away, but we still need to fix the bug in settings (if there is one).