### PR TITLE
[FIX] Prevent PickleError (owfile.py)

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -5,8 +5,7 @@ from warnings import catch_warnings
 import numpy as np
 from AnyQt.QtWidgets import \
     QStyle, QComboBox, QMessageBox, QFileDialog, QGridLayout, QLabel, \
-    QLineEdit
-from AnyQt.QtWidgets import QSizePolicy as Policy
+    QLineEdit, QSizePolicy as Policy
 from AnyQt.QtCore import Qt, QTimer, QSize
 
 from Orange.canvas.gui.utils import OSX_NSURL_toLocalFile

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -127,3 +127,15 @@ class TestOWFile(WidgetTest):
         # Open a sample dataset
         self.open_dataset("iris")
         self.assertFalse(self.widget.Error.file_not_found.is_shown())
+
+    def test_check_column_noname(self):
+        """
+        GH-2018
+        """
+        self.open_dataset("iris")
+        idx = self.widget.domain_editor.model().createIndex(1, 0)
+        temp = self.widget.domain_editor.model().data(idx, Qt.DisplayRole)
+        self.widget.domain_editor.model().setData(idx, "   ", Qt.EditRole)
+        self.assertEqual(self.widget.domain_editor.model().data(idx, Qt.DisplayRole), temp)
+        self.widget.domain_editor.model().setData(idx, "", Qt.EditRole)
+        self.assertEqual(self.widget.domain_editor.model().data(idx, Qt.DisplayRole), temp)

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -79,7 +79,7 @@ class VarTableModel(QAbstractTableModel):
         row, col = index.row(), index.column()
         row_data = self.variables[row]
         if role == Qt.EditRole:
-            if col == Column.name:
+            if col == Column.name and not (value.isspace() or value == ""):
                 row_data[col] = value
             elif col == Column.tpe:
                 vartype = self.name2type[value]
@@ -125,7 +125,7 @@ class ComboDelegate(HorizontalGridDelegate):
             def hidePopup(me):
                 if me.popup_shown:
                     self.view.model().setData(
-                            index, me.highlighted_text, Qt.EditRole)
+                        index, me.highlighted_text, Qt.EditRole)
                     self.popup_shown = False
                 super().hidePopup()
                 self.view.closeEditor(me, self.NoHint)
@@ -211,9 +211,9 @@ class DomainEditor(QTableView):
 
         for (name, tpe, place, _, _), (orig_var, orig_plc) in \
                 zip(variables,
-                    chain([(at, Place.feature) for at in domain.attributes],
-                          [(cl, Place.class_var) for cl in domain.class_vars],
-                          [(mt, Place.meta) for mt in domain.metas])):
+                        chain([(at, Place.feature) for at in domain.attributes],
+                              [(cl, Place.class_var) for cl in domain.class_vars],
+                              [(mt, Place.meta) for mt in domain.metas])):
             if place == Place.skip:
                 continue
             if orig_plc == Place.meta:
@@ -277,7 +277,8 @@ class DomainEditor(QTableView):
             return False
 
         def discrete_value_display(value_list):
-            result = ", ".join(str(v) for v in value_list[:VarTableModel.DISCRETE_VALUE_DISPLAY_LIMIT])
+            result = ", ".join(str(v)
+                               for v in value_list[:VarTableModel.DISCRETE_VALUE_DISPLAY_LIMIT])
             if len(value_list) > VarTableModel.DISCRETE_VALUE_DISPLAY_LIMIT:
                 result += ", ..."
             return result


### PR DESCRIPTION
##### Issue
PickleError thrown if a column does not have a name.

##### Description of changes
Column name cannot be changed to an empty string or a string with whitespaces.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation