### PR TITLE
owpca: fix error when variance is set to 100

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -308,6 +308,7 @@ class OWPCA(widget.OWWidget):
 
         cut = numpy.searchsorted(self._cumulative,
                                  self.variance_covered / 100.0) + 1
+        cut = min(cut, len(self._cumulative))
         self.ncomponents = cut
         if numpy.floor(self._line.value()) + 1 != cut:
             self._line.setValue(cut - 1)

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -1,0 +1,15 @@
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.unsupervised.owpca import OWPCA
+
+
+class TestOWDistanceMatrix(WidgetTest):
+
+    def setUp(self):
+        self.widget = self.create_widget(OWPCA)
+
+    def test_set_variance100(self):
+        iris = Table("iris")[:5]
+        self.widget.set_data(iris)
+        self.widget.variance_covered = 100
+        self.widget._update_selection_variance_spin()


### PR DESCRIPTION
##### Issue

When an user set covered variance to 100, the widget crashed.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation

