### PR TITLE
Improve code style in Orange.data module

### DIFF
--- a/Orange/data/__init__.py
+++ b/Orange/data/__init__.py
@@ -1,5 +1,8 @@
-from .instance import *
+# Pull members from modules to Orange.data namespace
+# pylint: disable=wildcard-import
+
 from .variable import *
+from .instance import *
 from .domain import *
 from .storage import *
 from .table import *

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -1,11 +1,17 @@
+import weakref
+
 from math import log
 from collections import Iterable
 from itertools import chain
 from numbers import Integral
 
-import weakref
-from .variable import *
 import numpy as np
+
+from Orange.data import (
+    Unknown, Variable, ContinuousVariable, DiscreteVariable, StringVariable
+)
+
+__all__ = ["DomainConversion", "Domain"]
 
 
 class DomainConversion:

--- a/Orange/data/filter.py
+++ b/Orange/data/filter.py
@@ -1,12 +1,14 @@
-from numbers import Real
 import random
 import re
-from math import isnan
 
-from ..misc.enum import Enum
+from math import isnan
+from numbers import Real
+
 import numpy as np
 import bottleneck as bn
+
 from Orange.data import Instance, Storage, Variable
+from Orange.misc.enum import Enum
 
 
 class Filter:

--- a/Orange/data/instance.py
+++ b/Orange/data/instance.py
@@ -1,8 +1,12 @@
 from itertools import chain
-from numbers import Real, Integral
-from ..data.variable import Value, Unknown
 from math import isnan
+from numbers import Real, Integral
+
 import numpy as np
+
+from Orange.data import Value, Unknown
+
+__all__ = ["Instance"]
 
 
 class Instance:

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -1,21 +1,20 @@
 import contextlib
 import csv
 import locale
-import os
 import pickle
 import re
 import subprocess
 import sys
 import warnings
-from tempfile import NamedTemporaryFile
 
-from os import path, unlink
 from ast import literal_eval
+from collections import OrderedDict
+from functools import lru_cache
+from itertools import chain, repeat
 from math import isnan
 from numbers import Number
-from itertools import chain, repeat
-from functools import lru_cache
-from collections import OrderedDict
+from os import path, unlink
+from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse, urlsplit, urlunsplit, unquote as urlunquote
 from urllib.request import urlopen, Request
 
@@ -679,8 +678,8 @@ class CSVReader(FileFormat):
                     # Currently, some tests pass StringIO instead of
                     # the file name to a reader.
                     if isinstance(self.filename, str):
-                        data.name = os.path.splitext(
-                            os.path.split(self.filename)[-1])[0]
+                        data.name = path.splitext(
+                            path.split(self.filename)[-1])[0]
                     if error and isinstance(error, UnicodeDecodeError):
                         pos, endpos = error.args[2], error.args[3]
                         warning = ('Skipped invalid byte(s) in position '
@@ -746,7 +745,7 @@ class BasketReader(FileFormat):
         domain = Domain(attrs, classes, meta_attrs)
         table = Table.from_numpy(
             domain, attrs and X, classes and Y, metas and meta_attrs)
-        table.name = os.path.splitext(os.path.split(self.filename)[-1])[0]
+        table.name = path.splitext(path.split(self.filename)[-1])[0]
         return table
 
 
@@ -782,7 +781,7 @@ class ExcelReader(FileFormat):
                              for col in range(first_col, row_len)]
                             for row in range(first_row, ss.nrows)])
             table = self.data_table(cells)
-            table.name = os.path.splitext(os.path.split(self.filename)[-1])[0]
+            table.name = path.splitext(path.split(self.filename)[-1])[0]
             if self.sheet:
                 table.name = '-'.join((table.name, self.sheet))
         except Exception:

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -169,39 +169,39 @@ class FileFormatMeta(Registry):
         return newcls
 
     @property
-    def formats(self):
-        return self.registry.values()
+    def formats(cls):
+        return cls.registry.values()
 
     @lru_cache(5)
-    def _ext_to_attr_if_attr2(self, attr, attr2):
+    def _ext_to_attr_if_attr2(cls, attr, attr2):
         """
         Return ``{ext: `attr`, ...}`` dict if ``cls`` has `attr2`.
         If `attr` is '', return ``{ext: cls, ...}`` instead.
         """
         return OrderedDict((ext, getattr(cls, attr, cls))
-                            for cls in self.registry.values()
-                            if hasattr(cls, attr2)
-                            for ext in getattr(cls, 'EXTENSIONS', []))
+                           for cls in cls.registry.values()
+                           if hasattr(cls, attr2)
+                           for ext in getattr(cls, 'EXTENSIONS', []))
 
     @property
-    def names(self):
-        return self._ext_to_attr_if_attr2('DESCRIPTION', '__class__')
+    def names(cls):
+        return cls._ext_to_attr_if_attr2('DESCRIPTION', '__class__')
 
     @property
-    def writers(self):
-        return self._ext_to_attr_if_attr2('', 'write_file')
+    def writers(cls):
+        return cls._ext_to_attr_if_attr2('', 'write_file')
 
     @property
-    def readers(self):
-        return self._ext_to_attr_if_attr2('', 'read')
+    def readers(cls):
+        return cls._ext_to_attr_if_attr2('', 'read')
 
     @property
-    def img_writers(self):
-        return self._ext_to_attr_if_attr2('', 'write_image')
+    def img_writers(cls):
+        return cls._ext_to_attr_if_attr2('', 'write_image')
 
     @property
-    def graph_writers(self):
-        return self._ext_to_attr_if_attr2('', 'write_graph')
+    def graph_writers(cls):
+        return cls._ext_to_attr_if_attr2('', 'write_graph')
 
 
 class FileFormat(metaclass=FileFormatMeta):

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -436,8 +436,10 @@ class FileFormat(metaclass=FileFormatMeta):
                         copy=False, dtype=object, order='F')
 
         # Data may actually be longer than headers were
-        try: rowlen = data.shape[1]
-        except IndexError: pass
+        try:
+            rowlen = data.shape[1]
+        except IndexError:
+            pass
         else:
             for lst in (names, types, flags):
                 _equal_length(lst)
@@ -451,7 +453,8 @@ class FileFormat(metaclass=FileFormatMeta):
         # Iterate through the columns
         for col in range(rowlen):
             flag = Flags(Flags.split(flags[col]))
-            if flag.i: continue
+            if flag.i:
+                continue
 
             type_flag = types and types[col].strip()
             try:
@@ -476,8 +479,10 @@ class FileFormat(metaclass=FileFormatMeta):
                     values = [float(i) for i in orig_values]
                 except ValueError:
                     for row, num in enumerate(orig_values):
-                        try: float(num)
-                        except ValueError: break
+                        try:
+                            float(num)
+                        except ValueError:
+                            break
                     raise ValueError('Non-continuous value in (1-based) '
                                      'line {}, column {}'.format(row + len(headers) + 1,
                                                                  col + 1))
@@ -499,10 +504,12 @@ class FileFormat(metaclass=FileFormatMeta):
                 if is_discrete:
                     valuemap = sorted(is_discrete)
                 else:
-                    try: values = [float(i) for i in orig_values]
+                    try:
+                        values = [float(i) for i in orig_values]
                     except ValueError:
                         tvar = TimeVariable('_')
-                        try: values = [tvar.parse(i) for i in orig_values]
+                        try:
+                            values = [tvar.parse(i) for i in orig_values]
                         except ValueError:
                             coltype = StringVariable
                         else:
@@ -513,8 +520,10 @@ class FileFormat(metaclass=FileFormatMeta):
             if valuemap:
                 # Map discrete data to ints
                 def valuemap_index(val):
-                    try: return valuemap.index(val)
-                    except ValueError: return np.nan
+                    try:
+                        return valuemap.index(val)
+                    except ValueError:
+                        return np.nan
 
                 values = np.vectorize(valuemap_index, otypes=[float])(orig_values)
                 coltype = DiscreteVariable
@@ -553,8 +562,10 @@ class FileFormat(metaclass=FileFormatMeta):
                         column = values if data.ndim > 1 else data
                         column += offset
                         for i, val in enumerate(var.values):
-                            try: oldval = old_order.index(val)
-                            except ValueError: continue
+                            try:
+                                oldval = old_order.index(val)
+                            except ValueError:
+                                continue
                             bn.replace(column, offset + oldval, new_order.index(val))
 
             if coltype is TimeVariable:
@@ -564,8 +575,10 @@ class FileFormat(metaclass=FileFormatMeta):
 
             # Write back the changed data. This is needeed to pass the
             # correct, converted values into Table.from_numpy below
-            try: data[:, col] = values
-            except IndexError: pass
+            try:
+                data[:, col] = values
+            except IndexError:
+                pass
 
         domain = Domain(attrs, clses, metas)
 
@@ -604,7 +617,7 @@ class FileFormat(metaclass=FileFormatMeta):
         return list(chain(['weight'] * data.has_weights(),
                           (Flags.join([flag], *('{}={}'.format(*a)
                                                 for a in sorted(var.attributes.items())))
-                           for flag, var in chain(zip(repeat(''),  data.domain.attributes),
+                           for flag, var in chain(zip(repeat(''), data.domain.attributes),
                                                   zip(repeat('class'), data.domain.class_vars),
                                                   zip(repeat('meta'), data.domain.metas)))))
 

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -855,9 +855,9 @@ class UrlReader(FileFormat):
     @staticmethod
     def _trim_googlesheet(url):
         match = re.match(r'(?:https?://)?(?:www\.)?'
-                         'docs\.google\.com/spreadsheets/d/'
-                         '(?P<workbook_id>[-\w_]+)'
-                         '(?:/.*?gid=(?P<sheet_id>\d+).*|.*)?',
+                         r'docs\.google\.com/spreadsheets/d/'
+                         r'(?P<workbook_id>[-\w_]+)'
+                         r'(?:/.*?gid=(?P<sheet_id>\d+).*|.*)?',
                          url, re.IGNORECASE)
         try:
             workbook, sheet = match.group('workbook_id'), match.group('sheet_id')

--- a/Orange/data/sql/filter.py
+++ b/Orange/data/sql/filter.py
@@ -1,4 +1,4 @@
-from .. import filter
+from Orange.data import filter
 
 
 class IsDefinedSql(filter.IsDefined):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1,29 +1,27 @@
+import operator
 import os
-import re
 import zlib
+
 from collections import MutableSequence, Iterable, Sequence, Sized
 from itertools import chain
 from numbers import Real, Integral
-import operator
 from functools import reduce
 from warnings import warn
 from threading import Lock
-from tempfile import NamedTemporaryFile
-from urllib.parse import urlparse, unquote as urlunquote
-from urllib.request import urlopen
-from urllib.error import URLError
 
+import numpy as np
 import bottleneck as bn
 from scipy import sparse as sp
 
+from Orange.data import (
+    _contingency, _valuecount,
+    Domain, Variable, Storage, StringVariable, Unknown, Value, Instance
+)
+from Orange.data.util import SharedComputeValue
 from Orange.statistics.util import bincount, countnans, contingency, stats as fast_stats
-from .instance import *
 from Orange.util import flatten
-from Orange.data import Domain, Variable, StringVariable
-from Orange.data.storage import Storage
-from . import _contingency
-from . import _valuecount
-from .util import SharedComputeValue
+
+__all__ = ["dataset_dirs", "get_sample_datasets_dir", "RowInstance", "Table"]
 
 
 def get_sample_datasets_dir():
@@ -885,10 +883,8 @@ class Table(MutableSequence, Storage):
                 table.extend(t)
             return table
         elif axis == CONCAT_COLS:
-            from operator import iand, attrgetter
-            from functools import reduce
-            if reduce(iand,
-                      (set(map(attrgetter('name'),
+            if reduce(operator.iand,
+                      (set(map(operator.attrgetter('name'),
                                chain(t.domain.variables, t.domain.metas)))
                        for t in tables)):
                 raise ValueError('Concatenating two domains with variables '

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -39,7 +39,8 @@ def is_discrete_values(values):
     ----
     Assumes consistent type of items of `values`.
     """
-    if not len(values): return None
+    if not len(values):
+        return None
     # If the first few values are, or can be converted to, floats,
     # the type is numeric
     try:
@@ -65,14 +66,16 @@ def is_discrete_values(values):
                   not (isinstance(i, Number) and np.isnan(i)))}
 
     # All NaNs => indeterminate
-    if not unique: return None
+    if not unique:
+        return None
 
     # Strings with |values| < max_unique
     if not is_numeric:
         return unique
 
     # Handle numbers
-    try: unique_float = set(map(float, unique))
+    try:
+        unique_float = set(map(float, unique))
     except ValueError:
         # Converting all the values to floats resulted in an error.
         # Since the values have enough unique values, they are probably
@@ -986,11 +989,13 @@ class TimeVariable(ContinuousVariable):
         # Convert time to UTC timezone. In dates without timezone,
         # localtime is assumed. See also:
         # https://docs.python.org/3.4/library/datetime.html#datetime.datetime.timestamp
-        if dt.tzinfo: dt -= dt.utcoffset()
+        if dt.tzinfo:
+            dt -= dt.utcoffset()
         dt = dt.replace(tzinfo=timezone.utc)
 
         # Unix epoch is the origin, older dates are negative
-        try: return dt.timestamp()
+        try:
+            return dt.timestamp()
         except OverflowError:
             return -(self.UNIX_EPOCH - dt).total_seconds()
 

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -1,16 +1,19 @@
-import re
-from numbers import Number, Real, Integral
-from math import isnan, floor, sqrt
-import numpy as np
-from pickle import PickleError
-import copy
-
 import collections
+import re
+
 from datetime import datetime, timedelta, timezone
+from numbers import Number, Real, Integral
+from math import isnan, floor
+from pickle import PickleError
 
-from . import _variable
+import numpy as np
 
+from Orange.data import _variable
 from Orange.util import Registry, color_to_hex, hex_to_color
+
+__all__ = ["Unknown", "MISSING_VALUES", "make_variable", "is_discrete_values",
+           "Value", "Variable", "ContinuousVariable", "DiscreteVariable",
+           "StringVariable", "TimeVariable"]
 
 
 # For storing unknowns

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -883,12 +883,12 @@ class TimeVariable(ContinuousVariable):
     ]
     # The regex that matches all above formats
     REGEX = (r'^('
-             '\d{1,4}-\d{2}-\d{2}([ T]\d{2}:\d{2}(:\d{2}(\.\d+)?([+-]\d{4})?)?)?|'
-             '\d{1,4}\d{2}\d{2}(T?\d{2}\d{2}\d{2}([+-]\d{4})?)?|'
-             '\d{2}:\d{2}(:\d{2}(\.\d+)?)?|'
-             '\d{2}\d{2}\d{2}\.\d+|'
-             '\d{1,4}(-?\d{2,3})?'
-             ')$')
+             r'\d{1,4}-\d{2}-\d{2}([ T]\d{2}:\d{2}(:\d{2}(\.\d+)?([+-]\d{4})?)?)?|'
+             r'\d{1,4}\d{2}\d{2}(T?\d{2}\d{2}\d{2}([+-]\d{4})?)?|'
+             r'\d{2}:\d{2}(:\d{2}(\.\d+)?)?|'
+             r'\d{2}\d{2}\d{2}\.\d+|'
+             r'\d{1,4}(-?\d{2,3})?'
+             r')$')
     _matches_iso_format = re.compile(REGEX).match
 
     # UTC offset and associated timezone. If parsed datetime values provide an


### PR DESCRIPTION
Fixes 35% of lint errors in Orange.data errors

It was about time to remove `import *` imports, the rest are more or less cosmetic changes.