### PR TITLE
DomainContextHandler: Encode anonymous variables

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -987,9 +987,8 @@ class DomainContextHandler(ContextHandler):
             setattr(widget, self.reservoir, ll)
 
     def encode_setting(self, context, setting, value):
-        value = copy.copy(value)
         if isinstance(value, list):
-            return value
+            return copy.copy(value)
         elif isinstance(setting, ContextSetting):
             if isinstance(value, str):
                 if not setting.exclude_attributes and value in context.attributes:
@@ -998,7 +997,7 @@ class DomainContextHandler(ContextHandler):
                     return value, context.metas[value]
             elif isinstance(value, Variable):
                 return value.name, 100 + vartype(value)
-        return value, -2
+        return copy.copy(value), -2
 
     def decode_setting(self, setting, value, domain=None):
         if isinstance(value, tuple):

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -261,6 +261,11 @@ class TestDomainContextHandler(TestCase):
         val = self.handler.encode_setting(None, setting, var)
         self.assertEqual(val, (var.name, 100 + vartype(var)))
 
+        # Should not crash on anonymous variables
+        var.name = ""
+        val = self.handler.encode_setting(None, setting, var)
+        self.assertEqual(val, (var.name, 100 + vartype(var)))
+
     def test_decode_setting(self):
         setting = ContextSetting(None)
 


### PR DESCRIPTION
##### Issue
Variables are encoded as `name, type` pairs so there is no reason that anonymous variables could not be stored as settings.

The error was caused by calling copy.copy on all values, even those that would not be used in encoded representation.

##### Description of changes
copy only when necessary

##### Includes
- [X] Code changes
- [X] Tests
