### PR TITLE
[FIX] OWDistributions: Reset combos when data is removed

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -26,7 +26,7 @@ from Orange.widgets.widget import InputSignal
 from Orange.widgets.visualize.owlinearprojection import LegendItem, ScatterPlotItem
 from Orange.widgets.io import FileFormat
 
-from .owscatterplotgraph import HelpEventDelegate
+from Orange.widgets.visualize.owscatterplotgraph import HelpEventDelegate
 
 def selected_index(view):
     """Return the selected integer `index` (row) in the view.
@@ -250,6 +250,8 @@ class OWDistributions(widget.OWWidget):
         self.groupvar_idx = 0
         self._legend.clear()
         self._legend.hide()
+        self.groupvarview.clear()
+        self.cb_prob.clear()
 
     def _setup_smoothing(self):
         if not self.disc_cont and self.var and self.var.is_continuous:

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -14,6 +14,7 @@ class TestOWDistributions(WidgetTest):
         super().setUpClass()
         dataset_dirs.append(test_dirname())
         cls.data = Table("test9.tab")
+        cls.iris = Table("iris")
 
     def setUp(self):
         self.widget = self.create_widget(OWDistributions)
@@ -33,3 +34,12 @@ class TestOWDistributions(WidgetTest):
         self.widget.cb_disc_cont.setChecked(True)
         self.widget.variable_idx = 2
         self.widget._setup()
+
+    def test_remove_data(self):
+        """Check widget when data is removed"""
+        self.send_signal("Data", self.iris)
+        self.assertEqual(self.widget.cb_prob.count(), 5)
+        self.assertEqual(self.widget.groupvarview.count(), 2)
+        self.send_signal("Data", None)
+        self.assertEqual(self.widget.cb_prob.count(), 0)
+        self.assertEqual(self.widget.groupvarview.count(), 0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When data is removed from widget, initial state should appear in combo boxes.

##### Description of changes
Fixes #1885

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
