### PR TITLE
[FIX] Linear regression: Fix Elastic net; Fix Auto-apply buttons

### DIFF
--- a/Orange/widgets/regression/tests/test_owlinearregression.py
+++ b/Orange/widgets/regression/tests/test_owlinearregression.py
@@ -1,0 +1,9 @@
+from Orange.widgets.regression.owlinearregression import OWLinearRegression
+from Orange.widgets.tests.base import WidgetTest, WidgetLearnerTestMixin
+
+
+class TestOWLinearRegression(WidgetTest, WidgetLearnerTestMixin):
+    def setUp(self):
+        self.widget = self.create_widget(OWLinearRegression,
+                                         stored_settings={"auto_apply": False})
+        self.init()

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -331,6 +331,9 @@ class WidgetLearnerTestMixin:
             self.model_class = ModelRegression
         self.parameters = []
 
+    def test_has_unconditional_apply(self):
+        self.assertTrue(hasattr(self.widget, "unconditional_apply"))
+
     def test_input_data(self):
         """Check widget's data with data on the input"""
         self.assertEqual(self.widget.data, None)


### PR DESCRIPTION
- Elastic net were mixed L1 and L2 in the opposite proportions(!).
- The related slider used to be in the wrong part; while this was already fixed a few weeks ago, the code for constructing the slider was still in `add_bottom_buttons`.
- The widget did not have the auto-apply button and would fail the base learner widget tests; this was cause by the redundant method `add_bottom_buttons`.
- The widget did not have any tests (I assume that it's because it'd fail them)

I added a test to the base test class for learner widgets, which checks whether the class has `unconditional_apply` method. This method is be required for proper implementation of force-apply. If the widget intentionally removes it, it will have to override this test (or avoid being tested).