### PR TITLE
addons: Show nicer names in addon dialog

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -183,6 +183,15 @@ def get_meta_from_archive(path):
                 for key in ('Name', 'Version', 'Description', 'Summary')]
 
 
+def cleanup(name, sep="-"):
+    """Used for sanitizing addon names. The function removes Orange/Orange3
+    from the name and adds spaces before upper letters of the leftover to
+    separate its words."""
+    prefix, separator, postfix = name.partition(sep)
+    name = postfix if separator == sep else prefix
+    return " ".join(re.findall("[A-Z][a-z]*", name[0].upper() + name[1:]))
+
+
 class AddonManagerWidget(QWidget):
 
     statechanged = Signal()
@@ -277,7 +286,7 @@ class AddonManagerWidget(QWidget):
             else:
                 item1.setCheckState(Qt.Unchecked)
 
-            item2 = QStandardItem(name)
+            item2 = QStandardItem(cleanup(name))
 
             item2.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable)
             item2.setToolTip(summary)

--- a/Orange/canvas/application/tests/test_addons.py
+++ b/Orange/canvas/application/tests/test_addons.py
@@ -1,0 +1,15 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.canvas.application.addons import cleanup
+from Orange.canvas.gui import test
+
+
+class TestSchemeInfo(test.QAppTestCase):
+    def test_cleanup_name(self):
+        """Test 'cleaning up' of potential names for addons"""
+        names = ["Orange3-Data-Fusion", "Orange3 - Text", "Orange3-spark",
+                 "Orange-Bioinformatics", "Orange3-ImageAnalytics", "Associate"]
+        for name in names:
+            name = cleanup(name)
+            self.assertIsNotNone(name)
+            self.assertNotEqual("", name)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Names in addon dialog should be nicer.

##### Description of changes
Remove Orange/Orange3 from addon names and add spaces before upper letters to separate words of the name.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
