### PR TITLE
[FIX] Scatter Plot: dealing with scipy sparse matrix

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -1,4 +1,5 @@
 import numpy as np
+import scipy.sparse as sp
 
 from AnyQt.QtCore import Qt, QTimer
 from AnyQt.QtGui import (
@@ -394,7 +395,8 @@ class OWScatterPlot(OWWidget):
 
     # called when all signals are received, so the graph is updated only once
     def handleNewSignals(self):
-        self.graph.new_data(self.data_metas_X, self.subset_data)
+        self.graph.new_data(self.sparse_to_dense(self.data_metas_X),
+                            self.sparse_to_dense(self.subset_data))
         if self.attribute_selection_list and \
                 all(attr in self.graph.domain
                         for attr in self.attribute_selection_list):
@@ -406,6 +408,37 @@ class OWScatterPlot(OWWidget):
         self.cb_reg_line.setEnabled(self.graph.can_draw_regresssion_line())
         self.apply_selection()
         self.unconditional_commit()
+
+    def prepare_data(self):
+        """
+        Only when dealing with sparse matrices.
+        GH-2152
+        """
+        self.graph.new_data(self.sparse_to_dense(self.data_metas_X),
+                            self.sparse_to_dense(self.subset_data),
+                            new=False)
+
+    def sparse_to_dense(self, input_data=None):
+        self.vizrank_button.setEnabled(not (self.data and self.data.is_sparse()))
+        if input_data is None or not input_data.is_sparse():
+            return input_data
+        keys = []
+        attrs = {self.attr_x,
+                 self.attr_y,
+                 self.graph.attr_color,
+                 self.graph.attr_shape,
+                 self.graph.attr_size,
+                 self.graph.attr_label}
+        for i, attr in enumerate(input_data.domain):
+            if attr in attrs:
+                keys.append(i)
+        new_domain = input_data.domain.select_columns(keys)
+        dmx = Table.from_table(new_domain, input_data)
+        dmx.X = dmx.X.toarray()
+        # TODO: remove once we make sure Y is always dense.
+        if sp.issparse(dmx.Y):
+            dmx.Y = dmx.Y.toarray()
+        return dmx
 
     def apply_selection(self):
         """Apply selection saved in workflow."""
@@ -441,12 +474,14 @@ class OWScatterPlot(OWWidget):
         self.update_attr()
 
     def update_attr(self):
+        self.prepare_data()
         self.update_graph()
         self.cb_class_density.setEnabled(self.graph.can_draw_density())
         self.cb_reg_line.setEnabled(self.graph.can_draw_regresssion_line())
         self.send_features()
 
     def update_colors(self):
+        self.prepare_data()
         self.cb_class_density.setEnabled(self.graph.can_draw_density())
 
     def update_density(self):

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 from unittest.mock import MagicMock
 import numpy as np
+import scipy.sparse as sp
 
 from AnyQt.QtCore import QRectF, Qt
 
@@ -267,6 +268,23 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(w.graph.attr_color.name, "sepal width")
         self.assertEqual(w.graph.attr_shape.name, "iris")
         self.assertEqual(w.graph.attr_size.name, "petal width")
+
+    def test_sparse(self):
+        """
+        Test sparse data.
+        GH-2152
+        GH-2157
+        """
+        table = Table("iris")
+        table.X = sp.csr_matrix(table.X)
+        self.assertTrue(sp.issparse(table.X))
+        table.Y = sp.csr_matrix(table._Y)  # pylint: disable=protected-access
+        self.assertTrue(sp.issparse(table.Y))
+        self.send_signal("Data", table)
+        self.widget.set_subset_data(table[:30])
+        data = self.get_output("Data")
+        self.assertTrue(data.is_sparse())
+        self.assertEqual(len(data.domain), 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
Orange add-on "Text mining" sends "Corpus" instead of "Table". "Corpus" uses sparse matrices and numpy hstack does not know how to handle them. That is why scipy sparse matrix is converted into numpy array.
https://sentry.io/biolab/orange3/issues/243775748/
Fixes #2157.

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
