### PR TITLE
[ENH] Metadata for data files

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -283,10 +283,15 @@ class FileFormat(metaclass=FileFormatMeta):
 
     @classmethod
     def write_table_metadata(cls, filename, data):
-        if isinstance(filename, str) and getattr(data, 'attributes', {}):
-            with open(filename + '.metadata', 'w') as f:
-                f.write("\n".join(
-                        "{}: {}".format(*kv) for kv in data.attributes.items()))
+        if isinstance(filename, str) and hasattr(data, 'attributes'):
+            if all(isinstance(key, str) and isinstance(value, str)
+                   for key, value in data.attributes.items()):
+                with open(filename + '.metadata', 'w') as f:
+                    f.write("\n".join("{}: {}".format(*kv)
+                                      for kv in data.attributes.items()))
+            else:
+                with open(filename + '.metadata', 'wb') as f:
+                    pickle.dump(data.attributes, f, pickle.HIGHEST_PROTOCOL)
 
     @classmethod
     def set_table_metadata(cls, filename, table):

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -284,14 +284,24 @@ class FileFormat(metaclass=FileFormatMeta):
     @classmethod
     def write_table_metadata(cls, filename, data):
         if isinstance(filename, str) and getattr(data, 'attributes', {}):
-            with open(filename + '.metadata', 'wb') as f:
-                pickle.dump(data.attributes, f, pickle.HIGHEST_PROTOCOL)
+            with open(filename + '.metadata', 'w') as f:
+                f.write("\n".join(
+                        "{}: {}".format(*kv) for kv in data.attributes.items()))
 
     @classmethod
     def set_table_metadata(cls, filename, table):
+        # pylint: disable=bare-except
         if isinstance(filename, str) and path.exists(filename + '.metadata'):
-            with open(filename + '.metadata', 'rb') as f:
-                table.attributes = pickle.load(f)
+            try:
+                with open(filename + '.metadata', 'rb') as f:
+                    table.attributes = pickle.load(f)
+            # Unpickling throws different exceptions, not just UnpickleError
+            except:
+                with open(filename + '.metadata') as f:
+                    table.attributes = OrderedDict(
+                        (k.strip(), v.strip())
+                        for k, v in (line.split(":", 1)
+                                     for line in f.readlines()))
 
     @classmethod
     def locate(cls, filename, search_dirs=('.',)):

--- a/Orange/datasets/iris.tab.metadata
+++ b/Orange/datasets/iris.tab.metadata
@@ -1,0 +1,5 @@
+Name: Iris flower data set
+Description: Classical data set with 150 instances of Iris setosa, Iris virginica and Iris versicolor.
+Author: Edgar Anderson, Ronald Fisher
+Year: 1936
+Reference: R. A. Fisher (1936). "The use of multiple measurements in taxonomic problems". Annals of Eugenics. 7 (2): 179–188. doi:10.1111/j.1469-1809.1936.tb02137.x

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -6,6 +6,8 @@ from os import path, remove
 import unittest
 import tempfile
 import shutil
+import pickle
+from collections import OrderedDict
 
 import numpy as np
 
@@ -178,12 +180,25 @@ class TestTabReader(unittest.TestCase):
 
     def test_attributes_saving(self):
         tempdir = tempfile.mkdtemp()
-        table = Table("iris")
+        table = Table("titanic")
         self.assertEqual(table.attributes, {})
         table.attributes[1] = "test"
         table.save(path.join(tempdir, "out.tab"))
         table = Table(path.join(tempdir, "out.tab"))
         self.assertEqual(table.attributes[1], "test")
+        shutil.rmtree(tempdir)
+
+    def test_attributes_saving_as_txt(self):
+        tempdir = tempfile.mkdtemp()
+        table = Table("titanic")
+        table.attributes = OrderedDict()
+        table.attributes["a"] = "aa"
+        table.attributes["b"] = "bb"
+        table.save(path.join(tempdir, "out.tab"))
+        table = Table(path.join(tempdir, "out.tab"))
+        self.assertIsInstance(table.attributes, OrderedDict)
+        self.assertEqual(table.attributes["a"], "aa")
+        self.assertEqual(table.attributes["b"], "bb")
         shutil.rmtree(tempdir)
 
     def test_data_name(self):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1197,7 +1197,7 @@ class TableTestCase(unittest.TestCase):
         self.assertEqual(new_table.metas.dtype, np.float64)
 
     def test_attributes(self):
-        table = data.Table("iris")
+        table = data.Table("titanic")
         self.assertEqual(table.attributes, {})
         table.attributes[1] = "test"
         table2 = table[:4]

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1197,9 +1197,8 @@ class TableTestCase(unittest.TestCase):
         self.assertEqual(new_table.metas.dtype, np.float64)
 
     def test_attributes(self):
-        table = data.Table("titanic")
-        self.assertEqual(table.attributes, {})
-        table.attributes[1] = "test"
+        table = data.Table("iris")
+        table.attributes = {1: "test"}
         table2 = table[:4]
         self.assertEqual(table2.attributes[1], "test")
         table2.attributes[1] = "modified"

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -330,21 +330,33 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
     def _describe(self, table):
         domain = table.domain
-        text = "{} instance(s), {} feature(s), {} meta attribute(s)".format(
-            len(table), len(domain.attributes), len(domain.metas))
+        text = ""
+
+        attrs = getattr(table, "attributes", {})
+        descs = [attrs[desc]
+                 for desc in ("Name", "Description") if desc in attrs]
+        if len(descs) == 2:
+            descs[0] = "<b>{}</b>".format(descs[0])
+        if descs:
+            text += "<p>{}</p>".format("<br/>".join(descs))
+
+        text += "<p>{} instance(s), {} feature(s), {} meta attribute(s)".\
+            format(len(table), len(domain.attributes), len(domain.metas))
         if domain.has_continuous_class:
-            text += "\nRegression; numerical class."
+            text += "<br/>Regression; numerical class."
         elif domain.has_discrete_class:
-            text += "\nClassification; discrete class with {} values.".format(
-                len(domain.class_var.values))
+            text += "<br/>Classification; discrete class with {} values.".\
+                format(len(domain.class_var.values))
         elif table.domain.class_vars:
-            text += "\nMulti-target; {} target variables.".format(
+            text += "<br/>Multi-target; {} target variables.".format(
                 len(table.domain.class_vars))
         else:
-            text += "\nData has no target variable."
+            text += "<br/>Data has no target variable."
+        text += "</p>"
+
         if 'Timestamp' in table.domain:
             # Google Forms uses this header to timestamp responses
-            text += '\n\nFirst entry: {}\nLast entry: {}'.format(
+            text += '<p>First entry: {}<br/>Last entry: {}</p>'.format(
                 table[0, 'Timestamp'], table[-1, 'Timestamp'])
         return text
 


### PR DESCRIPTION
@astaric, you meant something like this?

<img width="642" alt="screen shot 2016-09-24 at 00 51 54" src="https://cloud.githubusercontent.com/assets/2387315/18803555/4429afd2-81f1-11e6-96b5-a4069b8a50c4.png">

Orange already read and wrote .metadata files, but in pickle format. This is highly inconvenient since the user can't edit it. I changed the format to a (very) simplified YAML: the file is expected to contain a single block mapping. Data is read as string. If we wish, we can either try to evaluate it (with fallback to string) or use PyYAML, although I don't think we need it.