### PR TITLE
[FIX] win-installer: Build scikit-learn in windows installer build script

### DIFF
--- a/scripts/windows/build-win-application.sh
+++ b/scripts/windows/build-win-application.sh
@@ -116,11 +116,6 @@ mkdir -p "$DISTDIR"
 
 touch "$BUILDBASE"/requirements.txt
 
-# pinned requirements (numpy and scipy are handled separately)
-echo "
-#:wheel: scikit-learn https://pypi.python.org/packages/b8/9a/02d5d76be66c57aaa9f917c87007b9b0bf486992cc7701512464d1ce11e9/scikit_learn-0.17.1-cp34-cp34m-win32.whl#md5=ab00daed7cdac4cb16ad0613b91be07e
-scikit-learn==0.17.1
-" > "$BUILDBASE"/requirements.txt
 
 function __download_url {
     local url=${1:?}
@@ -287,7 +282,7 @@ function prepare_orange {
         bdist_wheel -d "$BUILDBASE/wheelhouse"
 
     # Ensure all install dependencies are available in the wheelhouse
-    prepare_req --only-binary numpy,scipy,scikit-learn .
+    prepare_req --only-binary numpy,scipy .
 
     echo "# Orange " >> "$BUILDBASE/requirements.txt"
     echo "$name==$version" >> "$BUILDBASE/requirements.txt"


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

scikit-learn no longer provides wheels for Python 3.4 on windows for the latest 0.18 release.