### PR TITLE
[FIX] Scatterplot: Reintroduce sliders for size and opacity

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -197,6 +197,7 @@ class OWScatterPlot(OWWidget):
             **common_options)
 
         g = self.graph.gui
+        g.point_properties_box(self.controlArea, box)
         box = gui.vBox(self.controlArea, "Plot Properties")
         g.add_widgets([g.ShowLegend, g.ShowGridLines], box)
         gui.checkBox(


### PR DESCRIPTION
Fixes #1621.

@ajdapretnar also complained about the missing sliders, but I told her that it was intentional. We want to simplify the GUI's by selecting optimal colors/sizes/shapes... ourselves instead of having dozens of options.

I remember discussing this, but I'm no longer sure that we reached a conclusion and that the change was indeed intentional: the commit in which this was removed, 71ccfcdd3de7dc0bdc0170dd752800cdf806ab99, is named "Lint" and doesn't make any other non-lint-related changes.
