### PR TITLE
[FIX] WebEngineView: Insert JS if loading already started

### DIFF
--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -145,6 +145,7 @@ if HAVE_WEBENGINE:
             script.setInjectionPoint(injection_point)
             script.setWorldId(script.MainWorld)
             script.setRunsOnSubFrames(False)
+            self.page().scripts().insert(script)
             self.loadStarted.connect(
                 lambda: self.page().scripts().insert(script))
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When loading schemas with widgets that extend `Orange.widgets.highcharts.Highchart` Orange sometimes hangs with JS error:
```
js: Uncaught ReferenceError: fixupPythonObject is not defined
```

##### Description of changes
`WebEngineView._onloadJS` also calls `self.page().scripts().insert(script)` and not just connects it to `self.loadStarted`. In case that loading has already started (e.g. if WebEngineView receives QUrl among parameters to __init__) connecting of `self.loadStarted` occurs too late.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation