### PR TITLE
WidgetOutputsTestMixin: Make it work for OWFreeViz

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -631,10 +631,12 @@ class WidgetOutputsTestMixin:
     def test_outputs(self):
         self.send_signal(self.signal_name, self.signal_data)
 
-        # only needed in TestOWMDS
+        # only needed in widgets with event loop
         if type(self).__name__ == "TestOWMDS":
             from AnyQt.QtCore import QEvent
             self.widget.customEvent(QEvent(QEvent.User))
+            self.widget.commit()
+        elif type(self).__name__ == "TestOWFreeViz":
             self.widget.commit()
 
         # check selected data output


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The mixin could not be used on OWFreeViz unittest.

##### Description of changes
Add an additional commit for OWFreeViz

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
