### PR TITLE
[FIX] preprocess: Reset number_of_decimals after scaling

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -459,7 +459,11 @@ class Scale(Preprocess):
             else:
                 s = 1
             factor = 1 / s
-            return var.copy(compute_value=transformation.Normalizer(var, c, factor))
+            transformed_var = var.copy(
+                compute_value=transformation.Normalizer(var, c, factor))
+            if s != 1:
+                transformed_var.number_of_decimals = 3
+            return transformed_var
 
         newvars = []
         for var in data.domain.attributes:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
After normalization the scaled variable used the same number of decimals as the original.
This meant scaling integers 0..100 to a span of 1 resulted in numbers being shown as 0 or 1 only (instead of 0.4 for example)

##### Description of changes
After scaling, reset number_of_decimals to 3 (default value of the parameter)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
