### PR TITLE
Box plot: Fix labels outside of view

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -646,7 +646,7 @@ class OWBoxPlot(widget.OWWidget):
 
         bv = self.box_view
         viewrect = bv.viewport().rect().adjusted(15, 15, -15, -30)
-        self.scale_x = scale_x = viewrect.width() / (gtop - gbottom)
+        self.scale_x = scale_x = (viewrect.width() - 60) / (gtop - gbottom)
 
         # In principle we should repeat this until convergence since the new
         # scaling is too conservative. (No chance am I doing this.)
@@ -654,7 +654,7 @@ class OWBoxPlot(widget.OWWidget):
                   for stat, mean_lab in zip(stats, mean_labels))
         if mlb < gbottom:
             gbottom = mlb
-            self.scale_x = scale_x = viewrect.width() / (gtop - gbottom)
+            self.scale_x = scale_x = (viewrect.width() - 60) / (gtop - gbottom)
 
         self.scene_min_x = gbottom * scale_x
         self.scene_width = (gtop - gbottom) * scale_x


### PR DESCRIPTION
Fixes #1737.

Widget computes scaling based on positions of labels and lines; as I recall, I did this to avoid uncontrolled scaling of text and other elements. This complicates everything, but works ... except that the scene was to wide and the widget cropped it to avoid scrolling. If instead of cropping I try scaling, the view get a lot of white space, scale is too small and everything looks ugly.

##### Description of changes

Increases the width by 60.

It looks OK on Mac. @ajdapretnar, can you check it on Windows?

##### Includes
- [X] Code changes


