### PR TITLE
[FIX] Confusion Matrix: Show error on regression results

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -19,6 +19,7 @@ import Orange
 from Orange.widgets import widget, settings, gui
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
+from Orange.widgets.widget import Msg
 
 
 def confusion_matrix(res, index):
@@ -104,6 +105,9 @@ class OWConfusionMatrix(widget.OWWidget):
             "Clicking on cells or in headers outputs the corresponding "
             "data instances",
             "click_cell")]
+
+    class Error(widget.OWWidget.Error):
+        no_regression = Msg("Confusion Matrix cannot show regression results.")
 
     def __init__(self):
         super().__init__()
@@ -228,7 +232,10 @@ class OWConfusionMatrix(widget.OWWidget):
             data = results.data
 
         if data is not None and not data.domain.has_discrete_class:
-            self.warning("Confusion Matrix cannot show regression results.")
+            self.Error.no_regression()
+            data = results = None
+        else:
+            self.Error.no_regression.clear()
 
         self.results = results
         self.data = data

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -2,7 +2,8 @@
 
 from Orange.data import Table
 from Orange.classification import NaiveBayesLearner, TreeLearner
-from Orange.evaluation.testing import CrossValidation
+from Orange.regression import MeanLearner
+from Orange.evaluation.testing import CrossValidation, TestOnTrainingData
 from Orange.widgets.evaluate.owconfusionmatrix import OWConfusionMatrix
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 
@@ -54,3 +55,17 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
             self.widget.results.actual, self.widget.results.predicted[0]))
                     if t in indices]
         return self.widget.results.row_indices[selected]
+
+    def test_show_error_on_regression(self):
+        """On regression data, the widget must show error"""
+        housing = Table("housing")
+        results = TestOnTrainingData(housing, [MeanLearner()])
+        results.data = housing
+        self.send_signal("Evaluation Results", results)
+        self.assertTrue(self.widget.Error.no_regression.is_shown())
+        self.send_signal("Evaluation Results", None)
+        self.assertFalse(self.widget.Error.no_regression.is_shown())
+        self.send_signal("Evaluation Results", results)
+        self.assertTrue(self.widget.Error.no_regression.is_shown())
+        self.send_signal("Evaluation Results", self.results_1_iris)
+        self.assertFalse(self.widget.Error.no_regression.is_shown())


### PR DESCRIPTION
##### Issue

Confusion matrix set a warning (instead of error) when it received regression data. After that, it tried to use it and crashed.

##### Description of changes

The widget now shows an error and proceeds as if the data was None (e.g. clears the table if shown, disables the report button etc.)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation

