### PR TITLE
travis: Avoid multiple uploads of coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ matrix:
           script: source $TRAVIS_BUILD_DIR/.travis/build_doc.sh
         - &pyqt5
           python: '3.5'
-          env: PYQT5=true
+          env:
+            - PYQT5=true
+            - UPLOAD_COVERAGE=true
           dist: trusty
           addons: { apt: { packages: [] } }
     fast_finish: true

--- a/.travis/stage_after_success.sh
+++ b/.travis/stage_after_success.sh
@@ -8,5 +8,8 @@ if [ "$BUILD_DOCS" ] &&
         return 0
 fi
 
-codecov
+if [ "$UPLOAD_COVERAGE" ]; then
+    codecov
+fi
+
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Our build on travis uploads coverage multiple times, resulting in weird changes in coverage (depending on the order of execution of builds).