### PR TITLE
[FIX] OWImageViewer: Fix Selection Indexing

### DIFF
--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -991,12 +991,12 @@ class OWImageViewer(widget.OWWidget):
         if self.data:
             attr = self.stringAttrs[self.imageAttr]
             titleAttr = self.allAttrs[self.titleAttr]
-            instances = [inst for inst in self.data
-                         if numpy.isfinite(inst[attr])]
             assert self.thumbnailView.count() == 0
             size = QSizeF(self.imageSize, self.imageSize)
 
-            for i, inst in enumerate(instances):
+            for i, inst in enumerate(self.data):
+                if not numpy.isfinite(inst[attr]):  # skip missing
+                    continue
                 url = self.urlFromValue(inst[attr])
                 title = str(inst[titleAttr])
 


### PR DESCRIPTION
##### Issue
For data sets with missing images indexing was incorrect. Instead of using positions in the Data Table, positions from the ThumbnailView were used, resulting in mismatch betwen selected instances and instances on the output.

##### Description of changes
Use correct indices for output mask.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
