### PR TITLE
Table: Fix non-string metas filtering

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1122,6 +1122,7 @@ class Table(MutableSequence, Storage):
             if isinstance(f, data_filter.FilterDiscrete) and f.values is None \
                     or isinstance(f, data_filter.FilterContinuous) and \
                                     f.oper == f.IsDefined:
+                col = col.astype(float)
                 if conjunction:
                     sel *= ~np.isnan(col)
                 else:

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1022,6 +1022,12 @@ class TableTestCase(unittest.TestCase):
         x = filter.Values([f])(d)
         self.assertEqual(len(x), 7)
 
+    def test_valueFilter_discrete_meta_is_defined(self):
+        d = data.Table("test9.tab")
+        f = filter.FilterDiscrete(-4, None)
+        x = filter.Values([f])(d)
+        self.assertEqual(len(x), 8)
+
     def test_valueFilter_string_case_sens(self):
         d = data.Table("zoo")
         col = d[:, "name"].metas[:, 0]


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

OWSelectRows widget crashed, when filtering discrete meta attribute (if metas consist of both, discrete and string attributes).
Used condition was "is defined".