### PR TITLE
[FIX] Copy data attributes for annotated data set

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -539,10 +539,12 @@ class WidgetOutputsTestMixin:
                          self.same_input_output_domain)
         np.testing.assert_array_equal(selected.X[:, :n_attr],
                                       self.data.X[selected_indices])
+        self.assertEqual(selected.attributes, self.data.attributes)
 
         # check annotated data output
         annotated = self.get_output(ANNOTATED_DATA_SIGNAL_NAME)
         self.assertEqual(n_sel, np.sum([i[feature_name] for i in annotated]))
+        self.assertEqual(annotated.attributes, self.data.attributes)
 
         # compare selected and annotated data domains
         self._compare_selected_annotated_domains(selected, annotated)

--- a/Orange/widgets/utils/annotated_data.py
+++ b/Orange/widgets/utils/annotated_data.py
@@ -41,5 +41,7 @@ def create_annotated_table(data, selected_indices):
     annotated = np.zeros((len(data), 1))
     if selected_indices is not None:
         annotated[selected_indices] = 1
-    return Table(domain, data.X, data.Y,
-                 metas=np.hstack((data.metas, annotated)))
+    table = Table(domain, data.X, data.Y,
+                  metas=np.hstack((data.metas, annotated)))
+    table.attributes = data.attributes
+    return table


### PR DESCRIPTION
##### Issue
Any annotations that accompany the data set are passed from widget to widget by `attributes` attribute of the data table. Essentially, the attributes should be inherited from the input data set. Where the new, resulting data set is build from scratch (say, with Orange.data.Table), the attributes have to be copied manually (e.g., `new_table.attributes = old_table.attributes`). This was not done in the create_annotated_table function which is used by several widgets (Data Table, MDS, Hierarchical Clustering), resulting in crashes of the widgets that rely on table attributes.

##### Description of changes
Attributes are now set for the newly constructed table by copying from input data table.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation