### PR TITLE
Prevent changing outputs to type Table

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -228,7 +228,7 @@ class Model(Reprable):
             if not isinstance(data[0], (list, tuple)):
                 data = [data]
             data = Table(self.original_domain, data)
-            data = Table(self.domain, data)
+            data = data.transform(self.domain)
             prediction = self.predict_storage(data)
         else:
             raise TypeError("Unrecognized argument (instance of '{}')"

--- a/Orange/base.py
+++ b/Orange/base.py
@@ -222,7 +222,7 @@ class Model(Reprable):
             prediction = self.predict_storage(data)
         elif isinstance(data, Table):
             if data.domain != self.domain:
-                data = data.from_table(self.domain, data)
+                data = data.transform(self.domain)
             prediction = self.predict_storage(data)
         elif isinstance(data, (list, tuple)):
             if not isinstance(data[0], (list, tuple)):

--- a/Orange/clustering/dbscan.py
+++ b/Orange/clustering/dbscan.py
@@ -35,7 +35,7 @@ class DBSCANModel(Projection):
 
         if isinstance(data, Table):
             if data.domain is not self.pre_domain:
-                data = Table(self.pre_domain, data)
+                data = data.transform(self.pre_domain)
             y = self.proj.fit_predict(data.X)
             vals = [-1] + list(self.proj.core_sample_indices_)
             c = DiscreteVariable(name='Core sample index', values=vals)

--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -44,7 +44,7 @@ class KMeansModel(Projection):
     def __call__(self, data):
         if isinstance(data, Table):
             if data.domain is not self.pre_domain:
-                data = Table(self.pre_domain, data)
+                data = data.transform(self.pre_domain)
             c = DiscreteVariable(name='Cluster id', values=range(self.k))
             domain = Domain([c])
             return Table(

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -395,6 +395,31 @@ class Table(MutableSequence, Storage):
                 if new_cache:
                     _conversion_cache = None
 
+    def transform(self, domain):
+        """
+        Construct a table with a different domain.
+
+        The new table keeps the row ids and other information. If the table
+        is a subclass of :obj:`Table`, the resulting table will be of the same
+        type.
+
+        In a typical scenario, an existing table is augmented with a new
+        column by ::
+
+            domain = Domain(old_domain.attributes + [new_attribute],
+                            old_domain.class_vars,
+                            old_domain.metas)
+            table = data.transform(domain)
+            table[:, new_attribute] = new_column
+
+        Args:
+            domain (Domain): new domain
+
+        Returns:
+            A new table
+        """
+        return type(self).from_table(domain, self)
+
     @classmethod
     def from_table_rows(cls, source, row_indices):
         """

--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -19,7 +19,7 @@ def _preprocess(table):
         [a for a in table.domain.attributes if a.is_continuous],
         table.domain.class_vars,
         table.domain.metas)
-    new_data = data.Table(new_domain, table)
+    new_data = table.transform(new_domain)
     new_data = SklImpute()(new_data)
     return new_data
 

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -295,11 +295,10 @@ class Results:
         new_meta_attr = list(data.domain.metas) + new_meta_attr
         new_meta_vals = np.hstack((data.metas, new_meta_vals))
 
-        X = data.X if include_attrs else np.empty((len(data), 0))
         attrs = data.domain.attributes if include_attrs else []
-
         domain = Domain(attrs, data.domain.class_vars, metas=new_meta_attr)
-        predictions = Table.from_numpy(domain, X, data.Y, metas=new_meta_vals)
+        predictions = data.transform(domain)
+        predictions.metas = new_meta_vals
         predictions.name = data.name
         return predictions
 

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -81,7 +81,7 @@ class SelectBestFeatures(Reprable):
 
         domain = Orange.data.Domain([f for s, f in best],
                                     data.domain.class_vars, data.domain.metas)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
     def score_only_nice_features(self, data, method):
         mask = np.array([isinstance(a, method.feature_type)
@@ -119,7 +119,7 @@ class SelectRandomFeatures(Reprable):
             random.sample(data.domain.attributes,
                           min(self.k, len(data.domain.attributes))),
             data.domain.class_vars, data.domain.metas)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
 
 class RemoveNaNColumns(Preprocess):

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -148,4 +148,4 @@ class RemoveNaNColumns(Preprocess):
         att = [a for a, n in zip(data.domain.attributes, nans) if n < threshold]
         domain = Orange.data.Domain(att, data.domain.class_vars,
                                     data.domain.metas)
-        return Orange.data.Table(domain, data)
+        return data.transform(domain)

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -187,7 +187,7 @@ class Model(BaseImputeMethod):
         domain = domain_with_class_var(data.domain, variable)
 
         if self.learner.check_learner_adequacy(domain):
-            data = data.from_table(domain, data)
+            data = data.transform(domain)
             model = self.learner(data)
             assert model.domain.class_var == variable
             return variable.copy(

--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -28,7 +28,7 @@ class Normalizer(Reprable):
             new_class_vars = [self.normalize(dists[i + attr_len], var) for
                               (i, var) in enumerate(data.domain.class_vars)]
         domain = Domain(new_attrs, new_class_vars, data.domain.metas)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
     def normalize(self, dist, var):
         if not var.is_continuous:

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -53,7 +53,7 @@ class Continuize(Preprocess):
             zero_based=self.zero_based,
             multinomial_treatment=self.multinomial_treatment)
         domain = continuizer(data)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
 
 class Discretize(Preprocess):
@@ -110,7 +110,7 @@ class Discretize(Preprocess):
             discretized(data.domain.attributes, True),
             discretized(data.domain.class_vars, self.discretize_classes),
             discretized(data.domain.metas, self.discretize_metas))
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
 
 class Impute(Preprocess):
@@ -141,7 +141,7 @@ class Impute(Preprocess):
         newattrs = [method(data, var) for var in data.domain.attributes]
         domain = Orange.data.Domain(
             newattrs, data.domain.class_vars, data.domain.metas)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
 
 class SklImpute(Preprocess):
@@ -466,7 +466,7 @@ class Scale(Preprocess):
                 newvars.append(var)
         domain = Orange.data.Domain(newvars, data.domain.class_vars,
                                     data.domain.metas)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
 
 class PreprocessorList(Reprable):

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -9,7 +9,6 @@ from sklearn.utils import shuffle as skl_shuffle
 import bottleneck as bn
 
 import Orange.data
-from Orange.data import Table
 from Orange.preprocess.util import _RefuseDataInConstructor
 from Orange.statistics import distribution
 from Orange.util import Reprable, Enum
@@ -167,8 +166,8 @@ class SklImpute(Preprocess):
         assert X.shape[1] == len(features)
         domain = Orange.data.Domain(features, data.domain.class_vars,
                                     data.domain.metas)
-        new_data = Orange.data.Table(domain, X, data.Y, data.metas, W=data.W)
-        new_data.attributes = getattr(data, 'attributes', {})
+        new_data = data.transform(domain)
+        new_data.X = X
         return new_data
 
 
@@ -193,7 +192,7 @@ class RemoveConstant(Preprocess):
         atts = [data.domain.attributes[i] for i, ok in enumerate(oks) if ok]
         domain = Orange.data.Domain(atts, data.domain.class_vars,
                                     data.domain.metas)
-        return Orange.data.Table(domain, data)
+        return data.transform(domain)
 
 
 class RemoveNaNClasses(Preprocess):
@@ -219,7 +218,7 @@ class RemoveNaNClasses(Preprocess):
             nan_cls = np.any(np.isnan(data.Y), axis=1)
         else:
             nan_cls = np.isnan(data.Y)
-        return Table(data.domain, data, np.where(nan_cls == False))
+        return data[~nan_cls]
 
 
 class Normalize(Preprocess):
@@ -350,9 +349,7 @@ class Randomize(Preprocess):
         data : Orange.data.Table
             Randomized data table.
         """
-        new_data = Table(data)
-        new_data.ensure_copy()
-
+        new_data = data.copy()
         if self.rand_type & Randomize.RandomizeClasses:
             new_data.Y = self.randomize(new_data.Y)
         if self.rand_type & Randomize.RandomizeAttributes:

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -87,7 +87,7 @@ class Remove(Preprocess):
         meta_vars, self.meta_results = self.get_vars_and_results(metas_state)
 
         domain = Domain(att_vars, cls_vars, meta_vars)
-        return data.from_table(domain, data)
+        return data.transform(domain)
 
     def get_vars_and_results(self, state):
         removed, reduced, sorted = 0, 0, 0

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -65,7 +65,7 @@ class Scorer(_RefuseDataInConstructor, Reprable):
 
         if feature is not None:
             f = data.domain[feature]
-            data = data.from_table(Domain([f], data.domain.class_vars), data)
+            data = data.transform(Domain([f], data.domain.class_vars))
 
         for pp in self.preprocessors:
             data = pp(data)

--- a/Orange/projection/base.py
+++ b/Orange/projection/base.py
@@ -47,7 +47,7 @@ class Projection:
         return self.proj.transform(X)
 
     def __call__(self, data):
-        return data.from_table(self.domain, data)
+        return data.transform(self.domain)
 
     def __repr__(self):
         return self.name

--- a/Orange/projection/cur.py
+++ b/Orange/projection/cur.py
@@ -122,7 +122,7 @@ class CURModel(Projection):
 
     def __call__(self, data, axis=0):
         if data.domain is not self.domain:
-            data = Orange.data.Table(self.domain, data)
+            data = data.transform(self.domain)
         Xt = self.proj.transform(data.X, axis)
 
         if axis == 0:

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -96,7 +96,7 @@ class _PCATransformDomain:
 
     def __call__(self, data):
         if data.domain != self.pca.pre_domain:
-            data = data.from_table(self.pca.pre_domain, data)
+            data = data.transform(self.pca.pre_domain)
         return self.pca.transform(data.X)
 
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1721,6 +1721,20 @@ class CreateTableWithDomainAndTable(TableTests):
         self.assertIsNot(self.table, new_table)
         self.assertEqual(new_table.domain, self.domain)
 
+    def test_transform(self):
+        class MyTableClass(data.Table):
+            pass
+
+        table = MyTableClass.from_table(self.table.domain, self.table)
+        domain = table.domain
+        attr = ContinuousVariable("x")
+        new_domain = data.Domain(list(domain.attributes) + [attr], None)
+        new_table = table.transform(new_domain)
+
+        self.assertIsInstance(new_table, MyTableClass)
+        self.assertIsNot(table, new_table)
+        self.assertIs(new_table.domain, new_domain)
+
     def test_can_copy_table(self):
         new_table = data.Table.from_table(self.domain, self.table)
         self.assert_table_with_filter_matches(new_table, self.table)
@@ -1832,7 +1846,7 @@ class CreateTableWithDomainAndTable(TableTests):
         new_domain = data.domain.Domain([], iris.domain.class_vars,
                                         iris.domain.attributes, source=iris.domain)
         new_iris = data.Table.from_table(new_domain, iris)
-        
+
         self.assertTrue(sp.issparse(new_iris.X))
         self.assertTrue(sp.issparse(new_iris.metas))
         self.assertEqual(new_iris.X.shape, (len(iris), 0))

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -349,9 +349,7 @@ class OWColor(widget.OWWidget):
                                         self._create_proxies(domain.class_vars),
                                         self._create_proxies(domain.metas))
             self.openContext(data)
-            self.data = Orange.data.Table(domain, data)
-            self.data.domain = domain
-
+            self.data = data.transform(domain)
             self.disc_model.set_data(self.disc_colors)
             self.cont_model.set_data(self.cont_colors)
             self.disc_view.resizeColumnsToContents()

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -154,8 +154,7 @@ class OWConcatenate(widget.OWWidget):
                 domain = reduce(domain_intersection,
                                 (table.domain for table in tables))
 
-        tables = [Orange.data.Table.from_table(domain, table)
-                  for table in tables]
+        tables = [table.transform(domain) for table in tables]
 
         if tables:
             data = concat(tables)

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -128,7 +128,7 @@ class OWContinuize(widget.OWWidget):
         continuizer = self.constructContinuizer()
         if self.data is not None and len(self.data):
             domain = continuizer(self.data)
-            data = Table.from_table(domain, self.data)
+            data = self.data.transform(domain)
             self.send("Data", data)
         else:
             self.send("Data", self.data)  # None or empty data

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -468,7 +468,7 @@ class OWCreateClass(widget.OWWidget):
             self.class_name, names, compute_value=compute_value)
         new_domain = Domain(
             domain.attributes, new_class, domain.metas + domain.class_vars)
-        new_data = Table(new_domain, self.data)
+        new_data = self.data.transform(new_domain)
         self.send("Data", new_data)
 
     def send_report(self):

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -467,7 +467,7 @@ class OWDiscretize(widget.OWWidget):
         output = None
         if self.data is not None and len(self.data):
             domain = self.discretized_domain()
-            output = self.data.from_table(domain, self.data)
+            output = self.data.transform(domain)
         self.send("Data", output)
 
     def storeSpecificSettings(self):

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -558,7 +558,7 @@ class OWEditDomain(widget.OWWidget):
                 class_vars = all_new_vars[n_attrs: n_attrs + n_class_vars]
                 new_metas = all_new_vars[n_attrs + n_class_vars:]
                 new_domain = Orange.data.Domain(attrs, class_vars, new_metas)
-                new_data = self.data.from_table(new_domain, self.data)
+                new_data = self.data.transform(new_domain)
             else:
                 self.Error.duplicate_var_name()
 

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -595,7 +595,7 @@ class OWFeatureConstructor(OWWidget):
         )
 
         try:
-            data = Orange.data.Table(new_domain, self.data)
+            data = self.data.transform(new_domain)
         except Exception as err:
             log = logging.getLogger(__name__)
             log.error("", exc_info=True)

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -153,9 +153,8 @@ class OWOutliers(widget.OWWidget):
                 else:
                     inliers_ind = np.where(y_pred == 1)[0]
                     outliers_ind = np.where(y_pred == -1)[0]
-                    inliers = Table(self.new_domain, self.new_data, inliers_ind)
-                    outliers = Table(self.new_domain,
-                                     self.new_data, outliers_ind)
+                    inliers = self.new_data[inliers_ind]
+                    outliers = self.new_data[outliers_ind]
                     self.in_out_info_label.setText(
                         "{} inliers, {} outliers".format(len(inliers),
                                                          len(outliers)))
@@ -189,7 +188,7 @@ class OWOutliers(widget.OWWidget):
             new_metas = list(self.data.domain.metas) + \
                         [ContinuousVariable(name="Mahalanobis")]
             self.new_domain = Domain(attrs, classes, new_metas)
-            self.new_data = Table(self.new_domain, self.data)
+            self.new_data = self.data.transform(self.new_domain)
             self.new_data.metas = np.hstack((self.data.metas, mahal))
         else:
             self.new_domain = self.data.domain

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -652,8 +652,9 @@ class OWRank(OWWidget):
             self.send("Reduced Data", None)
             self.out_domain_desc = None
         else:
-            data = Table(Domain(selected, self.data.domain.class_var,
-                                self.data.domain.metas), self.data)
+            reduced_domain = Domain(
+                selected, self.data.domain.class_var, self.data.domain.metas)
+            data = self.data.transform(reduced_domain)
             self.send("Reduced Data", data)
             self.out_domain_desc = report.describe_domain(data.domain)
 

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -597,7 +597,7 @@ class OWSelectAttributes(widget.OWWidget):
             metas = list(self.meta_attrs)
 
             domain = Orange.data.Domain(attributes, class_var, metas)
-            newdata = self.data.from_table(domain, self.data)
+            newdata = self.data.transform(domain)
             self.output_data = newdata
             self.send("Data", newdata)
             self.send("Features", widget.AttributeList(attributes))

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -382,21 +382,13 @@ class OWConfusionMatrix(widget.OWWidget):
                          for value in class_var.values]
                 metas = metas + tuple(pvars)
 
-            X = self.data.X
-            Y = self.data.Y
-            M = self.data.metas
-            row_ids = self.data.ids
-
-            M = numpy.hstack((M,) + tuple(extra))
-            domain = Orange.data.Domain(
-                self.data.domain.attributes,
-                self.data.domain.class_vars,
-                metas
-            )
-            data = Orange.data.Table.from_numpy(domain, X, Y, M)
-            data.ids = row_ids
+            domain = Orange.data.Domain(self.data.domain.attributes,
+                                        self.data.domain.class_vars,
+                                        metas)
+            data = self.data.transform(domain)
+            data.metas[:, len(self.data.domain.metas):] = \
+                numpy.hstack(tuple(extra))
             data.name = learner_name
-            data.attributes = self.data.attributes
 
             if selected:
                 annotated_data = create_annotated_table(data, selected)

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -475,7 +475,7 @@ class OWPredictions(OWWidget):
         metas = list(self.data.domain.metas) + newmetas
         domain = \
             Orange.data.Domain(attrs, self.data.domain.class_var, metas=metas)
-        predictions = self.data.from_table(domain, self.data)
+        predictions = self.data.transform(domain)
         if newcolumns:
             newcolumns = numpy.hstack(
                 [numpy.atleast_2d(cols) for cols in newcolumns])

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -630,7 +630,7 @@ class OWDistanceMap(widget.OWWidget):
                     [self.items.domain[i] for i in indices],
                     self.items.domain.class_vars,
                     self.items.domain.metas)
-                datasubset = Orange.data.Table.from_table(domain, self.items)
+                datasubset = self.items.transform(domain)
         elif isinstance(self.items, widget.AttributeList):
             subset = [self.items[i] for i in self._selection]
             featuresubset = widget.AttributeList(subset)

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1160,7 +1160,7 @@ class OWHierarchicalClustering(widget.OWWidget):
                     metas = metas + (clust_var,)
 
                 domain = Orange.data.Domain(attrs, class_, metas)
-                data = Orange.data.Table.from_table(domain, items)
+                data = items.transform(domain)
                 data.get_column_view(clust_var)[0][:] = c
             else:
                 data = items

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -313,7 +313,7 @@ class OWKMeans(widget.OWWidget):
         domain = self.data.domain
         new_domain = Domain(
             domain.attributes, [clust_var], domain.metas + domain.class_vars)
-        new_table = Table.from_table(new_domain, self.data)
+        new_table = self.data.transform(new_domain)
         new_table.get_column_view(clust_var)[0][:] = clust_ids.X.ravel()
 
         centroids = Table(Domain(km.pre_domain.attributes), km.centroids)

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -1016,7 +1016,7 @@ class OWMDS(OWWidget):
                 metas += embedding.domain.attributes
 
             domain = Orange.data.Domain(attrs, class_vars, metas)
-            output = Orange.data.Table.from_table(domain, self.data)
+            output = self.data.transform(domain)
 
             if self.output_embedding_role == OWMDS.AttrRole:
                 output.X[:] = embedding.X

--- a/Orange/widgets/utils/annotated_data.py
+++ b/Orange/widgets/utils/annotated_data.py
@@ -1,6 +1,6 @@
 import re
 import numpy as np
-from Orange.data import Table, Domain, DiscreteVariable
+from Orange.data import Domain, DiscreteVariable
 
 ANNOTATED_DATA_SIGNAL_NAME = "Data"
 ANNOTATED_DATA_FEATURE_NAME = "Selected"
@@ -41,8 +41,6 @@ def create_annotated_table(data, selected_indices):
     annotated = np.zeros((len(data), 1))
     if selected_indices is not None:
         annotated[selected_indices] = 1
-    table = Table(domain, data.X, data.Y,
-                  metas=np.hstack((data.metas, annotated)))
-    table.attributes = data.attributes
-    table.ids = data.ids
+    table = data.transform(domain)
+    table[:, name] = annotated
     return table

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -68,7 +68,7 @@ def vstack_by_subdomain(data, sub_domains):
     newtable = Table(domain)
 
     for sub_dom in sub_domains:
-        sub_data = data.from_table(sub_dom, data)
+        sub_data = data.transform(sub_dom)
         # TODO: improve O(N ** 2)
         newtable.extend(sub_data)
 
@@ -680,12 +680,11 @@ class OWHeatMap(widget.OWWidget):
         if data is not None and \
                 any(var.is_discrete for var in data.domain.attributes):
             ndisc = sum(var.is_discrete for var in data.domain.attributes)
-            data = data.from_table(
+            data = data.transform(
                 Domain([var for var in data.domain.attributes
                         if var.is_continuous],
                        data.domain.class_vars,
-                       data.domain.metas),
-                data)
+                       data.domain.metas))
             if not data.domain.attributes:
                 self.Error.no_continuous()
                 input_data = data = None
@@ -849,14 +848,12 @@ class OWHeatMap(widget.OWWidget):
         group_label = split_label
         if self.merge_kmeans:
             if self.kmeans_model is None:
-                effective_data = self.input_data.from_table(
+                effective_data = self.input_data.transform(
                     Orange.data.Domain(
                         [var for var in self.input_data.domain.attributes
                          if var.is_continuous],
                         self.input_data.domain.class_vars,
-                        self.input_data.domain.metas),
-                    self.input_data
-                )
+                        self.input_data.domain.metas))
                 nclust = min(self.merge_kmeans_k, len(effective_data) - 1)
                 self.kmeans_model = kmeans_compress(effective_data, k=nclust)
                 effective_data.domain = self.kmeans_model.pre_domain

--- a/Orange/widgets/visualize/owmap.py
+++ b/Orange/widgets/visualize/owmap.py
@@ -833,7 +833,7 @@ class OWMap(widget.OWWidget):
             if self.lat_attr and self.lon_attr and self.class_attr in domain:
                 domain = Domain([domain[self.lat_attr], domain[self.lon_attr]],
                                 [domain[self.class_attr]])  # I am retarded
-                train = Table.from_table(domain, self.data)
+                train = self.data.transform(domain)
                 try:
                     model = self.learner(train)
                 except Exception as e:

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -445,7 +445,7 @@ class OWMosaicDisplay(OWWidget):
             self.unprocessed_subset_data = data
             return
         try:
-            self.subset_data = data.from_table(self.data.domain, data)
+            self.subset_data = data.transform(self.data.domain)
         except:
             self.subset_data = None
             self.Warning.incompatible_subset(shown=data is not None)

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -854,7 +854,7 @@ class OWNomogram(OWWidget):
 
         self.domain = self.reconstruct_domain(self.classifier.original_domain,
                                               self.domain)
-        self.data = Table.from_table(self.domain, self.classifier.original_data)
+        self.data = self.classifier.original_data.transform(self.domain)
         attrs, ranges, start = self.domain.attributes, [], 0
         for attr in attrs:
             stop = start + len(attr.values) if attr.is_discrete else start + 1

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -146,8 +146,7 @@ class OWPythagorasTree(OWWidget):
             # this bit is important for the regression classifier
             if self.instances is not None and \
                     self.instances.domain != model.domain:
-                self.clf_dataset = Table.from_table(
-                    self.model.domain, self.instances)
+                self.clf_dataset = self.instances.transform(self.model.domain)
             else:
                 self.clf_dataset = self.instances
 

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -123,7 +123,7 @@ class OWPythagoreanForest(OWWidget):
             self.instances = model.instances
             # this bit is important for the regression classifier
             if self.instances is not None and self.instances.domain != model.domain:
-                self.clf_dataset = Table.from_table(self.model.domain, self.instances)
+                self.clf_dataset = self.instances.transform(self.model.domain)
             else:
                 self.clf_dataset = self.instances
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -514,11 +514,9 @@ class OWScatterPlot(OWWidget):
                                   for i in range(np.max(selection))]),
         )
         domain = Domain(data.domain.attributes, data.domain.class_vars, metas)
-        table = Table(
-            domain, data.X, data.Y,
-            metas=np.hstack((data.metas, selection.reshape(len(data), 1))))
-        table.attributes = data.attributes
-        table.ids = data.ids
+        table = data.transform(domain)
+        table.metas[:, len(data.domain.metas):] = \
+            selection.reshape(len(data), 1)
         return table
 
     def send_data(self):

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -378,8 +378,8 @@ class OWScatterPlot(OWWidget):
             new_attrs = [a for a in data.domain.attributes + data.domain.metas
                          if a.is_primitive()]
             new_metas = [m for m in data.domain.metas if not m.is_primitive()]
-            data = Table.from_table(Domain(new_attrs, data.domain.class_vars,
-                                           new_metas), data)
+            new_domain = Domain(new_attrs, data.domain.class_vars, new_metas)
+            data = data.transform(new_domain)
         return data
 
     def set_subset_data(self, subset_data):
@@ -433,7 +433,7 @@ class OWScatterPlot(OWWidget):
             if attr in attrs:
                 keys.append(i)
         new_domain = input_data.domain.select_columns(keys)
-        dmx = Table.from_table(new_domain, input_data)
+        dmx = input_data.transform(new_domain)
         dmx.X = dmx.X.toarray()
         # TODO: remove once we make sure Y is always dense.
         if sp.issparse(dmx.Y):

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -381,8 +381,7 @@ class OWSilhouettePlot(widget.OWWidget):
                     self.data.domain.attributes,
                     self.data.domain.class_vars,
                     self.data.domain.metas + (silhouette_var, ))
-                data = self.data.from_table(
-                    domain, self.data)
+                data = self.data.transform(domain)
             else:
                 domain = self.data.domain
                 data = self.data

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -274,7 +274,7 @@ class OWTreeGraph(OWTreeViewer2D):
             self.domain = model.domain
             self.dataset = model.instances
             if self.dataset is not None and self.dataset.domain != self.domain:
-                self.clf_dataset = Table.from_table(model.domain, self.dataset)
+                self.clf_dataset = self.dataset.transform(model.domain)
             else:
                 self.clf_dataset = self.dataset
             class_var = self.domain.class_var


### PR DESCRIPTION
##### Issue

Fixes #2169.

##### Description of changes

- `Table` has  a new method `transform`, which provides a nicer way to transform a table into a table with a different domain but with the same type, ids and attributes.
- In widgets, calls to `Table.from_table(domain, data)` are changed to `data.transform(domain)`.
- The alternative, `data.from_table(domain, data)` is kept in places where the call has an additional argument, row indices, which is not supported (and won't be supported, although it would be trivial) by `transform`.
- Calls `data.from_table(domain, data)` are simplified to `data.transform(domain)`.

The two widgets that are not fixed are Concatenate and Venn diagram. The latter is similar to Concatenate, so I leave it to @astaric.

Widget's outputs are not `Dynamic`. We have to decide whether to make them such by default.
 
**e19e3f5ab23113d6ac6232ad52ccfde624637527 must be excluded before merging**

##### Includes
- [X] Code changes
- [X] Tests
