### PR TITLE
[MNT] ErrorReporting: Don't send scheme filename when no schema

### DIFF
--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -133,6 +133,8 @@ class ErrorReporting(QDialog):
 
         if QSettings().value('error-reporting/add-scheme', True, type=bool):
             data[F.WIDGET_SCHEME] = data['_' + F.WIDGET_SCHEME]
+        else:
+            data.pop(F.WIDGET_SCHEME, None)
         del data['_' + F.WIDGET_SCHEME]
 
         def _post_report(data):


### PR DESCRIPTION
##### Issue
When schema is not sent `data[WIDGET_SCHEME]` was not empty but contained the scheme's filename.

##### Description of changes
Remove `WIDGET_SCHEME` from data when scheme is not sent.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation