### PR TITLE
Actually use the SafeUrllibTransport defined in c6b7bbf7

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -651,7 +651,7 @@ def list_pypi_addons():
 
     pypi = xmlrpc.client.ServerProxy(
         "https://pypi.python.org/pypi/",
-        transport=xmlrpc.client.SafeTransport()
+        transport=SafeUrllibTransport()
     )
     addons = pypi.search(ADDON_PYPI_SEARCH_SPEC)
 


### PR DESCRIPTION
##### Issue
Listing packages did not work behind a proxy. Now it does.

Tested on linux with https_proxy set (where a proxy is really needed this time).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
