### PR TITLE
Focus adjustments

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -787,6 +787,7 @@ class LineEditWFocusOut(QtGui.QLineEdit):
         self.__changed = True
 
     def returnPressedHandler(self):
+        self.clearFocus()
         if self.__changed:
             self.__changed = False
             if hasattr(self, "cback") and self.cback:

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -205,6 +205,9 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
 
         sc = QShortcut(QKeySequence.Copy, self)
         sc.activated.connect(self.copy_to_clipboard)
+        if self.controlArea is not None:
+            # Otherwise, the first control has focus
+            self.controlArea.setFocus(Qt.ActiveWindowFocusReason)
         return self
 
     # pylint: disable=super-init-not-called


### PR DESCRIPTION
Pressing Enter in line edit should remove the focus. This signals that the data has been "entered". At least on Os X, keeping the focus looks as if the field is still being edited.

Second, when the widget open, the first field shouldn't have focus - especially if this is line edit. Editing should be triggered by the user.

For an example, open the Paint widget. The first line edit has focus and pressing Enter does not release it.