### PR TITLE
[FIX] Fix Chi2 computation for variables with values with no instances

### DIFF
--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -42,6 +42,7 @@ class ChiSqStats:
         self.expected = np.outer(self.probs_y, self.probs_x) * self.n
         self.residuals = \
             (self.observed - self.expected) / np.sqrt(self.expected)
+        self.residuals = np.nan_to_num(self.residuals)
         self.chisqs = self.residuals ** 2
         self.chisq = float(np.sum(self.chisqs))
         self.p = chi2.sf(

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from math import isnan
 import numpy as np
 
 from AnyQt.QtCore import QEvent, QPoint, Qt
@@ -8,6 +9,7 @@ from AnyQt.QtGui import QMouseEvent
 from Orange.data import DiscreteVariable, Domain, Table
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.visualize.owsieve import OWSieveDiagram
+from Orange.widgets.visualize.owsieve import ChiSqStats
 
 
 class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
@@ -46,3 +48,14 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         data = Table("iris")
         data = data[0:1]
         self.send_signal("Data", data)
+
+    def test_chisquare(self):
+        """
+         gh-2031
+         Check if it can calculate chi square when there are no attributes which suppose to be.
+        """
+        a = DiscreteVariable("a", values=["y", "n"])
+        b = DiscreteVariable("b", values=["y", "n", "o"])
+        table = Table(Domain([a, b]), list(zip("yynny", "ynyyn")))
+        chi = ChiSqStats(table, 0, 1)
+        self.assertFalse(isnan(chi.chisq))


### PR DESCRIPTION
Chi-squared test is nan when there are attributes which are not in the data. It is caused by division by zero because  code does not calculate limits. It actually suppose to be 0.

- [X] Code changes
- [X] Tests
- [ ] Documentation