### PR TITLE
[FIX] owpythonscript: Fix QFileDialog.get{Save,Open}FileName usage

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -541,13 +541,11 @@ class OWPythonScript(widget.OWWidget):
         self.setSelectedScript(len(self.libraryList) - 1)
 
     def onAddScriptFromFile(self, *args):
-        filename = QFileDialog.getOpenFileName(
+        filename, _ = QFileDialog.getOpenFileName(
             self, 'Open Python Script',
             os.path.expanduser("~/"),
             'Python files (*.py)\nAll files(*.*)'
         )
-
-        filename = str(filename)
         if filename:
             name = os.path.basename(filename)
             contents = open(filename, "rb").read().decode("utf-8", errors="ignore")
@@ -623,7 +621,7 @@ class OWPythonScript(widget.OWWidget):
         else:
             filename = os.path.expanduser("~/")
 
-        filename = QFileDialog.getSaveFileName(
+        filename, _ = QFileDialog.getSaveFileName(
             self, 'Save Python Script',
             filename,
             'Python files (*.py)\nAll files(*.*)'


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes

Fix QFileDialog.get{Save,Open}FileName usage in 'Python Script' widget

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation

Broken since 032afd295581770a9b81c893710a6e89c11ab514