### PR TITLE
Highcharts+WebView minor updates

### DIFF
--- a/Orange/widgets/_highcharts/orange-selection.js
+++ b/Orange/widgets/_highcharts/orange-selection.js
@@ -28,6 +28,21 @@ Highcharts.Chart.prototype.getSelectedPointsForExport = function() {
     return points;
 };
 
+Highcharts.wrap(Highcharts.Point.prototype, 'select', function (proceed) {
+    // Super call with the original arguments
+    proceed.apply(this, Array.prototype.slice.call(arguments, 1));
+
+    // Raise selected point to front
+    if (this.selected) {
+        this.graphic.element.parentNode.appendChild(this.graphic.element);
+    } else {
+        // or lower deselected point to back
+        this.graphic.element.parentNode.insertBefore(
+            this.graphic.element,
+            this.graphic.element.parentNode.firstChild);
+    }
+});
+
 function unselectAllPoints(e) {
     // Only handle left click on the canvas area, if no modifier pressed
     if (e.ctrlKey  ||

--- a/Orange/widgets/highcharts.py
+++ b/Orange/widgets/highcharts.py
@@ -242,15 +242,6 @@ class Highchart(WebviewWidget):
             }; 0;
         ''')
 
-    def svg(self):
-        """
-        Returns div that is container of a chart.
-        This method overrides svg method from WebView because
-        SVG itself does not contain chart labels (title, axis labels, ...)
-        """
-        html = self.html()
-        return html[html.index('<div id="container"'):html.rindex('</div>') + 6]
-
 
 def main():
     """ A simple test. """

--- a/Orange/widgets/io.py
+++ b/Orange/widgets/io.py
@@ -5,6 +5,7 @@ from AnyQt.QtWidgets import (
 )
 
 from Orange.data.io import FileFormat
+from Orange.widgets.utils.webview import WebviewWidget
 
 
 class ImgFormat(FileFormat):
@@ -148,3 +149,18 @@ class SvgFormat(ImgFormat):
     @staticmethod
     def _export(exporter, filename):
         exporter.export(filename)
+
+    @classmethod
+    def write_image(cls, filename, scene):
+        # WebviewWidget exposes its SVG contents more directly;
+        # no need to go via QPainter if we can avoid it
+        if isinstance(scene, WebviewWidget):
+            try:
+                svg = scene.svg()
+                with open(filename, 'w') as f:
+                    f.write(svg)
+                return
+            except (ValueError, IOError):
+                pass
+
+        super().write_image(filename, scene)

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -1,7 +1,9 @@
 import os
-import sip
+import time
 import unittest
 from unittest.mock import Mock
+
+import sip
 
 import numpy as np
 from AnyQt.QtWidgets import (
@@ -137,12 +139,34 @@ class WidgetTest(GuiTest):
             settings_handler.global_contexts = []
 
     @staticmethod
-    def process_events():
-        """Process Qt events.
+    def process_events(until: callable=None):
+        """Process Qt events, optionally until `until` returns
+        something True-ish.
 
         Needs to be called manually as QApplication.exec is never called.
+
+        Parameters
+        ----------
+        until: callable or None
+            If callable, the events are processed until the function returns
+            something True-ish.
+
+        Returns
+        -------
+        If until is not None, the True-ish result of its call.
         """
-        app.processEvents()
+        if until is None:
+            until = lambda: True
+
+        while True:
+            app.processEvents()
+            try:
+                result = until()
+                if result:
+                    return result
+            except Exception:  # until can fail with anything; pylint: disable=broad-except
+                pass
+            time.sleep(.05)
 
     def show(self, widget=None):
         """Show widget in interactive mode.

--- a/Orange/widgets/tests/test_highcharts.py
+++ b/Orange/widgets/tests/test_highcharts.py
@@ -12,15 +12,35 @@ from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.highcharts import Highchart
 
 
-class SelectionScatter(Highchart):
+class Scatter(Highchart):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args,
+                         options=dict(chart=dict(type='scatter')),
+                         **kwargs)
+
+
+class SelectionScatter(Scatter):
     def __init__(self, bridge, selected_indices_callback):
         super().__init__(bridge=bridge,
                          enable_select='xy+',
-                         selection_callback=selected_indices_callback,
-                         options=dict(chart=dict(type='scatter')))
+                         selection_callback=selected_indices_callback)
 
 
 class HighchartTest(WidgetTest):
+    def test_svg_is_svg(self):
+        scatter = Scatter()
+        scatter.chart(dict(series=dict(data=[[0, 1],
+                                             [1, 2]])))
+        while True:
+            try:
+                svg = scatter.svg()
+                break
+            except ValueError:
+                qApp.processEvents()
+
+        self.assertEqual(svg[:5], '<svg ')
+        self.assertEqual(svg[-6:], '</svg>')
+
     @unittest.skipIf(os.environ.get('APPVEYOR'), 'test stalls on AppVeyor')
     @unittest.skipIf(sys.version_info[:2] <= (3, 4),
                      'the second iteration stalls on Travis / Py3.4')

--- a/Orange/widgets/tests/test_highcharts.py
+++ b/Orange/widgets/tests/test_highcharts.py
@@ -4,7 +4,6 @@ import sys
 import unittest
 
 from AnyQt.QtCore import Qt, QPoint, QObject
-from AnyQt.QtWidgets import qApp
 from AnyQt.QtTest import QTest
 
 from Orange.data import Table
@@ -31,12 +30,7 @@ class HighchartTest(WidgetTest):
         scatter = Scatter()
         scatter.chart(dict(series=dict(data=[[0, 1],
                                              [1, 2]])))
-        while True:
-            try:
-                svg = scatter.svg()
-                break
-            except ValueError:
-                qApp.processEvents()
+        svg = self.process_events(lambda: scatter.svg())
 
         self.assertEqual(svg[:5], '<svg ')
         self.assertEqual(svg[-6:], '</svg>')
@@ -64,9 +58,7 @@ class HighchartTest(WidgetTest):
         scatter.chart(options=dict(series=[dict(data=data.X[:, :2])]))
         scatter.show()
 
-        while scatter.isHidden() or not scatter.geometry().isValid():
-            qApp.processEvents()
-            time.sleep(.05)
+        self.process_events(lambda: not scatter.isHidden() and scatter.geometry().isValid())
 
         time.sleep(1)  # add some time for WM to place window or whatever
         topleft = scatter.geometry().topLeft()
@@ -76,14 +68,12 @@ class HighchartTest(WidgetTest):
 
         # Simulate selection
         QTest.mousePress(scatter, Qt.LeftButton, Qt.NoModifier, startpos, 1000)
-        qApp.processEvents()
+        self.process_events()
         QTest.mouseMove(scatter, endpos)
-        qApp.processEvents()
+        self.process_events()
         QTest.mouseRelease(scatter, Qt.LeftButton, Qt.NoModifier, endpos, 100)
 
-        while not selected_indices:
-            qApp.processEvents()
-            time.sleep(.05)
+        self.process_events(lambda: len(selected_indices))
 
         self.assertEqual(len(selected_indices), 1)
         self.assertGreater(len(selected_indices[0]), 0)
@@ -91,9 +81,7 @@ class HighchartTest(WidgetTest):
         # Simulate deselection
         QTest.mouseClick(scatter, Qt.LeftButton, Qt.NoModifier, startpos - QPoint(10, 10))
 
-        while selected_indices:
-            qApp.processEvents()
-            time.sleep(.05)
+        self.process_events(lambda: not len(selected_indices))
 
         self.assertFalse(len(selected_indices))
 

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -411,8 +411,10 @@ if HAVE_WEBKIT:
 
             def load_finished():
                 if not sip.isdeleted(self):
-                    self.frame.addToJavaScriptWindowObject('__bridge', _QWidgetJavaScriptWrapper(self))
-                    self._evalJS('setTimeout(function(){ __bridge.load_really_finished(); }, 100);')
+                    self.frame.addToJavaScriptWindowObject(
+                        '__bridge', _QWidgetJavaScriptWrapper(self))
+                    self._evalJS('setTimeout(function(){'
+                                 '__bridge.load_really_finished(); }, 100);')
 
             self.loadFinished.connect(load_finished)
 

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -345,7 +345,6 @@ class _WebViewBase:
         exposeObject() method are indeed exposed in JS, and the code `code`
         has finished evaluating.
         """
-
         def _later():
             if not self.__is_init and self.__js_queue:
                 return QTimer.singleShot(1, _later)
@@ -355,6 +354,10 @@ class _WebViewBase:
                 self.__js_queue.clear()
                 self._evalJS(code)
 
+        # WebView returns the result of the last evaluated expression.
+        # This result may be too complex an object to safely receive on this
+        # end, so instead, just make it return 0.
+        code += ';0;'
         self.__js_queue.append(code)
         QTimer.singleShot(1, _later)
 

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -397,7 +397,7 @@ if HAVE_WEBKIT:
             self._obj = dict(obj=obj)
 
         @pyqtProperty('QVariantMap')
-        def pop_object(self, constant=True):
+        def pop_object(self):
             return self._obj
 
     @inherit_docstrings


### PR DESCRIPTION
##### Description of changes
Of note:
* raise selected Highcharts points to front, and
* always suffix the evaluated JS code with `";0"` to avoid failing to interpret arbitrary complex objects the user's JS expression can evaluate to, and
* export SVG as SVG instead of HTML, and
* have `WidgetTest.wait_for()` that comes in handy with async GUI testing.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
