### PR TITLE
Confusion matrix: Fix crash when unselecting non-existing items

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -257,7 +257,8 @@ class OWConfusionMatrix(widget.OWWidget):
             self._init_table(len(class_values))
             self.openContext(data.domain.class_var)
             if not prev_sel_learner or prev_sel_learner[0] >= len(self.learners):
-                self.selected_learner[:] = [0]
+                if self.learners:
+                    self.selected_learner[:] = [0]
             else:
                 self.selected_learner[:] = prev_sel_learner
             self._update()

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2060,12 +2060,20 @@ class ControlledList(list):
             return item
 
     def __setitem__(self, index, item):
+        def unselect(i):
+            item = self.listBox.item(i)
+            if item is None:
+                # Labels changed before clearing the selection: clear everything
+                self.listBox.selectionModel().clear()
+            else:
+                item.setSelected(0)
+
         if isinstance(index, int):
-            self.listBox.item(self[index]).setSelected(0)
+            unselect(self[index])
             item.setSelected(1)
         else:
             for i in self[index]:
-                self.listBox.item(i).setSelected(0)
+                unselect(i)
             for i in item:
                 self.listBox.item(i).setSelected(1)
         super().__setitem__(index, item)


### PR DESCRIPTION
##### Issue

If labels in the list view are changed before changing the selection, unselecting items crashes. 

##### Description of changes

Fix clears the (invalid) selection in this case.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation

