### PR TITLE
[FIX] Tree: Fix crash when two attributes equal number of values

### DIFF
--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -36,13 +36,13 @@ class OWTreeLearner(OWTreeLearner):
         if not self.binary_trees:
             return True
         max_values, max_attr = max(
-            ((len(attr.values), attr)
+            ((len(attr.values), attr.name)
              for attr in self.data.domain.attributes if attr.is_discrete),
             default=(0, None))
         MAX_BINARIZATION = ClassificationTreeLearner.MAX_BINARIZATION
         if max_values > MAX_BINARIZATION:
             self.Error.cannot_binarize(
-                max_attr.name, max_values, MAX_BINARIZATION)
+                max_attr, max_values, MAX_BINARIZATION)
             return False
         return True
 


### PR DESCRIPTION
When two attributes had an equal number of values, the test before binarization tried to compare instances of `DiscreteVariable`.

##### Includes
- [X] Code changes
