### PR TITLE
[FIX] Do not show messages when data is removed

### DIFF
--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -175,6 +175,7 @@ class OWDataSampler(OWWidget):
             self.dataInfoLabel.setText('No data on input.')
             self.outputInfoLabel.setText('')
             self.indices = None
+            self.clear_messages()
         self.commit()
 
     def commit(self):

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -1,0 +1,27 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table
+from Orange.widgets.data.owdatasampler import OWDataSampler
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWDataSampler(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.iris = Table("iris")
+
+    def setUp(self):
+        self.widget = self.create_widget(OWDataSampler)
+
+    def test_error_message(self):
+        """ Check if error message appears and then disappears when
+        data is removed from input"""
+        self.widget.controlledAttributes["sampling_type"][0].control.buttons[
+            2].click()
+        self.send_signal("Data", self.iris)
+        self.assertFalse(self.widget.Error.too_many_folds.is_shown())
+        self.send_signal("Data", self.iris[:5])
+        self.assertTrue(self.widget.Error.too_many_folds.is_shown())
+        self.send_signal("Data", None)
+        self.assertFalse(self.widget.Error.too_many_folds.is_shown())

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -99,10 +99,10 @@ class OWDistances(OWWidget):
         self.send("Distances", self.compute_distances(metric, self.data))
 
     def compute_distances(self, metric, data):
+        self.clear_messages()
+
         if data is None:
             return
-
-        self.clear_messages()
 
         if issparse(data.X) and not metric.supports_sparse:
             self.Error.dense_metric_sparse_data()

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -1,0 +1,42 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+import numpy as np
+
+from Orange.data import Table
+from Orange.distance import MahalanobisDistance
+from Orange.widgets.unsupervised.owdistances import OWDistances, METRICS
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWDistances(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.iris = Table("iris")
+        cls.titanic = Table("titanic")
+
+    def setUp(self):
+        self.widget = self.create_widget(OWDistances)
+
+    def test_distance_combo(self):
+        """Check distances when the metric changes"""
+        self.assertEqual(self.widget.metrics_combo.count(), len(METRICS))
+        self.send_signal("Data", self.iris)
+        for i, metric in enumerate(METRICS):
+            if isinstance(metric, MahalanobisDistance):
+                metric.fit(self.iris)
+            self.widget.metrics_combo.activated.emit(i)
+            self.widget.metrics_combo.setCurrentIndex(i)
+            self.send_signal("Data", self.iris)
+            np.testing.assert_array_equal(
+                metric(self.iris), self.get_output("Distances"))
+
+    def test_error_message(self):
+        """Check if error message appears and then disappears when
+        data is removed from input"""
+        self.send_signal("Data", self.iris)
+        self.assertFalse(self.widget.Error.no_continuous_features.is_shown())
+        self.send_signal("Data", self.titanic)
+        self.assertTrue(self.widget.Error.no_continuous_features.is_shown())
+        self.send_signal("Data", None)
+        self.assertFalse(self.widget.Error.no_continuous_features.is_shown())

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -294,6 +294,7 @@ class OWScatterPlot(OWWidget):
         self.update_graph()
 
     def set_data(self, data):
+        self.clear_messages()
         self.Information.sampled_sql.clear()
         self.__timer.stop()
         self.sampling.setVisible(False)

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -81,3 +81,13 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
     def _select_data(self):
         self.widget.graph.select_by_rectangle(QRectF(4, 3, 3, 1))
         return self.widget.graph.get_selection()
+
+    def test_error_message(self):
+        """Check if error message appears and then disappears when
+        data is removed from input"""
+        data = self.data.copy()
+        data.X[:, 0] = np.nan
+        self.send_signal("Data", data)
+        self.assertTrue(self.widget.Warning.missing_coords.is_shown())
+        self.send_signal("Data", None)
+        self.assertFalse(self.widget.Warning.missing_coords.is_shown())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Some widgets retain (error, warning, info) messages event hough data is removed from the input.
When widgets receive None, any warning should go off (use Titanic and Distances to reproduce).

##### Description of changes
The problem was found and solved for widgets: OWDataSampler, OWDistances, OWScatterPlot.


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
