### PR TITLE
Fix pyqtgraphs Qt5 detection after importing Orange

### DIFF
--- a/Orange/__init__.py
+++ b/Orange/__init__.py
@@ -33,5 +33,7 @@ except ImportError:
     pass
 else:
     if AnyQt.USED_API == "pyqt5":
+        import pyqtgraph  # import pyqtgraph first so that it can detect Qt5
+        del pyqtgraph
         AnyQt.importhooks.install_backport_hook('pyqt4')
     del AnyQt


### PR DESCRIPTION
Orange install backport hooks for Qt4 in __init__ which
mess up pyqtgraph Qt dection. Importing pyqtgraph before
installing importhooks fixes this.