### PR TITLE
[MNT] ErrorReporting: Add Pip Freeze to Report

### DIFF
--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -1,4 +1,5 @@
 import os
+import pip
 import sys
 import time
 import logging
@@ -47,6 +48,7 @@ class ErrorReporting(QDialog):
         WIDGET_MODULE = 'Widget Module'
         VERSION = 'Version'
         ENVIRONMENT = 'Environment'
+        INSTALLED_PACKAGES = 'Installed Packages'
         MACHINE_ID = 'Machine ID'
         WIDGET_SCHEME = 'Widget Scheme'
         STACK_TRACE = 'Stack Trace'
@@ -98,6 +100,8 @@ class ErrorReporting(QDialog):
             for k, v in data.items():
                 if k.startswith('_'):
                     continue
+                if isinstance(v, list):
+                    v = ', '.join(v)
                 _v, v = v, escape(v)
                 if k == F.WIDGET_SCHEME:
                     if not add_scheme:
@@ -183,6 +187,9 @@ class ErrorReporting(QDialog):
             widget = frame.tb_frame.f_locals['self'].__class__
             widget_module = '{}:{}'.format(widget.__module__, frame.tb_lineno)
 
+        packages = sorted(["%s==%s" % (i.project_name, i.version)
+                           for i in pip.get_installed_distributions()])
+
         # If this exact error was already reported in this session,
         # just warn about it
         if (err_module, widget_module) in cls._cache:
@@ -219,6 +226,7 @@ class ErrorReporting(QDialog):
         data[F.ENVIRONMENT] = 'Python {} on {} {} {} {}'.format(
             platform.python_version(), platform.system(), platform.release(),
             platform.version(), platform.machine())
+        data[F.INSTALLED_PACKAGES] = packages
         data[F.MACHINE_ID] = str(uuid.getnode())
         data[F.STACK_TRACE] = stacktrace
         if err_locals:


### PR DESCRIPTION
##### Issue
When reporting errors we only got the version of Orange, but not the versions of all installed packages and addons.

##### Description of changes
Add equivalent of pip freeze to reported data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
