### PR TITLE
[FIX] Fix loading of datasets with paths in variable attributes

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -688,7 +688,7 @@ class CSVReader(FileFormat):
                 except Exception as e:
                     error = e
                     continue
-        raise ValueError('Cannot parse dataset {}: {}'.format(self.filename, error))
+        raise ValueError('Cannot parse dataset {}: {}'.format(self.filename, error)) from error
 
     @classmethod
     def write_file(cls, filename, data):

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -122,9 +122,13 @@ class Flags:
             if self._RE_ALL.match(flag):
                 if '=' in flag:
                     k, v = flag.split('=', 1)
-                    self.attributes[k] = (v if Flags._RE_ATTR_UNQUOTED_STR(v) else
-                                          literal_eval(v) if v else
-                                          '')
+                    if not Flags._RE_ATTR_UNQUOTED_STR(v):
+                        try:
+                            v = literal_eval(v)
+                        except SyntaxError:
+                            # If parsing failed, treat value as string
+                            pass
+                    self.attributes[k] = v
                 else:
                     setattr(self, flag, True)
                     setattr(self, self.ALL.get(flag, ''), True)

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -83,6 +83,17 @@ class TestTabReader(unittest.TestCase):
         self.assertEqual(c1.name, "Class 1")
         self.assertEqual(c1.attributes, {'x': 'a longer string'})
 
+        path = "/path/to/somewhere"
+        c1.attributes["path"] = path
+        outf = io.StringIO()
+        outf.close = lambda: None
+        TabReader.write_file(outf, table)
+        outf.seek(0)
+
+        table = read_tab_file(outf)
+        f1, f2, c1, c2 = table.domain.variables
+        self.assertEqual(c1.attributes["path"], path)
+
     def test_read_data_oneline_header(self):
         samplefile = """\
         data1\tdata2\tdata3


### PR DESCRIPTION
Fixes a problem where a dataset containing image filenames save from Orange could not be read again.