### PR TITLE
[FIX] Fix invalid settings reuse in File widget 

### DIFF
--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -7,8 +7,9 @@ import Orange
 
 
 @contextmanager
-def named_file(content, encoding=None):
-    file = tempfile.NamedTemporaryFile("wt", delete=False, encoding=encoding)
+def named_file(content, encoding=None, suffix=''):
+    file = tempfile.NamedTemporaryFile("wt", delete=False,
+                                       encoding=encoding, suffix=suffix)
     file.write(content)
     name = file.name
     file.close()

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -86,7 +86,9 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     SIZE_LIMIT = 1e7
     LOCAL_FILE, URL = range(2)
 
-    settingsHandler = PerfectDomainContextHandler()
+    settingsHandler = PerfectDomainContextHandler(
+        match_values=PerfectDomainContextHandler.MATCH_VALUES_ALL
+    )
 
     # Overload RecentPathsWidgetMixin.recent_paths to set defaults
     recent_paths = Setting([

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -11,6 +11,7 @@ from AnyQt.QtGui import QDragEnterEvent, QDropEvent
 import Orange
 from Orange.data import FileFormat, dataset_dirs, StringVariable, Table, \
     Domain, DiscreteVariable
+from Orange.tests import named_file
 from Orange.widgets.data.owfile import OWFile
 from Orange.widgets.tests.base import WidgetTest
 
@@ -140,3 +141,27 @@ class TestOWFile(WidgetTest):
         self.assertEqual(self.widget.domain_editor.model().data(idx, Qt.DisplayRole), temp)
         self.widget.domain_editor.model().setData(idx, "", Qt.EditRole)
         self.assertEqual(self.widget.domain_editor.model().data(idx, Qt.DisplayRole), temp)
+
+    def test_context_match_includes_variable_values(self):
+        file1 = """\
+var
+a b
+
+a
+"""
+        file2 = """\
+var
+a b c
+
+a
+"""
+        editor = self.widget.domain_editor
+        idx = self.widget.domain_editor.model().createIndex(0, 3)
+
+        with named_file(file1, suffix=".tab") as filename:
+            self.open_dataset(filename)
+            self.assertEqual(editor.model().data(idx, Qt.DisplayRole), "a, b")
+
+        with named_file(file2, suffix=".tab") as filename:
+            self.open_dataset(filename)
+            self.assertEqual(editor.model().data(idx, Qt.DisplayRole), "a, b, c")

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -1150,7 +1150,7 @@ class PerfectDomainContextHandler(DomainContextHandler):
 
         if self.match_values == self.MATCH_VALUES_ALL:
             def _encode(attrs):
-                return tuple((v.name, v.values if v.is_discrete else vartype(v))
+                return tuple((v.name, list(v.values) if v.is_discrete else vartype(v))
                              for v in attrs)
         else:
             def _encode(attrs):


### PR DESCRIPTION
##### Issue
When files with similar domain (same variable names, different values of discrete vars) were opened, domain editor always showed values from the first opened file.

Fixes gh-2132

##### Description of changes
ContextHandler now takes variable's values in account.

##### Includes
- [X] Code changes
- [X] Tests