### PR TITLE
Mahalanobis: Remove dimension restrictions.

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -208,12 +208,15 @@ class MahalanobisDistance(Distance):
         x = _orange_to_numpy(data)
         if axis == 0:
             x = x.T
-        n, m = x.shape
-        if n <= m:
-            raise ValueError(
-                'Too few observations for the number of dimensions.')
         self.axis = axis
-        self.VI = np.linalg.inv(np.cov(x.T))
+        try:
+            c = np.cov(x.T)
+        except:
+            raise MemoryError("Covariance matrix is too large.")
+        try:
+            self.VI = np.linalg.inv(c)
+        except:
+            raise ValueError("Computation of inverse covariance matrix failed.")
 
     def __call__(self, e1, e2=None, axis=None, impute=False):
         assert self.VI is not None, \

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -779,6 +779,14 @@ class TestMahalanobis(TestCase):
         self.assertRaises(AssertionError, mah, x, axis=1)
         self.assertEqual(mah(x, x).shape, (self.n, self.n))
 
+    def test_dimensions(self):
+        x = Table('iris')[:20].X
+        xt = Table('iris')[:20].X.T
+        mah = MahalanobisDistance(x)
+        mah(x[0], x[1])
+        mah = MahalanobisDistance(xt)
+        mah(xt[0], xt[1])
+
 
 class TestDistances(TestCase):
     @classmethod

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -42,7 +42,7 @@ class OWDistances(OWWidget):
         no_continuous_features = Msg("No continuous features")
         dense_metric_sparse_data = Msg("Selected metric does not support sparse data")
         empty_data = Msg("Empty data set")
-        too_few_observations = Msg("Too few observations for the number of dimensions")
+        mahalanobis_error = Msg("{}")
 
     class Warning(OWWidget.Warning):
         ignoring_discrete = Msg("Ignoring discrete features")
@@ -134,14 +134,15 @@ class OWDistances(OWWidget):
             n, m = data.X.shape
             if self.axis == 1:
                 n, m = m, n
-            if n <= m:
-                self.Error.too_few_observations()
-                return
 
         if isinstance(metric, distance.MahalanobisDistance):
             # Mahalanobis distance has to be trained before it can be used
             # to compute distances
-            metric.fit(data, axis=1 - self.axis)
+            try:
+                metric.fit(data, axis=1 - self.axis)
+            except (ValueError, MemoryError) as e:
+                self.Error.mahalanobis_error(e)
+                return
 
         return metric(data, data, 1 - self.axis, impute=True)
 

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -42,9 +42,21 @@ class TestOWDistances(WidgetTest):
         self.assertFalse(self.widget.Error.no_continuous_features.is_shown())
 
     def test_mahalanobis_error(self):
-        data = self.iris
-        data.X = np.vstack((data.X[0], data.X[0]))
-        data.Y = np.vstack((data.Y[0], data.Y[0]))
-        self.send_signal("Data", data)
-        self.widget.compute_distances(Mahalanobis, data)
-        self.assertTrue(self.widget.Error.mahalanobis_error.is_shown())
+        self.widget.metric_idx = METRICS.index(Mahalanobis)
+        self.widget.autocommit = True
+
+        invalid = self.iris[:]
+        invalid.X = np.vstack((invalid.X[0], invalid.X[0]))
+        invalid.Y = np.vstack((invalid.Y[0], invalid.Y[0]))
+        datasets = [self.iris, None, invalid]
+        bad = [False, False, True]
+        out = [True, False, False]
+
+        for data1, bad1, out1 in zip(datasets, bad, out):
+            for data2, bad2, out2 in zip(datasets, bad, out):
+                self.send_signal("Data", data1)
+                self.assertEqual(self.widget.Error.mahalanobis_error.is_shown(), bad1)
+                self.assertEqual(self.get_output("Distances") is not None, out1)
+                self.send_signal("Data", data2)
+                self.assertEqual(self.widget.Error.mahalanobis_error.is_shown(), bad2)
+                self.assertEqual(self.get_output("Distances") is not None, out2)

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -42,7 +42,9 @@ class TestOWDistances(WidgetTest):
         self.assertFalse(self.widget.Error.no_continuous_features.is_shown())
 
     def test_mahalanobis_error(self):
-        self.widget.axis = 1
-        self.send_signal("Data", self.iris)
-        self.widget.compute_distances(Mahalanobis, self.iris)
-        self.assertTrue(self.widget.Error.too_few_observations.is_shown())
+        data = self.iris
+        data.X = np.vstack((data.X[0], data.X[0]))
+        data.Y = np.vstack((data.Y[0], data.Y[0]))
+        self.send_signal("Data", data)
+        self.widget.compute_distances(Mahalanobis, data)
+        self.assertTrue(self.widget.Error.mahalanobis_error.is_shown())


### PR DESCRIPTION
##### Issue
Mahalanobis distance (intentionally) didn't work when the number of features exceeded the number of samples.

##### Description of changes
The restriction doesn't seem to be applicable anymore.
Added error handling of too large and singular covariance matrices.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
