### PR TITLE
[FIX] scatterplot: Fix density image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,14 @@ matrix:
           env: BUILD_DOCS=true
           python: '3.4'
           script: source $TRAVIS_BUILD_DIR/.travis/build_doc.sh
-        - python: '3.5'
+        - &pyqt5
+          python: '3.5'
           env: PYQT5=true
           dist: trusty
           addons: { apt: { packages: [] } }
     allow_failures:
         - *pylint
+        - *pyqt5
     fast_finish: true
 
 cache:

--- a/Orange/widgets/utils/classdensity.py
+++ b/Orange/widgets/utils/classdensity.py
@@ -27,7 +27,7 @@ def class_density_image(min_x, max_x, min_y, max_y, resolution, x_data, y_data, 
     y_grid_norm = (np.array(y_grid)-min_y)/(max_y-min_y)
     img = compute_density(x_grid_norm, y_grid_norm,
                           x_data_norm[sample], y_data_norm[sample], np.array(rgb_data)[sample])
-    density_img = ImageItem(img, autoLevels=False)
+    density_img = ImageItem(img.astype(np.uint8), autoLevels=False)
     density_img.setRect(QRectF(min_x-x_sz/2, min_y-y_sz/2,
                                     max_x-min_x+x_sz, max_y-min_y+y_sz))
     density_img.setZValue(-1)


### PR DESCRIPTION
##### Issue
The density image (crashes) in scatterplot doesn't display with the latest version of pyqtgraph 0.10.

##### Description of changes
Change the dtype of the computed numpy array of pixel values to reflect the actual range of values and prevent "automatic" scaling (crashing) by pyqtgraph.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
