### PR TITLE
[FIX] Preprocess Widget: Continuize type error

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -195,6 +195,8 @@ class DiscretizeEditor(BaseEditor):
 
 
 class ContinuizeEditor(BaseEditor):
+    _Type = type(Continuize.FirstAsBase)
+
     Continuizers = OrderedDict({
         Continuize.FrequentAsBase: "Most frequent is base",
         Continuize.Indicators: "One attribute per value",
@@ -206,7 +208,6 @@ class ContinuizeEditor(BaseEditor):
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
         self.setLayout(QVBoxLayout())
-
         self.__treatment = Continuize.Indicators
         self.__group = group = QButtonGroup(exclusive=True)
         group.buttonClicked.connect(self.__on_buttonClicked)
@@ -215,13 +216,15 @@ class ContinuizeEditor(BaseEditor):
             rb = QRadioButton(
                 text=text,
                 checked=self.__treatment == treatment)
-            group.addButton(rb, int(treatment))
+            group.addButton(rb, _enum_to_index(ContinuizeEditor._Type,
+                                               treatment))
             self.layout().addWidget(rb)
 
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
 
     def setTreatment(self, treatment):
-        b = self.__group.button(treatment)
+        buttonid = _enum_to_index(ContinuizeEditor._Type, treatment)
+        b = self.__group.button(buttonid)
         if b is not None:
             b.setChecked(True)
             self.__treatment = treatment
@@ -238,7 +241,8 @@ class ContinuizeEditor(BaseEditor):
         return {"multinomial_treatment": self.__treatment}
 
     def __on_buttonClicked(self):
-        self.__treatment = self.__group.checkedId()
+        self.__treatment = _index_to_enum(
+            ContinuizeEditor._Type, self.__group.checkedId())
         self.changed.emit()
         self.edited.emit()
 

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -1,10 +1,13 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-
 import numpy as np
 
 from Orange.data import Table
-from Orange.preprocess import Randomize, Scale
+from Orange.preprocess import (
+    Randomize, Scale, Discretize, Continuize, Impute, ProjectPCA, ProjectCUR
+)
+from Orange.preprocess import discretize, impute, fss, score
+from Orange.widgets.data import owpreprocess
 from Orange.widgets.data.owpreprocess import OWPreprocess
 from Orange.widgets.tests.base import WidgetTest
 
@@ -40,3 +43,129 @@ class TestOWPreprocess(WidgetTest):
 
         np.testing.assert_allclose(output.X.mean(0), 0, atol=1e-7)
         np.testing.assert_allclose(output.X.std(0), 1, atol=1e-7)
+
+
+# Test for editors
+class TestDiscretizeEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.DiscretizeEditor()
+        self.assertEqual(widget.parameters(),
+                         {"method": owpreprocess.DiscretizeEditor.EqualFreq,
+                          "n": 4})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Discretize)
+        self.assertIsInstance(p.method, discretize.EqualFreq)
+        widget.setParameters(
+            {"method": owpreprocess.DiscretizeEditor.EntropyMDL}
+        )
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Discretize)
+        self.assertIsInstance(p.method, discretize.EntropyMDL)
+
+        widget.setParameters(
+            {"method": owpreprocess.DiscretizeEditor.EqualWidth,
+             "n": 10}
+        )
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Discretize)
+        self.assertIsInstance(p.method, discretize.EqualWidth)
+        self.assertEqual(p.method.n, 10)
+
+
+class TestContinuizeEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.ContinuizeEditor()
+        self.assertEqual(widget.parameters(),
+                         {"multinomial_treatment": Continuize.Indicators})
+
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Continuize)
+        self.assertEqual(p.multinomial_treatment, Continuize.Indicators)
+
+        widget.setParameters(
+            {"multinomial_treatment": Continuize.FrequentAsBase})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Continuize)
+        self.assertEqual(p.multinomial_treatment, Continuize.FrequentAsBase)
+
+
+class TestImputeEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.ImputeEditor()
+        self.assertEqual(widget.parameters(),
+                         {"method": owpreprocess.ImputeEditor.Average})
+        widget.setParameters(
+            {"method": owpreprocess.ImputeEditor.Average}
+        )
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Impute)
+        self.assertIsInstance(p.method, impute.Average)
+
+
+class TestFeatureSelectEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.FeatureSelectEditor()
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, fss.SelectBestFeatures)
+        self.assertEqual(p.method, score.InfoGain)
+        self.assertEqual(p.k, 10)
+
+
+class TestRandomFeatureSelectEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.RandomFeatureSelectEditor()
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, fss.SelectRandomFeatures)
+        self.assertEqual(p.k, 10)
+
+        widget.setParameters(
+            {"strategy": owpreprocess.RandomFeatureSelectEditor.Percentage,
+             "p": 25})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, fss.SelectRandomFeatures)
+        self.assertEqual(p.k, 0.25)
+
+
+class TestRandomizeEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.Randomize()
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Randomize)
+        self.assertEqual(p.rand_type, Randomize.RandomizeClasses)
+
+        widget.setParameters({"rand_type": Randomize.RandomizeAttributes})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, Randomize)
+        self.assertEqual(p.rand_type, Randomize.RandomizeAttributes)
+
+
+class TestPCAEditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.PCA()
+        self.assertEqual(widget.parameters(),
+                         {"n_components": 10})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, ProjectPCA)
+        self.assertEqual(p.n_components, 10)
+
+        widget.setParameters({"n_components": 5})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, ProjectPCA)
+        self.assertEqual(p.n_components, 5)
+
+
+class TestCUREditor(WidgetTest):
+    def test_editor(self):
+        widget = owpreprocess.CUR()
+        self.assertEqual(widget.parameters(),
+                         {"rank": 10, "max_error": 1})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, ProjectCUR)
+        self.assertEqual(p.rank, 10)
+        self.assertEqual(p.max_error, 1)
+
+        widget.setParameters({"rank": 5, "max_error": 0.5})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, ProjectCUR)
+        self.assertEqual(p.rank, 5)
+        self.assertEqual(p.max_error, 0.5)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Due to 60e1369 the ContinuizeEditor raises an:
```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/scheme/widgetsscheme.py", line 454, in create_widget_instance
    widget.__init__()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpreprocess.py", line 1015, in __init__
    self._initialize()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpreprocess.py", line 1036, in _initialize
    self.set_model(model)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpreprocess.py", line 1108, in set_model
    self.controler.setModel(ppmodel)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/preprocess.py", line 265, in setModel
    self._initialize(model)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/preprocess.py", line 276, in _initialize
    self._insertWidgetFor(i, index)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/preprocess.py", line 398, in _insertWidgetFor
    widget = self.createWidgetFor(index)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/preprocess.py", line 415, in createWidgetFor
    widget = definition.viewclass()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpreprocess.py", line 218, in __init__
    group.addButton(rb, int(treatment))
TypeError: int() argument must be a string, a bytes-like object or a number, not 'Continuize'
-------------------------------------------------------------------------------
```

##### Description of changes

Map the enum value to an integer index for internal radio button id use.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
