### PR TITLE
[FIX] TimeVariable: don't crash Data Table when reloading and Visualize ...

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -921,7 +921,7 @@ class TimeVariable(ContinuousVariable):
             return '?'
         if not self.have_date and not self.have_time:
             # The time is relative, unitless. The value is absolute.
-            return str(val)
+            return str(val.value) if isinstance(val, Value) else str(val)
 
         # If you know how to simplify this, be my guest
         seconds = int(val)

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -382,6 +382,10 @@ time,continuous
         self.assertEqual(input_csv.getvalue().splitlines(),
                          output_csv.getvalue().splitlines())
 
+    def test_repr_value(self):
+        # https://github.com/biolab/orange3/pull/1760
+        var = TimeVariable('time')
+        self.assertEqual(var.repr_val(Value(var, 416.3)), '416.3')
 
 
 PickleContinuousVariable = create_pickling_tests(


### PR DESCRIPTION
##### Issue
The issue was with DataTable widget with Visualize continuous values enabled and reloading a timevariable as numeric and back. Now seems to work.

Fixes https://github.com/biolab/orange3/pull/1734#issuecomment-260641386

	Traceback (most recent call last):
	  File "/home/lan/dev/orange3/Orange/widgets/utils/itemmodels.py", line 1112, in data
		return coldesc.format(instance)
	  File "/home/lan/dev/orange3/Orange/widgets/utils/itemmodels.py", line 863, in format_dense
		return str(instance[var])
	  File "/home/lan/dev/orange3/Orange/data/variable.py", line 166, in __str__
		return self.variable.str_val(self)
	  File "/home/lan/dev/orange3/Orange/data/variable.py", line 924, in repr_val
		return str(val)
	  File "/home/lan/dev/orange3/Orange/data/variable.py", line 166, in __str__
		return self.variable.str_val(self)
	...
	RecursionError: maximum recursion depth exceeded while calling a Python object

##### Includes
- [X] Code changes
- [X] Tests