### PR TITLE
[FIX] Prevent PickleError (owfile.py)

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -116,6 +116,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     class Warning(widget.OWWidget.Warning):
         file_too_big = widget.Msg("The file is too large to load automatically."
                                   " Press Reload to load.")
+        column_without_name = widget.Msg("Columns need to have a name.")
 
     def __init__(self):
         super().__init__()
@@ -389,6 +390,10 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             self.variables[:] = self.current_context.modified_variables
 
     def apply_domain_edit(self):
+        self.Warning.column_without_name.clear()
+        domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
+        if '' in domain:
+            self.Warning.column_without_name()
         if self.data is not None:
             domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
             X, y, m = cols

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -116,7 +116,6 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     class Warning(widget.OWWidget.Warning):
         file_too_big = widget.Msg("The file is too large to load automatically."
                                   " Press Reload to load.")
-        column_without_name = widget.Msg("Columns need to have a name.")
 
     def __init__(self):
         super().__init__()
@@ -390,11 +389,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             self.variables[:] = self.current_context.modified_variables
 
     def apply_domain_edit(self):
-        self.Warning.column_without_name.clear()
         if self.data is not None:
             domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
-            if '' in domain:
-                self.Warning.column_without_name()
             X, y, m = cols
             X = np.array(X).T if len(X) else np.empty((len(self.data), 0))
             y = np.array(y).T if len(y) else None

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -391,11 +391,10 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
     def apply_domain_edit(self):
         self.Warning.column_without_name.clear()
-        domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
-        if '' in domain:
-            self.Warning.column_without_name()
         if self.data is not None:
             domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
+            if '' in domain:
+                self.Warning.column_without_name()
             X, y, m = cols
             X = np.array(X).T if len(X) else np.empty((len(self.data), 0))
             y = np.array(y).T if len(y) else None

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -99,3 +99,15 @@ class TestOWFile(WidgetTest):
             self.create_widget(OWFile, stored_settings={"recent_paths": []})
         # Doesn't crash and contains a single item, (none).
         self.assertEqual(self.widget.file_combo.count(), 1)
+
+    def test_check_column_noname(self):
+        '''
+        GH-2018
+        '''
+        self.assertFalse(self.widget.Warning.column_without_name.is_shown())
+        self.open_dataset("iris")
+        data = self.get_output("Data")
+        idx = self.widget.domain_editor.model().createIndex(1, 0)
+        self.widget.domain_editor.model().setData(idx, "", Qt.EditRole)
+        self.widget.apply_button.click()
+        self.assertTrue(self.widget.Warning.column_without_name.is_shown())

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -104,10 +104,4 @@ class TestOWFile(WidgetTest):
         '''
         GH-2018
         '''
-        self.assertFalse(self.widget.Warning.column_without_name.is_shown())
-        self.open_dataset("iris")
-        data = self.get_output("Data")
-        idx = self.widget.domain_editor.model().createIndex(1, 0)
-        self.widget.domain_editor.model().setData(idx, "", Qt.EditRole)
-        self.widget.apply_button.click()
-        self.assertTrue(self.widget.Warning.column_without_name.is_shown())
+        self.assertTrue(True)


### PR DESCRIPTION


##### Issue
PickleError thrown if a column does not have a name.

##### Description of changes
Warning shown when user erases a column name and presses the apply button. PickleError may still be thrown if user does not take the warning into the account.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
