### PR TITLE
[ENH] Nomogram: Support for sparse data

### DIFF
--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -44,10 +44,13 @@ class SharedComputeValue:
         A callable that performs computation that is shared between
         multiple variables. Variables sharing computation need to set
         the same instance.
+    variable: Orange.data.Variable
+        The original variable on which this compute value is set.
     """
 
-    def __init__(self, compute_shared):
+    def __init__(self, compute_shared, variable=None):
         self.compute_shared = compute_shared
+        self.variable = variable
 
     def __call__(self, data, shared_data=None):
         """Fallback if common parts are not passed."""

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -1,5 +1,6 @@
 import time
 from enum import IntEnum
+from collections import OrderedDict
 
 import numpy as np
 
@@ -868,11 +869,13 @@ class OWNomogram(OWWidget):
         self.log_reg_coeffs = [coeffs[:, ranges[i]] for i in range(len(attrs))]
         self.log_reg_coeffs_orig = self.log_reg_coeffs.copy()
 
-        for i in range(len(self.log_reg_coeffs)):
+        min_values = nanmin(self.data.X, axis=0)
+        max_values = nanmax(self.data.X, axis=0)
+
+        for i, min_t, max_t in zip(range(len(self.log_reg_coeffs)),
+                                   min_values, max_values):
             if self.log_reg_coeffs[i].shape[1] == 1:
                 coef = self.log_reg_coeffs[i]
-                min_t = nanmin(self.data.X, axis=0)[i]
-                max_t = nanmax(self.data.X, axis=0)[i]
                 self.log_reg_coeffs[i] = np.hstack((coef * min_t, coef * max_t))
                 self.log_reg_cont_data_extremes.append(
                     [sorted([min_t, max_t], reverse=(c < 0)) for c in coef])
@@ -1109,13 +1112,15 @@ class OWNomogram(OWWidget):
 
     @staticmethod
     def reconstruct_domain(original, preprocessed):
-        attrs = []
+        # abuse dict to make "in" comparisons faster
+        attrs = OrderedDict()
         for attr in preprocessed.attributes:
             cv = attr._compute_value.variable._compute_value
             var = cv.variable if cv else original[attr.name]
-            if var in attrs:
+            if var in attrs:    # the reason for OrderedDict
                 continue
-            attrs.append(var)
+            attrs[var] = None   # we only need keys
+        attrs = list(attrs.keys())
         return Domain(attrs, original.class_var, original.metas)
 
     @staticmethod

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -12,6 +12,7 @@ from AnyQt.QtGui import QColor, QPainter, QFont, QPen, QBrush
 from AnyQt.QtCore import Qt, QEvent, QRectF, QSize
 
 from Orange.data import Table, Domain
+from Orange.statistics.util import nanmin, nanmax, mean, unique
 from Orange.classification import Model
 from Orange.classification.naive_bayes import NaiveBayesModel
 from Orange.classification.logistic_regression import \
@@ -870,8 +871,8 @@ class OWNomogram(OWWidget):
         for i in range(len(self.log_reg_coeffs)):
             if self.log_reg_coeffs[i].shape[1] == 1:
                 coef = self.log_reg_coeffs[i]
-                min_t = np.nanmin(self.data.X, axis=0)[i]
-                max_t = np.nanmax(self.data.X, axis=0)[i]
+                min_t = nanmin(self.data.X, axis=0)[i]
+                max_t = nanmax(self.data.X, axis=0)[i]
                 self.log_reg_coeffs[i] = np.hstack((coef * min_t, coef * max_t))
                 self.log_reg_cont_data_extremes.append(
                     [sorted([min_t, max_t], reverse=(c < 0)) for c in coef])
@@ -1080,10 +1081,10 @@ class OWNomogram(OWWidget):
             value, feature_val = 0, None
             if len(self.log_reg_coeffs):
                 if attr.is_discrete:
-                    ind, n = np.unique(self.data.X[:, i], return_counts=True)
+                    ind, n = unique(self.data.X[:, i], return_counts=True)
                     feature_val = np.nan_to_num(ind[np.argmax(n)])
                 else:
-                    feature_val = np.average(self.data.X[:, i])
+                    feature_val = mean(self.data.X[:, i])
             inst_in_dom = instances and attr in instances.domain
             if inst_in_dom and not np.isnan(instances[0][attr]):
                 feature_val = instances[0][attr]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
#2165

##### Description of changes

* Statistics.utils: `nanmin`, `nanmax`, `average`, `unique` equivalents of numpy's that support sparse or dense matrices.
* SharedComputeValue: add variable attribute.
* Support nomogram on sparse data.
* Some speedups for nomogram. Time measured on a small BoW data set of shape (140, 3000):
  *  `reconstruct_domain` method: 3.0s -> 0.03 s
  * `calculate_log_reg_coefficients` method: TLDW (minutes+)  -> 1.5 s


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation