### PR TITLE
[FIX] OWDistributions: Fix binning of meta attributes

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -287,10 +287,12 @@ class OWDistributions(widget.OWWidget):
         if self.var is None:
             return
         if self.disc_cont:
-            data = self.data[:, (self.var, self.cvar) if self.cvar else self.var ]
+            domain = Orange.data.Domain(
+                [self.var, self.cvar] if self.cvar else [self.var])
+            data = Orange.data.Table(domain, data)
             disc = Orange.preprocess.discretize.EqualWidth(n=self.bins[self.smoothing_index])
             data = Orange.preprocess.Discretize(method=disc, remove_const=False)(data)
-            self.var = (list(data.domain) + list(data.domain.metas))[0]
+            self.var = data.domain[0]
         self.set_left_axis_name()
         self.enable_disable_rel_freq()
         if self.cvar:

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -1,7 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
-from Orange.data import Table
+from Orange.data import Table, Domain, DiscreteVariable
 from Orange.data.table import dataset_dirs
 from Orange.tests import test_dirname
 from Orange.widgets.tests.base import WidgetTest
@@ -43,3 +43,17 @@ class TestOWDistributions(WidgetTest):
         self.send_signal("Data", None)
         self.assertEqual(self.widget.cb_prob.count(), 0)
         self.assertEqual(self.widget.groupvarview.count(), 0)
+
+    def test_discretize_meta(self):
+        """The widget discretizes continuous meta attributes"""
+        domain = self.iris.domain
+        mdomain = Domain(domain.attributes[:-1], domain.class_var,
+                         metas=domain.attributes[-1:])
+        miris = Table(mdomain, self.iris)
+        self.send_signal("Data", miris)
+        widget = self.widget
+        widget.disc_cont = True
+        widget.varview.selectionModel().select(
+            widget.varview.model().index(4, 0))
+        self.assertIsInstance(widget.var, DiscreteVariable)
+        self.assertEqual(widget.var.name, mdomain.metas[0].name)


### PR DESCRIPTION
##### Issue

File -> Select columns -> Distributions

Load Iris, move one of the (continuous) attributes to meta attributes and select it in the Scatter plot. Instead of that attribute, the scatter plot shows the class.

The first problem is that the attribute was selected incorrectly - as the first attribute in domain + metas. When the grouping attribute was an ordinary attribute and the shown attribute a meta, this resulted in showing the grouping attributes.

The second problem is that discretization classes do not discretize meta attributes.

##### Description of changes

Construct the table for discretization so that the attribute that has to be discretized always appears as a normal attribute.

##### Includes
- [X] Code changes
- [X] Tests
