### PR TITLE
canvas/addons: Initialize `__items` list in `__init__`

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -189,7 +189,7 @@ class AddonManagerWidget(QWidget):
 
     def __init__(self, parent=None, **kwargs):
         super(AddonManagerWidget, self).__init__(parent, **kwargs)
-
+        self.__items = []
         self.setLayout(QVBoxLayout())
 
         self.__header = QLabel(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The AddonManagerWidget does no initialize `__items` attribute in its `__init__` and can raise an AttributeError on access if the dialog itself is accepted before the PyPi query completes.

```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/application/addons.py", line 590, in __accepted
    steps = self.addonwidget.item_state()
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/application/addons.py", line 311, in item_state
    for i, item in enumerate(self.__items):
AttributeError: 'AddonManagerWidget' object has no attribute '_AddonManagerWidget__items'
-------------------------------------------------------------------------------
```

##### Description of changes
Add a missing `self.__items = []` initialization in the dialog's `__init__`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
