### PR TITLE
[FIX] report comments and OWFile reporting filename

### DIFF
--- a/Orange/canvas/report/index.html
+++ b/Orange/canvas/report/index.html
@@ -99,7 +99,7 @@
     }
 
     textarea {
-        border: none;
+        border: 1px solid silver;
         font-style: italic;
         width: 100%;
         height: 4em;

--- a/Orange/canvas/report/owreport.py
+++ b/Orange/canvas/report/owreport.py
@@ -171,6 +171,7 @@ class OWReport(OWWidget):
             def _add_comment(myself, item_id, value):
                 item = self.table_model.get_item_by_id(item_id)
                 item.comment = value
+                self.report_changed = True
 
         self.report_view = WebviewWidget(self.mainArea, bridge=PyBridge(self))
         self.mainArea.layout().addWidget(self.report_view)
@@ -239,7 +240,7 @@ class OWReport(OWWidget):
             item = self.table_model.item(i)
             html += "<div id='{}' class='normal' " \
                     "onClick='pybridge._select_item(this.id)'>{}<div " \
-                    "class='textwrapper'><textarea required='required' " \
+                    "class='textwrapper'><textarea " \
                     "placeholder='Write a comment...'" \
                     "onInput='pybridge._add_comment(this.parentNode." \
                     "parentNode.id, this.value)'>{}</textarea></div>" \
@@ -260,18 +261,6 @@ class OWReport(OWWidget):
         self.report_view.evalJS(
             "document.getElementById('{}').className = 'selected';"
             .format(item.id))
-        self.report_changed = True
-
-
-    @pyqtSlot(str)
-    def _select_item(self, item_id):
-        item = self.table_model.get_item_by_id(item_id)
-        self.table.selectRow(self.table_model.indexFromItem(item).row())
-        self._change_selected_item(item)
-
-    def _add_comment(self, item_id, value):
-        item = self.table_model.get_item_by_id(item_id)
-        item.comment = value
         self.report_changed = True
 
     def make_report(self, widget):
@@ -410,8 +399,6 @@ class OWReport(OWWidget):
         if not hasattr(app_inst, "_report_window"):
             report = OWReport()
             app_inst._report_window = report
-            app_inst.sendPostedEvents(report, 0)
-            app_inst.aboutToQuit.connect(report.deleteLater)
         return app_inst._report_window
 
     @staticmethod

--- a/Orange/canvas/report/owreport.py
+++ b/Orange/canvas/report/owreport.py
@@ -242,8 +242,9 @@ class OWReport(OWWidget):
                     "onClick='pybridge._select_item(this.id)'>{}<div " \
                     "class='textwrapper'><textarea " \
                     "placeholder='Write a comment...'" \
-                    "onInput='pybridge._add_comment(this.parentNode." \
-                    "parentNode.id, this.value)'>{}</textarea></div>" \
+                    "onInput='this.innerHTML = this.value;" \
+                    "pybridge._add_comment(this.parentNode.parentNode.id, this.value);'" \
+                    ">{}</textarea></div>" \
                     "</div>".format(item.id, item.html, item.comment)
         html += "</body></html>"
         self.report_view.setHtml(html)


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3/issues/1899

##### Description of changes
Not sure what the problem was re comments. Removing `required=required` in HTML now works for me. in OWFile, `self.loaded_file` is now correctly set when the file is loaded, not when browsed for.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
