### PR TITLE
[FIX] Fix crash in listview if labels are changed before calling __setitem__

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2049,7 +2049,10 @@ class ControlledList(list):
 
     def __setitem__(self, index, item):
         def unselect(i):
-            item = self.listBox.item(i)
+            try:
+                item = self.listBox.item(i)
+            except RuntimeError:  # Underlying C/C++ object has been deleted
+                item = None
             if item is None:
                 # Labels changed before clearing the selection: clear everything
                 self.listBox.selectionModel().clear()


### PR DESCRIPTION
##### Issue

Confusion matrix, and possibly other widgets, may change the items in the listview before triggering `ControlledList.__setitem__`. `__setitem__` already took care about this by checking whether `self.listbox(item)` returned `None`. This apparently doesn't always work since one user got

```
        Traceback (most recent call last) 
          File "E:\\ORANGE\\Python34\\lib\\site-packages\\Orange\\canvas\\scheme\\widgetsscheme.py", line 822, in process_signals_for_widget
            handler(*args)
          File "E:\\ORANGE\\Python34\\lib\\site-packages\\Orange\\widgets\\evaluate\\owconfusionmatrix.py", line 270, in set_results
            self.selected_learner[:] = prev_sel_learner
          File "E:\\ORANGE\\Python34\\lib\\site-packages\\Orange\\widgets\\gui.py", line 2062, in __setitem__
            unselect(i)
          File "E:\\ORANGE\\Python34\\lib\\site-packages\\Orange\\widgets\\gui.py", line 2050, in unselect
            item = self.listBox.item(i)
        RuntimeError: wrapped C/C++ object of type OrangeListBox has been deleted
```

##### Description of changes

Besides checking for `None`, the method now also catches the exception.

##### Includes
- [X] Code changes
