### PR TITLE
OWSave: Offer Only Supported Writers for Sparse Data

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -211,6 +211,7 @@ class FileFormat(metaclass=FileFormatMeta):
         EXTENSIONS = ('.ext1', '.ext2', ...)
         DESCRIPTION = 'human-readable file format description'
         SUPPORT_COMPRESSED = False
+        SUPPORT_SPARSE_DATA = False
 
         def read(self):
             ...  # load headers, data, ...
@@ -681,6 +682,7 @@ class CSVReader(FileFormat):
     DESCRIPTION = 'Comma-separated values'
     DELIMITERS = ',;:\t$ '
     SUPPORT_COMPRESSED = True
+    SUPPORT_SPARSE_DATA = False
     PRIORITY = 20
 
     def read(self):
@@ -755,6 +757,7 @@ class PickleReader(FileFormat):
     """Reader for pickled Table objects"""
     EXTENSIONS = ('.pickle', '.pkl')
     DESCRIPTION = 'Pickled Python object file'
+    SUPPORT_SPARSE_DATA = True
 
     def read(self):
         with open(self.filename, 'rb') as f:
@@ -770,6 +773,7 @@ class BasketReader(FileFormat):
     """Reader for basket (sparse) files"""
     EXTENSIONS = ('.basket', '.bsk')
     DESCRIPTION = 'Basket file'
+    SUPPORT_SPARSE_DATA = True
 
     def read(self):
         def constr_vars(inds):
@@ -794,6 +798,7 @@ class ExcelReader(FileFormat):
     """Reader for excel files"""
     EXTENSIONS = ('.xls', '.xlsx')
     DESCRIPTION = 'Mircosoft Excel spreadsheet'
+    SUPPORT_SPARSE_DATA = False
 
     def __init__(self, filename):
         super().__init__(filename)
@@ -835,6 +840,7 @@ class DotReader(FileFormat):
     EXTENSIONS = ('.dot', '.gv')
     DESCRIPTION = 'Dot graph description'
     SUPPORT_COMPRESSED = True
+    SUPPORT_SPARSE_DATA = False
 
     @classmethod
     def write_graph(cls, filename, graph):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -946,6 +946,12 @@ class Table(MutableSequence, Storage):
                 (self.metas.base is None) and
                 (self.W.base is None))
 
+    def is_sparse(self):
+        """
+        Return `True` if the table stores data in sparse format
+        """
+        return any(sp.issparse(i) for i in [self.X, self.Y, self.metas])
+
     def ensure_copy(self):
         """
         Ensure that the table owns its data; copy arrays when necessary.

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1206,6 +1206,13 @@ class TableTestCase(unittest.TestCase):
 
     # TODO Test conjunctions and disjunctions of conditions
 
+    def test_is_sparse(self):
+        table = data.Table("iris")
+        self.assertFalse(table.is_sparse())
+
+        table.X = sp.csr_matrix(table.X)
+        self.assertTrue(table.is_sparse())
+
 
 def column_sizes(table):
     return (len(table.domain.attributes),

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -1,5 +1,4 @@
 import os.path
-from operator import attrgetter
 
 from Orange.data.table import Table
 from Orange.widgets import gui, widget
@@ -24,10 +23,9 @@ class OWSave(widget.OWWidget):
     last_filter = Setting("")
     auto_save = Setting(False)
 
-    formats = [(f.DESCRIPTION, f.EXTENSIONS)
-               for f in sorted(set(FileFormat.writers.values()),
-                               key=attrgetter("PRIORITY"))]
-    filters = ['{} (*{})'.format(x[0], ' *'.join(x[1])) for x in formats]
+    writers = FileFormat.writers
+    sparse_writers = {ext: w for ext, w in FileFormat.writers.items()
+                      if w.SUPPORT_SPARSE_DATA}
 
     def __init__(self):
         super().__init__()
@@ -63,7 +61,8 @@ class OWSave(widget.OWWidget):
             os.path.join(self.last_dir or os.path.expanduser("~"),
                          getattr(self.data, 'name', ''))
         filename, writer, filter = filedialogs.get_file_name(
-                file_name, self.last_filter, FileFormat.writers)
+            file_name, self.last_filter,
+            self.sparse_writers if self.data.is_sparse() else self.writers)
         if not filename:
             return
         self.filename = filename


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Save data allows storing sparse data to all formats; i.e. even formats that clearly do not support sparse formats (like `.tab` or `.csv`).
##### Description of changes
Each FileWriter has a `SUPPORT_SPARSE_DATA` flag and OWSave only offers supported writers when the data is sparse. Also, Table now has a `is_sparse` method to ease checking if sparse data is present.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
