### PR TITLE
Tests for settings_changed and fitter params

### DIFF
--- a/Orange/widgets/classify/tests/test_owadaboostclassification.py
+++ b/Orange/widgets/classify/tests/test_owadaboostclassification.py
@@ -13,6 +13,7 @@ class TestOWAdaBoostClassification(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(
             OWAdaBoost, stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.iris,)
         self.parameters = [
             ParameterMapping('algorithm', self.widget.cls_algorithm_combo,
                              self.widget.algorithms),

--- a/Orange/widgets/classify/tests/test_owclassificationtree.py
+++ b/Orange/widgets/classify/tests/test_owclassificationtree.py
@@ -18,6 +18,7 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(
             OWTreeLearner, stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.iris,)
         self.model_class = Model
 
         self.parameters = [

--- a/Orange/widgets/classify/tests/test_owclassificationtree.py
+++ b/Orange/widgets/classify/tests/test_owclassificationtree.py
@@ -4,8 +4,10 @@ from Orange.data import Table, Domain, DiscreteVariable
 from Orange.classification.tree import TreeLearner as ClassificationTreeLearner
 from Orange.base import Model
 from Orange.widgets.classify.owclassificationtree import OWTreeLearner
-from Orange.widgets.tests.base import (WidgetTest, DefaultParameterMapping,
-                                       ParameterMapping, WidgetLearnerTestMixin)
+from Orange.widgets.tests.base import (
+    WidgetTest, DefaultParameterMapping, ParameterMapping,
+    WidgetLearnerTestMixin
+)
 
 
 class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
@@ -27,8 +29,8 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
                 self.widget, 'min_internal', 'min_samples_split'),
             ParameterMapping.from_attribute(
                 self.widget, 'min_leaf', 'min_samples_leaf')]
-        # NB. sufficient_majority is divided by 100, so it cannot be tested like
-        # this
+        # NB. sufficient_majority is divided by 100, so it cannot be tested
+        # like this
 
         self.checks = [sb.gui_element.cbox for sb in self.parameters]
 
@@ -62,7 +64,7 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         domain = Domain([
             DiscreteVariable(
                 values=[str(x) for x in range(max_binarization + 1)])],
-            DiscreteVariable(values="01"))
+                DiscreteVariable(values="01"))
         self.send_signal("Data", Table(domain, [[0, 0], [1, 1]]))
         self.assertTrue(error_shown())
         # No more error on Iris
@@ -86,6 +88,6 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         domain = Domain([
             DiscreteVariable(
                 values=[str(x) for x in range(max_binarization + 1)])],
-            DiscreteVariable(values="01"))
+                DiscreteVariable(values="01"))
         self.send_signal("Data", Table(domain))
         self.assertFalse(error_shown())

--- a/Orange/widgets/classify/tests/test_owknnclassification.py
+++ b/Orange/widgets/classify/tests/test_owknnclassification.py
@@ -10,6 +10,7 @@ class TestOWKNNLearner(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(OWKNNLearner,
                                          stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.iris,)
         self.parameters = [
             ParameterMapping('metric', self.widget.metrics_combo,
                              self.widget.metrics),

--- a/Orange/widgets/classify/tests/test_owrandomforest.py
+++ b/Orange/widgets/classify/tests/test_owrandomforest.py
@@ -10,8 +10,10 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(OWRandomForest,
                                          stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.iris,)
         nest_spin = self.widget.n_estimators_spin
-        nest_min_max = [nest_spin.minimum() * 10, nest_spin.minimum()]
+        # Let's test this out with 1 and 3 trees, so this doesn't take forever
+        nest_min_max = [1, 3]
         self.parameters = [
             ParameterMapping("n_estimators", nest_spin, nest_min_max),
             ParameterMapping("min_samples_split",

--- a/Orange/widgets/classify/tests/test_owsgd.py
+++ b/Orange/widgets/classify/tests/test_owsgd.py
@@ -1,8 +1,9 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from Orange.widgets.classify.owsgd import OWSGD
-from Orange.widgets.tests.base import WidgetTest, WidgetLearnerTestMixin, \
-    ParameterMapping
+from Orange.widgets.tests.base import (
+    WidgetTest, WidgetLearnerTestMixin, ParameterMapping
+)
 
 
 class TestOWSGD(WidgetTest, WidgetLearnerTestMixin):
@@ -14,7 +15,7 @@ class TestOWSGD(WidgetTest, WidgetLearnerTestMixin):
         self.parameters = [
             ParameterMapping('loss', self.widget.cls_loss_function_combo,
                              list(zip(*self.widget.cls_losses))[1]),
-            ParameterMapping.from_attribute(self.widget, 'cls_epsilon', 'epsilon'),
+            ParameterMapping('epsilon', self.widget.cls_epsilon_spin),
             ParameterMapping('penalty', self.widget.penalty_combo,
                              list(zip(*self.widget.penalties))[1]),
             ParameterMapping.from_attribute(self.widget, 'alpha'),

--- a/Orange/widgets/classify/tests/test_owsgd.py
+++ b/Orange/widgets/classify/tests/test_owsgd.py
@@ -10,6 +10,7 @@ class TestOWSGD(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(
             OWSGD, stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.iris,)
         self.parameters = [
             ParameterMapping('loss', self.widget.cls_loss_function_combo,
                              list(zip(*self.widget.cls_losses))[1]),

--- a/Orange/widgets/model/tests/test_owsgd.py
+++ b/Orange/widgets/model/tests/test_owsgd.py
@@ -13,17 +13,25 @@ class TestOWSGD(WidgetTest, WidgetLearnerTestMixin):
             OWSGD, stored_settings={"auto_apply": False})
         self.init()
         self.parameters = [
-            # TODO Fix the base tests to support parameter delegation with
-            # different problem types
-            # ParameterMapping('loss', self.widget.loss_function_combo,
-            #                  list(zip(*self.widget.losses))[1]),
-            # ParameterMapping.from_attribute(self.widget, 'epsilon'),
-            ParameterMapping('penalty', self.widget.penalty_combo,
+            # Loss params for classification
+            ParameterMapping("loss", self.widget.cls_loss_function_combo,
+                             list(zip(*self.widget.cls_losses))[1],
+                             problem_type="classification"),
+            ParameterMapping("epsilon", self.widget.cls_epsilon_spin,
+                             problem_type="classification"),
+            # Loss params for regression
+            ParameterMapping("loss", self.widget.reg_loss_function_combo,
+                             list(zip(*self.widget.reg_losses))[1],
+                             problem_type="regression"),
+            ParameterMapping("epsilon", self.widget.reg_epsilon_spin,
+                             problem_type="regression"),
+            # Shared params
+            ParameterMapping("penalty", self.widget.penalty_combo,
                              list(zip(*self.widget.penalties))[1]),
-            ParameterMapping.from_attribute(self.widget, 'alpha'),
-            ParameterMapping.from_attribute(self.widget, 'l1_ratio'),
-            ParameterMapping('learning_rate', self.widget.learning_rate_combo,
+            ParameterMapping.from_attribute(self.widget, "alpha"),
+            ParameterMapping.from_attribute(self.widget, "l1_ratio"),
+            ParameterMapping("learning_rate", self.widget.learning_rate_combo,
                              list(zip(*self.widget.learning_rates))[1]),
-            ParameterMapping.from_attribute(self.widget, 'eta0'),
-            ParameterMapping.from_attribute(self.widget, 'power_t'),
+            ParameterMapping.from_attribute(self.widget, "eta0"),
+            ParameterMapping.from_attribute(self.widget, "power_t"),
         ]

--- a/Orange/widgets/regression/tests/test_owadaboostregression.py
+++ b/Orange/widgets/regression/tests/test_owadaboostregression.py
@@ -16,6 +16,7 @@ class TestOWAdaBoostRegression(WidgetTest, WidgetLearnerTestMixin):
         # Needed because the fitter type needs to be set to regression in order
         # to be tested properly
         self.data = self.housing[:10]
+        self.valid_datasets = (self.data,)
         losses = [loss.lower() for loss in self.widget.losses]
         self.parameters = [
             ParameterMapping('loss', self.widget.reg_algorithm_combo, losses),

--- a/Orange/widgets/regression/tests/test_owknnregression.py
+++ b/Orange/widgets/regression/tests/test_owknnregression.py
@@ -10,6 +10,7 @@ class TestOWKNNRegression(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(OWKNNLearner,
                                          stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.housing,)
         self.parameters = [
             ParameterMapping('metric', self.widget.metrics_combo,
                              self.widget.metrics),

--- a/Orange/widgets/regression/tests/test_owrandomforestregression.py
+++ b/Orange/widgets/regression/tests/test_owrandomforestregression.py
@@ -10,6 +10,7 @@ class TestOWRandomForestRegression(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(
             OWRandomForest, stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.housing,)
         nest_spin = self.widget.n_estimators_spin
         nest_min_max = [nest_spin.minimum() * 10, nest_spin.minimum()]
         self.parameters = [

--- a/Orange/widgets/regression/tests/test_owregressiontree.py
+++ b/Orange/widgets/regression/tests/test_owregressiontree.py
@@ -11,6 +11,7 @@ class TestOWRegressionTree(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(
             OWTreeLearner, stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.housing,)
         self.model_class = Model
         self.parameters = [
             ParameterMapping.from_attribute(self.widget, 'max_depth'),

--- a/Orange/widgets/regression/tests/test_owsgdregression.py
+++ b/Orange/widgets/regression/tests/test_owsgdregression.py
@@ -11,6 +11,7 @@ class TestOWSGDRegression(WidgetTest, WidgetLearnerTestMixin):
             OWSGD, stored_settings={"auto_apply": False})
         self.init()
         self.data = self.housing
+        self.valid_datasets = (self.housing,)
         self.parameters = [
             ParameterMapping('loss', self.widget.reg_loss_function_combo,
                              list(zip(*self.widget.reg_losses))[1]),

--- a/Orange/widgets/regression/tests/test_owsvmregression.py
+++ b/Orange/widgets/regression/tests/test_owsvmregression.py
@@ -10,6 +10,7 @@ class TestOWSVMRegression(WidgetTest, WidgetLearnerTestMixin):
         self.widget = self.create_widget(OWSVMRegression,
                                          stored_settings={"auto_apply": False})
         self.init()
+        self.valid_datasets = (self.housing,)
         gamma_spin = self.widget._kernel_params[0]
         values = [self.widget._default_gamma, gamma_spin.maximum()]
 

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -1,4 +1,5 @@
 import os
+import sip
 import unittest
 from unittest.mock import Mock
 
@@ -9,19 +10,21 @@ from AnyQt.QtWidgets import (
 
 from Orange.base import SklModel, Model
 from Orange.canvas.report.owreport import OWReport
-from Orange.classification.base_classification import (LearnerClassification,
-                                                       ModelClassification)
+from Orange.classification.base_classification import (
+    LearnerClassification, ModelClassification
+)
 from Orange.data import Table
 from Orange.modelling import Fitter
 from Orange.preprocess import RemoveNaNColumns, Randomize
 from Orange.preprocess.preprocess import PreprocessorList
-from Orange.regression.base_regression import LearnerRegression, ModelRegression
-from Orange.widgets.utils.annotated_data import (ANNOTATED_DATA_FEATURE_NAME,
-                                                 ANNOTATED_DATA_SIGNAL_NAME)
+from Orange.regression.base_regression import (
+    LearnerRegression, ModelRegression
+)
+from Orange.widgets.utils.annotated_data import (
+    ANNOTATED_DATA_FEATURE_NAME, ANNOTATED_DATA_SIGNAL_NAME
+)
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
-# For tests, let memory freeing entirely to Python / OS
-import sip
 sip.setdestroyonexit(False)
 
 app = None


### PR DESCRIPTION
##### Issue
Problem in #1878 was not caught by tests. Also, we were not able to test parameters specific to classification/regression datasets.

##### Description of changes
Fixed both of the above mentioned problems. Due to changes, I also had to set `valid_datasets` in each learner. These tests will all be removed when learners are fully merged.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
