### PR TITLE
Enable HighDPI support

### DIFF
--- a/Orange/canvas/application/application.py
+++ b/Orange/canvas/application/application.py
@@ -12,6 +12,9 @@ class CanvasApplication(QApplication):
     fileOpenRequest = Signal(QUrl)
 
     def __init__(self, argv):
+        if hasattr(Qt, "AA_EnableHighDpiScaling"):
+            # Turn on HighDPI support when available
+            QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
         QApplication.__init__(self, argv)
         self.setAttribute(Qt.AA_DontShowIconsInMenus, True)
 


### PR DESCRIPTION
Fixes #2009 when used with pyqt5. Does not seem to break anything on OSX. Could use some more testing on linux (@kernc @lanzagar) and windows (@ajda)