### PR TITLE
[FIX] owconcatenate: Fix domain intersection (remove duplicates)

### DIFF
--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -232,7 +232,7 @@ def domain_union(A, B):
 def domain_intersection(A, B):
     def tuple_intersection(t1, t2):
         inters = set(t1) & set(t2)
-        return tuple(el for el in t1 + t2 if el in inters)
+        return tuple(unique(el for el in t1 + t2 if el in inters))
 
     intersection = Orange.data.Domain(
         tuple_intersection(A.attributes, B.attributes),


### PR DESCRIPTION


##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

A naive attempt of preserving column order resulted in every
column in the intersection being repeated times the number of
inputs.

(ref gh-1943)

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
