### PR TITLE
[FIX] Catch errors during learning in learner widgets

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -178,7 +178,7 @@ class Model(Reprable):
     def __init__(self, domain=None):
         if isinstance(self, Learner):
             domain = None
-        elif not domain:
+        elif domain is None:
             raise ValueError("unspecified domain")
         self.domain = domain
 

--- a/Orange/widgets/classify/owlogisticregression.py
+++ b/Orange/widgets/classify/owlogisticregression.py
@@ -77,7 +77,7 @@ class OWLogisticRegression(OWBaseLearner):
     def update_model(self):
         super().update_model()
         coef_table = None
-        if self.valid_data:
+        if self.model is not None:
             coef_table = create_coef_table(self.model)
         self.send("Coefficients", coef_table)
 

--- a/Orange/widgets/classify/owsvmclassification.py
+++ b/Orange/widgets/classify/owsvmclassification.py
@@ -112,9 +112,8 @@ class OWBaseSVM(OWBaseLearner):
 
     def update_model(self):
         super().update_model()
-
         sv = None
-        if self.valid_data:
+        if self.model is not None:
             sv = self.data[self.model.skl_model.support_]
         self.send("Support vectors", sv)
 

--- a/Orange/widgets/regression/owlinearregression.py
+++ b/Orange/widgets/regression/owlinearregression.py
@@ -124,7 +124,7 @@ class OWLinearRegression(OWBaseLearner):
     def update_model(self):
         super().update_model()
         coef_table = None
-        if self.valid_data:
+        if self.model is not None:
             domain = Domain(
                     [ContinuousVariable("coef", number_of_decimals=7)],
                     metas=[StringVariable("name")])

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -118,6 +118,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
 
     class Error(OWWidget.Error):
         data_error = Msg("{}")
+        fitting_failed = Msg("Fitting failed.\n{}")
 
     class Warning(OWWidget.Warning):
         outdated_learner = Msg("Press Apply to submit changes.")
@@ -182,14 +183,22 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
         self.outdated_settings = False
         self.Warning.outdated_learner.clear()
 
+    def show_fitting_failed(self, exc):
+        """Show error when fitting fails.
+            Derived widgets can override this to show more specific messages."""
+        self.Error.fitting_failed(str(exc), shown=exc is not None)
+
     def update_model(self):
+        self.show_fitting_failed(None)
+        self.model = None
         if self.check_data():
-            self.model = self.learner(self.data)
-            self.model.name = self.learner_name
-            self.model.instances = self.data
-            self.valid_data = True
-        else:
-            self.model = None
+            try:
+                self.model = self.learner(self.data)
+            except BaseException as exc:
+                self.show_fitting_failed(exc)
+            else:
+                self.model.name = self.learner_name
+                self.model.instances = self.data
         self.send(self.OUTPUT_MODEL_NAME, self.model)
 
     def check_data(self):

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -1,0 +1,36 @@
+# pylint: disable=missing-docstring
+from Orange.base import Learner, Model
+from Orange.data import Table, Domain
+from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWBaseLearner(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.iris = Table("iris")
+
+    def test_error_on_learning(self):
+        """Check that widget shows error message when learner fails"""
+
+        class FailingLearner(Learner):
+            """A learner that fails when given data"""
+            __returns__ = Model
+
+            def __call__(self, data, *_):
+                if data is not None:
+                    raise ValueError("boom")
+                return Model(Domain([]))
+
+        class OWFailingLearner(OWBaseLearner):
+            """Widget for the above learner"""
+            name = learner_name = "foo"
+            LEARNER = FailingLearner
+            auto_apply = True
+
+        self.widget = self.create_widget(OWFailingLearner)
+        self.send_signal("Data", self.iris)
+        self.assertTrue(self.widget.Error.fitting_failed.is_shown())
+        self.send_signal("Data", None)
+        self.assertFalse(self.widget.Error.fitting_failed.is_shown())


### PR DESCRIPTION
##### Issue

The base widget for learners did not intercept errors occurring during fitting. 

##### Description of changes

Errors are now caught and a basic message that something went wrong is displayed. Widgets can provide more specific error messages when possible.

Some widgets tested `self.valid_data` to verify that fitting succeeded. This did not really work. Although it now would, the tests are replaced to check whether `self.model` is not `None`. This is more appropriate since the data may be valid when the model is not.

A minor fix needed for tests: `Model` checked whether the `domain` parameter is given by checking `if domain`. This is wrong since `Domain` does not have `__bool__`, so `__len__` is used instead, and so `Domain([])` is treated as `False`.


##### Includes
- [X] Code changes
- [X] Tests
