### PR TITLE
io.py: Enumerate duplicated column names

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -8,7 +8,7 @@ import sys
 import warnings
 
 from ast import literal_eval
-from collections import OrderedDict
+from collections import OrderedDict, Counter
 from functools import lru_cache
 from itertools import chain, repeat
 from math import isnan
@@ -449,6 +449,17 @@ class FileFormat(metaclass=FileFormatMeta):
         Mcols, metas = [], []
         Ycols, clses = [], []
         Wcols = []
+
+        # Rename variables if necessary
+        # Reusing across files still works if both files have same duplicates
+        name_counts = Counter(names)
+        del name_counts[""]
+        if len(name_counts) != len(names) and name_counts:
+            uses = {name: 0 for name, count in name_counts.items() if count > 1}
+            for i, name in enumerate(names):
+                if name in uses:
+                    uses[name] += 1
+                    names[i] = "{}_{}".format(name, uses[name])
 
         # Iterate through the columns
         for col in range(rowlen):

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-docstring
 
 import io
-from os import path
+from os import path, remove
 import unittest
 import tempfile
 import shutil
@@ -132,6 +132,27 @@ class TestTabReader(unittest.TestCase):
 
         self.assertSequenceEqual(t2.domain['x'].values, 'abcdgh')
         np.testing.assert_almost_equal(t2.X.ravel(), [5, 4, 0, 2, 1])
+
+    def test_renaming(self):
+        simplefile = """\
+            a\t  b\t  a\t  a\t  b\t     a\t     c\t  a\t b
+            c\t  c\t  c\t  c\t  c\t     c\t     c\t  c\t c
+             \t   \t  \t   \t   class\t class\t  \t  \t  meta
+            0\t  0\t  0\t  0\t  0\t     0\t     0\t  0 """
+        file = tempfile.NamedTemporaryFile("wt", delete=False, suffix=".tab")
+        filename = file.name
+        try:
+            file.write(simplefile)
+            file.close()
+            table = read_tab_file(filename)
+            domain = table.domain
+            self.assertEqual([x.name for x in domain.attributes],
+                             ["a_1", "b_1", "a_2", "a_3", "c", "a_5"])
+            self.assertEqual([x.name for x in domain.class_vars], ["b_2", "a_4"])
+            self.assertEqual([x.name for x in domain.metas], ["b_3"])
+        finally:
+            remove(filename)
+
 
     def test_dataset_with_weird_names_and_column_attributes(self):
         data = Table(path.join(path.dirname(__file__), 'weird.tab'))


### PR DESCRIPTION
If a name appears multiple times, _1, _2, _3 ... is appended to all occurrences (including the first one, to prevent the case when the user would index a later occurrence and get the first)