### PR TITLE
[FIX] Select Rows filter enum

### DIFF
--- a/.ci_tools/appveyor/step-test.ps1
+++ b/.ci_tools/appveyor/step-test.ps1
@@ -57,7 +57,7 @@ try {
 
     # Widget tests
     python -m pip install `
-        --extra-index-url "$Env:STAGING_INDEX" `
+        --index-url "$Env:STAGING_INDEX" `
         PyQt5
 
     echo "Running widget tests with PyQt5"

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -371,14 +371,17 @@ class OWSelectRows(widget.OWWidget):
         except Exception:
             pass
 
-        if not self.conditions and len(data.domain.variables):
+        variables = list(filter_visible(chain(data.domain.variables,
+                                              data.domain.metas)))
+        varnames = [v.name for v in variables]
+        if self.conditions:
+            for attr, cond_type, cond_value in self.conditions:
+                if attr in varnames:
+                    self.add_row(varnames.index(attr), cond_type, cond_value)
+        elif variables:
             self.add_row()
+
         self.update_info(data, self.data_in_variables, "In: ")
-        for attr, cond_type, cond_value in self.conditions:
-            attrs = [a.name for a in
-                     filter_visible(chain(data.domain.variables, data.domain.metas))]
-            if attr in attrs:
-                self.add_row(attrs.index(attr), cond_type, cond_value)
         self.unconditional_commit()
 
     def conditions_changed(self):

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -232,8 +232,8 @@ class OWSelectRows(widget.OWWidget):
         var = self.data.domain[attr_combo.currentText()]
         oper_combo.addItems(self.operator_names[type(var)])
         oper_combo.setCurrentIndex(selected_index or 0)
-        self.set_new_values(oper_combo, adding_all, selected_values)
         self.cond_list.setCellWidget(oper_combo.row, 1, oper_combo)
+        self.set_new_values(oper_combo, adding_all, selected_values)
         oper_combo.currentIndexChanged.connect(
             lambda _: self.set_new_values(oper_combo, False))
 

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -1,0 +1,81 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import (
+    Table, ContinuousVariable, StringVariable, DiscreteVariable)
+from Orange.widgets.data.owselectrows import OWSelectRows, FilterDiscreteType
+from Orange.widgets.tests.base import WidgetTest
+
+from Orange.data.filter import FilterContinuous, FilterString
+
+CFValues = {
+    FilterContinuous.Equal: ["5.4"],
+    FilterContinuous.NotEqual: ["5.4"],
+    FilterContinuous.Less: ["5.4"],
+    FilterContinuous.LessEqual: ["5.4"],
+    FilterContinuous.Greater: ["5.4"],
+    FilterContinuous.GreaterEqual: ["5.4"],
+    FilterContinuous.Between: ["5.4", "6.0"],
+    FilterContinuous.Outside: ["5.4", "6.0"],
+    FilterContinuous.IsDefined: [],
+}
+
+
+SFValues = {
+    FilterString.Equal: ["aardwark"],
+    FilterString.NotEqual: ["aardwark"],
+    FilterString.Less: ["aardwark"],
+    FilterString.LessEqual: ["aardwark"],
+    FilterString.Greater: ["aardwark"],
+    FilterString.GreaterEqual: ["aardwark"],
+    FilterString.Between: ["aardwark", "cat"],
+    FilterString.Outside: ["aardwark"],
+    FilterString.Contains: ["aa"],
+    FilterString.StartsWith: ["aa"],
+    FilterString.EndsWith: ["ark"],
+    FilterString.IsDefined: []
+}
+
+DFValues = {
+    FilterDiscreteType.Equal: [0],
+    FilterDiscreteType.NotEqual: [0],
+    FilterDiscreteType.In: [0, 1],
+    FilterDiscreteType.IsDefined: [],
+}
+
+
+class TestOWSelectRows(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWSelectRows)  # type: OWSelectRows
+
+    def test_filter_cont(self):
+        iris = Table("iris")[::5]
+        self.widget.auto_commit = True
+        self.widget.set_data(iris)
+
+        for i, (op, _) in enumerate(OWSelectRows.Operators[ContinuousVariable]):
+            self.widget.remove_all()
+            self.widget.add_row(0, i, CFValues[op])
+            self.widget.conditions_changed()
+            self.widget.unconditional_commit()
+
+    def test_filter_str(self):
+        zoo = Table("zoo")[::5]
+        self.widget.auto_commit = False
+        self.widget.set_data(zoo)
+        var_idx = len(zoo.domain)
+        for i, (op, _) in enumerate(OWSelectRows.Operators[StringVariable]):
+            self.widget.remove_all()
+            self.widget.add_row(var_idx, i, SFValues[op])
+            self.widget.conditions_changed()
+            self.widget.unconditional_commit()
+
+    def test_filter_disc(self):
+        lenses = Table("lenses")
+        self.widget.auto_commit = False
+        self.widget.set_data(lenses)
+
+        for i, (op, _) in enumerate(OWSelectRows.Operators[DiscreteVariable]):
+            self.widget.remove_all()
+            self.widget.add_row(0, i, DFValues[op])
+            self.widget.conditions_changed()
+            self.widget.unconditional_commit()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
```
Error:
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owselectrows.py", line 362, in conditions_changed
    self.commit()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 1972, in unconditional_commit
    do_commit()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 1980, in do_commit
    commit()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owselectrows.py", line 417, in commit
    matching_output = self.filters(self.data)
  File "/Users/aleserjavec/workspace/orange3/Orange/data/filter.py", line 216, in __call__
    return data._filter_values(self)
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 1246, in _filter_values
    sel = self._filter_values_indicators(filter)
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 1222, in _filter_values_indicators
    raise TypeError("Invalid operator")
TypeError: Invalid operator
```
The widget was broken since 60e1369b5070dd79310e1af4c02086020a7c0ab8 which changed the filter type enums.

##### Description of changes

Use proper Filter{Continuous,String}.Type enums for constructing filters.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
