### PR TITLE
[FIX] Select Rows and Table: Filtering string values

### DIFF
--- a/.travis/stage_after_success.sh
+++ b/.travis/stage_after_success.sh
@@ -9,6 +9,7 @@ if [ "$BUILD_DOCS" ] &&
 fi
 
 if [ "$UPLOAD_COVERAGE" ]; then
+    cp $TRAVIS_BUILD_DIR/codecov.yml .
     codecov
 fi
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1199,6 +1199,7 @@ class Table(MutableSequence, Storage):
                 sel = np.vectorize(f)(col)
             elif isinstance(f, (data_filter.FilterContinuous,
                                 data_filter.FilterString)):
+                col = col.astype(str) if isinstance(f, data_filter.FilterString) else col
                 if (isinstance(f, data_filter.FilterString) and
                         not f.case_sensitive):
                     # noinspection PyTypeChecker

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1202,6 +1202,24 @@ class TableTestCase(unittest.TestCase):
         x = filter.Values([f])(d)
         self.assertEqual(len(x), 7)
 
+    def test_valueFilter_stringList(self):
+        data = Table("zoo")
+        var = data.domain["name"]
+
+        fs = filter.FilterStringList
+        filters = [
+            ((["swan", "tuna", "wasp"], True), dict(rows=3)),
+            ((["swan", "tuna", "wasp"], False), dict(rows=3)),
+            ((["WoRm", "TOad", "vOLe"], True), dict(rows=0)),
+            ((["WoRm", "TOad", "vOLe"], False), dict(rows=3)),
+        ]
+
+        for args, expected in filters:
+            f = fs(var, *args)
+            filtered_data = filter.Values([f])(data)
+            self.assertEqual(len(filtered_data), expected["rows"],
+                             "{} returned wrong number of rows".format(args))
+
     def test_table_dtypes(self):
         table = data.Table("iris")
         metas = np.hstack((table.metas, table.Y.reshape(len(table), 1)))

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -881,6 +881,36 @@ class TableTestCase(unittest.TestCase):
         f = filter.Values([filter.Values([f1, f2], conjunction=False), f3])
         self.assertEqual(41, len(f(d)))
 
+    def test_filter_value_continuous_as_string(self):
+        """
+        When compares strings it should compare strings and not numbers.
+        GH-2176
+        """
+        d = data.Table("iris")
+        domain = Domain(attributes=[ContinuousVariable("a")],
+                        class_vars=d.domain.class_vars,
+                        metas=[ContinuousVariable("c")])
+        table = Table.from_numpy(domain=domain,
+                                 X=d.X[:, 0:1],
+                                 Y=d.Y,
+                                 metas=d.X[:, 1:2])
+        v = table.columns
+        filters = ("Greater",
+                   "NotEqual",
+                   "Equal",
+                   "Less",
+                   "IsDefined",
+                   "LessEqual",
+                   "GreaterEqual",
+                   "Between",
+                   "Outside")
+        for fil in filters:
+            f = filter.FilterString(v.c,
+                                    getattr(filter.FilterString, fil),
+                                    ref='4.2',
+                                    max='42.0')
+            filter.Values([f])(table)
+
     def test_filter_value_continuous(self):
         d = data.Table("iris")
         col = d.X[:, 2]


### PR DESCRIPTION
##### Issue
Table throws error when trying to compare string values. A string value written in Select Rows widgets and a numerical value which is set as string.
https://sentry.io/biolab/orange3/issues/244859655/


##### Description of changes

##### Steps to reproduce the behavior
Put _File_ and _Select Rows_ widgets and connect them. Then open _iris_. Set one of four features to _string_ and _meta_. Then choose that feature in _Select Rows_ and choose filter "_is before_" or some other one.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
