### PR TITLE
[RFC] ErrorReporting: Report developer names to Sentry

### DIFF
--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -190,6 +190,8 @@ class ErrorReporting(QDialog):
         packages = ', '.join(sorted("%s==%s" % (i.project_name, i.version)
                                     for i in pip.get_installed_distributions()))
 
+        machine_id = QSettings().value('error-reporting/machine-id', '', type=str)
+
         # If this exact error was already reported in this session,
         # just warn about it
         if (err_module, widget_module) in cls._cache:
@@ -227,7 +229,7 @@ class ErrorReporting(QDialog):
             platform.python_version(), platform.system(), platform.release(),
             platform.version(), platform.machine())
         data[F.INSTALLED_PACKAGES] = packages
-        data[F.MACHINE_ID] = str(uuid.getnode())
+        data[F.MACHINE_ID] = machine_id or str(uuid.getnode())
         data[F.STACK_TRACE] = stacktrace
         if err_locals:
             data[F.LOCALS] = err_locals

--- a/Orange/canvas/application/settings.py
+++ b/Orange/canvas/application/settings.py
@@ -16,7 +16,7 @@ from ..utils.propertybindings import (
 from AnyQt.QtWidgets import (
     QWidget, QMainWindow, QComboBox, QCheckBox, QListView, QTabWidget,
     QToolBar, QAction, QStackedWidget, QVBoxLayout, QHBoxLayout,
-    QFormLayout, QSizePolicy
+    QFormLayout, QSizePolicy, QLineEdit,
 )
 
 from AnyQt.QtCore import (
@@ -357,6 +357,17 @@ class UserSettingsDialog(QMainWindow):
         box.setLayout(layout)
         form.addRow(self.tr("Help window"), box)
 
+        tab.setLayout(form)
+
+        # Error Reporting Tab
+        tab = QWidget()
+        self.addTab(tab, self.tr("Error Reporting"),
+                    toolTip="Settings related to error reporting")
+
+        form = QFormLayout()
+        line_edit_mid = QLineEdit()
+        self.bind(line_edit_mid, "text", "error-reporting/machine-id")
+        form.addRow("Machine ID:", line_edit_mid)
         tab.setLayout(form)
 
         if self.__macUnified:

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -114,7 +114,10 @@ spec = \
      ("logging/dockable", bool, True, "Allow log window to be docked"),
 
      ("help/open-in-external-browser", bool, False,
-      "Open help in an external browser")
+      "Open help in an external browser"),
+
+     ("error-reporting/machine-id", str, '',
+     "Report custom name instead of machine ID"),
      ]
 
 spec = [config_slot(*t) for t in spec]


### PR DESCRIPTION
##### Issue
A while ago we discussed it would be nice if developers could report errors with their names rather than machine ids.

##### Description of changes
Machine ID line edit was added to Preferences menu. If the name is provided use it for reporting errors else fallback to reporting machine ids as before.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
