### PR TITLE
[FIX] Tree Viewer: check if there is selected class value

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -263,6 +263,7 @@ class OWTreeGraph(OWTreeViewer2D):
         self.color_combo.clear()
         self.closeContext()
         self.model = model
+        self.target_class_index = 0
         if model is None:
             self.info.setText('No tree.')
             self.root_node = None
@@ -440,7 +441,7 @@ class OWTreeGraph(OWTreeViewer2D):
         return TreeAdapter(model)
 
 
-def test():
+def main():
     """Standalone test"""
     import sys
     from AnyQt.QtWidgets import QApplication
@@ -458,4 +459,4 @@ def test():
     ow.saveSettings()
 
 if __name__ == "__main__":
-    test()
+    main()


### PR DESCRIPTION
##### Issue
Tree Viewer crashes when Target Class combo selected index number is higher than actual number of class values.
https://sentry.io/biolab/orange3/issues/205702715/

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
