### PR TITLE
OWSelectRows: locale-independent numeric value validation

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -51,7 +51,7 @@ class SelectRowsContextHandler(DomainContextHandler):
                 var = attr in domain and domain[attr]
                 if var and var.is_continuous and not isinstance(var, TimeVariable):
                     value[i] = (attr, op,
-                                list([QLocale().toString(i, 'f')
+                                list([QLocale().toString(float(i), 'f')
                                       for i in values]))
         return value
 
@@ -88,7 +88,7 @@ class OWSelectRows(widget.OWWidget):
             (FilterContinuous.NotEqual, "is not"),
             (FilterContinuous.Less, "is below"),
             (FilterContinuous.LessEqual, "is at most"),
-            (FilterContinuous.Greater,"is greater than"),
+            (FilterContinuous.Greater, "is greater than"),
             (FilterContinuous.GreaterEqual, "is at least"),
             (FilterContinuous.Between, "is between"),
             (FilterContinuous.Outside, "is outside"),

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -11,7 +11,7 @@ from AnyQt.QtGui import (
     QDoubleValidator, QRegExpValidator, QStandardItemModel, QStandardItem,
     QFontMetrics, QPalette
 )
-from AnyQt.QtCore import Qt, QPoint, QRegExp, QPersistentModelIndex
+from AnyQt.QtCore import Qt, QPoint, QRegExp, QPersistentModelIndex, QLocale
 
 from Orange.data import (ContinuousVariable, DiscreteVariable, StringVariable,
                          Table, TimeVariable)
@@ -33,6 +33,27 @@ class SelectRowsContextHandler(DomainContextHandler):
         """Return True if condition applies to a variable in given domain."""
         varname, *_ = condition
         return varname in attrs or varname in metas
+
+    def encode_setting(self, context, setting, value):
+        if setting.name == 'conditions':
+            CONTINUOUS = vartype(ContinuousVariable())
+            for i, (attr, op, values) in enumerate(value):
+                if context.attributes.get(attr) == CONTINUOUS:
+                    if isinstance(values[0], str):
+                        values = [QLocale().toDouble(v)[0] for v in values]
+                        value[i] = (attr, op, values)
+        return super().encode_setting(context, setting, value)
+
+    def decode_setting(self, setting, value, domain=None):
+        value = super().decode_setting(setting, value, domain)
+        if setting.name == 'conditions':
+            for i, (attr, op, values) in enumerate(value):
+                var = attr in domain and domain[attr]
+                if var and var.is_continuous and not isinstance(var, TimeVariable):
+                    value[i] = (attr, op,
+                                list([QLocale().toString(i, 'f')
+                                      for i in values]))
+        return value
 
 
 class FilterDiscreteType(enum.Enum):
@@ -272,9 +293,10 @@ class OWSelectRows(widget.OWWidget):
     class QDoubleValidatorEmpty(QDoubleValidator):
         def validate(self, input_, pos):
             if not input_:
-                return (QDoubleValidator.Acceptable, input_, pos)
-            else:
-                return super().validate(input_, pos)
+                return QDoubleValidator.Acceptable, input_, pos
+            if self.locale().groupSeparator() in input_:
+                return QDoubleValidator.Invalid, input_, pos
+            return super().validate(input_, pos)
 
     def set_new_values(self, oper_combo, adding_all, selected_values=None):
         # def remove_children():
@@ -403,6 +425,24 @@ class OWSelectRows(widget.OWWidget):
             # controls are being constructed
             pass
 
+    def _values_to_floats(self, attr, values):
+        if not all(values):
+            return None
+        if isinstance(attr, TimeVariable):
+            parse = lambda x: (attr.parse(x), True)
+        else:
+            parse = QLocale().toDouble
+
+        try:
+            floats, ok = zip(*[parse(v) for v in values])
+            if not all(ok):
+                raise ValueError('Some values could not be parsed as floats'
+                                 'in the current locale: {}'.format(values))
+        except TypeError:
+            floats = values  # values already floats
+        assert all(isinstance(v, float) for v in floats)
+        return floats
+
     def commit(self):
         matching_output = self.data
         non_matching_output = None
@@ -416,19 +456,15 @@ class OWSelectRows(widget.OWWidget):
                 operators = self.Operators[type(attr)]
                 opertype, _ = operators[oper_idx]
                 if attr.is_continuous:
-                    if any(not v for v in values):
+                    try:
+                        floats = self._values_to_floats(attr, values)
+                    except ValueError as e:
+                        self.error(e.args[0])
+                        return
+                    if floats is None:
                         continue
-
-                    # Parse datetime strings into floats
-                    if isinstance(attr, TimeVariable):
-                        try:
-                            values = [attr.parse(v) for v in values]
-                        except ValueError as e:
-                            self.error(e.args[0])
-                            return
-
                     filter = data_filter.FilterContinuous(
-                        attr_index, opertype, *[float(v) for v in values])
+                        attr_index, opertype, *floats)
                 elif attr.is_string:
                     filter = data_filter.FilterString(
                         attr_index, opertype, *[str(v) for v in values])

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -1,11 +1,17 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from AnyQt.QtCore import QLocale, Qt
+from AnyQt.QtTest import QTest
+from AnyQt.QtWidgets import QLineEdit
+
 from Orange.data import (
     Table, ContinuousVariable, StringVariable, DiscreteVariable)
-from Orange.widgets.data.owselectrows import OWSelectRows, FilterDiscreteType
+from Orange.widgets.data.owselectrows import (
+    OWSelectRows, FilterDiscreteType, SelectRowsContextHandler)
 from Orange.widgets.tests.base import WidgetTest
 
 from Orange.data.filter import FilterContinuous, FilterString
+from Orange.widgets.tests.utils import simulate, override_locale
 
 CFValues = {
     FilterContinuous.Equal: ["5.4"],
@@ -78,3 +84,116 @@ class TestOWSelectRows(WidgetTest):
             self.widget.add_row(0, i, DFValues[op])
             self.widget.conditions_changed()
             self.widget.unconditional_commit()
+
+    @override_locale(QLocale.C)  # Locale with decimal point
+    def test_continuous_filter_with_c_locale(self):
+        iris = Table("iris")[:5]
+        self.send_signal("Data", iris)
+
+        # Validating with C locale should accept decimal point
+        self.widget.remove_all_button.click()
+        self.enterFilter(iris.domain[2], "is below", "5.2")
+        self.assertEqual(self.widget.conditions[0][2], ("5.2",))
+
+        # but not decimal comma
+        self.widget.remove_all_button.click()
+        self.enterFilter(iris.domain[2], "is below", "5,2")
+        self.assertEqual(self.widget.conditions[0][2], ("52",))
+
+    @override_locale(QLocale.Slovenian)  # Locale with decimal comma
+    def test_continuous_filter_with_sl_SI_locale(self):
+        iris = Table("iris")[:5]
+        self.send_signal("Data", iris)
+
+        # sl_SI locale should accept decimal comma
+        self.widget.remove_all_button.click()
+        self.enterFilter(iris.domain[2], "is below", "5,2")
+        self.assertEqual(self.widget.conditions[0][2], ("5,2",))
+
+        # but not decimal point
+        self.widget.remove_all_button.click()
+        self.enterFilter(iris.domain[2], "is below", "5.2")
+        self.assertEqual(self.widget.conditions[0][2], ("52",))
+
+    def enterFilter(self, variable, filter, value, value2=None):
+        row = self.widget.cond_list.model().rowCount()
+        self.widget.add_button.click()
+
+        var_combo = self.widget.cond_list.cellWidget(row, 0)
+        simulate.combobox_activate_item(var_combo, variable.name, delay=0)
+
+        oper_combo = self.widget.cond_list.cellWidget(row, 1)
+        simulate.combobox_activate_item(oper_combo, filter, delay=0)
+
+        value_inputs = self.widget.cond_list.cellWidget(row, 2).children()
+        value_inputs = [w for w in value_inputs if isinstance(w, QLineEdit)]
+        QTest.mouseClick(value_inputs[0], Qt.LeftButton)
+        QTest.keyClicks(value_inputs[0], value, delay=0)
+        QTest.keyClick(value_inputs[0], Qt.Key_Enter)
+        if value2 is not None:
+            QTest.mouseClick(value_inputs[1], Qt.LeftButton)
+            QTest.keyClicks(value_inputs[1], value2, delay=0)
+            QTest.keyClick(value_inputs[1], Qt.Key_Enter)
+
+    @override_locale(QLocale.Slovenian)
+    def test_stores_settings_in_invariant_locale(self):
+        iris = Table("iris")[:5]
+        self.send_signal("Data", iris)
+
+        # sl_SI locale should accept decimal comma
+        self.widget.remove_all_button.click()
+        self.enterFilter(iris.domain[2], "is below", "5,2")
+        self.assertEqual(self.widget.conditions[0][2], ("5,2",))
+
+        context = self.widget.current_context
+        self.send_signal("Data", None)
+        saved_condition = context.values["conditions"][0]
+        self.assertEqual(saved_condition[2][0], 5.2)
+
+
+
+    @override_locale(QLocale.C)
+    def test_restores_continuous_filter_in_c_locale(self):
+        iris = Table("iris")[:5]
+        # Settings with string value
+        self.widget = self.widget_with_context(
+            iris.domain, [["sepal length", 2, ("5.2",)]])
+        self.send_signal("Data", iris)
+
+        values = self.widget.conditions[0][2]
+        self.assertTrue(values[0].startswith("5.2"))
+
+        # Settings with float value
+        self.widget = self.widget_with_context(
+            iris.domain, [["sepal length", 2, (5.2,)]])
+        self.send_signal("Data", iris)
+
+        values = self.widget.conditions[0][2]
+        self.assertTrue(values[0].startswith("5.2"))
+
+    @override_locale(QLocale.Slovenian)
+    def test_restores_continuous_filter_in_sl_SI_locale(self):
+        iris = Table("iris")[:5]
+        # Settings with string value
+        self.widget = self.widget_with_context(
+            iris.domain, [["sepal length", 2, ("5.2",)]])
+        self.send_signal("Data", iris)
+
+        values = self.widget.conditions[0][2]
+        self.assertTrue(values[0].startswith("5,2"))
+
+        # Settings with float value
+        self.widget = self.widget_with_context(
+            iris.domain, [["sepal length", 2, (5.2,)]])
+        self.send_signal("Data", iris)
+
+        values = self.widget.conditions[0][2]
+        self.assertTrue(values[0].startswith("5,2"))
+
+    def widget_with_context(self, domain, conditions):
+        ch = SelectRowsContextHandler()
+        context = ch.new_context(domain, *ch.encode_domain(domain))
+        context.values = dict(conditions=conditions)
+        settings = dict(context_settings=[context])
+
+        return self.create_widget(OWSelectRows, settings)

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -2,7 +2,7 @@ import sys
 import warnings
 import contextlib
 
-from AnyQt.QtCore import Qt, QObject, QEventLoop, QTimer
+from AnyQt.QtCore import Qt, QObject, QEventLoop, QTimer, QLocale
 from AnyQt.QtTest import QTest
 
 
@@ -285,3 +285,16 @@ class simulate:
         if index < 0:
             raise ValueError("{!r} not in {}".format(value, cbox))
         simulate.combobox_activate_index(cbox, index, delay)
+
+
+def override_locale(language):
+    """Execute the wrapped code with a different locale."""
+    def wrapper(f):
+        def wrap(*args, **kwargs):
+            locale = QLocale()
+            QLocale.setDefault(QLocale(language))
+            result = f(*args, **kwargs)
+            QLocale.setDefault(locale)
+            return result
+        return wrap
+    return wrapper

--- a/Orange/widgets/utils/__init__.py
+++ b/Orange/widgets/utils/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from PyQt4.QtCore import QObject
+from AnyQt.QtCore import QObject
 
 from Orange.data.variable import TimeVariable
 from Orange.util import deepgetattr


### PR DESCRIPTION
Fixes https://github.com/biolab/orange3/issues/1782

##### Description of changes
Replace locale-dependent `QDoubleValidator` with custom, hopefully correct regex validator.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
