### PR TITLE
OWMergeData: Merge by matching data

### DIFF
--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -268,6 +268,12 @@ def join_table_by_indices(left, right, indices):
     X = join_array_by_indices(left.X, right.X, indices)
     Y = join_array_by_indices(numpy.c_[left.Y], numpy.c_[right.Y], indices)
     metas = join_array_by_indices(left.metas, right.metas, indices)
+    for col, var in enumerate(domain.metas):
+        if var.is_string:
+            for row in range(metas.shape[0]):
+                cell = metas[row, col]
+                if type(cell) == float and numpy.isnan(cell):
+                    metas[row, col] = ""
 
     return Orange.data.Table.from_numpy(domain, X, Y, metas)
 
@@ -291,6 +297,10 @@ def join_array_by_indices(left, right, indices, masked=float("nan")):
     def hstack_blocks(blocks):
         return numpy.hstack(list(map(numpy.vstack, blocks)))
 
+    if left.shape[1] and left.dtype == object:
+        leftparts = numpy.array(leftparts).astype(object)
+    if right.shape[1] and right.dtype == object:
+        rightparts = numpy.array(rightparts).astype(object)
     return hstack_blocks((leftparts, rightparts))
 
 

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -228,37 +228,6 @@ def left_join_indices(table1, table2, vars1, vars2):
     return indices
 
 
-def right_join_indices(table1, table2, vars1, vars2):
-    indices = left_join_indices(table2, table1, vars2, vars1)
-    return [(j, i) for i, j in indices]
-
-
-def inner_join_indices(table1, table2, vars1, vars2):
-    indices = left_join_indices(table1, table2, vars1, vars2)
-    return [(i, j) for i, j in indices if j is not None]
-
-
-def left_join(left, right, left_vars, right_vars):
-    """
-    Left join `left` and `right` on values of `left/right_vars`.
-    """
-    indices = left_join_indices(left, right, left_vars, right_vars)
-    return join_table_by_indices(left, right, indices)
-
-
-def right_join(left, right, left_vars, right_vars):
-    """
-    Right join left and right on attributes attr1 and attr2
-    """
-    indices = right_join_indices(left, right, left_vars, right_vars)
-    return join_table_by_indices(left, right, indices)
-
-
-def inner_join(left, right, left_vars, right_vars):
-    indices = inner_join_indices(left, right, left_vars, right_vars)
-    return join_table_by_indices(left, right, indices)
-
-
 def join_table_by_indices(left, right, indices):
     domain = Orange.data.Domain(
         left.domain.attributes + right.domain.attributes,

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -1,20 +1,386 @@
-import unittest
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
 from collections import defaultdict
 
-from Orange.data import Table
-from Orange.widgets.data.owmergedata import group_table_indices
+import numpy as np
+
+from Orange.data import Table, Domain, DiscreteVariable, StringVariable
 from Orange.tests import test_filename
+from Orange.widgets.data.owmergedata import group_table_indices, OWMergeData
+from Orange.widgets.tests.base import WidgetTest
 
 
-class MergeDataTest(unittest.TestCase):
+class TestOWMergeData(WidgetTest):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        domainA = Domain([DiscreteVariable("d1", values=("a", "b"))],
+                         DiscreteVariable("c1", values=("aaa", "bbb")),
+                         [DiscreteVariable("m1", values=("aa", "bb"))])
+        XA = np.array([[0], [1], [0], [np.nan]])
+        yA = np.array([0, 1, 0, 1])
+        metasA = np.array([[0], [1], [np.nan], [1]]).astype(object)
+
+        domainB = Domain([DiscreteVariable("d2", values=("a", "c", "d"))],
+                         DiscreteVariable("c2", values=("bbb", "ddd")),
+                         [StringVariable("m2")])
+        XB = np.array([[1], [2], [1], [np.nan], [0]])
+        yB = np.array([0, 0, np.nan, 1, 1])
+        metasB = np.array([["cc"], [""], ["bb"], ["bb"], ["cc"]]).astype(object)
+        cls.dataA = Table(domainA, XA, yA, metasA)
+        cls.dataB = Table(domainB, XB, yB, metasB)
+
+    def setUp(self):
+        self.widget = self.create_widget(OWMergeData)
+
     def test_group_table_indices(self):
         table = Table(test_filename("test9.tab"))
         dd = defaultdict(list)
-        dd[("1",)] = [0, 1]
-        dd[("huh",)] = [2]
-        dd[("hoy",)] = [3]
-        dd[("?",)] = [4]
-        dd[("2",)] = [5]
-        dd[("oh yeah",)] = [6]
-        dd[("3",)] = [7]
-        self.assertEqual(dd, group_table_indices(table, ["g"]))
+        dd["1"] = [0, 1]
+        dd["huh"] = [2]
+        dd["hoy"] = [3]
+        dd["?"] = [4]
+        dd["2"] = [5]
+        dd["oh yeah"] = [6]
+        dd["3"] = [7]
+        self.assertEqual(dd, group_table_indices(table, "g"))
+
+    def test_output_merge_by_ids_inner(self):
+        """Check output for merging only matching values by IDs"""
+        domain = self.dataA.domain
+        result = Table(domain, np.array([[1], [0]]), np.array([1, 0]),
+                       np.array([[1.0], [np.nan]]).astype(object))
+        self.send_signal("Data A", self.dataA[:3, [0, -1]])
+        self.send_signal("Data B", self.dataA[1:, [0, "c1"]])
+        self.widget.attr_a = "Source position (index)"
+        self.widget.attr_b = "Source position (index)"
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_ids_outer(self):
+        """Check output for merging all values by IDs"""
+        self.send_signal("Data A", self.dataA[:, [0, -1]])
+        self.send_signal("Data B", self.dataA[:, [0, "c1"]])
+        self.widget.attr_a = "Source position (index)"
+        self.widget.attr_b = "Source position (index)"
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), self.dataA)
+
+    def test_output_merge_by_index_inner_AB(self):
+        """Check output for merging only matching values by row index"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[0, 1], [1, 2], [0, 1], [np.nan, np.nan]])
+        result_Y = np.array([[0, 0], [1, 0], [0, np.nan], [1, 1]])
+        result_M = np.array([[0.0, "cc"], [1.0, ""], [np.nan, "bb"],
+                             [1.0, "bb"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_index_inner_BA(self):
+        """Check output for merging only matching values by row index"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[1, 0], [2, 1], [1, 0], [np.nan, np.nan]])
+        result_Y = np.array([[0, 0], [0, 1], [np.nan, 0], [1, 1]])
+        result_M = np.array([["cc", 0.0], ["", 1.0], ["bb", np.nan],
+                             ["bb", 1.0]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_index_outer_AB(self):
+        """Check output for merging all values by row index"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[0, 1], [1, 2], [0, 1],
+                             [np.nan, np.nan], [np.nan, 0]])
+        result_Y = np.array([[0, 0], [1, 0], [0, np.nan], [1, 1], [np.nan, 1]])
+        result_M = np.array([[0.0, "cc"], [1.0, ""], [np.nan, "bb"],
+                             [1.0, "bb"], [np.nan, "cc"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_index_outer_BA(self):
+        """Check output for merging all values by row index"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[1, 0], [2, 1], [1, 0],
+                             [np.nan, np.nan], [0, np.nan]])
+        result_Y = np.array([[0, 0], [0, 1], [np.nan, 0], [1, 1], [1, np.nan]])
+        result_M = np.array([["cc", 0.0], ["", 1.0], ["bb", np.nan],
+                             ["bb", 1.0], ["cc", np.nan]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_attribute_inner_AB(self):
+        """Check output for merging only matching values by attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[0], [0]])
+        result_Y = np.array([[0, 1], [0, 1]])
+        result_M = np.array([[0.0, "cc"], [np.nan, "cc"]])
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.attr_a = domainA[0]
+        self.widget.attr_b = domainB[0]
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_attribute_inner_BA(self):
+        """Check output for merging only matching values by attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[0]])
+        result_Y = np.array([[1, 0]])
+        result_M = np.array([["cc", 0.0]])
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.attr_a = domainB[0]
+        self.widget.attr_b = domainA[0]
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_attribute_outer_AB(self):
+        """Check output for merging all values by attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[0, 0], [1, np.nan], [0, 0], [np.nan, np.nan],
+                             [np.nan, 1], [np.nan, 2], [np.nan, 1],
+                             [np.nan, np.nan]])
+        result_Y = np.array([[0, 1], [1, np.nan], [0, 1], [1, np.nan],
+                             [np.nan, 0], [np.nan, 0], [np.nan, np.nan],
+                             [np.nan, 1]])
+        result_M = np.array([[0.0, "cc"], [1.0, ""], [np.nan, "cc"], [1.0, ""],
+                             [np.nan, "cc"], [np.nan, ""], [np.nan, "bb"],
+                             [np.nan, "bb"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.attr_a = domainA[0]
+        self.widget.attr_b = domainB[0]
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_attribute_outer_BA(self):
+        """Check output for merging all values by attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[1, np.nan], [2, np.nan], [1, np.nan],
+                             [np.nan, np.nan], [0, 0], [np.nan, 1],
+                             [np.nan, np.nan]])
+        result_Y = np.array([[0, np.nan], [0, np.nan], [np.nan, np.nan],
+                             [1, np.nan], [1, 0], [np.nan, 1], [np.nan, 1]])
+        result_M = np.array([["cc", np.nan], ["", np.nan], ["bb", np.nan],
+                             ["bb", np.nan], ["cc", 0.0], ["", 1.0],
+                             ["", 1.0]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.attr_a = domainB[0]
+        self.widget.attr_b = domainA[0]
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_class_inner_AB(self):
+        """Check output for merging only matching values by class variable"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[1, 1], [np.nan, 1]])
+        result_Y = np.array([1, 1])
+        result_M = np.array([[1.0, "cc"], [1.0, "cc"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.attr_a = domainA.class_vars[0]
+        self.widget.attr_b = domainB.class_vars[0]
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_class_inner_BA(self):
+        """Check output for merging only matching values by class variable"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[1, 1], [2, 1]])
+        result_Y = np.array([0, 0])
+        result_M = np.array([["cc", 1.0], ["", 1.0]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.attr_a = domainB.class_vars[0]
+        self.widget.attr_b = domainA.class_vars[0]
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_class_outer_AB(self):
+        """Check output for merging all values by class variable"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[0, np.nan], [1, 1], [0, np.nan], [np.nan, 1],
+                             [np.nan, 1], [np.nan, np.nan], [np.nan, 0]])
+        result_Y = np.array([[0, np.nan], [1, 0], [0, np.nan], [1, 0],
+                             [np.nan, np.nan], [np.nan, 1], [np.nan, 1]])
+        result_M = np.array([[0.0, ""], [1.0, "cc"], [np.nan, ""], [1.0, "cc"],
+                             [np.nan, "bb"], [np.nan, "bb"],
+                             [np.nan, "cc"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.attr_a = domainA.class_vars[0]
+        self.widget.attr_b = domainB.class_vars[0]
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_class_outer_BA(self):
+        """Check output for merging all values by class variable"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[1, 1], [2, 1], [1, np.nan], [np.nan, np.nan],
+                             [0, np.nan], [np.nan, 0], [np.nan, 0]])
+        result_Y = np.array([[0, 1], [0, 1], [np.nan, np.nan], [1, np.nan],
+                             [1, np.nan], [np.nan, 0], [np.nan, 0]])
+        result_M = np.array([["cc", 1.0], ["", 1.0], ["bb", np.nan],
+                             ["bb", np.nan], ["cc", np.nan], ["", 0.0],
+                             ["", np.nan]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.attr_a = domainB.class_vars[0]
+        self.widget.attr_b = domainA.class_vars[0]
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_meta_inner_AB(self):
+        """Check output for merging only matching values by meta attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas)
+        result_X = np.array([[1, 1], [np.nan, 1]])
+        result_Y = np.array([[1, np.nan], [1, np.nan]])
+        result_M = np.array([[1.0], [1.0]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.attr_a = domainA.metas[0]
+        self.widget.attr_b = domainB.metas[0]
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_meta_inner_BA(self):
+        """Check output for merging only matching values by meta attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas)
+        result_X = np.array([[1, 1], [np.nan, 1]])
+        result_Y = np.array([[np.nan, 1], [1, 1]])
+        result_M = np.array([["bb"], ["bb"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.attr_a = domainB.metas[0]
+        self.widget.attr_b = domainA.metas[0]
+        self.widget.commit()
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_meta_outer_AB(self):
+        """Check output for merging all values by meta attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+
+        result_d = Domain(domainA.attributes + domainB.attributes,
+                          domainA.class_vars + domainB.class_vars,
+                          domainA.metas + domainB.metas)
+        result_X = np.array([[0, np.nan], [1, 1], [0, np.nan], [np.nan, 1],
+                             [np.nan, 1], [np.nan, 2], [np.nan, 0]])
+        result_Y = np.array([[0, np.nan], [1, np.nan], [0, np.nan], [1, np.nan],
+                             [np.nan, 0], [np.nan, 0], [np.nan, 1]])
+        result_M = np.array([[0.0, ""], [1.0, "bb"], [np.nan, ""], [1.0, "bb"],
+                             [np.nan, "cc"], [np.nan, ""],
+                             [np.nan, "cc"]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataA)
+        self.send_signal("Data B", self.dataB)
+        self.widget.attr_a = domainA.metas[0]
+        self.widget.attr_b = domainB.metas[0]
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def test_output_merge_by_meta_outer_BA(self):
+        """Check output for merging all values by meta attribute"""
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+        result_d = Domain(domainB.attributes + domainA.attributes,
+                          domainB.class_vars + domainA.class_vars,
+                          domainB.metas + domainA.metas)
+        result_X = np.array([[1, np.nan], [2, np.nan], [1, 1], [np.nan, 1],
+                             [0, np.nan], [np.nan, 0], [np.nan, 0]])
+        result_Y = np.array([[0, np.nan], [0, np.nan], [np.nan, 1], [1, 1],
+                             [1, np.nan], [np.nan, 0], [np.nan, 0]])
+        result_M = np.array([["cc", np.nan], ["", np.nan], ["bb", 1.0],
+                             ["bb", 1.0], ["cc", np.nan], ["", 0.0],
+                             ["", np.nan]]).astype(object)
+        result = Table(result_d, result_X, result_Y, result_M)
+
+        self.send_signal("Data A", self.dataB)
+        self.send_signal("Data B", self.dataA)
+        self.widget.attr_a = domainB.metas[0]
+        self.widget.attr_b = domainA.metas[0]
+        self.widget.controls.inner.setChecked(False)
+        self.assertTablesEqual(self.get_output("Merged Data"), result)
+
+    def assertTablesEqual(self, table1, table2):
+        self.assertEqual(table1.domain, table2.domain)
+        np.testing.assert_array_equal(table1.X, table2.X)
+        np.testing.assert_array_equal(table1.Y, table2.Y)
+        np.testing.assert_array_equal(table1.metas.astype(str),
+                                      table2.metas.astype(str))

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -596,7 +596,7 @@ class OWVennDiagram(widget.OWWidget):
             data = table_concat(selected_subsets)
             # Get all variables which are not constant between the same
             # item set
-            varying = varying_between(data, [item_id_var])
+            varying = varying_between(data, item_id_var)
 
             if source_var in varying:
                 varying.remove(source_var)
@@ -613,7 +613,7 @@ class OWVennDiagram(widget.OWWidget):
             annotated_data = table_concat(annotated_data_subsets)
             indices = numpy.hstack(annotated_data_masks)
             annotated_data = create_annotated_table(annotated_data, indices)
-            varying = varying_between(annotated_data, [item_id_var])
+            varying = varying_between(annotated_data, item_id_var)
             if source_var in varying:
                 varying.remove(source_var)
             annotated_data = reshape_wide(annotated_data, varying,
@@ -877,27 +877,22 @@ def unique_non_nan(ar):
     return uniq[~numpy.isnan(uniq)]
 
 
-def varying_between(table, idvarlist):
+def varying_between(table, idvar):
     """
     Return a list of all variables with non constant values between
-    groups defined by `idvarlist`.
+    groups defined by `idvar`.
 
     """
-    def inst_key(inst, vars):
-        return tuple(str(inst[var]) for var in vars)
-
-    excluded = set(idvarlist)
     all_possible = [var for var in table.domain.variables + table.domain.metas
-                    if var not in excluded]
+                    if var != idvar]
     candidate_set = set(all_possible)
 
-    idmap = group_table_indices(table, idvarlist)
-    values = {}
+    idmap = group_table_indices(table, idvar)
+
     varying = set()
     for indices in idmap.values():
         subset = table[indices]
         for var in list(candidate_set):
-            values = subset[:, var]
             values, _ = subset.get_column_view(var)
 
             if var.is_string:

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -53,7 +53,7 @@ class TestVennDiagram(unittest.TestCase):
 
     def test_varying_between_missing_vals(self):
         data = Table(test_filename("test9.tab"))
-        self.assertEqual(6, len(varying_between(data, [data.domain[0]])))
+        self.assertEqual(6, len(varying_between(data, data.domain[0])))
 
     def test_venn_diagram(self):
         sources = ["SVM Learner", "Naive Bayes", "Random Forest"]
@@ -79,7 +79,7 @@ class TestVennDiagram(unittest.TestCase):
             tables.append(temp_table)
 
         data = table_concat(tables)
-        varying = varying_between(data, [item_id_var])
+        varying = varying_between(data, item_id_var)
         if source_var in varying:
             varying.remove(source_var)
         data = reshape_wide(data, varying, [item_id_var], [source_var])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget should support two ways of producing output:
1. Merge data only by values that match - outputs inner join of the inputs
2. Merge all data - outputs outer join of the inputs

##### Description of changes
Use check box to distinguish between the two ways.
Fix appearance of missing values when metas are merged.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
