### PR TITLE
Refactor SqlTable

### DIFF
--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import re
 import threading
+import warnings
 
 from contextlib import contextmanager
 from itertools import islice
@@ -28,8 +29,76 @@ sql_log = logging.getLogger('sql_log')
 sql_log.debug("Logging started: {}".format(strftime("%Y-%m-%d %H:%M:%S")))
 
 
-class SqlTable(Table):
+class Psycopg2Backend:
+    """Backend for accesing data stored in a PostgreSql tdatabase
+
+    Parameters
+    ----------
+    connection_params: dict
+        connection params passed tot he psycopg2 drriver
+    """
+
+
     connection_pool = None
+
+    def __init__(self, connection_params):
+        self.connection_params = connection_params
+
+        if self.connection_pool is None:
+            self._create_connection_pool()
+
+    def _create_connection_pool(self):
+        self.connection_pool = psycopg2.pool.ThreadedConnectionPool(
+            1, 16, **self.connection_params)
+
+    @contextmanager
+    def execute_sql_query(self, query, params=None):
+        """Context manager for execution of sql queries
+
+        Usage:
+            ```
+            with backend.execute_sql_query("SELECT * FROM foo") as cur:
+                cur.fetch_all()
+            ```
+
+        Parameters
+        ----------
+        query : string
+            query to be executed
+        params: tuple
+            parameters to be passed to the query
+
+        Returns
+        -------
+        yields a cursor that can be used to access the data
+        """
+
+        connection = self.connection_pool.getconn()
+        cur = connection.cursor()
+        try:
+            utfquery = cur.mogrify(query, params).decode('utf-8')
+            sql_log.debug("Executing: {}".format(utfquery))
+            t = time()
+            cur.execute(query, params)
+            yield cur
+            sql_log.info("{:.2f} ms: {}".format(1000 * (time() - t), utfquery))
+        finally:
+            connection.commit()
+            self.connection_pool.putconn(connection)
+
+    def __getstate__(self):
+        # Drop connection_pool from state as it cannot be pickled
+        state = dict(self.__dict__)
+        state.pop('connection_pool')
+        return state
+
+    def __setstate__(self, state):
+        # Create a new connection pool
+        self.__dict__.update(state)
+        self._create_connection_pool()
+
+
+class SqlTable(Table):
     table_name = None
     domain = None
     row_filters = ()
@@ -75,10 +144,7 @@ class SqlTable(Table):
         """
         if isinstance(connection_params, str):
             connection_params = dict(database=connection_params)
-        self.connection_params = connection_params
-
-        if self.connection_pool is None:
-            self.create_connection_pool()
+        self.backend = Psycopg2Backend(connection_params)
 
         if table_or_sql is not None:
             if "SELECT" in table_or_sql.upper():
@@ -89,9 +155,10 @@ class SqlTable(Table):
             self.domain = self.get_domain(type_hints, inspect_values)
             self.name = table
 
-    def create_connection_pool(self):
-        self.connection_pool = psycopg2.pool.ThreadedConnectionPool(
-            1, 16, **self.connection_params)
+    @property
+    def connection_params(self):
+        warnings.warn("Use backend.connection_params", DeprecationWarning)
+        return self.backend.connection_params
 
     def get_domain(self, type_hints=None, guess_values=False):
         if type_hints is None:
@@ -99,7 +166,7 @@ class SqlTable(Table):
 
         fields = []
         query = "SELECT * FROM %s LIMIT 0" % self.table_name
-        with self._execute_sql_query(query) as cur:
+        with self.backend.execute_sql_query(query) as cur:
             for col in cur.description:
                 fields.append(col)
 
@@ -179,7 +246,7 @@ class SqlTable(Table):
                             self.quote_identifier(field_name)),
                         "ORDER BY", self.quote_identifier(field_name),
                         "LIMIT 21"])
-        with self._execute_sql_query(sql) as cur:
+        with self.backend.execute_sql_query(sql) as cur:
             values = cur.fetchall()
         if len(values) > 20:
             return ()
@@ -281,7 +348,7 @@ class SqlTable(Table):
 
         # TODO: this returns all rows between min(rows) and max(rows): fix!
         query = self._sql_query(fields, filters, offset=offset, limit=limit)
-        with self._execute_sql_query(query) as cur:
+        with self.backend.execute_sql_query(query) as cur:
             while True:
                 row = cur.fetchone()
                 if row is None:
@@ -291,18 +358,17 @@ class SqlTable(Table):
     def copy(self):
         """Return a copy of the SqlTable"""
         table = SqlTable.__new__(SqlTable)
-        table.connection_pool = self.connection_pool
+        table.backend = self.backend
         table.domain = self.domain
         table.row_filters = self.row_filters
         table.table_name = self.table_name
         table.name = self.name
-        table.connection_params = self.connection_params
         return table
 
     def __bool__(self):
         """Return True if the SqlTable is not empty."""
         query = self._sql_query(["1"], limit=1)
-        with self._execute_sql_query(query) as cur:
+        with self.backend.execute_sql_query(query) as cur:
             return cur.fetchone() is not None
 
     _cached__len__ = None
@@ -318,7 +384,7 @@ class SqlTable(Table):
 
     def _count_rows(self):
         query = self._sql_query(["COUNT(*)"])
-        with self._execute_sql_query(query) as cur:
+        with self.backend.execute_sql_query(query) as cur:
             self._cached__len__ = cur.fetchone()[0]
         return self._cached__len__
 
@@ -326,7 +392,7 @@ class SqlTable(Table):
         if self._cached__len__ is not None:
             return self._cached__len__
         sql = "EXPLAIN " + self._sql_query(["*"])
-        with self._execute_sql_query(sql) as cur:
+        with self.backend.execute_sql_query(sql) as cur:
             s = ''.join(row[0] for row in cur.fetchall())
         alen = int(re.findall('rows=(\d*)', s)[0])
         if get_exact:
@@ -424,7 +490,7 @@ class SqlTable(Table):
             stats = self.CONTINUOUS_STATS if continuous else self.DISCRETE_STATS
             sql_fields.append(stats % dict(field_name=field_name))
         query = self._sql_query(sql_fields)
-        with self._execute_sql_query(query) as cur:
+        with self.backend.execute_sql_query(query) as cur:
             results = cur.fetchone()
         stats = []
         i = 0
@@ -456,7 +522,7 @@ class SqlTable(Table):
                                     filters=['%s IS NOT NULL' % field_name],
                                     group_by=[field_name],
                                     order_by=[field_name])
-            with self._execute_sql_query(query) as cur:
+            with self.backend.execute_sql_query(query) as cur:
                 dist = np.array(cur.fetchall())
             if col.is_continuous:
                 dists.append((dist.T, []))
@@ -499,7 +565,7 @@ class SqlTable(Table):
                        for f in (row_field, column_field)]
             query = self._sql_query(fields, filters=filters,
                                     group_by=group_by, order_by=order_by)
-            with self._execute_sql_query(query) as cur:
+            with self.backend.execute_sql_query(query) as cur:
                 data = list(cur.fetchall())
                 if column.is_continuous:
                     all_contingencies[i] = \
@@ -684,11 +750,11 @@ class SqlTable(Table):
             str(parameter).replace('.', '_').replace('-', '_'))
         create = False
         try:
-            with self._execute_sql_query("SELECT * FROM %s LIMIT 0;" % self.quote_identifier(sample_table)) as cur:
+            with self.backend.execute_sql_query("SELECT * FROM %s LIMIT 0;" % self.quote_identifier(sample_table)) as cur:
                 cur.fetchall()
 
             if no_cache:
-                with self._execute_sql_query("DROP TABLE %s;" % self.quote_identifier(sample_table)) as cur:
+                with self.backend.execute_sql_query("DROP TABLE %s;" % self.quote_identifier(sample_table)) as cur:
                     cur.fetchall()
                 create = True
 
@@ -696,7 +762,7 @@ class SqlTable(Table):
             create = True
 
         if create:
-            with self._execute_sql_query((
+            with self.backend.execute_sql_query((
                     "CREATE TABLE {target} AS "
                     "SELECT * FROM {source} TABLESAMPLE {method}({param});"
                     ).format(target=self.quote_identifier(sample_table),
@@ -707,37 +773,19 @@ class SqlTable(Table):
 
         sampled_table = self.copy()
         sampled_table.table_name = self.quote_identifier(sample_table)
-        with sampled_table._execute_sql_query(
+        with sampled_table.backend.execute_sql_query(
                 'ANALYZE {}'.format(sampled_table.table_name)):
             pass
         return sampled_table
 
     @contextmanager
     def _execute_sql_query(self, query, param=None):
-        connection = self.connection_pool.getconn()
-        cur = connection.cursor()
-        try:
-            utfquery = cur.mogrify(query, param).decode('utf-8')
-            sql_log.debug("Executing: {}".format(utfquery))
-            t = time()
-            cur.execute(query, param)
+        warnings.warn("Use backend.execute_sql_query", DeprecationWarning)
+        with self.backend.execute_sql_query(query, param) as cur:
             yield cur
-            sql_log.info("{:.2f} ms: {}".format(1000 * (time() - t), utfquery))
-        finally:
-            connection.commit()
-            self.connection_pool.putconn(connection)
 
     def checksum(self, include_metas=True):
         return np.nan
-
-    def __getstate__(self):
-        state = dict(self.__dict__)
-        state.pop('connection_pool')
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self.create_connection_pool()
 
 
 class SqlRowInstance(Instance):

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -233,13 +233,14 @@ class Psycopg2Backend:
     def __getstate__(self):
         # Drop connection_pool from state as it cannot be pickled
         state = dict(self.__dict__)
-        state.pop('connection_pool')
+        state.pop('connection_pool', None)
         return state
 
     def __setstate__(self, state):
-        # Create a new connection pool
+        # Create a new connection pool if none exists
         self.__dict__.update(state)
-        self._create_connection_pool()
+        if self.connection_pool is None:
+            self._create_connection_pool()
 
 
 class SqlTable(Table):

--- a/Orange/tests/sql/test_misc.py
+++ b/Orange/tests/sql/test_misc.py
@@ -1,0 +1,28 @@
+"""Test for miscellaneous sql queries in widgets
+
+Please note that such use is deprecated.
+"""
+from Orange.data.sql.table import SqlTable
+from Orange.preprocess import Discretize
+from Orange.preprocess.discretize import EqualFreq
+from Orange.tests.sql.base import PostgresTest
+from Orange.widgets.visualize.owmosaic import get_conditional_distribution
+from Orange.widgets.visualize.utils.lac import create_sql_contingency, get_bin_centers
+
+
+class MiscSqlTests(PostgresTest):
+    def test_discretization(self):
+        iris = SqlTable(self.conn, self.iris, inspect_values=True)
+        sepal_length = iris.domain["sepal length"]
+        EqualFreq(n=4)(iris, sepal_length)
+
+    def test_get_conditional_distribution(self):
+        iris = SqlTable(self.conn, self.iris, inspect_values=True)
+        sepal_length = iris.domain["sepal length"]
+        get_conditional_distribution(iris, [sepal_length])
+        get_conditional_distribution(iris, list(iris.domain))
+
+    def test_create_sql_contingency(self):
+        iris = SqlTable(self.conn, self.iris, inspect_values=True)
+        d_iris = Discretize()(iris)
+        create_sql_contingency(d_iris, [0, 1], get_bin_centers(d_iris))

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -5,6 +5,7 @@ import unittest
 import unittest.mock
 
 import numpy as np
+import pickle
 from numpy.testing import assert_almost_equal
 
 from Orange.data import filter, ContinuousVariable, DiscreteVariable, \
@@ -587,6 +588,13 @@ class TestSqlTable(PostgresTest):
         self.assertIsInstance(conts[0], Continuous)
         self.assertIsInstance(conts[1], Continuous)
         self.assertIsInstance(conts[2], Discrete)
+
+    def test_pickling_restores_connection_pool(self):
+        iris = SqlTable(self.conn, self.iris, inspect_values=True)
+        iris2 = pickle.loads(pickle.dumps(iris))
+
+        self.assertEqual(iris[0], iris2[0])
+
 
     def assertFirstAttrIsInstance(self, table, variable_type):
         self.assertGreater(len(table.domain), 0)

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -530,14 +530,14 @@ class TestSqlTable(PostgresTest):
         try:
             broken_query = "SELECT 1/%s FROM %s" % (
                 sql_table.domain.attributes[0].to_sql(), sql_table.table_name)
-            with sql_table._execute_sql_query(broken_query) as cur:
+            with sql_table.backend.execute_sql_query(broken_query) as cur:
                 cur.fetchall()
         except psycopg2.DataError:
             pass
 
         working_query = "SELECT %s FROM %s" % (
             sql_table.domain.attributes[0].to_sql(), sql_table.table_name)
-        with sql_table._execute_sql_query(working_query) as cur:
+        with sql_table.backend.execute_sql_query(working_query) as cur:
             cur.fetchall()
 
     def test_basic_stats(self):

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -309,10 +309,10 @@ class OWSql(OWWidget):
             QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
             if sample:
                 s = table.sample_time(1)
-                domain = s.get_domain(guess_values=True)
+                domain = s.get_domain(inspect_values=True)
                 self.Information.data_sampled()
             else:
-                domain = table.get_domain(guess_values=True)
+                domain = table.get_domain(inspect_values=True)
             QApplication.restoreOverrideCursor()
             table.domain = domain
 

--- a/Orange/widgets/visualize/owparallelgraph.py
+++ b/Orange/widgets/visualize/owparallelgraph.py
@@ -1,18 +1,13 @@
 #
 # OWParallelGraph.py
 #
-from collections import defaultdict
-import os
-import sys
 import math
+from collections import defaultdict
 
 import numpy as np
 
 from PyQt4.QtCore import QLineF, Qt, QEvent, QRect, QPoint, QPointF
 from PyQt4.QtGui import QGraphicsPathItem, QPixmap, QColor, QBrush, QPen, QToolTip, QPainterPath, QPolygonF, QGraphicsPolygonItem
-
-from Orange.preprocess import Discretize
-from Orange.preprocess.discretize import EqualFreq
 
 from Orange.statistics.contingency import get_contingencies, get_contingency
 from Orange.widgets import gui
@@ -21,6 +16,7 @@ from Orange.widgets.utils.colorpalette import ContinuousPaletteGenerator
 from Orange.widgets.utils.plot import OWPlot, UserAxis, AxisStart, AxisEnd, OWCurve, OWPoint, PolygonCurve, \
     xBottom, yLeft, OWPlotItem
 from Orange.widgets.utils.scaling import get_variable_values_sorted, ScaleData
+from Orange.widgets.visualize.utils.lac import lac, create_contingencies
 
 NO_STATISTICS = 0
 MEANS = 1
@@ -655,206 +651,3 @@ class ParallelCoordinatePolygon(OWPlotItem):
     def update_properties(self):
         self.outer_box.setPolygon(self.graph_transform().map(self.twosigmapolygon))
         self.inner_box.setPolygon(self.graph_transform().map(self.sigmapolygon))
-
-
-def initialize_random(conts, k):
-    mu = np.zeros((k, len(conts)))
-    sigma = np.zeros((k, len(conts)))
-    for i, (c, cw) in enumerate(conts):
-        w = np.random.random((len(c), k))
-        w /= w.sum(axis=1)[:, None]
-
-        c = c[:, 0] if i == 0 else c[:, 1]
-
-        for j in range(k):
-            mu1 = np.dot(w[:, j] * cw, c) / (w[:, j] * cw).sum()
-            cn = c - mu1
-            sigma1 = np.sum(cn ** 2 * w[:, j] * cw, axis=0) / (w[:, j] * cw).sum()
-
-            mu[j, i] = mu1
-            sigma[j, i] = sigma1
-
-    return mu, sigma
-
-def initialize_kmeans(conts, k):
-    x = []
-    xm = {}
-    for i, (c, cw) in enumerate(conts[1:-1]):
-        oldx, oldxm, x, xm = x, xm, [], {}
-        if i == 0:
-            for a, w in zip(c, cw):
-                x.append((tuple(a), w))
-                xm.setdefault(tuple(a)[1:], []).append(len(x) - 1)
-        else:
-            for a, w in zip(c, cw):
-                for l in oldxm[tuple(a[:2])]:
-                    olda, oldw = oldx[l]
-                    x.append((olda + (a[2],), oldw+w))
-                    xm.setdefault(tuple(a)[1:], []).append(len(x) - 1)
-
-    X = np.array([y[0] for y in x])
-
-    import sklearn.cluster as skl_cluster
-    kmeans = skl_cluster.KMeans(n_clusters=k)
-    Y = kmeans.fit_predict(X)
-    means = kmeans.cluster_centers_
-    covars = np.zeros((k, len(conts)))
-    for j in range(k):
-        xn = X[Y == j, :] - means[j]
-        covars[j] = np.sum(xn ** 2, axis=0) / len(xn)
-
-    return means, covars
-
-
-def lac(conts, k, nsteps=30, window_size=1):
-    """
-    k expected classes,
-    m data points,
-    each with dim dimensions
-    """
-    dim = len(conts)
-
-    np.random.seed(42)
-    # Initialize parameters
-    priors = np.ones(k) / k
-
-
-    print("Initializing")
-    import sys; sys.stdout.flush()
-    means, covars = initialize_random(conts, k)
-    #means, covars = initialize_kmeans(conts, k)
-    print("Done")
-
-    w = [np.empty((k, len(c[0]),)) for c in conts]
-    active = np.ones(k, dtype=np.bool)
-
-    for i in range(1, nsteps + 1):
-        for l, (c, cw) in enumerate(conts):
-            lower = l - window_size if l - window_size >= 0 else None
-            upper = l + window_size + 1 if l + window_size + 1 <= dim else None
-            dims = slice(lower, upper)
-            active_dim = min(l, window_size)
-
-            x = c
-
-            # E step
-            for j in range(k):
-                if any(np.abs(covars[j, dims]) < 1e-15):
-                    active[j] = 0
-
-                if active[j]:
-                    det = covars[j, dims].prod()
-                    inv_covars = 1. / covars[j, dims]
-                    xn = x - means[j, dims]
-                    factor = (2.0 * np.pi) ** (x.shape[1]/ 2.0) * det ** 0.5
-                    w[l][j] = priors[j] * np.exp(np.sum(xn * inv_covars * xn, axis=1) * -.5) / factor
-                else:
-                    w[l][j] = 0
-            w[l][active] /= w[l][active].sum(axis=0)
-
-            # M step
-            n = np.sum(w[l], axis=1)
-            priors = n / np.sum(n)
-            for j in range(k):
-                if n[j]:
-                    mu = np.dot(w[l][j, :] * cw, x[:, active_dim]) / (w[l][j, :] * cw).sum()
-
-                    xn = x[:, active_dim] - mu
-                    sigma = np.sum(xn ** 2 * w[l][j] * cw, axis=0) / (w[l][j, :] * cw).sum()
-
-                    if np.isnan(mu).any() or np.isnan(sigma).any():
-                        return w, means, covars, priors
-                else:
-                    active[j] = 0
-                    mu = 0.
-                    sigma = 0.
-                means[j, l] = mu
-                covars[j, l] = sigma
-
-    # w = np.zeros((k, m))
-    # for j in range(k):
-    #     if active[j]:
-    #         det = covars[j].prod()
-    #         inv_covars = 1. / covars[j]
-    #         xn = X - means[j]
-    #         factor = (2.0 * np.pi) ** (xn.shape[1] / 2.0) * det ** 0.5
-    #         w[j] = priors[j] * exp(-.5 * np.sum(xn * inv_covars * xn, axis=1)) / factor
-    # w[active] /= w[active].sum(axis=0)
-
-    return w, means, covars, priors
-
-
-def create_contingencies(X, callback=None):
-    window_size = 1
-    dim = len(X.domain)
-
-    X_ = Discretize(method=EqualFreq(n=10))(X)
-    m = []
-    for i, var in enumerate(X_.domain):
-        cleaned_values = [tuple(map(str.strip, v.strip('[]()<>=≥').split('-')))
-                          for v in var.values]
-        try:
-            float_values = [[float(v) for v in vals] for vals in cleaned_values]
-            bin_centers = {
-                i: v[0] if len(v) == 1 else v[0] + (v[1] - v[0])
-                for i, v in enumerate(float_values)
-            }
-        except ValueError:
-            bin_centers = {
-                i: i
-                for i, v in enumerate(cleaned_values)
-            }
-        m.append(bin_centers)
-
-    from Orange.data.sql.table import SqlTable
-    if isinstance(X, SqlTable):
-        conts = []
-        al = len(X.domain)
-        if al > 1:
-            conts.append(create_sql_contingency(X_, [0, 1], m))
-            if callback:
-                callback(1, al)
-            for a1, a2, a3 in zip(range(al), range(1, al), range(2, al)):
-                conts.append(create_sql_contingency(X_, [a1, a2, a3], m))
-                if callback:
-                    callback(a3, al)
-            if al > 2:
-                conts.append(create_sql_contingency(X_, [al-2, al-1], m))
-                if callback:
-                    callback(al, al)
-    else:
-        conts = [defaultdict(float) for i in range(len(X_.domain))]
-        for i, r in enumerate(X_):
-            if any(np.isnan(r)):
-                continue
-            row = tuple(m[vi].get(v) for vi, v in enumerate(r))
-            for l in range(len(X_.domain)):
-                lower = l - window_size if l - window_size >= 0 else None
-                upper = l + window_size + 1 if l + window_size + 1 <= dim else None
-                dims = slice(lower, upper)
-
-                conts[l][row[dims]] += 1
-        conts = [zip(*x.items()) for x in conts]
-        conts = [(np.array(c), np.array(cw)) for c, cw in conts]
-
-    # for i, ((c1, cw1), (c2, cw2)) in enumerate(zip(contss, conts)):
-    #     a = np.sort(np.hstack((c1, cw1[:, None])), axis=0)
-    #     b = np.sort(np.hstack((c2, cw2[:, None])), axis=0)
-    #     assert_almost_equal(a, b)
-
-    return conts
-
-
-def create_sql_contingency(X, columns, m):
-    def convert(row):
-        c = len(row) - 1
-        return [m[columns[i]].get(v) if i != c else v
-                for i, v in enumerate(row)]
-
-    group_by = [a.to_sql() for a in (X.domain[c] for c in columns)]
-    filters = ['%s IS NOT NULL' % a for a in group_by]
-    fields = group_by + ['COUNT(%s)' % group_by[0]]
-    query = X._sql_query(fields, group_by=group_by, filters=filters)
-    with X._execute_sql_query(query) as cur:
-        cont = np.array(list(map(convert, cur.fetchall())), dtype='float')
-    return cont[:, :-1], cont[:, -1:].flatten()

--- a/Orange/widgets/visualize/utils/lac.py
+++ b/Orange/widgets/visualize/utils/lac.py
@@ -1,0 +1,214 @@
+from collections import defaultdict
+
+import numpy as np
+from Orange.preprocess import Discretize
+from Orange.preprocess.discretize import EqualFreq
+
+
+def create_sql_contingency(X, columns, m):
+    def convert(row):
+        c = len(row) - 1
+        return [m[columns[i]].get(v) if i != c else v
+                for i, v in enumerate(row)]
+
+    group_by = [a.to_sql() for a in (X.domain[c] for c in columns)]
+    filters = ['%s IS NOT NULL' % a for a in group_by]
+    fields = group_by + ['COUNT(%s)' % group_by[0]]
+    query = X._sql_query(fields, group_by=group_by, filters=filters)
+    with X._execute_sql_query(query) as cur:
+        cont = np.array(list(map(convert, cur.fetchall())), dtype='float')
+    return cont[:, :-1], cont[:, -1:].flatten()
+
+
+def initialize_random(conts, k):
+    mu = np.zeros((k, len(conts)))
+    sigma = np.zeros((k, len(conts)))
+    for i, (c, cw) in enumerate(conts):
+        w = np.random.random((len(c), k))
+        w /= w.sum(axis=1)[:, None]
+
+        c = c[:, 0] if i == 0 else c[:, 1]
+
+        for j in range(k):
+            mu1 = np.dot(w[:, j] * cw, c) / (w[:, j] * cw).sum()
+            cn = c - mu1
+            sigma1 = np.sum(cn ** 2 * w[:, j] * cw, axis=0) / (w[:, j] * cw).sum()
+
+            mu[j, i] = mu1
+            sigma[j, i] = sigma1
+
+    return mu, sigma
+
+
+def initialize_kmeans(conts, k):
+    x = []
+    xm = {}
+    for i, (c, cw) in enumerate(conts[1:-1]):
+        oldx, oldxm, x, xm = x, xm, [], {}
+        if i == 0:
+            for a, w in zip(c, cw):
+                x.append((tuple(a), w))
+                xm.setdefault(tuple(a)[1:], []).append(len(x) - 1)
+        else:
+            for a, w in zip(c, cw):
+                for l in oldxm[tuple(a[:2])]:
+                    olda, oldw = oldx[l]
+                    x.append((olda + (a[2],), oldw+w))
+                    xm.setdefault(tuple(a)[1:], []).append(len(x) - 1)
+
+    X = np.array([y[0] for y in x])
+
+    import sklearn.cluster as skl_cluster
+    kmeans = skl_cluster.KMeans(n_clusters=k)
+    Y = kmeans.fit_predict(X)
+    means = kmeans.cluster_centers_
+    covars = np.zeros((k, len(conts)))
+    for j in range(k):
+        xn = X[Y == j, :] - means[j]
+        covars[j] = np.sum(xn ** 2, axis=0) / len(xn)
+
+    return means, covars
+
+
+def lac(conts, k, nsteps=30, window_size=1):
+    """
+    k expected classes,
+    m data points,
+    each with dim dimensions
+    """
+    dim = len(conts)
+
+    np.random.seed(42)
+    # Initialize parameters
+    priors = np.ones(k) / k
+
+
+    print("Initializing")
+    import sys; sys.stdout.flush()
+    means, covars = initialize_random(conts, k)
+    #means, covars = initialize_kmeans(conts, k)
+    print("Done")
+
+    w = [np.empty((k, len(c[0]),)) for c in conts]
+    active = np.ones(k, dtype=np.bool)
+
+    for i in range(1, nsteps + 1):
+        for l, (c, cw) in enumerate(conts):
+            lower = l - window_size if l - window_size >= 0 else None
+            upper = l + window_size + 1 if l + window_size + 1 <= dim else None
+            dims = slice(lower, upper)
+            active_dim = min(l, window_size)
+
+            x = c
+
+            # E step
+            for j in range(k):
+                if any(np.abs(covars[j, dims]) < 1e-15):
+                    active[j] = 0
+
+                if active[j]:
+                    det = covars[j, dims].prod()
+                    inv_covars = 1. / covars[j, dims]
+                    xn = x - means[j, dims]
+                    factor = (2.0 * np.pi) ** (x.shape[1]/ 2.0) * det ** 0.5
+                    w[l][j] = priors[j] * np.exp(np.sum(xn * inv_covars * xn, axis=1) * -.5) / factor
+                else:
+                    w[l][j] = 0
+            w[l][active] /= w[l][active].sum(axis=0)
+
+            # M step
+            n = np.sum(w[l], axis=1)
+            priors = n / np.sum(n)
+            for j in range(k):
+                if n[j]:
+                    mu = np.dot(w[l][j, :] * cw, x[:, active_dim]) / (w[l][j, :] * cw).sum()
+
+                    xn = x[:, active_dim] - mu
+                    sigma = np.sum(xn ** 2 * w[l][j] * cw, axis=0) / (w[l][j, :] * cw).sum()
+
+                    if np.isnan(mu).any() or np.isnan(sigma).any():
+                        return w, means, covars, priors
+                else:
+                    active[j] = 0
+                    mu = 0.
+                    sigma = 0.
+                means[j, l] = mu
+                covars[j, l] = sigma
+
+    # w = np.zeros((k, m))
+    # for j in range(k):
+    #     if active[j]:
+    #         det = covars[j].prod()
+    #         inv_covars = 1. / covars[j]
+    #         xn = X - means[j]
+    #         factor = (2.0 * np.pi) ** (xn.shape[1] / 2.0) * det ** 0.5
+    #         w[j] = priors[j] * exp(-.5 * np.sum(xn * inv_covars * xn, axis=1)) / factor
+    # w[active] /= w[active].sum(axis=0)
+
+    return w, means, covars, priors
+
+
+def create_contingencies(X, callback=None):
+    window_size = 1
+    dim = len(X.domain)
+
+    X_ = Discretize(method=EqualFreq(n=10))(X)
+    m = get_bin_centers(X_)
+
+    from Orange.data.sql.table import SqlTable
+    if isinstance(X, SqlTable):
+        conts = []
+        al = len(X.domain)
+        if al > 1:
+            conts.append(create_sql_contingency(X_, [0, 1], m))
+            if callback:
+                callback(1, al)
+            for a1, a2, a3 in zip(range(al), range(1, al), range(2, al)):
+                conts.append(create_sql_contingency(X_, [a1, a2, a3], m))
+                if callback:
+                    callback(a3, al)
+            if al > 2:
+                conts.append(create_sql_contingency(X_, [al - 2, al - 1], m))
+                if callback:
+                    callback(al, al)
+    else:
+        conts = [defaultdict(float) for i in range(len(X_.domain))]
+        for i, r in enumerate(X_):
+            if any(np.isnan(r)):
+                continue
+            row = tuple(m[vi].get(v) for vi, v in enumerate(r))
+            for l in range(len(X_.domain)):
+                lower = l - window_size if l - window_size >= 0 else None
+                upper = l + window_size + 1 if l + window_size + 1 <= dim else None
+                dims = slice(lower, upper)
+
+                conts[l][row[dims]] += 1
+        conts = [zip(*x.items()) for x in conts]
+        conts = [(np.array(c), np.array(cw)) for c, cw in conts]
+
+    # for i, ((c1, cw1), (c2, cw2)) in enumerate(zip(contss, conts)):
+    #     a = np.sort(np.hstack((c1, cw1[:, None])), axis=0)
+    #     b = np.sort(np.hstack((c2, cw2[:, None])), axis=0)
+    #     assert_almost_equal(a, b)
+
+    return conts
+
+
+def get_bin_centers(X_):
+    m = []
+    for i, var in enumerate(X_.domain):
+        cleaned_values = [tuple(map(str.strip, v.strip('[]()<>=≥').split('-')))
+                          for v in var.values]
+        try:
+            float_values = [[float(v) for v in vals] for vals in cleaned_values]
+            bin_centers = {
+                i: v[0] if len(v) == 1 else v[0] + (v[1] - v[0])
+                for i, v in enumerate(float_values)
+                }
+        except ValueError:
+            bin_centers = {
+                i: i
+                for i, v in enumerate(cleaned_values)
+                }
+        m.append(bin_centers)
+    return m


### PR DESCRIPTION
Sql code is currently coupled with SqlTable, making support for other sql backends hard to implement. This PR moves (some of the) code that is dependent on sql driver to a separate class (Psycopg2Backend) which could (in theory) be replaces by another implementation of the database backend.