### PR TITLE
Context: Add rename and migrate_str_to_variable

### DIFF
--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -17,8 +17,7 @@ class TestOWDataSampler(WidgetTest):
     def test_error_message(self):
         """ Check if error message appears and then disappears when
         data is removed from input"""
-        self.widget.controlledAttributes["sampling_type"][0].control.buttons[
-            2].click()
+        self.widget.controls.sampling_type.buttons[2].click()
         self.send_signal("Data", self.iris)
         self.assertFalse(self.widget.Error.too_many_folds.is_shown())
         self.send_signal("Data", self.iris[:5])

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -447,7 +447,7 @@ class SettingsHandler:
     def _migrate_settings(self, settings):
         """Ask widget to migrate settings to the latest version."""
         if settings:
-            self.widget_class.migrate_settings(settings, settings.pop(VERSION_KEY, None))
+            self.widget_class.migrate_settings(settings, settings.pop(VERSION_KEY, 0))
 
     def _select_provider(self, instance):
         provider = self.provider.get_provider(instance.__class__)
@@ -612,7 +612,7 @@ class ContextHandler(SettingsHandler):
 
     def _migrate_contexts(self, contexts):
         for context in contexts:
-            self.widget_class.migrate_context(context, context.values.pop(VERSION_KEY, None))
+            self.widget_class.migrate_context(context, context.values.pop(VERSION_KEY, 0))
 
     def write_defaults_file(self, settings_file):
         """Call the inherited method, then add global context to the pickle."""

--- a/Orange/widgets/tests/test_context_handler.py
+++ b/Orange/widgets/tests/test_context_handler.py
@@ -59,7 +59,7 @@ class TestContextHandler(TestCase):
         with patch.object(SimpleWidget, "migrate_context", migrate_context):
             handler.read_defaults_file(create_defaults_file(contexts))
         self.assertSequenceEqual(handler.global_contexts, contexts)
-        migrate_context.assert_has_calls([call(c, None) for c in contexts])
+        migrate_context.assert_has_calls([call(c, 0) for c in contexts])
 
         # Settings with version
         contexts = [DummyContext(version=i) for i in range(1, 4)]
@@ -98,7 +98,7 @@ class TestContextHandler(TestCase):
         migrate_context = Mock()
         with patch.object(SimpleWidget, "migrate_context", migrate_context):
             handler.initialize(widget, dict(context_settings=contexts))
-        migrate_context.assert_has_calls([call(c, None) for c in contexts])
+        migrate_context.assert_has_calls([call(c, 0) for c in contexts])
 
         # Settings with version
         contexts = [DummyContext(version=i) for i in range(1, 4)]

--- a/Orange/widgets/tests/test_settings_handler.py
+++ b/Orange/widgets/tests/test_settings_handler.py
@@ -3,7 +3,7 @@ import os
 import pickle
 from tempfile import mkstemp
 import unittest
-from unittest.mock import patch, Mock, mock_open
+from unittest.mock import patch, Mock
 import warnings
 from Orange.widgets.settings import SettingsHandler, Setting, SettingProvider,\
     VERSION_KEY, rename_setting, Context, migrate_str_to_variable
@@ -224,7 +224,7 @@ class SettingHandlerTestCase(unittest.TestCase):
             settings = {"value": 5}
             with self.override_default_settings(SimpleWidget, settings):
                 handler.read_defaults()
-            migrate_settings.assert_called_with(settings, None)
+            migrate_settings.assert_called_with(settings, 0)
 
             migrate_settings.reset()
             # Settings with version
@@ -247,7 +247,7 @@ class SettingHandlerTestCase(unittest.TestCase):
             settings = {"value": 5}
 
             handler.initialize(widget, settings)
-            migrate_settings.assert_called_with(settings, None)
+            migrate_settings.assert_called_with(settings, 0)
 
             migrate_settings.reset_mock()
             # Settings with version

--- a/doc/development/source/tutorial-settings.rst
+++ b/doc/development/source/tutorial-settings.rst
@@ -272,5 +272,21 @@ Imagine opening a complex workflow you have designed a year ago with the
 new version of Orange and finding out that all the settings are back to
 default. Not fun!
 
+There are two helper functions you can use.
+:obj:`Orange.widget.settings.rename_settings(settings, old_name, new_name)`
+does the obvious operation on `settings`, which can be either a dictionary
+or a context, thus it can be called from `migrate_settings` or
+`migrate_context`.
+
+Another common operation may be upgrading your widget from storing variable
+names (as `str`) to storing variables (instances of classes derived from
+`Variable`). In a typical scenario, this happenswhen combo boxes are upgraded to
+using models. Function
+:obj:`Orange.widget.settings.migrate_str_to_variable(settings, names=None)`
+makes the necessary changes to the settings listed in `names`. `names` can be
+a list of setting names, a single string or `None`. In the latter case, all
+settings that may refer to variables (that is two-elements tuples constisting
+of a string and an int) are migrated.
+
 So take some time, write the migrations and do not forget to bump the
-settings_version when you do breaking changes.
+`settings_version` when you do breaking changes.


### PR DESCRIPTION
<strike>Needs #1724.</strike> Usage example in #1642 (8227b626609a5cae23430ef2dbfde4d7584c246e)

##### Description of changes

Add utility functions for two common setting migrations.

##### Includes
- [X] Code changes
- [x] Tests
- [X] Documentation

