### PR TITLE
io: detecting encoding, only trust chardet if confident

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -86,7 +86,9 @@ def detect_encoding(filename):
     def _from_file(f):
         detector.feed(f.read(MAX_BYTES))
         detector.close()
-        return detector.result.get('encoding')
+        return (detector.result.get('encoding')
+                if detector.result.get('confidence', 0) >= .85 else
+                'utf-8')
 
     if isinstance(filename, str):
         with open_compressed(filename, 'rb') as f:


### PR DESCRIPTION
##### Issue
With datasets with lots of different unicode characters (not pertinent to any single particular language) in utf-8 encoding (e.g. some twitter data), the detected encoding was wrong.

##### Description of changes
Only trust detected encoding if confidence is at a certain (arbitrary high) level, otherwise try utf-8 and continue.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
