### PR TITLE
OWHierarchicalClustering: Use meta attributes in settings

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -728,7 +728,7 @@ class OWHierarchicalClustering(widget.OWWidget):
     #: Selected linkage
     linkage = settings.Setting(1)
     #: Index of the selected annotation item (variable, ...)
-    annotation = settings.ContextSetting("Enumeration")
+    annotation = settings.ContextSetting("Enumeration", exclude_metas=False)
     #: Out-of-context setting for the case when the "Name" option is available
     annotation_if_names = settings.Setting("Name")
     #: Out-of-context setting for the case with just "Enumerate" and "None"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Meta attributes used for annotation were not saved in settings.

##### Description of changes
Allow meta attributes

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
