### PR TITLE
Fix multiple warnings in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ In addition, we add the following guidelines:
 * Only ever `import *` to make objects available in another namespace,
   preferably in *\_\_init\_\_.py*. Everywhere else use explicit object
   imports.
-* Use [Napoleon]-comaptible (e.g. NumPy style) docstrings, preferably with
+* Use [Napoleon]-compatible (e.g. NumPy style) docstrings, preferably with
   [tests].
 * When instantiating Qt widgets, pass static property values as
   [keyword args to the constructor] instead of calling separate property
@@ -182,8 +182,10 @@ Read more [about squashing commits].
 
 Documentation
 -------------
-Documentation in located in doc folder. You can build it with:
+Documentation in located in doc folder. It is split into three parts:
+data-mining-library (scripting api), development (development guides),
+and visual-programming (widget help files). You can build it with:
 
-    cd doc
+    cd doc/<part>
     make html
     # Now open build/html/index.html to see it

--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -103,6 +103,7 @@ class Recall(Score):
 class F1(Score):
     """
     ${sklpar}
+
     Parameters
     ----------
     results : Orange.evaluation.Results
@@ -144,6 +145,7 @@ class PrecisionRecallFSupport(Score):
 class AUC(Score):
     """
     ${sklpar}
+
     Parameters
     ----------
     results : Orange.evaluation.Results
@@ -200,6 +202,7 @@ class AUC(Score):
 class LogLoss(Score):
     """
     ${sklpar}
+
     Parameters
     ----------
     results : Orange.evaluation.Results

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -308,11 +308,12 @@ class Results:
     def fit(self, train_data, test_data=None):
         """Fits `self.learners` using folds sampled from the provided data.
 
-        Args:
-            train_data (Table): table to sample train folds
-            test_data (Optional[Table]): tap to sample test folds
-                of None then `train_data` will be used
-
+        Parameters
+        ----------
+        train_data : Table
+            table to sample train folds
+        test_data : Optional[Table]
+            tap to sample test folds of None then `train_data` will be used
         """
         test_data = test_data or train_data
         self.setup_indices(train_data, test_data)

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -26,17 +26,23 @@ class TreeLearner(Learner):
 
     If the tree is not binary, it can contain zero-branches.
 
-    Args:
-        binarize: if `True` the inducer will find optimal split into two
-            subsets for values of discrete attributes. If `False` (default),
-            each value gets its branch.
-        min_samples_leaf: the minimal number of data instances in a leaf
-        min_samples_split: the minimal number of data instances that is split
-            into subgroups
-        max_depth: the maximal depth of the tree
+    Parameters
+    ----------
+    binarize
+        if `True` the inducer will find optimal split into two
+        subsets for values of discrete attributes. If `False` (default),
+        each value gets its branch.
+    min_samples_leaf
+        the minimal number of data instances in a leaf
+    min_samples_split
+        the minimal number of data instances that is split
+        into subgroups
+    max_depth
+        the maximal depth of the tree
 
-    Returns:
-        instance of OrangeTreeModel
+    Returns
+    -------
+    instance of OrangeTreeModel
     """
     __returns__ = TreeModel
 
@@ -57,10 +63,11 @@ class TreeLearner(Learner):
     def _select_attr(self, data):
         """Select the attribute for the next split.
 
-        Returns:
-            tuple with an instance of Node and a numpy array indicating
-            the branch index for each data instance, or -1 if data instance
-            is dropped
+        Returns
+        -------
+        tuple with an instance of Node and a numpy array indicating
+        the branch index for each data instance, or -1 if data instance
+        is dropped
         """
         # Prevent false warnings by pylint
         attr = attr_no = None

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -129,7 +129,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: responsible for displaying messages within the widget in an
     #: appropriate manner.
     want_message_bar = True
-    #: Widget painted by `Save graph" button
+    #: Widget painted by `Save graph` button
     graph_name = None
     graph_writers = FileFormat.img_writers
 

--- a/doc/data-mining-library/source/conf.py
+++ b/doc/data-mining-library/source/conf.py
@@ -154,7 +154,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/data-mining-library/source/reference/data.variable.rst
+++ b/doc/data-mining-library/source/reference/data.variable.rst
@@ -87,7 +87,7 @@ Base class
     .. automethod:: str_val
     .. automethod:: to_val
     .. automethod:: val_from_str_add
-    .. automethod:: compute_value
+    .. autoattribute:: compute_value
 
     Method `compute_value` is usually invoked behind the scenes in
     conversion of domains::

--- a/doc/development/source/conf.py
+++ b/doc/development/source/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
@@ -153,7 +153,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/doc/development/source/gui.rst
+++ b/doc/development/source/gui.rst
@@ -192,6 +192,5 @@ Other functions
 
 .. autofunction:: miscellanea
 .. autofunction:: setLayout
-.. autofunction:: _enterButton
 .. autofunction:: _addSpace
 .. autofunction:: createAttributePixmap

--- a/doc/development/source/tutorial-cont.rst
+++ b/doc/development/source/tutorial-cont.rst
@@ -94,7 +94,7 @@ sampled data is sent as a token to the output channel with a name
 
 Although our widget is now ready to test, for a final touch, let's
 design an icon for our widget. As specified in the widget header, we
-will call it :download:`DataSamplerA.svg <orange-demo/orangedeomo/icons/DataSamplerA.svg>` and will
+will call it :download:`DataSamplerA.svg <orange-demo/orangedemo/icons/DataSamplerA.svg>` and will
 put it in `icons` subdirectory of `orangedemo` directory.
 
 

--- a/doc/development/source/tutorial-settings.rst
+++ b/doc/development/source/tutorial-settings.rst
@@ -111,7 +111,7 @@ disabling. The data processing and token sending part of our widget
 now is
 
 
-.. literalinclude:: OWDataSamplerB.py
+.. literalinclude:: orange-demo/orangedemo/OWDataSamplerB.py
    :start-after: start-snippet-4
    :end-before: end-snippet-4
 

--- a/doc/visual-programming/source/widgets/unsupervised/manifoldlearning.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/manifoldlearning.rst
@@ -31,6 +31,7 @@ visualized with :doc:`Scatter Plot <../visualize/scatterplot>` or other visualiz
 .. figure:: images/manifold-learning-stamped.png
 
 1. Method for manifold learning:
+
    - `t-SNE <http://scikit-learn.org/stable/modules/manifold.html#t-distributed-stochastic-neighbor-embedding-t-sne>`_
    - `MDS <http://scikit-learn.org/stable/modules/manifold.html#multi-dimensional-scaling-mds>`_, see also :doc:`MDS widget <../unsupervised/mds>`
    - `Isomap <http://scikit-learn.org/stable/modules/manifold.html#isomap>`_
@@ -38,6 +39,7 @@ visualized with :doc:`Scatter Plot <../visualize/scatterplot>` or other visualiz
    - `Spectral Embedding <http://scikit-learn.org/stable/modules/manifold.html#spectral-embedding>`_
 
 2. Set parameters for the method:
+
    - t-SNE (distance measures):
       - *Euclidean* distance
       - *Manhattan*

--- a/doc/visual-programming/source/widgets/visualize/linearprojection.rst
+++ b/doc/visual-programming/source/widgets/visualize/linearprojection.rst
@@ -68,9 +68,9 @@ References
 Koren Y., Carmel L. (2003). Visualization of labeled data using linear
 transformations. In Proceedings of IEEE Information Visualization 2003,
 (InfoVis'03). Available
-`here <http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=3DDF0DB68D8AB9949820A19B0344C1F3?doi=10.1.1.13.8657&rep=rep1&type=pdf>`_.
+`here <http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=3DDF0DB68D8AB9949820A19B0344C1F3?doi=10.1.1.13.8657&rep=rep1&type=pdf>`__.
 
 Boulesteix A.-L., Strimmer K. (2006). Partial least squares: a versatile
 tool for the analysis of high-dimensional genomic data. Briefings in
 Bioinformatics, 8(1), 32-44. Abstract
-`here <http://bib.oxfordjournals.org/content/8/1/32.abstract>`_.
+`here <http://bib.oxfordjournals.org/content/8/1/32.abstract>`__.

--- a/doc/visual-programming/source/widgets/visualize/nomogram.rst
+++ b/doc/visual-programming/source/widgets/visualize/nomogram.rst
@@ -61,7 +61,7 @@ Example
 -------
 
 The **Nomogram** widget should be used immediately after trained classifier widget
-(e.g. :doc:`Naive Bayes <../classify/naivebayes>`. It can also be passed a data
+(e.g. :doc:`Naive Bayes <../model/naivebayes>`. It can also be passed a data
 instance using any widget that enables selection
 (e.g. :doc:`Data Table <../data/datatable>`) as shown in the workflow below.
 


### PR DESCRIPTION
##### Issue
When building documentation, lots of warnings are shown. Some resulted in badly rendered documentation (see lists in [manifold learning docs](https://docs.orange.biolab.si/3/visual-programming/widgets/unsupervised/manifoldlearning.html))

##### Description of changes
Fix most of the warnings.

What remains are warnings that are caused by "including" scikit-learn descriptions that contain references to labels in their user guide. We need to either inter-sphinx properly or remove those links.

##### Includes
- [x] Documentation
