### PR TITLE
[FIX] OWKMeans: Auto-commit fix and silhuette optimization

### DIFF
--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -26,7 +26,7 @@ class KMeans(SklProjector):
         proj.silhouette = np.nan
         try:
             if self._compute_silhouette and 2 <= proj.n_clusters < X.shape[0]:
-                proj.silhouette = silhouette_score(X, proj.labels_)
+                proj.silhouette = silhouette_score(X, proj.labels_, sample_size=5000)
         except MemoryError:  # Pairwise dist in silhouette fails for large data
             pass
         proj.inertia = proj.inertia_ / X.shape[0]

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -90,7 +90,7 @@ class OWKMeans(widget.OWWidget):
         layout = QGridLayout()
         bg = gui.radioButtonsInBox(
             self.controlArea, self, "optimize_k", orientation=layout,
-            box="Number of Clusters", callback=self.apply)
+            box="Number of Clusters", callback=self.invalidate)
         layout.addWidget(
             gui.appendRadioButton(bg, "Fixed:", addToLayout=False), 1, 1)
         sb = gui.hBox(None, margin=0)


### PR DESCRIPTION
##### Issue
- widget crashes with a memory error on large datasets (e.g., adult)
- auto-commit doesn't work (disabling it has no effect)

##### Description of changes
- compute silhuette score on a sample of at most 5000 instances
- remove connections of apply() before calling auto_commit

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
