### PR TITLE
Docs (contributing): Add QT_API env variable to testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Testing
 If you contribute new code, write [unit tests] for it in _Orange/tests_ or
 _Orange/widgets/*/tests_, as appropriate. Ensure the tests pass by running:
 
-    python setup.py test
+    QT_API=pyqt4 python setup.py test
 
 Additionally, check that the tests for widgets pass:
 


### PR DESCRIPTION
##### Issue
No documentation on how to run the full test suite since the introduction of AnyQt.


##### Description of changes
Add the environmental variable `QT_API=pyqt4` to CONTRIBUTING.md.

##### Includes
- [ ] Code changes
- [ ] Tests
- [x] Documentation
