### PR TITLE
OWPlotGUI: Make Points box reusable

### DIFF
--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -26,7 +26,10 @@ This module contains functions and classes for creating GUI elements commonly us
 '''
 
 import os
+
+from Orange.data import ContinuousVariable, DiscreteVariable
 from Orange.widgets import gui
+from Orange.widgets.utils.itemmodels import DomainModel
 
 from .owconstants import *
 
@@ -256,6 +259,15 @@ class OWPlotGUI:
     '''
     def __init__(self, plot):
         self._plot = plot
+        self.color_model = DomainModel(placeholder="(Same color)",
+                                       valid_types=DomainModel.PRIMITIVE)
+        self.shape_model = DomainModel(placeholder="(Same shape)",
+                                       valid_types=DiscreteVariable)
+        self.size_model = DomainModel(placeholder="(Same size)",
+                                      valid_types=ContinuousVariable)
+        self.label_model = DomainModel(placeholder="(No labels)")
+        self.points_models = [self.color_model, self.shape_model,
+                              self.size_model, self.label_model]
 
     Spacing = 0
 
@@ -264,6 +276,10 @@ class OWPlotGUI:
     ShowGridLines = 4
     PointSize = 5
     AlphaValue = 6
+    Color = 7
+    Shape = 8
+    Size = 9
+    Label = 10
 
     Zoom = 11
     Pan = 12
@@ -329,6 +345,7 @@ class OWPlotGUI:
         AntialiasLines : ('Antialias lines', 'antialias_lines', 'update_antialiasing'),
         AutoAdjustPerformance : ('Disable effects for large data sets', 'auto_adjust_performance', 'update_performance')
     }
+
     '''
         The list of built-in buttons. It is a map of
         id : (name, attr_name, attr_value, callback, icon_name)
@@ -392,15 +409,45 @@ class OWPlotGUI:
         '''
         self._slider(widget, 'alpha_value', "Opacity: ", 0, 255, 10, 'update_alpha_value')
 
+    def _combo(self, widget, value, label, cb_name, items=(), model=None):
+        gui.comboBox(widget, self._plot, value, label=label, items=items,
+                     model=model, callback=self._get_callback(cb_name),
+                     labelWidth=50, orientation=Qt.Horizontal, valueType=str,
+                     sendSelectedValue=True, contentsLength=12)
+
+    def color_value_combo(self, widget):
+        """Creates a combo box that controls point color"""
+        self._combo(widget, "attr_color", "Color: ", "update_colors",
+                    model=self.color_model)
+
+    def shape_value_combo(self, widget):
+        """Creates a combo box that controls point shape"""
+        self._combo(widget, "attr_shape", "Shape: ", "update_shapes",
+                    model=self.shape_model)
+
+    def size_value_combo(self, widget):
+        """Creates a combo box that controls point size"""
+        self._combo(widget, "attr_size", "Size: ", "update_sizes",
+                    model=self.size_model)
+
+    def label_value_combo(self, widget):
+        """Creates a combo box that controls point label"""
+        self._combo(widget, "attr_label", "Label: ", "update_labels",
+                    model=self.label_model)
+
     def point_properties_box(self, widget, box=None):
         '''
             Creates a box with controls for common point properties.
             Currently, these properties are point size and transparency.
         '''
         return self.create_box([
+            self.Color,
+            self.Shape,
+            self.Size,
+            self.Label,
             self.PointSize,
             self.AlphaValue
-            ], widget, box, "Point properties")
+            ], widget, box, "Points")
 
     def plot_settings_box(self, widget, box=None):
         '''
@@ -413,11 +460,15 @@ class OWPlotGUI:
             ], widget, box, "Plot settings")
 
     _functions = {
-        ShowLegend : show_legend_check_box,
-        ShowFilledSymbols : filled_symbols_check_box,
-        ShowGridLines : grid_lines_check_box,
-        PointSize : point_size_slider,
-        AlphaValue : alpha_value_slider,
+        ShowLegend: show_legend_check_box,
+        ShowFilledSymbols: filled_symbols_check_box,
+        ShowGridLines: grid_lines_check_box,
+        PointSize: point_size_slider,
+        AlphaValue: alpha_value_slider,
+        Color: color_value_combo,
+        Shape: shape_value_combo,
+        Size: size_value_combo,
+        Label: label_value_combo,
         }
 
     def add_widget(self, id, widget):

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -191,36 +191,10 @@ class OWScatterPlot(OWWidget):
             callback=self.switch_sampling, commit=lambda: self.add_data(1))
         self.sampling.setVisible(False)
 
-        box = gui.vBox(self.controlArea, "Points")
-        self.color_model = DomainModel(
-            placeholder="(Same color)", valid_types=dmod.PRIMITIVE)
-        self.cb_attr_color = gui.comboBox(
-            box, self, "graph.attr_color", label="Color:",
-            callback=self.update_colors,
-            model=self.color_model, **common_options)
-        self.label_model = DomainModel(
-            placeholder="(No labels)")
-        self.cb_attr_label = gui.comboBox(
-            box, self, "graph.attr_label", label="Label:",
-            callback=self.graph.update_labels,
-            model=self.label_model, **common_options)
-        self.shape_model = DomainModel(
-            placeholder="(Same shape)", valid_types=DiscreteVariable)
-        self.cb_attr_shape = gui.comboBox(
-            box, self, "graph.attr_shape", label="Shape:",
-            callback=self.graph.update_shapes,
-            model=self.shape_model, **common_options)
-        self.size_model = DomainModel(
-            placeholder="(Same size)", valid_types=ContinuousVariable)
-        self.cb_attr_size = gui.comboBox(
-            box, self, "graph.attr_size", label="Size:",
-            callback=self.graph.update_sizes,
-            model=self.size_model, **common_options)
-        self.models = [self.xy_model, self.color_model, self.label_model,
-                       self.shape_model, self.size_model]
-
         g = self.graph.gui
-        g.point_properties_box(self.controlArea, box)
+        g.point_properties_box(self.controlArea)
+        self.models = [self.xy_model] + g.points_models
+
         box = gui.vBox(self.controlArea, "Plot Properties")
         g.add_widgets([g.ShowLegend, g.ShowGridLines], box)
         gui.checkBox(

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -40,9 +40,9 @@ class TestOWLinearProjection(WidgetTest, WidgetOutputsTestMixin):
             if not espy.events():
                 assert espy.wait(1000)
 
-        cb_color = self.widget.controls.color_index
-        cb_size = self.widget.controls.size_index
-        cb_shape = self.widget.controls.shape_index
+        cb_color = self.widget.controls.attr_color
+        cb_size = self.widget.controls.attr_size
+        cb_shape = self.widget.controls.attr_shape
         cb_jitter = self.widget.controls.jitter_value
 
         simulate.combobox_run_through_all(cb_color)
@@ -72,3 +72,10 @@ class TestOWLinearProjection(WidgetTest, WidgetOutputsTestMixin):
 
         with excepthook_catch():
             simulate.combobox_activate_index(cb_jitter, 2, delay=1)
+
+    def test_points_combo_boxes(self):
+        self.send_signal("Data", self.data)
+        self.assertEqual(len(self.widget.controls.attr_color.model()), 8)
+        self.assertEqual(len(self.widget.controls.attr_shape.model()), 3)
+        self.assertEqual(len(self.widget.controls.attr_size.model()), 6)
+        self.assertEqual(len(self.widget.controls.attr_label.model()), 8)

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -113,8 +113,8 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         """
         table = datasets.data_one_column_nans()
         self.send_signal("Data", table)
-
-        simulate.combobox_activate_item(self.widget.cb_attr_color, "b")
+        cb_attr_color = self.widget.controls.graph.attr_color
+        simulate.combobox_activate_item(cb_attr_color, "b")
         simulate.combobox_activate_item(self.widget.cb_attr_x, "a")
         simulate.combobox_activate_item(self.widget.cb_attr_y, "a")
 
@@ -131,6 +131,18 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         self.widget.cb_attr_y.setCurrentIndex(4)
         self.assertFalse(self.widget.cb_reg_line.isEnabled())
         self.assertIsNone(self.widget.graph.reg_line_item)
+
+    def test_points_combo_boxes(self):
+        """Check Point box combo models and values"""
+        self.send_signal("Data", self.data)
+        self.assertEqual(len(self.widget.controls.graph.attr_color.model()), 8)
+        self.assertEqual(len(self.widget.controls.graph.attr_shape.model()), 3)
+        self.assertEqual(len(self.widget.controls.graph.attr_size.model()), 6)
+        self.assertEqual(len(self.widget.controls.graph.attr_label.model()), 8)
+        other_widget = self.create_widget(OWScatterPlot)
+        self.send_signal("Data", self.data, widget=other_widget)
+        self.assertEqual(self.widget.graph.controls.attr_color.currentText(),
+                         self.data.domain.class_var.name)
 
     def test_group_selections(self):
         self.send_signal("Data", self.data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Several widgets (ScatterPlot, LinearProjection, MDS, Map, FreeViz) has similar control area, especially Points box. They should all use components created by OWPlotGUI.

##### Description of changes
Make Points box usable for any widget.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
