### PR TITLE
[FIX] OWTreeViewer: Fix trees being displayed differently for same tree object

### DIFF
--- a/Orange/widgets/tests/datasets/same_entropy.tab
+++ b/Orange/widgets/tests/datasets/same_entropy.tab
@@ -1,0 +1,7 @@
+target	d1	d2
+d	d	d
+class
+A	2	2
+A	2	2
+B	1	1
+B	1	1

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from AnyQt.QtGui import (
     QBrush, QPen, QColor, QPainter, QPainterPath, QTransform
 )
@@ -20,16 +22,20 @@ DefDroppletBrush = QBrush(Qt.darkGray)
 
 class GraphNode:
     def __init__(self, *_, **kwargs):
-        self.edges = kwargs.get("edges", set())
+        # Implement edges as an ordered dict to get the nice speed benefits as
+        # well as adding ordering, which we need to make trees deterministic
+        self.__edges = kwargs.get("edges", OrderedDict())
 
     def graph_edges(self):
-        return self.edges
+        """Get a list of the edges that stem from the node."""
+        return self.__edges.keys()
 
     def graph_add_edge(self, edge):
-        self.edges.add(edge)
+        """Add an edge stemming from the node."""
+        self.__edges[edge] = 0
 
     def __iter__(self):
-        for edge in self.edges:
+        for edge in self.__edges.keys():
             yield edge.node2
 
     def graph_nodes(self, atype=1):
@@ -185,7 +191,7 @@ class GraphicsNode(TextTreeNode):
 
     # noinspection PyCallByClass,PyTypeChecker
     def update_edge(self):
-        for edge in self.edges:
+        for edge in self.graph_edges():
             if edge.node1 is self:
                 QTimer.singleShot(0, edge.update_ends)
             elif edge.node2 is self:
@@ -274,16 +280,17 @@ class TreeGraphicsScene(QGraphicsScene):
         self.update()
 
     def _fix_pos(self, node, x, y):
+        """Fix the position of the tree stemming from the given node."""
         def brect(node):
+            """Get the bounding box of the parent rect and all its children."""
             return node.boundingRect() | node.childrenBoundingRect()
 
         if node.branches and node.isOpen:
             for n in node.branches:
-                x, ry = self._fix_pos(n, x,
-                                      y + self._VSPACING + brect(node).height())
+                x, ry = self._fix_pos(n, x, y + self._VSPACING + brect(node).height())
             x = (node.branches[0].pos().x() + node.branches[-1].pos().x()) / 2
             node.setPos(x, y)
-            for e in node.edges:
+            for e in node.graph_edges():
                 e.update_ends()
         else:
             node.setPos(self.gx, y)

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -4,7 +4,7 @@ from AnyQt.QtGui import (
     QBrush, QPen, QColor, QPainter, QPainterPath, QTransform
 )
 from AnyQt.QtWidgets import (
-    QGraphicsItem, QGraphicsEllipseItem, QGraphicsRectItem, QGraphicsTextItem,
+    QGraphicsItem, QGraphicsEllipseItem, QGraphicsTextItem,
     QGraphicsLineItem, QGraphicsScene, QGraphicsView, QStyle, QSizePolicy,
     QFormLayout
 )
@@ -287,7 +287,7 @@ class TreeGraphicsScene(QGraphicsScene):
 
         if node.branches and node.isOpen:
             for n in node.branches:
-                x, ry = self._fix_pos(n, x, y + self._VSPACING + brect(node).height())
+                x, _ = self._fix_pos(n, x, y + self._VSPACING + brect(node).height())
             x = (node.branches[0].pos().x() + node.branches[-1].pos().x()) / 2
             node.setPos(x, y)
             for e in node.graph_edges():
@@ -435,7 +435,7 @@ class OWTreeViewer2D(OWWidget):
 
         if self.model:
             self.reportSection("Tree")
-            urlfn, filefn = self.getUniqueImageName(ext=".svg")
+            _, filefn = self.getUniqueImageName(ext=".svg")
             svg = QSvgGenerator()
             svg.setFileName(filefn)
             ssize = self.scene.sceneRect().size()

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -314,7 +314,8 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         # Make sure trees are deterministic with data where some variables have
         # the same entropy
         data_same_entropy = Table(path.join(
-            path.dirname(__file__), "../../tests/datasets/same_entropy.tab"))
+            path.dirname(path.dirname(path.dirname(__file__))), "tests",
+            "datasets", "same_entropy.tab"))
         data_same_entropy = TreeLearner()(data_same_entropy)
         scene_nodes = []
         for _ in range(n_tries):

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -2,9 +2,10 @@
 import math
 import unittest
 
-from Orange.classification import TreeLearner as TreeClassificationLearner
+from os import path
+
 from Orange.data import Table
-from Orange.regression import TreeLearner as TreeRegressionLearner
+from Orange.modelling import TreeLearner
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.visualize.owpythagorastree import OWPythagorasTree
 from Orange.widgets.visualize.pythagorastreeviewer import (
@@ -93,7 +94,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         WidgetOutputsTestMixin.init(cls)
 
         # Set up for output tests
-        tree = TreeClassificationLearner()
+        tree = TreeLearner()
         cls.model = tree(cls.data)
         cls.model.instances = cls.data
 
@@ -102,11 +103,11 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
 
         # Set up for widget tests
         titanic_data = Table('titanic')[::50]
-        cls.titanic = TreeClassificationLearner(max_depth=1)(titanic_data)
+        cls.titanic = TreeLearner(max_depth=1)(titanic_data)
         cls.titanic.instances = titanic_data
 
         housing_data = Table('housing')[:10]
-        cls.housing = TreeRegressionLearner(max_depth=1)(housing_data)
+        cls.housing = TreeLearner(max_depth=1)(housing_data)
         cls.housing.instances = housing_data
 
     def setUp(self):
@@ -283,3 +284,46 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         self.assertNotRegex(
             self.widget.info.text(), regex,
             'Initial info should not contain node or depth info')
+
+    def test_tree_determinism(self):
+        """Check that the tree is drawn identically upon receiving the same
+        dataset with no parameter changes."""
+        n_tries = 10
+
+        def _check_all_same(data):
+            """Check that all the elements within an iterable are identical."""
+            iterator = iter(data)
+            try:
+                first = next(iterator)
+            except StopIteration:
+                return True
+            return all(first == rest for rest in iterator)
+
+        # Make sure the tree are deterministic for iris
+        scene_nodes = []
+        for i in range(n_tries):
+            self.send_signal(self.signal_name, self.signal_data)
+            scene_nodes.append([n.pos() for n in self.get_visible_squares()])
+        for node_row in zip(*scene_nodes):
+            self.assertTrue(
+                _check_all_same(node_row),
+                "The tree was not drawn identically in the %d times it was "
+                "sent to widget after receiving the iris dataset." % n_tries
+            )
+
+        # Make sure trees are deterministic with data where some variables have
+        # the same entropy
+        data_same_entropy = Table(path.join(
+            path.dirname(__file__), "../../tests/datasets/same_entropy.tab"))
+        data_same_entropy = TreeLearner()(data_same_entropy)
+        scene_nodes = []
+        for i in range(n_tries):
+            self.send_signal(self.signal_name, data_same_entropy)
+            scene_nodes.append([n.pos() for n in self.get_visible_squares()])
+        for node_row in zip(*scene_nodes):
+            self.assertTrue(
+                _check_all_same(node_row),
+                "The tree was not drawn identically in the %d times it was "
+                "sent to widget after receiving a dataset with variables with "
+                "same entropy." % n_tries
+            )

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -301,7 +301,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
 
         # Make sure the tree are deterministic for iris
         scene_nodes = []
-        for i in range(n_tries):
+        for _ in range(n_tries):
             self.send_signal(self.signal_name, self.signal_data)
             scene_nodes.append([n.pos() for n in self.get_visible_squares()])
         for node_row in zip(*scene_nodes):
@@ -317,7 +317,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
             path.dirname(__file__), "../../tests/datasets/same_entropy.tab"))
         data_same_entropy = TreeLearner()(data_same_entropy)
         scene_nodes = []
-        for i in range(n_tries):
+        for _ in range(n_tries):
             self.send_signal(self.signal_name, data_same_entropy)
             scene_nodes.append([n.pos() for n in self.get_visible_squares()])
         for node_row in zip(*scene_nodes):

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -1,9 +1,11 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from os import path
+
 from Orange.classification import TreeLearner
+from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
-from Orange.widgets.visualize.owtreeviewer import \
-    OWTreeGraph
+from Orange.widgets.visualize.owtreeviewer import OWTreeGraph
 
 
 class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
@@ -18,6 +20,12 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
 
         cls.signal_name = "Tree"
         cls.signal_data = cls.model
+
+        # Load a dataset that contains two variables with the same entropy
+        data_same_entropy = Table(path.join(
+            path.dirname(__file__), "../../tests/datasets/same_entropy.tab"))
+        cls.data_same_entropy = tree(data_same_entropy)
+        cls.data_same_entropy.instances = data_same_entropy
 
     def setUp(self):
         self.widget = self.create_widget(OWTreeGraph)
@@ -35,3 +43,43 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
         self.widget.color_combo.activated.emit(1)
         self.widget.color_combo.setCurrentIndex(1)
         self.assertNotEqual(nodes[0].toPlainText(), text)
+
+    def test_tree_determinism(self):
+        """Check that the tree is drawn identically upon receiving the same
+        dataset with no parameter changes."""
+        n_tries = 10
+
+        def _check_all_same(data):
+            """Check that all the elements within an iterable are identical."""
+            iterator = iter(data)
+            try:
+                first = next(iterator)
+            except StopIteration:
+                return True
+            return all(first == rest for rest in iterator)
+
+        # Make sure the tree are deterministic for iris
+        scene_nodes = []
+        for i in range(n_tries):
+            self.send_signal(self.signal_name, self.signal_data)
+            scene_nodes.append([n.pos() for n in self.widget.scene.nodes()])
+        for node_row in zip(*scene_nodes):
+            self.assertTrue(
+                _check_all_same(node_row),
+                "The tree was not drawn identically in the %d times it was "
+                "sent to widget after receiving the iris dataset." % n_tries
+            )
+
+        # Make sure trees are deterministic with data where some variables have
+        # the same entropy
+        scene_nodes = []
+        for i in range(n_tries):
+            self.send_signal(self.signal_name, self.data_same_entropy)
+            scene_nodes.append([n.pos() for n in self.widget.scene.nodes()])
+        for node_row in zip(*scene_nodes):
+            self.assertTrue(
+                _check_all_same(node_row),
+                "The tree was not drawn identically in the %d times it was "
+                "sent to widget after receiving a dataset with variables with "
+                "same entropy." % n_tries
+            )

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -23,7 +23,8 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
 
         # Load a dataset that contains two variables with the same entropy
         data_same_entropy = Table(path.join(
-            path.dirname(__file__), "../../tests/datasets/same_entropy.tab"))
+            path.dirname(path.dirname(path.dirname(__file__))), "tests",
+            "datasets", "same_entropy.tab"))
         cls.data_same_entropy = tree(data_same_entropy)
         cls.data_same_entropy.instances = data_same_entropy
 

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -60,7 +60,7 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
 
         # Make sure the tree are deterministic for iris
         scene_nodes = []
-        for i in range(n_tries):
+        for _ in range(n_tries):
             self.send_signal(self.signal_name, self.signal_data)
             scene_nodes.append([n.pos() for n in self.widget.scene.nodes()])
         for node_row in zip(*scene_nodes):
@@ -73,7 +73,7 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
         # Make sure trees are deterministic with data where some variables have
         # the same entropy
         scene_nodes = []
-        for i in range(n_tries):
+        for _ in range(n_tries):
             self.send_signal(self.signal_name, self.data_same_entropy)
             scene_nodes.append([n.pos() for n in self.widget.scene.nodes()])
         for node_row in zip(*scene_nodes):


### PR DESCRIPTION
##### Issue
OWTreeViewer was not deterministic in showing trees. This was not specific to trees where attributes had the same entropy or whatever the selection criteria was, but occured on any tree (even with iris).

##### Description of changes
This happened because the layout was updated w.r.t the graph node edges, which were stored in a set object, which is unordered.

I assume that a set was used because speed is important, so I've implemented edges as an ordered dict, to keep the speed benefits as well as getting an ordering.

I've written a test that draws the tree 10x and compares the node positions, but since the ordering of the nodes was completely random before, this is not guaranteed to fail in case the trees are drawn with random ordering. The ordering could *happen* to be the same 10x. This hasn't actually happened to me yet on iris, since there are more nodes that can fail there, but this could potentially happen.

I have no idea how to test this so that it would always fail, due to the random nature of the ordering.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
