### PR TITLE
[FIX] ScatterPlot: Fix crash when coloring by column of unknowns

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from AnyQt.QtCore import QSize, Qt, QTimer
+from AnyQt.QtCore import Qt, QTimer
 from AnyQt.QtGui import (
     QPen, QFont, QFontInfo, QPalette, QKeySequence,
 )
@@ -162,7 +162,7 @@ class OWScatterPlot(OWWidget):
         box = gui.vBox(self.controlArea, "Axis Data")
         dmod = DomainModel
         self.xy_model = DomainModel(dmod.MIXED, valid_types=dmod.PRIMITIVE)
-        gui.comboBox(
+        self.cb_attr_x = gui.comboBox(
             box, self, "attr_x", label="Axis x:", callback=self.update_attr,
             model=self.xy_model, **common_options)
         self.cb_attr_y = gui.comboBox(
@@ -409,7 +409,7 @@ class OWScatterPlot(OWWidget):
         self.graph.new_data(self.data_metas_X, self.subset_data)
         if self.attribute_selection_list and \
                 all(attr in self.graph.domain
-                    for attr in self.attribute_selection_list):
+                        for attr in self.attribute_selection_list):
             self.attr_x = self.attribute_selection_list[0]
             self.attr_y = self.attribute_selection_list[1]
         self.attribute_selection_list = None

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -12,7 +12,6 @@ from AnyQt.QtWidgets import QApplication, QToolTip, QPinchGesture
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ViewBox import ViewBox
 import pyqtgraph.graphicsItems.ScatterPlotItem
-from pyqtgraph.graphicsItems.ImageItem import ImageItem
 from pyqtgraph.graphicsItems.LegendItem import LegendItem, ItemSample
 from pyqtgraph.graphicsItems.ScatterPlotItem import ScatterPlotItem
 from pyqtgraph.graphicsItems.TextItem import TextItem
@@ -298,7 +297,11 @@ class DiscretizedScale:
         """
         super().__init__()
         dif = max_v - min_v if max_v != min_v else 1
-        decimals = -floor(log10(dif))
+        if np.isnan(dif):
+            min_v = 0
+            dif = decimals = 1
+        else:
+            decimals = -floor(log10(dif))
         resolution = 10 ** -decimals
         bins = ceil(dif / resolution)
         if bins < 6:

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -1,15 +1,15 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from unittest.mock import MagicMock
-
 import numpy as np
 
 from AnyQt.QtCore import QRectF
 
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
-from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin, datasets
 from Orange.widgets.visualize.owscatterplot import \
     OWScatterPlot, ScatterPlotVizRank
+from Orange.widgets.tests.utils import simulate
 
 
 class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
@@ -70,7 +70,7 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
     def test_optional_combos(self):
         domain = self.data.domain
         d1 = Domain(domain.attributes[:2], domain.class_var,
-                   [domain.attributes[2]])
+                    [domain.attributes[2]])
         t1 = Table(d1, self.data)
         self.send_signal("Data", t1)
         self.widget.graph.attr_size = domain.attributes[2]
@@ -102,3 +102,18 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         self.widget.report_plot.assert_not_called()
         self.widget.report_caption.assert_not_called()
         self.widget.report_items.assert_not_called()
+
+    def test_data_column_nans(self):
+        """
+        ValueError cannot convert float NaN to integer.
+        In case when all column values are NaN then it throws that error.
+        GH-2061
+        """
+        table = datasets.data_one_column_nans()
+        self.send_signal("Data", table)
+
+        simulate.combobox_activate_item(self.widget.cb_attr_color, "b")
+        simulate.combobox_activate_item(self.widget.cb_attr_x, "a")
+        simulate.combobox_activate_item(self.widget.cb_attr_y, "a")
+
+        self.widget.update_graph()


### PR DESCRIPTION
##### Issue
ValueError cannot convert float NaN to integer owscatterplot
In case when all column values are NaN then it throws that error.
https://sentry.io/biolab/orange3/issues/196744604/

##### Description of changes
Logarithm of zero and division by zero are prevented.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
