### PR TITLE
codeclimate: relax radon check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,6 +8,8 @@ engines:
    enabled: false
  radon:
    enabled: true
+   config:
+     threshold: "C"
  eslint:
    enabled: false
  shellcheck:


### PR DESCRIPTION
##### Issue
codeclimate is stricter when checking radon complexity that our existing script


##### Description of changes
Allow both A and B methods in radon check.

