### PR TITLE
[FIX] Handle KeyError Sieve Diagram widget (owsieve) when one row

### DIFF
--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -168,7 +168,7 @@ class OWSieveDiagram(OWWidget):
             self.domain_model.set_domain(data.domain)
             if any(attr.is_continuous for attr in data.domain):
                 discretizer = Discretize(
-                    method=EqualFreq(n=4),
+                    method=EqualFreq(n=4),remove_const=False,
                     discretize_classes=True, discretize_metas=True)
                 self.discrete_data = discretizer(data)
             else:

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -37,3 +37,12 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         X = np.array([1, 2, 0, 1, 0, 2])[:, None]
         data = Table(Domain(attrs, class_var), X, np.array([np.nan] * 6))
         self.send_signal("Data", data)
+
+    def test_keyerror(self):
+        """gh-2007
+        Check if it works when a table has only one row or duplicates.
+        Discretizer must have remove_const set to False.
+        """
+        data = Table("iris")
+        data = data[0:1]
+        self.send_signal("Data", data)


### PR DESCRIPTION
… selected


##### Issue
KeyError thrown when only one row selected in data table.


##### Description of changes
KeyError fix - Handle the error and show the message on top of the widget.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
