### PR TITLE
[FIX] owfeaturecontructor: Fix an IndexError accessing exception's args

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -12,6 +12,9 @@ import functools
 import builtins
 import math
 import random
+import logging
+
+from traceback import format_exception_only
 from collections import namedtuple, OrderedDict
 from itertools import chain, count
 
@@ -581,7 +584,9 @@ class OWFeatureConstructor(OWWidget):
         try:
             data = Orange.data.Table(new_domain, self.data)
         except Exception as err:
-            self.error(err.args[0])
+            log = logging.getLogger(__name__)
+            log.error("", exc_info=True)
+            self.error("".join(format_exception_only(type(err), err)).rstrip())
             return
         disc_attrs_not_ok = self.check_attrs_values(
             [var for var in attrs if var.is_discrete], data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Indexing exception's args member in [owfeatureconstructor.py#L584](https://github.com/biolab/orange3/blob/662faf463ca4629c838fe142cbf7bb20ac970a86/Orange/widgets/data/owfeatureconstructor.py#L584) can raise an IndexError when an exception is constructed without arguments

##### Description of changes

Use `traceback.format_exception_only` helper to display the exception message. Also log the full stack trace for easier debugging.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
