### PR TITLE
[FIX] OWDistanceMatrix: attribute in context

### DIFF
--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -192,7 +192,8 @@ class DistanceMatrixContextHandler(ContextHandler):
 
     def settings_to_widget(self, widget, *args):
         context = widget.current_context
-        widget.annotation_idx = context.annotations.index(context.annotation)
+        if hasattr(context, 'annotation'):
+            widget.annotation_idx = context.annotations.index(context.annotation)
         widget.tableview.selectionModel().set_selected_items(context.selection)
 
 

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -172,7 +172,7 @@ class DistanceMatrixContextHandler(ContextHandler):
         context = super().new_context()
         context.dim = matrix.shape[0]
         context.annotations = self._var_names(annotations)
-        context.annotation_idx = 1
+        context.annotation = context.annotations[1]
         context.selection = []
         return context
 
@@ -192,8 +192,7 @@ class DistanceMatrixContextHandler(ContextHandler):
 
     def settings_to_widget(self, widget, *args):
         context = widget.current_context
-        if hasattr(context, 'annotation'):
-            widget.annotation_idx = context.annotations.index(context.annotation)
+        widget.annotation_idx = context.annotations.index(context.annotation)
         widget.tableview.selectionModel().set_selected_items(context.selection)
 
 

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -3,7 +3,6 @@ from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owdistancematrix import OWDistanceMatrix
 
-
 class TestOWDistanceMatrix(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWDistanceMatrix)
@@ -22,3 +21,10 @@ class TestOWDistanceMatrix(WidgetTest):
         distances.row_items = None
         self.widget.set_distances(distances)
         self.assertNotIn(iris.domain[0], self.widget.annot_combo.model())
+
+    def test_context_attribute(self):
+        iris = Table("iris")
+        distances = Euclidean(iris, axis=0)
+        annotations = ["None", "Enumerate"]
+        self.widget.set_distances(distances)
+        self.widget.openContext(distances, annotations)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
AttributeError: Context has no attribute 'annotation'

Workflow: 
1. File widget (iris) -> Distance (choose rows, euclidean) -> DistanceMatrix.
2. Open Distance widget and select columns.

##### Description of changes
Attribute check.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation

owdistancematrix.py: prevent attribute error when showing distances between columns with an empty context.