### PR TITLE
OWBoxPlot: Select and send selected data

### DIFF
--- a/Orange/data/filter.py
+++ b/Orange/data/filter.py
@@ -286,6 +286,10 @@ class FilterDiscrete(ValueFilter):
         else:
             return value in self.values
 
+    def __eq__(self, other):
+        return isinstance(other, FilterDiscrete) and \
+               self.column == other.column and self.values == other.values
+
 
 class FilterContinuous(ValueFilter):
     """
@@ -357,6 +361,11 @@ class FilterContinuous(ValueFilter):
         if self.oper == self.IsDefined:
             return True
         raise ValueError("invalid operator")
+
+    def __eq__(self, other):
+        return isinstance(other, FilterContinuous) and \
+               self.column == other.column and self.oper == other.oper and \
+               self.oper == other.oper and self.oper == other.oper
 
     def __str__(self):
         if isinstance(self.column, str):

--- a/Orange/tests/test_filter.py
+++ b/Orange/tests/test_filter.py
@@ -246,6 +246,18 @@ class TestFilterContinuous(unittest.TestCase):
         flt.oper = -1
         self.assertEqual(str(flt), "invalid operator")
 
+    def test_eq(self):
+        flt1 = FilterContinuous(1, FilterContinuous.Between, 1, 2)
+        flt2 = FilterContinuous(1, FilterContinuous.Between, 1, 2)
+        self.assertEqual(flt1, flt2)
+
+
+class TestFilterDiscrete(unittest.TestCase):
+    def test_eq(self):
+        flt1 = FilterDiscrete(1, None)
+        flt2 = FilterDiscrete(1, None)
+        self.assertEqual(flt1, flt2)
+
 
 class TestFilterString(unittest.TestCase):
 

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -1,22 +1,27 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-from unittest import skip
 
 import numpy as np
+
 from Orange.data import Table, ContinuousVariable
-from Orange.widgets.visualize.owboxplot import OWBoxPlot
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.visualize.owboxplot import OWBoxPlot, FilterGraphicsRectItem
+from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 
 
-class OWBoxPlotTests(WidgetTest):
+class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        WidgetOutputsTestMixin.init(cls)
+
         cls.iris = Table("iris")
         cls.zoo = Table("zoo")
         cls.housing = Table("housing")
         cls.titanic = Table("titanic")
         cls.heart = Table("heart_disease")
+        cls.data = cls.iris
+        cls.signal_name = "Data"
+        cls.signal_data = cls.data
 
     def setUp(self):
         self.widget = self.create_widget(OWBoxPlot)
@@ -36,7 +41,7 @@ class OWBoxPlotTests(WidgetTest):
 
     def test_input_data_missings_cont_group_var(self):
         """Check widget with continuous data with missing values and group variable"""
-        data = self.iris
+        data = self.iris.copy()
         data.X[:, 0] = np.nan
         self.send_signal("Data", data)
         # used to crash, see #1568
@@ -100,3 +105,11 @@ class OWBoxPlotTests(WidgetTest):
                           'slope peak exc ST', 'gender', 'age', 'rest SBP',
                           'rest ECG', 'cholesterol',
                           'fasting blood sugar > 120', 'diameter narrowing'])
+
+    def _select_data(self):
+        items = [item for item in self.widget.box_scene.items()
+                 if isinstance(item, FilterGraphicsRectItem)]
+        items[0].setSelected(True)
+        return [100, 103, 104, 108, 110, 111, 112, 115, 116,
+                120, 123, 124, 126, 128, 132, 133, 136, 137,
+                139, 140, 141, 143, 144, 145, 146, 147, 148]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Make OWBoxPlot clickable.

##### Description of changes
Enable data selection (and send selected data to output).
Only data instances in squares are selectable. This could be upgraded for continuous variables.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation

