### PR TITLE
Remove .metadata file if meta data is removed

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 from itertools import chain, repeat
 from math import isnan
 from numbers import Number
-from os import path, unlink
+from os import path, remove
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse, urlsplit, urlunsplit, unquote as urlunquote
 from urllib.request import urlopen, Request
@@ -395,7 +395,7 @@ class FileFormat(metaclass=FileFormatMeta):
             if getattr(data, 'attributes', None):
                 write_file(metafile)
             elif path.exists(metafile):
-                unlink(metafile)
+                remove(metafile)
 
     @classmethod
     def set_table_metadata(cls, filename, table):
@@ -941,7 +941,7 @@ class UrlReader(FileFormat):
 
             reader = self.get_reader(f.name)
             data = reader.read()
-            unlink(f.name)
+            remove(f.name)
         # Override name set in from_file() to avoid holding the temp prefix
         data.name = path.splitext(name)[0]
         data.origin = self.filename

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -379,15 +379,23 @@ class FileFormat(metaclass=FileFormatMeta):
 
     @classmethod
     def write_table_metadata(cls, filename, data):
-        if isinstance(filename, str) and getattr(data, 'attributes', None):
+
+        def write_file(fn):
             if all(isinstance(key, str) and isinstance(value, str)
                    for key, value in data.attributes.items()):
-                with open(filename + '.metadata', 'w', encoding='utf-8') as f:
+                with open(fn, 'w', encoding='utf-8') as f:
                     f.write("\n".join("{}: {}".format(*kv)
                                       for kv in data.attributes.items()))
             else:
-                with open(filename + '.metadata', 'wb') as f:
+                with open(fn, 'wb') as f:
                     pickle.dump(data.attributes, f, pickle.HIGHEST_PROTOCOL)
+
+        if isinstance(filename, str):
+            metafile = filename + '.metadata'
+            if getattr(data, 'attributes', None):
+                write_file(metafile)
+            elif path.exists(metafile):
+                unlink(metafile)
 
     @classmethod
     def set_table_metadata(cls, filename, table):

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -6,7 +6,6 @@ from os import path, remove
 import unittest
 import tempfile
 import shutil
-import pickle
 from collections import OrderedDict
 
 import numpy as np
@@ -223,6 +222,18 @@ class TestTabReader(unittest.TestCase):
         table = Table("titanic")
         table.attributes = OrderedDict()
         fname = path.join(tempdir, "out.tab")
+        TabReader.write_table_metadata(fname, table)
+        self.assertFalse(path.isfile(fname + ".metadata"))
+        shutil.rmtree(tempdir)
+
+    def test_had_metadata_now_there_is_none(self):
+        tempdir = tempfile.mkdtemp()
+        table = Table("titanic")
+        table.attributes["a"] = "aa"
+        fname = path.join(tempdir, "out.tab")
+        TabReader.write_table_metadata(fname, table)
+        self.assertTrue(path.isfile(fname + ".metadata"))
+        del table.attributes["a"]
         TabReader.write_table_metadata(fname, table)
         self.assertFalse(path.isfile(fname + ".metadata"))
         shutil.rmtree(tempdir)

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -179,26 +179,30 @@ class TestTabReader(unittest.TestCase):
 
     def test_attributes_saving(self):
         tempdir = tempfile.mkdtemp()
-        table = Table("titanic")
-        self.assertEqual(table.attributes, {})
-        table.attributes[1] = "test"
-        table.save(path.join(tempdir, "out.tab"))
-        table = Table(path.join(tempdir, "out.tab"))
-        self.assertEqual(table.attributes[1], "test")
-        shutil.rmtree(tempdir)
+        try:
+            table = Table("titanic")
+            self.assertEqual(table.attributes, {})
+            table.attributes[1] = "test"
+            table.save(path.join(tempdir, "out.tab"))
+            table = Table(path.join(tempdir, "out.tab"))
+            self.assertEqual(table.attributes[1], "test")
+        finally:
+            shutil.rmtree(tempdir)
 
     def test_attributes_saving_as_txt(self):
         tempdir = tempfile.mkdtemp()
-        table = Table("titanic")
-        table.attributes = OrderedDict()
-        table.attributes["a"] = "aa"
-        table.attributes["b"] = "bb"
-        table.save(path.join(tempdir, "out.tab"))
-        table = Table(path.join(tempdir, "out.tab"))
-        self.assertIsInstance(table.attributes, OrderedDict)
-        self.assertEqual(table.attributes["a"], "aa")
-        self.assertEqual(table.attributes["b"], "bb")
-        shutil.rmtree(tempdir)
+        try:
+            table = Table("titanic")
+            table.attributes = OrderedDict()
+            table.attributes["a"] = "aa"
+            table.attributes["b"] = "bb"
+            table.save(path.join(tempdir, "out.tab"))
+            table = Table(path.join(tempdir, "out.tab"))
+            self.assertIsInstance(table.attributes, OrderedDict)
+            self.assertEqual(table.attributes["a"], "aa")
+            self.assertEqual(table.attributes["b"], "bb")
+        finally:
+            shutil.rmtree(tempdir)
 
     def test_data_name(self):
         table1 = Table('iris')
@@ -208,32 +212,38 @@ class TestTabReader(unittest.TestCase):
 
     def test_metadata(self):
         tempdir = tempfile.mkdtemp()
-        table = Table("titanic")
-        table.attributes = OrderedDict()
-        table.attributes["a"] = "aa"
-        table.attributes["b"] = "bb"
-        fname = path.join(tempdir, "out.tab")
-        TabReader.write_table_metadata(fname, table)
-        self.assertTrue(path.isfile(fname + ".metadata"))
-        shutil.rmtree(tempdir)
+        try:
+            table = Table("titanic")
+            table.attributes = OrderedDict()
+            table.attributes["a"] = "aa"
+            table.attributes["b"] = "bb"
+            fname = path.join(tempdir, "out.tab")
+            TabReader.write_table_metadata(fname, table)
+            self.assertTrue(path.isfile(fname + ".metadata"))
+        finally:
+            shutil.rmtree(tempdir)
 
     def test_no_metadata(self):
         tempdir = tempfile.mkdtemp()
-        table = Table("titanic")
-        table.attributes = OrderedDict()
-        fname = path.join(tempdir, "out.tab")
-        TabReader.write_table_metadata(fname, table)
-        self.assertFalse(path.isfile(fname + ".metadata"))
-        shutil.rmtree(tempdir)
+        try:
+            table = Table("titanic")
+            table.attributes = OrderedDict()
+            fname = path.join(tempdir, "out.tab")
+            TabReader.write_table_metadata(fname, table)
+            self.assertFalse(path.isfile(fname + ".metadata"))
+        finally:
+            shutil.rmtree(tempdir)
 
     def test_had_metadata_now_there_is_none(self):
         tempdir = tempfile.mkdtemp()
-        table = Table("titanic")
-        table.attributes["a"] = "aa"
-        fname = path.join(tempdir, "out.tab")
-        TabReader.write_table_metadata(fname, table)
-        self.assertTrue(path.isfile(fname + ".metadata"))
-        del table.attributes["a"]
-        TabReader.write_table_metadata(fname, table)
-        self.assertFalse(path.isfile(fname + ".metadata"))
-        shutil.rmtree(tempdir)
+        try:
+            table = Table("titanic")
+            table.attributes["a"] = "aa"
+            fname = path.join(tempdir, "out.tab")
+            TabReader.write_table_metadata(fname, table)
+            self.assertTrue(path.isfile(fname + ".metadata"))
+            del table.attributes["a"]
+            TabReader.write_table_metadata(fname, table)
+            self.assertFalse(path.isfile(fname + ".metadata"))
+        finally:
+            shutil.rmtree(tempdir)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -742,6 +742,7 @@ class TableTestCase(unittest.TestCase):
                 self.assertEqual(e1, e2)
         finally:
             os.remove("test-save.tab")
+            os.remove("test-save.tab.metadata")
 
         dom = data.Domain([data.ContinuousVariable("a")])
         d = data.Table(dom)
@@ -755,7 +756,6 @@ class TableTestCase(unittest.TestCase):
                 self.assertEqual(d2[i], [i])
         finally:
             os.remove("test-save.tab")
-            os.remove("test-save.tab.metadata")
 
         dom = data.Domain([data.ContinuousVariable("a")], None)
         d = data.Table(dom)


### PR DESCRIPTION
Fixes a bug when meta data is removed, data saved. In this case the old meta
data file still exists and will be loaded the next time the data is opened.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
