### PR TITLE
Fix tree models with rf

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -361,6 +361,10 @@ class Tree:
     pass
 
 
+class TreeModel(Tree, Model):
+    pass
+
+
 class RandomForest:
     """Interface for random forest models
     """

--- a/Orange/base.py
+++ b/Orange/base.py
@@ -356,6 +356,11 @@ class SklLearner(_ReprableWithParams, Learner, metaclass=WrapperMeta):
         return 'sample_weight' in self.__wraps__.fit.__code__.co_varnames
 
 
+class Tree:
+    """Interface for any kind of trees"""
+    pass
+
+
 class RandomForest:
     """Interface for random forest models
     """

--- a/Orange/base.py
+++ b/Orange/base.py
@@ -356,12 +356,7 @@ class SklLearner(_ReprableWithParams, Learner, metaclass=WrapperMeta):
         return 'sample_weight' in self.__wraps__.fit.__code__.co_varnames
 
 
-class Tree:
-    """Interface for any kind of trees"""
-    pass
-
-
-class TreeModel(Tree, Model):
+class TreeModel(Model):
     pass
 
 

--- a/Orange/base.py
+++ b/Orange/base.py
@@ -365,7 +365,7 @@ class TreeModel(Tree, Model):
     pass
 
 
-class RandomForest:
+class RandomForestModel(Model):
     """Interface for random forest models
     """
 

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -24,6 +24,7 @@ class RandomForestClassifier(SklModel, RandomForest):
         def wrap(tree, i):
             t = SklTreeClassifier(tree)
             t.domain = self.domain
+            t.instances = self.instances
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -24,7 +24,6 @@ class RandomForestClassifier(SklModel, RandomForest):
         def wrap(tree, i):
             t = SklTreeClassifier(tree)
             t.domain = self.domain
-            t.instances = self.instances
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -1,6 +1,6 @@
 import sklearn.ensemble as skl_ensemble
 
-from Orange.base import RandomForest
+from Orange.base import RandomForestModel
 from Orange.classification import SklLearner, SklModel
 from Orange.classification.tree import SklTreeClassifier
 from Orange.data import Variable, DiscreteVariable
@@ -18,7 +18,7 @@ class _FeatureScorerMixin(LearnerScorer):
         return model.skl_model.feature_importances_
 
 
-class RandomForestClassifier(SklModel, RandomForest):
+class RandomForestClassifier(SklModel, RandomForestModel):
     @property
     def trees(self):
         def wrap(tree, i):

--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -2,6 +2,7 @@
 import numpy as np
 import sklearn.tree as skl_tree
 
+from Orange.base import Tree
 from Orange.classification import SklLearner, SklModel, Learner
 from Orange.classification import _tree_scorers
 from Orange.statistics import distribution, contingency
@@ -213,7 +214,7 @@ class TreeLearner(Learner):
         return model
 
 
-class SklTreeClassifier(SklModel):
+class SklTreeClassifier(SklModel, Tree):
     """Wrapper for SKL's tree classifier with the interface API for
     visualizations"""
     def __init__(self, *args, **kwargs):

--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -2,7 +2,7 @@
 import numpy as np
 import sklearn.tree as skl_tree
 
-from Orange.base import Tree
+from Orange.base import TreeModel as TreeModelInterface
 from Orange.classification import SklLearner, SklModel, Learner
 from Orange.classification import _tree_scorers
 from Orange.statistics import distribution, contingency
@@ -214,7 +214,7 @@ class TreeLearner(Learner):
         return model
 
 
-class SklTreeClassifier(SklModel, Tree):
+class SklTreeClassifier(SklModel, TreeModelInterface):
     """Wrapper for SKL's tree classifier with the interface API for
     visualizations"""
     def __init__(self, *args, **kwargs):

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -1,6 +1,6 @@
 import sklearn.ensemble as skl_ensemble
 
-from Orange.base import RandomForest
+from Orange.base import RandomForestModel
 from Orange.regression import SklLearner, SklModel
 from Orange.data import Variable, ContinuousVariable
 from Orange.preprocess.score import LearnerScorer
@@ -18,7 +18,7 @@ class _FeatureScorerMixin(LearnerScorer):
         return model.skl_model.feature_importances_
 
 
-class RandomForestRegressor(SklModel, RandomForest):
+class RandomForestRegressor(SklModel, RandomForestModel):
     @property
     def trees(self):
         def wrap(tree, i):

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -24,7 +24,6 @@ class RandomForestRegressor(SklModel, RandomForest):
         def wrap(tree, i):
             t = SklTreeRegressor(tree)
             t.domain = self.domain
-            t.instances = self.instances
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -24,6 +24,7 @@ class RandomForestRegressor(SklModel, RandomForest):
         def wrap(tree, i):
             t = SklTreeRegressor(tree)
             t.domain = self.domain
+            t.instances = self.instances
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -3,7 +3,7 @@
 import numpy as np
 import sklearn.tree as skl_tree
 
-from Orange.base import Tree
+from Orange.base import TreeModel as TreeModelInterface
 from Orange.tree import Node, DiscreteNode, MappedDiscreteNode, \
     NumericNode, TreeModel
 from Orange.regression import SklLearner, SklModel, Learner
@@ -163,7 +163,7 @@ class TreeLearner(Learner):
         return model
 
 
-class SklTreeRegressor(SklModel, Tree):
+class SklTreeRegressor(SklModel, TreeModelInterface):
     pass
 
 

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -3,6 +3,7 @@
 import numpy as np
 import sklearn.tree as skl_tree
 
+from Orange.base import Tree
 from Orange.tree import Node, DiscreteNode, MappedDiscreteNode, \
     NumericNode, TreeModel
 from Orange.regression import SklLearner, SklModel, Learner
@@ -162,10 +163,8 @@ class TreeLearner(Learner):
         return model
 
 
-class SklTreeRegressor(SklModel):
-    @property
-    def tree(self):
-        return self.skl_model.tree_
+class SklTreeRegressor(SklModel, Tree):
+    pass
 
 
 class SklTreeRegressionLearner(SklLearner):

--- a/Orange/tree.py
+++ b/Orange/tree.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-from Orange.base import Model, Tree
+from Orange.base import Model, TreeModel as TreeModelInterface
 
 
 class Node:
@@ -128,7 +128,7 @@ class NumericNode(Node):
             "{} {}".format("≤>"[child_idx], attr.str_val(threshold))
 
 
-class TreeModel(Model, Tree):
+class TreeModel(TreeModelInterface):
     """
     Tree classifier with proper handling of nominal attributes and binarization
     and the interface API for visualization.

--- a/Orange/tree.py
+++ b/Orange/tree.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-from Orange.base import Model
+from Orange.base import Model, Tree
 
 
 class Node:
@@ -128,7 +128,7 @@ class NumericNode(Node):
             "{} {}".format("≤>"[child_idx], attr.str_val(threshold))
 
 
-class TreeModel(Model):
+class TreeModel(Model, Tree):
     """
     Tree classifier with proper handling of nominal attributes and binarization
     and the interface API for visualization.

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -365,7 +365,7 @@ class OWPythagorasTree(OWWidget):
         data = self.tree_adapter.get_instances_in_nodes(
             self.clf_dataset, nodes)
         self.send('Selected Data', data)
-        selected_indices = self.model.get_indices(nodes)
+        selected_indices = self.tree_adapter.get_indices(nodes)
         self.send(ANNOTATED_DATA_SIGNAL_NAME,
                   create_annotated_table(self.instances, selected_indices))
 

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -24,7 +24,7 @@ from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QLabel, QSizePolicy
 from AnyQt.QtGui import QColor, QPainter
 
-from Orange.base import Tree, SklModel
+from Orange.base import TreeModel, SklModel
 from Orange.widgets.visualize.utils.scene import \
     UpdateItemsOnSelectGraphicsScene
 from Orange.widgets.visualize.utils.tree.rules import Rule
@@ -64,7 +64,7 @@ class OWPythagorasTree(OWWidget):
 
     priority = 1000
 
-    inputs = [('Tree', Tree, 'set_tree')]
+    inputs = [('Tree', TreeModel, 'set_tree')]
     outputs = [('Selected Data', Table, widget.Default),
                (ANNOTATED_DATA_SIGNAL_NAME, Table)]
 

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -16,7 +16,6 @@ to be used, and the methods need to be implemented, then it should work for any
 kind of trees.
 
 """
-import sys
 from math import sqrt, log
 
 import numpy as np
@@ -25,10 +24,11 @@ from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QLabel, QSizePolicy
 from AnyQt.QtGui import QColor, QPainter
 
-from Orange.tree import TreeModel
+from Orange.base import Tree, SklModel
 from Orange.widgets.visualize.utils.scene import \
     UpdateItemsOnSelectGraphicsScene
 from Orange.widgets.visualize.utils.tree.rules import Rule
+from Orange.widgets.visualize.utils.tree.skltreeadapter import SklTreeAdapter
 from Orange.widgets.visualize.utils.view import (
     PannableGraphicsView,
     ZoomableGraphicsView,
@@ -64,7 +64,7 @@ class OWPythagorasTree(OWWidget):
 
     priority = 1000
 
-    inputs = [('Tree', TreeModel, 'set_tree')]
+    inputs = [('Tree', Tree, 'set_tree')]
     outputs = [('Selected Data', Table, widget.Default),
                (ANNOTATED_DATA_SIGNAL_NAME, Table)]
 
@@ -345,6 +345,8 @@ class OWPythagorasTree(OWWidget):
         self.view.update_anchored_items()
 
     def _get_tree_adapter(self, model):
+        if isinstance(model, SklModel):
+            return SklTreeAdapter(model)
         return TreeAdapter(model)
 
     def onDeleteWidget(self):
@@ -607,37 +609,27 @@ class TreeGraphicsScene(UpdateItemsOnSelectGraphicsScene):
     pass
 
 
-def main(argv=sys.argv):
+def main():
     from AnyQt.QtWidgets import QApplication
-    import Orange
+    import sys
 
-    app = QApplication(list(argv))
-    argv = app.arguments()
-
-    if len(argv) > 1:
-        filename = argv[1]
-    else:
-        filename = 'iris'
+    app = QApplication(sys.argv)
 
     ow = OWPythagorasTree()
-    data = Orange.data.Table(filename)
+    data = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
 
     if data.domain.has_discrete_class:
-        from Orange.classification.tree import TreeLearner
+        from Orange.classification.tree import SklTreeLearner as TreeLearner
     else:
-        from Orange.regression.tree import TreeLearner
+        from Orange.regression.tree import SklTreeRegressionLearner as TreeLearner
     model = TreeLearner(max_depth=1000)(data)
-
     model.instances = data
-
     ow.set_tree(model)
 
     ow.show()
     ow.raise_()
     ow.handleNewSignals()
     app.exec_()
-
-    sys.exit(0)
 
 if __name__ == '__main__':
     main()

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -7,7 +7,7 @@ from AnyQt.QtWidgets import QSizePolicy, QGraphicsScene, QGraphicsView
 from AnyQt.QtGui import QPainter, QColor
 from AnyQt.QtCore import Qt
 
-from Orange.base import RandomForest
+from Orange.base import RandomForest, TreeModel
 from Orange.classification.random_forest import RandomForestClassifier
 from Orange.classification.tree import SklTreeClassifier
 from Orange.data import Table
@@ -34,7 +34,7 @@ class OWPythagoreanForest(OWWidget):
     priority = 1001
 
     inputs = [('Random forest', RandomForest, 'set_rf')]
-    outputs = [('Tree', SklTreeClassifier)]
+    outputs = [('Tree', TreeModel)]
 
     # Enable the save as feature
     graph_name = 'scene'
@@ -273,15 +273,7 @@ class OWPythagoreanForest(OWWidget):
 
         selected_item = self.scene.selectedItems()[0]
         self.selected_tree_index = self.grid_items.index(selected_item)
-        tree = self.model.skl_model.estimators_[self.selected_tree_index]
-
-        if self.forest_type == self.CLASSIFICATION:
-            obj = SklTreeClassifier(tree)
-        else:
-            obj = SklTreeRegressor(tree)
-        obj.domain = self.model.domain
-        obj.instances = self.model.instances
-
+        obj = self.model.trees[self.selected_tree_index]
         obj.meta_target_class_index = self.target_class_index
         obj.meta_size_calc_idx = self.size_calc_idx
         obj.meta_size_log_scale = self.size_log_scale

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -274,6 +274,7 @@ class OWPythagoreanForest(OWWidget):
         selected_item = self.scene.selectedItems()[0]
         self.selected_tree_index = self.grid_items.index(selected_item)
         obj = self.model.trees[self.selected_tree_index]
+        obj.instances = self.dataset
         obj.meta_target_class_index = self.target_class_index
         obj.meta_size_calc_idx = self.size_calc_idx
         obj.meta_size_log_scale = self.size_log_scale

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -2,17 +2,14 @@
 from math import log, sqrt
 
 import numpy as np
-
-from AnyQt.QtWidgets import QSizePolicy, QGraphicsScene, QGraphicsView
-from AnyQt.QtGui import QPainter, QColor
 from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QPainter, QColor
+from AnyQt.QtWidgets import QSizePolicy, QGraphicsScene, QGraphicsView
 
-from Orange.base import RandomForest, TreeModel
+from Orange.base import RandomForestModel, TreeModel
 from Orange.classification.random_forest import RandomForestClassifier
-from Orange.classification.tree import SklTreeClassifier
 from Orange.data import Table
 from Orange.regression.random_forest import RandomForestRegressor
-from Orange.regression.tree import SklTreeRegressor
 from Orange.widgets import gui, settings
 from Orange.widgets.utils.colorpalette import ContinuousPaletteGenerator
 from Orange.widgets.visualize.pythagorastreeviewer import PythagorasTreeViewer
@@ -33,7 +30,7 @@ class OWPythagoreanForest(OWWidget):
 
     priority = 1001
 
-    inputs = [('Random forest', RandomForest, 'set_rf')]
+    inputs = [('Random forest', RandomForestModel, 'set_rf')]
     outputs = [('Tree', TreeModel)]
 
     # Enable the save as feature

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -263,3 +263,17 @@ class SklTreeAdapter(BaseTreeAdapter):
             indices = []
 
         return dataset[indices] if len(indices) else None
+
+    def get_indices(self, nodes):
+        if not isinstance(nodes, (list, tuple)):
+            nodes = [nodes]
+
+        node_leaves = [self.leaves(n) for n in nodes]
+        if len(node_leaves) > 0:
+            # get the leaves of the selected tree node
+            node_leaves = np.unique(np.hstack(node_leaves))
+
+            all_leaves = self.leaves(self.root)
+
+            return np.searchsorted(all_leaves, node_leaves)
+        return []

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -223,6 +223,10 @@ class BaseTreeAdapter(metaclass=ABCMeta):
         """
         pass
 
+    @abstractmethod
+    def get_indices(self, nodes):
+        pass
+
     @property
     @abstractmethod
     def max_depth(self):
@@ -321,6 +325,9 @@ class TreeAdapter(BaseTreeAdapter):
         if isinstance(nodes, tree.Node):
             nodes = [nodes]
         return self.model.get_instances(nodes)
+
+    def get_indices(self, nodes):
+        return self.model.get_indices(nodes)
 
     @property
     def max_depth(self):


### PR DESCRIPTION
##### Issue
Since the Orange trees were added, the pythagorean forest output was unable to connect with other tree visualisation widgets.

##### Description of changes

The issue was that Orange trees didn't use the Tree interface and removed it entirely, which meant that sklearn trees were not able to be displayed in the pythagorean tree viewer. Sklearn trees are still present in Orange since we still use sklearn's random forests.

This PR re-introduces the tree interfaces so this at least the pythagorean forest and trees work together again. Since TreeViewer only supports Orange trees, random forest trees can't be visualised there. This could be fixed if changes were made to TreeViewer to use the TreeAdapter that the pythagoras tree widget uses, but that would require major changes to TreeViewer.

I'm not satisfied with the interfaces I've defined, since they are empty (then again, that's what interfaces are for...), so if anybody has a better way, I'd love to hear it.

##### Includes
- [x] Code changes
- [ ] Tests
- [ ] Documentation
