### PR TITLE
[FIX] OWSVR: Update learner when SVR type changes

### DIFF
--- a/Orange/widgets/regression/owsvmregression.py
+++ b/Orange/widgets/regression/owsvmregression.py
@@ -36,15 +36,17 @@ class OWSVMRegression(OWBaseSVM):
     def _add_type_box(self):
         form = QGridLayout()
         self.type_box = box = gui.radioButtonsInBox(
-                self.controlArea, self, "svrtype", [], box="SVR Type",
-                orientation=form)
+            self.controlArea, self, "svrtype", [], box="SVR Type",
+            orientation=form, callback=self.settings_changed)
 
-        self.epsilon_radio = gui.appendRadioButton(box, "ε-SVR",
-                                                   addToLayout=False)
-        self.epsilon_C_spin = gui.doubleSpin(box, self, "epsilon_C", 0.1, 512.0,
-                                             0.1, decimals=2, addToLayout=False)
-        self.epsilon_spin = gui.doubleSpin(box, self, "epsilon", 0.1, 512.0,
-                                           0.1, decimals=2, addToLayout=False)
+        self.epsilon_radio = gui.appendRadioButton(
+            box, "ε-SVR", addToLayout=False)
+        self.epsilon_C_spin = gui.doubleSpin(
+            box, self, "epsilon_C", 0.1, 512.0, 0.1, decimals=2,
+            addToLayout=False, callback=self.settings_changed)
+        self.epsilon_spin = gui.doubleSpin(
+            box, self, "epsilon", 0.1, 512.0, 0.1, decimals=2,
+            addToLayout=False, callback=self.settings_changed)
         form.addWidget(self.epsilon_radio, 0, 0, Qt.AlignLeft)
         form.addWidget(QLabel("Cost (C):"), 0, 1, Qt.AlignRight)
         form.addWidget(self.epsilon_C_spin, 0, 2)
@@ -52,10 +54,12 @@ class OWSVMRegression(OWBaseSVM):
         form.addWidget(self.epsilon_spin, 1, 2)
 
         self.nu_radio = gui.appendRadioButton(box, "ν-SVR", addToLayout=False)
-        self.nu_C_spin = gui.doubleSpin(box, self, "nu_C", 0.1, 512.0, 0.1,
-                                        decimals=2, addToLayout=False)
-        self.nu_spin = gui.doubleSpin(box, self, "nu", 0.05, 1.0, 0.05,
-                                      decimals=2, addToLayout=False)
+        self.nu_C_spin = gui.doubleSpin(
+            box, self, "nu_C", 0.1, 512.0, 0.1, decimals=2, addToLayout=False,
+            callback=self.settings_changed)
+        self.nu_spin = gui.doubleSpin(
+            box, self, "nu", 0.05, 1.0, 0.05, decimals=2, addToLayout=False,
+            callback=self.settings_changed)
         form.addWidget(self.nu_radio, 2, 0, Qt.AlignLeft)
         form.addWidget(QLabel("Cost (C):"), 2, 1, Qt.AlignRight)
         form.addWidget(self.nu_C_spin, 2, 2)


### PR DESCRIPTION
##### Issue
When changing any options inside the `SVR Type` box, the learner (and model) were not updated.


##### Description of changes
Settings are now updated on any change.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
