### PR TITLE
OWTranspose: Show warning when table.X is empty

### DIFF
--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -25,6 +25,7 @@ class OWTranspose(OWWidget):
 
     class Error(OWWidget.Error):
         value_error = Msg("{}")
+        no_features = Msg("Cannot transpose data without features.")
 
     def __init__(self):
         super().__init__()
@@ -79,11 +80,15 @@ class OWTranspose(OWWidget):
         self.clear_messages()
         transposed = None
         if self.data:
-            try:
-                transposed = Table.transpose(
-                    self.data, self.feature_type and self.feature_names_column)
-            except ValueError as e:
-                self.Error.value_error(e)
+            if not len(self.data.domain.attributes):
+                self.Error.no_features()
+            else:
+                try:
+                    transposed = Table.transpose(
+                        self.data,
+                        self.feature_type and self.feature_names_column)
+                except ValueError as e:
+                    self.Error.value_error(e)
         self.send("Data", transposed)
 
     def send_report(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
OWTable crashed, when passed data table with no data (produced by OWTranspose).
To reproduce: transpose table that consists only of meta attributes and pass it to OWTable.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
