### PR TITLE
[FIX] OWPCA: Fix crash for dataset with no rows or no attributes

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -48,6 +48,10 @@ class OWPCA(widget.OWWidget):
             "All components of the PCA are trivial (explain 0 variance). "
             "Input data is constant (or near constant).")
 
+    class Error(widget.OWWidget.Error):
+        no_features = widget.Msg("At least 1 feature is required")
+        no_instances = widget.Msg("At least 1 data instance is required")
+
     def __init__(self):
         super().__init__()
         self.data = None
@@ -178,6 +182,7 @@ class OWPCA(widget.OWWidget):
         self.fit()
 
     def fit(self):
+        self.clear_messages()
         self.clear()
         self.start_button.setEnabled(False)
         if self.data is None:
@@ -190,6 +195,19 @@ class OWPCA(widget.OWWidget):
             self.start_button.setEnabled(True)
         else:
             self.sampling_box.setVisible(False)
+            if len(data.domain.attributes) == 0:
+                self.Error.no_features()
+                self.send("Transformed data", None)
+                self.send("Components", None)
+                self.send("PCA", None)
+                return
+            if len(data) == 0:
+                self.Error.no_instances()
+                self.send("Transformed data", None)
+                self.send("Components", None)
+                self.send("PCA", None)
+                return
+
             pca = self._pca_projector(data)
             variance_ratio = pca.explained_variance_ratio_
             cumulative = numpy.cumsum(variance_ratio)

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -1,10 +1,11 @@
-from Orange.data import Table
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table, Domain
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owpca import OWPCA
 
 
-class TestOWDistanceMatrix(WidgetTest):
-
+class TestOWPCA(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWPCA)  # type: OWPCA
 
@@ -21,3 +22,18 @@ class TestOWDistanceMatrix(WidgetTest):
         self.assertTrue(self.widget.Warning.trivial_components.is_shown())
         self.assertIsNone(self.get_output("Transformed Data"))
         self.assertIsNone(self.get_output("Components"))
+
+    def test_empty_data(self):
+        """ Check widget for dataset with no rows and for dataset with no attributes """
+        data = Table("iris")
+        self.send_signal("Data", data[:0])
+        self.assertTrue(self.widget.Error.no_instances.is_shown())
+
+        domain = Domain([], None, data.domain.variables)
+        new_data = Table.from_table(domain, data)
+        self.send_signal("Data", new_data)
+        self.assertTrue(self.widget.Error.no_features.is_shown())
+        self.assertFalse(self.widget.Error.no_instances.is_shown())
+
+        self.send_signal("Data", None)
+        self.assertFalse(self.widget.Error.no_features.is_shown())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #1913

##### Description of changes
To reproduce: 
- No attributes: File (Iris) -> move all attributes to metas -> PCA 
- No rows: File (Iris) -> SelectRows (condition that results in 0 rows) -> PCA 

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
