### PR TITLE
[FIX] OWTreeGraph: Update node text when selecting target class

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -237,6 +237,7 @@ class OWTreeGraph(OWTreeViewer2D):
         if self.domain.class_var.is_discrete:
             self.target_class_index = i
             self.toggle_node_color_cls()
+            self.set_node_info()
         else:
             self.regression_colors = i
             self.toggle_node_color_reg()

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -26,3 +26,12 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
         node = self.widget.scene.nodes()[0]
         node.setSelected(True)
         return self.model.get_indices([node.node_inst])
+
+    def test_target_class_changed(self):
+        """Check if node content has changed after selecting target class"""
+        self.send_signal(self.signal_name, self.signal_data)
+        nodes = self.widget.scene.nodes()
+        text = nodes[0].toPlainText()
+        self.widget.color_combo.activated.emit(1)
+        self.widget.color_combo.setCurrentIndex(1)
+        self.assertNotEqual(nodes[0].toPlainText(), text)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
To reproduce: File (iris) -> Classification Tree -> Tree Viewer -> Select i.e. Iris-setosa (Target class combo) -> nodes texts remain unchanged (only color changes).

##### Description of changes
Change nodes text after Target class has changed

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
