### PR TITLE
[FIX] Paint Data: in-place output modification

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1027,6 +1027,7 @@ class OWPaintData(OWWidget):
         else:
             self.input_data = np.column_stack((X, y))
         self.reset_to_input()
+        self.unconditional_commit()
 
     def reset_to_input(self):
         """Reset the painting to input data if present."""

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -583,6 +583,7 @@ class ClearTool(DataTool):
     only2d = False
 
     def activate(self):
+        self.editingStarted.emit()
         self.issueCommand.emit(SelectRegion(self._plot.rect()))
         self.issueCommand.emit(DeleteSelection())
         self.editingFinished.emit()

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -775,7 +775,7 @@ class OWPaintData(OWWidget):
 
     brushRadius = Setting(75)
     density = Setting(7)
-
+    #: current data array (shape=(N, 3)) as presented on the output
     data = Setting(None, schema_only=True)
 
     graph_name = "plot"
@@ -797,7 +797,10 @@ class OWPaintData(OWWidget):
         self.current_tool = None
         self._selected_indices = None
         self._scatter_item = None
-
+        #: A private data buffer (can be modified in place). `self.data` is
+        #: a copy of this array (as seen when the `invalidate` method is
+        #: called
+        self.__buffer = None
         self.labels = ["C1", "C2"]
 
         self.undo_stack = QUndoStack(self)
@@ -813,6 +816,8 @@ class OWPaintData(OWWidget):
 
         if self.data is None:
             self.data = np.zeros((0, 3))
+        self.__buffer = self.data.copy()
+
         self.colors = colorpalette.ColorPaletteGenerator(
             len(colorpalette.DefaultRGBColors))
         self.tools_cache = {}
@@ -1034,6 +1039,8 @@ class OWPaintData(OWWidget):
         itemmodels.select_row(self.classValuesView, newindex)
 
         self.data = self.input_data
+        self.__buffer = self.data.copy()
+
         prev_attr2 = self.hasAttr2
         self.hasAttr2 = self.input_has_attr2
         if prev_attr2 != self.hasAttr2:
@@ -1062,8 +1069,8 @@ class OWPaintData(OWWidget):
             return
 
         label = self.class_model[index]
-        mask = self.data[:, 2] == index
-        move_mask = self.data[~mask][:, 2] > index
+        mask = self.__buffer[:, 2] == index
+        move_mask = self.__buffer[~mask][:, 2] > index
 
         self.undo_stack.beginMacro("Delete class label")
         self.undo_stack.push(UndoCommand(DeleteIndices(mask), self))
@@ -1144,7 +1151,7 @@ class OWPaintData(OWWidget):
                 if isinstance(self.current_tool, SelectTool):
                     self.current_tool._reset()
 
-            self.data, undo = transform(command, self.data)
+            self.__buffer, undo = transform(command, self.__buffer)
             self._replot()
             return undo
         else:
@@ -1166,7 +1173,7 @@ class OWPaintData(OWWidget):
         elif isinstance(cmd, Move):
             self.undo_stack.push(UndoCommand(cmd, self, text=name))
         elif isinstance(cmd, SelectRegion):
-            indices = [i for i, (x, y) in enumerate(self.data[:, :2])
+            indices = [i for i, (x, y) in enumerate(self.__buffer[:, :2])
                        if cmd.region.contains(QPointF(x, y))]
             indices = np.array(indices, dtype=int)
             self._selected_indices = indices
@@ -1196,12 +1203,12 @@ class OWPaintData(OWWidget):
             self._add_command(Append([QPointF(*p) for p in zip(*data.T)]))
         elif isinstance(cmd, Jitter):
             point = np.array([cmd.pos.x(), cmd.pos.y()])
-            delta = - apply_jitter(self.data[:, :2], point,
+            delta = - apply_jitter(self.__buffer[:, :2], point,
                                    self.density / 100.0, 0, cmd.rstate)
             self._add_command(Move((..., slice(0, 2)), delta))
         elif isinstance(cmd, Magnet):
             point = np.array([cmd.pos.x(), cmd.pos.y()])
-            delta = - apply_attractor(self.data[:, :2], point,
+            delta = - apply_attractor(self.__buffer[:, :2], point,
                                       self.density / 100.0, 0)
             self._add_command(Move((..., slice(0, 2)), delta))
         else:
@@ -1220,13 +1227,16 @@ class OWPaintData(OWWidget):
         nclasses = len(self.class_model)
         pens = [pen(self.colors[i]) for i in range(nclasses)]
 
-        self._scatter_item = pg.ScatterPlotItem(
-            self.data[:, 0],
-            self.data[:, 1] if self.hasAttr2 else np.zeros(self.data.shape[0]),
-            symbol="+",
-            pen=[pens[int(ci)] for ci in self.data[:, 2]]
-        )
+        x = self.__buffer[:, 0].copy()
+        if self.hasAttr2:
+            y = self.__buffer[:, 1].copy()
+        else:
+            y = np.zeros(self.__buffer.shape[0])
+        pen = [pens[ci] for ci in self.__buffer[:, 2].astype(int)]
 
+        self._scatter_item = pg.ScatterPlotItem(
+            x, y, symbol="+", pen=pen
+        )
         self.plot.addItem(self._scatter_item)
 
     def _attr_name_changed(self):
@@ -1235,6 +1245,7 @@ class OWPaintData(OWWidget):
         self.invalidate()
 
     def invalidate(self):
+        self.data = self.__buffer.copy()
         self.commit()
 
     def commit(self):

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -1,16 +1,45 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring, protected-access
+
+import numpy as np
+from AnyQt.QtCore import QRectF, QPointF
+
 from Orange.data import Table
+from Orange.widgets.data import owpaintdata
 from Orange.widgets.data.owpaintdata import OWPaintData
 from Orange.widgets.tests.base import WidgetTest
 
 
 class TestOWPaintData(WidgetTest):
     def setUp(self):
-        self.widget = self.create_widget(OWPaintData)
+        self.widget = self.create_widget(
+            OWPaintData,
+            stored_settings={
+                "autocommit": True
+            }
+        )  # type: OWPaintData
 
     def test_empty_data(self):
         """No crash on empty data"""
         data = Table("iris")
         self.send_signal("Data", data)
         self.send_signal("Data", Table(data.domain))
+
+    def test_output_shares_internal_buffer(self):
+        data = Table("iris")[::5]
+        self.send_signal("Data", data)
+        output1 = self.get_output("Data")
+        output1_copy = output1.copy()
+        self.widget._add_command(
+            owpaintdata.SelectRegion(QRectF(0.25, 0.25, 0.5, 0.5))
+        )
+        self.widget._add_command(
+            owpaintdata.MoveSelection(QPointF(0.1, 0.1))
+        )
+        output2 = self.get_output("Data")
+        self.assertIsNot(output1, output2)
+
+        np.testing.assert_equal(output1.X, output1_copy.X)
+        np.testing.assert_equal(output1.Y, output1_copy.Y)
+
+        self.assertTrue(np.any(output1.X != output2.X))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The widget outputs a table created from a view of its data which should have been used only internally to the widget as it is modified in-place.

##### Description of changes

Ensure the output data is not a view of the working data.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
