### PR TITLE
Merge OWTree

### DIFF
--- a/Orange/modelling/__init__.py
+++ b/Orange/modelling/__init__.py
@@ -1,3 +1,4 @@
 from .base import *
 
 from .knn import *
+from .tree import *

--- a/Orange/modelling/tree.py
+++ b/Orange/modelling/tree.py
@@ -1,0 +1,22 @@
+from Orange.classification import SklTreeLearner
+from Orange.classification import TreeLearner as ClassificationTreeLearner
+from Orange.modelling import Fitter
+from Orange.regression import TreeLearner as RegressionTreeLearner
+from Orange.regression.tree import SklTreeRegressionLearner
+from Orange.tree import TreeModel
+
+
+class SklTreeLearner(Fitter):
+    name = 'tree'
+
+    __fits__ = {'classification': SklTreeLearner,
+                'regression': SklTreeRegressionLearner}
+
+
+class TreeLearner(Fitter):
+    name = 'tree'
+
+    __fits__ = {'classification': ClassificationTreeLearner,
+                'regression': RegressionTreeLearner}
+
+    __returns__ = TreeModel

--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -6,7 +6,7 @@ from Orange.widgets.model.owtree import OWTreeLearner
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 
-class OWClassificationTree(OWTreeLearner):
+class OWTreeLearner(OWTreeLearner):
     """Classification tree algorithm with forward pruning."""
 
     name = "Classification Tree"

--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -1,70 +1,9 @@
 """General tree learner base widget, and classification tree widget"""
 
-from collections import OrderedDict
-
-from AnyQt.QtCore import Qt
-
 from Orange.data import Table
-from Orange.classification.tree import TreeLearner
-from Orange.widgets import gui
-from Orange.widgets.settings import Setting
+from Orange.modelling.tree import TreeLearner
+from Orange.widgets.model.owtree import OWTreeLearner
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
-
-
-class OWTreeLearner(OWBaseLearner):
-    """Base widget for tree learners"""
-    binary_trees = Setting(True)
-    limit_min_leaf = Setting(True)
-    min_leaf = Setting(2)
-    limit_min_internal = Setting(True)
-    min_internal = Setting(5)
-    limit_depth = Setting(True)
-    max_depth = Setting(100)
-
-    spin_boxes = (
-        ("Min. number of instances in leaves: ",
-         "limit_min_leaf", "min_leaf", 1, 1000),
-        ("Do not split subsets smaller than: ",
-         "limit_min_internal", "min_internal", 1, 1000),
-        ("Limit the maximal tree depth to: ",
-         "limit_depth", "max_depth", 1, 1000))
-
-    def add_main_layout(self):
-        box = gui.vBox(self.controlArea, True)
-        # the checkbox is put into vBox for alignemnt with other checkboxes
-        gui.checkBox(gui.vBox(box), self, "binary_trees", "Induce binary tree",
-                     callback=self.settings_changed)
-        for label, check, setting, fromv, tov in self.spin_boxes:
-            gui.spin(box, self, setting, fromv, tov, label=label, checked=check,
-                     alignment=Qt.AlignRight, callback=self.settings_changed,
-                     checkCallback=self.settings_changed, controlWidth=80)
-
-    def learner_kwargs(self):
-        # Pylint doesn't get our Settings
-        # pylint: disable=invalid-sequence-index
-        return dict(
-            max_depth=(None, self.max_depth)[self.limit_depth],
-            min_samples_split=(2, self.min_internal)[self.limit_min_internal],
-            min_samples_leaf=(1, self.min_leaf)[self.limit_min_leaf],
-            binarize=self.binary_trees,
-            preprocessors=self.preprocessors)
-
-    def create_learner(self):
-        # pylint: disable=not-callable
-        return self.LEARNER(**self.learner_kwargs())
-
-    def get_learner_parameters(self):
-        from Orange.canvas.report import plural_w
-        items = OrderedDict()
-        items["Pruning"] = ", ".join(s for s, c in (
-            (plural_w("at least {number} instance{s} in leaves",
-                      self.min_leaf), self.limit_min_leaf),
-            (plural_w("at least {number} instance{s} in internal nodes",
-                      self.min_internal), self.limit_min_internal),
-            ("maximum depth {}".format(self.max_depth), self.limit_depth)
-        ) if c) or "None"
-        items["Binary trees"] = ("No", "Yes")[self.binary_trees]
-        return items
 
 
 class OWClassificationTree(OWTreeLearner):
@@ -75,9 +14,6 @@ class OWClassificationTree(OWTreeLearner):
     priority = 30
 
     LEARNER = TreeLearner
-
-    limit_majority = Setting(True)
-    sufficient_majority = Setting(95)
 
     spin_boxes = \
         OWTreeLearner.spin_boxes[:-1] + \
@@ -97,6 +33,10 @@ class OWClassificationTree(OWTreeLearner):
             items["Pruning"] = ", " * bool(items["Pruning"]) + \
                 "stop splitting when the majority class reaches {} %".format(
                     self.sufficient_majority)
+
+    # Disable the special classification layout to be used when widgets are
+    # fully merged
+    add_classification_layout = OWBaseLearner.add_classification_layout
 
 
 def _test():

--- a/Orange/widgets/classify/tests/test_owclassificationtree.py
+++ b/Orange/widgets/classify/tests/test_owclassificationtree.py
@@ -1,15 +1,15 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from Orange.base import Model
-from Orange.widgets.classify.owclassificationtree import OWClassificationTree
+from Orange.widgets.classify.owclassificationtree import OWTreeLearner
 from Orange.widgets.tests.base import (WidgetTest, DefaultParameterMapping,
                                        ParameterMapping, WidgetLearnerTestMixin)
 
 
 class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
     def setUp(self):
-        self.widget = self.create_widget(OWClassificationTree,
-                                         stored_settings={"auto_apply": False})
+        self.widget = self.create_widget(
+            OWTreeLearner, stored_settings={"auto_apply": False})
         self.init()
         self.model_class = Model
 

--- a/Orange/widgets/model/icons/Tree.svg
+++ b/Orange/widgets/model/icons/Tree.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="48px" height="48px" viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
+<g>
+	<path fill="#666666" d="M40,23.125l-15-2v-2.266C24.679,18.942,24.348,19,24,19s-0.679-0.058-1-0.142v2.266l-15,2V27h2v-2.125
+		l13-1.733V29h2v-5.858l13,1.733V27h2V23.125z"/>
+	<polygon fill="#333333" points="10,27 8,27 5,27 5,35 13,35 13,27 	"/>
+	<polygon fill="#333333" points="25,29 23,29 20,29 20,37 28,37 28,29 	"/>
+	<polygon fill="#333333" points="40,27 38,27 35,27 35,35 43,35 43,27 	"/>
+	<path fill="#333333" d="M24,11c-2.209,0-4,1.79-4,4c0,1.862,1.278,3.413,3,3.858C23.321,18.942,23.652,19,24,19
+		s0.679-0.058,1-0.142c1.722-0.446,3-1.996,3-3.858C28,12.79,26.208,11,24,11z"/>
+</g>
+</svg>

--- a/Orange/widgets/model/owtree.py
+++ b/Orange/widgets/model/owtree.py
@@ -1,0 +1,105 @@
+"""General tree learner base widget, and classification tree widget"""
+
+from PyQt4.QtCore import Qt
+from collections import OrderedDict
+
+from Orange.data import Table
+from Orange.modelling.tree import TreeLearner
+from Orange.widgets import gui
+from Orange.widgets.settings import Setting
+from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
+
+
+class OWTreeLearner(OWBaseLearner):
+    name = "Tree"
+    icon = "icons/Tree.svg"
+    priority = 30
+
+    LEARNER = TreeLearner
+
+    binary_trees = Setting(True)
+    limit_min_leaf = Setting(True)
+    min_leaf = Setting(2)
+    limit_min_internal = Setting(True)
+    min_internal = Setting(5)
+    limit_depth = Setting(True)
+    max_depth = Setting(100)
+
+    # Classification only settings
+    limit_majority = Setting(True)
+    sufficient_majority = Setting(95)
+
+    spin_boxes = (
+        ("Min. number of instances in leaves: ",
+         "limit_min_leaf", "min_leaf", 1, 1000),
+        ("Do not split subsets smaller than: ",
+         "limit_min_internal", "min_internal", 1, 1000),
+        ("Limit the maximal tree depth to: ",
+         "limit_depth", "max_depth", 1, 1000))
+
+    classification_spin_boxes = (
+        ("Stop when majority reaches [%]: ",
+         "limit_majority", "sufficient_majority", 51, 100),)
+
+    def add_main_layout(self):
+        box = gui.widgetBox(self.controlArea, 'Parameters')
+        # the checkbox is put into vBox for alignemnt with other checkboxes
+        gui.checkBox(gui.vBox(box), self, "binary_trees", "Induce binary tree",
+                     callback=self.settings_changed)
+        for label, check, setting, fromv, tov in self.spin_boxes:
+            gui.spin(box, self, setting, fromv, tov, label=label,
+                     checked=check, alignment=Qt.AlignRight,
+                     callback=self.settings_changed,
+                     checkCallback=self.settings_changed, controlWidth=80)
+
+    def add_classification_layout(self, box):
+        for label, check, setting, minv, maxv in self.classification_spin_boxes:
+            gui.spin(box, self, setting, minv, maxv,
+                     label=label, checked=check, alignment=Qt.AlignRight,
+                     callback=self.settings_changed, controlWidth=80,
+                     checkCallback=self.settings_changed)
+
+    def learner_kwargs(self):
+        # Pylint doesn't get our Settings
+        # pylint: disable=invalid-sequence-index
+        return dict(
+            max_depth=(None, self.max_depth)[self.limit_depth],
+            min_samples_split=(2, self.min_internal)[self.limit_min_internal],
+            min_samples_leaf=(1, self.min_leaf)[self.limit_min_leaf],
+            binarize=self.binary_trees,
+            preprocessors=self.preprocessors,
+            sufficient_majority=(1, self.sufficient_majority / 100)[
+                self.limit_majority])
+
+    def create_learner(self):
+        # pylint: disable=not-callable
+        return self.LEARNER(**self.learner_kwargs())
+
+    def get_learner_parameters(self):
+        from Orange.canvas.report import plural_w
+        items = OrderedDict()
+        items["Pruning"] = ", ".join(s for s, c in (
+            (plural_w("at least {number} instance{s} in leaves",
+                      self.min_leaf), self.limit_min_leaf),
+            (plural_w("at least {number} instance{s} in internal nodes",
+                      self.min_internal), self.limit_min_internal),
+            ("maximum depth {}".format(self.max_depth), self.limit_depth)
+        ) if c) or "None"
+        items["Binary trees"] = ("No", "Yes")[self.binary_trees]
+        return items
+
+
+def _test():
+    import sys
+    from PyQt4.QtGui import QApplication
+
+    a = QApplication(sys.argv)
+    ow = OWTreeLearner()
+    d = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
+    ow.set_data(d)
+    ow.show()
+    a.exec_()
+    ow.saveSettings()
+
+if __name__ == "__main__":
+    _test()

--- a/Orange/widgets/model/owtree.py
+++ b/Orange/widgets/model/owtree.py
@@ -1,4 +1,4 @@
-"""General tree learner base widget, and classification tree widget"""
+"""Tree learner widget"""
 
 from PyQt4.QtCore import Qt
 from collections import OrderedDict
@@ -11,6 +11,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 
 class OWTreeLearner(OWBaseLearner):
+    """Tree algorithm with forward pruning."""
     name = "Tree"
     icon = "icons/Tree.svg"
     priority = 30

--- a/Orange/widgets/model/owtree.py
+++ b/Orange/widgets/model/owtree.py
@@ -13,6 +13,7 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 class OWTreeLearner(OWBaseLearner):
     """Tree algorithm with forward pruning."""
     name = "Tree"
+    description = "A tree algorithm with forward pruning."
     icon = "icons/Tree.svg"
     priority = 30
 

--- a/Orange/widgets/model/owtree.py
+++ b/Orange/widgets/model/owtree.py
@@ -87,6 +87,10 @@ class OWTreeLearner(OWBaseLearner):
                       self.min_internal), self.limit_min_internal),
             ("maximum depth {}".format(self.max_depth), self.limit_depth)
         ) if c) or "None"
+        if self.limit_majority:
+            items["Splitting"] = "Stop splitting when majority reaches %d%% " \
+                                 "(classification only)" % \
+                                 self.sufficient_majority
         items["Binary trees"] = ("No", "Yes")[self.binary_trees]
         return items
 

--- a/Orange/widgets/model/owtree.py
+++ b/Orange/widgets/model/owtree.py
@@ -1,6 +1,6 @@
 """Tree learner widget"""
 
-from PyQt4.QtCore import Qt
+from AnyQt.QtCore import Qt
 from collections import OrderedDict
 
 from Orange.data import Table
@@ -93,7 +93,7 @@ class OWTreeLearner(OWBaseLearner):
 
 def _test():
     import sys
-    from PyQt4.QtGui import QApplication
+    from AnyQt.QtWidgets import QApplication
 
     a = QApplication(sys.argv)
     ow = OWTreeLearner()

--- a/Orange/widgets/model/tests/test_tree.py
+++ b/Orange/widgets/model/tests/test_tree.py
@@ -1,0 +1,37 @@
+from Orange.base import Model
+from Orange.widgets.model.owtree import OWTreeLearner
+from Orange.widgets.tests.base import (
+    DefaultParameterMapping,
+    ParameterMapping,
+    WidgetLearnerTestMixin,
+    WidgetTest,
+)
+
+
+class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
+    def setUp(self):
+        self.widget = self.create_widget(
+            OWTreeLearner, stored_settings={"auto_apply": False})
+        self.init()
+        self.model_class = Model
+
+        self.parameters = [
+            ParameterMapping.from_attribute(self.widget, 'max_depth'),
+            ParameterMapping.from_attribute(
+                self.widget, 'min_internal', 'min_samples_split'),
+            ParameterMapping.from_attribute(
+                self.widget, 'min_leaf', 'min_samples_leaf')]
+        # NB. sufficient_majority is divided by 100, so it cannot be tested
+        # like this
+
+        self.checks = [sb.gui_element.cbox for sb in self.parameters]
+
+    def test_parameters_unchecked(self):
+        """Check learner and model for various values of all parameters
+        when pruning parameters are not checked
+        """
+        for cb in self.checks:
+            cb.setCheckState(False)
+        self.parameters = [DefaultParameterMapping(par.name, val)
+                           for par, val in zip(self.parameters, (None, 2, 1))]
+        self.test_parameters()

--- a/Orange/widgets/regression/owregressiontree.py
+++ b/Orange/widgets/regression/owregressiontree.py
@@ -1,7 +1,8 @@
 """Widget for induction of regression trees"""
 
-from Orange.regression.tree import TreeLearner
-from Orange.widgets.classify.owclassificationtree import OWTreeLearner
+from Orange.modelling.tree import TreeLearner
+from Orange.widgets.model.owtree import OWTreeLearner
+from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 
 class OWRegressionTree(OWTreeLearner):
@@ -11,6 +12,10 @@ class OWRegressionTree(OWTreeLearner):
     priority = 30
 
     LEARNER = TreeLearner
+
+    # Disable the special classification layout to be used when widgets are
+    # fully merged
+    add_classification_layout = OWBaseLearner.add_classification_layout
 
 
 def _test():

--- a/Orange/widgets/regression/owregressiontree.py
+++ b/Orange/widgets/regression/owregressiontree.py
@@ -5,7 +5,7 @@ from Orange.widgets.model.owtree import OWTreeLearner
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 
-class OWRegressionTree(OWTreeLearner):
+class OWTreeLearner(OWTreeLearner):
     name = "Regression Tree"
     description = "A regression tree algorithm with forward pruning."
     icon = "icons/RegressionTree.svg"

--- a/Orange/widgets/regression/tests/test_owregressiontree.py
+++ b/Orange/widgets/regression/tests/test_owregressiontree.py
@@ -1,15 +1,15 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from Orange.base import Model
-from Orange.widgets.regression.owregressiontree import OWRegressionTree
+from Orange.widgets.regression.owregressiontree import OWTreeLearner
 from Orange.widgets.tests.base import (WidgetTest, DefaultParameterMapping,
                                        ParameterMapping, WidgetLearnerTestMixin)
 
 
 class TestOWRegressionTree(WidgetTest, WidgetLearnerTestMixin):
     def setUp(self):
-        self.widget = self.create_widget(OWRegressionTree,
-                                         stored_settings={"auto_apply": False})
+        self.widget = self.create_widget(
+            OWTreeLearner, stored_settings={"auto_apply": False})
         self.init()
         self.model_class = Model
         self.parameters = [


### PR DESCRIPTION
##### Issue
Merge Tree learner Widget to handle both classification and regression problems.

##### Description of changes
Fairly straightforward merge. Keep widgets in classify and regression categories until all the learners are merged. No noticeable difference except that both learners can handle any data type.

We did discuss that it would be a good idea to move `Orange.tree` into `Orange.modelling.tree` but I haven't been able to figure this out yet due to some cyclic imports. Perhaps that should go into its own PR?

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
