### PR TITLE
[FIX] Switch Sieve to DomainModel, which also fixes VizRank crash on meta attributes

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -456,6 +456,9 @@ class PyListModel(QAbstractListModel):
     def __len__(self):
         return len(self._list)
 
+    def __contains__(self, value):
+        return value in self._list
+
     def __iter__(self):
         return iter(self._list)
 

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -20,6 +20,7 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         self.widget = self.create_widget(OWSieveDiagram)
 
     def _select_data(self):
+        self.widget.attr_x, self.widget.attr_y = self.data.domain[:2]
         area = self.widget.areas[0]
         self.widget.select_area(area, QMouseEvent(
             QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,


### PR DESCRIPTION
Fixes #1546.
<strike>Breaks compatibility with old settings. See #1672 for a similar problem with the scatter plot.
Blocked by #1724 and #1727.</strike>