### PR TITLE
[FIX] owrank: Remove `super()` call from `migrate_settings`

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -691,7 +691,6 @@ class OWRank(OWWidget):
 
     @classmethod
     def migrate_settings(cls, settings, version):
-        super().migrate_settings(settings, version)
         if not version:
             # Before fc5caa1e1d716607f1f5c4e0b0be265c23280fa0
             # headerState had length 2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

super cannot be used in migrate_settings because the method is invoked
during type creation by the widget's metaclass while the implicit
`__class__` cell is not yet bound.

Prevents a warning during class import:

    Could not read defaults for widget <class 'Orange.widgets.data.owrank.OWRank'>
    The following error occurred:

    super(): empty __class__ cell

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
