### PR TITLE
Fixed axis scales on visualizations

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -43,7 +43,7 @@ def font_resize(font, factor, minsize=None, maxsize=None):
 
 class ScatterPlotVizRank(VizRankDialogAttrPair):
     captionTitle = "Score Plots"
-    K = 10
+    maxRows = 10
 
     def check_preconditions(self):
         self.Information.add_message(
@@ -69,9 +69,9 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         valid = graph.get_valid_list(ind12)
         X = graph.jittered_data[ind12, :][:, valid].T
         Y = self.master.data.Y[valid]
-        if X.shape[0] < self.K:
+        if X.shape[0] < self.maxRows:
             return
-        n_neighbors = min(self.K, len(X) - 1)
+        n_neighbors = min(self.maxRows, len(X) - 1)
         knn = NearestNeighbors(n_neighbors=n_neighbors).fit(X)
         ind = knn.kneighbors(return_distance=False)
         if self.master.data.domain.has_discrete_class:
@@ -92,7 +92,7 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         data = Table(dom, X, Y)
         relief = ReliefF if isinstance(dom.class_var, DiscreteVariable) \
             else RReliefF
-        weights = relief(n_iterations=100, k_nearest=self.K)(data)
+        weights = relief(n_iterations=100, k_nearest=self.maxRows)(data)
         attrs = sorted(zip(weights, mdomain.attributes),
                        key=lambda x: (-x[0], x[1].name))
         return [a for _, a in attrs]

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -235,6 +235,12 @@ class OWScatterPlot(OWWidget):
         gui.checkBox(
             box, self, 'graph.label_only_selected',
             'Label only selected points', callback=self.graph.update_labels)
+        self.cb_fixed_yaxis_scales = gui.checkBox(
+            box, self,
+            value='graph.flag_fixed_yaxis_scales',
+            label='Fixed y-axis scales',
+            callback=self.update_graph
+        )
 
         self.zoom_select_toolbar = g.zoom_select_toolbar(
             gui.vBox(self.controlArea, "Zoom/Select"), nomargin=True,
@@ -428,6 +434,7 @@ class OWScatterPlot(OWWidget):
         self.update_graph()
         self.cb_class_density.setEnabled(self.graph.can_draw_density())
         self.cb_reg_line.setEnabled(self.graph.can_draw_regresssion_line())
+        self.cb_fixed_yaxis_scales.setEnabled(self.graph.can_fixed_yaxis_scales())
         self.unconditional_commit()
 
     def set_shown_attributes(self, attributes):
@@ -459,6 +466,7 @@ class OWScatterPlot(OWWidget):
         self.update_graph()
         self.cb_class_density.setEnabled(self.graph.can_draw_density())
         self.cb_reg_line.setEnabled(self.graph.can_draw_regresssion_line())
+        self.cb_fixed_yaxis_scales.setEnabled(self.graph.can_fixed_yaxis_scales())
         self.send_features()
 
     def update_colors(self):


### PR DESCRIPTION
##### Issue
For some plots, you would want e.g. the y-axis scale to be 0-100 and not computed from current data.
GH-2109

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
