### PR TITLE
[ENH] Canvas: Use 'windowFilePath' to display display current filename instead of the title

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -226,9 +226,9 @@ class CanvasMainWindow(QMainWindow):
         frame.setColor(QColor(0, 0, 0, 100))
         frame.setWidget(self.scheme_widget)
 
-        # Main window title and title icon.
-        self.set_document_title(self.scheme_widget.scheme().title)
-        self.scheme_widget.titleChanged.connect(self.set_document_title)
+        # Window 'title'
+        self.setWindowFilePath(self.scheme_widget.path())
+        self.scheme_widget.pathChanged.connect(self.setWindowFilePath)
         self.scheme_widget.modificationChanged.connect(self.setWindowModified)
 
         # QMainWindow's Dock widget

--- a/Orange/canvas/application/schemeinfo.py
+++ b/Orange/canvas/application/schemeinfo.py
@@ -34,7 +34,7 @@ class SchemeInfoEdit(QWidget):
         self.desc_edit = QTextEdit(self)
         self.desc_edit.setTabChangesFocus(True)
 
-        layout.addRow(self.tr("Name"), self.name_edit)
+        layout.addRow(self.tr("Title"), self.name_edit)
         layout.addRow(self.tr("Description"), self.desc_edit)
 
         self.__schemeIsUntitled = True


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
