### PR TITLE
[FIX] Fix transformation for non primitive variables

### DIFF
--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -14,7 +14,6 @@ class Transformation:
         :type variable: int or str or :obj:`~Orange.data.Variable`
         """
         self.variable = variable
-        self._last_domain = None
 
     def __call__(self, data):
         """
@@ -26,11 +25,15 @@ class Transformation:
             data = Table(data.domain, [data])
         if self.variable.is_primitive():
             domain = Domain([self.variable])
-            data = Table.from_table(domain, data).X
+            data = Table.from_table(domain, data)
+            col = data.X
         else:
-            domain = Domain([], [], metas=[self.variable])
-            data = Table.from_table(domain, data).metas
-        transformed = self.transform(data if sp.issparse(data) else data.squeeze(axis=1))
+            domain = Domain([], metas=[self.variable])
+            data = Table.from_table(domain, data)
+            col = data.metas
+        if not sp.issparse(col):
+            col = col.squeeze(axis=1)
+        transformed = self.transform(col)
         if inst:
             transformed = transformed[0]
         return transformed

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -24,9 +24,13 @@ class Transformation:
         inst = isinstance(data, Instance)
         if inst:
             data = Table(data.domain, [data])
-        domain = Domain([self.variable])
-        data = Table.from_table(domain, data)
-        transformed = self.transform(data.X if sp.issparse(data.X) else data.X.squeeze(axis=1))
+        if self.variable.is_primitive():
+            domain = Domain([self.variable])
+            data = Table.from_table(domain, data).X
+        else:
+            domain = Domain([], [], metas=[self.variable])
+            data = Table.from_table(domain, data).metas
+        transformed = self.transform(data if sp.issparse(data) else data.squeeze(axis=1))
         if inst:
             transformed = transformed[0]
         return transformed

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -3,10 +3,44 @@ import numpy as np
 
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable, \
     StringVariable
-from Orange.preprocess.transformation import Identity
+from Orange.preprocess.transformation import Identity, Transformation
 
 
 class TestTransformation(unittest.TestCase):
+    class TransformationMock(Transformation):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.called_with = None
+
+        def transform(self, col):
+            self.called_with = col
+            return np.arange(len(col))
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data = Table("zoo")
+
+    def test_call(self):
+        """Call passes the column to `transform` and returns its results"""
+        data = self.data
+        trans = self.TransformationMock(data.domain[2])
+        np.testing.assert_almost_equal(trans(data), np.arange(len(data)))
+        np.testing.assert_array_equal(trans.called_with, data.X[:, 2])
+
+        np.testing.assert_almost_equal(trans(data[0]), np.array([0]))
+        np.testing.assert_array_equal(trans.called_with, data.X[0, 2])
+
+        trans = self.TransformationMock(data.domain.metas[0])
+        np.testing.assert_almost_equal(trans(data), np.arange(len(data)))
+        np.testing.assert_array_equal(trans.called_with, data.metas.flatten())
+
+        np.testing.assert_almost_equal(trans(data[0]), np.array([0]))
+        np.testing.assert_array_equal(trans.called_with, data.metas[0, 0])
+
+    def test_transform_fails(self):
+        trans = Transformation(self.data.domain[2])
+        self.assertRaises(NotImplementedError, trans, self.data)
+
     def test_identity(self):
         domain = Domain([ContinuousVariable("X")],
                         [DiscreteVariable("C", values=["0", "1", "2"])],

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -1,0 +1,27 @@
+import unittest
+import numpy as np
+
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable, \
+    StringVariable
+from Orange.preprocess.transformation import Identity
+
+
+class TestTransformation(unittest.TestCase):
+    def test_identity(self):
+        domain = Domain([ContinuousVariable("X")],
+                        [DiscreteVariable("C", values=["0", "1", "2"])],
+                        [StringVariable("S")])
+        X = np.random.normal(size=(4, 1))
+        Y = np.random.randint(3, size=(4, 1))
+        M = np.array(["A", "B", "C", "D"], dtype=object).reshape(-1, 1)
+
+        D = Table.from_numpy(domain, X, Y, metas=M)
+        X1 = domain[0].copy(compute_value=Identity(domain[0]))
+        Y1 = domain[1].copy(compute_value=Identity(domain[1]))
+        S1 = domain.metas[0].copy(compute_value=Identity(domain.metas[0]))
+        domain_1 = Domain([X1], [Y1], [S1])
+        D1 = Table.from_table(domain_1, D)
+
+        np.testing.assert_equal(D1.X, D.X)
+        np.testing.assert_equal(D1.Y, D.Y)
+        np.testing.assert_equal(D1.metas, D.metas)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When editing a StringVariable in "Edit Domain" widget an TypeError is raised:
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 1978, in do_commit
    commit()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/oweditdomain.py", line 543, in commit
    new_data = self.data.from_table(new_domain, self.data)
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 374, in from_table
    is_sparse=sp.issparse(source.metas))
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 324, in get_columns
    a[:, i] = match_type(col(source))
  File "/Users/aleserjavec/workspace/orange3/Orange/preprocess/transformation.py", line 27, in __call__
    domain = Domain([self.variable])
  File "/Users/aleserjavec/workspace/orange3/Orange/data/domain.py", line 127, in __init__
    raise TypeError("variables must be primitive")
TypeError: variables must be primitive
```

##### Description of changes

Fix base Transformation class to handle the non primitive variable case.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
