### PR TITLE
CN2: Remove time consuming tests and prints

### DIFF
--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -13,6 +13,7 @@ from Orange.base import SklLearner
 import Orange.classification
 from Orange.classification import (Learner, Model, NaiveBayesLearner,
                                    LogisticRegressionLearner, NuSVMLearner)
+from Orange.classification.rules import _RuleLearner
 from Orange.data import (ContinuousVariable, DiscreteVariable,
                          Domain, Table, Variable)
 from Orange.evaluation import CrossValidation
@@ -240,6 +241,9 @@ class UnknownValuesInPrediction(unittest.TestCase):
                 learner = learner()
                 if isinstance(learner, NuSVMLearner):
                     learner.params["nu"] = 0.01
+                # Skip slow tests
+                if isinstance(learner, _RuleLearner):
+                    continue
                 model = learner(table)
                 model(table)
             except TypeError:
@@ -284,6 +288,9 @@ class LearnerAccessibility(unittest.TestCase):
             except Exception as err:
                 print('%s cannot be used with default parameters' % learner.__name__)
                 traceback.print_exc()
+                continue
+            # Skip slow tests
+            if isinstance(learner, _RuleLearner):
                 continue
 
             for ds in datasets:

--- a/Orange/tests/test_rules.py
+++ b/Orange/tests/test_rules.py
@@ -209,9 +209,5 @@ class TestRuleInduction(unittest.TestCase):
         self.assertEqual(argmaxrnd(temp, hash_dist(np.array([3, 4]))), 5)
         self.assertRaises(ValueError, argmaxrnd, np.ones((1, 1, 1)))
 
-    def testMain(self):
-        # test that the examples in rules.main raise no errors
-        rules_main()
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Tests for pickling and handling missing values doubled the execution time of the entire suite. I tried and failed to tune the parameters to decrease the time to something reasonable.