### PR TITLE
OWHierarchicalClustering, OWDistanceMap: Resend "Selected Data" when settings change

### DIFF
--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -528,6 +528,7 @@ class OWDistanceMap(widget.OWWidget):
             self._update_ordering()
             self._setup_scene()
             self._update_labels()
+            self._invalidate_selection()
 
     def _update_ordering(self):
         if self.sorting == OWDistanceMap.NoOrdering:

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1051,6 +1051,7 @@ class OWHierarchicalClustering(widget.OWWidget):
     def _invalidate_clustering(self):
         self._update()
         self._update_labels()
+        self._invalidate_output()
 
     def _invalidate_output(self):
         self.commit()


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->
When some drop down values are changed, no more data is selected. Therefore Selected Data output should be resend as None.