### PR TITLE
[FIX] Predictions widget: handle similar but different domains

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -313,11 +313,14 @@ class OWPredictions(OWWidget):
             slots = self._valid_predictors()
             results = []
             class_var = self.class_var
-            nvalues = len(class_var.values)
             for p in slots:
                 values, prob = p.results
-                prob = numpy.c_[prob, numpy.zeros((prob.shape[0], nvalues - prob.shape[1]))]
                 if self.class_var.is_discrete:
+                    # if values were added to class_var between building the
+                    # model and predicting, add zeros for new class values,
+                    # which are always at the end
+                    prob = numpy.c_[prob,
+                                    numpy.zeros((prob.shape[0], len(class_var.values) - prob.shape[1]))]
                     values = [Value(class_var, v) for v in values]
                 results.append((values, prob))
             results = list(zip(*(zip(*res) for res in results)))

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -313,8 +313,10 @@ class OWPredictions(OWWidget):
             slots = self._valid_predictors()
             results = []
             class_var = self.class_var
+            nvalues = len(class_var.values)
             for p in slots:
                 values, prob = p.results
+                prob = numpy.c_[prob, numpy.zeros((prob.shape[0], nvalues - prob.shape[1]))]
                 if self.class_var.is_discrete:
                     values = [Value(class_var, v) for v in values]
                 results.append((values, prob))

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -9,6 +9,7 @@ from Orange.widgets.evaluate.owpredictions import OWPredictions
 from Orange.data import Table, Domain
 from Orange.classification import MajorityLearner, TreeLearner
 from Orange.evaluation import Results
+from Orange.widgets.tests.utils import excepthook_catch
 
 
 class TestOWPredictions(WidgetTest):
@@ -157,4 +158,6 @@ class TestOWPredictions(WidgetTest):
         bad_table = TabReader(file2).read()
 
         self.send_signal("Predictors", tree, 1)
-        self.send_signal("Data", bad_table)
+
+        with excepthook_catch():
+            self.send_signal("Data", bad_table)

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -6,7 +6,7 @@ from Orange.data.io import TabReader
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.evaluate.owpredictions import OWPredictions
 
-from Orange.data import Table, Domain
+from Orange.data import Table, Domain, Variable
 from Orange.modelling import ConstantLearner, TreeLearner
 from Orange.evaluation import Results
 from Orange.widgets.tests.utils import excepthook_catch
@@ -130,6 +130,8 @@ class TestOWPredictions(WidgetTest):
         different target values instead of two.
         GH-2129
         """
+        Variable._clear_all_caches()
+
         filestr1 = """\
         age\tsex\tsurvived
         d\td\td
@@ -141,7 +143,6 @@ class TestOWPredictions(WidgetTest):
         """
         file1 = io.StringIO(filestr1)
         table = TabReader(file1).read()
-
         learner = TreeLearner()
         tree = learner(table)
 
@@ -161,6 +162,8 @@ class TestOWPredictions(WidgetTest):
 
         with excepthook_catch():
             self.send_signal("Data", bad_table)
+
+        Variable._clear_all_caches()  # so that test excepting standard titanic work
 
     def test_continuous_class(self):
         data = Table("housing")


### PR DESCRIPTION
##### Issue
Widget throws an error similar to "index 1 is out of bounds for axis 0 with size 1". That occurs when predictions which are sent to Predictions widget are made from a data with different domain than a domain which is also sent to that widget. For instance, predictions predict only two possible target values but the data has also a third value.
https://sentry.io/biolab/orange3/issues/223474227/
https://sentry.io/biolab/orange3/issues/216151441/


##### Description of changes
Predictions table is extended to match the number of the data target's values.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
