### PR TITLE
LoadClassifier: Use singleShot timer for loading

### DIFF
--- a/Orange/widgets/classify/owloadclassifier.py
+++ b/Orange/widgets/classify/owloadclassifier.py
@@ -2,6 +2,8 @@ import os
 import pickle
 
 from PyQt4 import QtGui
+from PyQt4.QtCore import QTimer
+
 from Orange.base import Model
 
 from Orange.widgets import widget, gui
@@ -70,7 +72,7 @@ class OWLoadClassifier(widget.OWWidget):
             self.reloadbutton.setEnabled(False)
 
         if self.filename:
-            self.load(self.filename)
+            QTimer.singleShot(0, lambda: self.load(self.filename))
 
     def browse(self):
         """Select a filename using an open file dialog."""


### PR DESCRIPTION
Fixes loading to use single shot timer as discussed in #1584.
