### PR TITLE
OWBaseLearner.set_preprocessor: accept a single preprocessor

### DIFF
--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -1,3 +1,5 @@
+from collections import Sequence
+
 import numpy as np
 from AnyQt.QtCore import QTimer, Qt
 
@@ -158,6 +160,8 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
         return []
 
     def set_preprocessor(self, preprocessor):
+        if not isinstance(preprocessor, Sequence):
+            preprocessor = (preprocessor,)
         self.preprocessors = preprocessor
         self.apply()
 

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring
 from Orange.base import Learner, Model
 from Orange.data import Table, Domain
+from Orange.preprocess import Normalize
+from Orange.widgets.model.owlogisticregression import OWLogisticRegression
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 from Orange.widgets.tests.base import WidgetTest
 
@@ -34,3 +36,14 @@ class TestOWBaseLearner(WidgetTest):
         self.assertTrue(self.widget.Error.fitting_failed.is_shown())
         self.send_signal("Data", None)
         self.assertFalse(self.widget.Error.fitting_failed.is_shown())
+
+    def test_set_preprocessor(self):
+        w = self.create_widget(OWLogisticRegression)  # type: OWLogisticRegression
+        assert isinstance(w, OWBaseLearner)
+
+        for preprocessor in (Normalize(),
+                             [Normalize()]):
+            with self.subTest(preprocessor=preprocessor):
+                w.set_preprocessor(preprocessor)
+                learner = w.create_learner()
+                learner.fit_storage(self.iris)


### PR DESCRIPTION
Before e3dc8f212397f6b95eace371e61f809fbd39fbfb, passing a single
preprocessor was allowed. Any reason not to?

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
