### PR TITLE
[FIX] owpaintdata: Adjust color model to input dataset

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -794,6 +794,7 @@ class OWPaintData(OWWidget):
 
         self.input_data = None
         self.input_classes = []
+        self.input_colors = None
         self.input_has_attr2 = True
         self.current_tool = None
         self._selected_indices = None
@@ -1016,9 +1017,12 @@ class OWPaintData(OWWidget):
             if data.domain.class_vars:
                 self.Warning.continuous_target()
             self.input_classes = ["C1"]
+            self.input_colors = None
             y = np.zeros(len(data))
         else:
             self.input_classes = y.values
+            self.input_colors = y.colors
+
             y = data[:, y].Y
 
         self.input_has_attr2 = len(data.domain.attributes) >= 2
@@ -1036,7 +1040,16 @@ class OWPaintData(OWWidget):
         self.undo_stack.clear()
 
         index = self.selected_class_label()
+        if self.input_colors is not None:
+            colors = self.input_colors
+        else:
+            colors = colorpalette.DefaultRGBColors
+        palette = colorpalette.ColorPaletteGenerator(
+            number_of_colors=len(colors), rgb_colors=colors)
+        self.colors = palette
+        self.class_model.colors = palette
         self.class_model[:] = self.input_classes
+
         newindex = min(max(index, 0), len(self.class_model) - 1)
         itemmodels.select_row(self.classValuesView, newindex)
 

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -4,7 +4,7 @@
 import numpy as np
 from AnyQt.QtCore import QRectF, QPointF
 
-from Orange.data import Table
+from Orange.data import Table, DiscreteVariable, ContinuousVariable, Domain
 from Orange.widgets.data import owpaintdata
 from Orange.widgets.data.owpaintdata import OWPaintData
 from Orange.widgets.tests.base import WidgetTest
@@ -43,3 +43,12 @@ class TestOWPaintData(WidgetTest):
         np.testing.assert_equal(output1.Y, output1_copy.Y)
 
         self.assertTrue(np.any(output1.X != output2.X))
+
+    def test_20_values_class(self):
+        domain = Domain(
+            [ContinuousVariable("A"),
+             ContinuousVariable("B")],
+            DiscreteVariable("C", values=[chr(ord("a") + i) for i in range(20)])
+        )
+        data = Table(domain, [[0.1, 0.2, "a"], [0.4, 0.7, "t"]])
+        self.send_signal("Data", data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix a IndexError when the input dataset's class variable has more then 17 values.
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/scheme/widgetsscheme.py", line 822, in process_signals_for_widget
    handler(*args)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1029, in set_data
    self.reset_to_input()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1051, in reset_to_input
    self._replot()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1230, in _replot
    pens = [pen(self.colors[i]) for i in range(nclasses)]
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owpaintdata.py", line 1230, in <listcomp>
    pens = [pen(self.colors[i]) for i in range(nclasses)]
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/colorpalette.py", line 657, in __getitem__
    return QColor(*self.getRGB(value))
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/colorpalette.py", line 667, in getRGB
    return self.rgb_array[-1 if np.isnan(value) else int(value)]
IndexError: index 18 is out of bounds for axis 0 with size 18
```

##### Description of changes

Adjust the color palette to the input dataset's class var colors.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
