### PR TITLE
Sparse concatenate

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -18,7 +18,7 @@ from Orange.data import (
     Domain, Variable, Storage, StringVariable, Unknown, Value, Instance,
     ContinuousVariable, DiscreteVariable, MISSING_VALUES
 )
-from Orange.data.util import SharedComputeValue
+from Orange.data.util import SharedComputeValue, vstack, hstack
 from Orange.statistics.util import bincount, countnans, contingency, stats as fast_stats
 from Orange.util import flatten
 
@@ -898,30 +898,25 @@ class Table(MutableSequence, Storage):
         :param instances: additional instances
         :type instances: Orange.data.Table or a sequence of instances
         """
-        old_length = len(self)
-        self._resize_all(old_length + len(instances))
-        try:
-            # shortcut
-            if isinstance(instances, Table) and instances.domain == self.domain:
-                self.X[old_length:] = instances.X
-                self._Y[old_length:] = instances._Y
-                self.metas[old_length:] = instances.metas
-                if self.W.shape[-1]:
-                    if instances.W.shape[-1]:
-                        self.W[old_length:] = instances.W
-                    else:
-                        self.W[old_length:] = 1
-                self.ids[old_length:] = instances.ids
-            else:
+        if isinstance(instances, Table) and instances.domain == self.domain:
+            self.X = vstack((self.X, instances.X))
+            self._Y = vstack((self._Y, instances._Y))
+            self.metas = vstack((self.metas, instances.metas))
+            self.W = vstack((self.W, instances.W))
+            self.ids = hstack((self.ids, instances.ids))
+        else:
+            try:
+                old_length = len(self)
+                self._resize_all(old_length + len(instances))
                 for i, example in enumerate(instances):
                     self[old_length + i] = example
                     try:
                         self.ids[old_length + i] = example.id
                     except AttributeError:
                         self.ids[old_length + i] = self.new_id()
-        except Exception:
-            self._resize_all(old_length)
-            raise
+            except Exception:
+                self._resize_all(old_length)
+                raise
 
     @staticmethod
     def concatenate(tables, axis=1):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -795,19 +795,13 @@ class Table(MutableSequence, Storage):
             if value is None:
                 value = Unknown
 
-            if not isinstance(value, Real) and \
+            if not isinstance(value, (Real, np.ndarray)) and \
                     (len(attr_cols) or len(class_cols)):
                 raise TypeError(
                     "Ordinary attributes can only have primitive values")
             if len(attr_cols):
-                if len(attr_cols) == 1:
-                    # scipy.sparse matrices only allow primitive indices.
-                    attr_cols = attr_cols[0]
                 self.X[row_idx, attr_cols] = value
             if len(class_cols):
-                if len(class_cols) == 1:
-                    # scipy.sparse matrices only allow primitive indices.
-                    class_cols = class_cols[0]
                 self._Y[row_idx, class_cols] = value
             if len(meta_cols):
                 self.metas[row_idx, meta_cols] = value

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -3,6 +3,7 @@ Data-manipulation utilities.
 """
 import numpy as np
 import bottleneck as bn
+from scipy import sparse as sp
 
 
 def one_hot(values, dtype=float):
@@ -62,3 +63,29 @@ class SharedComputeValue:
         """Given precomputed shared data, perform variable-specific
         part of computation and return new variable values."""
         raise NotImplementedError
+
+
+def vstack(arrays):
+    """vstack that supports sparse and dense arrays
+
+    If all arrays are dense, result is dense. Otherwise,
+    result is a sparse (csr) array.
+    """
+    if any(sp.issparse(arr) for arr in arrays):
+        arrays = [sp.csr_matrix(arr) for arr in arrays]
+        return sp.vstack(arrays)
+    else:
+        return np.vstack(arrays)
+
+
+def hstack(arrays):
+    """hstack that supports sparse and dense arrays
+
+    If all arrays are dense, result is dense. Otherwise,
+    result is a sparse (csc) array.
+    """
+    if any(sp.issparse(arr) for arr in arrays):
+        arrays = [sp.csc_matrix(arr) for arr in arrays]
+        return sp.hstack(arrays)
+    else:
+        return np.hstack(arrays)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -618,10 +618,6 @@ class TableTestCase(unittest.TestCase):
         for i in range(5):
             self.assertEqual(d[i], d[-5 + i])
 
-        x = d[:5]
-        with self.assertRaises(ValueError):
-            d.extend(x)
-
         y = d[:2, 1]
         x.ensure_copy()
         x.extend(y)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -689,7 +689,15 @@ class TableTestCase(unittest.TestCase):
                                        [1, np.nan],
                                        [2, np.nan]])
 
-
+    def test_sparse_concatenate_rows(self):
+        iris = Table("iris")
+        iris.X = sp.csc_matrix(iris.X)
+        new = Table.concatenate([iris, iris], axis=0)
+        self.assertEqual(len(new), 300)
+        self.assertTrue(sp.issparse(new.X), "Concatenated X is not sparse.")
+        self.assertFalse(sp.issparse(new.Y), "Concatenated Y is not dense.")
+        self.assertFalse(sp.issparse(new.metas), "Concatenated metas is not dense.")
+        self.assertEqual(len(new.ids), 300)
 
     def test_convert_through_append(self):
         d = data.Table("iris")

--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -3,9 +3,11 @@ import unittest
 import warnings
 
 import numpy as np
+import scipy.sparse as sp
 
 from Orange.util import export_globals, flatten, deprecated, try_, deepgetattr, \
     OrangeDeprecationWarning
+from Orange.data.util import vstack, hstack
 
 SOMETHING = 0xf00babe
 
@@ -58,6 +60,46 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(deepgetattr(a, 'l.__len__.__call__'), a.l.__len__.__call__)
         self.assertTrue(deepgetattr(a, 'l.__nx__.__x__', 42), 42)
         self.assertRaises(AttributeError, lambda: deepgetattr(a, 'l.__nx__.__x__'))
+
+    def test_vstack(self):
+        numpy = np.array([[1., 2.], [3., 4.]])
+        csr = sp.csr_matrix(numpy)
+        csc = sp.csc_matrix(numpy)
+
+        self.assertCorrectArrayType(
+            vstack([numpy, numpy]),
+            shape=(4, 2), sparsity="dense")
+        self.assertCorrectArrayType(
+            vstack([csr, numpy]),
+            shape=(4, 2), sparsity="sparse")
+        self.assertCorrectArrayType(
+            vstack([numpy, csc]),
+            shape=(4, 2), sparsity="sparse")
+        self.assertCorrectArrayType(
+            vstack([csc, csr]),
+            shape=(4, 2), sparsity="sparse")
+
+    def test_hstack(self):
+        numpy = np.array([[1., 2.], [3., 4.]])
+        csr = sp.csr_matrix(numpy)
+        csc = sp.csc_matrix(numpy)
+
+        self.assertCorrectArrayType(
+            hstack([numpy, numpy]),
+            shape=(2, 4), sparsity="dense")
+        self.assertCorrectArrayType(
+            hstack([csr, numpy]),
+            shape=(2, 4), sparsity="sparse")
+        self.assertCorrectArrayType(
+            hstack([numpy, csc]),
+            shape=(2, 4), sparsity="sparse")
+        self.assertCorrectArrayType(
+            hstack([csc, csr]),
+            shape=(2, 4), sparsity="sparse")
+
+    def assertCorrectArrayType(self, array, shape, sparsity):
+        self.assertEqual(array.shape, shape)
+        self.assertEqual(["dense", "sparse"][sp.issparse(array)], sparsity)
 
     @unittest.skipUnless(os.environ.get('ORANGE_DEPRECATIONS_ERROR'),
                          'ORANGE_DEPRECATIONS_ERROR not set')

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -157,7 +157,7 @@ class OWConcatenate(widget.OWWidget):
         tables = [table.transform(domain) for table in tables]
 
         if tables:
-            data = concat(tables)
+            data = type(tables[0]).concatenate(tables, axis=0)
             if self.append_source_column:
                 source_var = Orange.data.DiscreteVariable(
                     self.source_attr_name,
@@ -196,19 +196,6 @@ class OWConcatenate(widget.OWWidget):
                 self.source_attr_name,
                 self.id_roles[self.source_column_role].lower())
         self.report_items(items)
-
-
-def concat(tables):
-    Xs = [table.X for table in tables]
-    Ys = [numpy.c_[table.Y] for table in tables]
-    metas = [table.metas for table in tables]
-
-    domain = tables[0].domain
-
-    X = numpy.vstack(Xs)
-    Y = numpy.vstack(Ys)
-    metas = numpy.vstack(metas)
-    return Orange.data.Table.from_numpy(domain, X, Y, metas)
 
 
 def unique(seq):

--- a/Orange/widgets/utils/annotated_data.py
+++ b/Orange/widgets/utils/annotated_data.py
@@ -6,6 +6,30 @@ ANNOTATED_DATA_SIGNAL_NAME = "Data"
 ANNOTATED_DATA_FEATURE_NAME = "Selected"
 
 
+def add_columns(domain, attributes=(), class_vars=(), metas=()):
+    """Construct a new domain with new columns added to the specified place
+
+    Parameters
+    ----------
+    domain : Domain
+        source domain
+    attributes
+        list of variables to append to attributes from source domain
+    class_vars
+        list of variables to append to class_vars from source domain
+    metas
+        list of variables to append to metas from source domain
+
+    Returns
+    -------
+    Domain
+    """
+    attributes = domain.attributes + tuple(attributes)
+    class_vars = domain.class_vars + tuple(class_vars)
+    metas = domain.metas + tuple(metas)
+    return Domain(attributes, class_vars, metas)
+
+
 def get_next_name(names, name):
     """
     Returns next 'possible' attribute name. The name should not be duplicated
@@ -36,8 +60,7 @@ def create_annotated_table(data, selected_indices):
         return None
     names = [var.name for var in data.domain.variables + data.domain.metas]
     name = get_next_name(names, ANNOTATED_DATA_FEATURE_NAME)
-    metas = data.domain.metas + (DiscreteVariable(name, ("No", "Yes")),)
-    domain = Domain(data.domain.attributes, data.domain.class_vars, metas)
+    domain = add_columns(data.domain, metas=[DiscreteVariable(name, ("No", "Yes"))])
     annotated = np.zeros((len(data), 1))
     if selected_indices is not None:
         annotated[selected_indices] = 1


### PR DESCRIPTION
##### Issue
Add support for sparse tables to Table.concatenate. Fixes #2154.

##### Description of changes
Modify Table.extend to use vstack to concatenate compatible table, use scipy.sparse.vstack if some of the arrays are sparse.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
