### PR TITLE
util.Reprable: more generic equals (handle array_like types)

### DIFF
--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -33,6 +33,19 @@ class TestUtil(unittest.TestCase):
         self.assertFalse(try_(lambda: np.whatever()))
         self.assertEqual(try_(len, default=SOMETHING), SOMETHING)
 
+    def test_reprable(self):
+        from Orange.data import ContinuousVariable
+        from Orange.preprocess.impute import ReplaceUnknownsRandom
+        from Orange.statistics.distribution import Continuous
+
+        var = ContinuousVariable('x')
+        transform = ReplaceUnknownsRandom(var, Continuous(1, var))
+
+        self.assertEqual(repr(transform).replace('\n       ', ' '),
+                         "ReplaceUnknownsRandom("
+                         "variable=ContinuousVariable(name='x', number_of_decimals=3), "
+                         "distribution=Continuous([[ 0.], [ 0.]]))")
+
     def test_deepgetattr(self):
         class a:
             l = []


### PR DESCRIPTION
##### Issue
`repr()` on complex Reprable objects with reprable properties of `np.ndarray` (or similar array_like types) would  fail with standard
```text
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

##### Description of changes
Make equality comparison more robust. Can't believe how hard it is in Python to equals-compare two object's values in a generic fashion!

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
