### PR TITLE
[FIX] Loading iris on C locale

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -376,7 +376,7 @@ class FileFormat(metaclass=FileFormatMeta):
         if isinstance(filename, str) and hasattr(data, 'attributes'):
             if all(isinstance(key, str) and isinstance(value, str)
                    for key, value in data.attributes.items()):
-                with open(filename + '.metadata', 'w') as f:
+                with open(filename + '.metadata', 'w', encoding='utf-8') as f:
                     f.write("\n".join("{}: {}".format(*kv)
                                       for kv in data.attributes.items()))
             else:
@@ -392,7 +392,7 @@ class FileFormat(metaclass=FileFormatMeta):
                     table.attributes = pickle.load(f)
             # Unpickling throws different exceptions, not just UnpickleError
             except:
-                with open(filename + '.metadata') as f:
+                with open(filename + '.metadata', encoding='utf-8') as f:
                     table.attributes = OrderedDict(
                         (k.strip(), v.strip())
                         for k, v in (line.split(":", 1)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -259,7 +259,6 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             self, 'Open Orange Data File', start_file, self.dlg_formats)
         if not filename:
             return
-        self.loaded_file = filename
         self.add_path(filename)
         self.source = self.LOCAL_FILE
         self.load_data()
@@ -305,7 +304,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         self.info.setText(self._describe(data))
 
-        add_origin(data, self.loaded_file or self.last_path())
+        self.loaded_file = self.last_path()
+        add_origin(data, self.loaded_file)
         self.data = data
         self.openContext(data.domain)
         self.apply_domain_edit()  # sends data
@@ -426,7 +426,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             home = os.path.expanduser("~")
             if self.loaded_file.startswith(home):
                 # os.path.join does not like ~
-                name = "~/" + \
+                name = "~" + os.path.sep + \
                        self.loaded_file[len(home):].lstrip("/").lstrip("\\")
             else:
                 name = self.loaded_file


### PR DESCRIPTION
##### Issue
https://github.com/biolab/orange3/issues/1997

##### Description of changes
Load *.metadata as UTF-8. Additionally, fix reporting filename and filetype in OWFile.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
