### PR TITLE
[FIX] Python 3.6 compatibility

### DIFF
--- a/Orange/classification/majority.py
+++ b/Orange/classification/majority.py
@@ -33,7 +33,8 @@ class MajorityLearner(Learner):
         probs = np.array(dist)
         ties = np.flatnonzero(probs == probs.max())
         if len(ties) > 1:
-            random_idx = int(sha1(bytes(dat.Y)).hexdigest(), 16) % len(ties)
+            random_idx = int(sha1(np.ascontiguousarray(dat.Y).data)
+                             .hexdigest(), 16) % len(ties)
             unif_maj = ties[random_idx]
         else:
             unif_maj = None

--- a/Orange/classification/rules.py
+++ b/Orange/classification/rules.py
@@ -149,7 +149,8 @@ def hash_dist(x):
     hash : int
         Hash function result.
     """
-    return int(sha1(bytes(x)).hexdigest(), base=16) & 0xffffffff
+    return int(sha1(np.ascontiguousarray(x).data)
+               .hexdigest(), base=16) & 0xffffffff
 
 
 class Evaluator:

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -50,7 +50,11 @@ class TestPreprocess(unittest.TestCase):
             self.assertTrue(os.environ.get('ORANGE_DEPRECATIONS_ERROR'))
         expected = self.assertRaises if is_CI else self.assertWarns
         with expected(OrangeDeprecationWarning):
-            Orange.preprocess.preprocess.Preprocess(Table('iris'))
+            try:
+                Orange.preprocess.preprocess.Preprocess(Table('iris'))
+            except NotImplementedError:
+                # Expected from default Preprocess.__call__
+                pass
 
 
 class RemoveConstant(unittest.TestCase):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
On Python 3.6 `bytes(numpy.array([1,2]))` raises a 

    TypeError: only integer scalar arrays can be converted to a scalar index

##### Description of changes

Fix this use in two places where sha1 digest of an array is requested, passing the array memory view directly to sha1 (if the arrays is c contiguous this also avoids a copy. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
