### PR TITLE
[ENH] Setting migration

### DIFF
--- a/Orange/widgets/tests/test_context_handler.py
+++ b/Orange/widgets/tests/test_context_handler.py
@@ -1,33 +1,111 @@
-from copy import copy
+import pickle
+from copy import copy, deepcopy
+from io import BytesIO
 from unittest import TestCase
-from unittest.mock import Mock
-from Orange.widgets.settings import ContextHandler, Setting, ContextSetting, Context
+from unittest.mock import Mock, patch, call
+from Orange.widgets.settings import ContextHandler, Setting, ContextSetting, Context, VERSION_KEY
 
 __author__ = 'anze'
 
 
 class SimpleWidget:
+    settings_version = 1
+
     setting = Setting(42)
 
     context_setting = ContextSetting(42)
 
+    migrate_settings = Mock()
+    migrate_context = Mock()
+
+
+class DummyContext(Context):
+    id = 0
+
+    def __init__(self, version=None):
+        super().__init__()
+        DummyContext.id += 1
+        self.id = DummyContext.id
+        if version:
+            self.values[VERSION_KEY] = version
+
+    def __repr__(self):
+        return "Context(id={})".format(self.id)
+    __str__ = __repr__
+
+    def __eq__(self, other):
+        if not isinstance(other, DummyContext):
+            return False
+        return self.id == other.id
+
+
+def create_defaults_file(contexts):
+    b = BytesIO()
+    pickle.dump({"x": 5}, b)
+    pickle.dump(contexts, b)
+    b.seek(0)
+    return b
+
 
 class TestContextHandler(TestCase):
+    def test_read_defaults(self):
+        contexts = [DummyContext() for _ in range(3)]
+
+        handler = ContextHandler()
+        handler.widget_class = SimpleWidget
+
+        # Old settings without version
+        migrate_context = Mock()
+        with patch.object(SimpleWidget, "migrate_context", migrate_context):
+            handler.read_defaults_file(create_defaults_file(contexts))
+        self.assertSequenceEqual(handler.global_contexts, contexts)
+        migrate_context.assert_has_calls([call(c, None) for c in contexts])
+
+        # Settings with version
+        contexts = [DummyContext(version=i) for i in range(1, 4)]
+        migrate_context.reset_mock()
+        with patch.object(SimpleWidget, "migrate_context", migrate_context):
+            handler.read_defaults_file(create_defaults_file(contexts))
+        self.assertSequenceEqual(handler.global_contexts, contexts)
+        migrate_context.assert_has_calls([call(c, c.values[VERSION_KEY]) for c in contexts])
+
     def test_initialize(self):
         handler = ContextHandler()
         handler.provider = Mock()
+        handler.widget_class = SimpleWidget
 
         # Context settings from data
         widget = SimpleWidget()
-        handler.initialize(widget, {'context_settings': 5})
+        context_settings = [DummyContext()]
+        handler.initialize(widget, {'context_settings': context_settings})
         self.assertTrue(hasattr(widget, 'context_settings'))
-        self.assertEqual(widget.context_settings, 5)
+        self.assertEqual(widget.context_settings, context_settings)
 
         # Default (global) context settings
         widget = SimpleWidget()
         handler.initialize(widget)
         self.assertTrue(hasattr(widget, 'context_settings'))
         self.assertEqual(widget.context_settings, handler.global_contexts)
+
+    def test_initialize_migrates_contexts(self):
+        handler = ContextHandler()
+        handler.bind(SimpleWidget)
+
+        widget = SimpleWidget()
+
+        # Old settings without version
+        contexts = [DummyContext() for _ in range(3)]
+        migrate_context = Mock()
+        with patch.object(SimpleWidget, "migrate_context", migrate_context):
+            handler.initialize(widget, dict(context_settings=contexts))
+        migrate_context.assert_has_calls([call(c, None) for c in contexts])
+
+        # Settings with version
+        contexts = [DummyContext(version=i) for i in range(1, 4)]
+        migrate_context = Mock()
+        with patch.object(SimpleWidget, "migrate_context", migrate_context):
+            handler.initialize(widget, dict(context_settings=deepcopy(contexts)))
+        migrate_context.assert_has_calls([call(c, c.values[VERSION_KEY]) for c in contexts])
 
     def test_fast_save(self):
         handler = ContextHandler()
@@ -68,3 +146,16 @@ class TestContextHandler(TestCase):
         self.assertEqual(context.i, 5)
         self.assertEqual([c.i for c in widget.context_settings], [5, 2])
         self.assertEqual([c.i for c in handler.global_contexts], [3, 7])
+
+    def test_pack_settings_stores_version(self):
+        handler = ContextHandler()
+        handler.bind(SimpleWidget)
+
+        widget = SimpleWidget()
+        handler.initialize(widget)
+        widget.context_setting = [DummyContext() for _ in range(3)]
+
+        settings = handler.pack_data(widget)
+        self.assertIn("context_settings", settings)
+        for c in settings["context_settings"]:
+            self.assertIn(VERSION_KEY, c.values)

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -154,6 +154,13 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
     settingsHandler = None
     """:type: SettingsHandler"""
 
+    #: Version of the settings representation
+    #: Subclasses should increase this number when they make breaking
+    #: changes to settings representation (a settings that used to store
+    #: int now stores string) and handle migrations in migrate and
+    #: migrate_context settings.
+    settings_version = 1
+
     savedWidgetGeometry = settings.Setting(None)
 
     #: A list of advice messages (:class:`Message`) to display to the user.
@@ -737,6 +744,32 @@ class OWWidget(QDialog, Report, ProgressBarMixin, WidgetMessagesMixin,
             session_hist.sync()
 
         self.__msgwidget.accepted.connect(_userconfirmed)
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        """Fix settings to work with the current version of widgets
+
+        Parameters
+        ----------
+        settings : dict
+            dict of name - value mappings
+        version : Optional[int]
+            version of the saved settings
+            or None if settings were created before migrations
+        """
+
+    @classmethod
+    def migrate_context(cls, context, version):
+        """Fix contexts to work with the current version of widgets
+
+        Parameters
+        ----------
+        context : Context
+            Context object
+        version : Optional[int]
+            version of the saved context
+            or None if context was created before migrations
+        """
 
 
 class Message(object):

--- a/doc/development/source/tutorial-settings.rst
+++ b/doc/development/source/tutorial-settings.rst
@@ -227,3 +227,50 @@ its class definition
 ``settingsHandler = DomainContextHandler()`` declares that Scatter plot uses
 :class:`DomainContextHandler`. The :obj:`attr_x` and :obj:`attr_y` are
 declared as :class:`~Orange.widgets.settings.ContextSetting`.
+
+
+Migrations
+**********
+
+At the beginning of this section of the tutorial, we created a widget with
+a setting called proportion, which contains a value between 0 and 100. But
+imagine that for some reason, we are not satisfied with the value any more
+and decide that the setting should hold a value between 0 and 1.
+
+We update the setting's default value, modify the appropriate code and we
+are done. That is, until someone that has already used the old version of
+the widget open the new one and the widget crashes. Remember, when the
+widget is opened, it has the same settings that were used the last time.
+
+Is there anything we can do, as settings are replaced with saved before
+the __init__ function is called? There is! Migrations to the rescue.
+
+Widget has a special attribute called `settings_version`. All widgets start
+with a settings_version of 1. When incompatible changes are done to the
+widget's settings, its settings_version should be increased. But increasing
+the version by it self does not solve our problems. While the widget now
+knows that it uses different settings, the old ones are still broken and
+need to be updated before they can be used with the new widget. This can be
+accomplished by reimplementing widget's methods `migrate_settings`
+(for ordinary settings) and `migrate_context` (for context settings).
+Both method are called with the old object and the version of the settings
+stored with it.
+
+If we bumped settings_version from 1 to 2 when we did the above mentioned
+change, our migrate_settings method would look like this:
+
+.. code-block:: python
+
+    def migrate_settings(settings, version):
+       if version < 2:
+         if "proportion" in settings:
+            settings["proportion"] = settings["proportion"] / 100
+
+Your migration rules can be simple or complex, but try to avoid simply
+forgetting the values, as settings are also used in saved workflows.
+Imagine opening a complex workflow you have designed a year ago with the
+new version of Orange and finding out that all the settings are back to
+default. Not fun!
+
+So take some time, write the migrations and do not forget to bump the
+settings_version when you do breaking changes.


### PR DESCRIPTION
##### Issue
When widgets are opened with old version of settings, they break in many different ways.

##### Description of changes
This PR introduces the concept of setting versions and migrations. When a widget changes its settings in a way that is not compatible with old version, it should raise its settings_version attribute and implement the migrate_settings (migrate_context for context settings) method.

##### Includes
- [X] Code changes
- [X] Tests
- [x] Documentation
