### PR TITLE
[FIX] owimpute: Fix editing of individual imputers

### DIFF
--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -352,7 +352,7 @@ class OWImpute(OWWidget):
     def set_method_for_indexes(self, indexes, method_index):
         if method_index == self.DEFAULT:
             for index in indexes:
-                self.variable_methods.pop(index, None)
+                self.variable_methods.pop(index.row(), None)
         else:
             method = self.METHODS[method_index].copy()
             for index in indexes:
@@ -386,7 +386,7 @@ class OWImpute(OWWidget):
             self.set_method_for_current_selection(index)
 
     def reset_variable_methods(self):
-        indexes = map(self.varmodel.index, range(len(self.varmodel)))
+        indexes = list(map(self.varmodel.index, range(len(self.varmodel))))
         self.set_method_for_indexes(indexes, self.DEFAULT)
         self.variable_button_group.button(self.DEFAULT).setChecked(True)
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -4,8 +4,8 @@ import copy
 import numpy as np
 
 from AnyQt.QtWidgets import (
-    QWidget, QGroupBox, QRadioButton, QPushButton, QHBoxLayout,
-    QVBoxLayout, QStackedLayout, QComboBox, QLineEdit,
+    QGroupBox, QRadioButton, QPushButton, QHBoxLayout,
+    QVBoxLayout, QStackedWidget, QComboBox,
     QButtonGroup, QStyledItemDelegate, QListView, QDoubleSpinBox
 )
 from AnyQt.QtCore import Qt
@@ -146,10 +146,10 @@ class OWImpute(OWWidget):
             minimum=-1000., maximum=1000., singleStep=.1, decimals=3,
             value=self.default_value
             )
-        self.value_stack = value_stack = QStackedLayout()
+        self.value_stack = value_stack = QStackedWidget()
         value_stack.addWidget(self.value_combo)
         value_stack.addWidget(self.value_double)
-        method_layout.addLayout(value_stack)
+        method_layout.addWidget(value_stack)
 
         button_group.buttonClicked[int].connect(
             self.set_method_for_current_selection

--- a/Orange/widgets/data/tests/test_owimpute.py
+++ b/Orange/widgets/data/tests/test_owimpute.py
@@ -8,6 +8,7 @@ from Orange.widgets.data.owimpute import OWImpute, AsDefault
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.itemmodels import select_row
 
+
 class TestOWImpute(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWImpute)  # type: OWImpute
@@ -17,7 +18,7 @@ class TestOWImpute(WidgetTest):
         data = Table("iris")
         widget = self.widget
         widget.default_method_index = widget.MODEL_BASED_IMPUTER
-        widget.default_method = widget.METHODS[widget.default_method_index]
+        widget.default_method = widget.methods[widget.default_method_index]
 
         self.send_signal("Data", data)
         widget.unconditional_commit()
@@ -33,7 +34,7 @@ class TestOWImpute(WidgetTest):
     def test_no_features(self):
         widget = self.widget
         widget.default_method_index = widget.MODEL_BASED_IMPUTER
-        widget.default_method = widget.METHODS[widget.default_method_index]
+        widget.default_method = widget.methods[widget.default_method_index]
 
         self.send_signal("Data", Table("iris"))
 

--- a/Orange/widgets/data/tests/test_owimpute.py
+++ b/Orange/widgets/data/tests/test_owimpute.py
@@ -3,13 +3,14 @@
 import numpy as np
 
 from Orange.data import Table
-from Orange.widgets.data.owimpute import OWImpute
+from Orange.preprocess import impute
+from Orange.widgets.data.owimpute import OWImpute, AsDefault
 from Orange.widgets.tests.base import WidgetTest
-
+from Orange.widgets.utils.itemmodels import select_row
 
 class TestOWImpute(WidgetTest):
     def setUp(self):
-        self.widget = self.create_widget(OWImpute)
+        self.widget = self.create_widget(OWImpute)  # type: OWImpute
 
     def test_empty_data(self):
         """No crash on empty data"""
@@ -43,3 +44,49 @@ class TestOWImpute(WidgetTest):
         self.send_signal("Learner", lambda *_: (lambda *_: 1/0))  # Model fails
         widget.unconditional_commit()
         self.assertTrue(widget.Error.imputation_failed.is_shown())
+
+    def test_select_method(self):
+        data = Table("iris")[::5]
+
+        self.send_signal("Data", data)
+        method_types = [type(m) for m in OWImpute.METHODS]
+
+        widget = self.widget
+        model = widget.varmodel
+        view = widget.varview
+        defbg = widget.default_button_group
+        varbg = widget.variable_button_group
+        self.assertSequenceEqual(list(model), data.domain.variables)
+        asdefid = method_types.index(AsDefault)
+        leaveid = method_types.index(impute.DoNotImpute)
+        avgid = method_types.index(impute.Average)
+        defbg.button(avgid).click()
+        self.assertEqual(widget.default_method_index, avgid)
+
+        self.assertTrue(
+            all(isinstance(m, AsDefault) and isinstance(m.method, impute.Average)
+                for m in map(widget.get_method_for_column,
+                             range(len(data.domain.variables)))))
+
+        # change method for first variable
+        select_row(view, 0)
+        varbg.button(avgid).click()
+        met = widget.get_method_for_column(0)
+        self.assertIsInstance(met, impute.Average)
+
+        # select a second var
+        selmodel = view.selectionModel()
+        selmodel.select(model.index(2), selmodel.Select)
+        # the current checked button must unset
+        self.assertEqual(varbg.checkedId(), -1)
+
+        varbg.button(leaveid).click()
+        self.assertIsInstance(widget.get_method_for_column(0),
+                              impute.DoNotImpute)
+        self.assertIsInstance(widget.get_method_for_column(2),
+                              impute.DoNotImpute)
+
+        # reset both back to default
+        varbg.button(asdefid).click()
+        self.assertIsInstance(widget.get_method_for_column(0), AsDefault)
+        self.assertIsInstance(widget.get_method_for_column(2), AsDefault)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-1920 and gh-1965

##### Description of changes

* Fix reseting of individual variable imputers back to default (gh-1920)
* Prevent global modification of OWImpute.METHODS
* Properly disable the 'Value' {Combo,Spin}Box for setting fixed replacement values
* Fix editing of per-variable specific replacement values (gh-1965)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
