### PR TITLE
File formats: wildcard matching

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -17,6 +17,8 @@ from os import path, unlink
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse, urlsplit, urlunsplit, unquote as urlunquote
 from urllib.request import urlopen, Request
+from fnmatch import fnmatch
+from glob import glob
 
 import bottleneck as bn
 import numpy as np
@@ -362,7 +364,7 @@ class FileFormat(metaclass=FileFormatMeta):
             # Skip ambiguous, invalid compression-only extensions added on OSX
             if ext in Compression.all:
                 continue
-            if filename.endswith(ext):
+            if fnmatch(path.basename(filename), '*' + ext):
                 return reader(filename)
 
         raise IOError('No readers for file "{}"'.format(filename))
@@ -421,10 +423,12 @@ class FileFormat(metaclass=FileFormatMeta):
             if path.exists(absolute_filename):
                 break
             for ext in cls.readers:
-                if filename.endswith(ext):
+                if fnmatch(path.basename(filename), '*' + ext):
                     break
-                if path.exists(absolute_filename + ext):
-                    absolute_filename += ext
+                # glob uses fnmatch internally
+                matching_files = glob(absolute_filename + ext)
+                if matching_files:
+                    absolute_filename = matching_files[0]
                     break
             if path.exists(absolute_filename):
                 break

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -1,0 +1,65 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
+import unittest
+import os
+import tempfile
+import shutil
+
+from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader
+from Orange.data.table import get_sample_datasets_dir
+
+class WildcardReader(FileFormat):
+    EXTENSIONS = ('.wild', '.wild[0-9]')
+    DESCRIPTION = "Dummy reader for testing extensions"
+
+    def read(self):
+        pass
+
+
+class TestChooseReader(unittest.TestCase):
+
+    def test_usual_extensions(self):
+        self.assertIsInstance(FileFormat.get_reader("t.tab"), TabReader)
+        self.assertIsInstance(FileFormat.get_reader("t.csv"), CSVReader)
+        self.assertIsInstance(FileFormat.get_reader("t.pkl"), PickleReader)
+        with self.assertRaises(OSError):
+            FileFormat.get_reader("test.undefined_extension")
+
+    def test_wildcard_extension(self):
+        self.assertIsInstance(FileFormat.get_reader("t.wild"),
+                              WildcardReader)
+        self.assertIsInstance(FileFormat.get_reader("t.wild2"),
+                              WildcardReader)
+        with self.assertRaises(OSError):
+            FileFormat.get_reader("t.wild2a")
+
+
+class TestLocate(unittest.TestCase):
+
+    def test_locate_sample_datasets(self):
+        with self.assertRaises(OSError):
+            FileFormat.locate("iris.tab",
+                              search_dirs=[os.path.dirname(__file__)])
+        iris = FileFormat.locate("iris.tab",
+                                 search_dirs=[get_sample_datasets_dir()])
+        self.assertEqual(os.path.basename(iris), "iris.tab")
+        # test extension adding
+        iris = FileFormat.locate("iris",
+                                 search_dirs=[get_sample_datasets_dir()])
+        self.assertEqual(os.path.basename(iris), "iris.tab")
+
+
+    def test_locate_wildcard_extension(self):
+        tempdir = tempfile.mkdtemp()
+        with self.assertRaises(OSError):
+            FileFormat.locate("t.wild9", search_dirs=[tempdir])
+        fn = os.path.join(tempdir, "t.wild8")
+        with open(fn, "wt") as f:
+            f.write("\n")
+        l = FileFormat.locate("t.wild8", search_dirs=[tempdir])
+        self.assertEqual(l, fn)
+        # test extension adding
+        l = FileFormat.locate("t", search_dirs=[tempdir])
+        self.assertEqual(l, fn)
+        shutil.rmtree(tempdir)


### PR DESCRIPTION
##### Issue

For one file format I would like to match extension ".[0-9]*" and this allows it.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
