### PR TITLE
[FIX] owsilhouetteplot: Fix TypeError when cluster column is an object array

### DIFF
--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -260,6 +260,7 @@ class OWSilhouettePlot(widget.OWWidget):
 
         labelvar = self.cluster_var_model[self.cluster_var_idx]
         labels, _ = self.data.get_column_view(labelvar)
+        labels = numpy.asarray(labels, dtype=float)
         mask = numpy.isnan(labels)
         labels = labels.astype(int)
         labels = labels[~mask]

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -4,6 +4,7 @@ import random
 
 import numpy as np
 
+import Orange.data
 from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_SIGNAL_NAME
 from Orange.widgets.visualize.owsilhouetteplot import OWSilhouettePlot
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -72,3 +73,14 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertTrue(np.all(np.isfinite(scores_1)))
         # the scores must match
         np.testing.assert_almost_equal(scores_1, scores[valid], decimal=12)
+
+    def test_meta_object_dtype(self):
+        # gh-1875: Test on mixed string/discrete metas
+        data = self.data[::5]
+        domain = Orange.data.Domain(
+            data.domain.attributes, [],
+            [data.domain["iris"],
+             Orange.data.StringVariable("S")]
+        )
+        data = data.from_table(domain, data)
+        self.send_signal("Data", data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-1875

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
