### PR TITLE
[FIX] OWMosaic: Discretize metas as well

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -404,7 +404,8 @@ class OWMosaicDisplay(OWWidget):
             self.discrete_data = None
         elif any(attr.is_continuous for attr in data.domain):
             self.discrete_data = Discretize(
-                method=EqualFreq(n=4), discretize_classes=True)(data)
+                method=EqualFreq(n=4), discretize_classes=True,
+                discretize_metas=True)(data)
         else:
             self.discrete_data = self.data
 

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -1,9 +1,11 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import numpy as np
+
 from AnyQt.QtCore import QEvent, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
 
-from Orange.data import Table, DiscreteVariable, Domain
+from Orange.data import Table, DiscreteVariable, Domain, ContinuousVariable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.visualize.owmosaic import OWMosaicDisplay, MosaicVizRank
 
@@ -25,6 +27,14 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
             QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,
             Qt.LeftButton, Qt.KeyboardModifiers()))
         return [2, 3, 9, 23, 29, 30, 34, 35, 37, 42, 47, 49]
+
+    def test_continuous_metas(self):
+        """Check widget for dataset with continuous metas"""
+        domain = Domain([ContinuousVariable("c1")],
+                        metas=[ContinuousVariable("m")])
+        data = Table(domain, np.arange(6).reshape(6, 1),
+                     metas=np.arange(6).reshape(6, 1))
+        self.send_signal("Data", data)
 
 
 # Derive from WidgetTest to simplify creation of the Mosaic widget, although


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #1911

##### Description of changes
To reproduce: Connect dataset with continuous meta attribute to Mosaic Display and select it.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
