### PR TITLE
[FIX] Continuize: prevent crashing - column with equal and NaN values

### DIFF
--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -1,3 +1,7 @@
+from functools import reduce
+
+import numpy as np
+
 from AnyQt import QtWidgets
 from AnyQt.QtCore import Qt
 
@@ -5,6 +9,8 @@ import Orange.data
 from Orange.util import Reprable
 from Orange.statistics import distribution
 from Orange.preprocess import Continuize, Normalize
+from Orange.preprocess.transformation import \
+    Identity, Indicator, Indicator1, Normalizer
 from Orange.data.table import Table
 from Orange.widgets import gui, widget
 from Orange.widgets.settings import Setting
@@ -138,12 +144,6 @@ class OWContinuize(widget.OWWidget):
              ("Value range", self.value_ranges[self.zero_based])])
 
 
-from Orange.preprocess.transformation import \
-    Identity, Indicator, Indicator1, Normalizer
-
-from functools import reduce
-
-
 class WeightedIndicator(Indicator):
     def __init__(self, variable, value, weight=1.0):
         super().__init__(variable, value)
@@ -156,7 +156,7 @@ class WeightedIndicator(Indicator):
         return t
 
 
-class WeightedIndicator_1(Indicator1):
+class WeightedIndicator1(Indicator1):
     def __init__(self, variable, value, weight=1.0):
         super().__init__(variable, value)
         self.weight = weight
@@ -176,7 +176,7 @@ def make_indicator_var(source, value_ind, weight=None, zero_based=True):
     elif weight is None:
         indicator = Indicator1(source, value=value_ind)
     else:
-        indicator = WeightedIndicator_1(source, value=value_ind, weight=weight)
+        indicator = WeightedIndicator1(source, value=value_ind, weight=weight)
     return Orange.data.ContinuousVariable(
         "{}={}".format(source.name, source.values[value_ind]),
         compute_value=indicator
@@ -279,7 +279,7 @@ def continuize_var(var,
         elif multinomial_treatment == Continuize.AsOrdinal:
             return [ordinal_to_continuous(var)]
         elif multinomial_treatment == Continuize.AsNormalizedOrdinal:
-            return [ordinal_to_normalized_continuous(var, zero_based)]
+            return [ordinal_to_norm_continuous(var, zero_based)]
         elif multinomial_treatment == Continuize.Indicators:
             return one_hot_coding(var, zero_based)
         elif multinomial_treatment == Continuize.FirstAsBase or \
@@ -320,7 +320,7 @@ def ordinal_to_continuous(var):
                                           compute_value=Identity(var))
 
 
-def ordinal_to_normalized_continuous(var, zero_based=True):
+def ordinal_to_norm_continuous(var, zero_based=True):
     n_values = len(var.values)
     if zero_based:
         return normalized_var(var, 0, 1 / (n_values - 1))
@@ -330,8 +330,11 @@ def ordinal_to_normalized_continuous(var, zero_based=True):
 
 def normalize_by_span(var, data_or_dist, zero_based=True):
     dist = _ensure_dist(var, data_or_dist)
-    v_max, v_min = dist.max(), dist.min()
-    span = v_max - v_min
+    if dist.shape[1] > 0:
+        v_max, v_min = dist.max(), dist.min()
+    else:
+        v_max, v_min = 0, 0
+    span = (v_max - v_min)
     if span < 1e-15:
         span = 1
 
@@ -344,6 +347,7 @@ def normalize_by_span(var, data_or_dist, zero_based=True):
 def normalize_by_sd(var, data_or_dist):
     dist = _ensure_dist(var, data_or_dist)
     mean, sd = dist.mean(), dist.standard_deviation()
+    sd = sd if sd > 1e-10 else 1
     return normalized_var(var, mean, 1 / sd)
 
 
@@ -365,7 +369,7 @@ class DomainContinuizer(Reprable):
             domain = data.domain
 
         if (treat == Continuize.ReportError and
-            any(var.is_discrete and len(var.values) > 2 for var in domain)):
+                any(var.is_discrete and len(var.values) > 2 for var in domain)):
             raise ValueError("Domain has multinomial attributes")
 
         newdomain = continuize_domain(

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -346,7 +346,10 @@ def normalize_by_span(var, data_or_dist, zero_based=True):
 
 def normalize_by_sd(var, data_or_dist):
     dist = _ensure_dist(var, data_or_dist)
-    mean, sd = dist.mean(), dist.standard_deviation()
+    if dist.shape[1] > 0:
+        mean, sd = dist.mean(), dist.standard_deviation()
+    else:
+        mean, sd = 0, 1
     sd = sd if sd > 1e-10 else 1
     return normalized_var(var, mean, 1 / sd)
 

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -65,3 +65,21 @@ class TestOWContinuize(WidgetTest):
         table[1, 2] = np.NaN
         self.send_signal("Data", table)
         self.widget.unconditional_commit()
+
+
+    def test_one_column_nan_values_normalize_span(self):
+        """
+        No crash on a column with NaN values and with selected option
+        normalize by span.
+        GH-2144
+        """
+        table = Table("iris")
+        table[:, 2] = np.NaN
+        self.send_signal("Data", table)
+        # Normalize.NormalizeBySpan
+        self.widget.continuous_treatment = 1
+        self.widget.unconditional_commit()
+        table = Table("iris")
+        table[1, 2] = np.NaN
+        self.send_signal("Data", table)
+        self.widget.unconditional_commit()

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -33,3 +33,17 @@ class TestOWContinuize(WidgetTest):
         widget.unconditional_commit()
         imp_data = self.get_output("Data")
         self.assertIsNone(imp_data)
+
+    def test_one_column_equal_values(self):
+        """
+        No crash on a column with equal values and with selected option
+        normalize by standard deviation.
+        GH-2144
+        """
+        table = Table("iris")
+        table = table[:, 1]
+        table[:] = 42.0
+        self.send_signal("Data", table)
+        # Normalize.NormalizeBySD
+        self.widget.continuous_treatment = 2
+        self.widget.unconditional_commit()

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -47,3 +47,21 @@ class TestOWContinuize(WidgetTest):
         # Normalize.NormalizeBySD
         self.widget.continuous_treatment = 2
         self.widget.unconditional_commit()
+
+    def test_one_column_nan_values_normalize_sd(self):
+        """
+        No crash on a column with NaN values and with selected option
+        normalize by standard deviation (Not the same issue which is
+        tested above).
+        GH-2144
+        """
+        table = Table("iris")
+        table[:, 2] = np.NaN
+        self.send_signal("Data", table)
+        # Normalize.NormalizeBySD
+        self.widget.continuous_treatment = 2
+        self.widget.unconditional_commit()
+        table = Table("iris")
+        table[1, 2] = np.NaN
+        self.send_signal("Data", table)
+        self.widget.unconditional_commit()


### PR DESCRIPTION
##### Issue
Crashing prevented when dealing with a column with NaN or equal values
and choosing option normalize by standard deviation or by span.
https://sentry.io/biolab/orange3/issues/242520198/
https://sentry.io/biolab/orange3/issues/227119466/
https://sentry.io/biolab/orange3/issues/242519777/

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
