### PR TITLE
[FIX] oweditdomain: Initialize `var` attribute

### DIFF
--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -122,6 +122,7 @@ class VariableEditor(QWidget):
 
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
+        self.var = None
         self.setup_gui()
 
     def setup_gui(self):
@@ -231,7 +232,8 @@ class VariableEditor(QWidget):
         name = str(self.name_edit.text())
         labels = self.labels_model.get_dict()
 
-        return self.var and name == self.var.name and labels == self.var.attributes
+        return (self.var is not None and name == self.var.name and
+                labels == self.var.attributes)
 
     def clear(self):
         """Clear the editor state.

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -217,7 +217,7 @@ class VariableEditor(QWidget):
         labels = self.labels_model.get_dict()
 
         # Is the variable actually changed.
-        if not self.is_same():
+        if self.var is not None and not self.is_same():
             var = type(self.var)(name)
             var.attributes.update(labels)
             self.var = var
@@ -321,7 +321,7 @@ class DiscreteVariableEditor(VariableEditor):
         labels = self.labels_model.get_dict()
         values = map(str, self.values_model)
 
-        if not self.is_same():
+        if self.var is not None and not self.is_same():
             var = type(self.var)(name, values=values)
             var.attributes.update(labels)
             self.var = var
@@ -333,8 +333,9 @@ class DiscreteVariableEditor(VariableEditor):
     def is_same(self):
         """Is the current model state the same as the input.
         """
-        values = map(str, self.values_model)
-        return VariableEditor.is_same(self) and self.var.values == values
+        values = list(map(str, self.values_model))
+        return (VariableEditor.is_same(self) and self.var is not None and
+                self.var.values == values)
 
     def clear(self):
         """Clear the model state.

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -6,11 +6,12 @@ import numpy as np
 
 from AnyQt.QtCore import QModelIndex, Qt
 
-from Orange.data import ContinuousVariable, DiscreteVariable, Table, Domain
+from Orange.data import ContinuousVariable, DiscreteVariable, \
+    StringVariable, Table, Domain
 from Orange.widgets.data.oweditdomain import EditDomainReport, OWEditDomain, \
-    ContinuousVariableEditor
+    ContinuousVariableEditor, DiscreteVariableEditor, VariableEditor
 from Orange.widgets.data.owcolor import OWColor, ColorRole
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.base import WidgetTest, GuiTest
 
 SECTION_NAME = "NAME"
 
@@ -138,3 +139,56 @@ class TestOWEditDomain(WidgetTest):
         self.widget.unconditional_commit()
         t2 = self.get_output("Data")
         self.assertEqual(t2.domain["a"].attributes["list"], [1, 2, 4])
+
+
+class TestEditors(GuiTest):
+    def test_variable_editor(self):
+        w = VariableEditor()
+        self.assertIs(w.get_data(), None)
+
+        v = StringVariable(name="S")
+        v.attributes.update({"A": 1, "B": "b"},)
+        w.set_data(v)
+
+        self.assertEqual(w.name_edit.text(), v.name)
+        self.assertEqual(w.labels_model.get_dict(), v.attributes)
+        self.assertTrue(w.is_same())
+
+        w.set_data(None)
+        self.assertEqual(w.name_edit.text(), "")
+        self.assertEqual(w.labels_model.get_dict(), {})
+        self.assertIs(w.get_data(), None)
+
+    def test_continuous_editor(self):
+        w = ContinuousVariableEditor()
+        self.assertIs(w.get_data(), None)
+
+        v = ContinuousVariable("X", number_of_decimals=5)
+        v.attributes.update({"A": 1, "B": "b"})
+        w.set_data(v)
+
+        self.assertEqual(w.name_edit.text(), v.name)
+        self.assertEqual(w.labels_model.get_dict(), v.attributes)
+        self.assertTrue(w.is_same())
+
+        w.set_data(None)
+        self.assertEqual(w.name_edit.text(), "")
+        self.assertEqual(w.labels_model.get_dict(), {})
+        self.assertIs(w.get_data(), None)
+
+    def test_discrete_editor(self):
+        w = DiscreteVariableEditor()
+        self.assertIs(w.get_data(), None)
+
+        v = DiscreteVariable("C", values=["a", "b", "c"])
+        v.attributes.update({"A": 1, "B": "b"})
+        w.set_data(v)
+
+        self.assertEqual(w.name_edit.text(), v.name)
+        self.assertEqual(w.labels_model.get_dict(), v.attributes)
+        self.assertTrue(w.is_same())
+
+        w.set_data(None)
+        self.assertEqual(w.name_edit.text(), "")
+        self.assertEqual(w.labels_model.get_dict(), {})
+        self.assertIs(w.get_data(), None)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The `VariableEditor.var` attribute was left uninitialized causing a error on when calling editor methods before a call to `set_data`.

##### Description of changes

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation

Fix an AttributeError due to an uninitialized attribute