### PR TITLE
[FIX] Treeviewer sklearn tree compatibility

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -132,8 +132,7 @@ class TreeNode(GraphicsNode):
         font = self.document().defaultFont()
         painter.setFont(font)
         if self.parent:
-            # TODO This is not yet good, description is  >3 for each node
-            draw_text = str(self.tree_adapter.rules(self.node_inst)[0])
+            draw_text = str(self.tree_adapter.short_rule(self.node_inst))
             if self.parent.x() > self.x():  # node is to the left
                 fm = QFontMetrics(font)
                 x = rect.width() / 2 - fm.width(draw_text) - 4
@@ -448,9 +447,9 @@ def test():
     from Orange.regression.tree import TreeLearner, SklTreeRegressionLearner
     a = QApplication(sys.argv)
     ow = OWTreeGraph()
-    # data = Table("iris")
-    data = Table("housing")[:30]
-    clf = SklTreeRegressionLearner()(data)
+    data = Table("iris")
+    # data = Table("housing")[:30]
+    clf = SklTreeLearner()(data)
     # clf = TreeLearner()(data)
     clf.instances = data
 

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -352,7 +352,7 @@ class OWTreeGraph(OWTreeViewer2D):
         """Update the printed contents of the node for classification trees"""
         node_inst = node.node_inst
         distr = self.tree_adapter.get_distribution(node_inst)[0]
-        total = len(self.tree_adapter.get_instances_in_nodes(self.dataset, [node_inst]))
+        total = self.tree_adapter.num_samples(node_inst)
         distr = distr / np.sum(distr)
         if self.target_class_index:
             tabs = distr[self.target_class_index - 1]
@@ -376,7 +376,7 @@ class OWTreeGraph(OWTreeViewer2D):
         """Update the printed contents of the node for regression trees"""
         node_inst = node.node_inst
         mean, var = self.tree_adapter.get_distribution(node_inst)[0]
-        insts = len(self.tree_adapter.get_instances_in_nodes(self.dataset, [node_inst]))
+        insts = self.tree_adapter.num_samples(node_inst)
         text = "{:.1f} ± {:.1f}<br/>".format(mean, var)
         text += "{} instances".format(insts)
         text = self._update_node_info_attr_name(node, text)
@@ -447,9 +447,10 @@ def test():
     from Orange.regression.tree import TreeLearner, SklTreeRegressionLearner
     a = QApplication(sys.argv)
     ow = OWTreeGraph()
-    data = Table("iris")
+    data = Table("titanic")
     # data = Table("housing")[:30]
     clf = SklTreeLearner()(data)
+    print(clf.skl_model.tree_.feature)
     # clf = TreeLearner()(data)
     clf.instances = data
 

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -376,8 +376,7 @@ class OWTreeGraph(OWTreeViewer2D):
     def update_node_info_reg(self, node):
         """Update the printed contents of the node for regression trees"""
         node_inst = node.node_inst
-        # TODO calculate variance in tree adapter
-        mean, var = self.tree_adapter.get_distribution(node_inst)[0][0], 0.
+        mean, var = self.tree_adapter.get_distribution(node_inst)[0]
         insts = len(self.tree_adapter.get_instances_in_nodes(self.dataset, [node_inst]))
         text = "{:.1f} ± {:.1f}<br/>".format(mean, var)
         text += "{} instances".format(insts)
@@ -427,8 +426,8 @@ class OWTreeGraph(OWTreeViewer2D):
                 node.backgroundBrush = QBrush(colors[fact * (node_mean - minv)])
         else:
             nodes = list(self.scene.nodes())
-            # TODO Get variance from tree adapter
-            variances = [node.node_inst.value[1] for node in nodes]
+            variances = [self.tree_adapter.get_distribution(node.node_inst)[0][1]
+                         for node in nodes]
             max_var = max(variances)
             for node, var in zip(nodes, variances):
                 node.backgroundBrush = QBrush(def_color.lighter(
@@ -450,7 +449,7 @@ def test():
     a = QApplication(sys.argv)
     ow = OWTreeGraph()
     # data = Table("iris")
-    data = Table("housing")
+    data = Table("housing")[:30]
     clf = SklTreeRegressionLearner()(data)
     # clf = TreeLearner()(data)
     clf.instances = data

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -8,7 +8,7 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import QColor, QBrush, QPen, QFontMetrics
 from AnyQt.QtCore import Qt, QPointF, QSizeF, QRectF
 
-from Orange.tree import TreeModel
+from Orange.base import TreeModel, SklModel
 from Orange.widgets.visualize.owtreeviewer2d import \
     GraphicsNode, GraphicsEdge, OWTreeViewer2D
 from Orange.widgets.utils import to_html
@@ -20,6 +20,8 @@ from Orange.widgets import gui, widget
 from Orange.widgets.utils.colorpalette import ContinuousPaletteGenerator
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
+from Orange.widgets.visualize.utils.tree.skltreeadapter import SklTreeAdapter
+from Orange.widgets.visualize.utils.tree.treeadapter import TreeAdapter
 
 
 class PieChart(QGraphicsRectItem):
@@ -66,20 +68,21 @@ class TreeNode(GraphicsNode):
     # Methods are documented in PyQt documentation
     # pylint: disable=missing-docstring
 
-    def __init__(self, model, node_inst, parent=None):
+    def __init__(self, tree_adapter, node_inst, parent=None):
         super().__init__(parent)
-        self.model = model
+        self.tree_adapter = tree_adapter
+        self.model = self.tree_adapter.model
         self.node_inst = node_inst
 
         fm = QFontMetrics(self.document().defaultFont())
-        attr = node_inst.attr
+        attr = self.tree_adapter.attribute(node_inst)
         self.attr_text_w = fm.width(attr.name if attr else "")
         self.attr_text_h = fm.lineSpacing()
         self.line_descent = fm.descent()
         self._rect = None
 
-        if model.domain.class_var.is_discrete:
-            self.pie = PieChart(node_inst.value, 8, self)
+        if self.model.domain.class_var.is_discrete:
+            self.pie = PieChart(self.tree_adapter.get_distribution(node_inst)[0], 8, self)
         else:
             self.pie = None
 
@@ -90,7 +93,7 @@ class TreeNode(GraphicsNode):
         self.droplet.setPos(self.rect().center().x(), self.rect().height())
         self.droplet.setVisible(bool(self.branches))
         fm = QFontMetrics(self.document().defaultFont())
-        attr = self.node_inst.attr
+        attr = self.tree_adapter.attribute(self.node_inst)
         self.attr_text_w = fm.width(attr.name if attr else "")
         self.attr_text_h = fm.lineSpacing()
         self.line_descent = fm.descent()
@@ -129,7 +132,8 @@ class TreeNode(GraphicsNode):
         font = self.document().defaultFont()
         painter.setFont(font)
         if self.parent:
-            draw_text = self.node_inst.description
+            # TODO This is not yet good, description is  >3 for each node
+            draw_text = str(self.tree_adapter.rules(self.node_inst)[0])
             if self.parent.x() > self.x():  # node is to the left
                 fm = QFontMetrics(font)
                 x = rect.width() / 2 - fm.width(draw_text) - 4
@@ -140,7 +144,7 @@ class TreeNode(GraphicsNode):
         painter.setBrush(self.backgroundBrush)
         painter.setPen(QPen(Qt.black, 3 if self.isSelected() else 0))
         adjrect = rect.adjusted(-3, 0, 0, 0)
-        if not self.node_inst.children:
+        if not self.tree_adapter.has_children(self.node_inst):
             painter.drawRoundedRect(adjrect, 4, 4)
         else:
             painter.drawRect(adjrect)
@@ -188,6 +192,7 @@ class OWTreeGraph(OWTreeViewer2D):
         self.domain = None
         self.dataset = None
         self.clf_dataset = None
+        self.tree_adapter = None
 
         self.color_label = QLabel("Target class: ")
         combo = self.color_combo = gui.OrangeComboBox()
@@ -211,9 +216,8 @@ class OWTreeGraph(OWTreeViewer2D):
             node.set_rect(QRectF(rect.x(), rect.y(), w, rect.height()))
         self.scene.fix_pos(self.root_node, 10, 10)
 
-    @staticmethod
-    def _update_node_info_attr_name(node, text):
-        attr = node.node_inst.attr
+    def _update_node_info_attr_name(self, node, text):
+        attr = self.tree_adapter.attribute(node.node_inst)
         if attr is not None:
             text += "<hr/>{}".format(attr.name)
         return text
@@ -263,7 +267,9 @@ class OWTreeGraph(OWTreeViewer2D):
             self.info.setText('No tree.')
             self.root_node = None
             self.dataset = None
+            self.tree_adapter = None
         else:
+            self.tree_adapter = self._get_tree_adapter(model)
             self.domain = model.domain
             self.dataset = model.instances
             if self.dataset is not None and self.dataset.domain != self.domain:
@@ -284,41 +290,43 @@ class OWTreeGraph(OWTreeViewer2D):
                 self.color_combo.addItems(self.COL_OPTIONS)
                 self.color_combo.setCurrentIndex(self.regression_colors)
             self.openContext(self.domain.class_var)
-            self.root_node = self.walkcreate(model.root, None)
-            self.info.setText('{} nodes, {} leaves'.
-                              format(model.node_count(), model.leaf_count()))
+            # self.root_node = self.walkcreate(model.root, None)
+            self.root_node = self.walkcreate(self.tree_adapter.root)
+            self.info.setText('{} nodes, {} leaves'.format(
+                self.tree_adapter.num_nodes,
+                len(self.tree_adapter.leaves(self.tree_adapter.root))))
         self.setup_scene()
         self.send("Selected Data", None)
         self.send(ANNOTATED_DATA_SIGNAL_NAME,
                   create_annotated_table(self.dataset, []))
 
-    def walkcreate(self, node_inst, parent=None):
+    def walkcreate(self, node, parent=None):
         """Create a structure of tree nodes from the given model"""
-        node = TreeNode(self.model, node_inst, parent)
-        self.scene.addItem(node)
+        node_obj = TreeNode(self.tree_adapter, node, parent)
+        self.scene.addItem(node_obj)
         if parent:
-            edge = GraphicsEdge(node1=parent, node2=node)
+            edge = GraphicsEdge(node1=parent, node2=node_obj)
             self.scene.addItem(edge)
             parent.graph_add_edge(edge)
-        for child_inst in node_inst.children:
+        for child_inst in self.tree_adapter.children(node):
             if child_inst is not None:
-                self.walkcreate(child_inst, node)
-        return node
+                self.walkcreate(child_inst, node_obj)
+        return node_obj
 
     def node_tooltip(self, node):
-        return "<br>".join(to_html(rule)
-                           for rule in self.model.rule(node.node_inst))
+        return "<br>".join(to_html(str(rule))
+                           for rule in self.tree_adapter.rules(node.node_inst))
 
     def update_selection(self):
         if self.model is None:
             return
         nodes = [item.node_inst for item in self.scene.selectedItems()
                  if isinstance(item, TreeNode)]
-        data = self.model.get_instances(nodes)
+        data = self.tree_adapter.get_instances_in_nodes(self.dataset, nodes)
         self.send("Selected Data", data)
-        self.send(ANNOTATED_DATA_SIGNAL_NAME,
-                  create_annotated_table(self.dataset,
-                                         self.model.get_indices(nodes)))
+        self.send(ANNOTATED_DATA_SIGNAL_NAME, create_annotated_table(
+            self.dataset,
+            self.tree_adapter.get_indices(nodes)))
 
     def send_report(self):
         if not self.model:
@@ -344,8 +352,8 @@ class OWTreeGraph(OWTreeViewer2D):
     def update_node_info_cls(self, node):
         """Update the printed contents of the node for classification trees"""
         node_inst = node.node_inst
-        distr = node_inst.value
-        total = len(node_inst.subset)
+        distr = self.tree_adapter.get_distribution(node_inst)[0]
+        total = len(self.tree_adapter.get_instances_in_nodes(self.dataset, [node_inst]))
         distr = distr / np.sum(distr)
         if self.target_class_index:
             tabs = distr[self.target_class_index - 1]
@@ -368,6 +376,7 @@ class OWTreeGraph(OWTreeViewer2D):
     def update_node_info_reg(self, node):
         """Update the printed contents of the node for regression trees"""
         node_inst = node.node_inst
+        print(self.tree_adapter.get_distribution(node_inst)[0])
         mean, var = node_inst.value
         insts = len(node_inst.subset)
         text = "{:.1f} ± {:.1f}<br/>".format(mean, var)
@@ -380,7 +389,7 @@ class OWTreeGraph(OWTreeViewer2D):
         """Update the node color for classification trees"""
         colors = self.scene.colors
         for node in self.scene.nodes():
-            distr = node.node_inst.value
+            distr = node.tree_adapter.get_distribution(node.node_inst)[0]
             total = sum(distr)
             if self.target_class_index:
                 p = distr[self.target_class_index - 1] / total
@@ -422,18 +431,23 @@ class OWTreeGraph(OWTreeViewer2D):
                     120 - 20 * var / max_var))
         self.scene.update()
 
+    def _get_tree_adapter(self, model):
+        if isinstance(model, SklModel):
+            return SklTreeAdapter(model)
+        return TreeAdapter(model)
+
 
 def test():
     """Standalone test"""
     import sys
     from AnyQt.QtWidgets import QApplication
-#    from Orange.classification.tree import TreeLearner
-    from Orange.regression.tree import TreeLearner
+    from Orange.classification.tree import TreeLearner, SklTreeLearner
+    from Orange.regression.tree import TreeLearner, SklTreeRegressionLearner
     a = QApplication(sys.argv)
     ow = OWTreeGraph()
-    # data = Table("iris")
-    data = Table("housing")
-    clf = TreeLearner()(data)
+    data = Table("iris")
+    # data = Table("housing")
+    clf = SklTreeLearner()(data)
     clf.instances = data
 
     ow.ctree(clf)

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -321,7 +321,8 @@ class OWTreeGraph(OWTreeViewer2D):
             return
         nodes = [item.node_inst for item in self.scene.selectedItems()
                  if isinstance(item, TreeNode)]
-        data = self.tree_adapter.get_instances_in_nodes(self.dataset, nodes)
+        data = self.tree_adapter.get_instances_in_nodes(
+            self.clf_dataset, nodes)
         self.send("Selected Data", data)
         self.send(ANNOTATED_DATA_SIGNAL_NAME, create_annotated_table(
             self.dataset,
@@ -450,7 +451,6 @@ def test():
     data = Table("titanic")
     # data = Table("housing")[:30]
     clf = SklTreeLearner()(data)
-    print(clf.skl_model.tree_.feature)
     # clf = TreeLearner()(data)
     clf.instances = data
 

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -455,14 +455,18 @@ class OWTreeViewer2D(OWWidget):
             return
 
         model = self.model
-        root_instances = len(model.instances)
+        tree_adapter = self.root_node.tree_adapter
+        root_instances = len(tree_adapter.get_instances_in_nodes(
+            self.dataset, [self.root_node.node_inst]))
         width = 3
         for edge in self.scene.edges():
-            num_inst = len(edge.node2.node_inst.subset)
+            num_inst = len(tree_adapter.get_instances_in_nodes(
+                self.dataset, [edge.node2.node_inst]))
             if self.line_width_method == 1:
                 width = 8 * num_inst / root_instances
             elif self.line_width_method == 2:
-                width = 8 * num_inst / len(edge.node1.node_inst.subset)
+                width = 8 * num_inst / len(tree_adapter.get_instances_in_nodes(
+                    self.dataset, [edge.node1.node_inst]))
             edge.setPen(QPen(Qt.gray, width, Qt.SolidLine, Qt.RoundCap))
         self.scene.update()
 

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -455,17 +455,15 @@ class OWTreeViewer2D(OWWidget):
             return
 
         tree_adapter = self.root_node.tree_adapter
-        root_instances = len(tree_adapter.get_instances_in_nodes(
-            self.dataset, [self.root_node.node_inst]))
+        root_instances = tree_adapter.num_samples(self.root_node.node_inst)
         width = 3
         for edge in self.scene.edges():
-            num_inst = len(tree_adapter.get_instances_in_nodes(
-                self.dataset, [edge.node2.node_inst]))
+            num_inst = tree_adapter.num_samples(edge.node2.node_inst)
             if self.line_width_method == 1:
                 width = 8 * num_inst / root_instances
             elif self.line_width_method == 2:
-                width = 8 * num_inst / len(tree_adapter.get_instances_in_nodes(
-                    self.dataset, [edge.node1.node_inst]))
+                width = 8 * num_inst / tree_adapter.num_samples(
+                    edge.node1.node_inst)
             edge.setPen(QPen(Qt.gray, width, Qt.SolidLine, Qt.RoundCap))
         self.scene.update()
 

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -454,7 +454,6 @@ class OWTreeViewer2D(OWWidget):
         if self.root_node is None:
             return
 
-        model = self.model
         tree_adapter = self.root_node.tree_adapter
         root_instances = len(tree_adapter.get_instances_in_nodes(
             self.dataset, [self.root_node.node_inst]))

--- a/Orange/widgets/visualize/utils/tree/rules.py
+++ b/Orange/widgets/visualize/utils/tree/rules.py
@@ -31,6 +31,10 @@ class Rule:
         """
         raise NotImplementedError()
 
+    @property
+    def description(self):
+        return str(self)
+
 
 class DiscreteRule(Rule):
     """Discrete rule class for handling Indicator rules.
@@ -67,6 +71,10 @@ class DiscreteRule(Rule):
         # be eq or not eq.
         warnings.warn('Merged two discrete rules `%s` and `%s`' % (self, rule))
         return rule
+
+    @property
+    def description(self):
+        return '{} {}'.format('=' if self.equals else '≠', self.value)
 
     def __str__(self):
         return '{} {} {}'.format(
@@ -129,6 +137,10 @@ class ContinuousRule(Rule):
         else:
             lt_rule, gt_rule = (rule, self) if self.greater else (self, rule)
             return IntervalRule(self.attr_name, gt_rule, lt_rule)
+
+    @property
+    def description(self):
+        return '%s %.3f' % ('>' if self.greater else '≤', self.value)
 
     def __str__(self):
         return '%s %s %.3f' % (
@@ -196,6 +208,15 @@ class IntervalRule(Rule):
                 self.attr_name,
                 self.left_rule.merge_with(rule.left_rule),
                 self.right_rule.merge_with(rule.right_rule))
+
+    @property
+    def description(self):
+        return '∈ %s%.3f, %.3f%s' % (
+            '[' if self.left_rule.inclusive else '(',
+            self.left_rule.value,
+            self.right_rule.value,
+            ']' if self.right_rule.inclusive else ')'
+        )
 
     def __str__(self):
         return '%s ∈ %s%.3f, %.3f%s' % (

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -28,6 +28,7 @@ class SklTreeAdapter(BaseTreeAdapter):
     FEATURE_UNDEFINED = -2
 
     def __init__(self, model):
+        self.model = model
         self._tree = model.skl_model.tree_
         self._domain = model.domain
 

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -141,6 +141,9 @@ class SklTreeAdapter(BaseTreeAdapter):
         else:
             return []
 
+    def short_rule(self, node):
+        return self.rules(node)[0].description
+
     def attribute(self, node):
         feature_idx = self.splitting_attribute(node)
         if feature_idx != self.FEATURE_UNDEFINED:

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -66,7 +66,15 @@ class SklTreeAdapter(BaseTreeAdapter):
         return self._tree.children_right[node]
 
     def get_distribution(self, node):
-        return self._tree.value[node]
+        value = self._tree.value[node]
+        # If regression tree, we have to compute variance by hand, we can
+        # detect this because you can't have classification trees when there's
+        # only one class
+        if value.shape[1] == 1:
+            var = np.var(self.get_instances_in_nodes(self.model.instances, node).Y)
+            variances = np.array([(var * np.ones(value.shape[0]))]).T
+            value = np.hstack((value, variances))
+        return value
 
     def get_impurity(self, node):
         return self._tree.impurity[node]

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -301,7 +301,7 @@ class TreeAdapter(BaseTreeAdapter):
         return not any(node.children)
 
     def children(self, node):
-        return node.children
+        return [child for child in node.children if child is not None]
 
     def get_distribution(self, node):
         return [node.value]

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -165,6 +165,10 @@ class BaseTreeAdapter(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def short_rule(self, node):
+        pass
+
+    @abstractmethod
     def attribute(self, node):
         """Get the attribute that splits the given tree.
 
@@ -311,6 +315,9 @@ class TreeAdapter(BaseTreeAdapter):
 
     def rules(self, node):
         return self.model.rule(node)
+
+    def short_rule(self, node):
+        return node.description
 
     def attribute(self, node):
         return node.attr

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -301,7 +301,7 @@ class TreeAdapter(BaseTreeAdapter):
         return not any(node.children)
 
     def children(self, node):
-        return [child for child in node.children if child is not None]
+        return node.children
 
     def get_distribution(self, node):
         return [node.value]


### PR DESCRIPTION
##### Issue
Trees output from Pythagorean forest are not compatible with the TreeViewer widget.

##### Description of changes
Having established that #1850  would cause far too much confusion and make the overall tree model code completely non-understandable (Adapter for sklearn trees, but now also vice versa, tree model for sklearn trees?), I've taken another stab at it.

It seems that converting the TreeViewer widget to use the TreeAdapter actually doesn't require any major changes at all. So this is what I did in this PR, TreeViewer now uses the TreeAdapter, just like PythagoreanTree, so at least it's less confusing.

This is still based on #1786 since that fixes the PythagoreanTree compatibility.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
