### PR TITLE
owselectrows: Change order of variables in dropdown

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -173,7 +173,9 @@ class OWSelectRows(widget.OWWidget):
             minimumContentsLength=12,
             sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon)
         attr_combo.row = row
-        for var in filter_visible(chain(self.data.domain.variables, self.data.domain.metas)):
+        for var in filter_visible(chain(self.data.domain.class_vars,
+                                        self.data.domain.metas,
+                                        self.data.domain.attributes)):
             attr_combo.addItem(*gui.attributeItem(var))
         attr_combo.setCurrentIndex(attr or 0)
         self.cond_list.setCellWidget(row, 0, attr_combo)

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -54,7 +54,7 @@ class TestOWSelectRows(WidgetTest):
 
         for i, (op, _) in enumerate(OWSelectRows.Operators[ContinuousVariable]):
             self.widget.remove_all()
-            self.widget.add_row(0, i, CFValues[op])
+            self.widget.add_row(1, i, CFValues[op])
             self.widget.conditions_changed()
             self.widget.unconditional_commit()
 
@@ -62,10 +62,9 @@ class TestOWSelectRows(WidgetTest):
         zoo = Table("zoo")[::5]
         self.widget.auto_commit = False
         self.widget.set_data(zoo)
-        var_idx = len(zoo.domain)
         for i, (op, _) in enumerate(OWSelectRows.Operators[StringVariable]):
             self.widget.remove_all()
-            self.widget.add_row(var_idx, i, SFValues[op])
+            self.widget.add_row(1, i, SFValues[op])
             self.widget.conditions_changed()
             self.widget.unconditional_commit()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Class and meta variables are listed after (possibly large number of) attributes.

##### Description of changes
Follow recent policy to list class_vars first, then metas, and attributes last.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
