### PR TITLE
[FIX] Import from AnyQt instead from PyQt4

### DIFF
--- a/Orange/widgets/utils/__init__.py
+++ b/Orange/widgets/utils/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from PyQt4.QtCore import QObject
+from AnyQt.QtCore import QObject
 
 from Orange.data.variable import TimeVariable
 from Orange.util import deepgetattr


### PR DESCRIPTION
##### Issue
Get rids of a RuntimeWarning when starting Orange

##### Description of changes
Import from AnyQt instead from PyQt4

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation