### PR TITLE
[FIX] OWSave: Safer Check if Writer Support Sparse

### DIFF
--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -25,7 +25,7 @@ class OWSave(widget.OWWidget):
 
     writers = FileFormat.writers
     sparse_writers = {ext: w for ext, w in FileFormat.writers.items()
-                      if w.SUPPORT_SPARSE_DATA}
+                      if getattr(w, 'SUPPORT_SPARSE_DATA', False)}
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
##### Issue
Some writers in addons did not have `SUPPORT_SPARSE_DATA` flag which caused `OWSave` to crash.

##### Description of changes
Check if writer supports sparse more safely; i.e. if there is no flag assume it does not support sparse.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
