### PR TITLE
 WebviewWidget: avoid hangs with webengine

### DIFF
--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -6,25 +6,24 @@ around either WebEngineView (extends QWebEngineView) or WebKitView
 """
 import os
 import threading
-from os.path import join, dirname, abspath
 import warnings
-from random import random
-from collections.abc import Mapping, Set, Sequence, Iterable
-from numbers import Integral, Real
+from collections.abc import Iterable, Mapping, Set, Sequence
 from itertools import count
-
+from numbers import Integral, Real
+from os.path import abspath, dirname, join
+from random import random
 from urllib.parse import urljoin
 from urllib.request import pathname2url
 
 import numpy as np
+import sip
+
+from Orange.util import inherit_docstrings, OrangeDeprecationWarning
 
 from AnyQt.QtCore import Qt, QObject, QFile, QTimer, QUrl, QSize, QEventLoop, \
     pyqtProperty, pyqtSlot, pyqtSignal
 from AnyQt.QtGui import QColor
 from AnyQt.QtWidgets import QSizePolicy, QWidget, qApp
-import sip
-
-from Orange.util import inherit_docstrings, OrangeDeprecationWarning
 
 try:
     from AnyQt.QtWebKitWidgets import QWebView

--- a/Orange/widgets/visualize/owmap.py
+++ b/Orange/widgets/visualize/owmap.py
@@ -370,7 +370,7 @@ class LeafletMap(WebviewWidget):
                                    raw_values=self._raw_sizes[visible]))
         self.evalJS('''
             window.latlon_data = latlon_data.data;
-            window.selected_markers = selected_markers.data
+            window.selected_markers = selected_markers.data;
             add_markers(latlon_data);
         ''')
 


### PR DESCRIPTION
##### Issue
Waiting for execution to complete was handled in an unsafe way. As all
js executions set the same flag when they were done, it was possible
that multiple executions set the flag before the thread waiting for them
could have noticed it. As a result, if two or more executions ended at
the same time the first waiting thread to notice that would clear the
flag and remaining threads would keep waiting indefinitely.

To reproduce, try run visualization widget tests on my computer :)    

##### Description of changes
Track each scheduled execution separately

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation