### PR TITLE
Reorder visualization widgets

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -377,7 +377,7 @@ class OWHeatMap(widget.OWWidget):
     name = "Heat Map"
     description = "Plot a heat map for a pair of attributes."
     icon = "icons/Heatmap.svg"
-    priority = 330
+    priority = 260
 
     inputs = [("Data", Table, "set_dataset")]
     outputs = [("Selected Data", Table, widget.Default)]

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -218,7 +218,7 @@ class OWLinearProjection(widget.OWWidget):
     description = "A multi-axis projection of data onto " \
                   "a two-dimensional plane."
     icon = "icons/LinearProjection.svg"
-    priority = 420
+    priority = 240
 
     inputs = [("Data", Table, "set_data", widget.Default),
               ("Data Subset", Table, "set_subset_data")]

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -28,7 +28,7 @@ class OWMosaicDisplay(OWWidget):
     name = "Mosaic Display"
     description = "Display data in a mosaic plot."
     icon = "icons/MosaicDisplay.svg"
-    priority = 320
+    priority = 220
 
     inputs = [("Data", Table, "set_data", Default),
               ("Data Subset", Table, "set_subset_data")]

--- a/Orange/widgets/visualize/owparallelcoordinates.py
+++ b/Orange/widgets/visualize/owparallelcoordinates.py
@@ -22,7 +22,7 @@ class OWParallelCoordinates(OWVisWidget):
     name = "Parallel Coordinates"
     description = "Parallel coordinates display of multi-dimensional data."
     icon = "icons/ParallelCoordinates.svg"
-    priority = 100
+    priority = 900
     inputs = [("Data", Orange.data.Table, 'set_data', Default),
               ("Data Subset", Orange.data.Table, 'set_subset_data'),
               ("Features", AttributeList, 'set_shown_attributes')]

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -54,7 +54,7 @@ class OWPythagorasTree(OWWidget):
     description = 'Pythagorean Tree visualization for tree like-structures.'
     icon = 'icons/PythagoreanTree.svg'
 
-    priority = 610
+    priority = 1000
 
     inputs = [('Tree', Tree, 'set_tree')]
     outputs = [('Selected Data', Table)]

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -29,7 +29,7 @@ class OWPythagoreanForest(OWWidget):
     description = 'Pythagorean forest for visualising random forests.'
     icon = 'icons/PythagoreanForest.svg'
 
-    priority = 620
+    priority = 1001
 
     inputs = [('Random forest', RandomForest, 'set_rf')]
     outputs = [('Tree', Tree)]

--- a/Orange/widgets/visualize/owruleviewer.py
+++ b/Orange/widgets/visualize/owruleviewer.py
@@ -13,7 +13,7 @@ class OWRuleViewer(widget.OWWidget):
     name = "CN2 Rule Viewer"
     description = "Review rules induced from data."
     icon = "icons/CN2RuleViewer.svg"
-    priority = 18
+    priority = 1140
 
     inputs = [("Data", Table, 'set_data'),
               ("Classifier", _RuleClassifier, 'set_classifier')]

--- a/Orange/widgets/visualize/owscattermap.py
+++ b/Orange/widgets/visualize/owscattermap.py
@@ -455,7 +455,7 @@ class OWScatterMap(widget.OWWidget):
     name = "Scatter Map"
     description = "Draw a two dimensional rectangular bin density plot."
     icon = "icons/Scattermap.svg"
-    priority = 500
+    priority = 5000
 
     inputs = [("Data", Orange.data.Table, "set_data")]
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -95,7 +95,7 @@ class OWScatterPlot(OWWidget):
     description = "Interactive scatter plot visualization with " \
                   "intelligent data visualization enhancements."
     icon = "icons/ScatterPlot.svg"
-    priority = 210
+    priority = 140
 
     inputs = [("Data", Table, "set_data", Default),
               ("Data Subset", Table, "set_subset_data"),

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -56,7 +56,7 @@ class OWSieveDiagram(OWWidget):
     description = "Visualize the observed and expected frequencies " \
                   "for a combination of values."
     icon = "icons/SieveDiagram.svg"
-    priority = 310
+    priority = 200
 
     inputs = [("Data", Table, "set_data", Default),
               ("Features", AttributeList, "set_input_features")]

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -30,7 +30,7 @@ class OWSilhouettePlot(widget.OWWidget):
                   "the degree of cluster membership."
 
     icon = "icons/SilhouettePlot.svg"
-    priority = 510
+    priority = 300
 
     inputs = [("Data", Orange.data.Table, "set_data")]
     outputs = [("Selected Data", Orange.data.Table, widget.Default),

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -37,7 +37,7 @@ class OWVennDiagram(widget.OWWidget):
     description = "A graphical visualization of the overlap of data instances " \
                   "from a collection of input data sets."
     icon = "icons/VennDiagram.svg"
-    priority = 410
+    priority = 280
 
     inputs = [("Data", Orange.data.Table, "setData", widget.Multiple)]
     outputs = [("Selected Data", Orange.data.Table)]


### PR DESCRIPTION
The order of widgets was weird: it started with CN2 rules viewer, while Scatter plot was somewhere in the third row. I changed it to put the common visualizations to the front, and model visualizations towards the end.