### PR TITLE
DiscreteVariable: Raise exception on non-string values

### DIFF
--- a/Orange/clustering/dbscan.py
+++ b/Orange/clustering/dbscan.py
@@ -38,7 +38,8 @@ class DBSCANModel(Projection):
                 data = data.transform(self.pre_domain)
             y = self.proj.fit_predict(data.X)
             vals = [-1] + list(self.proj.core_sample_indices_)
-            c = DiscreteVariable(name='Core sample index', values=vals)
+            c = DiscreteVariable(name='Core sample index',
+                                 values=[str(v) for v in vals])
             domain = Domain([c])
             return Table(domain, y.reshape(len(y), 1))
 

--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -45,7 +45,8 @@ class KMeansModel(Projection):
         if isinstance(data, Table):
             if data.domain is not self.pre_domain:
                 data = data.transform(self.pre_domain)
-            c = DiscreteVariable(name='Cluster id', values=range(self.k))
+            c = DiscreteVariable(name='Cluster id',
+                                 values=[str(i) for i in range(self.k)])
             domain = Domain([c])
             return Table(
                 domain,
@@ -53,7 +54,8 @@ class KMeansModel(Projection):
         elif isinstance(data, Instance):
             if data.domain is not self.pre_domain:
                 data = Instance(self.pre_domain, data)
-            c = DiscreteVariable(name='Cluster id', values=range(self.k))
+            c = DiscreteVariable(name='Cluster id',
+                                 values=[str(i) for i in range(self.k)])
             domain = Domain([c])
             return Table(
                 domain,

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -552,11 +552,11 @@ class DiscreteVariable(Variable):
 
     def __init__(self, name="", values=(), ordered=False, base_value=-1, compute_value=None):
         """ Construct a discrete variable descriptor with the given values. """
-        if not all(isinstance(value, str) for value in values):
+        self.values = list(values)
+        if not all(isinstance(value, str) for value in self.values):
             raise TypeError("values of DiscreteVariables must be strings")
         super().__init__(name, compute_value)
         self.ordered = ordered
-        self.values = list(values)
         self.base_value = base_value
 
     @property

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -552,6 +552,8 @@ class DiscreteVariable(Variable):
 
     def __init__(self, name="", values=(), ordered=False, base_value=-1, compute_value=None):
         """ Construct a discrete variable descriptor with the given values. """
+        if not all(isinstance(value, str) for value in values):
+            raise TypeError("values of DiscreteVariables must be strings")
         super().__init__(name, compute_value)
         self.ordered = ordered
         self.values = list(values)
@@ -610,6 +612,8 @@ class DiscreteVariable(Variable):
     def add_value(self, s):
         """ Add a value `s` to the list of values.
         """
+        if not isinstance(s, str):
+            raise TypeError("values of DiscreteVariables must be strings")
         self.values.append(s)
         self._colors = None
 

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -94,7 +94,7 @@ class ModelTest(unittest.TestCase):
         y[:, 0] = y[:, 0] // 3          # majority = 1
         y[:, 1] = (y[:, 1] + 4) // 3    # majority = 2
         domain = Domain([ContinuousVariable('i' + str(i)) for i in range(ncols)],
-                        [DiscreteVariable('c' + str(i), values=range(4))
+                        [DiscreteVariable('c' + str(i), values="0123")
                          for i in range(y.shape[1])])
         t = Table(domain, x, y)
         learn = DummyMulticlassLearner()
@@ -113,10 +113,12 @@ class ModelTest(unittest.TestCase):
 
         # single class variable
         y = np.random.randint(0, 2, (nrows, 1))
-        t = Table(Domain([DiscreteVariable('v' + str(i), values=np.unique(x[:, i]))
-                          for i in range(ncols)],
-                         DiscreteVariable('c', values=[1, 2])),
-                  x, y)
+        d = Domain([DiscreteVariable('v' + str(i),
+                                     values=[str(v)
+                                             for v in np.unique(x[:, i])])
+                    for i in range(ncols)],
+                   DiscreteVariable('c', values="12"))
+        t = Table(d, x, y)
         learn = DummyLearner()
         clf = learn(t)
         clf.ret = Model.Value
@@ -131,7 +133,7 @@ class ModelTest(unittest.TestCase):
         y[:, 0] = y[:, 0] // 3             # majority = 1
         y[:, 1] = (y[:, 1] + 4) // 3 - 1   # majority = 1
         domain = Domain([ContinuousVariable('i' + str(i)) for i in range(ncols)],
-                        [DiscreteVariable('c' + str(i), values=range(4))
+                        [DiscreteVariable('c' + str(i), values="0123")
                          for i in range(y.shape[1])])
         t = Table(domain, x, y)
         learn = DummyMulticlassLearner()
@@ -148,10 +150,11 @@ class ExpandProbabilitiesTest(unittest.TestCase):
     def prepareTable(self, rows, attr, vars, class_var_domain):
         attributes = ["Feature %i" % i for i in range(attr)]
         classes = ["Class %i" % i for i in range(vars)]
-        attr_vars = [DiscreteVariable(name=a, values=range(2))
-                     for a in attributes]
+        attr_vars = [DiscreteVariable(name=a, values="01") for a in attributes]
         class_vars = [DiscreteVariable(name=c,
-                                       values=range(class_var_domain))
+                                       values=[str(v)
+                                               for v in range(class_var_domain)]
+                                       )
                       for c in classes]
         meta_vars = []
         self.domain = Domain(attr_vars, class_vars, meta_vars)
@@ -345,9 +348,13 @@ class LearnerReprs(unittest.TestCase):
         srf = SimpleRandomForestLearner(n_estimators=20)
 
         learners = [lr, m, nb, rf, st, sm, svm,
-            lsvm, nsvm, osvm, tl, knn, el, srf]
+                    lsvm, nsvm, osvm, tl, knn, el, srf]
 
         for l in learners:
             repr_str = repr(l)
             new_l = eval(repr_str)
             self.assertEqual(repr(new_l), repr_str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -95,7 +95,7 @@ class TestEntropyMDL(TestCase):
     def test_entropy_constant(self):
         X = np.zeros((100, 1))
         domain = Domain([ContinuousVariable('v1')],
-                        [DiscreteVariable('c1', values=[1])])
+                        [DiscreteVariable('c1', values=["1"])])
         table = data.Table(domain, X, X)
         disc = discretize.EntropyMDL()
         dvar = disc(table, table.domain[0])

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -64,7 +64,8 @@ class FeatureScoringTest(unittest.TestCase):
         y = 10 + (-3*X[:, 1] + X[:, 3]) // 2
         domain = Domain.from_numpy(X, y)
         domain = Domain(domain.attributes,
-                        DiscreteVariable('c', values=np.unique(y)))
+                        DiscreteVariable('c',
+                                         values=[str(v) for v in np.unique(y)]))
         table = Table(domain, X, y)
         data = preprocess.Discretize()(table)
         scorer = Chi2()
@@ -77,7 +78,8 @@ class FeatureScoringTest(unittest.TestCase):
         y = 4 + (-3*X[:, 1] + X[:, 3]) // 2
         domain = Domain.from_numpy(X, y)
         domain = Domain(domain.attributes,
-                        DiscreteVariable('c', values=np.unique(y)))
+                        DiscreteVariable('c',
+                                         values=[str(v) for v in np.unique(y)]))
         data = Table(domain, X, y)
         scorer = ANOVA()
         sc = [scorer(data, a) for a in range(ncols)]

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -30,10 +30,10 @@ class TestSimpleTreeLearner(unittest.TestCase):
         y_reg[np.random.random(self.N) < 0.1] = np.nan
 
         di = [Orange.data.domain.DiscreteVariable(
-            'd{}'.format(i), [0, 1]) for i in range(self.Mi)]
+            'd{}'.format(i), ["0", "1"]) for i in range(self.Mi)]
         df = [Orange.data.domain.ContinuousVariable(
             'c{}'.format(i)) for i in range(self.Mf)]
-        dcls = Orange.data.domain.DiscreteVariable('yc', [0, 1, 2])
+        dcls = Orange.data.domain.DiscreteVariable('yc', ["0", "1", "2"])
         dreg = Orange.data.domain.ContinuousVariable('yr')
         domain_cls = Orange.data.domain.Domain(di + df, dcls)
         domain_reg = Orange.data.domain.Domain(di + df, dreg)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2086,7 +2086,7 @@ class InterfaceTest(unittest.TestCase):
     features = (
         data.ContinuousVariable(name="Continuous Feature 1"),
         data.ContinuousVariable(name="Continuous Feature 2"),
-        data.DiscreteVariable(name="Discrete Feature 1", values=[0, 1]),
+        data.DiscreteVariable(name="Discrete Feature 1", values=["0", "1"]),
         data.DiscreteVariable(name="Discrete Feature 2",
                               values=["value1", "value2"]),
     )

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -247,6 +247,11 @@ class TestDiscreteVariable(VariableTest):
         self.assertEqual(len(var.colors), 4)
         np.testing.assert_array_equal(var.colors[2], user_defined)
 
+    def test_no_nonstringvalues(self):
+        self.assertRaises(TypeError, DiscreteVariable, "foo", values=["a", 42])
+        a = DiscreteVariable("foo", values=["a", "b", "c"])
+        self.assertRaises(TypeError, a.add_value, 42)
+
 
 @variabletest(ContinuousVariable)
 class TestContinuousVariable(VariableTest):
@@ -407,8 +412,6 @@ PickleContinuousVariable = create_pickling_tests(
 PickleDiscreteVariable = create_pickling_tests(
     "PickleDiscreteVariable",
     ("with_name", lambda: DiscreteVariable(name="Feature 0")),
-    ("with_int_values", lambda: DiscreteVariable(name="Feature 0",
-                                                 values=[1, 2, 3])),
     ("with_str_value", lambda: DiscreteVariable(name="Feature 0",
                                                 values=["F", "M"])),
     ("ordered", lambda: DiscreteVariable(name="Feature 0",

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -204,7 +204,7 @@ class TestOWRank(WidgetTest):
         table = Table(
             Domain(
                 [ContinuousVariable("c")],
-                [DiscreteVariable("d", values=[0, 1])]
+                [DiscreteVariable("d", values="01")]
             ),
             list(zip(
                 [-np.power(10, 10), 1, 1],


### PR DESCRIPTION
##### Issue

Test & Score created discrete variables with non-string values, which cause problems in Distributions. In #2274 we discussed that we should prohibit this and raise the exception early.

##### Description of changes

- Raise an exception in `DiscreteVariable`'s constructor and in `add_value` if the value is not a string.
- Add a test
- Remove a test that assigned `[1, 2, 3]` to values.
- Fix Results.get_augmented_data that used in int's instead of str's and broke Test & Score.

There are other ways to add a non-string value. But if one want to be destructive, she can easily assign a dict to `values`, and we're not preventing this either.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation