### PR TITLE
[FIX] Highcharts: Fix freezing on Qt5

### DIFF
--- a/Orange/widgets/_highcharts/orange-selection.js
+++ b/Orange/widgets/_highcharts/orange-selection.js
@@ -37,7 +37,7 @@ function unselectAllPoints(e) {
           e.target.parentElement.tagName.toLowerCase() == 'svg'))
         return true;
     this.deselectPointsIfNot(false);
-    _highcharts_bridge.on_selected_points([]);
+    pybridge._highcharts_on_selected_points([]);
 }
 
 function clickedPointSelect(e) {
@@ -49,7 +49,7 @@ function clickedPointSelect(e) {
         selected.splice(selected.indexOf(this.index), 1);
     } else
         points[this.series.index].push(this.index);
-    _highcharts_bridge.on_selected_points(points);
+    pybridge._highcharts_on_selected_points(points);
     return true;
 }
 
@@ -83,6 +83,6 @@ function rectSelectPoints(e) {
         }
     }
 
-    _highcharts_bridge.on_selected_points(this.getSelectedPointsForExport());
+    pybridge._highcharts_on_selected_points(this.getSelectedPointsForExport());
     return false;  // Don't zoom
 }

--- a/Orange/widgets/highcharts.py
+++ b/Orange/widgets/highcharts.py
@@ -152,6 +152,18 @@ class Highchart(WebviewWidget):
         self.enable_zoom = enable_zoom
         enable_point_select = '+' in enable_select
         enable_rect_select = enable_select.replace('+', '')
+
+        self._update_options_dict(options, enable_zoom, enable_select,
+                                  enable_point_select, enable_rect_select,
+                                  kwargs)
+
+        with open(self._HIGHCHARTS_HTML) as html:
+            self.setHtml(html.read() % dict(javascript=javascript,
+                                            options=json(options)),
+                         self.toFileURL(dirname(self._HIGHCHARTS_HTML)) + '/')
+
+    def _update_options_dict(self, options, enable_zoom, enable_select,
+                             enable_point_select, enable_rect_select, kwargs):
         if enable_zoom:
             _merge_dicts(options, _kwargs_options(dict(
                 mapNavigation_enableMouseWheelZoom=True,
@@ -169,11 +181,6 @@ class Highchart(WebviewWidget):
                 chart_events_selection='/**/rectSelectPoints/**/')))
         if kwargs:
             _merge_dicts(options, _kwargs_options(kwargs))
-
-        with open(self._HIGHCHARTS_HTML) as html:
-            self.setHtml(html.read() % dict(javascript=javascript,
-                                            options=json(options)),
-                         self.toFileURL(dirname(self._HIGHCHARTS_HTML)) + '/')
 
     def contextMenuEvent(self, event):
         """ Zoom out on right click. Also disable context menu."""

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -5,6 +5,7 @@ around either WebEngineView (extends QWebEngineView) or WebKitView
 (extends QWebView), as available.
 """
 import os
+from os.path import join, dirname, abspath
 import warnings
 from random import random
 from collections.abc import Mapping, Set, Sequence, Iterable
@@ -13,7 +14,6 @@ from itertools import count
 
 from urllib.parse import urljoin
 from urllib.request import pathname2url
-from os.path import join, dirname, abspath
 
 import numpy as np
 
@@ -92,7 +92,7 @@ if HAVE_WEBENGINE:
                 warnings.warn(
                     'To debug QWebEngineView, set environment variable '
                     'QTWEBENGINE_REMOTE_DEBUGGING={port} and then visit '
-                    'http://localhost:{port}/ in a Chromium-based browser. '
+                    'http://127.0.0.1:{port}/ in a Chromium-based browser. '
                     'See https://doc.qt.io/qt-5/qtwebengine-debugging.html '
                     'This has also been done for you.'.format(port=port))
             super().__init__(parent,
@@ -113,7 +113,7 @@ if HAVE_WEBENGINE:
                 with open(_WEBENGINE_INIT_WEBCHANNEL, encoding="utf-8") as f:
                     init_webchannel_src = f.read()
                 self._onloadJS(source + init_webchannel_src %
-                                   dict(exposeObject_prefix=self._EXPOSED_OBJ_PREFIX),
+                               dict(exposeObject_prefix=self._EXPOSED_OBJ_PREFIX),
                                name='webchannel_init',
                                injection_point=QWebEngineScript.DocumentCreation)
             else:
@@ -456,6 +456,11 @@ elif HAVE_WEBENGINE:
             self._objects = {}
 
         def send_object(self, name, obj):
+            if isinstance(obj, QObject):
+                raise ValueError(
+                    "QWebChannel doesn't transmit QObject instances. If you "
+                    "need a QObject available in JavaScript, pass it as a "
+                    "bridge in WebviewWidget constructor.")
             id = next(self._id_gen)
             value = self._objects[id] = dict(id=id, name=name, obj=obj)
             # Wait till JS is connected to receive objects

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -60,7 +60,7 @@ class _QWidgetJavaScriptWrapper(QObject):
         while isinstance(w, QWidget):
             if w.windowFlags() & (Qt.Window | Qt.Dialog):
                 return w.hide()
-            w = w.parent()
+            w = w.parent() if callable(w.parent) else w.parent
 
 
 if HAVE_WEBENGINE:


### PR DESCRIPTION
##### Issue
Highcharts froze on Qt5.

##### Description of changes
No longer freezes on Qt5 by passing a core object into JS by a different mechanism and at a different time.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
