### PR TITLE
[FIX] data/io.py Metadata file not saved anymore when it is empty

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -373,7 +373,7 @@ class FileFormat(metaclass=FileFormatMeta):
 
     @classmethod
     def write_table_metadata(cls, filename, data):
-        if isinstance(filename, str) and hasattr(data, 'attributes'):
+        if isinstance(filename, str) and getattr(data, 'attributes', None):
             if all(isinstance(key, str) and isinstance(value, str)
                    for key, value in data.attributes.items()):
                 with open(filename + '.metadata', 'w') as f:

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -206,3 +206,23 @@ class TestTabReader(unittest.TestCase):
         table2 = TabReader(table1.__file__).read()
         self.assertEqual(table1.name, 'iris')
         self.assertEqual(table2.name, 'iris')
+
+    def test_metadata(self):
+        tempdir = tempfile.mkdtemp()
+        table = Table("titanic")
+        table.attributes = OrderedDict()
+        table.attributes["a"] = "aa"
+        table.attributes["b"] = "bb"
+        fname = path.join(tempdir, "out.tab")
+        TabReader.write_table_metadata(fname, table)
+        self.assertTrue(path.isfile(fname + ".metadata"))
+        shutil.rmtree(tempdir)
+
+    def test_no_metadata(self):
+        tempdir = tempfile.mkdtemp()
+        table = Table("titanic")
+        table.attributes = OrderedDict()
+        fname = path.join(tempdir, "out.tab")
+        TabReader.write_table_metadata(fname, table)
+        self.assertFalse(path.isfile(fname + ".metadata"))
+        shutil.rmtree(tempdir)


### PR DESCRIPTION
##### Issue
Do not save the metadata file (when saving the data) if this is empty (0 Bytes)


##### Description of changes
Change if statement and add third condition. It implies that attribute should not be empty. Add test file to check if metadata is saved when empty

##### Includes
- [x] Code changes
- [X] Tests
- [ ] Documentation
