### PR TITLE
[FIX] OWDistances: Mahalanobis wrong dimensions notification.

### DIFF
--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -42,6 +42,7 @@ class OWDistances(OWWidget):
         no_continuous_features = Msg("No continuous features")
         dense_metric_sparse_data = Msg("Selected metric does not support sparse data")
         empty_data = Msg("Empty data (shape = {})")
+        too_few_observations = Msg("Too few observations for the number of dimensions")
 
     class Warning(OWWidget.Warning):
         ignoring_discrete = Msg("Ignoring discrete features")
@@ -128,6 +129,14 @@ class OWDistances(OWWidget):
         if not data.X.size:
             self.Error.empty_data(data.X.shape)
             return
+
+        if isinstance(metric, distance.MahalanobisDistance):
+            n, m = data.X.shape
+            if self.axis == 1:
+                n, m = m, n
+            if n <= m:
+                self.Error.too_few_observations()
+                return
 
         if isinstance(metric, distance.MahalanobisDistance):
             # Mahalanobis distance has to be trained before it can be used

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from Orange.data import Table
-from Orange.distance import MahalanobisDistance
+from Orange.distance import MahalanobisDistance, Mahalanobis
 from Orange.widgets.unsupervised.owdistances import OWDistances, METRICS
 from Orange.widgets.tests.base import WidgetTest
 
@@ -40,3 +40,9 @@ class TestOWDistances(WidgetTest):
         self.assertTrue(self.widget.Error.no_continuous_features.is_shown())
         self.send_signal("Data", None)
         self.assertFalse(self.widget.Error.no_continuous_features.is_shown())
+
+    def test_mahalanobis_error(self):
+        self.widget.axis = 1
+        self.send_signal("Data", self.iris)
+        self.widget.compute_distances(Mahalanobis, self.iris)
+        self.assertTrue(self.widget.Error.too_few_observations.is_shown())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
ValueError: 'Too few observations for the number of dimensions.'

Workflow:
1. Paint data (paint & send)  -> Distance.
2. Select columns and Mahalanobis metric.

##### Description of changes
Adds shape check and error notification.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation

owdistances.py: error notification when there is too few observations for Mahalanobis distance. Prevents ValueError exception from distance/__init__.py class MahalanobisDistance.