### PR TITLE
[FIX] OWSelectRows: Output None when data has 0 rows

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -473,8 +473,14 @@ class OWSelectRows(widget.OWWidget):
                 matching_output = remover(matching_output)
                 non_matching_output = remover(non_matching_output)
 
-        self.send("Matching Data", matching_output)
-        self.send("Unmatched Data", non_matching_output)
+        if matching_output is not None and not len(matching_output):
+            self.send("Matching Data", None)
+        else:
+            self.send("Matching Data", matching_output)
+        if non_matching_output is not None and not len(non_matching_output):
+            self.send("Unmatched Data", None)
+        else:
+            self.send("Unmatched Data", non_matching_output)
 
         self.match_desc = report.describe_data_brief(matching_output)
         self.nonmatch_desc = report.describe_data_brief(non_matching_output)

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -79,3 +79,13 @@ class TestOWSelectRows(WidgetTest):
             self.widget.add_row(0, i, DFValues[op])
             self.widget.conditions_changed()
             self.widget.unconditional_commit()
+
+    def test_output(self):
+        iris = Table("iris")
+        self.send_signal("Data", iris)
+        self.assertIsNotNone(self.get_output("Matching Data"))
+        self.assertIsNone(self.get_output("Unmatched Data"))
+        self.widget.conditions = [('sepal length', 0, ('0.0',))]
+        self.widget.commit()
+        self.assertIsNone(self.get_output("Matching Data"))
+        self.assertIsNotNone(self.get_output("Unmatched Data"))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When conditions result in a table with 0 rows, None should be sent to the output.

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
