### PR TITLE
[FIX] Canvas: Replace illegal file-name characters with _ when saving workf…

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1170,6 +1170,8 @@ class CanvasMainWindow(QMainWindow):
         document = self.current_document()
         curr_scheme = document.scheme()
         title = curr_scheme.title or "untitled"
+        for illegal in r'<>:"\/|?*\0':
+            title = title.replace(illegal, '_')
 
         if document.path():
             start_dir = document.path()


### PR DESCRIPTION
Fixes #1582. Can somebody on Windows check this?

- Use illegal characters in the workflow name when opening a new workflow, and try saving it with the suggested name
- Try using illegal characters in the save dialog