### PR TITLE
[FIX] Scatter Plot - Prevent crash due to missing data

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -305,8 +305,9 @@ class OWScatterPlot(OWWidget):
     #         self.graph.selectionCurveList.append(c)
 
     def reset_graph_data(self, *_):
-        self.graph.rescale_data()
-        self.update_graph()
+        if self.data is not None:
+            self.graph.rescale_data()
+            self.update_graph()
 
     def set_data(self, data):
         self.clear_messages()

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -43,7 +43,7 @@ def font_resize(font, factor, minsize=None, maxsize=None):
 
 class ScatterPlotVizRank(VizRankDialogAttrPair):
     captionTitle = "Score Plots"
-    K = 10
+    minK = 10
 
     def check_preconditions(self):
         self.Information.add_message(
@@ -69,9 +69,9 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         valid = graph.get_valid_list(ind12)
         X = graph.jittered_data[ind12, :][:, valid].T
         Y = self.master.data.Y[valid]
-        if X.shape[0] < self.K:
+        if X.shape[0] < self.minK:
             return
-        n_neighbors = min(self.K, len(X) - 1)
+        n_neighbors = min(self.minK, len(X) - 1)
         knn = NearestNeighbors(n_neighbors=n_neighbors).fit(X)
         ind = knn.kneighbors(return_distance=False)
         if self.master.data.domain.has_discrete_class:
@@ -92,7 +92,7 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         data = Table(dom, X, Y)
         relief = ReliefF if isinstance(dom.class_var, DiscreteVariable) \
             else RReliefF
-        weights = relief(n_iterations=100, k_nearest=self.K)(data)
+        weights = relief(n_iterations=100, k_nearest=self.minK)(data)
         attrs = sorted(zip(weights, mdomain.attributes),
                        key=lambda x: (-x[0], x[1].name))
         return [a for _, a in attrs]

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -198,6 +198,23 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         np.testing.assert_equal(annotated(), sel_column)
         self.assertEqual(len(annotations()), 3)
 
+    def test_none_data(self):
+        """
+        Prevent crash due to missing data.
+        GH-2122
+        """
+        table = Table(
+            Domain(
+                [ContinuousVariable("a"),
+                 DiscreteVariable("b", values=["y", "n"])]
+            ),
+            list(zip(
+                [],
+                ""))
+        )
+        self.send_signal("Data", table)
+        self.widget.reset_graph_data()
+
 if __name__ == "__main__":
     import unittest
     unittest.main()


### PR DESCRIPTION
Widgets crashes when table is None.
https://sentry.io/biolab/orange3/issues/196744557/

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
