### PR TITLE
Pythagorean trees: Refactor

### DIFF
--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -27,6 +27,7 @@ class RandomForestClassifier(SklModel, RandomForestModel):
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain
+            t.instances = self.instances
             return t
 
         return [wrap(tree, i)

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -27,7 +27,8 @@ class RandomForestClassifier(SklModel, RandomForestModel):
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain
-            t.instances = self.instances
+            if hasattr(self, 'instances'):
+                t.instances = self.instances
             return t
 
         return [wrap(tree, i)

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -27,6 +27,7 @@ class RandomForestRegressor(SklModel, RandomForestModel):
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain
+            t.instances = self.instances
             return t
 
         return [wrap(tree, i)

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -27,7 +27,8 @@ class RandomForestRegressor(SklModel, RandomForestModel):
             t.supports_multiclass = self.supports_multiclass
             t.name = "{} - tree {}".format(self.name, i)
             t.original_domain = self.original_domain
-            t.instances = self.instances
+            if hasattr(self, 'instances'):
+                t.instances = self.instances
             return t
 
         return [wrap(tree, i)

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -172,7 +172,7 @@ class simulate:
     Utility functions for simulating user interactions with Qt widgets.
     """
     @staticmethod
-    def combobox_run_through_all(cbox, delay=-1):
+    def combobox_run_through_all(cbox, delay=-1, callback=None):
         """
         Run through all items in a given combo box, simulating the user
         focusing the combo box and pressing the Down arrow key activating
@@ -187,6 +187,9 @@ class simulate:
         delay : int
             Run the event loop after the simulated key press (-1, the default,
             means no delay)
+        callback : callable
+            A callback that will be executed after every item change. Takes no
+            parameters.
 
         See Also
         --------
@@ -198,6 +201,8 @@ class simulate:
         for i in range(cbox.count()):
             with excepthook_catch() as exlist:
                 QTest.keyClick(cbox, Qt.Key_Down, delay=delay)
+                if callback:
+                    callback()
             if exlist:
                 raise exlist[0][1] from exlist[0][1]
 

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -154,9 +154,6 @@ class OWPythagorasTree(OWWidget):
             self.tree_adapter = self._get_tree_adapter(self.model)
             self.ptree.clear()
 
-            # The target class can also be passed from the meta properties
-            if hasattr(model, 'meta_target_class_index'):
-                self.target_class_index = model.meta_target_class_index
             self.ptree.set_tree(
                 self.tree_adapter,
                 weight_adjustment=self.SIZE_CALCULATION[self.size_calc_idx][1],
@@ -167,9 +164,6 @@ class OWPythagorasTree(OWWidget):
             # if the tree is passed from the Pythagorean forest widget.
             if hasattr(model, 'meta_size_calc_idx'):
                 self.size_calc_idx = model.meta_size_calc_idx
-            # Updating the size calc redraws the whole tree
-            if hasattr(model, 'meta_size_calc_idx') or \
-                    hasattr(model, 'meta_size_log_scale'):
                 self.update_size_calc()
 
             self._update_depth_slider()
@@ -183,6 +177,12 @@ class OWPythagorasTree(OWWidget):
             self._update_legend_visibility()
             self._update_info_box()
             self._update_target_class_combo()
+
+            # The target class can also be passed from the meta properties
+            # This must be set after `_update_target_class_combo`
+            if hasattr(model, 'meta_target_class_index'):
+                self.target_class_index = model.meta_target_class_index
+                self.update_colors()
 
             self._update_main_area()
 

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -323,7 +323,7 @@ class OWPythagorasTree(OWWidget):
             values.insert(0, 'None')
         else:
             label_text = 'Node color'
-            values = ContinuousTreeNode.COLOR_METHODS.keys()
+            values = list(ContinuousTreeNode.COLOR_METHODS.keys())
         label.setText(label_text)
         self.target_class_combo.addItems(values)
         self.target_class_combo.setCurrentIndex(self.target_class_index)
@@ -386,10 +386,10 @@ class OWPythagorasTree(OWWidget):
 
 
 class TreeGraphicsView(
-    PannableGraphicsView,
-    ZoomableGraphicsView,
-    AnchorableGraphicsView,
-    PreventDefaultWheelEvent
+        PannableGraphicsView,
+        ZoomableGraphicsView,
+        AnchorableGraphicsView,
+        PreventDefaultWheelEvent
 ):
     """QGraphicsView that contains all functionality we will use to display
     tree."""

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -160,23 +160,14 @@ class OWPythagorasTree(OWWidget):
                 target_class_index=self.target_class_index,
             )
 
-            # Get meta variables describing what the settings should look like
-            # if the tree is passed from the Pythagorean forest widget.
-            if hasattr(model, 'meta_size_calc_idx'):
-                self.size_calc_idx = model.meta_size_calc_idx
-                self.update_size_calc()
-
             self._update_depth_slider()
-            if hasattr(model, 'meta_depth_limit'):
-                self.depth_limit = model.meta_depth_limit
-                self.update_depth()
-
             self.color_palette = self.ptree.root.color_palette
-
             self._update_legend_colors()
             self._update_legend_visibility()
             self._update_info_box()
             self._update_target_class_combo()
+
+            self._update_main_area()
 
             # The target class can also be passed from the meta properties
             # This must be set after `_update_target_class_combo`
@@ -184,7 +175,16 @@ class OWPythagorasTree(OWWidget):
                 self.target_class_index = model.meta_target_class_index
                 self.update_colors()
 
-            self._update_main_area()
+            # Get meta variables describing what the settings should look like
+            # if the tree is passed from the Pythagorean forest widget.
+            if hasattr(model, 'meta_size_calc_idx'):
+                self.size_calc_idx = model.meta_size_calc_idx
+                self.update_size_calc()
+
+            # TODO There is still something wrong with this
+            # if hasattr(model, 'meta_depth_limit'):
+            #     self.depth_limit = model.meta_depth_limit
+            #     self.update_depth()
 
         self.send(ANNOTATED_DATA_SIGNAL_NAME,
                   create_annotated_table(self.instances, None))

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -363,11 +363,8 @@ class OWPythagorasTree(OWWidget):
                 lst_colors = [QColor(*c) for c in [start, end]]
             return lst_colors
 
-        # Currently, the first index just draws the outline without any color
-        if self.target_class_index == 0:
-            items = None
         # The colors are the class mean
-        elif self.target_class_index == 1:
+        if self.target_class_index == 1:
             values = (np.min(self.clf_dataset.Y), np.max(self.clf_dataset.Y))
             colors = _get_colors_domain(self.model.domain)
             while len(values) != len(colors):
@@ -380,6 +377,8 @@ class OWPythagorasTree(OWWidget):
             while len(values) != len(colors):
                 values.insert(1, -1)
             items = list(zip(values, colors))
+        else:
+            items = None
 
         self.legend = OWContinuousLegend(items=items, **self.LEGEND_OPTIONS)
         self.legend.setVisible(self.show_legend)

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -1,59 +1,38 @@
-"""Pythagorean tree viewer for visualizing trees.
-
-The widget currently supports 3 different kinds of trees that may come in handy
-though only 2 are implemented - (GENERAL, CLASSIFICATION, REGRESSION) with
-(CLASSIFICATION and REGRESSION implemented.
-
-These modes are necessary since it is impossible to have one tree viewer for
-both classification and regression type trees, since they need specialized
-tootips and colors.
-
-The general tree exists for the purpose of easy extension, since a new `Tree`
-type has been introduced to Orange, which this widget accepts (both the
-classification and regression tree extend that base Tree class). In case the
-widget is ever required to support more general trees, the enum type is there
-to be used, and the methods need to be implemented, then it should work for any
-kind of trees.
-
-"""
+"""Pythagorean tree viewer for visualizing trees."""
 from math import sqrt, log
 
 import numpy as np
-
 from AnyQt.QtCore import Qt
-from AnyQt.QtWidgets import QLabel, QSizePolicy
 from AnyQt.QtGui import QColor, QPainter
+from AnyQt.QtWidgets import QLabel, QSizePolicy
 
 from Orange.base import TreeModel, SklModel
-from Orange.widgets.visualize.utils.scene import \
-    UpdateItemsOnSelectGraphicsScene
-from Orange.widgets.visualize.utils.tree.rules import Rule
-from Orange.widgets.visualize.utils.tree.skltreeadapter import SklTreeAdapter
-from Orange.widgets.visualize.utils.view import (
-    PannableGraphicsView,
-    ZoomableGraphicsView,
-    PreventDefaultWheelEvent
-)
-
 from Orange.data.table import Table
 from Orange.widgets import gui, settings, widget
-from Orange.widgets.utils import to_html
 from Orange.widgets.utils.annotated_data import (
     create_annotated_table,
     ANNOTATED_DATA_SIGNAL_NAME
 )
-from Orange.widgets.utils.colorpalette import ContinuousPaletteGenerator
 from Orange.widgets.visualize.pythagorastreeviewer import (
     PythagorasTreeViewer,
-    SquareGraphicsItem
+    SquareGraphicsItem,
+    ContinuousTreeNode,
 )
 from Orange.widgets.visualize.utils.owlegend import (
     AnchorableGraphicsView,
     Anchorable,
     OWDiscreteLegend,
-    OWContinuousLegend
+    OWContinuousLegend,
 )
+from Orange.widgets.visualize.utils.scene import \
+    UpdateItemsOnSelectGraphicsScene
+from Orange.widgets.visualize.utils.tree.skltreeadapter import SklTreeAdapter
 from Orange.widgets.visualize.utils.tree.treeadapter import TreeAdapter
+from Orange.widgets.visualize.utils.view import (
+    PannableGraphicsView,
+    ZoomableGraphicsView,
+    PreventDefaultWheelEvent,
+)
 from Orange.widgets.widget import OWWidget
 
 
@@ -79,8 +58,6 @@ class OWPythagorasTree(OWWidget):
     tooltips_enabled = settings.Setting(True)
     show_legend = settings.Setting(False)
 
-    GENERAL, CLASSIFICATION, REGRESSION = range(3)
-
     LEGEND_OPTIONS = {
         'corner': Anchorable.BOTTOM_RIGHT,
         'offset': (10, 10),
@@ -89,7 +66,6 @@ class OWPythagorasTree(OWWidget):
     def __init__(self):
         super().__init__()
         # Instance variables
-        self.tree_type = self.GENERAL
         self.model = None
         self.instances = None
         self.clf_dataset = None
@@ -103,15 +79,7 @@ class OWPythagorasTree(OWWidget):
         self.SIZE_CALCULATION = [
             ('Normal', lambda x: x),
             ('Square root', lambda x: sqrt(x)),
-            # The +1 is there so that we don't get division by 0 exceptions
             ('Logarithmic', lambda x: log(x * self.size_log_scale + 1)),
-        ]
-
-        # Color modes for regression trees
-        self.REGRESSION_COLOR_CALC = [
-            ('None', lambda _, __: QColor(255, 255, 255)),
-            ('Class mean', self._color_class_mean),
-            ('Standard deviation', self._color_stddev),
         ]
 
         # CONTROL AREA
@@ -154,9 +122,6 @@ class OWPythagorasTree(OWWidget):
             QSizePolicy.Preferred, QSizePolicy.Expanding)
 
         # MAIN AREA
-        # The QGraphicsScene doesn't actually require a parent, but not linking
-        # the widget to the scene causes errors and a segfault on close due to
-        # the way Qt deallocates memory and deletes objects.
         self.scene = TreeGraphicsScene(self)
         self.scene.selectionChanged.connect(self.commit)
         self.view = TreeGraphicsView(self.scene, padding=(150, 150))
@@ -177,15 +142,6 @@ class OWPythagorasTree(OWWidget):
         self.model = model
 
         if model is not None:
-            # We need to know what kind of tree we have in order to properly
-            # show colors and tooltips
-            if model.domain.class_var.is_discrete:
-                self.tree_type = self.CLASSIFICATION
-            elif model.domain.class_var.is_continuous:
-                self.tree_type = self.REGRESSION
-            else:
-                self.tree_type = self.GENERAL
-
             self.instances = model.instances
             # this bit is important for the regression classifier
             if self.instances is not None and \
@@ -196,46 +152,40 @@ class OWPythagorasTree(OWWidget):
                 self.clf_dataset = self.instances
 
             self.tree_adapter = self._get_tree_adapter(self.model)
-            self.color_palette = self._tree_specific('_get_color_palette')()
-
             self.ptree.clear()
+
+            # The target class can also be passed from the meta properties
+            if hasattr(model, 'meta_target_class_index'):
+                self.target_class_index = model.meta_target_class_index
             self.ptree.set_tree(
                 self.tree_adapter,
-                weight_adjustment=self.SIZE_CALCULATION[self.size_calc_idx][1])
-            self.ptree.set_tooltip_func(self._tree_specific('_get_tooltip'))
-            self.ptree.set_node_color_func(
-                self._tree_specific('_get_node_color')
+                weight_adjustment=self.SIZE_CALCULATION[self.size_calc_idx][1],
+                target_class_index=self.target_class_index,
             )
 
-            self._tree_specific('_update_legend_colors')()
-            self._update_legend_visibility()
-
-            self._update_info_box()
-            self._update_depth_slider()
-
-            self._tree_specific('_update_target_class_combo')()
-
-            self._update_main_area()
-
-            # Get meta variables describing pythagoras tree if given from
-            # forest.
+            # Get meta variables describing what the settings should look like
+            # if the tree is passed from the Pythagorean forest widget.
             if hasattr(model, 'meta_size_calc_idx'):
                 self.size_calc_idx = model.meta_size_calc_idx
-            if hasattr(model, 'meta_size_log_scale'):
-                self.size_log_scale = model.meta_size_log_scale
             # Updating the size calc redraws the whole tree
             if hasattr(model, 'meta_size_calc_idx') or \
                     hasattr(model, 'meta_size_log_scale'):
                 self.update_size_calc()
-            # The target class can also be passed from the meta properties
-            if hasattr(model, 'meta_target_class_index'):
-                self.target_class_index = model.meta_target_class_index
-                self.update_colors()
-            # TODO this messes up the viewport in pythagoras tree viewer
-            # it seems the viewport doesn't reset its size if this is applied
-            # if hasattr(model, 'meta_depth_limit'):
-            #     self.depth_limit = model.meta_depth_limit
-            #     self.update_depth()
+
+            self._update_depth_slider()
+            if hasattr(model, 'meta_depth_limit'):
+                self.depth_limit = model.meta_depth_limit
+                self.update_depth()
+
+            self.color_palette = self.ptree.root.color_palette
+
+            self._update_legend_colors()
+            self._update_legend_visibility()
+            self._update_info_box()
+            self._update_target_class_combo()
+
+            self._update_main_area()
+
         self.send(ANNOTATED_DATA_SIGNAL_NAME,
                   create_annotated_table(self.instances, None))
 
@@ -256,15 +206,14 @@ class OWPythagorasTree(OWWidget):
         self._clear_depth_slider()
         self._update_log_scale_slider()
 
-    # CONTROL AREA CALLBACKS
     def update_depth(self):
         """This method should be called when the depth changes"""
         self.ptree.set_depth_limit(self.depth_limit)
 
     def update_colors(self):
         """When the target class / node coloring needs to be updated."""
-        self.ptree.target_class_has_changed()
-        self._tree_specific('_update_legend_colors')()
+        self.ptree.target_class_changed(self.target_class_index)
+        self._update_legend_colors()
 
     def update_size_calc(self):
         """When the tree size calculation is updated."""
@@ -272,31 +221,24 @@ class OWPythagorasTree(OWWidget):
         self.invalidate_tree()
 
     def invalidate_tree(self):
-        """When the tree needs to be recalculated. E.g. change of size calc."""
+        """When the tree needs to be completely recalculated."""
         if self.model is not None:
-            self.tree_adapter = self._get_tree_adapter(self.model)
             self.ptree.set_tree(
                 self.tree_adapter,
-                weight_adjustment=self.SIZE_CALCULATION[self.size_calc_idx][1]
+                weight_adjustment=self.SIZE_CALCULATION[self.size_calc_idx][1],
+                target_class_index=self.target_class_index,
             )
             self.ptree.set_depth_limit(self.depth_limit)
             self._update_main_area()
 
     def update_tooltip_enabled(self):
         """When the tooltip visibility is changed and need to be updated."""
-        if self.tooltips_enabled:
-            self.ptree.set_tooltip_func(
-                self._tree_specific('_get_tooltip')
-            )
-        else:
-            self.ptree.set_tooltip_func(lambda _: None)
-        self.ptree.tooltip_has_changed()
+        self.ptree.tooltip_changed(self.tooltips_enabled)
 
     def update_show_legend(self):
         """When the legend visibility needs to be updated."""
         self._update_legend_visibility()
 
-    # MODEL CHANGED CONTROL ELEMENTS UPDATE METHODS
     def _update_info_box(self):
         self.info.setText('Nodes: {}\nDepth: {}'.format(
             self.tree_adapter.num_nodes,
@@ -317,7 +259,6 @@ class OWPythagorasTree(OWWidget):
         self.log_scale_box.parent().setEnabled(
             self.SIZE_CALCULATION[self.size_calc_idx][0] == 'Logarithmic')
 
-    # MODEL REMOVED CONTROL ELEMENTS CLEAR METHODS
     def _clear_info_box(self):
         self.info.setText('No tree on input')
 
@@ -330,7 +271,6 @@ class OWPythagorasTree(OWWidget):
         self.target_class_index = 0
         self.target_class_combo.setCurrentIndex(self.target_class_index)
 
-    # HELPFUL METHODS
     def _set_max_depth(self):
         """Set the depth to the max depth and update appropriate actors."""
         self.depth_limit = self.tree_adapter.max_depth
@@ -362,8 +302,7 @@ class OWPythagorasTree(OWWidget):
             return
         nodes = [i.tree_node.label for i in self.scene.selectedItems()
                  if isinstance(i, SquareGraphicsItem)]
-        data = self.tree_adapter.get_instances_in_nodes(
-            self.clf_dataset, nodes)
+        data = self.tree_adapter.get_instances_in_nodes(nodes)
         self.send('Selected Data', data)
         selected_indices = self.tree_adapter.get_indices(nodes)
         self.send(ANNOTATED_DATA_SIGNAL_NAME,
@@ -373,49 +312,32 @@ class OWPythagorasTree(OWWidget):
         """Send report."""
         self.report_plot()
 
-    def _tree_specific(self, method):
-        """A best effort method getter that somewhat separates logic specific
-        to classification and regression trees.
-        This relies on conventional naming of specific methods, e.g.
-        a method name _get_tooltip would need to be defined like so:
-        _classification_get_tooltip and _regression_get_tooltip, since they are
-        both specific.
-
-        Parameters
-        ----------
-        method : str
-            Method name that we would like to call.
-
-        Returns
-        -------
-        callable or None
-
-        """
-        if self.tree_type == self.GENERAL:
-            return getattr(self, '_general' + method)
-        elif self.tree_type == self.CLASSIFICATION:
-            return getattr(self, '_classification' + method)
-        elif self.tree_type == self.REGRESSION:
-            return getattr(self, '_regression' + method)
-        else:
-            return None
-
-    # CLASSIFICATION TREE SPECIFIC METHODS
-    def _classification_update_target_class_combo(self):
+    def _update_target_class_combo(self):
         self._clear_target_class_combo()
-        list(filter(
-            lambda x: isinstance(x, QLabel),
-            self.target_class_combo.parent().children()
-        ))[0].setText('Target class')
-        self.target_class_combo.addItem('None')
-        values = [c.title() for c in
-                  self.tree_adapter.domain.class_vars[0].values]
-        self.target_class_combo.addItems(values)
+        label = [x for x in self.target_class_combo.parent().children()
+                 if isinstance(x, QLabel)][0]
 
-    def _classification_update_legend_colors(self):
+        if self.instances.domain.has_discrete_class:
+            label_text = 'Target class'
+            values = [c.title() for c in self.instances.domain.class_vars[0].values]
+            values.insert(0, 'None')
+        else:
+            label_text = 'Node color'
+            values = ContinuousTreeNode.COLOR_METHODS.keys()
+        label.setText(label_text)
+        self.target_class_combo.addItems(values)
+        self.target_class_combo.setCurrentIndex(self.target_class_index)
+
+    def _update_legend_colors(self):
         if self.legend is not None:
             self.scene.removeItem(self.legend)
 
+        if self.instances.domain.has_discrete_class:
+            self._classification_update_legend_colors()
+        else:
+            self._regression_update_legend_colors()
+
+    def _classification_update_legend_colors(self):
         if self.target_class_index == 0:
             self.legend = OWDiscreteLegend(domain=self.model.domain,
                                            **self.LEGEND_OPTIONS)
@@ -430,81 +352,7 @@ class OWPythagorasTree(OWWidget):
         self.legend.setVisible(self.show_legend)
         self.scene.addItem(self.legend)
 
-    def _classification_get_color_palette(self):
-        return [QColor(*c) for c in self.model.domain.class_var.colors]
-
-    def _classification_get_node_color(self, adapter, tree_node):
-        # this is taken almost directly from the existing classification tree
-        # viewer
-        colors = self.color_palette
-        distribution = adapter.get_distribution(tree_node.label)[0]
-        total = np.sum(distribution)
-
-        if self.target_class_index:
-            p = distribution[self.target_class_index - 1] / total
-            color = colors[self.target_class_index - 1].lighter(200 - 100 * p)
-        else:
-            modus = np.argmax(distribution)
-            p = distribution[modus] / (total or 1)
-            color = colors[int(modus)].lighter(400 - 300 * p)
-        return color
-
-    def _rules_for_tooltip(self, node):
-        rules = self.tree_adapter.rules(node.label)
-        if len(rules):
-            if isinstance(rules[0], Rule):
-                sorted_rules = sorted(rules[:-1], key=lambda rule: rule.attr_name)
-                return '<br>'.join(str(rule) for rule in sorted_rules) + \
-                       '<br><b>%s</b>' % rules[-1]
-            else:
-                return '<br>'.join(to_html(rule) for rule in rules)
-        else:
-            return ''
-
-    def _classification_get_tooltip(self, node):
-        distribution = self.tree_adapter.get_distribution(node.label)[0]
-        total = int(np.sum(distribution))
-        if self.target_class_index:
-            samples = distribution[self.target_class_index - 1]
-            text = ''
-        else:
-            modus = np.argmax(distribution)
-            samples = distribution[modus]
-            text = self.tree_adapter.domain.class_vars[0].values[modus] + \
-                '<br>'
-        ratio = samples / np.sum(distribution)
-
-        rules_str = self._rules_for_tooltip(node)
-        splitting_attr = self.tree_adapter.attribute(node.label)
-
-        return '<p>' \
-            + text \
-            + '{}/{} samples ({:2.3f}%)'.format(
-                int(samples), total, ratio * 100) \
-            + '<hr>' \
-            + ('Split by ' + splitting_attr.name
-               if not self.tree_adapter.is_leaf(node.label) else '') \
-            + ('<br><br>'
-               if rules_str and not self.tree_adapter.is_leaf(node.label)
-               else '') \
-            + rules_str \
-            + '</p>'
-
-    # REGRESSION TREE SPECIFIC METHODS
-    def _regression_update_target_class_combo(self):
-        self._clear_target_class_combo()
-        list(filter(
-            lambda x: isinstance(x, QLabel),
-            self.target_class_combo.parent().children()
-        ))[0].setText('Node color')
-        self.target_class_combo.addItems(
-            list(zip(*self.REGRESSION_COLOR_CALC))[0])
-        self.target_class_combo.setCurrentIndex(self.target_class_index)
-
     def _regression_update_legend_colors(self):
-        if self.legend is not None:
-            self.scene.removeItem(self.legend)
-
         def _get_colors_domain(domain):
             class_var = domain.class_var
             start, end, pass_through_black = class_var.colors
@@ -517,87 +365,32 @@ class OWPythagorasTree(OWWidget):
 
         # Currently, the first index just draws the outline without any color
         if self.target_class_index == 0:
-            self.legend = None
-            return
+            items = None
         # The colors are the class mean
         elif self.target_class_index == 1:
             values = (np.min(self.clf_dataset.Y), np.max(self.clf_dataset.Y))
             colors = _get_colors_domain(self.model.domain)
             while len(values) != len(colors):
                 values.insert(1, -1)
-
-            self.legend = OWContinuousLegend(items=list(zip(values, colors)),
-                                             **self.LEGEND_OPTIONS)
+            items = list(zip(values, colors))
         # Colors are the stddev
         elif self.target_class_index == 2:
             values = (0, np.std(self.clf_dataset.Y))
             colors = _get_colors_domain(self.model.domain)
             while len(values) != len(colors):
                 values.insert(1, -1)
+            items = list(zip(values, colors))
 
-            self.legend = OWContinuousLegend(items=list(zip(values, colors)),
-                                             **self.LEGEND_OPTIONS)
-
+        self.legend = OWContinuousLegend(items=items, **self.LEGEND_OPTIONS)
         self.legend.setVisible(self.show_legend)
         self.scene.addItem(self.legend)
 
-    def _regression_get_color_palette(self):
-        return ContinuousPaletteGenerator(
-            *self.tree_adapter.domain.class_var.colors)
-
-    def _regression_get_node_color(self, adapter, tree_node):
-        return self.REGRESSION_COLOR_CALC[self.target_class_index][1](
-            adapter, tree_node
-        )
-
-    def _color_class_mean(self, adapter, tree_node):
-        # calculate node colors relative to the mean of the node samples
-        min_mean = np.min(self.clf_dataset.Y)
-        max_mean = np.max(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset,
-                                                   tree_node.label)
-        mean = np.mean(instances.Y)
-
-        return self.color_palette[(mean - min_mean) / (max_mean - min_mean)]
-
-    def _color_stddev(self, adapter, tree_node):
-        # calculate node colors relative to the standard deviation in the node
-        # samples
-        min_mean, max_mean = 0, np.std(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset,
-                                                   tree_node.label)
-        std = np.std(instances.Y)
-
-        return self.color_palette[(std - min_mean) / (max_mean - min_mean)]
-
-    def _regression_get_tooltip(self, node):
-        num_samples = self.tree_adapter.num_samples(node.label)
-
-        instances = self.tree_adapter.get_instances_in_nodes(
-            self.clf_dataset, node.label)
-        mean = np.mean(instances.Y)
-        std = np.std(instances.Y)
-
-        rules_str = self._rules_for_tooltip(node)
-        splitting_attr = self.tree_adapter.attribute(node.label)
-
-        return '<p>Mean: {:2.3f}'.format(mean) \
-            + '<br>Standard deviation: {:2.3f}'.format(std) \
-            + '<br>{} samples'.format(num_samples) \
-            + '<hr>' \
-            + ('Split by ' + splitting_attr.name
-               if not self.tree_adapter.is_leaf(node.label) else '') \
-            + ('<br><br>' if rules_str and not self.tree_adapter.is_leaf(
-               node.label) else '') \
-            + rules_str \
-            + '</p>'
-
 
 class TreeGraphicsView(
-        PannableGraphicsView,
-        ZoomableGraphicsView,
-        AnchorableGraphicsView,
-        PreventDefaultWheelEvent
+    PannableGraphicsView,
+    ZoomableGraphicsView,
+    AnchorableGraphicsView,
+    PreventDefaultWheelEvent
 ):
     """QGraphicsView that contains all functionality we will use to display
     tree."""
@@ -610,6 +403,7 @@ class TreeGraphicsScene(UpdateItemsOnSelectGraphicsScene):
 
 
 def main():
+    from Orange.modelling import TreeLearner
     from AnyQt.QtWidgets import QApplication
     import sys
 
@@ -618,10 +412,6 @@ def main():
     ow = OWPythagorasTree()
     data = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
 
-    if data.domain.has_discrete_class:
-        from Orange.classification.tree import SklTreeLearner as TreeLearner
-    else:
-        from Orange.regression.tree import SklTreeRegressionLearner as TreeLearner
     model = TreeLearner(max_depth=1000)(data)
     model.instances = data
     ow.set_tree(model)
@@ -630,6 +420,7 @@ def main():
     ow.raise_()
     ow.handleNewSignals()
     app.exec_()
+
 
 if __name__ == '__main__':
     main()

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -206,7 +206,7 @@ class OWPythagoreanForest(OWWidget):
         self.ui_depth_slider.setMaximum(0)
 
     def _get_max_depth(self):
-        return max([tree.tree_adapter.max_depth for tree in self.ptrees])
+        return max(tree.tree_adapter.max_depth for tree in self.ptrees)
 
     def _get_forest_adapter(self, model):
         return SklRandomForestAdapter(model)

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -268,7 +268,7 @@ class OWPythagoreanForest(OWWidget):
         if self.__prevent_commit:
             return
 
-        if len(self.scene.selectedItems()) == 0:
+        if not self.scene.selectedItems():
             self.send('Tree', None)
             # The selected tree index should only reset when model changes
             if self.model is None:
@@ -303,7 +303,7 @@ class OWPythagoreanForest(OWWidget):
             values.insert(0, 'None')
         else:
             label_text = 'Node color'
-            values = ContinuousTreeNode.COLOR_METHODS.keys()
+            values = list(ContinuousTreeNode.COLOR_METHODS.keys())
         label.setText(label_text)
         self.ui_target_class_combo.addItems(values)
         self.ui_target_class_combo.setCurrentIndex(self.target_class_index)
@@ -325,18 +325,14 @@ class SklRandomForestAdapter:
     """Take a `RandomForest` and wrap all the trees into the `SklTreeAdapter`
     instances that Pythagorean trees use."""
     def __init__(self, model):
-        self._adapters = []
+        self._adapters = None
         self._domain = model.domain
         self._trees = model.trees
 
     def get_trees(self):
         """Get the tree adapters in the random forest."""
-        if len(self._adapters) > 0:
-            return self._adapters
-        if len(self._trees) < 1:
-            return self._adapters
-
-        self._adapters = list(map(SklTreeAdapter, self._trees))
+        if not self._adapters:
+            self._adapters = list(map(SklTreeAdapter, self._trees))
         return self._adapters
 
     @property

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -177,9 +177,11 @@ class OWPythagoreanForest(OWWidget):
 
     @contextmanager
     def _prevent_commit(self):
-        self.__prevent_commit = True
-        yield
-        self.__prevent_commit = False
+        try:
+            self.__prevent_commit = True
+            yield
+        finally:
+            self.__prevent_commit = False
 
     def _update_info_box(self):
         self.ui_info.setText('Trees: {}'.format(len(self.forest_adapter.get_trees())))
@@ -212,15 +214,17 @@ class OWPythagoreanForest(OWWidget):
     @contextmanager
     def disable_ui(self):
         """Temporarly disable the UI while trees may be redrawn."""
-        self.ui_size_calc_combo.setEnabled(False)
-        self.ui_depth_slider.setEnabled(False)
-        self.ui_target_class_combo.setEnabled(False)
-        self.ui_zoom_slider.setEnabled(False)
-        yield
-        self.ui_size_calc_combo.setEnabled(True)
-        self.ui_depth_slider.setEnabled(True)
-        self.ui_target_class_combo.setEnabled(True)
-        self.ui_zoom_slider.setEnabled(True)
+        try:
+            self.ui_size_calc_combo.setEnabled(False)
+            self.ui_depth_slider.setEnabled(False)
+            self.ui_target_class_combo.setEnabled(False)
+            self.ui_zoom_slider.setEnabled(False)
+            yield
+        finally:
+            self.ui_size_calc_combo.setEnabled(True)
+            self.ui_depth_slider.setEnabled(True)
+            self.ui_target_class_combo.setEnabled(True)
+            self.ui_zoom_slider.setEnabled(True)
 
     def _draw_trees(self):
         self.grid_items, self.ptrees = [], []

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -1,18 +1,18 @@
 """Pythagorean forest widget for visualizing random forests."""
+from contextlib import contextmanager
 from math import log, sqrt
 
-import numpy as np
 from AnyQt.QtCore import Qt
-from AnyQt.QtGui import QPainter, QColor
-from AnyQt.QtWidgets import QSizePolicy, QGraphicsScene, QGraphicsView
+from AnyQt.QtGui import QPainter
+from AnyQt.QtWidgets import QSizePolicy, QGraphicsScene, QGraphicsView, QLabel
 
 from Orange.base import RandomForestModel, TreeModel
-from Orange.classification.random_forest import RandomForestClassifier
 from Orange.data import Table
-from Orange.regression.random_forest import RandomForestRegressor
 from Orange.widgets import gui, settings
-from Orange.widgets.utils.colorpalette import ContinuousPaletteGenerator
-from Orange.widgets.visualize.pythagorastreeviewer import PythagorasTreeViewer
+from Orange.widgets.visualize.pythagorastreeviewer import (
+    PythagorasTreeViewer,
+    ContinuousTreeNode,
+)
 from Orange.widgets.visualize.utils.owgrid import (
     OWGrid,
     SelectableGridItem,
@@ -40,19 +40,14 @@ class OWPythagoreanForest(OWWidget):
     depth_limit = settings.ContextSetting(10)
     target_class_index = settings.ContextSetting(0)
     size_calc_idx = settings.Setting(0)
-    size_log_scale = settings.Setting(2)
     zoom = settings.Setting(50)
     selected_tree_index = settings.ContextSetting(-1)
 
-    CLASSIFICATION, REGRESSION = range(2)
-
     def __init__(self):
         super().__init__()
-        # Instance variables
-        self.forest_type = self.CLASSIFICATION
         self.model = None
         self.forest_adapter = None
-        self.dataset = None
+        self.instances = None
         self.clf_dataset = None
         # We need to store refernces to the trees and grid items
         self.grid_items, self.ptrees = [], []
@@ -63,34 +58,28 @@ class OWPythagoreanForest(OWWidget):
         self.SIZE_CALCULATION = [
             ('Normal', lambda x: x),
             ('Square root', lambda x: sqrt(x)),
-            ('Logarithmic', lambda x: log(x * self.size_log_scale)),
-        ]
-
-        self.REGRESSION_COLOR_CALC = [
-            ('None', lambda _, __: QColor(255, 255, 255)),
-            ('Class mean', self._color_class_mean),
-            ('Standard deviation', self._color_stddev),
+            ('Logarithmic', lambda x: log(x + 1)),
         ]
 
         # CONTROL AREA
         # Tree info area
         box_info = gui.widgetBox(self.controlArea, 'Forest')
-        self.ui_info = gui.widgetLabel(box_info, label='')
+        self.ui_info = gui.widgetLabel(box_info)
 
         # Display controls area
         box_display = gui.widgetBox(self.controlArea, 'Display')
         self.ui_depth_slider = gui.hSlider(
             box_display, self, 'depth_limit', label='Depth', ticks=False,
-            callback=self.max_depth_changed)
+            callback=self.update_depth)
         self.ui_target_class_combo = gui.comboBox(
             box_display, self, 'target_class_index', label='Target class',
             orientation=Qt.Horizontal, items=[], contentsLength=8,
-            callback=self.target_colors_changed)
+            callback=self.update_colors)
         self.ui_size_calc_combo = gui.comboBox(
             box_display, self, 'size_calc_idx', label='Size',
             orientation=Qt.Horizontal,
             items=list(zip(*self.SIZE_CALCULATION))[0], contentsLength=8,
-            callback=self.size_calc_changed)
+            callback=self.update_size_calc)
         self.ui_zoom_slider = gui.hSlider(
             box_display, self, 'zoom', label='Zoom', ticks=False, minValue=20,
             maxValue=150, callback=self.zoom_changed, createLabel=False)
@@ -98,8 +87,7 @@ class OWPythagoreanForest(OWWidget):
         # Stretch to fit the rest of the unsused area
         gui.rubber(self.controlArea)
 
-        self.controlArea.setSizePolicy(
-            QSizePolicy.Preferred, QSizePolicy.Expanding)
+        self.controlArea.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
 
         # MAIN AREA
         self.scene = QGraphicsScene(self)
@@ -123,28 +111,19 @@ class OWPythagoreanForest(OWWidget):
         self.model = model
 
         if model is not None:
-            if isinstance(model, RandomForestClassifier):
-                self.forest_type = self.CLASSIFICATION
-            elif isinstance(model, RandomForestRegressor):
-                self.forest_type = self.REGRESSION
-            else:
-                raise RuntimeError('Invalid type of forest.')
-
             self.forest_adapter = self._get_forest_adapter(self.model)
-            self.color_palette = self._type_specific('_get_color_palette')()
             self._draw_trees()
+            self.color_palette = self.forest_adapter.get_trees()[0]
 
-            self.dataset = model.instances
+            self.instances = model.instances
             # this bit is important for the regression classifier
-            if self.dataset is not None and \
-                    self.dataset.domain != model.domain:
-                self.clf_dataset = Table.from_table(
-                    self.model.domain, self.dataset)
+            if self.instances is not None and self.instances.domain != model.domain:
+                self.clf_dataset = Table.from_table(self.model.domain, self.instances)
             else:
-                self.clf_dataset = self.dataset
+                self.clf_dataset = self.instances
 
             self._update_info_box()
-            self._type_specific('_update_target_class_combo')()
+            self._update_target_class_combo()
             self._update_depth_slider()
 
             self.selected_tree_index = -1
@@ -161,27 +140,25 @@ class OWPythagoreanForest(OWWidget):
         self._clear_target_class_combo()
         self._clear_depth_slider()
 
-    # CONTROL AREA CALLBACKS
-    def max_depth_changed(self):
+    def update_depth(self):
         """When the max depth slider is changed."""
         for tree in self.ptrees:
             tree.set_depth_limit(self.depth_limit)
 
-    def target_colors_changed(self):
+    def update_colors(self):
         """When the target class or coloring method is changed."""
         for tree in self.ptrees:
-            tree.target_class_has_changed()
+            tree.target_class_changed(self.target_class_index)
 
-    def size_calc_changed(self):
+    def update_size_calc(self):
         """When the size calculation of the trees is changed."""
         if self.model is not None:
-            self.forest_adapter = self._get_forest_adapter(self.model)
             self.grid.clear()
             self._draw_trees()
             # Keep the selected item
             if self.selected_tree_index != -1:
                 self.grid_items[self.selected_tree_index].setSelected(True)
-            self.max_depth_changed()
+            self.update_depth()
 
     def zoom_changed(self):
         """When we update the "Zoom" slider."""
@@ -192,11 +169,8 @@ class OWPythagoreanForest(OWWidget):
         self.grid.reflow(width)
         self.grid.setPreferredWidth(width)
 
-    # MODEL CHANGED METHODS
     def _update_info_box(self):
-        self.ui_info.setText(
-            'Trees: {}'.format(len(self.forest_adapter.get_trees()))
-        )
+        self.ui_info.setText('Trees: {}'.format(len(self.forest_adapter.get_trees())))
 
     def _update_depth_slider(self):
         self.depth_limit = self._get_max_depth()
@@ -205,7 +179,6 @@ class OWPythagoreanForest(OWWidget):
         self.ui_depth_slider.setMaximum(self.depth_limit)
         self.ui_depth_slider.setValue(self.depth_limit)
 
-    # MODEL CLEARED METHODS
     def _clear_info_box(self):
         self.ui_info.setText('No forest on input.')
 
@@ -218,36 +191,55 @@ class OWPythagoreanForest(OWWidget):
         self.ui_depth_slider.parent().setEnabled(False)
         self.ui_depth_slider.setMaximum(0)
 
-    # HELPFUL METHODS
     def _get_max_depth(self):
         return max([tree.tree_adapter.max_depth for tree in self.ptrees])
 
     def _get_forest_adapter(self, model):
         return SklRandomForestAdapter(model)
 
-    def _draw_trees(self):
+    @contextmanager
+    def disable_ui(self):
+        """Temporarly disable the UI while trees may be redrawn."""
         self.ui_size_calc_combo.setEnabled(False)
+        self.ui_depth_slider.setEnabled(False)
+        self.ui_target_class_combo.setEnabled(False)
+        self.ui_zoom_slider.setEnabled(False)
+        yield
+        self.ui_size_calc_combo.setEnabled(True)
+        self.ui_depth_slider.setEnabled(True)
+        self.ui_target_class_combo.setEnabled(True)
+        self.ui_zoom_slider.setEnabled(True)
+
+    def _draw_trees(self):
         self.grid_items, self.ptrees = [], []
 
-        with self.progressBar(len(self.forest_adapter.get_trees())) as prg:
+        num_trees = len(self.forest_adapter.get_trees())
+        with self.progressBar(num_trees) as prg, self.disable_ui():
             for tree in self.forest_adapter.get_trees():
                 ptree = PythagorasTreeViewer(
-                    None, tree,
-                    node_color_func=self._type_specific('_get_node_color'),
-                    interactive=False, padding=100)
-                self.grid_items.append(GridItem(
+                    None, tree, interactive=False, padding=100,
+                    target_class_index=self.target_class_index,
+                    weight_adjustment=self.SIZE_CALCULATION[self.size_calc_idx][1]
+                )
+                grid_item = GridItem(
                     ptree, self.grid, max_size=self._calculate_zoom(self.zoom)
-                ))
+                )
+                # We don't want to show flickering while the trees are being
+                grid_item.setVisible(False)
+
+                self.grid_items.append(grid_item)
                 self.ptrees.append(ptree)
                 prg.advance()
-        self.grid.set_items(self.grid_items)
-        # This is necessary when adding items for the first time
-        if self.grid:
-            width = (self.view.width() -
-                     self.view.verticalScrollBar().width())
-            self.grid.reflow(width)
-            self.grid.setPreferredWidth(width)
-        self.ui_size_calc_combo.setEnabled(True)
+            
+            self.grid.set_items(self.grid_items)
+            # This is necessary when adding items for the first time
+            if self.grid:
+                width = (self.view.width() - self.view.verticalScrollBar().width())
+                self.grid.reflow(width)
+                self.grid.setPreferredWidth(width)
+                # After drawing is complete, we show the trees
+                for grid_item in self.grid_items:
+                    grid_item.setVisible(True)
 
     @staticmethod
     def _calculate_zoom(zoom_level):
@@ -270,14 +262,13 @@ class OWPythagoreanForest(OWWidget):
 
         selected_item = self.scene.selectedItems()[0]
         self.selected_tree_index = self.grid_items.index(selected_item)
-        obj = self.model.trees[self.selected_tree_index]
-        obj.instances = self.dataset
-        obj.meta_target_class_index = self.target_class_index
-        obj.meta_size_calc_idx = self.size_calc_idx
-        obj.meta_size_log_scale = self.size_log_scale
-        obj.meta_depth_limit = self.depth_limit
+        tree = self.model.trees[self.selected_tree_index]
+        tree.instances = self.instances
+        tree.meta_target_class_index = self.target_class_index
+        tree.meta_size_calc_idx = self.size_calc_idx
+        tree.meta_depth_limit = self.depth_limit
 
-        self.send('Tree', obj)
+        self.send('Tree', tree)
 
     def send_report(self):
         """Send report."""
@@ -286,100 +277,28 @@ class OWPythagoreanForest(OWWidget):
     def _update_scene_rect(self):
         self.scene.setSceneRect(self.scene.itemsBoundingRect())
 
+    def _update_target_class_combo(self):
+        self._clear_target_class_combo()
+        label = [x for x in self.ui_target_class_combo.parent().children()
+                 if isinstance(x, QLabel)][0]
+
+        if self.instances.domain.has_discrete_class:
+            label_text = 'Target class'
+            values = [c.title() for c in self.instances.domain.class_vars[0].values]
+            values.insert(0, 'None')
+        else:
+            label_text = 'Node color'
+            values = ContinuousTreeNode.COLOR_METHODS.keys()
+        label.setText(label_text)
+        self.ui_target_class_combo.addItems(values)
+        self.ui_target_class_combo.setCurrentIndex(self.target_class_index)
+
     def resizeEvent(self, ev):
         width = (self.view.width() - self.view.verticalScrollBar().width())
         self.grid.reflow(width)
         self.grid.setPreferredWidth(width)
 
         super().resizeEvent(ev)
-
-    def _type_specific(self, method):
-        """A best effort method getter that somewhat separates logic specific
-        to classification and regression trees.
-        This relies on conventional naming of specific methods, e.g.
-        a method name _get_tooltip would need to be defined like so:
-        _classification_get_tooltip and _regression_get_tooltip, since they are
-        both specific.
-
-        Parameters
-        ----------
-        method : str
-            Method name that we would like to call.
-
-        Returns
-        -------
-        callable or None
-
-        """
-        if self.forest_type == self.CLASSIFICATION:
-            return getattr(self, '_classification' + method)
-        elif self.forest_type == self.REGRESSION:
-            return getattr(self, '_regression' + method)
-        else:
-            return None
-
-    # CLASSIFICATION FOREST SPECIFIC METHODS
-    def _classification_update_target_class_combo(self):
-        self._clear_target_class_combo()
-        self.ui_target_class_combo.addItem('None')
-        values = [c.title() for c in
-                  self.model.domain.class_vars[0].values]
-        self.ui_target_class_combo.addItems(values)
-
-    def _classification_get_color_palette(self):
-        return [QColor(*c) for c in self.model.domain.class_var.colors]
-
-    def _classification_get_node_color(self, adapter, tree_node):
-        # this is taken almost directly from the existing classification tree
-        # viewer
-        colors = self.color_palette
-        distribution = adapter.get_distribution(tree_node.label)[0]
-        total = np.sum(distribution)
-
-        if self.target_class_index:
-            p = distribution[self.target_class_index - 1] / total
-            color = colors[self.target_class_index - 1].lighter(200 - 100 * p)
-        else:
-            modus = np.argmax(distribution)
-            p = distribution[modus] / (total or 1)
-            color = colors[int(modus)].lighter(400 - 300 * p)
-        return color
-
-    # REGRESSION FOREST SPECIFIC METHODS
-    def _regression_update_target_class_combo(self):
-        self._clear_target_class_combo()
-        self.ui_target_class_combo.addItems(
-            list(zip(*self.REGRESSION_COLOR_CALC))[0])
-        self.ui_target_class_combo.setCurrentIndex(self.target_class_index)
-
-    def _regression_get_color_palette(self):
-        return ContinuousPaletteGenerator(
-            *self.forest_adapter.domain.class_var.colors)
-
-    def _regression_get_node_color(self, adapter, tree_node):
-        return self.REGRESSION_COLOR_CALC[self.target_class_index][1](
-            adapter, tree_node
-        )
-
-    def _color_class_mean(self, adapter, tree_node):
-        # calculate node colors relative to the mean of the node samples
-        min_mean = np.min(self.clf_dataset.Y)
-        max_mean = np.max(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset,
-                                                   tree_node.label)
-        mean = np.mean(instances.Y)
-
-        return self.color_palette[(mean - min_mean) / (max_mean - min_mean)]
-
-    def _color_stddev(self, adapter, tree_node):
-        # calculate node colors relative to the standard deviation in the node
-        # samples
-        min_mean, max_mean = 0, np.std(self.clf_dataset.Y)
-        instances = adapter.get_instances_in_nodes(self.clf_dataset,
-                                                   tree_node.label)
-        std = np.std(instances.Y)
-
-        return self.color_palette[(std - min_mean) / (max_mean - min_mean)]
 
 
 class GridItem(SelectableGridItem, ZoomableGridItem):
@@ -412,20 +331,14 @@ class SklRandomForestAdapter:
 
 
 if __name__ == '__main__':
+    from Orange.modelling import RandomForestLearner
     from AnyQt.QtWidgets import QApplication
     import sys
 
     app = QApplication(sys.argv)
     ow = OWPythagoreanForest()
     data = Table(sys.argv[1] if len(sys.argv) > 1 else 'iris')
-
-    if data.domain.has_discrete_class:
-        from Orange.classification.random_forest import \
-            RandomForestLearner as RFLearner
-    else:
-        from Orange.regression.random_forest import \
-            RandomForestRegressionLearner as RFLearner
-    rf = RFLearner(n_estimators=10, max_depth=1000)(data)
+    rf = RandomForestLearner(n_estimators=10)(data)
     rf.instances = data
     ow.set_rf(rf)
 

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -322,8 +322,7 @@ class OWTreeGraph(OWTreeViewer2D):
             return
         nodes = [item.node_inst for item in self.scene.selectedItems()
                  if isinstance(item, TreeNode)]
-        data = self.tree_adapter.get_instances_in_nodes(
-            self.clf_dataset, nodes)
+        data = self.tree_adapter.get_instances_in_nodes(nodes)
         self.send("Selected Data", data)
         self.send(ANNOTATED_DATA_SIGNAL_NAME, create_annotated_table(
             self.dataset,
@@ -411,10 +410,10 @@ class OWTreeGraph(OWTreeViewer2D):
                 node.backgroundBrush = brush
         elif self.regression_colors == self.COL_INSTANCE:
             max_insts = len(self.tree_adapter.get_instances_in_nodes(
-                self.dataset, [self.tree_adapter.root]))
+                [self.tree_adapter.root]))
             for node in self.scene.nodes():
                 node_insts = len(self.tree_adapter.get_instances_in_nodes(
-                    self.dataset, [node.node_inst]))
+                    [node.node_inst]))
                 node.backgroundBrush = QBrush(def_color.lighter(
                     120 - 20 * node_insts / max_insts))
         elif self.regression_colors == self.COL_MEAN:

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -444,14 +444,11 @@ def test():
     """Standalone test"""
     import sys
     from AnyQt.QtWidgets import QApplication
-    from Orange.classification.tree import TreeLearner, SklTreeLearner
-    from Orange.regression.tree import TreeLearner, SklTreeRegressionLearner
+    from Orange.modelling.tree import TreeLearner
     a = QApplication(sys.argv)
     ow = OWTreeGraph()
-    data = Table("titanic")
-    # data = Table("housing")[:30]
-    clf = SklTreeLearner()(data)
-    # clf = TreeLearner()(data)
+    data = Table(sys.argv[1] if len(sys.argv) > 1 else "titanic")
+    clf = TreeLearner()(data)
     clf.instances = data
 
     ow.ctree(clf)

--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -164,9 +164,8 @@ class PythagorasTreeViewer(QGraphicsWidget):
 
         def _recurse(node):
             node.target_class_index = target_class_index
-            if len(node.children) > 0:
-                for child in node.children:
-                    _recurse(child)
+            for child in node.children:
+                _recurse(child)
 
         _recurse(self.root)
 
@@ -584,7 +583,7 @@ class TreeNode(metaclass=ABCMeta):
 
     def _rules_str(self):
         rules = self.tree.rules(self.label)
-        if len(rules):
+        if rules:
             if isinstance(rules[0], Rule):
                 sorted_rules = sorted(rules[:-1], key=lambda rule: rule.attr_name)
                 return '<br>'.join(str(rule) for rule in sorted_rules) + \
@@ -645,9 +644,7 @@ class DiscreteTreeNode(TreeNode):
             + '<hr>' \
             + ('Split by ' + splitting_attr.name
                if not self.tree.is_leaf(self.label) else '') \
-            + ('<br><br>'
-               if rules_str and not self.tree.is_leaf(self.label)
-               else '') \
+            + ('<br><br>' if rules_str and not self.tree.is_leaf(self.label) else '') \
             + rules_str \
             + '</p>'
 
@@ -716,8 +713,7 @@ class ContinuousTreeNode(TreeNode):
             + '<hr>' \
             + ('Split by ' + splitting_attr.name
                if not self.tree.is_leaf(self.label) else '') \
-            + ('<br><br>' if rules_str and not self.tree.is_leaf(
-               self.label) else '') \
+            + ('<br><br>' if rules_str and not self.tree.is_leaf(self.label) else '') \
             + rules_str \
             + '</p>'
 

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -7,6 +7,7 @@ from os import path
 from Orange.data import Table
 from Orange.modelling import TreeLearner
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+from Orange.widgets.tests.utils import simulate
 from Orange.widgets.visualize.owpythagorastree import OWPythagorasTree
 from Orange.widgets.visualize.pythagorastreeviewer import (
     PythagorasTree,
@@ -16,7 +17,7 @@ from Orange.widgets.visualize.pythagorastreeviewer import (
 )
 from Orange.widgets.visualize.utils.owlegend import (
     OWDiscreteLegend,
-    OWContinuousLegend
+    OWContinuousLegend,
 )
 
 
@@ -88,6 +89,7 @@ class TestPythagorasTree(unittest.TestCase):
 
 
 class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -111,7 +113,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         cls.housing.instances = housing_data
 
     def setUp(self):
-        self.widget = self.create_widget(OWPythagorasTree)
+        self.widget = self.create_widget(OWPythagorasTree)  # type: OWPythagorasTree
 
     def _select_data(self):
         item = [i for i in self.widget.scene.items() if
@@ -131,60 +133,54 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         """Get all the `TreeNode` instances in the widget scene."""
         return (sq.tree_node for sq in self.get_squares())
 
-    @staticmethod
-    def set_combo_option(combo_box, text):
-        """Set a given combo box value to some text (given that it exists)."""
-        index = combo_box.findText(text)
-        # This only changes the selection, need to emit signal to call callback
-        combo_box.setCurrentIndex(index)
-        # Apparently `currentIndexChanged` just isn't good enough...
-        combo_box.activated.emit(index)
-
-    def test_sending_classification_tree_is_drawn(self):
+    def test_tree_is_drawn(self):
         self.send_signal('Tree', self.housing)
         self.assertTrue(len(self.get_squares()) > 0)
 
+    def _check_all_same(self, items):
+        iter_items = iter(items)
+        try:
+            first = next(iter_items)
+        except StopIteration:
+            return True
+        return all(first == curr for curr in iter_items)
+
     def test_changing_color_changes_node_coloring(self):
         """Changing the `Target class` combo box should update colors."""
+        def _test(data_type):
+            squares = []
+
+            def _callback():
+                squares.append([sq.brush().color() for sq in self.get_visible_squares()])
+
+            simulate.combobox_run_through_all(
+                self.widget.target_class_combo, callback=_callback)
+
+            # Check that individual squares all have different colors
+            squares_same = [self._check_all_same(x) for x in zip(*squares)]
+            # Check that at least some of the squares have different colors
+            self.assertTrue(any(x is False for x in squares_same),
+                            'Colors did not change for %s data' % data_type)
+
         self.send_signal('Tree', self.titanic)
-
-        # Get colors for default coloring
-        def_colors_sq = self.get_squares()
-        default_colors = [sq.brush().color() for sq in def_colors_sq]
-
-        # Get colors for `Yes` class coloring
-        self.set_combo_option(self.widget.target_class_combo, 'Yes')
-        yes_colors_sq = self.get_squares()
-        yes_colors = [sq.brush().color() for sq in yes_colors_sq]
-
-        # Get colors for `No` class coloring
-        self.set_combo_option(self.widget.target_class_combo, 'No')
-        no_colors_sq = self.get_squares()
-        no_colors = [sq.brush().color() for sq in no_colors_sq]
-
-        # Make sure all the colors aren't the same in any event
-        eqs = [d != y and d != n and y != n for d, y, n in
-               zip(default_colors, yes_colors, no_colors)]
-
-        self.assertTrue(all(eqs))
+        _test('classification')
+        self.send_signal('Tree', self.housing)
+        _test('regression')
 
     def test_changing_size_adjustment_changes_sizes(self):
         self.send_signal('Tree', self.titanic)
+        squares = []
 
-        basic_sizing_sq = [n.square for n in self.get_tree_nodes()]
+        def _callback():
+            squares.append([sq.rect() for sq in self.get_visible_squares()])
 
-        self.set_combo_option(self.widget.size_calc_combo, 'Square root')
-        sqroot_sizing_sq = [n.square for n in self.get_tree_nodes()]
+        simulate.combobox_run_through_all(
+            self.widget.size_calc_combo, callback=_callback)
 
-        self.set_combo_option(self.widget.size_calc_combo, 'Logarithmic')
-        log_sizing_sq = [n.square for n in self.get_tree_nodes()]
-
-        eqs = [b != s and b != l and s != l for b, s, l in
-               zip(basic_sizing_sq, sqroot_sizing_sq, log_sizing_sq)]
-
-        # Only compare to the -1 list element since the base square is always
-        # the same
-        self.assertTrue(all(eqs[:-1]))
+        # Check that individual squares are in different position
+        squares_same = [self._check_all_same(x) for x in zip(*squares)]
+        # Check that at least some of the squares have different positions
+        self.assertTrue(any(x is False for x in squares_same))
 
     def test_log_scale_slider(self):
         # Disabled when no tree
@@ -193,15 +189,15 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
 
         self.send_signal('Tree', self.titanic)
         # No size adjustment
-        self.set_combo_option(self.widget.size_calc_combo, 'Normal')
+        simulate.combobox_activate_item(self.widget.size_calc_combo, 'Normal')
         self.assertFalse(self.widget.log_scale_box.isEnabled(),
                          'Should be disabled when no size adjustment')
         # Square root adjustment
-        self.set_combo_option(self.widget.size_calc_combo, 'Square root')
+        simulate.combobox_activate_item(self.widget.size_calc_combo, 'Square root')
         self.assertFalse(self.widget.log_scale_box.isEnabled(),
                          'Should be disabled when square root size adjustment')
         # Log adjustment
-        self.set_combo_option(self.widget.size_calc_combo, 'Logarithmic')
+        simulate.combobox_activate_item(self.widget.size_calc_combo, 'Logarithmic')
         self.assertTrue(self.widget.log_scale_box.isEnabled(),
                         'Should be enabled when square root size adjustment')
 
@@ -212,34 +208,58 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         self.widget.log_scale_box.setValue(2)
         updated_sizing_sq = [n.square for n in self.get_tree_nodes()]
 
-        eqs = [x != y for x, y in zip(inital_sizing_sq, updated_sizing_sq)]
         # Only compare to the -1 list element since the base square is always
         # the same
         self.assertTrue(
-            all(eqs[:-1]),
+            any([x != y for x, y in zip(inital_sizing_sq, updated_sizing_sq)]),
             'Squares are drawn in same positions after changing log factor')
 
-    def test_classification_tree_creates_correct_legend(self):
+    def test_test_legend(self):
+        """Test legend behaviour."""
+        self.widget.cb_show_legend.setChecked(True)
+
         self.send_signal('Tree', self.titanic)
         self.assertIsInstance(self.widget.legend, OWDiscreteLegend)
+        self.assertTrue(self.widget.legend.isVisible())
 
-    def test_regression_tree_creates_correct_legend(self):
+        # The legend should be invisible when regression coloring is none
         self.send_signal('Tree', self.housing)
-        # Put the widget into a coloring scheme that builds the legend
-        # We'll put it into the the class mean coloring mode
-        self.set_combo_option(self.widget.target_class_combo, 'Class mean')
         self.assertIsInstance(self.widget.legend, OWContinuousLegend)
+        self.assertFalse(self.widget.legend.isVisible())
+
+        # The legend should appear when there is a coloring
+        simulate.combobox_activate_item(self.widget.target_class_combo, 'Mean')
+        self.assertIsInstance(self.widget.legend, OWContinuousLegend)
+        self.assertTrue(self.widget.legend.isVisible())
+
+        # Check that switching back to a discrete target class works
+        self.send_signal('Tree', self.titanic)
+        self.assertIsInstance(self.widget.legend, OWDiscreteLegend)
+        self.assertTrue(self.widget.legend.isVisible())
 
     def test_checking_legend_checkbox_shows_and_hides_legend(self):
         self.send_signal('Tree', self.titanic)
         # Hide the legend
         self.widget.cb_show_legend.setChecked(False)
-        self.assertFalse(self.widget.legend.isVisible(),
-                         'Hiding legend failed')
+        self.assertFalse(self.widget.legend.isVisible(), 'Hiding legend failed')
         # Show the legend
         self.widget.cb_show_legend.setChecked(True)
-        self.assertTrue(self.widget.legend.isVisible(),
-                        'Showing legend failed')
+        self.assertTrue(self.widget.legend.isVisible(), 'Showing legend failed')
+
+    def test_tooltip_changes_for_classification_target_class(self):
+        """Tooltips should change when a target class is specified with a
+        discrete target class."""
+        self.widget.cb_show_tooltips.setChecked(True)
+        self.send_signal('Tree', self.titanic)
+        tooltips = []
+
+        def _callback():
+            tooltips.append(self.get_visible_squares()[2].toolTip())
+
+        simulate.combobox_run_through_all(
+            self.widget.target_class_combo, callback=_callback)
+
+        self.assertFalse(self._check_all_same(tooltips))
 
     def test_checking_tooltip_shows_and_hides_tooltips(self):
         self.send_signal('Tree', self.titanic)
@@ -328,3 +348,17 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
                 "sent to widget after receiving a dataset with variables with "
                 "same entropy." % n_tries
             )
+    def test_keep_colors_on_sizing_change(self):
+        """The color should be the same after a full recompute of the tree."""
+        self.send_signal('Tree', self.titanic)
+        colors = []
+
+        def _callback():
+            colors.append([sq.brush().color() for sq in self.get_visible_squares()])
+
+        simulate.combobox_run_through_all(
+            self.widget.size_calc_combo, callback=_callback)
+
+        # Check that individual squares all have the same color
+        colors_same = [self._check_all_same(x) for x in zip(*colors)]
+        self.assertTrue(all(colors_same))

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -145,7 +145,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
             return True
         return all(first == curr for curr in iter_items)
 
-    def test_changing_color_changes_node_coloring(self):
+    def test_changing_target_class_changes_node_coloring(self):
         """Changing the `Target class` combo box should update colors."""
         def _test(data_type):
             squares = []

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -214,7 +214,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
             any([x != y for x, y in zip(inital_sizing_sq, updated_sizing_sq)]),
             'Squares are drawn in same positions after changing log factor')
 
-    def test_test_legend(self):
+    def test_legend(self):
         """Test legend behaviour."""
         self.widget.cb_show_legend.setChecked(True)
 
@@ -227,8 +227,9 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         self.assertIsInstance(self.widget.legend, OWContinuousLegend)
         self.assertFalse(self.widget.legend.isVisible())
 
-        # The legend should appear when there is a coloring
-        simulate.combobox_activate_item(self.widget.target_class_combo, 'Mean')
+        # The legend should appear when there is a coloring (2 is mean coloring)
+        index = 2
+        simulate.combobox_activate_index(self.widget.target_class_combo, index)
         self.assertIsInstance(self.widget.legend, OWContinuousLegend)
         self.assertTrue(self.widget.legend.isVisible())
 
@@ -309,16 +310,6 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         """Check that the tree is drawn identically upon receiving the same
         dataset with no parameter changes."""
         n_tries = 10
-
-        def _check_all_same(data):
-            """Check that all the elements within an iterable are identical."""
-            iterator = iter(data)
-            try:
-                first = next(iterator)
-            except StopIteration:
-                return True
-            return all(first == rest for rest in iterator)
-
         # Make sure the tree are deterministic for iris
         scene_nodes = []
         for _ in range(n_tries):
@@ -326,7 +317,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
             scene_nodes.append([n.pos() for n in self.get_visible_squares()])
         for node_row in zip(*scene_nodes):
             self.assertTrue(
-                _check_all_same(node_row),
+                self._check_all_same(node_row),
                 "The tree was not drawn identically in the %d times it was "
                 "sent to widget after receiving the iris dataset." % n_tries
             )
@@ -343,11 +334,12 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
             scene_nodes.append([n.pos() for n in self.get_visible_squares()])
         for node_row in zip(*scene_nodes):
             self.assertTrue(
-                _check_all_same(node_row),
+                self._check_all_same(node_row),
                 "The tree was not drawn identically in the %d times it was "
                 "sent to widget after receiving a dataset with variables with "
                 "same entropy." % n_tries
             )
+
     def test_keep_colors_on_sizing_change(self):
         """The color should be the same after a full recompute of the tree."""
         self.send_signal('Tree', self.titanic)

--- a/Orange/widgets/visualize/tests/test_owpythagoreanforest.py
+++ b/Orange/widgets/visualize/tests/test_owpythagoreanforest.py
@@ -1,9 +1,11 @@
+import random
 from unittest.mock import Mock
 
 from Orange.classification.random_forest import RandomForestLearner
 from Orange.data import Table
 from Orange.regression.random_forest import RandomForestRegressionLearner
 from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.utils import simulate
 from Orange.widgets.visualize.owpythagoreanforest import OWPythagoreanForest, \
     GridItem
 from Orange.widgets.visualize.pythagorastreeviewer import PythagorasTreeViewer
@@ -25,7 +27,8 @@ class TestOWPythagoreanForest(WidgetTest):
         cls.housing.instances = housing_data
 
     def setUp(self):
-        self.widget = self.create_widget(OWPythagoreanForest)
+        self.widget = self.create_widget(OWPythagoreanForest)  # type: OWPythagoreanForest
+
 
     def get_tree_widgets(self):
         return [x for x in self.widget.scene.items()
@@ -34,15 +37,6 @@ class TestOWPythagoreanForest(WidgetTest):
     def get_grid_items(self):
         return [x for x in self.widget.scene.items()
                 if isinstance(x, GridItem)]
-
-    @staticmethod
-    def set_combo_option(combo_box, text):
-        """Set a given combo box value to some text (given that it exists)."""
-        index = combo_box.findText(text)
-        # This only changes the selection, need to emit signal to call callback
-        combo_box.setCurrentIndex(index)
-        # Apparently `currentIndexChanged` just isn't good enough...
-        combo_box.activated.emit(index)
 
     def test_sending_rf_draws_trees(self):
         # No trees by default
@@ -89,55 +83,101 @@ class TestOWPythagoreanForest(WidgetTest):
         for tree in trees:
             tree.set_depth_limit.assert_called_once_with(0)
 
-    def test_target_class_for_classification_rf(self):
+    def _pick_random_tree(self):
+        """Pick a random tree from all the trees on the grid.
+
+        Returns
+        -------
+        PythagorasTreeViewer
+
+        """
+        return random.choice(self.get_tree_widgets())
+
+    def _get_visible_squares(self, tree):
+        return [x for _, x in tree._square_objects.items() if x.isVisible()]
+
+    def _check_all_same(self, items):
+        iter_items = iter(items)
+        try:
+            first = next(iter_items)
+        except StopIteration:
+            return True
+        return all(first == curr for curr in iter_items)
+
+    def test_changing_target_class_changes_coloring(self):
+        """Changing the `Target class` combo box should update colors."""
+        def _test(data_type):
+            colors, tree = [], self._pick_random_tree()
+
+            def _callback():
+                colors.append([sq.brush().color() for sq in self._get_visible_squares(tree)])
+
+            simulate.combobox_run_through_all(
+                self.widget.ui_target_class_combo, callback=_callback)
+
+            # Check that individual squares all have different colors
+            squares_same = [self._check_all_same(x) for x in zip(*colors)]
+            # Check that at least some of the squares have different colors
+            self.assertTrue(any(x is False for x in squares_same),
+                            'Colors did not change for %s data' % data_type)
+
         self.send_signal('Random forest', self.titanic)
-
-        trees = self.get_tree_widgets()
-        for tree in trees:
-            tree.target_class_changed = Mock()
-
-        self.set_combo_option(self.widget.ui_target_class_combo, 'No')
-        for tree in trees:
-            tree.target_class_changed.assert_called()
-            tree.target_class_changed.reset_mock()
-
-        self.set_combo_option(self.widget.ui_target_class_combo, 'Yes')
-        for tree in trees:
-            tree.target_class_changed.assert_called()
-
-    def test_target_class_for_regression_rf(self):
+        _test('classification')
         self.send_signal('Random forest', self.housing)
+        _test('regression')
 
-        trees = self.get_tree_widgets()
-        for tree in trees:
-            tree.target_class_changed = Mock()
+    def test_changing_size_adjustment_changes_sizes(self):
+        self.send_signal('Random forest', self.titanic)
+        squares = []
+        # We have to get the same tree with an index on the grid items since
+        # the tree objects are deleted and recreated with every invalidation
+        tree_index = self.widget.grid_items.index(random.choice(self.get_grid_items()))
 
-        self.set_combo_option(self.widget.ui_target_class_combo, 'Mean')
-        for tree in trees:
-            tree.target_class_changed.assert_called()
-            tree.target_class_changed.reset_mock()
+        def _callback():
+            squares.append([sq.rect() for sq in self._get_visible_squares(
+                self.get_tree_widgets()[tree_index])])
 
-        self.set_combo_option(self.widget.ui_target_class_combo,
-                              'Standard deviation')
-        for tree in trees:
-            tree.target_class_changed.assert_called()
+        simulate.combobox_run_through_all(
+            self.widget.ui_size_calc_combo, callback=_callback)
+
+        # Check that individual squares are in different position
+        squares_same = [self._check_all_same(x) for x in zip(*squares)]
+        # Check that at least some of the squares have different positions
+        self.assertTrue(any(x is False for x in squares_same))
 
     def test_zoom(self):
         self.send_signal('Random forest', self.titanic)
 
         grid_item, zoom = self.get_grid_items()[0], self.widget.zoom
 
-        def destructure_rectf(r):
+        def _destructure_rectf(r):
             return r.width(), r.height()
 
-        iw, ih = destructure_rectf(grid_item.boundingRect())
+        iw, ih = _destructure_rectf(grid_item.boundingRect())
 
         # Increase the size of grid item
         self.widget.ui_zoom_slider.setValue(zoom + 1)
-        lw, lh = destructure_rectf(grid_item.boundingRect())
+        lw, lh = _destructure_rectf(grid_item.boundingRect())
         self.assertTrue(iw < lw and ih < lh)
 
         # Decrease the size of grid item
         self.widget.ui_zoom_slider.setValue(zoom - 1)
-        lw, lh = destructure_rectf(grid_item.boundingRect())
+        lw, lh = _destructure_rectf(grid_item.boundingRect())
         self.assertTrue(iw > lw and ih > lh)
+
+    def test_keep_colors_on_sizing_change(self):
+        """The color should be the same after a full recompute of the tree."""
+        self.send_signal('Random forest', self.titanic)
+        colors = []
+        tree_index = self.widget.grid_items.index(random.choice(self.get_grid_items()))
+
+        def _callback():
+            colors.append([sq.brush().color() for sq in self._get_visible_squares(
+                self.get_tree_widgets()[tree_index])])
+
+        simulate.combobox_run_through_all(
+            self.widget.ui_size_calc_combo, callback=_callback)
+
+        # Check that individual squares all have the same color
+        colors_same = [self._check_all_same(x) for x in zip(*colors)]
+        self.assertTrue(all(colors_same))

--- a/Orange/widgets/visualize/tests/test_owpythagoreanforest.py
+++ b/Orange/widgets/visualize/tests/test_owpythagoreanforest.py
@@ -94,33 +94,33 @@ class TestOWPythagoreanForest(WidgetTest):
 
         trees = self.get_tree_widgets()
         for tree in trees:
-            tree.target_class_has_changed = Mock()
+            tree.target_class_changed = Mock()
 
         self.set_combo_option(self.widget.ui_target_class_combo, 'No')
         for tree in trees:
-            tree.target_class_has_changed.assert_called_with()
-            tree.target_class_has_changed.reset_mock()
+            tree.target_class_changed.assert_called()
+            tree.target_class_changed.reset_mock()
 
         self.set_combo_option(self.widget.ui_target_class_combo, 'Yes')
         for tree in trees:
-            tree.target_class_has_changed.assert_called_with()
+            tree.target_class_changed.assert_called()
 
     def test_target_class_for_regression_rf(self):
         self.send_signal('Random forest', self.housing)
 
         trees = self.get_tree_widgets()
         for tree in trees:
-            tree.target_class_has_changed = Mock()
+            tree.target_class_changed = Mock()
 
-        self.set_combo_option(self.widget.ui_target_class_combo, 'Class mean')
+        self.set_combo_option(self.widget.ui_target_class_combo, 'Mean')
         for tree in trees:
-            tree.target_class_has_changed.assert_called_with()
-            tree.target_class_has_changed.reset_mock()
+            tree.target_class_changed.assert_called()
+            tree.target_class_changed.reset_mock()
 
         self.set_combo_option(self.widget.ui_target_class_combo,
                               'Standard deviation')
         for tree in trees:
-            tree.target_class_has_changed.assert_called_with()
+            tree.target_class_changed.assert_called()
 
     def test_zoom(self):
         self.send_signal('Random forest', self.titanic)

--- a/Orange/widgets/visualize/utils/owlegend.py
+++ b/Orange/widgets/visualize/utils/owlegend.py
@@ -496,6 +496,7 @@ class Legend(Anchorable):
         self.setFlags(QGraphicsWidget.ItemIsMovable |
                       QGraphicsItem.ItemIgnoresTransformations)
 
+        self._setup_layout()
         if domain is not None:
             self.set_domain(domain)
         elif items is not None:
@@ -560,6 +561,10 @@ class Legend(Anchorable):
         else:
             return QColor(obj)
 
+    def setVisible(self, is_visible):
+        """Only display the legend if it contains any items."""
+        return super().setVisible(is_visible and len(self._layout) > 0)
+
     def paint(self, painter, options, widget=None):
         painter.save()
         pen = QPen(QColor(196, 197, 193, 200), 1)
@@ -591,7 +596,6 @@ class OWDiscreteLegend(Legend):
         self.set_items(zip(class_var.values, class_var.colors.tolist()))
 
     def set_items(self, values):
-        self._setup_layout()
         for class_name, color in values:
             legend_item = LegendItem(
                 color=self._convert_to_color(color),
@@ -651,7 +655,6 @@ class OWContinuousLegend(Legend):
         if self.orientation == Qt.Vertical and vals[0] < vals[len(vals) - 1]:
             colors, vals = list(reversed(colors)), list(reversed(vals))
 
-        self._setup_layout()
         self._layout.addItem(ContinuousLegendItem(
             palette=colors,
             values=vals,

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -63,6 +63,7 @@ class SklTreeAdapter(BaseTreeAdapter):
     def __right_child(self, node):
         return self._tree.children_right[node]
 
+    @memoize_method(maxsize=1024)
     def get_distribution(self, node):
         value = self._tree.value[node]
         # If regression tree, we have to compute variance by hand, we can
@@ -233,11 +234,6 @@ class SklTreeAdapter(BaseTreeAdapter):
                                   indices[~leftmask])
                 return list.__iadd__(leftind, rightind)
 
-        # TODO this kind of cache can lead to all sorts of problems, but numpy
-        # arrays are unhashable, and this gives huge performance boosts
-        # also this would only become a problem if the function required to
-        # handle multiple datasets, which it doesn't, it just deals with the
-        # one the classification tree was fit to.
         if self._all_leaves is not None:
             return self._all_leaves
 

--- a/Orange/widgets/visualize/utils/tree/tests/test_treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/tests/test_treeadapter.py
@@ -61,10 +61,10 @@ class TestTreeAdapter(unittest.TestCase):
             adapt.leaves(self.root),
             self.left.children + [self.right.children[0]])
         np.testing.assert_almost_equal(
-            adapt.get_instances_in_nodes(self.data, self.root).X,
+            adapt.get_instances_in_nodes(self.root).X,
             self.data.X)
         np.testing.assert_almost_equal(
-            adapt.get_instances_in_nodes(self.data, [self.left, self.right]).X,
+            adapt.get_instances_in_nodes([self.left, self.right]).X,
             np.array([[8,  9, 10],
                       [12, 13, 14],
                       [16, 17, 18],

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -17,6 +17,11 @@ class BaseTreeAdapter(metaclass=ABCMeta):
     NO_CHILD = -1
     FEATURE_UNDEFINED = -2
 
+    def __init__(self, model):
+        self.model = model
+        self.domain = model.domain
+        self.instances = model.instances
+
     @abstractmethod
     def weight(self, node):
         """Get the weight of the given node.
@@ -270,25 +275,8 @@ class BaseTreeAdapter(metaclass=ABCMeta):
         """
         pass
 
-    @property
-    @abstractmethod
-    def domain(self):
-        """Get the domain of the given tree.
-
-        The domain contains information about the classes what the tree
-        represents.
-
-        Returns
-        -------
-
-        """
-        pass
-
 
 class TreeAdapter(BaseTreeAdapter):
-    def __init__(self, model):
-        self.model = model
-
     def weight(self, node):
         return len(node.subset) / len(node.parent.subset)
 
@@ -327,7 +315,7 @@ class TreeAdapter(BaseTreeAdapter):
             return reduce(add, map(_leaves, self.children(node)), []) or [node]
         return _leaves(node)
 
-    def get_instances_in_nodes(self, dataset, nodes):
+    def get_instances_in_nodes(self, nodes):
         from Orange import tree
         if isinstance(nodes, tree.Node):
             nodes = [nodes]
@@ -347,7 +335,3 @@ class TreeAdapter(BaseTreeAdapter):
     @property
     def root(self):
         return self.model.root
-
-    @property
-    def domain(self):
-        return self.model.domain


### PR DESCRIPTION
##### Issue
Some of the Pythagrean tree and Pythagorean forest code was written very poorly with some duplication and poor handling of continuous vs discrete target classes.

##### Description of changes
Pretty major refactoring to remove all the duplicated code as well as several small fixes that were discovered along the way.

- Add `callback` to qt testing utilis `combobox_run_through_all` that enables us to call a function after the combobox changes to perform additional checks.
- Remove all the `tree_specific` stuff in the tree and forest in favour of more oop code so that messy callbacks are not needed.
- Make the `TreeAdapter` simpler by allowing it to store the data. This makes sense because since all the models have the data they were trained on, there really is no reason to complicate the adapter.
- Forest: Hide the trees while they are being drawn, since they would all bunch up in the first cell of the grid and flicker there until all would be drawn.
- Forest: Disable UI options while the trees are being drawn. This is so we can't accidentally change a setting while the trees are being drawn.
- Forest: The output is now consistent. Before, it used to be that when we changed the colors or the max depth on the forest the output wouldn't update, but when we changed the sizing, it would. This is fixed so the output changes only whenever we select a different tree.
- Tree: The tree can properly process all the display options that are passed from the forest (sizing, coloring, depth) so that when we select a tree on the forest widget, we get exactly what we are looking at in the tree widget. Before, the sizing was not functional.
- The tests now use the much better testing utils. I've also added several tests to the tree and forest to test the various UI setting combinations.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
