### PR TITLE
Highcharts: Fix Bring Selection to Front

### DIFF
--- a/Orange/widgets/_highcharts/orange-selection.js
+++ b/Orange/widgets/_highcharts/orange-selection.js
@@ -33,14 +33,7 @@ Highcharts.wrap(Highcharts.Point.prototype, 'select', function (proceed) {
     proceed.apply(this, Array.prototype.slice.call(arguments, 1));
 
     // Raise selected point to front
-    if (this.selected) {
-        this.graphic.element.parentNode.appendChild(this.graphic.element);
-    } else {
-        // or lower deselected point to back
-        this.graphic.element.parentNode.insertBefore(
-            this.graphic.element,
-            this.graphic.element.parentNode.firstChild);
-    }
+    this.series.group.toFront();
 });
 
 function unselectAllPoints(e) {


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Some highcharts objects don't have `this.graphics` property and for them selection was broken. 

##### Description of changes
Bring to front in hopefully more robust way.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
