### PR TITLE
[FIX] Learner: Generalize params and used_vals to all learners

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -82,17 +82,21 @@ class Learner(_ReprableWithPreprocessors):
     preprocessors = ()
     learner_adequacy_err_msg = ''
 
-    # Just a fallback in case learners don't specify their params. Params
-    # should be specified instance-wise, every learner can be constructed with
-    # different params, so we should store those.
-    params = {}
-
     def __init__(self, preprocessors=None):
         self.use_default_preprocessors = False
+        self.__params = {}
         if isinstance(preprocessors, Iterable):
             self.preprocessors = tuple(preprocessors)
         elif preprocessors:
             self.preprocessors = (preprocessors,)
+
+    @property
+    def params(self):
+        return self.__params
+
+    @params.setter
+    def params(self, value):
+        self.__params = value
 
     def fit(self, X, Y, W=None):
         raise RuntimeError(
@@ -320,16 +324,16 @@ class SklLearner(_ReprableWithParams, Learner, metaclass=WrapperMeta):
     ]
 
     def __init__(self, *args, **kwargs):
-        self._params = {}
+        self.__params = {}
         super().__init__(*args, **kwargs)
 
     @property
     def params(self):
-        return self._params
+        return self.__params
 
     @params.setter
     def params(self, value):
-        self._params = self._get_sklparams(value)
+        self.__params = self._get_sklparams(value)
 
     def _get_sklparams(self, values):
         skllearner = self.__wraps__

--- a/Orange/modelling/base.py
+++ b/Orange/modelling/base.py
@@ -29,6 +29,14 @@ class Fitter(Learner, metaclass=FitterMeta):
     will then determine which parameters have to be passed to individual
     learners.
 
+    Attributes
+    ----------
+    params : dict
+        All the parameters used to construct the learner, including
+        classification and regression parameters. If you need parameters for
+        only a specific learner to handle e.g. classification, see
+        `get_params`.
+
     """
     __fits__ = None
     __returns__ = Model
@@ -38,9 +46,9 @@ class Fitter(Learner, metaclass=FitterMeta):
 
     def __init__(self, preprocessors=None, **kwargs):
         super().__init__(preprocessors=preprocessors)
-        self.kwargs = kwargs
+        self.params = kwargs
         # Make sure to pass preprocessor params to individual learners
-        self.kwargs['preprocessors'] = preprocessors
+        self.params['preprocessors'] = preprocessors
         self.__learners = {self.CLASSIFICATION: None, self.REGRESSION: None}
 
     def _fit_model(self, data):
@@ -89,7 +97,7 @@ class Fitter(Learner, metaclass=FitterMeta):
     def __kwargs(self, problem_type):
         learner_kwargs = set(
             self.__fits__[problem_type].__init__.__code__.co_varnames[1:])
-        changed_kwargs = self._change_kwargs(self.kwargs, problem_type)
+        changed_kwargs = self._change_kwargs(self.params, problem_type)
         return {k: v for k, v in changed_kwargs.items() if k in learner_kwargs}
 
     def _change_kwargs(self, kwargs, problem_type):
@@ -103,6 +111,10 @@ class Fitter(Learner, metaclass=FitterMeta):
         renamed into `loss` before passed to the actual learner instance. This
         is done here.
 
+        It is important that in case the parameter is not passed, that we do
+        not throw an exception here and that `None` is passed for that param.
+        I would recommend using `kwargs.get(...)`.
+
         """
         return kwargs
 
@@ -115,12 +127,6 @@ class Fitter(Learner, metaclass=FitterMeta):
             and self.get_learner(self.CLASSIFICATION).supports_weights) and (
             hasattr(self.get_learner(self.REGRESSION), 'supports_weights')
             and self.get_learner(self.REGRESSION).supports_weights)
-
-    @property
-    def params(self):
-        raise TypeError(
-            'A fitter does not have its own params. If you need to access '
-            'learner params, please use the `get_params` method.')
 
     def get_params(self, problem_type):
         """Access the specific learner params of a given learner."""

--- a/Orange/modelling/base.py
+++ b/Orange/modelling/base.py
@@ -50,10 +50,17 @@ class Fitter(Learner, metaclass=FitterMeta):
             learner = self.get_learner(self.REGRESSION)
 
         if type(self).fit is Learner.fit:
-            return learner.fit_storage(data)
+            model = learner.fit_storage(data)
         else:
             X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
-            return learner.fit(X, Y, W)
+            model = learner.fit(X, Y, W)
+
+        if data.domain.has_discrete_class:
+            model.params = self.get_params(self.CLASSIFICATION)
+        else:
+            model.params = self.get_params(self.REGRESSION)
+
+        return model
 
     def preprocess(self, data):
         if data.domain.has_discrete_class:


### PR DESCRIPTION
##### Issue
#2125 6.

##### Description of changes
The fix I've provided does basically one thing. We now expect every learner to have a `params` attribute. We also expect every learner to output a model with the `used_vals` field. These attributes seem very general to all learners and models and there doesn't seem to be any reason whatsoever for scikit wrapped learners to be special and have their own separate attributes on their public API. This makes everything very confusing and difficult to work with. By moving everything up to the base learner, it makes the API of any learners much simpler and more uniform.

In case this is not a desired solution, I can also provide a quick and dirty workaround that also fixes the main issue with SGD and other wrapped learners.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
