### PR TITLE
WebView: Fix evalJS for scripts ending with comments

### DIFF
--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -310,7 +310,8 @@ class _WebViewBase:
             if not self.__is_init and self.__js_queue:
                 return QTimer.singleShot(1, _later)
             if self.__js_queue:
-                code = ';'.join(self.__js_queue)
+                # '/n' is required when the last line is a comment
+                code = '\n;'.join(self.__js_queue)
                 self.__js_queue.clear()
                 self._evalJS(code)
 
@@ -365,9 +366,10 @@ if HAVE_WEBKIT:
             WebKitView.__init__(self, parent, bridge, debug=debug, **kwargs)
             _WebViewBase.__init__(self)
 
-            self.frame.addToJavaScriptWindowObject('__self', self)
-            self.loadFinished.connect(
-                lambda: self._evalJS('setTimeout(function(){ __self._load_really_finished(); }, 100);'))
+            def load_finished():
+                self.frame.addToJavaScriptWindowObject('__self', self)
+                self._evalJS('setTimeout(function(){ __self._load_really_finished(); }, 100);')
+            self.loadFinished.connect(load_finished)
 
         @pyqtSlot()
         def _load_really_finished(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When loading multiple JS scripts in WebView and one of the first n-1 ends with a comment syntax error is raised even when the code is syntactically correct. This happens since these scripts are joined with a `;` and hence the first line of the following script is commented out.

##### Description of changes
Join multiple JS scripts with `;\n` instead.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation