### PR TITLE
[FIX] Widget Logistic Regression: can handle unused values

### DIFF
--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -92,10 +92,10 @@ class OWLogisticRegression(OWBaseLearner):
 def create_coef_table(classifier):
     i = classifier.intercept
     c = classifier.coefficients
-    if len(classifier.domain.class_var.values) > 2:
-        values = classifier.domain.class_var.values
+    if c.shape[0] > 2:
+        values = [classifier.domain.class_var.values[int(i)] for i in classifier.used_vals[0]]
     else:
-        values = ["coef"]
+        values = [classifier.domain.class_var.values[int(classifier.used_vals[0][1])]]
     domain = Domain([ContinuousVariable(value, number_of_decimals=7)
                      for value in values], metas=[StringVariable("name")])
     coefs = np.vstack((i.reshape(1, len(i)), c.T))

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -1,5 +1,5 @@
-import numpy as np
 from itertools import chain
+import numpy as np
 from AnyQt import QtWidgets
 from AnyQt.QtCore import Qt
 
@@ -61,9 +61,9 @@ class OWLogisticRegression(OWBaseLearner):
         self.set_c()
 
     def set_c(self):
-        self.C = self.C_s[self.C_index]
-        fmt = "C={}" if self.C >= 1 else "C={:.3f}"
-        self.c_label.setText(fmt.format(self.C))
+        self.strength_C = self.C_s[self.C_index]
+        fmt = "C={}" if self.strength_C >= 1 else "C={:.3f}"
+        self.c_label.setText(fmt.format(self.strength_C))
 
     def create_learner(self):
         penalty = self.penalty_types_short[self.penalty_type]
@@ -71,7 +71,7 @@ class OWLogisticRegression(OWBaseLearner):
             penalty=penalty,
             dual=self.dual,
             tol=self.tol,
-            C=self.C,
+            C=self.strength_C,
             fit_intercept=self.fit_intercept,
             intercept_scaling=self.intercept_scaling,
             preprocessors=self.preprocessors
@@ -86,7 +86,7 @@ class OWLogisticRegression(OWBaseLearner):
 
     def get_learner_parameters(self):
         return (("Regularization", "{}, C={}".format(
-                self.penalty_types[self.penalty_type], self.C_s[self.C_index])),)
+            self.penalty_types[self.penalty_type], self.C_s[self.C_index])),)
 
 
 def create_coef_table(classifier):

--- a/Orange/widgets/model/tests/test_owlogisticregression.py
+++ b/Orange/widgets/model/tests/test_owlogisticregression.py
@@ -3,13 +3,12 @@
 import unittest
 
 from Orange.classification import LogisticRegressionLearner
-from Orange.data import Table
+from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.statistics.util import stats
 from Orange.widgets.model.owlogisticregression import (create_coef_table,
                                                        OWLogisticRegression)
 from Orange.widgets.tests.base import (WidgetTest, WidgetLearnerTestMixin,
                                        ParameterMapping)
-
 
 class LogisticRegressionTest(unittest.TestCase):
     def test_coef_table_single(self):
@@ -58,3 +57,41 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         self.send_signal("Data", self.data)
         self.widget.apply_button.button.click()
         self.assertIsInstance(self.get_output("Coefficients"), Table)
+
+    def test_domain_with_more_values_than_table(self):
+        """
+        When the data with a domain which has more values than
+        a table was sent, the widget threw error Invalid number of variable columns.
+        GH-2116
+        """
+        table = Table("iris")
+        cases = [[list(range(80))],
+                 [list(range(90, 140))],
+                 [list(range(30)) + list(range(120, 140))]]
+        for case in cases:
+            data = table[case, :]
+            self.send_signal("Data", data)
+            self.widget.apply_button.button.click()
+
+    def test_coefficients_one_value(self):
+        """
+        In case we have only two values of a target we get coefficients of only value.
+        Instead of writing "coef" or sth similar it is written a second value name.
+        GH-2116
+        """
+        table = Table(
+            Domain(
+                [ContinuousVariable("a"),
+                 ContinuousVariable("b")],
+                [DiscreteVariable("c", values=["yes", "no"])]
+            ),
+            list(zip(
+                [1., 0.],
+                [0., 1.],
+                ["yes", "no"]))
+        )
+        self.send_signal("Data", table)
+        self.widget.apply_button.button.click()
+        coef = self.get_output("Coefficients")
+        self.assertEqual(coef.domain[0].name, "no")
+        self.assertGreater(coef[2][0], 0.)


### PR DESCRIPTION
##### Issue

I can handle unused values
and instead of writing "coef" or sth similar I write a second value name
when only two values are considered.
https://sentry.io/biolab/orange3/issues/222366525/
https://sentry.io/biolab/orange3/issues/208659372/

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
