### PR TITLE
[FIX] Statistics.util.stats: Fix negative #nans for sparse

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -192,7 +192,7 @@ def stats(X, weights=None, compute_variance=False):
             X.max(axis=0).toarray().ravel(),
             np.asarray(X.mean(axis=0)).ravel() if not weighted else weighted_mean,
             np.zeros(X.shape[1]),      # variance not supported
-            X.shape[1] - non_zero,
+            X.shape[0] - non_zero,
             non_zero))
     else:
         nans = (~X.astype(bool)).sum(axis=0) if X.size else np.zeros(X.shape[1])

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -48,11 +48,11 @@ class TestUtil(unittest.TestCase):
 
         # assure last two columns have just zero elements
         X = X[:3]
-        np.testing.assert_equal(stats(X), [[0, 1, 1/3, 0, 4, 1],
-                                           [0, 1, 1/3, 0, 4, 1],
-                                           [0, 1, 1/3, 0, 4, 1],
-                                           [0, 0,   0, 0, 5, 0],
-                                           [0, 0,   0, 0, 5, 0]])
+        np.testing.assert_equal(stats(X), [[0, 1, 1/3, 0, 2, 1],
+                                           [0, 1, 1/3, 0, 2, 1],
+                                           [0, 1, 1/3, 0, 2, 1],
+                                           [0, 0,   0, 0, 3, 0],
+                                           [0, 0,   0, 0, 3, 0]])
 
     def test_stats_weights(self):
         X = np.arange(4).reshape(2, 2).astype(float)


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Computing the number of nans for sparse matrices was broken and sometimes returned negative numbers.

Variable `non_zero` contains the number of defined values in each column. So to calculate the number of undefined (nans) for each column we have to substract `non_zero` from the number of values in the column i.e. `X.shape[0]` and not `X.shape[1]`. The bug was noticed when the number of defined values in some column was larger than the number of features and consequenlty the number of nans was negative. This caused density in OWTable to exceeded 100%.

<img width="933" alt="screen shot 2016-10-13 at 11 55 57" src="https://cloud.githubusercontent.com/assets/713026/19344975/ac680418-913c-11e6-8c19-7081a9578ca7.png">
