### PR TITLE
[ENH] Canvas: Always show the link dialog if the user holds Shift

### DIFF
--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -228,6 +228,7 @@ class NewLinkAction(UserInteraction):
         self.sink_item = None
         self.from_item = None
         self.direction = None
+        self.force_link_dialog = False
 
         # An `NodeItem` currently under the mouse as a possible
         # link drop target.
@@ -324,6 +325,8 @@ class NewLinkAction(UserInteraction):
                 self.tr('<h3>Create new link</h3>'
                         '<p>Drag a link to an existing node or release on '
                         'an empty spot to create a new node.</p>'
+                        '<p>Hold Shift when releasing the mouse button to '
+                        'edit connections.</p>'
 #                        '<a href="help://orange-canvas/create-new-links">'
 #                        'More ...</a>'
                         )
@@ -392,6 +395,7 @@ class NewLinkAction(UserInteraction):
 
     def mouseReleaseEvent(self, event):
         if self.tmp_link_item:
+            self.force_link_dialog = bool(event.modifiers() & Qt.ShiftModifier)
             item = self.target_node_item_at(event.scenePos())
             node = None
             stack = self.document.undoStack()
@@ -501,7 +505,7 @@ class NewLinkAction(UserInteraction):
             # to SchemeLinks later
             links_to_add = [(source, sink)]
             links_to_remove = []
-            show_link_dialog = False
+            show_link_dialog = self.force_link_dialog
 
             # Ambiguous new link request.
             if len(possible) >= 2:
@@ -582,6 +586,8 @@ class NewLinkAction(UserInteraction):
             log.error("An error occurred during the creation of a new link.",
                       exc_info=True)
             self.cancel()
+        finally:
+            self.force_link_dialog = False
 
     def edit_links(self, source_node, sink_node, initial_links=None):
         """


### PR DESCRIPTION
Numerous widgets now provide the signal with annotated data (#1655), which will be used quite often, but it is not the default output. Selected data should stay the default; even always showing the dialog would be annoying. The user thus has to connect the widgets, double click the link, and reroute. This annoyed me a lot.

I suggest that holding shift while connecting should trigger opening the link dialog. To not confuse the user, this should happen even when there's just a single signal on both sides.

I know this feature is a bit of easter egg, but a really useful one.

@ales-erjavec, the change is really simple. Have I overlooked anything?