### PR TITLE
[FIX] KMeans: should not crash when there is less data rows than k

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -209,12 +209,12 @@ class OWKMeans(widget.OWWidget):
         try:
             self.controlArea.setDisabled(True)
             if not self.check_data_size(self.k_from, self.Error):
-                return
+                return False
             self.check_data_size(self.k_to, self.Warning)
             needed_ks = [k for k in range(self.k_from, self.k_to + 1)
                          if k not in self.clusterings]
             if not needed_ks:
-                return  # Skip showing progress bar
+                return True  # Skip showing progress bar
             with self.progressBar(len(needed_ks)) as progress:
                 for k in needed_ks:
                     progress.advance()
@@ -227,6 +227,7 @@ class OWKMeans(widget.OWWidget):
                 self.mainArea.hide()
         finally:
             self.controlArea.setDisabled(False)
+        return True
 
     def cluster(self):
         if self.k in self.clusterings or \
@@ -242,8 +243,7 @@ class OWKMeans(widget.OWWidget):
     def apply(self):
         self.clear_messages()
         if self.data is not None:
-            if self.optimize_k:
-                self.run_optimization()
+            if self.optimize_k and self.run_optimization():
                 self.mainArea.show()
                 self.update_results()
             else:

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -298,6 +298,33 @@ class TestOWKMeans(WidgetTest):
             self.assertIs(report_table.call_args[0][1],
                           widget.table_view)
 
+    def test_not_enough_rows(self):
+        """
+        Widget should not crash when there is less rows than k_from.
+        GH-2172
+        """
+        table = Table("iris")
+        self.widget.controls.k_from.setValue(2)
+        self.widget.controls.k_to.setValue(9)
+        self.send_signal("Data", table[0:1, :])
+
+    def test_from_to_table(self):
+        """
+        From and To spins and number of rows in a scores table changes.
+        GH-2172
+        """
+        table = Table("iris")
+        k_from, k_to = 2, 9
+        self.widget.controls.k_from.setValue(k_from)
+        self.send_signal("Data", table)
+        check = lambda x: 2 if x - k_from + 1 < 2 else x - k_from + 1
+        for i in range(k_from, k_to):
+            self.widget.controls.k_to.setValue(i)
+            self.assertEqual(len(self.widget.table_view.model().scores), check(i))
+        for i in range(k_to, k_from, -1):
+            self.widget.controls.k_to.setValue(i)
+            self.assertEqual(len(self.widget.table_view.model().scores), check(i))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
When there is less rows in a data than selected (from - to, second option) the widget crashes. 
https://sentry.io/biolab/orange3/issues/235248479/


##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
