### PR TITLE
Change defaults in Select Rows

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -47,8 +47,8 @@ class OWSelectRows(widget.OWWidget):
     settingsHandler = SelectRowsContextHandler()
     conditions = ContextSetting([])
     update_on_change = Setting(True)
-    purge_attributes = Setting(True)
-    purge_classes = Setting(True)
+    purge_attributes = Setting(False)
+    purge_classes = Setting(False)
     auto_commit = Setting(True)
 
     operator_names = {


### PR DESCRIPTION
##### Issue
Purging results in non-matching data and causes many issues.

##### Description of changes
Default are now set to False for purging.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
