### PR TITLE
Make TreeAdapters for Pythagorean trees more general

### DIFF
--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -350,7 +350,7 @@ class OWPythagorasTree(OWWidget):
                        self.scene.selectedItems())
 
         data = self.tree_adapter.get_instances_in_nodes(
-            self.clf_dataset, [item.tree_node for item in items])
+            self.clf_dataset, [item.tree_node.label for item in items])
         self.send('Selected Data', data)
 
     def send_report(self):
@@ -532,7 +532,8 @@ class OWPythagorasTree(OWWidget):
         # calculate node colors relative to the mean of the node samples
         min_mean = np.min(self.clf_dataset.Y)
         max_mean = np.max(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset, tree_node)
+        instances = adapter.get_instances_in_nodes(self.clf_dataset,
+                                                   tree_node.label)
         mean = np.mean(instances.Y)
 
         return self.color_palette[(mean - min_mean) / (max_mean - min_mean)]
@@ -541,7 +542,8 @@ class OWPythagorasTree(OWWidget):
         # calculate node colors relative to the standard deviation in the node
         # samples
         min_mean, max_mean = 0, np.std(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset, tree_node)
+        instances = adapter.get_instances_in_nodes(self.clf_dataset,
+                                                   tree_node.label)
         std = np.std(instances.Y)
 
         return self.color_palette[(std - min_mean) / (max_mean - min_mean)]
@@ -553,7 +555,7 @@ class OWPythagorasTree(OWWidget):
         ratio = samples / total
 
         instances = self.tree_adapter.get_instances_in_nodes(
-            self.clf_dataset, node)
+            self.clf_dataset, node.label)
         mean = np.mean(instances.Y)
         std = np.std(instances.Y)
 

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -375,7 +375,8 @@ class OWPythagoreanForest(OWWidget):
         # calculate node colors relative to the mean of the node samples
         min_mean = np.min(self.clf_dataset.Y)
         max_mean = np.max(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset, tree_node)
+        instances = adapter.get_instances_in_nodes(self.clf_dataset,
+                                                   tree_node.label)
         mean = np.mean(instances.Y)
 
         return self.color_palette[(mean - min_mean) / (max_mean - min_mean)]
@@ -384,7 +385,8 @@ class OWPythagoreanForest(OWWidget):
         # calculate node colors relative to the standard deviation in the node
         # samples
         min_mean, max_mean = 0, np.std(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset, tree_node)
+        instances = adapter.get_instances_in_nodes(self.clf_dataset,
+                                                   tree_node.label)
         std = np.std(instances.Y)
 
         return self.color_palette[(std - min_mean) / (max_mean - min_mean)]

--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -21,6 +21,8 @@ from math import pi, sqrt, cos, sin, degrees
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import Qt
 
+from Orange.widgets.visualize.utils.tree.treeadapter import TreeAdapter
+
 # z index range, increase if needed
 Z_STEP = 5000000
 
@@ -384,7 +386,7 @@ class SquareGraphicsItem(QtGui.QGraphicsRectItem):
         self.z_step = Z_STEP
 
         # calculate the correct z values based on the parent
-        if self.tree_node.parent != -1:
+        if self.tree_node.parent != TreeAdapter.ROOT_PARENT:
             p = self.tree_node.parent
             # override root z step
             num_children = len(p.children)
@@ -503,7 +505,7 @@ class InteractiveSquareGraphicsItem(SquareGraphicsItem):
 
     def _propagate_to_parents(self, graphics_item, fnc, other_fnc):
         # propagate function that handles graphics item to appropriate parents
-        if graphics_item.tree_node.parent != -1:
+        if graphics_item.tree_node.parent != TreeAdapter.ROOT_PARENT:
             parent = graphics_item.tree_node.parent.graphics_item
             # handle the non relevant children nodes
             for c in parent.tree_node.children:

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -30,7 +30,6 @@ class SklTreeAdapter(TreeAdapter):
 
     """
 
-    ROOT_PARENT = -1
     NO_CHILD = -1
     FEATURE_UNDEFINED = -2
 

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -279,7 +279,7 @@ class SklTreeAdapter(TreeAdapter):
         if not isinstance(nodes, (list, tuple)):
             nodes = [nodes]
 
-        node_leaves = [self.leaves(n.label) for n in nodes]
+        node_leaves = [self.leaves(n) for n in nodes]
         if len(node_leaves) > 0:
             # get the leaves of the selected tree node
             node_leaves = np.unique(np.hstack(node_leaves))

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -11,7 +11,7 @@ class TreeAdapter(metaclass=ABCMeta):
 
     """
 
-    ROOT_PARENT = -1
+    ROOT_PARENT = None
     NO_CHILD = -1
     FEATURE_UNDEFINED = -2
 
@@ -52,7 +52,7 @@ class TreeAdapter(metaclass=ABCMeta):
 
     @abstractmethod
     def parent(self, node):
-        """Get the parent of a given node. Return -1 if the node is the root.
+        """Get the parent of a given node or ROOT_PARENT if the node is the root.
 
         Parameters
         ----------

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -212,7 +212,7 @@ class TreeAdapter(metaclass=ABCMeta):
         ----------
         dataset : Table
             A Orange Table dataset.
-        nodes : iterable[TreeNode]
+        nodes : iterable[node]
             A list of tree nodes for which we want the instances.
 
         Returns


### PR DESCRIPTION
TreeAdapters are great and potentially useful elsewhere, too.

When implementing another adapter, I guess I found two (cosmetic) slips:

- `get_instances_in_nodes` accepts instances of `TreeNode`, which is specific Pythagorean trees,
- `ROOT_PARENT` is defined as `-1`, which is specific to SKL trees. A value of `None` would be more pythonic. Besides, the code in pythagorasviewer.py compares the node with `-1` instead of with `ROOT_PARENT`. Finally, the constant is defined in the base `TreeAdapter` as well as in the derived `SklTreeAdapter`.

@pavlin-policar, can you take a look at these two cosmetic changes? Did I overlook any place that needs to be changed w.r.t this?