### PR TITLE
[FIX] Confusion matrix: Map annotated data through row_indices, add probabi…

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -229,7 +229,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
         data = None
         if results is not None and results.data is not None:
-            data = results.data
+            data = results.data[results.row_indices]
 
         if data is not None and not data.domain.has_discrete_class:
             self.Error.no_regression()
@@ -374,9 +374,8 @@ class OWConfusionMatrix(widget.OWWidget):
             data.name = learner_name
 
             if selected:
-                row_indices = self.results.row_indices[selected]
-                annotated_data = create_annotated_table(data, row_indices)
-                data = data[row_indices]
+                annotated_data = create_annotated_table(data, selected)
+                data = data[selected]
             else:
                 annotated_data = create_annotated_table(data, [])
                 data = None


### PR DESCRIPTION
…lities to mapped data

##### Issue

Confusion matrix does not work correctly if the data comes from random sampling, not cross validation. Probabilities are not of the same shape as data, so hstack crashes. Also, annotated data outputs the original data instead of the mapped. For example, (re)sampling iris can produce 510 testing instances, while annotated data contains the original 150.

##### Description of changes

Widget's self.data now contains mapped data. 

##### Includes
- [X] Code changes
- [X] Tests
