### PR TITLE
[FIX] owsql: Fix bug when using connection before established

### DIFF
--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -171,6 +171,7 @@ class OWSql(OWWidget):
                 ("Host", self.host), ("Port", self.port),
                 ("Database", self.database), ("User name", self.username)
             ))
+            self.create_extensions()
             self.refresh_tables()
             self.select_table()
         except psycopg2.Error as err:
@@ -236,7 +237,6 @@ class OWSql(OWWidget):
             shown=missing)
 
     def open_table(self):
-        self.create_extensions()
         table = self.get_table()
         self.data_desc_table = table
         self.send("Data", table)


### PR DESCRIPTION
Move the attempt to create missing extensions right after the connection to the database is established.
Before, this could be attempted even before the connection existed, which resulted in an error (reproduced by setting parameters and before refreshing tick a checkbox).


<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

