### PR TITLE
Model: Do not pickle stored data

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -273,6 +273,14 @@ class Model(Reprable):
         else:  # ret == Model.ValueProbs
             return value, probs
 
+    def __getstate__(self):
+        """Skip (possibly large) data when pickling models"""
+        state = self.__dict__
+        if 'original_data' in state:
+            state = state.copy()
+            state['original_data'] = None
+        return state
+
 
 class SklModel(Model, metaclass=WrapperMeta):
     used_vals = None

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -1,8 +1,10 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import pickle
 import unittest
 
-from Orange.base import SklLearner, Learner
+from Orange.base import SklLearner, Learner, Model
+from Orange.data import Domain
 from Orange.preprocess import Discretize, Randomize
 from Orange.regression import LinearRegressionLearner
 
@@ -98,3 +100,14 @@ class TestSklLearner(unittest.TestCase):
             LinearRegressionLearner().supports_weights,
             "Either LinearRegression no longer supports weighted tables or "
             "SklLearner.supports_weights is out-of-date.")
+
+
+class TestModel(unittest.TestCase):
+    def test_pickle(self):
+        """Make sure data is not saved when pickling a model."""
+        model = Model(Domain([]))
+        model.original_data = [1, 2, 3]
+        model2 = pickle.loads(pickle.dumps(model))
+        self.assertEqual(model.domain, model2.domain)
+        self.assertEqual(model.original_data, [1, 2, 3])
+        self.assertEqual(model2.original_data, None)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Models store a pointer to the original training set. This can be huge and causes problems when pickling/unpickling.

##### Description of changes
Skip `original_data` when pickling `Model`s.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
