### PR TITLE
Tests OWAdaBoost: Add param tests for classification/regression data

### DIFF
--- a/Orange/widgets/model/tests/test_owadaboost.py
+++ b/Orange/widgets/model/tests/test_owadaboost.py
@@ -14,13 +14,12 @@ class TestOWAdaBoost(WidgetTest, WidgetLearnerTestMixin):
             OWAdaBoost, stored_settings={"auto_apply": False})
         self.init()
         self.parameters = [
-            # TODO Due to the way params are tested on the learner and the fact
-            # that learners only receive a subset of these parameters, this
-            # method of testing these parameters is not viable
-            # ParameterMapping('algorithm', self.widget.cls_algorithm_combo,
-            #                  self.widget.algorithms),
-            # ParameterMapping('loss', self.widget.reg_algorithm_combo,
-            #                  self.widget.losses),
+            ParameterMapping('algorithm', self.widget.cls_algorithm_combo,
+                             self.widget.algorithms,
+                             problem_type="classification"),
+            ParameterMapping('loss', self.widget.reg_algorithm_combo,
+                             [x.lower() for x in self.widget.losses],
+                             problem_type="regression"),
             ParameterMapping('learning_rate', self.widget.learning_rate_spin),
             ParameterMapping('n_estimators', self.widget.n_estimators_spin),
             ParameterMapping.from_attribute(


### PR DESCRIPTION
##### Issue
Re-enable the tests for ada boost widget now that #1968 is merged.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
