### PR TITLE
[ENH] Create Class widget

### DIFF
--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -1,3 +1,4 @@
+import numpy as np
 import scipy.sparse as sp
 
 from Orange.data import Instance, Table, Domain
@@ -137,5 +138,9 @@ class Lookup(Transformation):
         super().__init__(variable)
         self.lookup_table = lookup_table
 
-    def transform(self, c):
-        return self.lookup_table[c]
+    def transform(self, column):
+        mask = np.isnan(column)
+        column = column.astype(int)
+        column[mask] = 0
+        values = self.lookup_table[column]
+        return np.where(mask, np.nan, values)

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -1,9 +1,10 @@
 import unittest
+
 import numpy as np
 
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable, \
     StringVariable
-from Orange.preprocess.transformation import Identity, Transformation
+from Orange.preprocess.transformation import Identity, Transformation, Lookup
 
 
 class TestTransformation(unittest.TestCase):
@@ -59,3 +60,12 @@ class TestTransformation(unittest.TestCase):
         np.testing.assert_equal(D1.X, D.X)
         np.testing.assert_equal(D1.Y, D.Y)
         np.testing.assert_equal(D1.metas, D.metas)
+
+
+class LookupTest(unittest.TestCase):
+    def test_transform(self):
+        lookup = Lookup(None, np.array([1, 2, 0, 2]))
+        column = np.array([1, 2, 3, 0, np.nan, 0], dtype=np.float64)
+        np.testing.assert_array_equal(
+            lookup.transform(column),
+            np.array([2, 0, 2, 1, np.nan, 1], dtype=np.float64))

--- a/Orange/widgets/data/icons/CreateClass.svg
+++ b/Orange/widgets/data/icons/CreateClass.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="48px" height="48px" viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
+<g>
+	<path fill="#333333" d="M6,6v36h36V6H6z M40,22L40,22v1l0,0v8l0,0v1l0,0v8l0,0H30h-1H19h-1H8l0,0V14l0,0h10h1h10h1h10l0,0V22z"/>
+	<path fill="#666666" d="M30,14h-1v8H19v-8h-1v8H8v-8l0,0v26l0,0v-8h10v8h1v-8h10v8h1v-8h10v-1H30v-8h10v-1H30V14z M18,31H8v-8h10
+		V31z M29,31H19v-8h10V31z"/>
+	<rect x="8" y="32" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="8" y="23" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="8" y="14" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="19" y="32" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="19" y="23" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="19" y="14" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="40" y="32" fill="#FFFFFF" width="0" height="8"/>
+	<rect x="30" y="32" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="40" y="23" fill="#FFFFFF" width="0" height="8"/>
+	<rect x="30" y="23" fill="#FFFFFF" width="10" height="8"/>
+	<rect x="40" y="14" fill="#FFFFFF" width="0" height="8"/>
+	<rect x="30" y="14" fill="#FFFFFF" width="10" height="8"/>
+</g>
+<rect x="30" y="14" fill="#B5B5B5" width="10" height="8"/>
+<rect x="30" y="23" fill="#B5B5B5" width="10" height="8"/>
+<rect x="30" y="32" fill="#B5B5B5" width="10" height="8"/>
+<g>
+	<polygon stroke="#FFFFFF" stroke-width="0.49" stroke-miterlimit="10" points="14.915,48 33.765,18.344 30.148,16.395 
+		11.299,46.051 	"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="2.0007" stroke-miterlimit="10" x1="31.025" y1="18.828" x2="26.111" y2="26.564"/>
+	
+		<line fill="none" stroke="#FFFFFF" stroke-width="2.0007" stroke-miterlimit="10" x1="23.357" y1="30.898" x2="25.133" y2="28.103"/>
+</g>
+<path fill="#FFFFFF" stroke="#000000" stroke-width="0.2878" stroke-miterlimit="10" d="M34.188,7.185L31.06,7.123l1.952-2.443
+	l-0.906-2.992l2.926,1.1L37.597,1l-0.142,3.124l2.49,1.886L36.933,6.84l-1.025,2.955L34.188,7.185z"/>
+<path fill="#FFFFFF" stroke="#000000" stroke-width="0.2878" stroke-miterlimit="10" d="M28.573,13.33l-3.138,0.735l1.324-2.939
+	l-1.669-2.759l3.204,0.354l2.109-2.44l0.653,3.157l2.973,1.251l-2.802,1.598l-0.27,3.213L28.573,13.33z M29.023,11.598"/>
+<path fill="#FFFFFF" stroke="#000000" stroke-width="0.2588" stroke-miterlimit="10" d="M35.842,15.561l-2.35-1.547l2.657-0.922
+	l0.747-2.71l1.696,2.24l2.809-0.128L39.795,14.8l0.99,2.631l-2.691-0.815l-2.196,1.756L35.842,15.561z"/>
+<polygon fill="#FFFFFF" stroke="#000000" stroke-width="0.2878" stroke-miterlimit="10" points="41.41,10.406 43.471,8.76 
+	45.993,9.524 45.064,7.057 46.569,4.894 43.938,5.015 42.346,2.914 41.647,5.456 39.156,6.32 41.357,7.77 "/>
+</svg>

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -1,0 +1,266 @@
+import numpy as np
+
+from AnyQt.QtWidgets import QGridLayout, QLabel, QLineEdit, QSizePolicy
+from AnyQt.QtCore import QSize, Qt
+
+from Orange.data import StringVariable, DiscreteVariable, Domain
+from Orange.data.table import Table
+from Orange.statistics.util import bincount
+from Orange.preprocess.transformation import Transformation, Lookup
+from Orange.widgets import gui, widget
+from Orange.widgets.settings import DomainContextHandler, ContextSetting
+from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.widget import Msg
+
+
+def map_by_substring(a, patterns):
+    res = np.full(len(a), np.nan)
+    for val_idx, pattern in reversed(list(enumerate(patterns))):
+        res[np.char.find(a, pattern) != -1] = val_idx
+    return res
+
+
+class ClassFromStringSubstring(Transformation):
+    def __init__(self, variable, patterns):
+        super().__init__(variable)
+        self.patterns = patterns
+
+    def transform(self, c):
+        nans = np.equal(c, None)
+        c = c.astype(str)
+        c[nans] = ""
+        res = map_by_substring(c, self.patterns)
+        res[nans] = np.nan
+        return res
+
+
+class ClassFromDiscreteSubstring(Lookup):
+    def __init__(self, variable, patterns):
+        lookup_table = map_by_substring(variable.values, patterns)
+        super().__init__(variable, lookup_table)
+
+
+class OWCreateClass(widget.OWWidget):
+    name = "Create Class"
+    description = "Create class attribute from a string attribute"
+    icon = "icons/CreateClass.svg"
+    category = "Data"
+    keywords = ["data"]
+
+    inputs = [("Data", Table, "set_data")]
+    outputs = [("Data", Table)]
+
+    want_main_area = False
+
+    settingsHandler = DomainContextHandler()
+    attribute = ContextSetting(None)
+    rules = ContextSetting({})
+
+    TRANSFORMERS = {StringVariable: ClassFromStringSubstring,
+                    DiscreteVariable: ClassFromDiscreteSubstring}
+
+    class Warning(widget.OWWidget.Warning):
+        no_nonnumeric_vars = Msg("Data contains only numeric variables.")
+
+    def __init__(self):
+        super().__init__()
+        self.data = None
+        self.line_edits = []
+        self.remove_buttons = []
+        self.counts = []
+        self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
+
+        box = gui.hBox(self.controlArea)
+        gui.widgetLabel(box, "Class from column: ", addSpace=12)
+        gui.comboBox(
+            box, self, "attribute", callback=self.update_rules,
+            model=DomainModel(valid_types=(StringVariable, DiscreteVariable)),
+            sizePolicy=(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed))
+
+        self.rules_box = rules_box = QGridLayout()
+        self.controlArea.layout().addLayout(self.rules_box)
+        self.add_button = gui.button(None, self, "+", flat=True,
+                                     callback=self.add_row,
+                                     minimumSize=QSize(12, 20))
+        self.rules_box.setColumnMinimumWidth(1, 80)
+        self.rules_box.setColumnMinimumWidth(0, 10)
+        self.rules_box.setColumnStretch(0, 1)
+        self.rules_box.setColumnStretch(1, 1)
+        self.rules_box.setColumnStretch(2, 100)
+        rules_box.addWidget(QLabel("Name"), 0, 1)
+        rules_box.addWidget(QLabel("Pattern"), 0, 2)
+        rules_box.addWidget(QLabel("#Instances"), 0, 3, 1, 2)
+        self.update_rules()
+
+        box = gui.hBox(self.controlArea)
+        gui.rubber(box)
+        gui.button(box, self, "Apply", autoDefault=False, callback=self.apply)
+
+    @property
+    def active_rules(self):
+        return self.rules.setdefault(self.attribute and self.attribute.name,
+                                     [["C1", ""], ["C2", ""]])
+
+    def rules_to_edits(self):
+        for editr, textr in zip(self.line_edits, self.active_rules):
+            for edit, text in zip(editr, textr):
+                edit.setText(text)
+
+    def set_data(self, data):
+        self.closeContext()
+        self.rules = {}
+        self.data = data
+        model = self.controls.attribute.model()
+        model.set_domain(data and data.domain)
+        self.Warning.no_nonnumeric_vars(shown=data is not None and not model)
+        if not model:
+            self.attribute = None
+            self.send("Data", None)
+            return
+        self.attribute = model[0]
+        self.openContext(data)
+        self.update_rules()
+        self.apply()
+
+    def update_rules(self):
+        self.adjust_n_rule_rows()
+        self.rules_to_edits()
+        self.update_counts()
+
+    def adjust_n_rule_rows(self):
+        def _add_line():
+            self.line_edits.append([])
+            n_lines = len(self.line_edits)
+            for coli in range(1, 3):
+                edit = QLineEdit()
+                self.line_edits[-1].append(edit)
+                self.rules_box.addWidget(edit, n_lines, coli)
+                edit.textChanged.connect(self.sync_edit)
+            button = gui.button(
+                None, self, label='×', flat=True, height=20,
+                styleSheet='* {font-size: 16pt; color: silver}'
+                           '*:hover {color: black}',
+                callback=self.remove_row)
+            button.setMinimumSize(QSize(12, 20))
+            self.remove_buttons.append(button)
+            self.rules_box.addWidget(button, n_lines, 0)
+            self.counts.append([])
+            for coli, kwargs in enumerate(
+                    (dict(alignment=Qt.AlignRight),
+                     dict(alignment=Qt.AlignLeft, styleSheet="color: gray"))):
+                label = QLabel(**kwargs)
+                self.counts[-1].append(label)
+                self.rules_box.addWidget(label, n_lines, 3 + coli)
+
+        def _remove_line():
+            for edit in self.line_edits.pop():
+                edit.deleteLater()
+            self.remove_buttons.pop().deleteLater()
+            for label in self.counts.pop():
+                label.deleteLater()
+
+        def _fix_tab_order():
+            prev = None
+            for row, rule in zip(self.line_edits, self.active_rules):
+                for col_idx, edit in enumerate(row):
+                    edit.row, edit.col_idx = rule, col_idx
+                    if prev is not None:
+                        self.setTabOrder(prev, edit)
+                    prev = edit
+
+        n = len(self.active_rules)
+        while n > len(self.line_edits):
+            _add_line()
+        while len(self.line_edits) > n:
+            _remove_line()
+        self.rules_box.addWidget(self.add_button, n + 1, 0)
+        _fix_tab_order()
+
+    def add_row(self):
+        self.active_rules.append(["", ""])
+        self.adjust_n_rule_rows()
+
+    def remove_row(self):
+        remove_idx = self.remove_buttons.index(self.sender())
+        del self.active_rules[remove_idx]
+        self.update_rules()
+
+    def sync_edit(self, text):
+        edit = self.sender()
+        edit.row[edit.col_idx] = text
+        self.update_counts()
+
+    def update_counts(self):
+        def _set_labels(labels, matching, total_matching):
+            n_matched = int(np.sum(matching))
+            n_before = int(np.sum(total_matching)) - n_matched
+            labels[0].setText("{}".format(n_matched))
+            if n_before:
+                labels[1].setText("+ {}".format(n_before))
+
+        def _string_counts(data):
+            data = data.astype(str)
+            data = data[~np.char.equal(data, "")]
+            remaining = np.array(data)
+            for labels, (_, pattern) in zip(self.counts, self.active_rules):
+                matching = np.char.find(remaining, pattern) != -1
+                total_matching = np.char.find(data, pattern) != -1
+                _set_labels(labels, matching, total_matching)
+                remaining = remaining[~matching]
+                if len(remaining) == 0:
+                    break
+
+        def _discrete_counts(data):
+            attr_vals = np.array(attr.values)
+            bins = bincount(data, max_val=len(attr.values) - 1)[0]
+            remaining = np.array(bins)
+            for labels, (_, pattern) in zip(self.counts, self.active_rules):
+                matching = np.char.find(attr_vals, pattern) != -1
+                _set_labels(labels, remaining[matching], bins[matching])
+                remaining[matching] = 0
+                if not np.any(remaining):
+                    break
+
+        for labels in self.counts:
+            for label in labels:
+                label.setText("")
+        attr = self.attribute
+        if attr is None:
+            return
+        data = self.data.get_column_view(attr)[0]
+        if isinstance(attr, StringVariable):
+            _string_counts(data)
+        else:
+            _discrete_counts(data)
+
+    def apply(self):
+        if not self.attribute or not self.active_rules:
+            self.send("Data", None)
+            return
+        domain = self.data.domain
+        names, patterns = \
+            zip(*((name.strip(), pattern)
+                  for name, pattern in self.active_rules if name.strip()))
+        transformer = self.TRANSFORMERS[type(self.attribute)]
+        new_class = DiscreteVariable(
+            "class", names, compute_value=transformer(self.attribute, patterns))
+        new_domain = Domain(domain.attributes, new_class,
+                            domain.metas + domain.class_vars)
+        new_data = Table(new_domain, self.data)
+        self.send("Data", new_data)
+
+
+def main():  # pragma: no cover
+    import sys
+    from AnyQt.QtWidgets import QApplication
+
+    a = QApplication(sys.argv)
+    table = Table("zoo")
+    ow = OWCreateClass()
+    ow.show()
+    ow.set_data(table)
+    a.exec()
+    ow.saveSettings()
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -174,7 +174,7 @@ class OWCreateClass(widget.OWWidget):
         self.rules_box = rules_box = QGridLayout()
         patternbox.layout().addLayout(self.rules_box)
         self.add_button = gui.button(None, self, "+", flat=True,
-                                     callback=self.add_row,
+                                     callback=self.add_row, autoDefault=False,
                                      minimumSize=QSize(12, 20))
         self.rules_box.setColumnMinimumWidth(1, 80)
         self.rules_box.setColumnMinimumWidth(0, 10)
@@ -260,7 +260,7 @@ class OWCreateClass(widget.OWWidget):
                 None, self, label='×', flat=True, height=20,
                 styleSheet='* {font-size: 16pt; color: silver}'
                            '*:hover {color: black}',
-                callback=self.remove_row)
+                autoDefault=False, callback=self.remove_row)
             button.setMinimumSize(QSize(12, 20))
             self.remove_buttons.append(button)
             self.rules_box.addWidget(button, n_lines, 0)
@@ -322,7 +322,7 @@ class OWCreateClass(widget.OWWidget):
             are fixed on the fly."""
             if not self.case_sensitive:
                 pattern = pattern.lower()
-            indices = np.char.find(strings, pattern)
+            indices = np.char.find(strings, pattern.strip())
             return indices == 0 if self.match_beginning else indices != -1
 
         def _lower_if_needed(strings):

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -1,0 +1,254 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from Orange.data import Table, StringVariable, DiscreteVariable
+from Orange.widgets.data.owcreateclass import (
+    OWCreateClass,
+    map_by_substring, ClassFromStringSubstring, ClassFromDiscreteSubstring)
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestHelpers(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.patterns = ["abc", "a", "bc", ""]
+        cls.arr = np.array(["abcd", "aa", "bcd", "rabc", "x"])
+
+    def test_map_by_substring(self):
+        np.testing.assert_equal(map_by_substring(self.arr, self.patterns),
+                                [0, 1, 2, 0, 3])
+        np.testing.assert_equal(map_by_substring(self.arr, ["", ""]), 0)
+        self.assertTrue(np.all(np.isnan(map_by_substring(self.arr, []))))
+
+    def test_class_from_string_substring(self):
+        trans = ClassFromStringSubstring(StringVariable(), self.patterns)
+        arr2 = np.hstack((self.arr.astype(object), [None]))
+
+        with patch('Orange.widgets.data.owcreateclass.map_by_substring') as mbs:
+            trans.transform(self.arr)
+            arg1, arg2 = mbs.call_args[0]
+            np.testing.assert_equal(arg1, self.arr)
+            self.assertEqual(arg2, self.patterns)
+
+            trans.transform(arr2)
+            arg1, arg2 = mbs.call_args[0]
+            np.testing.assert_equal(arg1,
+                                    np.hstack((self.arr.astype(str), "")))
+
+        np.testing.assert_equal(trans.transform(arr2),
+                                [0, 1, 2, 0, 3, np.nan])
+
+    def test_class_from_discrete_substring(self):
+        trans = ClassFromDiscreteSubstring(
+            DiscreteVariable(values=self.arr), self.patterns)
+        np.testing.assert_equal(trans.lookup_table, [0, 1, 2, 0, 3])
+
+
+class TestOWCreateClass(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWCreateClass)
+        self.heart = Table("heart_disease")
+        self.zoo = Table("zoo")
+        self.no_attributes = Table("iris")[:, :4]
+
+    def _test_default_rules(self):
+        self.assertEqual(self.widget.active_rules, [["C1", ""], ["C2", ""]])
+        for i, (label, pattern) in enumerate(self.widget.line_edits):
+            self.assertEqual(label.text(), "C{}".format(i + 1))
+            self.assertEqual(pattern.text(), "")
+
+    def _set_attr(self, attr):
+        attr_combo = self.widget.controls.attribute
+        idx = attr_combo.model().indexOf(attr)
+        attr_combo.setCurrentIndex(idx)
+        attr_combo.activated.emit(idx)
+
+    def _check_counts(self, expected):
+        for countrow, expectedrow in zip(self.widget.counts, expected):
+            for count, exp in zip(countrow, expectedrow):
+                self.assertEqual(count.text(), exp)
+
+    def test_no_data(self):
+        widget = self.widget
+        self.send_signal("Data", None)
+        attr_combo = widget.controls.attribute
+
+        self.assertFalse(attr_combo.model())
+        self.assertIsNone(widget.attribute)
+        self.assertIsNone(self.get_output("Data"))
+        # That's all. I don't care if line edits retain the content
+
+        widget.apply()
+        self.assertIsNone(self.get_output("Data"))
+
+    def test_no_useful_data(self):
+        widget = self.widget
+        self.send_signal("Data", self.no_attributes)
+        attr_combo = widget.controls.attribute
+
+        self.assertFalse(attr_combo.model())
+        self.assertIsNone(widget.attribute)
+        self.assertIsNone(self.get_output("Data"))
+        self.assertTrue(widget.Warning.no_nonnumeric_vars.is_shown())
+
+        widget.apply()
+        self.assertIsNone(self.get_output("Data"))
+
+        self.send_signal("Data", self.heart)
+        self.assertFalse(widget.Warning.no_nonnumeric_vars.is_shown())
+
+    def test_string_data(self):
+        widget = self.widget
+        self.send_signal("Data", self.zoo)
+        self._set_attr(self.zoo.domain.metas[0])
+        widget.line_edits[0][1].setText("a")
+
+        self._check_counts([["54", ""], ["47", "+ 54"]])
+
+        widget.apply()
+        outdata = self.get_output("Data")
+        classes = outdata.get_column_view("class")[0]
+        attr = outdata.get_column_view("name")[0].astype(str)
+        has_a = np.char.find(attr, "a") != -1
+        np.testing.assert_equal(classes[has_a], 0)
+        np.testing.assert_equal(classes[~has_a], 1)
+
+    def _set_thal(self):
+        widget = self.widget
+        thal = self.heart.domain["thal"]
+        self._set_attr(thal)
+
+        widget.line_edits[0][0].setText("Cls1")
+        widget.line_edits[1][0].setText("Cls2")
+        widget.line_edits[0][1].setText("eversa")
+        widget.line_edits[1][1].setText("efect")
+
+    def _check_thal(self):
+        widget = self.widget
+        self.assertEqual(widget.attribute.name, "thal")
+        # This line indeed tests an implementational detail, but the one I
+        # got wrong. Until implementation changes, it makes me feel safe.
+        self.assertIs(widget.rules["thal"], widget.active_rules)
+
+        self._check_counts([["117", ""], ["18", "+ 117"]])
+
+        widget.apply()
+        outdata = self.get_output("Data")
+        self.assertEqual(outdata.domain.class_var.values, ["Cls1", "Cls2"])
+        classes = outdata.get_column_view("class")[0]
+        attr = outdata.get_column_view("thal")[0]
+        thal = self.heart.domain["thal"]
+        reversable = np.equal(attr, thal.values.index("reversable defect"))
+        fixed = np.equal(attr, thal.values.index("fixed defect"))
+        np.testing.assert_equal(classes[reversable], 0)
+        np.testing.assert_equal(classes[fixed], 1)
+        self.assertTrue(np.all(np.isnan(classes[~(reversable | fixed)])))
+
+    def test_flow_and_context_handling(self):
+        widget = self.widget
+        self.send_signal("Data", self.heart)
+        self._test_default_rules()
+
+        widget.apply()
+        outdata = self.get_output("Data")
+        self.assertEqual(outdata.domain.class_var.values, ["C1", "C2"])
+        classes = outdata.get_column_view("class")[0]
+        np.testing.assert_equal(classes, 0)
+
+        thal = self.heart.domain["thal"]
+        self._set_attr(thal)
+        self.assertIs(widget.rules["thal"], widget.active_rules)
+        self._test_default_rules()
+
+        self._set_thal()
+        self._check_thal()
+
+        gender = self.heart.domain["gender"]
+        self._set_attr(gender)
+        self.assertIs(widget.rules["gender"], widget.active_rules)
+        self._test_default_rules()
+
+        widget.line_edits[0][1].setText("ema")
+        self._check_counts([["97", ""], ["206", "+ 97"]])
+
+        widget.apply()
+        outdata = self.get_output("Data")
+        self.assertEqual(outdata.domain.class_var.values, ["C1", "C2"])
+        classes = outdata.get_column_view("class")[0]
+        attr = outdata.get_column_view("gender")[0]
+        female = np.equal(attr, gender.values.index("female"))
+        np.testing.assert_equal(classes[female], 0)
+        np.testing.assert_equal(classes[~female], 1)
+
+        self._set_attr(thal)
+        self._check_thal()
+
+        prev_rules = widget.rules
+        self.send_signal("Data", self.zoo)
+        self.assertIsNot(widget.rules, prev_rules)
+
+        self.send_signal("Data", self.heart)
+        self._check_thal()
+
+        # Check that sending None as data does not ruin the context, and that
+        # the empty context does not match the true one later
+        self.send_signal("Data", None)
+        self.assertIsNot(widget.rules, prev_rules)
+
+        self.send_signal("Data", self.heart)
+        self._check_thal()
+
+        self.send_signal("Data", self.no_attributes)
+        self.assertIsNot(widget.rules, prev_rules)
+
+        self.send_signal("Data", self.heart)
+        self._check_thal()
+
+    def test_add_remove_lines(self):
+        widget = self.widget
+        self.send_signal("Data", self.heart)
+        self._set_thal()
+        widget.add_button.click()
+        self.assertEqual(len(widget.line_edits), 3)
+        widget.line_edits[2][0].setText("Cls3")
+        widget.line_edits[2][1].setText("a")
+        # Observing counts suffices to deduct that rules are set correctly
+        self._check_counts([["117", ""], ["18", "+ 117"], ["166", "+ 117"]])
+
+        widget.add_button.click()
+        widget.add_button.click()
+        widget.line_edits[3][1].setText("c")
+        widget.line_edits[4][1].setText("b")
+        widget.apply()
+        outdata = self.get_output("Data")
+        # Ignore classes without labels
+        self._check_counts([["117", ""], ["18", "+ 117"], ["166", "+ 117"],
+                            ["", ""], ["", ""]])
+        self.assertEqual(outdata.domain.class_var.values,
+                         ["Cls1", "Cls2", "Cls3"])
+
+        widget.remove_buttons[1].click()
+        self._check_counts([["117", ""], ["166", "+ 117"], ["18", "+ 117"],
+                            ["", ""], ["", ""]])
+        self.assertEqual([lab.text() for _, lab in widget.line_edits],
+                         ["eversa", "a", "c", "b"])
+
+        # Removal preserves integrity of connections
+        widget.line_edits[1][1].setText("efect")
+        widget.line_edits[2][1].setText("a")
+        self._check_counts([["117", ""], ["18", "+ 117"], ["166", "+ 117"],
+                            ["", ""]])
+
+        while widget.remove_buttons:
+            widget.remove_buttons[0].click()
+        widget.apply()
+        outdata = self.get_output("Data")
+        self.assertIsNone(outdata)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -22,22 +22,22 @@ class TestHelpers(unittest.TestCase):
         np.testing.assert_equal(
             map_by_substring(self.arr,
                              ["abc", "a", "bc", ""],
-                             case_sensitive=True, at_beginning=False),
+                             case_sensitive=True, match_beginning=False),
             [0, 1, 2, 0, 3])
         np.testing.assert_equal(
             map_by_substring(self.arr,
                              ["abc", "a", "Bc", ""],
-                             case_sensitive=True, at_beginning=False),
+                             case_sensitive=True, match_beginning=False),
             [0, 1, 3, 0, 3])
         np.testing.assert_equal(
             map_by_substring(self.arr,
                              ["abc", "a", "Bc", ""],
-                             case_sensitive=False, at_beginning=False),
+                             case_sensitive=False, match_beginning=False),
             [0, 1, 2, 0, 3])
         np.testing.assert_equal(
             map_by_substring(self.arr,
                              ["abc", "a", "bc", ""],
-                             case_sensitive=False, at_beginning=True),
+                             case_sensitive=False, match_beginning=True),
             [0, 1, 2, 3, 3])
         np.testing.assert_equal(
             map_by_substring(self.arr, ["", ""], False, False),

--- a/doc/visual-programming/source/widgets/data/createclass.rst
+++ b/doc/visual-programming/source/widgets/data/createclass.rst
@@ -1,0 +1,30 @@
+Create Class
+============
+
+.. figure:: icons/create_class.png
+
+Create class attribute from a string attribute
+
+Signals
+-------
+
+**Inputs**:
+
+-  **Data**
+
+   Input data set
+
+**Outputs**:
+
+-  **Data**
+
+   Output data set
+
+Description
+-----------
+
+Create class attribute from a string attribute
+
+Examples
+--------
+


### PR DESCRIPTION
In line with my widely known and well established tradition of impeccable pull requests and thoroughly tested code, I am presenting a new widget that creates a class attribute with values based on substrings of the chosen string or discrete attribute. The widget is needed for infraorange and presumably also in bioinformatics.

The widget has zero pylint warnings, was assigned a straight A by radon, and has a 100 % coverage with unit tests of the highest quality. The latter rely on simulated user interaction with the widget, and restrict themselves from testing the implementational details except where appropriate. The abundance of documentation strings explaining even the smallest nuances of the private methods - but without going into unnecessary details - will make the future maintenance of the widget pure joy.

This whole grand endeavour is topped by a carefully crafted icon that complements the widget's amazing user interface.

----

A minor shortcoming that may need to be mentioned is that I can't make the widget properly shrink vertically when lines are removed. Not for lack of trying. Any help appreciated.

I have not written any documentation for the widget catalog so far. This will wait for any suggestions and for @ajdapretnar's help with screenshots.

The code of the widget contains two general classes derived from `Transform` and `Lookup` -- but perhaps not general enough to pollute the namespace of the `transformation` module.

The pull request includes a fix for `Orange.preprocess.transformation.Lookup`, which probably nobody used since it was plain broken. This commit could belong to another pull request, but processing/merging chains of pull requests tends to take too long in my experience. Being broken and useless, the class has two relatives of the same name in other modules, one of which does exactly the same thing as the original `Lookup` did not do.

----

@markotoplak, can you test this on files with hyperspectral data? After this glorious presentation, let's hope the widget doesn't crash on the very first use. ;)

##### Includes

- [X] Code changes
- [X] Tests
- [X] Documentation
