### PR TITLE
[WIP] compute_contigency: convert X to CSC

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1465,6 +1465,8 @@ class Table(MutableSequence, Storage):
             arr_indi = [e for e, ind in enumerate(col_indi) if f_cond(ind)]
 
             vars = [(e, f_ind(col_indi[e]), col_desc[e]) for e in arr_indi]
+            if vars and arr is self.X and sp.issparse(self.X):
+                self.X = self.X.tocsc()
             disc_vars = [v for v in vars if v[2].is_discrete]
             if disc_vars:
                 if sp.issparse(arr):


### PR DESCRIPTION
Speedups if a user successively computes contingencies for single columns. See #2283

Fixes https://github.com/biolab/orange3/issues/2167.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
