### PR TITLE
OWPreprocess: Randomize - Enable replicable shuffling

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -326,6 +326,9 @@ class Randomize(Preprocess):
         If Randomize.RandomizeAttributes, attributes are shuffled.
         If Randomize.RandomizeMetas, metas are shuffled.
 
+    rand_seed : int (optional)
+        Random seed
+
     Examples
     --------
     >>> from Orange.data import Table
@@ -339,8 +342,9 @@ class Randomize(Preprocess):
                      "RandomizeMetas")
     (RandomizeClasses, RandomizeAttributes, RandomizeMetas) = RandTypes
 
-    def __init__(self, rand_type=RandomizeClasses):
+    def __init__(self, rand_type=RandomizeClasses, rand_seed=None):
         self.rand_type = rand_type
+        self.rand_seed = rand_seed
 
     def __call__(self, data):
         """
@@ -372,9 +376,10 @@ class Randomize(Preprocess):
         return new_data
 
     def randomize(self, table):
+        np.random.seed(self.rand_seed)
         if len(table.shape) > 1:
             for i in range(table.shape[1]):
-                np.random.shuffle(table[:,i])
+                np.random.shuffle(table[:, i])
         else:
             np.random.shuffle(table)
 

--- a/Orange/tests/test_randomize.py
+++ b/Orange/tests/test_randomize.py
@@ -24,7 +24,6 @@ class TestRandomizer(unittest.TestCase):
         self.assertTrue((np.sort(data.Y, axis=0) == np.sort(
             data_rand.Y, axis=0)).all())
 
-
     def test_randomize_classes(self):
         data = self.zoo
         randomizer = Randomize(rand_type=Randomize.RandomizeClasses)
@@ -64,3 +63,12 @@ class TestRandomizer(unittest.TestCase):
         self.assertTrue((data.X == data_orig.X).all())
         self.assertTrue((data.metas == data_orig.metas).all())
         self.assertTrue((data.Y == data_orig.Y).all())
+
+    def test_randomize_replicate(self):
+        randomizer1 = Randomize(rand_seed=1)
+        rand_data11 = randomizer1(self.zoo)
+        rand_data12 = randomizer1(self.zoo)
+        randomizer2 = Randomize(rand_seed=1)
+        rand_data2 = randomizer2(self.zoo)
+        np.testing.assert_array_equal(rand_data11.Y, rand_data12.Y)
+        np.testing.assert_array_equal(rand_data11.Y, rand_data2.Y)

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -1,0 +1,27 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
+import numpy as np
+
+from Orange.data import Table
+from Orange.widgets.data.owpreprocess import OWPreprocess
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWPreprocess(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWPreprocess)
+        self.zoo = Table("zoo")
+
+    def test_randomize(self):
+        saved = {"preprocessors": [("orange.preprocess.randomize",
+                                    {"rand_type": 0, "rand_seed": 1})]}
+        model = self.widget.load(saved)
+        self.widget.set_model(model)
+        self.send_signal("Data", self.zoo)
+        output = self.get_output("Preprocessed Data")
+        np.random.seed(1)
+        np.random.shuffle(self.zoo.Y)
+        np.testing.assert_array_equal(self.zoo.X, output.X)
+        np.testing.assert_array_equal(self.zoo.Y, output.Y)
+        np.testing.assert_array_equal(self.zoo.metas, output.metas)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Randomize should have a check box for replicable results

##### Description of changes
Enable setting random seed for Randomize preprocessor.
Add checkbox to OWPreprocess (Randomize editor).

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation

