### PR TITLE
[FIX] Load Classifier widget sends classifier on init

### DIFF
--- a/Orange/widgets/classify/owloadclassifier.py
+++ b/Orange/widgets/classify/owloadclassifier.py
@@ -69,6 +69,9 @@ class OWLoadClassifier(widget.OWWidget):
             self.filename = None
             self.reloadbutton.setEnabled(False)
 
+        if self.filename:
+            self.load(self.filename)
+
     def browse(self):
         """Select a filename using an open file dialog."""
         if self.filename is None:


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Filenames are stored in settings but when the new instance is created the most recent file was not loaded - it was only added to dropdown. The manual click on reload was necessary to load the classifier.