### PR TITLE
[FIX]canvas/readwrite: Fix byte literal serialization

### DIFF
--- a/Orange/canvas/scheme/readwrite.py
+++ b/Orange/canvas/scheme/readwrite.py
@@ -1004,7 +1004,7 @@ def literal_dumps(obj, prettyprint=False, indent=4):
     NoneType = type(None)
 
     def check(obj):
-        if type(obj) in [int, int, float, bool, NoneType, str, str]:
+        if type(obj) in [int, float, bool, NoneType, str, bytes]:
             return True
 
         if id(obj) in memo:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

bytes objects were not allowed in literal serialization format (2to3 conversion?)

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
