### PR TITLE
[FIX] VizRankDialog: Stop computation when parent widget is deleted

### DIFF
--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -158,6 +158,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin):
 
         master_close_event = master.closeEvent
         master_hide_event = master.hideEvent
+        master_delete_event = master.onDeleteWidget
 
         def closeEvent(event):
             vizrank.close()
@@ -167,8 +168,13 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin):
             vizrank.hide()
             master_hide_event(event)
 
+        def deleteEvent():
+            vizrank.keep_running = False
+            master_delete_event()
+
         master.closeEvent = closeEvent
         master.hideEvent = hideEvent
+        master.onDeleteWidget = deleteEvent
         return vizrank, button
 
     def reshow(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
