### PR TITLE
Fix some Orange Widget writing tutorial errors

### DIFF
--- a/doc/development/source/tutorial.rst
+++ b/doc/development/source/tutorial.rst
@@ -137,7 +137,7 @@ How about displaying a number?
        description = "Print out a number"
        icon = "icons/print.svg"
 
-       inputs = [("Number", int, "set_number")
+       inputs = [("Number", int, "set_number")]
        outputs = []
 
        want_main_area = False

--- a/doc/development/source/tutorial.rst
+++ b/doc/development/source/tutorial.rst
@@ -52,13 +52,14 @@ We will start with a very simple example. A widget that will output
 a single integer specified by the user.
 
 .. code-block:: python
+
     from Orange.widgets import widget, gui
 
     class IntNumber(widget.OWWidget):
         # Widget's name as displayed in the canvas
         name = "Integer Number"
         # Short widget description
-        description "Lets the user input a number"
+        description = "Lets the user input a number"
 
         # An icon resource file path for this widget
         # (a path relative to the module where this widget is defined)


### PR DESCRIPTION
##### Issue
- Missing assignment `=` in code example.
- Missing ending square bracket of list in code example.
- Missing blank line after `.. code-block:: python` resulting with an invisible code example.

##### Description of changes

Added the above.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
