### PR TITLE
[FIX] Widgets crash on empty data

### DIFF
--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -18,11 +18,15 @@ def one_hot(values, dtype=float):
     result
         2d array with ones in respective indicator columns.
     """
+    if not len(values):
+       return np.zeros((0, 0), dtype=dtype)
     return np.eye(int(np.max(values) + 1), dtype=dtype)[np.asanyarray(values, dtype=int)]
 
 
 def scale(values, min=0, max=1):
     """Return values scaled to [min, max]"""
+    if not len(values):
+        return np.array([])
     minval = np.float_(bn.nanmin(values))
     ptp = bn.nanmax(values) - minval
     if ptp == 0:

--- a/Orange/tests/test_data_util.py
+++ b/Orange/tests/test_data_util.py
@@ -11,6 +11,7 @@ class TestDataUtil(unittest.TestCase):
         np.testing.assert_equal(scale([0, 1, 2], -1, 1), [-1, 0, 1])
         np.testing.assert_equal(scale([3, 3, 3]), [1, 1, 1])
         np.testing.assert_equal(scale([.1, .5, np.nan]), [0, 1, np.nan])
+        np.testing.assert_equal(scale(np.array([])), np.array([]))
 
     def test_one_hot(self):
         np.testing.assert_equal(
@@ -18,6 +19,7 @@ class TestDataUtil(unittest.TestCase):
                                          [0, 1, 0],
                                          [0, 0, 1],
                                          [0, 1, 0]])
+        np.testing.assert_equal(one_hot([], int), np.zeros((0, 0), dtype=int))
 
 
 class DummyPlus(SharedComputeValue):

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -119,12 +119,12 @@ class OWContinuize(widget.OWWidget):
 
     def commit(self):
         continuizer = self.constructContinuizer()
-        if self.data is not None:
+        if self.data is not None and len(self.data):
             domain = continuizer(self.data)
             data = Table.from_table(domain, self.data)
             self.send("Data", data)
         else:
-            self.send("Data", None)
+            self.send("Data", self.data)  # None or empty data
 
     def send_report(self):
         self.report_items(

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -49,6 +49,7 @@ class OWDataSampler(OWWidget):
         too_many_folds = Msg("Number of folds exceeds data size")
         sample_larger_than_data = Msg("Sample must be smaller than data")
         not_enough_to_stratify = Msg("Data is too small to stratify")
+        no_data = Msg("Data set is empty")
 
     def __init__(self):
         super().__init__()
@@ -227,7 +228,9 @@ class OWDataSampler(OWWidget):
             if self.data.domain.has_discrete_class else 0
 
         size = None
-        if self.sampling_type == self.FixedSize:
+        if not data_length:
+            self.Error.no_data()
+        elif self.sampling_type == self.FixedSize:
             size = self.sampleSizeNumber
             repl = self.replacement
         elif self.sampling_type == self.FixedProportion:

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -309,6 +309,9 @@ class OWDiscretize(widget.OWWidget):
         """
         Update the induced cut points.
         """
+        if self.data is None or not len(self.data):
+            return
+
         def induce_cuts(method, data, var):
             dvar = _dispatch[type(method)](method, data, var)
             if dvar is None:
@@ -327,7 +330,6 @@ class OWDiscretize(widget.OWWidget):
                 points, dvar = induce_cuts(state.method, self.data, var)
                 new_state = state._replace(points=points, disc_var=dvar)
                 self._set_var_state(i, new_state)
-        self.commit()
 
     def _method_index(self, method):
         return METHODS.index((type(method), ))
@@ -389,6 +391,7 @@ class OWDiscretize(widget.OWWidget):
             if isinstance(self.var_state[i].method, Default):
                 self._set_var_state(i, state)
         self._update_points()
+        self.commit()
 
     def _disc_method_changed(self):
         self._update_spin_positions()
@@ -398,6 +401,7 @@ class OWDiscretize(widget.OWWidget):
         for idx in indices:
             self._set_var_state(idx, state)
         self._update_points()
+        self.commit()
 
     def _var_selection_changed(self, *args):
         indices = self.selected_indices()
@@ -461,7 +465,7 @@ class OWDiscretize(widget.OWWidget):
 
     def commit(self):
         output = None
-        if self.data is not None:
+        if self.data is not None and len(self.data):
             domain = self.discretized_domain()
             output = self.data.from_table(domain, self.data)
         self.send("Data", output)

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -240,6 +240,11 @@ class OWImpute(OWWidget):
         data = self.data
 
         if self.data is not None:
+            if not len(self.data):
+                self.send("Data", self.data)
+                self.modified = False
+                return
+
             drop_mask = np.zeros(len(self.data), bool)
 
             attributes = []

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -990,7 +990,7 @@ class OWPaintData(OWWidget):
         """Set the input_data and call reset_to_input"""
         def _check_and_set_data(data):
             self.clear_messages()
-            if data is not None:
+            if data is not None and len(data):
                 if not data.domain.attributes:
                     self.Warning.no_input_variables()
                     data = None
@@ -998,7 +998,7 @@ class OWPaintData(OWWidget):
                     self.Information.use_first_two()
             self.input_data = data
             self.btResetToInput.setDisabled(data is None)
-            return data is not None
+            return data is not None and len(data)
 
         if not _check_and_set_data(data):
             return

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -1,0 +1,35 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+import numpy as np
+
+from Orange.data import Table
+from Orange.widgets.data.owcontinuize import OWContinuize
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWContinuize(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWContinuize)
+
+    def test_empty_data(self):
+        """No crash on empty data"""
+        data = Table("iris")
+        widget = self.widget
+        widget.multinomial_treatment = 1
+
+        self.send_signal("Data", data)
+        widget.unconditional_commit()
+        imp_data = self.get_output("Data")
+        np.testing.assert_equal(imp_data.X, data.X)
+        np.testing.assert_equal(imp_data.Y, data.Y)
+
+        widget.continuous_treatment = 1
+        self.send_signal("Data", Table(data.domain))
+        widget.unconditional_commit()
+        imp_data = self.get_output("Data")
+        self.assertEqual(len(imp_data), 0)
+
+        self.send_signal("Data", None)
+        widget.unconditional_commit()
+        imp_data = self.get_output("Data")
+        self.assertIsNone(imp_data)

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -24,3 +24,5 @@ class TestOWDataSampler(WidgetTest):
         self.assertTrue(self.widget.Error.too_many_folds.is_shown())
         self.send_signal("Data", None)
         self.assertFalse(self.widget.Error.too_many_folds.is_shown())
+        self.send_signal("Data", Table(self.iris.domain))
+        self.assertTrue(self.widget.Error.no_data.is_shown())

--- a/Orange/widgets/data/tests/test_owdiscretize.py
+++ b/Orange/widgets/data/tests/test_owdiscretize.py
@@ -1,0 +1,18 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table
+from Orange.widgets.data.owdiscretize import OWDiscretize
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWDiscretize(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWDiscretize)
+
+    def test_empty_data(self):
+        """No crash on empty data"""
+        data = Table("iris")
+        widget = self.widget
+        widget.default_method = 3
+        self.send_signal("Data", Table(data.domain))
+        widget.unconditional_commit()

--- a/Orange/widgets/data/tests/test_owimpute.py
+++ b/Orange/widgets/data/tests/test_owimpute.py
@@ -1,0 +1,30 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+import numpy as np
+
+from Orange.data import Table
+from Orange.widgets.data.owimpute import OWImpute
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWImpute(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWImpute)
+
+    def test_empty_data(self):
+        """No crash on empty data"""
+        data = Table("iris")
+        widget = self.widget
+        widget.default_method_index = widget.MODEL_BASED_IMPUTER
+        widget.default_method = widget.METHODS[widget.default_method_index]
+
+        self.send_signal("Data", data)
+        widget.unconditional_commit()
+        imp_data = self.get_output("Data")
+        np.testing.assert_equal(imp_data.X, data.X)
+        np.testing.assert_equal(imp_data.Y, data.Y)
+
+        self.send_signal("Data", Table(data.domain))
+        widget.unconditional_commit()
+        imp_data = self.get_output("Data")
+        self.assertEqual(len(imp_data), 0)

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -1,0 +1,16 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table
+from Orange.widgets.data.owpaintdata import OWPaintData
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWPaintData(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWPaintData)
+
+    def test_empty_data(self):
+        """No crash on empty data"""
+        data = Table("iris")
+        self.send_signal("Data", data)
+        self.send_signal("Data", Table(data.domain))

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -202,6 +202,12 @@ class OWPredictions(widget.OWWidget):
 
     def handleNewSignals(self):
         self.clear_messages()
+        if self.data is not None and not len(self.data):
+            # The logic of this widget is complicated, so let us just pretend
+            # that we have not data. (Even issuing an error message here doesn't
+            # work since the next signal would clear it.). If the widget
+            # shows nothing, the user will check the data table anyway.
+            self.data = None
         if self.data is not None:
             for inputid, pred in list(self.predictors.items()):
                 if pred.results is None or numpy.isnan(pred.results[0]).all():

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -165,6 +165,8 @@ class OWTestLearners(OWWidget):
     class_selection = settings.ContextSetting(TARGET_AVERAGE)
 
     class Error(OWWidget.Error):
+        train_data_empty = Msg("Train data set is empty.")
+        test_data_empty = Msg("Test data set is empty.")
         class_required = Msg("Train data input requires a target variable.")
         too_many_classes = Msg("Too many target variables.")
         class_required_test = Msg("Test data input requires a target variable.")
@@ -274,6 +276,10 @@ class OWTestLearners(OWWidget):
         Set the input training dataset.
         """
         self.Information.data_sampled.clear()
+        self.Error.train_data_empty.clear()
+        if data is not None and not len(data):
+            self.Error.train_data_empty()
+            data = None
         if data and not data.domain.class_vars:
             self.Error.class_required()
             data = None
@@ -314,6 +320,10 @@ class OWTestLearners(OWWidget):
         Set the input separate testing dataset.
         """
         self.Information.test_data_sampled.clear()
+        self.Error.test_data_empty.clear()
+        if data is not None and not len(data):
+            self.Error.test_data_empty()
+            data = None
         if data and not data.domain.class_var:
             self.Error.class_required()
             data = None
@@ -388,7 +398,8 @@ class OWTestLearners(OWWidget):
 
         if self.resampling == OWTestLearners.TestOnTest:
             if self.test_data is None:
-                self.Warning.test_data_missing()
+                if not self.Error.test_data_empty.is_shown():
+                    self.Warning.test_data_missing()
                 return
             elif self.test_data.domain.class_var != class_var:
                 self.Error.class_inconsistent()

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -56,6 +56,9 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
 
     graph_name = "plot.plotItem"
 
+    class Error(widget.OWWidget.Error):
+        empty_data = widget.Msg("Empty data set")
+
     def __init__(self):
         super().__init__()
 
@@ -95,8 +98,14 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     def set_data(self, data):
         self.closeContext()
         self.clear()
-        self.data = data
 
+        if data is not None and not len(data):
+            self.Error.empty_data()
+            data = None
+        else:
+            self.Error.empty_data.clear()
+
+        self.data = data
         if data is not None:
             self.varlist[:] = [var for var in data.domain.variables
                                if var.is_discrete]

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -41,7 +41,7 @@ class OWDistances(OWWidget):
     class Error(OWWidget.Error):
         no_continuous_features = Msg("No continuous features")
         dense_metric_sparse_data = Msg("Selected metric does not support sparse data")
-        empty_data = Msg("Empty data (shape = {})")
+        empty_data = Msg("Empty data set")
         too_few_observations = Msg("Too few observations for the number of dimensions")
 
     class Warning(OWWidget.Warning):
@@ -127,7 +127,7 @@ class OWDistances(OWWidget):
             data = distance._preprocess(data)
 
         if not data.X.size:
-            self.Error.empty_data(data.X.shape)
+            self.Error.empty_data()
             return
 
         if isinstance(metric, distance.MahalanobisDistance):

--- a/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
+++ b/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
@@ -1,0 +1,17 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.unsupervised.owcorrespondence \
+    import OWCorrespondenceAnalysis
+
+
+class TestOWCorrespondence(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWCorrespondenceAnalysis)
+
+    def test_no_data(self):
+        """Check that the widget doesn't crash on empty data"""
+        self.send_signal("Data", Table(Table("iris").domain))
+        self.assertTrue(self.widget.Error.empty_data.is_shown())
+        self.assertIsNone(self.widget.data)

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -187,6 +187,8 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
             self.Error.data_error.clear()
             if not self.learner.check_learner_adequacy(self.data.domain):
                 self.Error.data_error(self.learner.learner_adequacy_err_msg)
+            elif not len(self.data):
+                self.Error.data_error("Data set is empty.")
             elif len(np.unique(self.data.Y)) < 2:
                 self.Error.data_error("Data contains a single target value.")
             elif self.data.X.size == 0:

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -692,6 +692,9 @@ class OWHeatMap(widget.OWWidget):
                 data_sample.download_data(2000, partial=True)
                 data = Table(data_sample)
 
+        if data is not None and not len(data):
+            data = None
+
         if data is not None and sp.issparse(data.X):
             try:
                 data = data.copy()

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -526,7 +526,7 @@ class OWLinearProjection(widget.OWWidget):
                 data_sample.download_data(2000, partial=True)
                 data = Table(data_sample)
         self.data = data
-        if data is not None:
+        if data is not None and len(data):
             self._initialize(data)
             # get the default encoded state, replacing the position with Inf
             state = self._encode_var_state(

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -400,7 +400,7 @@ class OWMosaicDisplay(OWWidget):
         self.closeContext()
         self.data = data
         self.init_combos(self.data)
-        if self.data is None:
+        if self.data is None or not len(self.data):
             self.discrete_data = None
         elif any(attr.is_continuous for attr in data.domain):
             self.discrete_data = Discretize(

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -246,7 +246,7 @@ class OWSilhouettePlot(widget.OWWidget):
 
     def _update(self):
         # Update/recompute the distances/scores as required
-        if self.data is None:
+        if self.data is None or not len(self.data):
             self._mask = None
             self._silhouette = None
             self._labels = None

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -533,6 +533,8 @@ class OWVennDiagram(widget.OWWidget):
         names = uniquify(names)
 
         for i, (key, input) in enumerate(self.data.items()):
+            if not len(input.table):
+                continue
             if self.useidentifiers:
                 attr = self.itemsetAttr(key)
                 if attr is not None:

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -32,6 +32,8 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
             self.assertFalse(self.widget.Information.active)
             self.send_signal("Data", None)
 
+        self.send_signal("Data", self.data[:0])
+
     def test_error_message(self):
         self.send_signal("Data", self.titanic)
         self.assertTrue(self.widget.Error.active)

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 import random
 
+from Orange.data import Table
 from Orange.widgets.visualize.owlinearprojection import OWLinearProjection
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 
@@ -23,3 +24,7 @@ class TestOWLinearProjection(WidgetTest, WidgetOutputsTestMixin):
         points = random.sample(range(0, len(self.data)), 20)
         self.widget.select_indices(points)
         return sorted(points)
+
+    def test_no_data(self):
+        """Check that the widget doesn't crash on empty data"""
+        self.send_signal("Data", Table(Table("iris").domain))

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -22,6 +22,10 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
     def setUp(self):
         self.widget = self.create_widget(OWMosaicDisplay)
 
+    def test_no_data(self):
+        """Check that the widget doesn't crash on empty data"""
+        self.send_signal("Data", self.data[:0])
+
     def _select_data(self):
         self.widget.select_area(1, QMouseEvent(
             QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -24,6 +24,10 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
                                          stored_settings={"auto_commit": True})
         self.widget = self.widget  # type: OWSilhouettePlot
 
+    def test_no_data(self):
+        """Check that the widget doesn't crash on empty data"""
+        self.send_signal("Data", self.data[:0])
+
     def test_outputs_add_scores(self):
         # check output when appending scores
         self.send_signal("Data", self.data)

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -154,3 +154,23 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.signal_name, None, 2)
         self.assertIsNone(self.get_output("Selected Data"))
         self.assertIsNone(self.get_output(ANNOTATED_DATA_SIGNAL_NAME))
+
+    def test_no_data(self):
+        """Check that the widget doesn't crash on empty data"""
+        self.send_signal(self.signal_name, self.data[:0], 1)
+        self.send_signal(self.signal_name, self.data[:100], 2)
+        self.send_signal(self.signal_name, self.data[50:], 3)
+
+        for i in range(1, 4):
+            self.send_signal(self.signal_name, None, i)
+
+        self.send_signal(self.signal_name, self.data[:100], 1)
+        self.send_signal(self.signal_name, self.data[:0], 1)
+        self.send_signal(self.signal_name, self.data[50:], 3)
+
+        for i in range(1, 4):
+            self.send_signal(self.signal_name, None, i)
+
+        self.send_signal(self.signal_name, self.data[:100], 1)
+        self.send_signal(self.signal_name, self.data[50:], 2)
+        self.send_signal(self.signal_name, self.data[:0], 3)


### PR DESCRIPTION
##### Issue

Many widgets crashed when receiving a table with no rows. 

##### Description of changes

Widgets now give errors or behave as if they had no data -- depending on the type of the widget, the obviousness of the situation and the intrusiveness of the error message.

Review by commits: every commit contains a small change in the widget and the corresponding test.

##### Includes
- [X] Code changes
- [X] Tests
