### PR TITLE
doc: Include category in widget catalog

### DIFF
--- a/doc/visual-programming/build_widget_catalog.py
+++ b/doc/visual-programming/build_widget_catalog.py
@@ -28,7 +28,7 @@ def build_widget_catalog(index_html, outfile, webdocprefix):
     ret = []
 
     for li in div.find_all():
-        if li.name == "h2":
+        if li.name == "h3":
             cat = li.text.strip("¶").strip()
             ret.append((cat, []))
         if li.name == "li":


### PR DESCRIPTION
Categories are shown as h3 elements in the documentation, not h2.