### PR TITLE
[FIX] owpaintdata: Fix an error when the input dataset contains NaN

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1226,18 +1226,16 @@ class OWPaintData(OWWidget):
             self.plot.removeItem(self._scatter_item)
             self._scatter_item = None
 
-        nclasses = len(self.class_model)
-        pens = [pen(self.colors[i]) for i in range(nclasses)]
-
         x = self.__buffer[:, 0].copy()
         if self.hasAttr2:
             y = self.__buffer[:, 1].copy()
         else:
             y = np.zeros(self.__buffer.shape[0])
-        pen = [pens[ci] for ci in self.__buffer[:, 2].astype(int)]
 
+        colors = self.colors[self.__buffer[:, 2]]
+        pens = [pen(c) for c in colors]
         self._scatter_item = pg.ScatterPlotItem(
-            x, y, symbol="+", pen=pen
+            x, y, symbol="+", pen=pens
         )
         self.plot.addItem(self._scatter_item)
 

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -7,7 +7,7 @@ from AnyQt.QtCore import QRectF, QPointF
 from Orange.data import Table
 from Orange.widgets.data import owpaintdata
 from Orange.widgets.data.owpaintdata import OWPaintData
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.base import WidgetTest, datasets
 
 
 class TestOWPaintData(WidgetTest):
@@ -24,6 +24,10 @@ class TestOWPaintData(WidgetTest):
         data = Table("iris")
         self.send_signal("Data", data)
         self.send_signal("Data", Table(data.domain))
+
+    def test_nan_data(self):
+        data = datasets.missing_data_2()
+        self.send_signal("Data", data)
 
     def test_output_shares_internal_buffer(self):
         data = Table("iris")[::5]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Input
```
X1,X2,D
c,c,d
,,class
1,1,a
1,1,?
2,1,b
```
To Paint Data widget (i.e. an unknown in the class column)

-> On current master
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/scheme/widgetsscheme.py", line 822, in process_signals_for_widget
    handler(*args)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1029, in set_data
    self.reset_to_input()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1051, in reset_to_input
    self._replot()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1237, in _replot
    pen = [pens[ci] for ci in self.__buffer[:, 2].astype(int)]
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1237, in <listcomp>
    pen = [pens[ci] for ci in self.__buffer[:, 2].astype(int)]
IndexError: list index out of range
```
-> On 3.3.10
```
Traceback (most recent call last):
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/Orange/canvas/scheme/widgetsscheme.py", line 822, in process_signals_for_widget
    handler(*args)
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/Orange/widgets/data/owpaintdata.py", line 1023, in set_data
    self.reset_to_input()
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/Orange/widgets/data/owpaintdata.py", line 1042, in reset_to_input
    self._replot()
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/Orange/widgets/data/owpaintdata.py", line 1227, in _replot
    pen=[pens[int(ci)] for ci in self.data[:, 2]]
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/Orange/widgets/data/owpaintdata.py", line 1227, in <listcomp>
    pen=[pens[int(ci)] for ci in self.data[:, 2]]
ValueError: cannot convert float NaN to integer
```

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
