### PR TITLE
[FIX] Variable: Fix Variable.copy for StringVariable and TimeVariable

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -427,7 +427,7 @@ class Variable(metaclass=VariableMeta):
         return make_variable, (self.__class__, self._compute_value, self.name), self.__dict__
 
     def copy(self, compute_value):
-        var = Variable(self.name, compute_value)
+        var = type(self)(self.name, compute_value=compute_value)
         var.attributes = dict(self.attributes)
         return var
 
@@ -524,7 +524,7 @@ class ContinuousVariable(Variable):
     str_val = repr_val
 
     def copy(self, compute_value=None):
-        var = ContinuousVariable(self.name, self.number_of_decimals, compute_value)
+        var = type(self)(self.name, self.number_of_decimals, compute_value)
         var.attributes = dict(self.attributes)
         return var
 
@@ -904,6 +904,12 @@ class TimeVariable(ContinuousVariable):
         super().__init__(*args, **kwargs)
         self.have_date = 0
         self.have_time = 0
+
+    def copy(self, compute_value=None):
+        copy = super().copy(compute_value=compute_value)
+        copy.have_date = self.have_date
+        copy.have_time = self.have_time
+        return copy
 
     @staticmethod
     def _tzre_sub(s, _subtz=re.compile(r'([+-])(\d\d):(\d\d)$').sub):

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -58,6 +58,7 @@ class VariableTest:
         var.attributes["a"] = "b"
         var2 = var.copy(compute_value=None)
         self.assertIn("a", var2.attributes)
+        self.assertIsInstance(var2, type(var))
 
         var2.attributes["a"] = "c"
         # Attributes of original value should not change


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Due to static constructors in Variable.copy and ContinuousVariable.copy
the StringVariable.copy and TimeVariable.copy used to return Variable
and ContinuousVariable instances respectively.

Fix this by dispatching on `type(self)`.

Also add the missing entry for `vartype(Variable)` in
`gui.attributeIconDict`