### PR TITLE
[FIX] Fix copy to clipboard in "Data Table" widget

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -432,9 +432,8 @@ class OWDataTable(widget.OWWidget):
         self.tabs = gui.tabWidget(self.mainArea)
         self.tabs.currentChanged.connect(self._on_current_tab_changed)
 
-        copy = QAction("Copy", self, shortcut=QKeySequence.Copy,
-                             triggered=self.copy)
-        self.addAction(copy)
+    def copy_to_clipboard(self):
+        self.copy()
 
     def sizeHint(self):
         return QSize(800, 500)

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -320,8 +320,8 @@ def table_selection_to_mime_data(table):
     """
     lines = table_selection_to_list(table)
 
-    csv = lines_to_csv_string(lines, dialect="excel")
-    tsv = lines_to_csv_string(lines, dialect="excel-tab")
+    csv = lines_to_csv_string(lines, dialect="excel").encode("utf-8")
+    tsv = lines_to_csv_string(lines, dialect="excel-tab").encode("utf-8")
 
     mime = QMimeData()
     mime.setData("text/csv", QByteArray(csv))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Copy to clipboard shortcut (Ctrl-C) did not work since 55d31c159d179a53700d96fca5d6359c9ea4349b due to ambiguous shortcut overload.

It also raised a TypeError when running with PyQt5.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
