### PR TITLE
[FIX] OWTable: Sort Continuous metas as floats; not strings

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -1015,6 +1015,9 @@ class TableModel(QAbstractTableModel):
                 and role == TableModel.ValueRole:
             col_view, _ = self.source.get_column_view(coldesc.var)
             col_data = numpy.asarray(col_view)
+            if coldesc.var.is_continuous:
+                # continuous from metas have dtype object; cast it to float
+                col_data = col_data.astype(float)
             if self.__sortInd is not None:
                 col_data = col_data[self.__sortInd]
             return col_data


### PR DESCRIPTION
<!--
Squash the commits, as appropriate. See .github/CONTRIBUTING.md for
more information.

Describe the relevant changes in the commit messages, if they need explaining.
 
If the pull request introduces a new feature or an important bug fix, consider
adding _one_ of the below tags, enclosed in square brackets, in its title:

    ENH, FIX, DOC, WIP

For some example:

    [ENH] CrossValidation: Parallelize computation
    [FIX] NaiveBayesLearner: Don't crash on input containing nan values
    [DOC] Extend documentation for widget development
    [WIP] Working on X ... RFC please

Pull-requests not so tagged will be batched as "other features and bugfixes,"
which is fine for stuff you don't go home and brag to your mother about.
-->

Continuous variables inside meta attributes are currently sorted by their string represenation and not by float values. This happens since dtype for metas is object and we map all object to strings before sorting. This PR checks whether the sorting variable is ContinuousVariable and casts values to floats.