### PR TITLE
Avoid random tests stalling

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -90,6 +90,10 @@ class WidgetTest(GuiTest):
         cls.widgets.append(report)
         OWReport.get_instance = lambda: report
 
+    def tearDown(self):
+        """Process any pending events before the next test is executed."""
+        self.process_events()
+
     def create_widget(self, cls, stored_settings=None, reset_default_settings=True):
         """Create a widget instance using mock signal_manager.
 


### PR DESCRIPTION
##### Issue
Tests sometimes freeze, restart usually helps.

##### Description of changes
Add timeouts to blocking operations, raise TimeoutError after a predetermined amount of time passes. This way the test results will show which tests are problematic and we can consider changing, skipping, or removing them.

##### Includes
- [X] Code changes
- [X] Tests
