### PR TITLE
[FIX] OWPredictions: Fix crash when opening report

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -504,7 +504,7 @@ class OWPredictions(widget.OWWidget):
             text = self.infolabel.text().replace('\n', '<br>')
             if self.show_probabilities and self.selected_classes:
                 text += '<br>Showing probabilities for: '
-                text += ', '. join([self.data.domain.class_var.values[i]
+                text += ', '. join([self.class_values[i]
                                     for i in self.selected_classes])
             self.report_paragraph('Info', text)
             self.report_table("Data & Predictions", merge_data_with_predictions(),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget crashes when predictor's domain differs from data domain (and trying to open report)

##### Description of changes
Fixes #1883
To reproduce, use Iris dataset to learn on and Titanic dataset to make predictions for.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
