### PR TITLE
Settings: Copy mutable default values

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -142,13 +142,14 @@ class SettingProvider:
         self._initialize_providers(instance, data)
 
     def _initialize_settings(self, instance, data):
+        if data is None:
+            data = {}
         for name, setting in self.settings.items():
-            if data and name in data:
-                setattr(instance, name, data[name])
-            elif isinstance(setting.default, _IMMUTABLES):
-                setattr(instance, name, setting.default)
+            value = data.get(name, setting.default)
+            if isinstance(value, _IMMUTABLES):
+                setattr(instance, name, value)
             else:
-                setattr(instance, name, copy.copy(setting.default))
+                setattr(instance, name, copy.copy(value))
 
     def _initialize_providers(self, instance, data):
         if not data:

--- a/Orange/widgets/tests/test_settings_handler.py
+++ b/Orange/widgets/tests/test_settings_handler.py
@@ -266,6 +266,19 @@ class SettingHandlerTestCase(unittest.TestCase):
         settings = handler.pack_data(widget)
         self.assertIn(VERSION_KEY, settings)
 
+    def test_initialize_copies_mutables(self):
+        handler = SettingsHandler()
+        handler.bind(SimpleWidget)
+        handler.defaults = dict(list_setting=[])
+
+        widget = SimpleWidget()
+        handler.initialize(widget)
+
+        widget2 = SimpleWidget()
+        handler.initialize(widget2)
+
+        self.assertNotEqual(id(widget.list_setting), id(widget2.list_setting))
+
     @contextmanager
     def override_default_settings(self, widget, defaults=None):
         if defaults is None:
@@ -292,6 +305,7 @@ class SimpleWidget:
 
     setting = Setting(42)
     schema_only_setting = Setting(None, schema_only=True)
+    list_setting = Setting([])
     non_setting = 5
 
     component = SettingProvider(Component)


### PR DESCRIPTION
##### Issue
Clear settings, open canvas, add file widget, close, then open canvas again (to ensure that there are some stored settings).
Put two instances of file widget, select different file in each, save workflow, open workflow. Both widgets have the same file selected.

Also fixes #2030

##### Description of changes
Copy mutable default values before setting them to widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
