### PR TITLE
[FIX] Show informative error when a tree cannot binarize

### DIFF
--- a/Orange/widgets/classify/tests/test_owclassificationtree.py
+++ b/Orange/widgets/classify/tests/test_owclassificationtree.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from Orange.data import Table, Domain, DiscreteVariable
+from Orange.classification.tree import TreeLearner as ClassificationTreeLearner
 from Orange.base import Model
 from Orange.widgets.classify.owclassificationtree import OWClassificationTree
 from Orange.widgets.tests.base import (WidgetTest, DefaultParameterMapping,
@@ -7,6 +9,11 @@ from Orange.widgets.tests.base import (WidgetTest, DefaultParameterMapping,
 
 
 class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.iris = Table("iris")
+
     def setUp(self):
         self.widget = self.create_widget(OWClassificationTree,
                                          stored_settings={"auto_apply": False})
@@ -34,3 +41,49 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
                            for par, val in zip(self.parameters, (None, 2, 1))]
         self.test_parameters()
 
+    def test_cannot_binarize(self):
+        widget = self.widget
+        error_shown = widget.Error.cannot_binarize.is_shown
+        self.assertFalse(error_shown())
+        self.send_signal("Data", self.iris)
+
+        # The widget outputs ClassificationTreeLearner.
+        # If not, below tests may not make sense
+        learner = self.get_output("Learner")
+        self.assertTrue(learner, ClassificationTreeLearner)
+
+        # No error on Iris
+        max_binarization = learner.MAX_BINARIZATION
+        self.assertFalse(error_shown())
+
+        # Error when too many values
+        domain = Domain([
+            DiscreteVariable(
+                values=[str(x) for x in range(max_binarization + 1)])],
+            DiscreteVariable(values="01"))
+        self.send_signal("Data", Table(domain, [[0, 0], [1, 1]]))
+        self.assertTrue(error_shown())
+        # No more error on Iris
+        self.send_signal("Data", self.iris)
+        self.assertFalse(error_shown())
+
+        # Checking and unchecking binarization works
+        widget.controls.binary_trees.click()
+        self.assertFalse(widget.binary_trees)
+        widget.unconditional_apply()
+        self.send_signal("Data", Table(domain, [[0, 0], [1, 1]]))
+        self.assertFalse(error_shown())
+        widget.controls.binary_trees.click()
+        widget.unconditional_apply()
+        self.assertTrue(error_shown())
+        widget.controls.binary_trees.click()
+        widget.unconditional_apply()
+        self.assertFalse(error_shown())
+
+        # If something is wrong with the data, no error appears
+        domain = Domain([
+            DiscreteVariable(
+                values=[str(x) for x in range(max_binarization + 1)])],
+            DiscreteVariable(values="01"))
+        self.send_signal("Data", Table(domain))
+        self.assertFalse(error_shown())

--- a/Orange/widgets/utils/messages.py
+++ b/Orange/widgets/utils/messages.py
@@ -335,7 +335,7 @@ class WidgetMessagesMixin(MessagesMixin):
         elif self.message_bar is not None:
             font_size = self.message_bar.fontInfo().pixelSize()
             group = messages[0].group
-            text = str(messages[0]) if len(messages) == 1 \
+            text = str(messages[0]).split("\n")[0] if len(messages) == 1 \
                 else "{} problems during execution".format(len(messages))
             # TODO: fix tooltip background color - it is not white
             tooltip = ''.join(
@@ -346,7 +346,8 @@ class WidgetMessagesMixin(MessagesMixin):
                 &nbsp;&nbsp;&nbsp;</nobr>
                 <span style="font-size:9pt"><br></span>
                 </p>'''.
-                format(msg.group.bar_background, font_size, str(msg))
+                format(msg.group.bar_background, font_size,
+                       str(msg).replace("\n", "<br/>&nbsp;&nbsp;&nbsp; "))
                 for msg in messages)
             self._set_message_bar(group, text, tooltip)
 


### PR DESCRIPTION
Backport of #1837 (applied to the current master) to fix release 3.3.10.

##### Issue

Fixes #1835.
Allows error messages in multiple lines.

##### Description of changes

Overload `check_data` to check the number of values issue an error.

##### Includes
- [X] Code changes
- [X] Tests
