### PR TITLE
[FIX] Preprocess: enums containing function names changed

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -33,12 +33,12 @@ class Preprocess(_RefuseDataInConstructor, Reprable):
 
 
 class Continuize(Preprocess):
-    (Indicators, FirstAsBase, FrequentAsBase,Remove, RemoveMultinomial,
+    (Indicators, FirstAsBase, FrequentAsBase, Remove, RemoveMultinomial,
      ReportError, AsOrdinal, AsNormalizedOrdinal, Leave) = Enum(
-        "Continuize",
-        "Indicators, FirstAsBase, FrequentAsBase,"
-        "Remove, RemoveMultinomial, ReportError, AsOrdinal,"
-        "AsNormalizedOrdinal, Leave")
+         "Continuize",
+         "Indicators, FirstAsBase, FrequentAsBase,"
+         "Remove, RemoveMultinomial, ReportError, AsOrdinal,"
+         "AsNormalizedOrdinal, Leave")
 
     def __init__(self, zero_based=True,
                  multinomial_treatment=Indicators):
@@ -288,9 +288,9 @@ class Normalize(Preprocess):
                for a in data.domain.attributes if a.is_continuous):
             # Skip normalization for data sets where all features are marked as already normalized.
             # Required for SVMs (with normalizer as their default preprocessor) on sparse data to
-            # retain sparse structure. Normalizing sparse data would otherwise result in a dense matrix,
-            # which requires too much memory. For example, this is used for Bag of Words models where
-            # normalization is not really needed.
+            # retain sparse structure. Normalizing sparse data would otherwise result in a dense
+            # matrix, which requires too much memory. For example, this is used for Bag of Words
+            # models where normalization is not really needed.
             return data
         normalizer = normalize.Normalizer(
             zero_based=self.zero_based,

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -403,8 +403,8 @@ class Scale(Preprocess):
         def __call__(self, *args, **kwargs):
             return getattr(Scale, '_' + self.name)(*args, **kwargs)
 
-    CenteringType = _MethodEnum('Scale', 'NoCentering, Mean, Median', type=int)
-    ScalingType = _MethodEnum('Scale', 'NoScaling, Std, Span', type=int)
+    CenteringType = _MethodEnum('Scale', 'NoCentering, Mean, Median')
+    ScalingType = _MethodEnum('Scale', 'NoScaling, Std, Span')
     NoCentering, Mean, Median = CenteringType
     NoScaling, Std, Span = ScalingType
 


### PR DESCRIPTION
##### Issue
When loaded schema from file, function names are loaded as integers. That is why functions cannot be called anymore (int is not callable).
https://sentry.io/biolab/orange3/issues/227119437/


##### Description of changes
Enums in Scale preprocess now saved as string and not as int anymore.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
