### PR TITLE
[FIX] Test & Score: crashing prevented when learner disconnects

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -466,6 +466,15 @@ class OWTestLearners(OWWidget):
             else:
                 self.error()
 
+        self.puts_results(learners, results, class_var)
+
+        self.setStatusMessage("")
+
+    def puts_results(self, learners, results, class_var):
+        """
+        Called by _update_results. This method prepares calculated results and
+        put them into self.learners.
+        """
         learner_key = {slot.learner: key for key, slot in self.learners.items()}
         for learner, result in zip(learners, results.split_by_model()):
             stats = None
@@ -483,11 +492,10 @@ class OWTestLearners(OWWidget):
                 else:
                     stats = [Try(lambda: score(result)) for score in scorers]
                     result = Try.Success(result)
-            key = learner_key[learner]
-            self.learners[key] = \
-                self.learners[key]._replace(results=result, stats=stats)
-
-        self.setStatusMessage("")
+            if learner in learner_key:
+                key = learner_key.get(learner)
+                self.learners[key] = \
+                    self.learners[key]._replace(results=result, stats=stats)
 
     def _update_header(self):
         # Set the correct horizontal header labels on the results_model.


### PR DESCRIPTION
##### Issue
When Test & Score performs evaluation sb might disconnect connection from some learner. Widget then crashes.
https://sentry.io/biolab/orange3/issues/227231658/

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
