### PR TITLE
[FIX] SelectRows: Fix loading of conditions

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -194,9 +194,7 @@ class OWSelectRows(widget.OWWidget):
             minimumContentsLength=12,
             sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon)
         attr_combo.row = row
-        for var in filter_visible(chain(self.data.domain.class_vars,
-                                        self.data.domain.metas,
-                                        self.data.domain.attributes)):
+        for var in self._visible_variables(self.data.domain):
             attr_combo.addItem(*gui.attributeItem(var))
         attr_combo.setCurrentIndex(attr or 0)
         self.cond_list.setCellWidget(row, 0, attr_combo)
@@ -215,6 +213,13 @@ class OWSelectRows(widget.OWWidget):
             lambda _: self.set_new_operators(attr_combo, False))
 
         self.cond_list.resizeRowToContents(row)
+
+    @staticmethod
+    def _visible_variables(domain):
+        """Generate variables in order they should be presented in in combos."""
+        return filter_visible(chain(domain.class_vars,
+                                    domain.metas,
+                                    domain.attributes))
 
     def add_all(self):
         if self.cond_list.rowCount():
@@ -395,8 +400,7 @@ class OWSelectRows(widget.OWWidget):
         except Exception:
             pass
 
-        variables = list(filter_visible(chain(data.domain.variables,
-                                              data.domain.metas)))
+        variables = list(self._visible_variables(self.data.domain))
         varnames = [v.name for v in variables]
         if self.conditions:
             for attr, cond_type, cond_value in self.conditions:

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -190,6 +190,31 @@ class TestOWSelectRows(WidgetTest):
         values = self.widget.conditions[0][2]
         self.assertTrue(values[0].startswith("5,2"))
 
+    def test_load_settings(self):
+        iris = Table("iris")[:5]
+        self.send_signal("Data", iris)
+
+        sepal_length, sepal_width = iris.domain[:2]
+
+        self.widget.remove_all_button.click()
+        self.enterFilter(sepal_width, "is below", "5.2")
+        self.enterFilter(sepal_length, "is at most", "4")
+        data = self.widget.settingsHandler.pack_data(self.widget)
+
+        w2 = self.create_widget(OWSelectRows, data)
+        self.send_signal("Data", iris, widget=w2)
+
+        var_combo = w2.cond_list.cellWidget(0, 0)
+        self.assertEqual(var_combo.currentText(), "sepal width")
+        oper_combo = w2.cond_list.cellWidget(0, 1)
+        self.assertEqual(oper_combo.currentText(), "is below")
+
+        var_combo = w2.cond_list.cellWidget(1, 0)
+        self.assertEqual(var_combo.currentText(), "sepal length")
+        oper_combo = w2.cond_list.cellWidget(1, 1)
+        self.assertEqual(oper_combo.currentText(), "is at most")
+
+
     def widget_with_context(self, domain, conditions):
         ch = SelectRowsContextHandler()
         context = ch.new_context(domain, *ch.encode_domain(domain))


### PR DESCRIPTION
##### Issue
Conditions in select rows are not loaded properly when reading from file (gh-2062)

##### Description of changes
Make sure the correct ordering of variables is used when restoring conditions.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
