### PR TITLE
Fix subsequent repring of SklLearner

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -29,7 +29,7 @@ class _ReprableWithPreprocessors(Reprable):
 class _ReprableWithParams(Reprable):
     def __repr__(self):
         # In addition to saving values onto self, SklLearners save into params
-        with patch.object(self, '__dict__', dict(self.__dict__, **self.params)):
+        with patch.dict(self.__dict__, self.params):
             return super().__repr__()
 
 

--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -37,6 +37,7 @@ class TestUtil(unittest.TestCase):
         from Orange.data import ContinuousVariable
         from Orange.preprocess.impute import ReplaceUnknownsRandom
         from Orange.statistics.distribution import Continuous
+        from Orange.classification import LogisticRegressionLearner
 
         var = ContinuousVariable('x')
         transform = ReplaceUnknownsRandom(var, Continuous(1, var))
@@ -45,6 +46,11 @@ class TestUtil(unittest.TestCase):
                          "ReplaceUnknownsRandom("
                          "variable=ContinuousVariable(name='x', number_of_decimals=3), "
                          "distribution=Continuous([[ 0.], [ 0.]]))")
+
+        # GH 2275
+        logit = LogisticRegressionLearner()
+        for _ in range(2):
+            self.assertEqual(repr(logit), 'LogisticRegressionLearner()')
 
     def test_deepgetattr(self):
         class a:


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3/issues/2275
`patch.object()` (why was that used anyway?) didn't correctly restore _params_ key.

##### Description of changes
Use `patch.dict()` instead.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
