### PR TITLE
build_doc: fix recognizing RGB images in docs

### DIFF
--- a/.travis/build_doc.sh
+++ b/.travis/build_doc.sh
@@ -8,11 +8,13 @@ cd "$TRAVIS_BUILD_DIR"
 # Ensure new images have indexed palettes
 images="$(git diff --name-only origin/master..HEAD |
           grep -E '\bdoc/' | grep -iE '\.(png|jpg)$' || true )"
-echo -e "Checking if images are indexed:\n$images"
+echo "Checking if images are indexed:"
 while read image; do
     [ "$image" ] || break;
-    if identify -verbose "$image" | grep -q '^ *Type: TrueColor'; then
-        echo "Error: image '$image' is true color" >&2
+    imtype=$(identify -verbose "$image" | awk '/^ *Type: /{ print $2 }')
+    echo "$image  $imtype"
+    if ! echo "$imtype" | grep -Eq '(Palette|Grayscale)'; then
+        echo "Error: image '$image' is not indexed or grayscale" >&2
         not_ok=1
     fi
 done < <(echo "$images")


### PR DESCRIPTION
##### Issue
The docs building script didn't correctly recognize non-indexed images (see for example _Nomogram-LogisticRegression.png_ in [#2016](https://github.com/biolab/orange3/pull/2016/files#diff-ccb8318320da1f9b2bf947f0534d2c27)). Not certain why it failed as it worked locally.

##### Description of changes
Whitelist instead of blacklist. Now should work. Tested in https://travis-ci.org/kernc/orange3/jobs/208991228.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
