### PR TITLE
gui.comboBox: Set model before calling callfront.action

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1602,7 +1602,9 @@ def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
 
     if value:
         cindex = getdeepattr(master, value)
-        model = misc.get("model", None)
+        model = misc.pop("model", None)
+        if model is not None:
+            combo.setModel(model)
         if isinstance(model, VariableListModel):
             callfront = CallFrontComboBoxModel(combo, model)
             callfront.action(cindex)

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -34,3 +34,12 @@ class TestListModel(GuiTest):
         selection = view.selectedIndexes()
         self.assertEqual(len(selection), 1)
         self.assertEqual(selection[0].row(), 1)
+
+class ComboBoxText(GuiTest):
+    def test_set_initial_value(self):
+        widget = OWWidget()
+        variables = [ContinuousVariable(x) for x in "abc"]
+        model = VariableListModel(variables)
+        widget.foo = variables[1]
+        combo = gui.comboBox(widget.controlArea, widget, "foo", model=model)
+        self.assertEqual(combo.currentIndex(), 1)


### PR DESCRIPTION
##### Issue

`gui.comboBox` calls `callfront.action` to set the current item, but the model is only set later, within the call to `miscellanea` (miscellanea calls `control.set<key>` for all keyword arguments). As a consequence, the first item is always chosen.

The issue was first noticed in #1748, where the default value is "Enumeration", which is the second and not the first value in the combo.

##### Description of changes

Set the model earlier.

##### Includes
- [X] Code changes
- [X] Tests
