### PR TITLE
SGD: Fix default loss parameter

### DIFF
--- a/Orange/classification/sgd.py
+++ b/Orange/classification/sgd.py
@@ -13,7 +13,7 @@ class SGDClassificationLearner(SklLearner):
     __returns__ = LinearModel
     preprocessors = SklLearner.preprocessors + [Normalize()]
 
-    def __init__(self, loss='squared_loss',penalty='l2', alpha=0.0001,
+    def __init__(self, loss='hinge', penalty='l2', alpha=0.0001,
                  l1_ratio=0.15,fit_intercept=True, n_iter=5, shuffle=True,
                  epsilon=0.1, random_state=None, learning_rate='invscaling',
                  eta0=0.01, power_t=0.25, warm_start=False, average=False,

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -83,7 +83,7 @@ class SGDRegressionLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.SGDRegressor
     preprocessors = SklLearner.preprocessors + [Normalize()]
 
-    def __init__(self, loss='squared_loss',penalty='l2', alpha=0.0001,
+    def __init__(self, loss='squared_loss', penalty='l2', alpha=0.0001,
                  l1_ratio=0.15, fit_intercept=True, n_iter=5, shuffle=True,
                  epsilon=0.1, n_jobs=1, random_state=None,
                  learning_rate='invscaling', eta0=0.01, power_t=0.25,

--- a/Orange/tests/test_sgd.py
+++ b/Orange/tests/test_sgd.py
@@ -35,7 +35,7 @@ class TestSGDClassificationLearner(unittest.TestCase):
     def test_SGDClassification(self):
         sgd = SGDClassificationLearner()
         res = CrossValidation(self.iris, [sgd], k=3)
-        self.assertGreater(AUC(res)[0], 0.85)
+        self.assertGreater(AUC(res)[0], 0.8)
 
     def test_coefficients(self):
         lrn = SGDClassificationLearner()


### PR DESCRIPTION
##### Issue
SGD did not have correct default parameters. See sklearn docs for [classification](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html) and [regression](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDRegressor.html)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
