### PR TITLE
DiscreteVariable: reset colors when new values added

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -568,14 +568,11 @@ class DiscreteVariable(Variable):
     @property
     def colors(self):
         if self._colors is None:
-            if "colors" in self.attributes:
-                self._colors = np.array(
-                    [hex_to_color(col) for col in self.attributes["colors"]],
-                    dtype=np.uint8)
-            else:
-                from Orange.widgets.utils.colorpalette import \
-                    ColorPaletteGenerator
-                self._colors = ColorPaletteGenerator.palette(self)
+            from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
+            self._colors = ColorPaletteGenerator.palette(self)
+            colors = self.attributes.get('colors')
+            if colors:
+                self._colors[:len(colors)] = [hex_to_color(color) for color in colors]
             self._colors.flags.writeable = False
         return self._colors
 
@@ -636,6 +633,7 @@ class DiscreteVariable(Variable):
         """ Add a value `s` to the list of values.
         """
         self.values.append(s)
+        self._colors = None
 
     def val_from_str_add(self, s):
         """

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -215,7 +215,7 @@ class TestDiscreteVariable(VariableTest):
             repr(var),
             "DiscreteVariable('a', values=['1', '2', '3', '4', '5', ...])")
 
-    @unittest.skipUnless(is_on_path("PyQt4"), "PyQt4 is not importable")
+    @unittest.skipUnless(is_on_path("PyQt4") or is_on_path("PyQt5"), "PyQt is not importable")
     def test_colors(self):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertIsNone(var._colors)
@@ -235,6 +235,17 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("x", values=["A", "B"])
         var.attributes["colors"] = ['#0a0b0c', '#0d0e0f']
         np.testing.assert_almost_equal(var.colors, [[10, 11, 12], [13, 14, 15]])
+
+        # Test ncolors adapts to nvalues
+        var = DiscreteVariable.make('foo', values=['d', 'r'])
+        self.assertEqual(len(var.colors), 2)
+        var.add_value('e')
+        self.assertEqual(len(var.colors), 3)
+        user_defined = (0, 0, 0)
+        var.set_color(2, user_defined)
+        var.add_value('k')
+        self.assertEqual(len(var.colors), 4)
+        np.testing.assert_array_equal(var.colors[2], user_defined)
 
 
 @variabletest(ContinuousVariable)


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3-prototypes/pull/55#issuecomment-264719890 .. https://github.com/biolab/orange3-prototypes/pull/55#issuecomment-265985095


##### Description of changes
Resets `_colors` when new `DiscreteVariable.values` are added.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] ~~Documentation~~

