### PR TITLE
[FIX] Table.transpose: Keep metas array two dimensional when no attributes in domain

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1513,7 +1513,8 @@ class Table(MutableSequence, Storage):
         # metas
         # - feature names and attributes of attributes to metas
         self.metas, metas = np.empty((self.n_rows, 0), dtype=object), []
-        if meta_attr_name not in [m.name for m in table.domain.metas]:
+        if meta_attr_name not in [m.name for m in table.domain.metas] and \
+                table.domain.attributes:
             self.metas = np.array([[a.name] for a in table.domain.attributes],
                                   dtype=object)
             metas.append(StringVariable(meta_attr_name))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
OWTable crashed, when passed data table with no data (produced by OWTranspose).
To reproduce: transpose table that consists only of meta attributes and pass it to OWTable.

##### Description of changes
Alternative to #1845

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
