### PR TITLE
[FIX] Crash on ctrl-c/cmd-c in widgets without graphs

### DIFF
--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -342,10 +342,11 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         saveplot.save_plot(graph_obj, self.graph_writers)
 
     def copy_to_clipboard(self):
-        graph_obj = getdeepattr(self, self.graph_name, None)
-        if graph_obj is None:
-            return
-        ClipboardFormat.write_image(None, graph_obj)
+        if self.graph_name:
+            graph_obj = getdeepattr(self, self.graph_name, None)
+            if graph_obj is None:
+                return
+            ClipboardFormat.write_image(None, graph_obj)
 
     def __restoreWidgetGeometry(self):
 


### PR DESCRIPTION
##### Issue

Ctrl-C/Cmd-C copies the widget's graph to clipboard. If the widget had no graph, this crashed.
(errors/Orange.canvas.report.owreport/3.3.9/Orange.util%3A141/)

##### Description of changes

Add the necessary check.

##### Includes
- [X] Code changes

