### PR TITLE
OWDistributions: Fix crash for feature with no values

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -321,7 +321,8 @@ class OWDistributions(widget.OWWidget):
     def display_distribution(self):
         dist = self.distributions
         var = self.var
-        assert len(dist) > 0
+        if not len(dist):
+            return
         self.plot.clear()
         self.plot_prob.clear()
         self.ploti.hideAxis('right')
@@ -372,7 +373,8 @@ class OWDistributions(widget.OWWidget):
         """
         cont = self.contingencies
         var, cvar = self.var, self.cvar
-        assert len(cont) > 0
+        if not len(cont):
+            return
         self.plot.clear()
         self.plot_prob.clear()
         self._legend.clear()

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -1,6 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
-# pylint: disable=protected-access
+# pylint: disable=missing-docstring,protected-access
 
 from Orange.data import Table, Domain, DiscreteVariable
 from Orange.data.table import dataset_dirs

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -1,10 +1,11 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 
 from Orange.data import Table, Domain, DiscreteVariable
 from Orange.data.table import dataset_dirs
 from Orange.tests import test_dirname
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.base import WidgetTest, datasets
 from Orange.widgets.visualize.owdistributions import OWDistributions
 
 
@@ -57,3 +58,13 @@ class TestOWDistributions(WidgetTest):
             widget.varview.model().index(4, 0))
         self.assertIsInstance(widget.var, DiscreteVariable)
         self.assertEqual(widget.var.name, mdomain.metas[0].name)
+
+    def test_variable_group_combinations(self):
+        """Check widget for all combinations of variable and group for dataset
+        with constant columns and missing data"""
+        self.send_signal("Data", Table(datasets.path("testing_dataset_cls")))
+        for groupvar_idx in range(len(self.widget.groupvarmodel)):
+            self.widget.groupvar_idx = groupvar_idx
+            for var_idx in range(len(self.widget.varmodel)):
+                self.widget.variable_idx = var_idx
+                self.widget._setup()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://sentry.io/biolab/orange3/issues/232048055/

##### Description of changes
The widget crashed when variable (or group) with only missing values was selected.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
