### PR TITLE
OWPreprocess: fix Normalize crash since 60e1369b

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -406,10 +406,10 @@ class Scale(Preprocess):
         def __call__(self, *args, **kwargs):
             return getattr(Scale, '_' + self.name)(*args, **kwargs)
 
-    CenteringType = _MethodEnum('Scale', 'Mean, Median', type=int)
-    ScalingType = _MethodEnum('Scale', 'Std, Span', type=int)
-    Mean, Median = CenteringType
-    Std, Span = ScalingType
+    CenteringType = _MethodEnum('Scale', 'NoCentering, Mean, Median', type=int)
+    ScalingType = _MethodEnum('Scale', 'NoScaling, Std, Span', type=int)
+    NoCentering, Mean, Median = CenteringType
+    NoScaling, Std, Span = ScalingType
 
     @staticmethod
     def _Mean(dist):
@@ -446,13 +446,13 @@ class Scale(Preprocess):
 
         def transform(var):
             dist = distribution.get_distribution(data, var)
-            if self.center:
+            if self.center != self.NoCentering:
                 c = self.center(dist)
                 dist[0, :] -= c
             else:
                 c = 0
 
-            if self.scale:
+            if self.scale != self.NoScaling:
                 s = self.scale(dist)
                 if s < 1e-15:
                     s = 1

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -30,7 +30,7 @@ from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 import Orange.data
 from Orange import preprocess
 from Orange.preprocess import Continuize, ProjectPCA, \
-    ProjectCUR, Scale, Randomize as _Randomize
+    ProjectCUR, Scale as _Scale, Randomize as _Randomize
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.overlay import OverlayWidget
 from Orange.widgets.utils.sql import check_sql_input
@@ -666,41 +666,22 @@ class Scale(BaseEditor):
         self.__scalecb.activated.connect(self.edited)
 
     def setParameters(self, params):
-        center = params.get("center", Scale.CenterMean)
-        scale = params.get("scale", Scale.ScaleBySD)
-        self.__centercb.setCurrentIndex(_enum_to_index(Scale.CenteringType, center))
-        self.__scalecb.setCurrentIndex(_enum_to_index(Scale.ScalingType, scale))
+        center = params.get("center", _Scale.CenteringType.Mean)
+        scale = params.get("scale", _Scale.ScalingType.Std)
+        self.__centercb.setCurrentIndex(_enum_to_index(_Scale.CenteringType, center))
+        self.__scalecb.setCurrentIndex(_enum_to_index(_Scale.ScalingType, scale))
 
     def parameters(self):
-        return {"center": _index_to_enum(Scale.CenteringType,
+        return {"center": _index_to_enum(_Scale.CenteringType,
                                          self.__centercb.currentIndex()),
-                "scale": _index_to_enum(Scale.ScalingType,
+                "scale": _index_to_enum(_Scale.ScalingType,
                                         self.__scalecb.currentIndex())}
 
     @staticmethod
     def createinstance(params):
-        center = params.get("center", Scale.CenterMean)
-        scale = params.get("scale", Scale.ScaleBySD)
-
-        if center == Scale.NoCentering:
-            center = None
-        elif center == Scale.CenterMean:
-            center = Scale.Mean
-        elif center == Scale.CenterMedian:
-            center = Scale.Median
-        else:
-            assert False
-
-        if scale == Scale.NoScaling:
-            scale = None
-        elif scale == Scale.ScaleBySD:
-            scale = Scale.Std
-        elif scale == Scale.ScaleBySpan:
-            scale = Scale.Span
-        else:
-            assert False
-
-        return Scale(center=center, scale=scale)
+        center = params.get("center", _Scale.CenteringType.Mean)
+        scale = params.get("scale", _Scale.ScalingType.Std)
+        return _Scale(center=center, scale=scale)
 
     def __repr__(self):
         return "{}, {}".format(self.__centercb.currentText(),

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from Orange.data import Table
-from Orange.preprocess import Randomize
+from Orange.preprocess import Randomize, Scale
 from Orange.widgets.data.owpreprocess import OWPreprocess
 from Orange.widgets.tests.base import WidgetTest
 
@@ -27,3 +27,16 @@ class TestOWPreprocess(WidgetTest):
         np.testing.assert_array_equal(self.zoo.X, output.X)
         np.testing.assert_array_equal(self.zoo.Y, output.Y)
         np.testing.assert_array_equal(self.zoo.metas, output.metas)
+
+    def test_normalize(self):
+        data = Table("iris")
+        saved = {"preprocessors": [("orange.preprocess.scale",
+                                    {"center": Scale.CenteringType.Mean,
+                                     "scale": Scale.ScalingType.Std})]}
+        model = self.widget.load(saved)
+        self.widget.set_model(model)
+        self.send_signal("Data", data)
+        output = self.get_output("Preprocessed Data")
+
+        np.testing.assert_allclose(output.X.mean(0), 0, atol=1e-7)
+        np.testing.assert_allclose(output.X.std(0), 1, atol=1e-7)


### PR DESCRIPTION
##### Issue
OWPreprocess crashes on PyQt5 when using Normalize action. 

##### Description of changes
Fix the crash.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
