### PR TITLE
[FIX] owrank: Add migrate_settings

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -77,6 +77,7 @@ class OWRank(OWWidget):
     # Header state for discrete/continuous/no_class scores
     headerState = Setting([None, None, None])
 
+    settings_version = 1
     settingsHandler = DomainContextHandler()
     selected_rows = ContextSetting([])
 
@@ -687,6 +688,19 @@ class OWRank(OWWidget):
         new_table = Table(domain, scores, metas=feature_names)
         new_table.name = "Feature Scores"
         return new_table
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        super().migrate_settings(settings, version)
+        if not version:
+            # Before fc5caa1e1d716607f1f5c4e0b0be265c23280fa0
+            # headerState had length 2
+            headerState = settings.get("headerState", None)
+            if headerState is not None and \
+                    isinstance(headerState, tuple) and \
+                    len(headerState) < 3:
+                headerState = (list(headerState) + [None] * 3)[:3]
+                settings["headerState"] = headerState
 
 
 class ScoreValueItem(QStandardItem):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

ref #1794

Fix an error when restoring from a workflow that was saved before widget supported ranking features on data with no class.

```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/scheme/widgetsscheme.py", line 454, in create_widget_instance
    widget.__init__()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owrank.py", line 260, in __init__
    if self.headerState[2] is not None:
IndexError: tuple index out of range
```

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation

