### PR TITLE
[FIX] All widgets are set to auto* when they are used for the first time

### DIFF
--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -367,7 +367,7 @@ class OWEditDomain(widget.OWWidget):
     domain_change_hints = settings.ContextSetting({})
     selected_index = settings.ContextSetting({})
 
-    autocommit = settings.Setting(False)
+    autocommit = settings.Setting(True)
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/data/owimageviewer.py
+++ b/Orange/widgets/data/owimageviewer.py
@@ -872,7 +872,7 @@ class OWImageViewer(widget.OWWidget):
     titleAttr = settings.ContextSetting(0)
 
     imageSize = settings.Setting(100)
-    autoCommit = settings.Setting(False)
+    autoCommit = settings.Setting(True)
 
     buttons_area_orientation = Qt.Vertical
     graph_name = "scene"

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -76,7 +76,7 @@ class OWImpute(OWWidget):
 
     _default_method_index = settings.Setting(DO_NOT_IMPUTE)
     variable_methods = settings.ContextSetting({})
-    autocommit = settings.Setting(False)
+    autocommit = settings.Setting(True)
 
     want_main_area = False
     resizing_enabled = False

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -948,7 +948,7 @@ class OWPreprocess(widget.OWWidget):
                ("Preprocessed Data", Orange.data.Table)]
 
     storedsettings = settings.Setting({})
-    autocommit = settings.Setting(False)
+    autocommit = settings.Setting(True)
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -23,7 +23,7 @@ class OWPurgeDomain(widget.OWWidget):
     removeClassAttribute = Setting(1)
     removeMetaAttributeValues = Setting(1)
     removeMetaAttributes = Setting(1)
-    autoSend = Setting(False)
+    autoSend = Setting(True)
     sortValues = Setting(True)
     sortClasses = Setting(True)
 

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -376,7 +376,7 @@ class OWPythonScript(widget.OWWidget):
         Setting([Script("Hello world", "print('Hello world')\n")])
     currentScriptIndex = Setting(0)
     splitterState = Setting(None)
-    auto_execute = Setting(False)
+    auto_execute = Setting(True)
 
     def __init__(self):
         super().__init__()
@@ -386,7 +386,6 @@ class OWPythonScript(widget.OWWidget):
         self.in_learner = None
         self.in_classifier = None
         self.in_object = None
-        self.auto_execute = False
 
         for s in self.libraryListSource:
             s.flags = 0

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -256,7 +256,7 @@ class OWSelectAttributes(widget.OWWidget):
 
     settingsHandler = SelectAttributesDomainContextHandler()
     domain_role_hints = ContextSetting({})
-    auto_commit = Setting(False)
+    auto_commit = Setting(True)
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -42,6 +42,7 @@ class TestOWPythonScript(WidgetTest):
 
     def test_local_variable(self):
         """Check if variable remains in locals after removed from script"""
+        self.widget.execute_button.checkbox.setCheckState(False)
         self.widget.text.setPlainText("temp = 42\nprint(temp)")
         self.widget.execute_button.button.click()
         self.assertIn("42", self.widget.console.toPlainText())

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -33,7 +33,7 @@ class OWDistances(OWWidget):
 
     axis = settings.Setting(0)
     metric_idx = settings.Setting(0)
-    autocommit = settings.Setting(False)
+    autocommit = settings.Setting(True)
 
     want_main_area = False
     buttons_area_orientation = Qt.Vertical

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -20,7 +20,7 @@ class OWDistanceTransformation(widget.OWWidget):
 
     normalization_method = settings.Setting(0)
     inversion_method = settings.Setting(0)
-    autocommit = settings.Setting(False)
+    autocommit = settings.Setting(True)
 
     normalization_options = (
         ("No normalization", lambda x: x),

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -66,7 +66,7 @@ class OWSilhouettePlot(widget.OWWidget):
     bar_size = settings.Setting(3)
     #: Add silhouette scores to output data
     add_scores = settings.Setting(False)
-    auto_commit = settings.Setting(False)
+    auto_commit = settings.Setting(True)
 
     Distances = [("Euclidean", Orange.distance.Euclidean),
                  ("Manhattan", Orange.distance.Manhattan)]


### PR DESCRIPTION
##### Description of changes
All widgets are set to autocommit/autoapply/autosend/autoexecute when they are used for the first time.
Python Script test changed.
GH-2038

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
