### PR TITLE
[FIX] File: Fix crash when last_path is None

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -217,10 +217,11 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         self.setAcceptDrops(True)
 
-        if self.source == self.LOCAL_FILE and \
-                        os.path.getsize(self.last_path()) > self.SIZE_LIMIT:
-            self.Warning.file_too_big()
-            return
+        if self.source == self.LOCAL_FILE:
+            last_path = self.last_path()
+            if last_path and os.path.getsize(last_path) > self.SIZE_LIMIT:
+                self.Warning.file_too_big()
+                return
 
         QTimer.singleShot(0, self.load_data)
 

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -93,3 +93,9 @@ class TestOWFile(WidgetTest):
         filename = FileFormat.locate(name, dataset_dirs)
         self.widget.add_path(filename)
         self.widget.load_data()
+
+    def test_no_last_path(self):
+        self.widget =\
+            self.create_widget(OWFile, stored_settings={"recent_paths": []})
+        # Doesn't crash and contains a single item, (none).
+        self.assertEqual(self.widget.file_combo.count(), 1)


### PR DESCRIPTION
https://sentry.io/biolab/orange3/issues/196743788/

The error also appeared when I tried to reproduce some unrelated bugs.

##### Description of changes

Check whether `last_path` is `None` before checking its size.

##### Includes
- [X] Code changes
- [X] Tests
