### PR TITLE
[FIX] Evaluation Results input validation

### DIFF
--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -144,7 +144,7 @@ class Results:
         if nmethods is not None:
             self.failed = [False] * nmethods
 
-        if data:
+        if data is not None:
             self.data = data if self.store_data else None
             self.domain = data.domain
             self.dtype = getattr(data.Y, 'dtype', self.dtype)

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -32,8 +32,13 @@ def confusion_matrix(res, index):
 
     Returns: Confusion matrix
     """
-    return skl_metrics.confusion_matrix(
-        res.actual, res.predicted[index])
+    labels = numpy.arange(len(res.domain.class_var.values))
+    if not res.actual.size:
+        # scikit-learn will not return an zero matrix
+        return numpy.zeros((len(labels), len(labels)))
+    else:
+        return skl_metrics.confusion_matrix(
+            res.actual, res.predicted[index], labels=labels)
 
 
 BorderRole = next(gui.OrangeUserRole)

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -509,7 +509,6 @@ class OWConfusionMatrix(widget.OWWidget):
 
     @classmethod
     def migrate_settings(cls, settings, version):
-        super().migrate_settings(settings, version)
         if not version:
             # For some period of time the 'selected_learner' property was
             # changed from List[int] -> int

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -200,6 +200,15 @@ class OWLiftCurve(widget.OWWidget):
         pen.setCosmetic(True)
         self.plot.plot([0, 1], [0, 1], pen=pen, antialias=True)
 
+        warning = ""
+        if not all(c.curve.is_valid for c in curves):
+            if any(c.curve.is_valid for c in curves):
+                warning = "Some lift curves are undefined"
+            else:
+                warning = "All lift curves are undefined"
+
+        self.warning(warning)
+
     def _replot(self):
         self.plot.clear()
         if self.results is not None:
@@ -231,6 +240,11 @@ def lift_curve_from_results(results, target, clf_idx, subset=slice(0, -1)):
 def lift_curve(ytrue, ypred, target=1):
     P = numpy.sum(ytrue == target)
     N = ytrue.size - P
+
+    if P == 0 or N == 0:
+        # Undefined TP and FP rate
+        return numpy.array([]), numpy.array([]), numpy.array([])
+
     fpr, tpr, thresholds = skl_metrics.roc_curve(ytrue, ypred, target)
     rpp = fpr * (N / (P + N)) + tpr * (P / (P + N))
     return rpp, tpr, thresholds

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -298,6 +298,10 @@ class OWROCAnalysis(widget.OWWidget):
     priority = 1010
     inputs = [("Evaluation Results", Orange.evaluation.Results, "set_results")]
 
+    class Warning(widget.OWWidget.Warning):
+        empty_results = widget.Msg(
+            "Empty results on input. There is nothing to display.")
+
     target_index = settings.Setting(0)
     selected_classifiers = []
 
@@ -420,6 +424,8 @@ class OWROCAnalysis(widget.OWWidget):
         if self.results is not None:
             self._initialize(results)
             self._setup_plot()
+        else:
+            self.warning()
 
     def clear(self):
         """Clear the widget state."""
@@ -517,7 +523,7 @@ class OWROCAnalysis(widget.OWWidget):
                 if self.display_convex_curve:
                     self.plot.addItem(graphics.hull_item)
 
-                if self.display_def_threshold:
+                if self.display_def_threshold and curve.is_valid:
                     points = curve.points
                     ind = numpy.argmin(numpy.abs(points.thresholds - 0.5))
                     item = pg.TextItem(
@@ -559,6 +565,8 @@ class OWROCAnalysis(widget.OWWidget):
                     if self.display_convex_curve:
                         self.plot.addItem(fold.hull_item)
             hull_curves = [fold.hull for curve in selected for fold in curve.folds]
+        else:
+            assert False
 
         if self.display_convex_hull and hull_curves:
             hull = convex_hull(hull_curves)
@@ -577,6 +585,14 @@ class OWROCAnalysis(widget.OWWidget):
 
         if self.roc_averaging == OWROCAnalysis.Merge:
             self._update_perf_line()
+
+        warning = ""
+        if not all(c.is_valid for c in hull_curves):
+            if any(c.is_valid for c in hull_curves):
+                warning = "Some ROC curves are undefined"
+            else:
+                warning = "All ROC curves are undefined"
+        self.warning(warning)
 
     def _on_target_changed(self):
         self.plot.clear()
@@ -612,10 +628,13 @@ class OWROCAnalysis(widget.OWWidget):
                 self.fp_cost, self.fn_cost, self.target_prior / 100.0)
 
             hull = self._rocch
-            ind = roc_iso_performance_line(m, hull)
-            angle = numpy.arctan2(m, 1)  # in radians
-            self._perf_line.setAngle(angle * 180 / numpy.pi)
-            self._perf_line.setPos((hull.fpr[ind[0]], hull.tpr[ind[0]]))
+            if hull.is_valid:
+                ind = roc_iso_performance_line(m, hull)
+                angle = numpy.arctan2(m, 1)  # in radians
+                self._perf_line.setAngle(angle * 180 / numpy.pi)
+                self._perf_line.setPos((hull.fpr[ind[0]], hull.tpr[ind[0]]))
+            else:
+                self._perf_line.setVisible(False)
 
     def onDeleteWidget(self):
         self.clear()

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -422,7 +422,7 @@ class OWROCAnalysis(widget.OWWidget):
         self.clear()
         self.results = check_results_adequacy(results, self.Error)
         if self.results is not None:
-            self._initialize(results)
+            self._initialize(self.results)
             self._setup_plot()
         else:
             self.warning()

--- a/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
+++ b/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
@@ -1,0 +1,51 @@
+import copy
+
+import numpy as np
+
+import Orange.data
+import Orange.evaluation
+import Orange.classification
+
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.evaluate.owcalibrationplot import OWCalibrationPlot
+
+
+class TestOWCalibrationPlot(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.lenses = data = Orange.data.Table("lenses")
+        cls.res = Orange.evaluation.TestOnTestData(
+            train_data=data[::2], test_data=data[1::2],
+            learners=[Orange.classification.MajorityLearner(),
+                      Orange.classification.KNNLearner()],
+            store_data=True,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.widget = self.create_widget(OWCalibrationPlot)  # type: OWCalibrationPlot
+
+    def test_basic(self):
+        self.send_signal("Evaluation Results", self.res)
+        self.widget.controls.display_rug.click()
+
+    def test_empty(self):
+        res = copy.copy(self.res)
+        res.row_indices = res.row_indices[:0]
+        res.actual = res.actual[:0]
+        res.predicted = res.predicted[:, 0]
+        res.probabilities = res.probabilities[:, :0, :]
+        self.send_signal("Evaluation Results", res)
+
+    def test_nan_input(self):
+        res = copy.copy(self.res)
+        res.actual = res.actual.copy()
+        res.probabilities = res.probabilities.copy()
+
+        res.actual[0] = np.nan
+        res.probabilities[:, [0, 3], :] = np.nan
+        self.send_signal("Evaluation Results", res)
+        self.assertTrue(self.widget.Error.invalid_results.is_shown())
+        self.send_signal("Evaluation Results", None)
+        self.assertFalse(self.widget.Error.invalid_results.is_shown())

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -5,7 +5,7 @@ from Orange.data import Table
 from Orange.classification import NaiveBayesLearner, TreeLearner
 from Orange.regression import MeanLearner
 from Orange.evaluation.testing import CrossValidation, TestOnTrainingData, \
-    ShuffleSplit
+    ShuffleSplit, Results
 from Orange.widgets.evaluate.owconfusionmatrix import OWConfusionMatrix
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 
@@ -82,3 +82,14 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
         correct_indices = results.row_indices[correct]
         self.assertSetEqual(set(self.iris[correct_indices].ids),
                             set(selected.ids))
+
+    def test_empty_results(self):
+        """Test on empty results."""
+        res = Results(data=self.iris[:0], store_data=True)
+        res.row_indices = np.array([], dtype=int)
+        res.actual = np.array([])
+        res.predicted = np.array([[]])
+        res.probabilities = np.zeros((1, 0, 3))
+        self.send_signal("Evaluation Results", res)
+        self.widget.select_correct()
+        self.widget.select_wrong()

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -93,3 +93,16 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal("Evaluation Results", res)
         self.widget.select_correct()
         self.widget.select_wrong()
+
+    def test_nan_results(self):
+        """Test on results with nan values in actual/predicted"""
+        res = Results(data=self.iris, nmethods=2, store_data=True)
+        res.row_indices = np.array([0, 50, 100], dtype=int)
+        res.actual = np.array([0., np.nan, 2.])
+        res.predicted = np.array([[np.nan, 1, 2],
+                                  [np.nan, np.nan, np.nan]])
+        res.probabilities = np.zeros((1, 3, 3))
+        self.send_signal("Evaluation Results", res)
+        self.assertTrue(self.widget.Error.invalid_values.is_shown())
+        self.send_signal("Evaluation Results", None)
+        self.assertFalse(self.widget.Error.invalid_values.is_shown())

--- a/Orange/widgets/evaluate/tests/test_owliftcurve.py
+++ b/Orange/widgets/evaluate/tests/test_owliftcurve.py
@@ -1,0 +1,53 @@
+import copy
+
+import numpy as np
+
+import Orange.data
+import Orange.evaluation
+import Orange.classification
+
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.utils import simulate
+from Orange.widgets.evaluate.owliftcurve import OWLiftCurve
+
+
+class TestOWLiftCurve(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.lenses = data = Orange.data.Table("lenses")
+        cls.res = Orange.evaluation.TestOnTestData(
+            train_data=data[::2], test_data=data[1::2],
+            learners=[Orange.classification.MajorityLearner(),
+                      Orange.classification.KNNLearner()],
+            store_data=True,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.widget = self.create_widget(
+            OWLiftCurve,
+            stored_settings={
+                "display_convex_hull": True
+            }
+        )  # type: OWLiftCurve
+
+    def test_basic(self):
+        self.send_signal("Evaluation Results", self.res)
+        simulate.combobox_run_through_all(self.widget.target_cb)
+
+    def test_empty_input(self):
+        res = copy.copy(self.res)
+        res.actual = res.actual[:0]
+        res.row_indices = res.row_indices[:0]
+        res.predicted = res.predicted[:, :0]
+        res.probabilities = res.probabilities[:, :0, :]
+        self.send_signal("Evaluation Results", res)
+
+    def test_nan_input(self):
+        res = copy.copy(self.res)
+        res.actual[0] = np.nan
+        self.send_signal("Evaluation Results", res)
+        self.assertTrue(self.widget.Error.invalid_results.is_shown())
+        self.send_signal("Evaluation Results", None)
+        self.assertFalse(self.widget.Error.invalid_results.is_shown())

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1,16 +1,47 @@
 """Tests for OWPredictions"""
 
+import numpy as np
+
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.evaluate.owpredictions import OWPredictions
 
 from Orange.data import Table
+from Orange.classification import MajorityLearner
+from Orange.evaluation import Results
+
+
 class TestOWPredictions(WidgetTest):
 
     def setUp(self):
-        self.widget = self.create_widget(OWPredictions)
+        self.widget = self.create_widget(OWPredictions)  # type: OWPredictions
         self.iris = Table("iris")
 
     def test_rowCount_from_model(self):
         """Don't crash if the bottom row is visible"""
         self.send_signal("Data", self.iris[:5])
         self.widget.dataview.sizeHintForColumn(0)
+
+    def test_nan_target_input(self):
+        data = self.iris[::10].copy()
+        data.Y[1] = np.nan
+        yvec, _ = data.get_column_view(data.domain.class_var)
+        nanmask = np.isnan(yvec)
+        self.send_signal("Data", data)
+        self.send_signal("Predictors", MajorityLearner()(data), 1)
+        pred = self.get_output("Predictions", )
+        self.assertIsInstance(pred, Table)
+        np.testing.assert_array_equal(
+            yvec, pred.get_column_view(data.domain.class_var)[0])
+
+        evres = self.get_output("Evaluation Results")
+        self.assertIsInstance(evres, Results)
+        self.assertIsInstance(evres.data, Table)
+        ev_yvec, _ = evres.data.get_column_view(data.domain.class_var)
+
+        self.assertTrue(np.all(~np.isnan(ev_yvec)))
+        self.assertTrue(np.all(~np.isnan(evres.actual)))
+
+        data.Y[:] = np.nan
+        self.send_signal("Data", data)
+        evres = self.get_output("Evaluation Results")
+        self.assertEqual(len(evres.data), 0)

--- a/Orange/widgets/evaluate/tests/test_owrocanalysis.py
+++ b/Orange/widgets/evaluate/tests/test_owrocanalysis.py
@@ -6,6 +6,8 @@ import Orange.evaluation
 import Orange.classification
 
 from Orange.widgets.evaluate import owrocanalysis
+from Orange.widgets.evaluate.owrocanalysis import OWROCAnalysis
+from Orange.widgets.tests.base import WidgetTest
 
 
 class TestROC(unittest.TestCase):
@@ -55,3 +57,81 @@ class TestROC(unittest.TestCase):
                 self.assertTrue(all(not c.is_valid for c in rocdata.folds))
                 self.assertFalse(rocdata.avg_vertical.is_valid)
                 self.assertFalse(rocdata.avg_threshold.is_valid)
+
+
+class TestOWROCAnalysis(WidgetTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.lenses = data = Orange.data.Table("lenses")
+        cls.res = Orange.evaluation.TestOnTestData(
+            train_data=data[::2], test_data=data[1::2],
+            learners=[Orange.classification.MajorityLearner(),
+                      Orange.classification.KNNLearner()],
+            store_data=True,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.widget = self.create_widget(
+            OWROCAnalysis,
+            stored_settings={
+                "display_perf_line": True,
+                "display_def_threshold": True,
+                "display_convex_hull": True,
+                "display_convex_curve": True
+            }
+        )  # type: OWROCAnalysis
+
+    def tearDown(self):
+        super().tearDown()
+        self.widget.onDeleteWidget()
+        self.widgets.remove(self.widget)
+        self.widget = None
+
+    def test_basic(self):
+        res = self.res
+        self.send_signal("Evaluation Results", res)
+        self.widget.roc_averaging = OWROCAnalysis.Merge
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.Vertical
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.Threshold
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.NoAveraging
+        self.widget._replot()
+        self.send_signal("Evaluation Results", None)
+
+    def test_empty_input(self):
+        res = Orange.evaluation.Results(
+            data=self.lenses[:0], nmethods=2, store_data=True)
+        res.row_indices = numpy.array([], dtype=int)
+        res.actual = numpy.array([])
+        res.predicted = numpy.zeros((2, 0))
+        res.probabilities = numpy.zeros((2, 0, 3))
+
+        self.send_signal("Evaluation Results", res)
+        self.widget.roc_averaging = OWROCAnalysis.Merge
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.Vertical
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.Threshold
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.NoAveraging
+        self.widget._replot()
+
+        res.row_indices = numpy.array([1], dtype=int)
+        res.actual = numpy.array([0.0])
+        res.predicted = numpy.zeros((2, 1))
+        res.probabilities = numpy.zeros((2, 1, 3))
+
+        self.send_signal("Evaluation Results", res)
+        self.widget.roc_averaging = OWROCAnalysis.Merge
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.Vertical
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.Threshold
+        self.widget._replot()
+        self.widget.roc_averaging = OWROCAnalysis.NoAveraging
+        self.widget._replot()

--- a/Orange/widgets/evaluate/tests/test_owrocanalysis.py
+++ b/Orange/widgets/evaluate/tests/test_owrocanalysis.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 import numpy
 
 import Orange.data
@@ -135,3 +136,18 @@ class TestOWROCAnalysis(WidgetTest):
         self.widget._replot()
         self.widget.roc_averaging = OWROCAnalysis.NoAveraging
         self.widget._replot()
+
+    def test_nan_input(self):
+        res = copy.copy(self.res)
+        res.actual = res.actual.copy()
+        res.predicted = res.predicted.copy()
+        res.probabilities = res.probabilities.copy()
+
+        res.actual[0] = numpy.nan
+        res.predicted[:, 1] = numpy.nan
+        res.probabilities[0, 1, :] = numpy.nan
+
+        self.send_signal("Evaluation Results", res)
+        self.assertTrue(self.widget.Error.invalid_results.is_shown())
+        self.send_signal("Evaluation Results", None)
+        self.assertFalse(self.widget.Error.invalid_results.is_shown())

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -1,6 +1,13 @@
-def check_results_adequacy(results, error_group):
+import numpy
+
+
+def check_results_adequacy(results, error_group, check_nan=True):
     error_group.add_message("invalid_results")
     error_group.invalid_results.clear()
+
+    def anynan(a):
+        return numpy.any(numpy.isnan(a))
+
     if results is None:
         return None
     if results.data is None:
@@ -9,5 +16,11 @@ def check_results_adequacy(results, error_group):
     elif not results.data.domain.has_discrete_class:
         error_group.invalid_results(
             "Discrete outcome variable is required")
+    elif check_nan and (anynan(results.actual) or
+                        anynan(results.predicted) or
+                        (results.probabilities is not None and
+                         anynan(results.probabilities))):
+        error_group.invalid_results(
+            "Results contains invalid values")
     else:
         return results


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Most widget in evaluation category fail when presented either an empty Evaluation Results instance or one containing nan values. The source of these is in most cases the 'Predictions' widget.

##### Description of changes

* 'Predictions' widget filters out unknown values from the 'Evaluation Results' when the corresponding true target value is unknown
* Confusion Matrix, ROC Analysis, Lift Curve and Calibration plot widgets handle empty results
* Confusion Matrix, ROC Analysis, Lift Curve and Calibration plot widgets check for the presence of Nan values and bail out early with an error message.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
