### PR TITLE
[FIX] Support Sparse Data in Domain Editor

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -290,7 +290,7 @@ def nanmean(x):
     return np.nansum(x.data) / n_values
 
 
-def unique(x, return_counts=True):
+def unique(x, return_counts=False):
     """ Equivalent of np.unique that supports sparse or dense matrices. """
     if not sp.issparse(x):
         return np.unique(x, return_counts=return_counts)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -403,11 +403,6 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         if self.data is not None:
             domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
             X, y, m = cols
-            X = np.array(X).T if len(X) else np.empty((len(self.data), 0))
-            y = np.array(y).T if len(y) else None
-            dtpe = object if any(isinstance(m, StringVariable)
-                                 for m in domain.metas) else float
-            m = np.array(m, dtype=dtpe).T if len(m) else None
             table = Table.from_numpy(domain, X, y, m, self.data.W)
             table.name = self.data.name
             table.ids = np.array(self.data.ids)

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -253,12 +253,7 @@ class DomainEditor(QTableView):
             if place == Place.skip:
                 continue
 
-            if orig_plc == Place.meta:
-                col_data = data[:, orig_var].metas
-            elif orig_plc == Place.class_var:
-                col_data = data[:, orig_var].Y.reshape(-1, 1)
-            else:
-                col_data = data[:, orig_var].X
+            col_data = self._get_column(data, orig_var, orig_plc)
             is_sparse = sp.issparse(col_data)
             if name == orig_var.name and tpe == type(orig_var):
                 var = orig_var
@@ -291,6 +286,16 @@ class DomainEditor(QTableView):
         m = self._merge(cols[Place.meta], force_dense=True)
         domain = Domain(*places)
         return domain, [X, Y, m]
+
+    def _get_column(self, data, source_var, source_place):
+        """ Extract column from data and preserve sparsity. """
+        if source_place == Place.meta:
+            col_data = data[:, source_var].metas
+        elif source_place == Place.class_var:
+            col_data = data[:, source_var].Y.reshape(-1, 1)
+        else:
+            col_data = data[:, source_var].X
+        return col_data
 
     def set_domain(self, domain):
         self.variables = self.parse_domain(domain)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #2188.

##### Description of changes
Enhance `DomainEditor.get_domain` to handle sparse data. Also instead of returning a list of columns' the method itself merges them to appropriate `X`, `y` and `meta` arrays.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation