### PR TITLE
[FIX] Scatter plot: don't crash on report without data

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -494,6 +494,8 @@ class OWScatterPlot(OWWidget):
             return "{} vs {}".format(self.attr_x.name, self.attr_y.name)
 
     def send_report(self):
+        if self.data is None:
+            return
         def name(var):
             return var and var.name
         caption = report.render_items_vert((

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from unittest.mock import MagicMock
+
 import numpy as np
 
 from AnyQt.QtCore import QRectF
@@ -91,3 +93,12 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertTrue(self.widget.Warning.missing_coords.is_shown())
         self.send_signal("Data", None)
         self.assertFalse(self.widget.Warning.missing_coords.is_shown())
+
+    def test_report_on_empty(self):
+        self.widget.report_plot = MagicMock()
+        self.widget.report_caption = MagicMock()
+        self.widget.report_items = MagicMock()
+        self.widget.send_report()  # Essentially, don't crash
+        self.widget.report_plot.assert_not_called()
+        self.widget.report_caption.assert_not_called()
+        self.widget.report_items.assert_not_called()


### PR DESCRIPTION
##### Issue

Fixes #1839.

##### Description of changes

Do nothing when there is no data.

##### Includes
- [X] Code changes
- [X] Tests