### PR TITLE
Fix pythagorean forest overlap

### DIFF
--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -233,6 +233,7 @@ class OWPythagoreanForest(OWWidget):
         )
 
     def _draw_trees(self):
+        self.ui_size_calc_combo.setEnabled(False)
         self.grid_items, self.ptrees = [], []
 
         with self.progressBar(len(self.forest_adapter.get_trees())) as prg:
@@ -253,6 +254,7 @@ class OWPythagoreanForest(OWWidget):
                      self.view.verticalScrollBar().width())
             self.grid.reflow(width)
             self.grid.setPreferredWidth(width)
+        self.ui_size_calc_combo.setEnabled(True)
 
     @staticmethod
     def _calculate_zoom(zoom_level):

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -428,3 +428,26 @@ class SklRandomForestAdapter:
     def domain(self):
         """Get the domain."""
         return self._domain
+
+
+if __name__ == '__main__':
+    from AnyQt.QtWidgets import QApplication
+    import sys
+
+    app = QApplication(sys.argv)
+    data = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
+
+    if data.domain.has_discrete_class:
+        from Orange.classification.random_forest import RandomForestLearner
+    else:
+        from Orange.regression.random_forest import \
+            RandomForestRegressionLearner as RandomForestLearner
+    rf = RandomForestLearner()(data)
+    rf.instances = data
+
+    ow = OWPythagoreanForest()
+    ow.set_rf(rf)
+
+    ow.show()
+    ow.handleNewSignals()
+    app.exec_()


### PR DESCRIPTION
##### Issue
The Pythagorean Forest had an issue if we changed the size calculation combo box while still handling the changes from before.


##### Description of changes
Disable the size calculation combo box when beginning to draw and re-enable it when the drawing process is complete. Hopefully the enabled/disabled flickering is not noticeable enough to cause a problem. 


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
