### PR TITLE
[FIX] owcorrespondence: Handle variables with one value

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
+++ b/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
@@ -1,6 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-from Orange.data import Table
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owcorrespondence \
     import OWCorrespondenceAnalysis
@@ -15,3 +15,25 @@ class TestOWCorrespondence(WidgetTest):
         self.send_signal("Data", Table(Table("iris").domain))
         self.assertTrue(self.widget.Error.empty_data.is_shown())
         self.assertIsNone(self.widget.data)
+
+    def test_data_values_in_column(self):
+        """
+        Check that the widget does not crash when:
+        1) Domain has a two or more discrete variables but less than in a table
+        2) There is at least one NaN value in a column.
+        GH-2066
+        """
+        table = Table(
+            Domain(
+                [ContinuousVariable("a"),
+                 DiscreteVariable("b", values=["t", "f"]),
+                 DiscreteVariable("c", values=["y", "n"]),
+                 DiscreteVariable("d", values=["k", "l", "z"])]
+            ),
+            list(zip(
+                [42.48, 16.84, 15.23, 23.8],
+                ["t", "t", "", "f"],
+                "yyyy",
+                "klkk"
+            )))
+        self.send_signal("Data", table)


### PR DESCRIPTION
##### Issues
1) IndexError: index 1 is out of bounds for axis 1 with size 1
2) SVD did not converge
3) Must specify at least one of rect, xRange, or yRange. (gave rect=<class 'NoneType'>)

Check that the widget does not crash when domain has a discrete variable with only one value.

##### Description of changes
Discrete variables with only one value are not taken into account.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
