### PR TITLE
Scatter Plot: Rank Informative projections & color variable

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -47,12 +47,12 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
 
     def check_preconditions(self):
         self.Information.add_message(
-            "class_required", "Data with a class variable is required.")
-        self.Information.class_required.clear()
+            "color_required", "Color is not selected.")
+        self.Information.color_required.clear()
         if not super().check_preconditions():
             return False
-        if not self.master.data.domain.class_var:
-            self.Information.class_required()
+        if not self.master.graph.attr_color:
+            self.Information.color_required()
             return False
         return True
 
@@ -87,13 +87,16 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         X = self.master.graph.jittered_data.T
         Y = self.master.data.Y
         mdomain = self.master.data.domain
+        color_var = mdomain[self.master.graph.attr_color]
         dom = Domain([ContinuousVariable(str(i)) for i in range(X.shape[1])],
-                     mdomain.class_vars)
+                     color_var)
         data = Table(dom, X, Y)
         relief = ReliefF if isinstance(dom.class_var, DiscreteVariable) \
             else RReliefF
         weights = relief(n_iterations=100, k_nearest=self.minK)(data)
-        attrs = sorted(zip(weights, mdomain.attributes),
+        mdomain_var = list(mdomain.variables)
+        mdomain_var.remove(color_var)
+        attrs = sorted(zip(weights, tuple(mdomain_var)),
                        key=lambda x: (-x[0], x[1].name))
         return [a for _, a in attrs]
 
@@ -447,7 +450,7 @@ class OWScatterPlot(OWWidget):
         self.send_features()
 
     def update_colors(self):
-        self.graph.update_colors()
+        self.vizrank.initialize()
         self.cb_class_density.setEnabled(self.graph.can_draw_density())
 
     def update_density(self):

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -906,6 +906,7 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         return pen, brush
 
     def update_colors(self, keep_colors=False):
+        self.master.update_colors()
         if self.scatterplot_item:
             pen_data, brush_data = self.compute_colors(keep_colors)
             pen_data_sel, brush_data_sel = self.compute_colors_sel(keep_colors)


### PR DESCRIPTION
Rank Informative projections with regard to the color variable

##### Issue
Scatter plot's find informative projections currently uses the class_variable to rank different projections. This should be modified to use the variable selected in color instead.
#2037

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
