### PR TITLE
preprocess.score.Scorer: Improve error messages

### DIFF
--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -65,12 +65,6 @@ class SelectBestFeatures(Reprable):
             else:
                 method = UnivariateLinearRegression()
 
-        if not isinstance(data.domain.class_var, method.class_type):
-            raise ValueError(("Scoring method {} requires a class variable " +
-                              "of type {}.").format(
-                (method if type(method) == type else type(method)).__name__,
-                method.class_type.__name__)
-            )
         features = data.domain.attributes
         try:
             scores = method(data)

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from itertools import chain
 
@@ -30,12 +31,37 @@ class Scorer(_RefuseDataInConstructor, Reprable):
         RemoveNaNClasses()
     ]
 
+    @property
+    def friendly_name(self):
+        """Return type name with camel-case separated into words.
+        Derived classes can provide a better property or a class attribute.
+        """
+        return re.sub("([a-z])([A-Z])",
+                      lambda mo: mo.group(1) + " " + mo.group(2).lower(),
+                      type(self).__name__)
+
+    @staticmethod
+    def _friendly_vartype_name(vartype):
+        if vartype == DiscreteVariable:
+            return "categorical"
+        if vartype == ContinuousVariable:
+            return "numeric"
+        # Fallbacks
+        name = vartype.__name__
+        if name.endswith("Variable"):
+            return name.lower()[:-8]
+        return name
+
     def __call__(self, data, feature=None):
         if not data.domain.class_var:
-            raise ValueError("Data with class labels required.")
+            raise ValueError(
+                "{} requires data with a target variable."
+                .format(self.friendly_name))
         if not isinstance(data.domain.class_var, self.class_type):
-            raise ValueError("Scoring method %s requires a class variable of type %s." %
-                             (type(self).__name__, self.class_type.__name__))
+            raise ValueError(
+                "{} requires a {} target variable."
+                .format(self.friendly_name,
+                        self._friendly_vartype_name(self.class_type)))
 
         if feature is not None:
             f = data.domain[feature]
@@ -44,9 +70,12 @@ class Scorer(_RefuseDataInConstructor, Reprable):
         for pp in self.preprocessors:
             data = pp(data)
 
-        if any(not isinstance(a, self.feature_type)
-               for a in data.domain.attributes):
-            raise ValueError('Only %ss are supported' % self.feature_type)
+        for var in data.domain.attributes:
+            if not isinstance(var, self.feature_type):
+                raise ValueError(
+                    "{} cannot score {} variables."
+                    .format(self.friendly_name,
+                            self._friendly_vartype_name(type(var))))
 
         return self.score_data(data, feature)
 
@@ -299,6 +328,7 @@ class ReliefF(Scorer):
     feature_type = Variable
     class_type = DiscreteVariable
     supports_sparse_data = False
+    friendly_name = "ReliefF"
 
     def __init__(self, n_iterations=50, k_nearest=10):
         self.n_iterations = n_iterations
@@ -326,6 +356,7 @@ class RReliefF(Scorer):
     feature_type = Variable
     class_type = ContinuousVariable
     supports_sparse_data = False
+    friendly_name = "RReliefF"
 
     def __init__(self, n_iterations=50, k_nearest=50):
         self.n_iterations = n_iterations


### PR DESCRIPTION
##### Issue

As we discussed in #2205, features selection in the Preprocess widget shows ugly error messages. This happens since it shows exceptions raised by `preprocess.score.Scorer`, which are, in turn, in need of improvement.

##### Description of changes

This PR makes the exceptions issued by `preprocess.score.Scorer` presentable.

I think we should not do this in general since exceptions are for programmers and error messages in the widgets are for the end-user, so the former have to be exact and technical, including the type names etc, while the latter favour readability over exactness.

A check in `preproces.fss` is removed since it is also done in `preprocess.score.Scorer`.

##### Includes
- [X] Code changes

No additional tests are needed.