### PR TITLE
[FIX] Stats: Fix counting of missing values for non-numeric data

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -195,7 +195,7 @@ def stats(X, weights=None, compute_variance=False):
             X.shape[1] - non_zero,
             non_zero))
     else:
-        nans = ~X.astype(bool).sum(axis=0) if X.size else np.zeros(X.shape[1])
+        nans = (~X.astype(bool)).sum(axis=0) if X.size else np.zeros(X.shape[1])
         return np.column_stack((
             np.tile(np.inf, X.shape[1]),
             np.tile(-np.inf, X.shape[1]),

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -69,3 +69,13 @@ class TestUtil(unittest.TestCase):
         weights = np.array([1, 3])
         np.testing.assert_equal(stats(X, weights), [[0, 2, 1.5, 0, 1, 1],
                                                     [1, 3, 2.5, 0, 0, 2]])
+
+    def test_stats_non_numeric(self):
+        X = np.array([
+            ['', 'a', 'b'],
+            ['a', '', 'b'],
+            ['a', 'b', ''],
+        ], dtype=object)
+        np.testing.assert_equal(stats(X), [[np.inf, -np.inf, 0, 0, 1, 2],
+                                           [np.inf, -np.inf, 0, 0, 1, 2],
+                                           [np.inf, -np.inf, 0, 0, 1, 2]])


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Stats returned negative numbers of nans on non-numberic data (metas). Hence, for metas, table widget always showed 'no missing values'. The problem was in priorities. We should first negate binary array and only then sum. Without brackets binary array was first summed and only then ~ was applied. On integers ~ returns -(x+1) which lead to negative values.