### PR TITLE
Expose widget controls by attribute names

### DIFF
--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -52,7 +52,7 @@ class OWLinearRegression(OWBaseLearner):
         gui.separator(box, 20, 20)
         self.alpha_box = box2 = gui.vBox(box, margin=10)
         gui.widgetLabel(box2, "Regularization strength:")
-        self.alpha_slider = gui.hSlider(
+        gui.hSlider(
             box2, self, "alpha_index",
             minValue=0, maxValue=len(self.alphas) - 1,
             callback=self._alpha_changed, createLabel=False)
@@ -80,14 +80,14 @@ class OWLinearRegression(OWBaseLearner):
         box5.layout().setAlignment(Qt.AlignCenter)
         self._set_l2_ratio_label()
         self.layout().setSizeConstraint(QLayout.SetFixedSize)
-        self.alpha_slider.setEnabled(self.reg_type != self.OLS)
+        self.controls.alpha_index.setEnabled(self.reg_type != self.OLS)
         self.l2_ratio_slider.setEnabled(self.reg_type == self.Elastic)
 
     def handleNewSignals(self):
         self.apply()
 
     def _reg_type_changed(self):
-        self.alpha_slider.setEnabled(self.reg_type != self.OLS)
+        self.controls.alpha_index.setEnabled(self.reg_type != self.OLS)
         self.l2_ratio_slider.setEnabled(self.reg_type == self.Elastic)
         self.apply()
 

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -280,7 +280,7 @@ class ParameterMapping(BaseParameterMapping):
 
     @staticmethod
     def get_gui_element(widget, attribute):
-        return widget.controlledAttributes[attribute][0].control
+        return widget.controlled_attributes[attribute][0].control
 
     @classmethod
     def from_attribute(cls, widget, attribute, parameter=None):

--- a/Orange/widgets/tests/test_control_getter.py
+++ b/Orange/widgets/tests/test_control_getter.py
@@ -1,0 +1,33 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.widgets import gui
+from Orange.widgets.gui import OWComponent
+from Orange.widgets.settings import SettingProvider
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.widget import OWWidget
+
+
+class DummyComponent(OWComponent):
+    foo = True
+
+
+class MyWidget(OWWidget):
+    foo = True
+
+    component = SettingProvider(DummyComponent)
+
+    def __init__(self):
+        super().__init__()
+
+        self.component = DummyComponent(self)
+        self.foo_control = gui.checkBox(self.controlArea, self, "foo", "")
+        self.component_foo_control = \
+            gui.checkBox(self.controlArea, self, "component.foo", "")
+
+
+class ControlGetterTests(WidgetTest):
+    def test_getter(self):
+        widget = self.create_widget(MyWidget)
+        self.assertIs(widget.controls.foo, widget.foo_control)
+        self.assertIs(widget.controls.component.foo,
+                      widget.component_foo_control)

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -6,14 +6,13 @@ from Orange.widgets.widget import OWWidget
 
 
 class TestDoubleSpin(GuiTest):
-    some_param = 0
-    some_option = False
-
     # make sure that the gui element does not crash when
     # 'checked' parameter is forwarded, ie. is not None
     def test_checked_extension(self):
         widget = OWWidget()
-        gui.doubleSpin(widget=widget, master=self, value="some_param",
+        widget.some_param = 0
+        widget.some_option = False
+        gui.doubleSpin(widget=widget, master=widget, value="some_param",
                        minv=1, maxv=10, checked="some_option")
 
 

--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -1,9 +1,9 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
-from Orange.widgets.gui import CONTROLLED_ATTRIBUTES, OWComponent
+from Orange.widgets.gui import OWComponent
 from Orange.widgets.settings import Setting
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.widget import OWWidget, Msg
@@ -50,31 +50,15 @@ class WidgetTestCase(WidgetTest):
 
     def test_notify_controller_on_attribute_change(self):
         widget = self.create_widget(MyWidget)
-        widget.widget = self.create_widget(MyWidget)
-        widget.widget.widget = self.create_widget(MyWidget)
-        widget.widget.widget.widget = self.create_widget(MyWidget)
 
-        delattr(widget.widget, CONTROLLED_ATTRIBUTES)
-        delattr(widget.widget.widget, CONTROLLED_ATTRIBUTES)
-        delattr(widget.widget.widget.widget, CONTROLLED_ATTRIBUTES)
-        calls = []
+        callback = MagicMock()
+        callback2 = MagicMock()
 
-        def callback(*args, **kwargs):
-            calls.append((args, kwargs))
-
-        getattr(widget, CONTROLLED_ATTRIBUTES)['field'] = callback
-        getattr(widget, CONTROLLED_ATTRIBUTES)['component.b'] = callback
-        getattr(widget, CONTROLLED_ATTRIBUTES)['widget.field'] = callback
-        getattr(widget, CONTROLLED_ATTRIBUTES)['widget.widget.component.b'] = callback
-        getattr(widget, CONTROLLED_ATTRIBUTES)['widget.widget.widget.field'] = callback
-
+        widget.connect_control('field', callback)
+        widget.connect_control('field', callback2)
         widget.field = 5
-        widget.component.b = 5
-        widget.widget.field = 5
-        widget.widget.widget.component.b = 5
-        widget.widget.widget.widget.field = 5
-
-        self.assertEqual(len(calls), 5)
+        self.assertTrue(callback.called)
+        self.assertTrue(callback2.called)
 
     def test_widget_tests_do_not_use_stored_settings(self):
         widget = self.create_widget(MyWidget)

--- a/Orange/widgets/utils/constants.py
+++ b/Orange/widgets/utils/constants.py
@@ -1,5 +1,0 @@
-"""Some functionalities (settings and controlled attributes) add custom
-fields to the object. Names of those fields are defined here."""
-
-CONTROLLED_ATTRIBUTES = "controlledAttributes"
-ATTRIBUTE_CONTROLLERS = "__attributeControllers"

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -398,6 +398,7 @@ class OWScatterPlot(OWWidget):
                 self.warning("Data subset does not support large Sql tables")
                 subset_data = None
         self.subset_data = self.move_primitive_metas_to_X(subset_data)
+        self.controls.graph.alpha_value.setEnabled(subset_data is None)
 
     # called when all signals are received, so the graph is updated only once
     def handleNewSignals(self):

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -62,9 +62,9 @@ class OWBoxPlotTests(WidgetTest):
         self.send_signal("Data", data)
 
     def test_apply_sorting(self):
-        controls = self.widget.controlledAttributes
-        group_list = controls["group_var"][0].control
-        order_check = controls["order_by_importance"][0].control
+        controls = self.widget.controls
+        group_list = controls.group_var
+        order_check = controls.order_by_importance
         attributes = self.widget.attrs
 
         def select_group(i):

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -64,7 +64,7 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         # check output when "Merge by k-means" setting changes
         self._select_data()
         self.assertIsNotNone(self.get_output("Selected Data"))
-        self.widget.controlledAttributes["merge_kmeans"][0].control.setChecked(True)
+        self.widget.controls.merge_kmeans.setChecked(True)
         self.assertIsNone(self.get_output("Selected Data"))
 
     def _select_data(self):

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -25,7 +25,7 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
     def test_outputs_add_scores(self):
         # check output when appending scores
         self.send_signal("Data", self.data)
-        self.widget.controlledAttributes["add_scores"][0].control.setChecked(1)
+        self.widget.controls.add_scores.setChecked(1)
         selected_indices = self._select_data()
         name = "Silhouette ({})".format(self.data.domain.class_var.name)
         selected = self.get_output("Selected Data")

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import types
-from functools import reduce
 
 from AnyQt.QtWidgets import (
     QWidget, QDialog, QVBoxLayout, QSizePolicy, QApplication, QStyle,
@@ -16,8 +15,7 @@ from Orange.data import FileFormat
 from Orange.widgets import settings, gui
 from Orange.canvas.registry import description as widget_description
 from Orange.canvas.report import Report
-from Orange.widgets.gui import \
-    ControlledAttributesDict, notify_changed, ControlGetter
+from Orange.widgets.gui import OWComponent
 from Orange.widgets.io import ClipboardFormat
 from Orange.widgets.settings import SettingsHandler
 from Orange.widgets.utils import saveplot, getdeepattr
@@ -75,8 +73,8 @@ class WidgetMetaClass(type(QDialog)):
         return cls
 
 
-class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
-               metaclass=WidgetMetaClass):
+class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
+               WidgetMessagesMixin, metaclass=WidgetMetaClass):
     """Base widget class"""
 
     # Global widget count
@@ -170,6 +168,7 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
     def __new__(cls, *args, captionTitle=None, **kwargs):
         self = super().__new__(cls, None, cls.get_flags())
         QDialog.__init__(self, None, self.get_flags())
+        OWComponent.__init__(self)
         WidgetMessagesMixin.__init__(self)
 
         stored_settings = kwargs.get('stored_settings', None)
@@ -179,8 +178,6 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
         self.signalManager = kwargs.get('signal_manager', None)
         self.__env = _asmappingproxy(kwargs.get("env", {}))
 
-        setattr(self, gui.CONTROLLED_ATTRIBUTES, ControlledAttributesDict(self))
-        self.controls = ControlGetter(self)
         self.graphButton = None
         self.report_button = None
 
@@ -463,30 +460,6 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
                 signalName, self.name))
         if self.signalManager is not None:
             self.signalManager.send(self, signalName, value, id)
-
-    def __setattr__(self, name, value):
-        """Set value to members of this instance or any of its members.
-
-        If member is used in a gui control, notify the control about the change.
-
-        name: name of the member, dot is used for nesting ("graph.point.size").
-        value: value to set to the member.
-        """
-        names = name.rsplit(".")
-        field_name = names.pop()
-        obj = reduce(lambda o, n: getattr(o, n, None), names, self)
-        if obj is None:
-            raise AttributeError("Cannot set '{}' to {} ".format(name, value))
-
-        if obj is self:
-            super().__setattr__(field_name, value)
-        else:
-            setattr(obj, field_name, value)
-
-        notify_changed(obj, field_name, value)
-
-        if self.settingsHandler:
-            self.settingsHandler.fast_save(self, name, value)
 
     def openContext(self, *a):
         """Open a new context corresponding to the given data.

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -16,7 +16,8 @@ from Orange.data import FileFormat
 from Orange.widgets import settings, gui
 from Orange.canvas.registry import description as widget_description
 from Orange.canvas.report import Report
-from Orange.widgets.gui import ControlledAttributesDict, notify_changed
+from Orange.widgets.gui import \
+    ControlledAttributesDict, notify_changed, ControlGetter
 from Orange.widgets.io import ClipboardFormat
 from Orange.widgets.settings import SettingsHandler
 from Orange.widgets.utils import saveplot, getdeepattr
@@ -179,6 +180,7 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
         self.__env = _asmappingproxy(kwargs.get("env", {}))
 
         setattr(self, gui.CONTROLLED_ATTRIBUTES, ControlledAttributesDict(self))
+        self.controls = ControlGetter(self)
         self.graphButton = None
         self.report_button = None
 

--- a/doc/development/source/widget.rst
+++ b/doc/development/source/widget.rst
@@ -109,7 +109,7 @@ Input/Output flags:
 .. attribute:: Dynamic
 
    Only applies to output. Specifies that the instances on the output
-   will in general be subtypes of the declared type and that the output 
+   will in general be subtypes of the declared type and that the output
    can be connected to any input which can accept a subtype of the
    declared output type.
 
@@ -152,6 +152,27 @@ connection/link on which the value was sent (see also :doc:`tutorial-channels`)
 
 The widgets publish their outputs using :meth:`OWWidget.send` method.
 
+Accessing Controls though Attribute Names
+-----------------------------------------
+
+The preferred way for constructing the user interface is to use functions from
+module :obj:`Orange.widgets.gui` that insert a Qt widget and establish the
+signals for synchronization with the widget's attributes.
+
+     gui.checkBox(box, self, "binary_trees", "Induce binary tree")
+
+This inserts a `QCheckBox` into the layout of `box`, and make it reflect and
+changes the attriubte `self.binary_trees`. The instance of `QCheckbox`
+can be accessed through the name it controls. E.g. we can disable the check box
+by calling
+
+   self.controls.binary_trees.setDisabled(True)
+
+This may be more practical than having to store the attribute and the Qt
+widget that controls it, e.g. with
+
+     self.binarization_cb = gui.checkBox(
+         box, self, "binary_trees", "Induce binary tree")
 
 Class Member Documentation
 --------------------------


### PR DESCRIPTION
The motivation behind this is that we refer to the control by the name of the attribute it controls. 

This should reduce the number of attributes per widget and save us from similar names, like `binarize` for the attribute and `cb_binarize` for the checkbox that controls binarization.

If we decide we like it, I have to close one possible problem; in the dictionary that is used here to map attributes to controls, an attribute can be related to multiple controls. This is rare and can be fixed easily.
