### PR TITLE
[FIX] Table.__repr__: Fix for sparse data with < 5 instances

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -803,8 +803,11 @@ class Table(MutableSequence, Storage):
         return "[" + ",\n ".join(str(ex) for ex in self)
 
     def __repr__(self):
-        s = "[" + ",\n ".join(repr(ex) for ex in self[:5])
-        if len(self) > 5:
+        head = 5
+        if self.is_sparse():
+            head = min(self.X.shape[0], head)
+        s = "[" + ",\n ".join(repr(ex) for ex in self[:head])
+        if len(self) > head:
             s += ",\n ..."
         s += "\n]"
         return s

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1213,6 +1213,11 @@ class TableTestCase(unittest.TestCase):
         table.X = sp.csr_matrix(table.X)
         self.assertTrue(table.is_sparse())
 
+    def test_repr_sparse_with_one_row(self):
+        table = data.Table("iris")[:1]
+        table.X = sp.csr_matrix(table.X)
+        repr(table)     # make sure repr does not crash
+
 
 def column_sizes(table):
     return (len(table.domain.attributes),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #1950.

##### Description of changes
Fix `Table.__repr__` for sparse.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
