### PR TITLE
[FIX] owconfusionmatix: Add migrate_settings

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -91,6 +91,7 @@ class OWConfusionMatrix(widget.OWWidget):
                   "Proportion of predicted",
                   "Proportion of actual"]
 
+    settings_version = 1
     settingsHandler = settings.ClassValuesContextHandler()
 
     selected_learner = settings.Setting([0], schema_only=True)
@@ -482,6 +483,19 @@ class OWConfusionMatrix(widget.OWWidget):
                 format(self.learners[self.selected_learner[0]],
                        self.quantities[self.selected_quantity].lower()),
                 self.tableview)
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        super().migrate_settings(settings, version)
+        if not version:
+            # For some period of time the 'selected_learner' property was
+            # changed from List[int] -> int
+            # (commit 4e49bb3fd0e11262f3ebf4b1116a91a4b49cc982) and then back
+            # again (commit 8a492d79a2e17154a0881e24a05843406c8892c0)
+            if "selected_learner" in settings and \
+                    isinstance(settings["selected_learner"], int):
+                settings["selected_learner"] = [settings["selected_learner"]]
+
 
 if __name__ == "__main__":
     from AnyQt.QtWidgets import QApplication


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

ref #1794

For some period of time the 'selected_learner' property was changed from List[int] -> int (4e49bb3fd0e11262f3ebf4b1116a91a4b49cc982) and then back again (8a492d79a2e17154a0881e24a05843406c8892c0)

When opening a workflow that was saved between that time (between releases 3.3.4 and 3.3.7) the widget would raise an exception
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/scheme/widgetsscheme.py", line 822, in process_signals_for_widget
    handler(*args)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/evaluate/owconfusionmatrix.py", line 225, in set_results
    prev_sel_learner = self.selected_learner.copy()
AttributeError: 'int' object has no attribute 'copy'
```
##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
