### PR TITLE
Make all signals dynamic by default

### DIFF
--- a/Orange/canvas/registry/base.py
+++ b/Orange/canvas/registry/base.py
@@ -15,7 +15,7 @@ from . import description
 log = logging.getLogger(__name__)
 
 # Registry hex version
-VERSION_HEX = 0x000103
+VERSION_HEX = 0x000104
 
 
 class WidgetRegistry(object):

--- a/Orange/canvas/registry/description.py
+++ b/Orange/canvas/registry/description.py
@@ -9,6 +9,7 @@ import copy
 import warnings
 
 # Exceptions
+from Orange.util import OrangeDeprecationWarning
 
 
 class DescriptionError(Exception):
@@ -44,9 +45,11 @@ NonDefault = 16
 # Explicit - only connected if specifically requested or the only possibility
 Explicit = 32
 
-# Dynamic type output signal
+# (Deprecated) Dynamic type output signal
 Dynamic = 64
 
+# This output can only be connected to inputs of the same class or superclass
+Strict = 128
 
 # Input/output signal (channel) description
 
@@ -156,10 +159,13 @@ class OutputSignal(object):
         if not (flags & Default or flags & NonDefault):
             flags += NonDefault
 
+        if flags & Dynamic:
+            warnings.warn("all outputs are dynamic; flag Dynamic is deprecated",
+                          OrangeDeprecationWarning)
         self.single = flags & Single
         self.default = flags & Default
         self.explicit = flags & Explicit
-        self.dynamic = flags & Dynamic
+        self.dynamic = not (flags & Strict)
         self.flags = flags
 
         if self.dynamic and not self.single:

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1832,7 +1832,7 @@ class CreateTableWithDomainAndTable(TableTests):
         new_domain = data.domain.Domain([], iris.domain.class_vars,
                                         iris.domain.attributes, source=iris.domain)
         new_iris = data.Table.from_table(new_domain, iris)
-        
+
         self.assertTrue(sp.issparse(new_iris.X))
         self.assertTrue(sp.issparse(new_iris.metas))
         self.assertEqual(new_iris.X.shape, (len(iris), 0))

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -369,8 +369,8 @@ class OWPythonScript(widget.OWWidget):
     outputs = [("out_data", Orange.data.Table, ),
 #                ("out_distance", Orange.misc.SymMatrix, ),
                ("out_learner", Learner, ),
-               ("out_classifier", Model, widget.Dynamic),
-               ("out_object", object, widget.Dynamic)]
+               ("out_classifier", Model),
+               ("out_object", object)]
 
     libraryListSource = \
         Setting([Script("Hello world", "print('Hello world')\n")])

--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -21,7 +21,7 @@ class OWLoadModel(widget.OWWidget):
     replaces = ["Orange.widgets.classify.owloadclassifier.OWLoadClassifier"]
     icon = "icons/LoadModel.svg"
 
-    outputs = [("Model", Model, widget.Dynamic)]
+    outputs = [("Model", Model)]
 
     #: List of recent filenames.
     history = Setting([])

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -814,12 +814,17 @@ Multiple = widget_description.Multiple
 #: Only connected if specifically requested (in a dedicated "Links" dialog)
 #: or it is the only possible connection.
 Explicit = widget_description.Explicit
-#: Dynamic output type.
+#: Dynamic output type (obsolete and ignored).
 #: Specifies that the instances on the output will in general be
 #: subtypes of the declared type and that the output can be connected
 #: to any input signal which can accept a subtype of the declared output
 #: type.
 Dynamic = widget_description.Dynamic
+#: Only applies to output. Specifies that this output can be connected only
+#: to inputs that expect this type of its supertypes. Otherwise, the output
+#: can be connected to any input which can accept a subtype of the
+#: declared output type.
+Strict = widget_description.Strict
 
 InputSignal = widget_description.InputSignal
 OutputSignal = widget_description.OutputSignal

--- a/doc/development/source/widget.rst
+++ b/doc/development/source/widget.rst
@@ -106,12 +106,17 @@ Input/Output flags:
    Multiple signal (more then one input on the channel). Input with this
    flag receive a second parameter `id`.
 
-.. attribute:: Dynamic
+.. attribute:: Strict
 
-   Only applies to output. Specifies that the instances on the output
-   will in general be subtypes of the declared type and that the output
-   can be connected to any input which can accept a subtype of the
-   declared output type.
+   Only applies to output. Specifies that this output can be connected only
+   to inputs that expect this type or its supertypes. Without explicitly
+   setting this flag, the output can also be connected to any input which
+   accepts a subtype of the declared output type.
+
+.. attribute:: Dynamic (obsolete and ignored)
+
+   Opposite of `Strict`. All output signals are now dynamic by default.
+   Non-dynamic signals can be specified by using the flag `Strict`.
 
 .. attribute:: Explicit
 


### PR DESCRIPTION
##### Issue

Following #2285, we would need to make almost all outputs of type `Table` dynamic to allow passing instances of `Corpus` (and potential future other subclasses of `Table`). There seem to be no reason not to make all signals dynamic by default.

##### Description of changes

Flag `Dynamic` is on by default and declared as deprecated. A new flag `Strict` can be used to prevent dynamic signals.

@ales-erjavec, have I overlooked something important?

##### Includes
- [X] Code changes
