### PR TITLE
testing: Use sklearn model_selection module instead of cross_validation module

### DIFF
--- a/Orange/regression/linear_bfgs.py
+++ b/Orange/regression/linear_bfgs.py
@@ -102,8 +102,8 @@ class LinearRegressionModel(Model):
 
 if __name__ == '__main__':
     import Orange.data
-    import sklearn.cross_validation as skl_cross_validation
-    
+    from Orange.evaluation import CrossValidation
+
     np.random.seed(42)
 
     def numerical_grad(f, params, e=1e-4):
@@ -136,7 +136,8 @@ if __name__ == '__main__':
     for lambda_ in (0.01, 0.03, 0.1, 0.3, 1, 3):
         m = LinearRegressionLearner(lambda_=lambda_)
         scores = []
-        for tr_ind, te_ind in skl_cross_validation.KFold(d.X.shape[0]):
+        res = CrossValidation(d, [m], 3, False)
+        for tr_ind, te_ind in res.indices:
             s = np.mean((m(d[tr_ind])(d[te_ind]) - d[te_ind].Y.ravel())**2)
             scores.append(s)
         print('{:5.2f} {}'.format(lambda_, np.mean(scores)))

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -1657,18 +1657,17 @@ def drop_columns(data, columns):
 
 
 def test():
-    import sklearn.cross_validation as skl_cross_validation
+    from Orange.evaluation import ShuffleSplit
+
     app = QApplication([])
     w = OWVennDiagram()
     data = Orange.data.Table("brown-selected")
     data = append_column(data, "M", Orange.data.StringVariable("Test"),
                          numpy.arange(len(data)).reshape(-1, 1) % 30)
 
-    indices = skl_cross_validation.ShuffleSplit(
-        len(data), n_iter=5, test_size=0.7
-    )
-
-    indices = iter(indices)
+    res = ShuffleSplit(data, [None], n_resamples=5,
+                       test_size=0.7, stratified=False)
+    indices = iter(res.indices)
 
     def select(data):
         sample, _ = next(indices)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Sklearn cross_validation module is deprecated and will be removed in 0.20, so module model_selection should be used instead.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
