### PR TITLE
[ENH, PERF] Auto n_jobs=-1 in widgets

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -349,6 +349,11 @@ class SklLearner(_ReprableWithParams, Learner, metaclass=WrapperMeta):
 
     def fit(self, X, Y, W=None):
         clf = self.__wraps__(**self.params)
+
+        # If problem "small enough", running it on a single core is probably faster
+        if hasattr(clf, 'n_jobs') and np.multiply(*X.shape) < 20000:
+            clf.set_params(n_jobs=1)
+
         Y = Y.reshape(-1)
         if W is None or not self.supports_weights:
             return self.__returns__(clf.fit(X, Y))

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -14,6 +14,7 @@ import pickle
 import shlex
 import shutil
 from unittest.mock import patch
+import multiprocessing as mp
 
 import pkg_resources
 
@@ -42,6 +43,13 @@ log = logging.getLogger(__name__)
 # Allow termination with CTRL + C
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+
+# In widgets, we default algorithms to n_jobs=-1 for performance.
+# Avoids lock-ups on incompatible libraries.
+# http://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux
+if not sys.platform.startswith('win'):
+    mp.set_start_method('forkserver')
 
 
 def fix_osx_10_9_private_font():

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -28,8 +28,9 @@ class _FeatureScorerMixin(LearnerScorer):
 class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):
     __wraps__ = skl_linear_model.LinearRegression
 
-    def __init__(self, preprocessors=None):
+    def __init__(self, preprocessors=None, n_jobs=1):
         super().__init__(preprocessors=preprocessors)
+        self.params = vars()
 
     def fit(self, X, Y, W):
         model = super().fit(X, Y, W)

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -115,7 +115,7 @@ class OWLinearRegression(OWBaseLearner):
         preprocessors = self.preprocessors
         args = {"preprocessors": preprocessors}
         if self.reg_type == OWLinearRegression.OLS:
-            learner = LinearRegressionLearner(**args)
+            learner = LinearRegressionLearner(n_jobs=-1, **args)
         elif self.reg_type == OWLinearRegression.Ridge:
             learner = RidgeRegressionLearner(alpha=alpha, **args)
         elif self.reg_type == OWLinearRegression.Lasso:

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -74,7 +74,8 @@ class OWLogisticRegression(OWBaseLearner):
             C=self.strength_C,
             fit_intercept=self.fit_intercept,
             intercept_scaling=self.intercept_scaling,
-            preprocessors=self.preprocessors
+            preprocessors=self.preprocessors,
+            n_jobs=-1,
         )
 
     def update_model(self):

--- a/Orange/widgets/model/owrandomforest.py
+++ b/Orange/widgets/model/owrandomforest.py
@@ -63,7 +63,8 @@ class OWRandomForest(OWBaseLearner):
             checkCallback=self.settings_changed, alignment=Qt.AlignRight)
 
     def create_learner(self):
-        common_args = {"n_estimators": self.n_estimators}
+        common_args = {"n_estimators": self.n_estimators,
+                       "n_jobs": -1}
         if self.use_max_features:
             common_args["max_features"] = self.max_features
         if self.use_random_state:

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 
 from xml.sax.saxutils import escape
 from itertools import chain
@@ -22,7 +21,7 @@ import pyqtgraph as pg
 import pyqtgraph.graphicsItems.ScatterPlotItem
 
 import Orange.data
-import Orange.projection
+from Orange.projection import MDS
 from Orange.projection.manifold import torgerson
 import Orange.distance
 from Orange.data.domain import filter_visible
@@ -513,7 +512,7 @@ class OWMDS(OWWidget):
             if self.matrix.axis == 0 and self.data is self.matrix_data:
                 self.data = None
         elif self.data.domain.attributes:
-            preprocessed_data = Orange.projection.MDS().preprocess(self.data)
+            preprocessed_data = MDS(n_jobs=-1).preprocess(self.data)
             self._effective_matrix = Orange.distance.Euclidean(preprocessed_data)
         else:
             self.Error.no_attributes()
@@ -565,9 +564,9 @@ class OWMDS(OWWidget):
 
             while not done:
                 step_iter = min(max_iter - iterations_done, step)
-                mds = Orange.projection.MDS(
+                mds = MDS(
                     dissimilarity="precomputed", n_components=2,
-                    n_init=1, max_iter=step_iter,
+                    n_init=1, max_iter=step_iter, n_jobs=-1,
                     init_type=init_type, init_data=init)
 
                 mdsfit = mds(X)


### PR DESCRIPTION
##### Issue
Slow computation on larger datasets, e.g. MDS.


##### Description of changes
Have algos in widgets use all CPU cores by passing `n_jobs=-1`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
