### PR TITLE
appveyor: replace $host.SetShouldExit() with throw

### DIFF
--- a/.ci_tools/appveyor/step-build.ps1
+++ b/.ci_tools/appveyor/step-build.ps1
@@ -9,4 +9,4 @@ cmd.exe /c @"
 .ci_tools\appveyor\build.cmd python setup.py $env:BUILD_GLOBAL_OPTIONS bdist_wheel --dist-dir dist
 "@
 
-if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }

--- a/.ci_tools/appveyor/step-install.ps1
+++ b/.ci_tools/appveyor/step-install.ps1
@@ -8,4 +8,4 @@ python -m pip install `
     --only-binary numpy `
     numpy==$env:NUMPY_BUILD_VERSION
 
-if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }

--- a/.ci_tools/appveyor/step-test-miniconda.ps1
+++ b/.ci_tools/appveyor/step-test-miniconda.ps1
@@ -28,7 +28,7 @@ echo "Starting conda build"
 echo "--------------------"
 & "$conda" build conda-recipe
 
-if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
 # also copy build conda pacakge to build artifacts
 echo "copying conda package to dist/conda"

--- a/.ci_tools/appveyor/step-test.ps1
+++ b/.ci_tools/appveyor/step-test.ps1
@@ -25,7 +25,7 @@ try {
         --index-url "$env:STAGING_INDEX" `
         --only-binary "numpy,scipy" numpy scipy
 
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
 
     # Install specific Orange3 version
@@ -33,7 +33,7 @@ try {
         --find-links ../../dist `
         Orange3==$version
 
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
     # Instal other remaining dependencies
     python -m pip install `
@@ -41,7 +41,7 @@ try {
         --only-binary "numpy,scipy" `
         Orange3==$version
 
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
     echo "Test environment:"
     echo "-----------------"
@@ -53,7 +53,7 @@ try {
     echo "-------------"
     python -m unittest -v Orange.tests
 
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
     # Widget tests
     python -m pip install `
@@ -65,7 +65,7 @@ try {
     try {
         $Env:ANYQT_HOOK_BACKPORT = "pyqt4"
         python -m unittest -v Orange.widgets.tests
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
     } finally {
         $Env:ANYQT_HOOK_BACKPORT = ""
     }
@@ -79,7 +79,7 @@ try {
     echo "-------------------------------"
 
     python -m unittest -v Orange.widgets.tests
-    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
 } finally {
     popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,12 +53,12 @@ build_script:
         $env:PATH="C:\Program Files (x86)\NSIS;C:\msys2\bin;$env:PATH"
 
         bash scripts\windows\build-win-application.sh -d dist\installers
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 
         bash scripts\windows\build-win-application.sh `
             -d installers `
             --standalone
-        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
       }
 
 test_script:


### PR DESCRIPTION
$host.SetShouldExit() does not end the execution imediatelly, making it
hard to figure out what went wrong when one of the eary build
steps/tests fails.