### PR TITLE
owpca: fix variance shown when changing ncomponents

### DIFF
--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -85,7 +85,7 @@ class _LinearCombination:
             return ' + '.join('{} * {}'.format(w, a.to_sql())
                               for a, w in zip(self.attrs, self.weights))
         return ' + '.join('{} * ({} - {})'.format(w, a.to_sql(), m, w)
-            for a, m, w in zip(self.attrs, self.mean, self.weights))
+                          for a, m, w in zip(self.attrs, self.mean, self.weights))
 
 
 class _PCATransformDomain:
@@ -108,7 +108,7 @@ class PCAModel(Projection, metaclass=WrapperMeta):
         def pca_variable(i):
             v = Orange.data.ContinuousVariable(
                 'PC%d' % (i + 1),
-                compute_value= Projector(self, i, pca_transform))
+                compute_value=Projector(self, i, pca_transform))
             v.to_sql = _LinearCombination(
                 domain.attributes, self.components_[i, :],
                 getattr(self, 'mean_', None))
@@ -119,7 +119,7 @@ class PCAModel(Projection, metaclass=WrapperMeta):
         self.n_components = self.components_.shape[0]
         self.domain = Orange.data.Domain(
             [pca_variable(i) for i in range(self.n_components)],
-             domain.class_vars, domain.metas)
+            domain.class_vars, domain.metas)
 
 
 class IncrementalPCA(SklProjector):

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -337,7 +337,7 @@ class OWPCA(widget.OWWidget):
 
         var = self._cumulative[cut - 1]
         if numpy.isfinite(var):
-            self.variance_covered = int(var) * 100
+            self.variance_covered = int(var * 100)
 
         if numpy.floor(self._line.value()) + 1 != cut:
             self._line.setValue(cut - 1)

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -58,3 +58,14 @@ class TestOWPCA(WidgetTest):
         settings = dict(ncomponents=101)
         OWPCA.migrate_settings(settings, 0)
         self.assertEqual(settings['ncomponents'], 100)
+
+    def test_variance_shown(self):
+        data = Table("iris")
+        self.send_signal("Data", data)
+        self.widget.maxp = 2
+        self.widget._setup_plot()
+        var2 = self.widget.variance_covered
+        self.widget.ncomponents = 3
+        self.widget._update_selection_component_spin()
+        var3 = self.widget.variance_covered
+        self.assertGreater(var3, var2)


### PR DESCRIPTION
##### Issue
When changing number of components to a value which was higher
then components shown the variance was incorrect.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
