### PR TITLE
Boxplot: Fix crashes when stats can't be computed

### DIFF
--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -128,6 +128,11 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
                           'rest ECG', 'cholesterol',
                           'fasting blood sugar > 120', 'diameter narrowing'])
 
+    def test_box_order_when_missing_stats(self):
+        self.widget.compare = 1
+        # The widget can't do anything smart here, but shouldn't crash
+        self.send_signal("Data", self.iris[49:51])
+
     def test_saved_selection(self):
         self.send_signal("Data", self.data)
         selected_indices = self._select_data()


### PR DESCRIPTION
##### Issue

Fixes #1892 

##### Description of changes

Put values with statistics that can't be computed (`None`) to the end of the list. Fix potentials problems at other places.

The PR doesn't fix another bug related to ordering which was introduced in 272233b3470efbfc57da05b51fb6db82e66e42f8. @VesnaT, please review those changes there (I've commented the offending change).

##### Includes
- [X] Code changes
- [X] Tests
