### PR TITLE
logistic_regression: Expand parameter list

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -40,7 +40,8 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
 
     def __init__(self, penalty="l2", dual=False, tol=0.0001, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,
-                 random_state=None, preprocessors=None):
+                 random_state=None, solver='liblinear', max_iter=100,
+                 multi_class='ovr', verbose=0, n_jobs=1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Parameters of the wrapped scikit-learn method were outdated and missing e.g. multi_class treatment.

##### Description of changes
Sync parameters with latest version of sklearn. Only warm_start is omitted as that does not work in Orange wrappers (new instance is created in Learner).

No changes to GUI for now, although we might want to consider adding some options to the widget in the future.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
