### PR TITLE
[FIX] OWMosaic:  Fix crash for empty column

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -353,6 +353,23 @@ class OWMosaicDisplay(OWWidget):
         else:
             self.update_graph()
 
+    def _get_discrete_data(self, data):
+        """
+        Discretizes continuous attributes.
+        Returns None when there is no data, no rows, or no discrete or continuous attributes.
+        """
+        if (data is None or
+                not len(data) or
+                not any(attr.is_discrete or attr.is_continuous
+                        for attr in chain(data.domain, data.domain.metas))):
+            return None
+        elif any(attr.is_continuous for attr in data.domain):
+            return Discretize(
+                method=EqualFreq(n=4), remove_const=False, discretize_classes=True,
+                discretize_metas=True)(data)
+        else:
+            return data
+
     def init_combos(self, data):
         for combo in self.attr_combos:
             combo.clear()
@@ -400,17 +417,7 @@ class OWMosaicDisplay(OWWidget):
         self.closeContext()
         self.data = data
         self.init_combos(self.data)
-        if (self.data is None or
-                not len(self.data) or
-                not any(attr.is_discrete or attr.is_continuous
-                        for attr in chain(data.domain, data.domain.metas))):
-            self.discrete_data = None
-        elif any(attr.is_continuous for attr in data.domain):
-            self.discrete_data = Discretize(
-                method=EqualFreq(n=4), remove_const=False, discretize_classes=True,
-                discretize_metas=True)(data)
-        else:
-            self.discrete_data = self.data
+        self.discrete_data = self._get_discrete_data(self.data)
 
         self.vizrank.stop_and_reset()
         self.vizrank_button.setEnabled(

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -400,8 +400,10 @@ class OWMosaicDisplay(OWWidget):
         self.closeContext()
         self.data = data
         self.init_combos(self.data)
-        if self.data is None or not len(self.data) or not  \
-                any(attr.is_discrete or attr.is_continuous for attr in chain(data.domain, data.domain.metas)):
+        if (self.data is None or
+                not len(self.data) or
+                not any(attr.is_discrete or attr.is_continuous
+                        for attr in chain(data.domain, data.domain.metas))):
             self.discrete_data = None
         elif any(attr.is_continuous for attr in data.domain):
             self.discrete_data = Discretize(

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -400,7 +400,8 @@ class OWMosaicDisplay(OWWidget):
         self.closeContext()
         self.data = data
         self.init_combos(self.data)
-        if self.data is None or not len(self.data):
+        if self.data is None or not len(self.data) or not  \
+                any(attr.is_discrete or attr.is_continuous for attr in chain(data.domain, data.domain.metas)):
             self.discrete_data = None
         elif any(attr.is_continuous for attr in data.domain):
             self.discrete_data = Discretize(

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -5,7 +5,7 @@ import numpy as np
 from AnyQt.QtCore import QEvent, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
 
-from Orange.data import Table, DiscreteVariable, Domain, ContinuousVariable
+from Orange.data import Table, DiscreteVariable, Domain, ContinuousVariable, StringVariable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.visualize.owmosaic import OWMosaicDisplay, MosaicVizRank
 
@@ -28,7 +28,7 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
 
     def test_empty_column(self):
         """Check that the widget doesn't crash if the columns are empty"""
-        self.send_signal("Data", self.data[:,:0])
+        self.send_signal("Data", self.data[:, :0])
 
     def _select_data(self):
         self.widget.select_area(1, QMouseEvent(
@@ -42,6 +42,13 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
                         metas=[ContinuousVariable("m")])
         data = Table(domain, np.arange(6).reshape(6, 1),
                      metas=np.arange(6).reshape(6, 1))
+        self.send_signal("Data", data)
+
+    def test_string_meta(self):
+        """Check widget for dataset with only one string meta"""
+        domain = Domain([], metas=[StringVariable("m")])
+        data = Table(domain, np.empty((6, 0)),
+                     metas=np.array(["meta"] * 6).reshape(6, 1))
         self.send_signal("Data", data)
 
     def test_missing_values(self):

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -26,6 +26,10 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         """Check that the widget doesn't crash on empty data"""
         self.send_signal("Data", self.data[:0])
 
+    def test_empty_column(self):
+        """Check that the widget doesn't crash if the columns are empty"""
+        self.send_signal("Data", self.data[:,:0])
+
     def _select_data(self):
         self.widget.select_area(1, QMouseEvent(
             QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,


### PR DESCRIPTION
##### Issue
Widget crashes if the columns are empty.
To reproduce: Connect data to Select Columns. Remove features, target variable and meta attributes. Connect to Mosaic Display.

##### Description of changes
Added an extra check in in set_data().

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
