### PR TITLE
[RFC] Lint: disable no-else-return, len-as-condition

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,7 @@ disable=
     parameter-unpacking,long-suffix,cmp-method,using-cmp-argument,
     useless-suppression,import-error,
     empty-docstring,missing-docstring,redefined-outer-name,redefined-builtin,
-    attribute-defined-outside-init
+    attribute-defined-outside-init, no-else-return, len-as-condition
 
 
 [REPORTS]


### PR DESCRIPTION
- `no-len-as-condition` is triggered by our common idiom `if data is None or not len(data)`. We should either disable the warning or decide to use `if data is None or len(data) == 0`. I think disabling the warning is OK since we are not (mis)using `if len(s):` instead of `if s`, but changing the code instead is OK for me, too.

- `no-else-return` is triggered by `else`'s in code like

```
    def compute_score(self, results, target=None):
        if target is None:
            if len(results.domain.class_var.values) <= 2:
                return self.from_predicted(results, skl_metrics.f1_score, average='binary')
            else:
                return self.from_predicted(results, skl_metrics.f1_score, average='weighted')
        else:
            return np.fromiter(
                (skl_metrics.f1_score(results.actual, predicted, average=None)[target]
                 for predicted in results.predicted),
                dtype=np.float64, count=len(results.predicted))
```

The code is better (more explicit) with `else`'s. I think we can disable this warning since we don't generally have a problem with such `else`'s, do we?