### PR TITLE
CategoryPopupMenu: Adjust size of popup window

### DIFF
--- a/Orange/canvas/application/canvastooldock.py
+++ b/Orange/canvas/application/canvastooldock.py
@@ -414,6 +414,7 @@ class CategoryPopupMenu(FramelessWindow):
     def popup(self, pos=None):
         if pos is None:
             pos = self.pos()
+        self.adjustSize()
         geom = widget_popup_geometry(pos, self)
         self.setGeometry(geom)
         self.show()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
For categories (or add-ons) with short widget names, horizontal scroll bar appeared in the category popup window.

##### Description of changes
The size of the popup window has been adjusted to its content.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
