### PR TITLE
[FIX] Distributions: make sure cvar values are strings and not ints

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -283,6 +283,7 @@ class OWDistributions(widget.OWWidget):
             self.var = self.varmodel[varidx]
         if self.groupvar_idx > 0:
             self.cvar = self.groupvarmodel[self.groupvar_idx]
+            self.cvar.values = list(map(str, self.cvar.values))
             self.cb_prob.clear()
             self.cb_prob.addItem("(None)")
             self.cb_prob.addItems(self.cvar.values)


### PR DESCRIPTION
##### Issue
Test & Score sends data where number of Folds is int and Distributions widget cannot handle that. ComboBox accepts only strings and there are some other issues as well.

https://sentry.io/biolab/orange3/issues/242009555/

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
