### PR TITLE
[FIX] Improve ada boost widget

### DIFF
--- a/Orange/widgets/classify/owadaboost.py
+++ b/Orange/widgets/classify/owadaboost.py
@@ -1,12 +1,13 @@
 from AnyQt.QtCore import Qt
 
+from Orange.classification import SklTreeLearner
 from Orange.classification.base_classification import LearnerClassification
 from Orange.data import Table
-from Orange.classification import SklTreeLearner
 from Orange.ensembles import SklAdaBoostLearner
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
+from Orange.widgets.widget import Msg
 
 
 class OWAdaBoostClassification(OWBaseLearner):
@@ -28,6 +29,9 @@ class OWAdaBoostClassification(OWBaseLearner):
 
     DEFAULT_BASE_ESTIMATOR = SklTreeLearner()
 
+    class Error(OWBaseLearner.Error):
+        no_weight_support = Msg('The base learner does not support weights.')
+
     def add_main_layout(self):
         box = gui.widgetBox(self.controlArea, "Parameters")
         self.base_estimator = self.DEFAULT_BASE_ESTIMATOR
@@ -36,10 +40,11 @@ class OWAdaBoostClassification(OWBaseLearner):
 
         self.n_estimators_spin = gui.spin(
             box, self, "n_estimators", 1, 100, label="Number of estimators:",
-            alignment=Qt.AlignRight, callback=self.settings_changed)
+            alignment=Qt.AlignRight, controlWidth=80,
+            callback=self.settings_changed)
         self.learning_rate_spin = gui.doubleSpin(
             box, self, "learning_rate", 1e-5, 1.0, 1e-5, label="Learning rate:",
-            decimals=5, alignment=Qt.AlignRight, controlWidth=90,
+            decimals=5, alignment=Qt.AlignRight, controlWidth=80,
             callback=self.settings_changed)
         self.add_specific_parameters(box)
 
@@ -49,18 +54,25 @@ class OWAdaBoostClassification(OWBaseLearner):
             orientation=Qt.Horizontal, callback=self.settings_changed)
 
     def create_learner(self):
+        if self.base_estimator is None:
+            return None
         return self.LEARNER(
             base_estimator=self.base_estimator,
             n_estimators=self.n_estimators,
             learning_rate=self.learning_rate,
             preprocessors=self.preprocessors,
-            algorithm=self.losses[self.algorithm]
-        )
+            algorithm=self.losses[self.algorithm])
 
     def set_base_learner(self, learner):
-        self.base_estimator = learner if learner \
-            else self.DEFAULT_BASE_ESTIMATOR
-        self.base_label.setText("Base estimator: " + self.base_estimator.name)
+        self.Error.no_weight_support.clear()
+        if learner and not learner.supports_weights:
+            # Clear the error and reset to default base learner
+            self.Error.no_weight_support()
+            self.base_estimator = None
+            self.base_label.setText("Base estimator: INVALID")
+        else:
+            self.base_estimator = learner or self.DEFAULT_BASE_ESTIMATOR
+            self.base_label.setText("Base estimator: " + self.base_estimator.name)
         if self.auto_apply:
             self.apply()
 
@@ -76,7 +88,7 @@ if __name__ == "__main__":
 
     a = QApplication(sys.argv)
     ow = OWAdaBoostClassification()
-    ow.set_data(Table("iris"))
+    ow.set_data(Table(sys.argv[1] if len(sys.argv) > 1 else 'iris'))
     ow.show()
     a.exec_()
     ow.saveSettings()

--- a/Orange/widgets/regression/owadaboostregression.py
+++ b/Orange/widgets/regression/owadaboostregression.py
@@ -1,9 +1,9 @@
 from AnyQt.QtCore import Qt
 
-from Orange.regression.base_regression import LearnerRegression
-from Orange.regression import SklTreeRegressionLearner
 from Orange.data import Table
 from Orange.ensembles import SklAdaBoostRegressionLearner
+from Orange.regression import SklTreeRegressionLearner
+from Orange.regression.base_regression import LearnerRegression
 from Orange.widgets import gui
 from Orange.widgets.classify import owadaboost
 from Orange.widgets.settings import Setting
@@ -36,8 +36,7 @@ class OWAdaBoostRegression(owadaboost.OWAdaBoostClassification):
             n_estimators=self.n_estimators,
             learning_rate=self.learning_rate,
             preprocessors=self.preprocessors,
-            loss=self.losses[self.loss].lower()
-        )
+            loss=self.losses[self.loss].lower())
 
     def get_learner_parameters(self):
         return (("Base estimator", self.base_estimator),
@@ -51,7 +50,7 @@ if __name__ == "__main__":
 
     a = QApplication(sys.argv)
     ow = OWAdaBoostRegression()
-    ow.set_data(Table("housing"))
+    ow.set_data(Table(sys.argv[1] if len(sys.argv) > 1 else 'housing'))
     ow.show()
     a.exec_()
     ow.saveSettings()

--- a/Orange/widgets/regression/tests/test_owadaboostregression.py
+++ b/Orange/widgets/regression/tests/test_owadaboostregression.py
@@ -1,9 +1,14 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-from Orange.regression import SklTreeRegressionLearner, KNNRegressionLearner
+from Orange.regression import (
+    SklTreeRegressionLearner,
+    KNNRegressionLearner,
+    RandomForestRegressionLearner
+)
 from Orange.widgets.regression.owadaboostregression import OWAdaBoostRegression
-from Orange.widgets.tests.base import (WidgetTest, WidgetLearnerTestMixin,
-                                       ParameterMapping)
+from Orange.widgets.tests.base import (
+    WidgetTest, WidgetLearnerTestMixin, ParameterMapping
+)
 
 
 class TestOWAdaBoostRegression(WidgetTest, WidgetLearnerTestMixin):
@@ -31,10 +36,34 @@ class TestOWAdaBoostRegression(WidgetTest, WidgetLearnerTestMixin):
         output_base_est = self.get_output("Learner").params.get("base_estimator")
         self.assertEqual(output_base_est.max_depth, max_depth)
 
+    def test_input_learner_that_does_not_support_sample_weights(self):
+        self.send_signal("Learner", KNNRegressionLearner())
+        self.assertNotIsInstance(
+            self.widget.base_estimator, KNNRegressionLearner)
+        self.assertIsNone(self.widget.base_estimator)
+        self.assertTrue(self.widget.Error.no_weight_support.is_shown())
+
+    def test_error_message_cleared_when_valid_learner_on_input(self):
+        # Disconnecting an invalid learner should use the default one and hide
+        # the error
+        self.send_signal("Learner", KNNRegressionLearner())
+        self.send_signal('Learner', None)
+        self.assertFalse(
+            self.widget.Error.no_weight_support.is_shown(),
+            'Error message was not hidden on input disconnect')
+        # Connecting a valid learner should also reset the error message
+        self.send_signal("Learner", KNNRegressionLearner())
+        self.send_signal('Learner', RandomForestRegressionLearner())
+        self.assertFalse(
+            self.widget.Error.no_weight_support.is_shown(),
+            'Error message was not hidden when a valid learner appeared on '
+            'input')
+
     def test_input_learner_disconnect(self):
         """Check base learner after disconnecting learner on the input"""
-        self.send_signal("Learner", KNNRegressionLearner())
-        self.assertIsInstance(self.widget.base_estimator, KNNRegressionLearner)
+        self.send_signal("Learner", RandomForestRegressionLearner())
+        self.assertIsInstance(
+            self.widget.base_estimator, RandomForestRegressionLearner)
         self.send_signal("Learner", None)
         self.assertEqual(self.widget.base_estimator,
                          self.widget.DEFAULT_BASE_ESTIMATOR)

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -165,7 +165,8 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
 
     def update_learner(self):
         self.learner = self.create_learner()
-        self.learner.name = self.learner_name
+        if self.learner is not None:
+            self.learner.name = self.learner_name
         self.send("Learner", self.learner)
         self.outdated_settings = False
         self.Warning.outdated_learner.clear()


### PR DESCRIPTION
##### Issue
AdaBoost simply crashed when a learner without support for `sample_weights` was put onto the input.

##### Description of changes
This does not happen any more, but it uses the Orange widget Error that tells us that the learner doesn't support sample weights. I've also changed the control widths to match most of the other learner widgets.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
