### PR TITLE
Feature constructor works with variables starting with numbers

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -819,7 +819,10 @@ def construct_variables(descriptions, source_vars):
 
 
 def sanitized_name(name):
-    return re.sub(r"\W", "_", name)
+    sanitized = re.sub(r"\W", "_", name)
+    if sanitized[0].isdigit():
+        sanitized = "_" + sanitized
+    return sanitized
 
 
 def bind_variable(descriptor, env):

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -338,6 +338,7 @@ class OWFeatureConstructor(OWWidget):
 
     class Error(OWWidget.Error):
         more_values_needed = Msg("Discrete feature {} needs more values.")
+        invalid_expressions = Msg("Invalid expressions: {}.")
 
     def __init__(self):
         super().__init__()
@@ -552,11 +553,7 @@ class OWFeatureConstructor(OWWidget):
                     return var.name
         return None
 
-    def apply(self):
-        if self.data is None:
-            return
-
-        desc = list(self.featuremodel)
+    def _validate_descriptors(self, desc):
 
         def validate(source):
             try:
@@ -564,11 +561,28 @@ class OWFeatureConstructor(OWWidget):
             except Exception:
                 return False
 
-        def remove_invalid_expression(desc):
-            return (desc if validate(desc.expression)
-                    else desc._replace(expression=""))
+        final = []
+        invalid = []
+        for d in desc:
+            if validate(d.expression):
+                final.append(d)
+            else:
+                final.append(d._replace(expression=""))
+                invalid.append(d)
 
-        desc = map(remove_invalid_expression, desc)
+        if invalid:
+            self.Error.invalid_expressions(", ".join(s.name for s in invalid))
+
+        return final
+
+    def apply(self):
+        self.Error.clear()
+
+        if self.data is None:
+            return
+
+        desc = list(self.featuremodel)
+        desc = self._validate_descriptors(desc)
         source_vars = tuple(self.data.domain) + self.data.domain.metas
         new_variables = construct_variables(desc, source_vars)
 
@@ -580,7 +594,6 @@ class OWFeatureConstructor(OWWidget):
             metas=self.data.domain.metas + tuple(metas)
         )
 
-        self.Error.clear()
         try:
             data = Orange.data.Table(new_domain, self.data)
         except Exception as err:

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -209,3 +209,17 @@ class OWFeatureConstructorTests(WidgetTest):
     def test_create_variable_with_no_data(self):
         self.widget.addFeature(
             ContinuousDescriptor("X1", "", 3))
+
+    def test_error_invalid_expression(self):
+        data = Table("iris")
+        self.widget.setData(data)
+        self.widget.addFeature(
+            ContinuousDescriptor("X", "0", 3)
+        )
+        self.widget.apply()
+        self.assertFalse(self.widget.Error.invalid_expressions.is_shown())
+        self.widget.addFeature(
+            ContinuousDescriptor("X", "0a", 3)
+        )
+        self.widget.apply()
+        self.assertTrue(self.widget.Error.invalid_expressions.is_shown())

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -2,6 +2,8 @@ import unittest
 import ast
 import sys
 
+import numpy as np
+
 from Orange.data import (Table, Domain, StringVariable,
                          ContinuousVariable, DiscreteVariable)
 from Orange.widgets.tests.base import WidgetTest
@@ -71,6 +73,21 @@ class FeatureConstructorTest(unittest.TestCase):
         for i in range(3):
             self.assertEqual(data[i * 50, name],
                              str(data[i * 50, "iris"]) + "_name")
+
+    def test_construct_numeric_names(self):
+        data = Table("iris")
+        data.domain.attributes[0].name = "0.1"
+        data.domain.attributes[1].name = "1"
+        desc = PyListModel(
+            [ContinuousDescriptor(name="S",
+                                  expression="_0_1 + _1",
+                                  number_of_decimals=3)]
+        )
+        nv = construct_variables(desc, data.domain)
+        ndata = Table(Domain(nv, None), data)
+        np.testing.assert_array_equal(ndata.X[:, 0],
+                                      data.X[:, :2].sum(axis=1))
+        ContinuousVariable._clear_all_caches()
 
 
 GLOBAL_CONST = 2


### PR DESCRIPTION
##### Issue
Feature constructor silently ignored variables starting with numbers.

##### Description of changes
Variable names starting with a number are prefixed with a "_" so that we get a valid ast. Also added error reporting when expressions are not valid. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
