### PR TITLE
[FIX] Discover widgets when some dependencies are missing

### DIFF
--- a/Orange/canvas/application/workflows/__init__.py
+++ b/Orange/canvas/application/workflows/__init__.py
@@ -46,7 +46,7 @@ def example_workflows():
     for ep in workflow_entry_points():
         workflows = None
         try:
-            workflows = ep.load()
+            workflows = ep.resolve()
         except pkg_resources.DistributionNotFound as ex:
             log.warning("Could not load workflows from %r (%r)",
                         ep.dist, ex)

--- a/Orange/canvas/help/manager.py
+++ b/Orange/canvas/help/manager.py
@@ -270,7 +270,7 @@ def qurl_from_path(urlpath):
 
 
 def create_intersphinx_provider(entry_point):
-    locations = entry_point.load()
+    locations = entry_point.resolve()
     replacements = _replacements_for_dist(entry_point.dist)
 
     formatter = string.Formatter()
@@ -317,7 +317,7 @@ def create_intersphinx_provider(entry_point):
 
 
 def create_html_provider(entry_point):
-    locations = entry_point.load()
+    locations = entry_point.resolve()
     replacements = _replacements_for_dist(entry_point.dist)
 
     formatter = string.Formatter()
@@ -350,7 +350,7 @@ def create_html_provider(entry_point):
 
 
 def create_html_inventory_provider(entry_point):
-    locations = entry_point.load()
+    locations = entry_point.resolve()
     replacements = _replacements_for_dist(entry_point.dist)
 
     formatter = string.Formatter()

--- a/Orange/canvas/registry/discovery.py
+++ b/Orange/canvas/registry/discovery.py
@@ -86,7 +86,7 @@ class WidgetDiscovery(object):
 
         for entry_point in entry_points_iter:
             try:
-                point = entry_point.load()
+                point = entry_point.resolve()
             except pkg_resources.DistributionNotFound:
                 log.error("Could not load '%s' (unsatisfied dependencies).",
                           entry_point, exc_info=True)

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -11,3 +11,4 @@ joblib>=0.9.4
 keyring
 keyrings.alt    # for alternative keyring implementations
 dill
+setuptools>=11.3


### PR DESCRIPTION
##### Issue
When one of the requirements (of their requirements (or their requirements...)) is missing, Orange opens with no widgets.

To reproduce, uninstall keyring and open canvas

##### Description of changes
use .resolve() to load entry points

.resolve() is available from setuptools 11.3 forward (released in 2015),
does the same thing as .load(), but ommits the requirements check.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
