### PR TITLE
misc.cache.memoize_method: expose cache_clear() on memoized method

### DIFF
--- a/Orange/misc/cache.py
+++ b/Orange/misc/cache.py
@@ -41,20 +41,16 @@ def memoize_method(*lru_args, **lru_kwargs):
     """
     def _decorator(func):
 
+        @lru_cache(*lru_args, **lru_kwargs)
+        def _cached_method(self_weak, *args, **kwargs):
+            return func(self_weak(), *args, **kwargs)
+
         @wraps(func)
         def _wrapped_func(self, *args, **kwargs):
-            self_weak = weakref.ref(self)
-            # We're storing the wrapped method inside the instance. If we had
-            # a strong reference to self the instance would never die.
+            return _cached_method(weakref.ref(self), *args, **kwargs)
 
-            @wraps(func)
-            @lru_cache(*lru_args, **lru_kwargs)
-            def _cached_method(*args, **kwargs):
-                return func(self_weak(), *args, **kwargs)
-
-            setattr(self, func.__name__, _cached_method)
-            return _cached_method(*args, **kwargs)
-
+        _wrapped_func.cache_clear = _cached_method.cache_clear
+        _wrapped_func.cache_info = _cached_method.cache_info
         return _wrapped_func
 
     return _decorator

--- a/Orange/misc/cache.py
+++ b/Orange/misc/cache.py
@@ -26,13 +26,13 @@ def single_cache(func):
 def memoize_method(*lru_args, **lru_kwargs):
     """Memoize methods without keeping reference to `self`.
 
+    Using ordinary lru_cache on methods keeps a reference to the object in the cache,
+    creating a cycle that keeps the object from getting garbage collected.
+
     Parameters
     ----------
     lru_args
     lru_kwargs
-
-    Returns
-    -------
 
     See Also
     --------

--- a/Orange/tests/test_misc.py
+++ b/Orange/tests/test_misc.py
@@ -25,6 +25,12 @@ class TestCache(unittest.TestCase):
     def test_memoize_method(self):
         calc = Calculator()
         self.assertEqual(calc.my_sum(1, 2, 3, 4, 5), 15)
+        self.assertEqual(calc.my_sum.cache_info().currsize, 1)
         self.assertEqual(calc.my_sum(1, 2, 3, 4, 5), 15)
+        self.assertEqual(calc.my_sum.cache_info().hits, 1)
         # Make sure different args produce different results
         self.assertEqual(calc.my_sum(1, 2, 3, 4), 10)
+        self.assertEqual(calc.my_sum.cache_info().currsize, 2)
+        # Clear cache
+        calc.my_sum.cache_clear()
+        self.assertEqual(calc.my_sum.cache_info().currsize, 0)


### PR DESCRIPTION
##### Issue
`.cache_clear()` / `.cache_info()` were not exposed on methods memoized with `misc.cache.memoize_method()`.

##### Description of changes
Expose by refactoring. Hope it's correct.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
