### PR TITLE
[FIX] Fitter: Fix infinite recursion in __getattr__

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -114,18 +114,20 @@ class Learner(_ReprableWithPreprocessors):
                             self.__class__.__name__)
 
         self.domain = data.domain
-
-        if type(self).fit is Learner.fit:
-            model = self.fit_storage(data)
-        else:
-            X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
-            model = self.fit(X, Y, W)
+        model = self._fit_model(data)
         model.domain = data.domain
         model.supports_multiclass = self.supports_multiclass
         model.name = self.name
         model.original_domain = origdomain
         model.original_data = origdata
         return model
+
+    def _fit_model(self, data):
+        if type(self).fit is Learner.fit:
+            return self.fit_storage(data)
+        else:
+            X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
+            return self.fit(X, Y, W)
 
     def preprocess(self, data):
         """Apply the `preprocessors` to the data"""

--- a/Orange/base.py
+++ b/Orange/base.py
@@ -72,6 +72,8 @@ class Learner(_ReprableWithPreprocessors):
         This property is needed mainly because of the `Fitter` class, which can
         not know in advance, which preprocessors it will need to use. Therefore
         this resolves the active preprocessors using a lazy approach.
+    params : dict
+        The params that the learner is constructed with.
 
     """
     supports_multiclass = False

--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -64,6 +64,8 @@ class TreeLearner(Learner):
         self.min_samples_split = min_samples_split
         self.sufficient_majority = sufficient_majority
         self.max_depth = max_depth
+        self.params = {k: v for k, v in vars().items()
+                       if k not in ('args', 'kwargs')}
 
     def _select_attr(self, data):
         """Select the attribute for the next split.

--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -59,13 +59,12 @@ class TreeLearner(Learner):
             min_samples_leaf=1, min_samples_split=2, sufficient_majority=0.95,
             **kwargs):
         super().__init__(*args, **kwargs)
-        self.binarize = binarize
-        self.min_samples_leaf = min_samples_leaf
-        self.min_samples_split = min_samples_split
-        self.sufficient_majority = sufficient_majority
-        self.max_depth = max_depth
-        self.params = {k: v for k, v in vars().items()
-                       if k not in ('args', 'kwargs')}
+        self.params = {}
+        self.binarize = self.params['binarize'] = binarize
+        self.min_samples_leaf = self.params['min_samples_leaf'] = min_samples_leaf
+        self.min_samples_split = self.params['min_samples_split'] = min_samples_split
+        self.sufficient_majority = self.params['sufficient_majority'] = sufficient_majority
+        self.max_depth = self.params['max_depth'] = max_depth
 
     def _select_attr(self, data):
         """Select the attribute for the next split.

--- a/Orange/modelling/base.py
+++ b/Orange/modelling/base.py
@@ -54,9 +54,7 @@ class Fitter(Learner, metaclass=FitterMeta):
         """Get the learner for a given problem type."""
         # Prevent trying to access the learner when problem type is None
         if problem_type not in self.__fits__:
-            # We're mostly called from __getattr__ via getattr, so we should
-            # raise AttributeError instead of TypeError
-            raise AttributeError("No learner to handle '{}'".format(problem_type))
+            raise TypeError("No learner to handle '{}'".format(problem_type))
         if self.__learners[problem_type] is None:
             learner = self.__fits__[problem_type](**self.__kwargs(problem_type))
             learner.use_default_preprocessors = self.use_default_preprocessors

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -52,6 +52,8 @@ class TreeLearner(Learner):
         self.min_samples_leaf = min_samples_leaf
         self.min_samples_split = min_samples_split
         self.max_depth = max_depth
+        self.params = {k: v for k, v in vars().items()
+                       if k not in ('args', 'kwargs')}
 
     def _select_attr(self, data):
         """Select the attribute for the next split.

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -48,12 +48,11 @@ class TreeLearner(Learner):
             binarize=False, min_samples_leaf=1, min_samples_split=2,
             max_depth=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.binarize = binarize
-        self.min_samples_leaf = min_samples_leaf
-        self.min_samples_split = min_samples_split
-        self.max_depth = max_depth
-        self.params = {k: v for k, v in vars().items()
-                       if k not in ('args', 'kwargs')}
+        self.params = {}
+        self.binarize = self.params['binarity'] = binarize
+        self.min_samples_leaf = self.params['min_samples_leaf'] = min_samples_leaf
+        self.min_samples_split = self.params['min_samples_split'] = min_samples_split
+        self.max_depth = self.params['max_depth'] = max_depth
 
     def _select_attr(self, data):
         """Select the attribute for the next split.

--- a/Orange/widgets/regression/tests/test_owadaboostregression.py
+++ b/Orange/widgets/regression/tests/test_owadaboostregression.py
@@ -19,7 +19,8 @@ class TestOWAdaBoostRegression(WidgetTest, WidgetLearnerTestMixin):
         self.valid_datasets = (self.data,)
         losses = [loss.lower() for loss in self.widget.losses]
         self.parameters = [
-            ParameterMapping('loss', self.widget.reg_algorithm_combo, losses),
+            ParameterMapping('loss', self.widget.reg_algorithm_combo, losses,
+                             problem_type='regression'),
             ParameterMapping('learning_rate', self.widget.learning_rate_spin),
             ParameterMapping('n_estimators', self.widget.n_estimators_spin)]
 

--- a/Orange/widgets/regression/tests/test_owsgdregression.py
+++ b/Orange/widgets/regression/tests/test_owsgdregression.py
@@ -15,8 +15,10 @@ class TestOWSGDRegression(WidgetTest, WidgetLearnerTestMixin):
         self.valid_datasets = (self.housing,)
         self.parameters = [
             ParameterMapping('loss', self.widget.reg_loss_function_combo,
-                             list(zip(*self.widget.reg_losses))[1]),
-            ParameterMapping.from_attribute(self.widget, 'reg_epsilon', 'epsilon'),
+                             list(zip(*self.widget.reg_losses))[1],
+                             problem_type='regression'),
+            ParameterMapping('epsilon', self.widget.reg_epsilon_spin,
+                             problem_type='regression'),
             ParameterMapping('penalty', self.widget.penalty_combo,
                              list(zip(*self.widget.penalties))[1]),
             ParameterMapping.from_attribute(self.widget, 'alpha'),

--- a/Orange/widgets/regression/tests/test_owsvmregression.py
+++ b/Orange/widgets/regression/tests/test_owsvmregression.py
@@ -28,8 +28,10 @@ class TestOWSVMRegression(WidgetTest, WidgetLearnerTestMixin):
                 gamma_spin.setValue(value)
 
         self.parameters = [
-            ParameterMapping("C", self.widget.C_spin),
-            ParameterMapping("epsilon", self.widget.epsilon_spin),
+            ParameterMapping("C", self.widget.C_spin,
+                             problem_type="regression"),
+            ParameterMapping("epsilon", self.widget.epsilon_spin,
+                             problem_type="regression"),
             ParameterMapping("gamma", self.widget._kernel_params[0],
                              values=values, setter=setter, getter=getter),
             ParameterMapping("coef0", self.widget._kernel_params[1]),
@@ -44,8 +46,10 @@ class TestOWSVMRegression(WidgetTest, WidgetLearnerTestMixin):
         # setChecked(True) does not trigger callback event
         self.widget.nu_radio.click()
         self.assertEqual(self.widget.svm_type, OWSVM.Nu_SVM)
-        self.parameters[0] = ParameterMapping("C", self.widget.nu_C_spin)
-        self.parameters[1] = ParameterMapping("nu", self.widget.nu_spin)
+        self.parameters[0] = ParameterMapping("C", self.widget.nu_C_spin,
+                                              problem_type="regression")
+        self.parameters[1] = ParameterMapping("nu", self.widget.nu_spin,
+                                              problem_type="regression")
         self.test_parameters()
 
     def test_kernel_equation(self):


### PR DESCRIPTION
##### Issue
Running fitters on large enough datasets through the test and score widget and setting it to cross validation would result in a stack overflow error.

I am not particularly sure why this happened, my theory is that when test and score receives a large enough dataset, it runs cross validation in parallel, and that the learner attributes were probably accessed statically and failing.

Unfortunately, I have no idea what caused this and how exactly it was called, so I don't really know how to test against this. But since I will most likely change this in the near future, I wouldn't spend too much time on this.

##### Description of changes
No longer rely on `self.kwargs` being on the object, but raise attribute error by explicitly getting `kwargs` with `__getattribute__`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
