### PR TITLE
Add Code Climate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,18 @@
+engines:
+  pep8:
+    enabled: true
+  eslint:
+    enabled: true
+  shellcheck:
+    enabled: true
+  csslint:
+    enabled: true
+
+ratings:
+  paths:
+  - "**.py"
+  - "**.js"
+  - "**.sh"
+  - "**.css"
+
+exclude_paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,18 +1,25 @@
 engines:
-  pep8:
-    enabled: true
-  eslint:
-    enabled: true
-  shellcheck:
-    enabled: true
-  csslint:
-    enabled: true
+ duplication:
+   enabled: true
+   config:
+     languages:
+     - python
+ pep8:
+   enabled: true
+ radon:
+   enabled: true
+ eslint:
+   enabled: false
+ shellcheck:
+   enabled: false
+ csslint:
+   enabled: false
 
 ratings:
-  paths:
-  - "**.py"
-  - "**.js"
-  - "**.sh"
-  - "**.css"
+ paths:
+ - "**.py"
+ - "**.js"
+ - "**.sh"
+ - "**.css"
 
 exclude_paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ engines:
      languages:
      - python
  pep8:
-   enabled: true
+   enabled: false
  radon:
    enabled: true
  eslint:


### PR DESCRIPTION
##### Issue
Adds Code Climate to Orange 3. 

##### Description of changes
This is a Code Climate config with Radon and our Python duplication engine enabled. I've also added a few other engines that can be enabled at a later date if needed (ie: ESLint, Shellcheck).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
