### PR TITLE
OWConfusionMatrix: Fix predicitons order

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -344,7 +344,13 @@ class OWConfusionMatrix(widget.OWWidget):
             metas = self.data.domain.metas
 
             if self.append_predictions:
-                extra.append(predicted.reshape(-1, 1))
+                # predictions are not in the same order as data (i.e. they are
+                # shuffled according to 'self.results.row_indices'). To append
+                # them to self.data the order must first be restored.
+                revert_results_shuffle = numpy.empty(len(self.data), dtype=int)
+                for i, ind in enumerate(self.results.row_indices):
+                    revert_results_shuffle[ind] = i
+                extra.append(predicted[revert_results_shuffle].reshape(-1, 1))
                 var = Orange.data.DiscreteVariable(
                     "{}({})".format(class_var.name, learner_name),
                     class_var.values


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In confusion matrix, as of #1655 (commit deb8585295eaed414c9ec2a09e511b7e4bb907fc), predictions were appended to the data in incorrect order. The core of the issue is due to the fact that `predictions` from `Results.predicted` are not in the same order as instances in data table.

For example, select only misclassified examples on iris and pass them to a table. Some of the misclassified examples have a predicted class that is the same as the correct one.
![screen shot 2016-11-14 at 16 27 06](https://cloud.githubusercontent.com/assets/713026/20271120/027b086c-aa8a-11e6-9f59-a08f8d7695fe.png)


##### Description of changes
Predictions from `Results.predicted` are first sorted into the order of data instances and only then appended. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation