### PR TITLE
Sparse fixups

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1392,8 +1392,10 @@ class Table(MutableSequence, Storage):
                     mask = [i in disc_indi for i in range(arr.shape[1])]
                     conts, nans = contingency(arr, row_data, max_vals - 1,
                                               n_rows - 1, W, mask)
-                    for col_i, arr_i, _ in disc_vars:
-                        contingencies[col_i] = (conts[arr_i], nans[arr_i])
+                    for col_i, arr_i, var in disc_vars:
+                        n_vals = len(var.values)
+                        contingencies[col_i] = (conts[arr_i][:, :n_vals],
+                                                nans[arr_i])
                 else:
                     for col_i, arr_i, var in disc_vars:
                         contingencies[col_i] = contingency(

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -1,4 +1,5 @@
 import numpy
+from scipy.sparse import issparse
 
 import Orange.data
 from Orange.statistics import distribution, basic_stats
@@ -24,7 +25,10 @@ class ReplaceUnknowns(Transformation):
         self.value = value
 
     def transform(self, c):
-        return numpy.where(numpy.isnan(c), self.value, c)
+        if issparse(c):     # sparse does not have unknown values
+            return c
+        else:
+            return numpy.where(numpy.isnan(c), self.value, c)
 
 
 class BaseImputeMethod:

--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -17,6 +17,7 @@ class Normalizer:
         self.transform_class = transform_class
 
     def __call__(self, data):
+
         dists = distribution.get_distributions(data)
         new_attrs = [self.normalize(dists[i], var) for
                      (i, var) in enumerate(data.domain.attributes)]
@@ -37,7 +38,7 @@ class Normalizer:
             return self.normalize_by_span(dist, var)
 
     def normalize_by_sd(self, dist, var):
-        avg, sd = dist.mean(), dist.standard_deviation()
+        avg, sd = (dist.mean(), dist.standard_deviation()) if dist.size else (0, 1)
         if sd == 0:
             sd = 1
         return ContinuousVariable(var.name, compute_value=Norm(var, avg, 1 / sd))

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -1,4 +1,4 @@
-import numpy as np
+import scipy.sparse as sp
 
 from Orange.data import Instance, Table, Domain
 
@@ -26,7 +26,7 @@ class Transformation:
             data = Table(data.domain, [data])
         domain = Domain([self.variable])
         data = Table.from_table(domain, data)
-        transformed = self.transform(data.X.squeeze(axis=1))
+        transformed = self.transform(data.X if sp.issparse(data.X) else data.X.squeeze(axis=1))
         if inst:
             transformed = transformed[0]
         return transformed

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -107,7 +107,13 @@ class Normalizer(Transformation):
         self.factor = factor
 
     def transform(self, c):
-        return (c - self.offset) * self.factor
+        if sp.issparse(c):
+            if self.offset != 0:
+                raise ValueError('Non-zero offset in normalization '
+                                 'of sparse data')
+            return c * self.factor
+        else:
+            return (c - self.offset) * self.factor
 
 
 class Lookup(Transformation):

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 import numpy as np
+import scipy.sparse as sp
 
 from Orange.preprocess import discretize, Discretize
 from Orange import data
@@ -150,6 +151,19 @@ class TestDiscretizer(TestCase):
             self.var, [1, 2, 3])
         X = np.array([0, 0.9, 1, 1.1, 1.9, 2, 2.5, 3, 3.5])
         np.testing.assert_equal(dvar.compute_value.transform(X), np.floor(X))
+
+    def test_discretizer_computation_sparse(self):
+        dvar = discretize.Discretizer.create_discretized_var(
+            self.var, [1, 2, 3])
+        X = sp.csr_matrix(np.array([0, 0.9, 1, 1.1, 1.9, 2, 2.5, 3, 3.5]))
+        self.assertEqual((dvar.compute_value.transform(X) != np.floor(X)).nnz, 0)
+
+    def test_discretizer_computation_sparse_no_points(self):
+        dvar = discretize.Discretizer.create_discretized_var(
+            self.var, [])
+        X = sp.csr_matrix(np.array([0, 0.9, 1, 1.1, 1.9, 2, 2.5, 3, 3.5]))
+        empty = sp.csr_matrix(X.shape)
+        self.assertEqual((dvar.compute_value.transform(X) != empty).nnz, 0)
 
     def test_transform(self):
         table = data.Table('iris')

--- a/Orange/tests/test_impute.py
+++ b/Orange/tests/test_impute.py
@@ -4,6 +4,7 @@
 import unittest
 from functools import reduce
 import numpy as np
+import scipy.sparse as sp
 
 from Orange import preprocess
 from Orange.preprocess import impute
@@ -23,6 +24,11 @@ class TestReplaceUnknowns(unittest.TestCase):
         a[1] = a[5] = Unknown
         ia = preprocess.ReplaceUnknowns(None, value=42).transform(a)
         np.testing.assert_equal(ia, [0, 42, 2, 3, 4, 42, 6, 7, 8, 9])
+
+    def test_sparse(self):
+        m = sp.csr_matrix(np.eye(10))
+        rm = preprocess.ReplaceUnknowns(None, value=42).transform(m)
+        self.assertEqual((m!=rm).nnz, 0)
 
 
 class TestDropInstances(unittest.TestCase):

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -3,9 +3,13 @@
 
 import unittest
 
-from Orange.data import Table
+import numpy as np
+import scipy.sparse as sp
+
+from Orange.data import Table, Domain, ContinuousVariable
 from Orange.preprocess import Normalize
 from Orange.tests import test_filename
+
 
 class TestNormalizer(unittest.TestCase):
     def compare_tables(self, dataNorm, solution):
@@ -90,3 +94,31 @@ class TestNormalizer(unittest.TestCase):
                     [0., 0., 'a', 'b', 0., '?', 0.5, 'b', 'b', 0.],
                     [0., 0.5, 'a', 'b', 1., 'b', 0., 'c', 'c', 0.5]]
         self.compare_tables(data_norm, solution)
+
+    def test_normalize_sparse(self):
+        domain = Domain([ContinuousVariable(str(i)) for i in range(3)])
+        X = sp.csr_matrix(np.array([
+            [0, 0, 0,],
+            [0, -1, -2],
+            [0, 1, 2],
+        ]))
+        data = Table.from_numpy(domain, X)
+
+        solution = sp.csr_matrix(np.array([
+            [0, 0, 0,],
+            [0, -1, -1],
+            [0, 1, 1],
+        ]))
+
+        normalizer = Normalize()
+        normalized = normalizer(data)
+        self.assertEqual((normalized.X != solution).nnz, 0)
+
+        # raise error for non-zero offsets
+        data.X = sp.csr_matrix(np.array([
+            [0, 0, 0, ],
+            [0, 1, 3],
+            [0, 2, 4],
+        ]))
+        with self.assertRaises(ValueError):
+            normalizer(data)


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
Various bug-fixes required for sparse data:

- `preprocess.Transformation` should not call .squeeze since sparse matrices does not support it.
- `ReplaceUnknown` should be skipped for sparse since _missing_ are considered to be zero.
- `Discretizer` support sparse data.
- `Normalizer` support zero-based sparse data.
- `Table.from_table` should consider sparsity of initial array. For example, when adding columns to sparse X it should remain sparse.
- `Table._compute_contingency` fix for sparse on bottleneck.
- `OWHeatMap` widget converts sparse data to dense. Though this is probably not optimal it at least enables the use of heat map on sparse data where number of attributes is reasonable. On larger we probably couldn't see anything anyway. I tried and failed to make it work on sparse. The problem is in pyqtgraph's `makeARGB` function which only accepts numpy arrays. Even if that was bypassed we would probably  need to create a dense pixmap array at some point.