### PR TITLE
Table.from_table: match_type handle python's lists

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -299,6 +299,7 @@ class Table(MutableSequence, Storage):
                 if is_sparse == sp.issparse(x):
                     return x
                 elif is_sparse:
+                    x = np.asarray(x)
                     return sp.csc_matrix(x.reshape(-1, 1).astype(np.float))
                 else:
                     return np.ravel(x.toarray())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When using Feature Constructor to add discrete features to sparse array the code crashed inside `Table.from_table` in `match_type` function. Most easily reproducible on Text addon. Load some tweets and use Feature Constructor to create a discrete variable if some word is present in the content.
##### Description of changes
`match_type` was modified to assure the input, when dense, is a numpy array. That is, if python's list is provided (as is the case for Feature Constructor) it is transformed to a numpy array.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation