### PR TITLE
[FIX] DendrogramWidget: Prevent a zero division error

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -605,10 +605,20 @@ class DendrogramWidget(QGraphicsWidget):
         else:
             drect = QSizeF(leaf_count, self._root.value.height)
 
-        transform = QTransform().scale(
-            crect.width() / drect.width(),
-            crect.height() / drect.height()
-        )
+        eps = numpy.finfo(numpy.float64).eps
+
+        if abs(drect.width()) < eps:
+            sx = 1.0
+        else:
+            sx = crect.width() / drect.width()
+
+        if abs(drect.height()) < eps:
+            sy = 1.0
+        else:
+            sy = crect.height() / drect.height()
+
+        transform = QTransform().scale(sx, sy)
+
         self._itemgroup.setPos(crect.topLeft())
         self._itemgroup.setTransform(transform)
         self._selection_items = None

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -827,7 +827,6 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.top_n_spin = gui.spin(self.selection_box, self, "top_n", 1, 20,
                                    callback=self._selection_method_changed)
         grid.addWidget(self.top_n_spin, 2, 1)
-        self.selection_box.layout().addLayout(grid)
 
         self.zoom_slider = gui.hSlider(
             self.controlArea, self, "zoom_factor", box="Zoom",

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import numpy
+import Orange.misc
 from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
@@ -50,3 +52,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         self.widget.selection_box.buttons[2].click()
         self.assertIsNotNone(self.get_output("Selected Data"))
         self.assertIsNone(self.get_output(ANNOTATED_DATA_SIGNAL_NAME))
+
+    def test_all_zero_inputs(self):
+        d = Orange.misc.DistMatrix(numpy.zeros((10, 10)))
+        self.widget.set_distances(d)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes

* Prevent a ZeroDivisionError when the dendrogram has zero height.
* Also remove a duplicated layout insertion.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
