### PR TITLE
[FIX] canvas/toolgrid: Remove (unused) mouse press event tracking

### DIFF
--- a/Orange/canvas/gui/toolgrid.py
+++ b/Orange/canvas/gui/toolgrid.py
@@ -309,7 +309,7 @@ class ToolGrid(QFrame):
         self.__shiftGrid(index, 1)
         button = self.createButtonForAction(action)
 
-        row = index / self.__columns
+        row = index // self.__columns
         column = index % self.__columns
 
         self.layout().addWidget(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Under some circumstances a MouseRelease event could be delivered without a preceding MousePress event causing a `AttributeError: 'NoneType' object has no attribute 'underMouse'` in the `ToolButtonEventListener.eventFilter`

##### Description of changes

Remove the `ToolButtonEventListener` altogether as the mouse press tracking was not even used.
Parts that were needed were merged into the `ToolGrid` class itself.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
