### PR TITLE
travis: disable trusty builds (for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 sudo: false
-dist: trusty
 
 matrix:
     include:


### PR DESCRIPTION
Trusty (beta) causes build failures with python3.4 builds