### PR TITLE
[FIX] WebviewWidget: WebEngine Don't Grab Focus on setHtml

### DIFF
--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -518,3 +518,18 @@ elif HAVE_WEBENGINE:
         def exposeObject(self, name, obj):
             obj = _to_primitive_types(obj)
             self._jsobject_channel.send_object(name, obj)
+
+        def setHtml(self, html, base_url=''):
+            # TODO: remove once anaconda will provide PyQt without this bug.
+            #
+            # At least on some installations of PyQt 5.6.0 with anaconda
+            # WebViewWidget grabs focus on setHTML which can be quite annoying.
+            # For example, if you have a line edit as filter and show results
+            # in WebWiew, then WebView grabs focus after every typed character.
+            #
+            # http://stackoverflow.com/questions/36609489
+            # https://bugreports.qt.io/browse/QTBUG-52999
+            initial_state = self.isEnabled()
+            self.setEnabled(False)
+            super().setHtml(html, base_url)
+            self.setEnabled(initial_state)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
If running on WebEngine the call to `setHtml` grabs focus and sets it to WebViewWidget. This is quite annoying behaviour when for example one would like to filter some data set and show the results in WebView. Due to WebViewWidget's focus grabbing the input filter looses focus after every character is typed.

##### Description of changes
Override `setHtml` to that the widget's state is first set to disabled, then call `super().setHtlm` and finally restore the initial state.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation