### PR TITLE
[FIX] Table: Ensure correct dtype in `_compute_distributions`

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1309,6 +1309,8 @@ class Table(MutableSequence, Storage):
                 m, W, Xcsc = _get_matrix(self.X, Xcsc, col)
             elif col < 0:
                 m, W, Xcsc = _get_matrix(self.metas, Xcsc, col * (-1) - 1)
+                if np.issubdtype(m.dtype, np.dtype(object)):
+                    m = m.astype(float)
             else:
                 m, W, Ycsc = _get_matrix(self._Y, Ycsc, col - self.X.shape[1])
             if var.is_discrete:

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+# Test internal methods
+# pylint: disable=missing-docstring, protected-access
 
 import unittest
 from unittest.mock import Mock
@@ -430,7 +431,13 @@ class TestDomainDistribution(unittest.TestCase):
         variable = d.domain[-2]
         dist, _ = d._compute_distributions([variable])[0]
         np.testing.assert_almost_equal(dist, [3, 3, 2])
-
+        # repeat with nan values
+        assert d.metas.dtype.kind == "O"
+        assert d.metas[0, 1] == 0
+        d.metas[0, 1] = np.nan
+        dist, nanc = d._compute_distributions([variable])[0]
+        np.testing.assert_almost_equal(dist, [2, 3, 2])
+        self.assertEqual(nanc, 1)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

```python
import Orange.data
from Orange.statistics import distribution

domain = Orange.data.Domain(
    [], [],
    [Orange.data.StringVariable("S"),
     Orange.data.DiscreteVariable("D", ["a", "b"])])

data = Orange.data.Table(domain, [["", 1], ["", float("nan")]])
distribution.get_distribution(data, domain.metas[1])
```
results in
```
Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "/Users/aleserjavec/workspace/orange3/Orange/statistics/distribution.py", line 295, in get_distribution
    return Discrete(dat, variable, unknowns)
  File "/Users/aleserjavec/workspace/orange3/Orange/statistics/distribution.py", line 39, in __new__
    return cls.from_data(dat, variable)
  File "/Users/aleserjavec/workspace/orange3/Orange/statistics/distribution.py", line 63, in from_data
    dist, unknowns = data._compute_distributions([variable])[0]
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 1317, in _compute_distributions
    dist, unknowns = bincount(m, len(var.values) - 1, W)
  File "/Users/aleserjavec/workspace/orange3/Orange/statistics/util.py", line 50, in bincount
    return (np.bincount(X.astype(np.int32, copy=False),
ValueError: cannot convert float NaN to integer
```


##### Description of changes

Ensure correct dtype in `_compute_distributions` when the column data comes from the metas array.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
