### PR TITLE
[RFC] Signals as objects

### DIFF
--- a/Orange/canvas/document/editlinksdialog.py
+++ b/Orange/canvas/document/editlinksdialog.py
@@ -26,7 +26,7 @@ from AnyQt.QtCore import (
 from AnyQt.QtCore import pyqtSignal as Signal
 
 from ..scheme import SchemeNode, SchemeLink, compatible_channels
-from ..registry import InputSignal, OutputSignal
+from Orange.widgets.utils.signals import InputSignal, OutputSignal
 
 from ..resources import icon_loader
 

--- a/Orange/canvas/registry/__init__.py
+++ b/Orange/canvas/registry/__init__.py
@@ -43,11 +43,7 @@ NAMED_COLORS = \
 DEFAULT_COLOR = "light-yellow"
 
 
-from .description import (
-    WidgetDescription, CategoryDescription,
-    InputSignal, OutputSignal
-)
-
+from .description import WidgetDescription, CategoryDescription
 from .base import WidgetRegistry, VERSION_HEX
 from . import discovery
 from .discovery import WidgetDiscovery

--- a/Orange/canvas/registry/base.py
+++ b/Orange/canvas/registry/base.py
@@ -15,7 +15,7 @@ from . import description
 log = logging.getLogger(__name__)
 
 # Registry hex version
-VERSION_HEX = 0x000103
+VERSION_HEX = 0x000104
 
 
 class WidgetRegistry(object):

--- a/Orange/canvas/scheme/readwrite.py
+++ b/Orange/canvas/scheme/readwrite.py
@@ -25,7 +25,8 @@ from .annotations import SchemeTextAnnotation, SchemeArrowAnnotation
 from .errors import IncompatibleChannelTypeError
 
 from ..registry import global_registry
-from ..registry import WidgetDescription, InputSignal, OutputSignal
+from ..registry import WidgetDescription
+from Orange.widgets.utils.signals import InputSignal, OutputSignal
 
 log = logging.getLogger(__name__)
 

--- a/Orange/canvas/scheme/scheme.py
+++ b/Orange/canvas/scheme/scheme.py
@@ -28,8 +28,6 @@ from .errors import (
 
 from . import readwrite
 
-from ..registry import WidgetDescription, InputSignal, OutputSignal
-
 log = logging.getLogger(__name__)
 
 

--- a/Orange/canvas/scheme/tests/test_links.py
+++ b/Orange/canvas/scheme/tests/test_links.py
@@ -4,7 +4,6 @@ Tests for SchemeLink
 
 from ...gui import test
 from ...registry.tests import small_testing_registry
-from ...registry import InputSignal, OutputSignal
 
 from .. import SchemeNode, SchemeLink, IncompatibleChannelTypeError
 

--- a/Orange/canvas/scheme/tests/test_nodes.py
+++ b/Orange/canvas/scheme/tests/test_nodes.py
@@ -3,7 +3,7 @@
 
 from ...gui import test
 from ...registry.tests import small_testing_registry
-from ...registry import InputSignal, OutputSignal
+from Orange.widgets.utils.signals import InputSignal, OutputSignal
 
 from .. import SchemeNode
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1832,7 +1832,7 @@ class CreateTableWithDomainAndTable(TableTests):
         new_domain = data.domain.Domain([], iris.domain.class_vars,
                                         iris.domain.attributes, source=iris.domain)
         new_iris = data.Table.from_table(new_domain, iris)
-        
+
         self.assertTrue(sp.issparse(new_iris.X))
         self.assertTrue(sp.issparse(new_iris.metas))
         self.assertEqual(new_iris.X.shape, (len(iris), 0))

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -11,7 +11,7 @@ import Orange.preprocess.discretize as disc
 
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils import itemmodels, vartype
-from Orange.widgets.widget import OutputSignal, InputSignal
+from Orange.widgets.widget import Output, Input
 
 __all__ = ["OWDiscretize"]
 
@@ -127,10 +127,13 @@ class OWDiscretize(widget.OWWidget):
     name = "Discretize"
     description = "Discretize the numeric data features."
     icon = "icons/Discretize.svg"
-    inputs = [InputSignal("Data", Orange.data.Table, "set_data",
-                          doc="Input data table")]
-    outputs = [OutputSignal("Data", Orange.data.Table,
-                            doc="Table with discretized features")]
+
+    class Inputs:
+        data = Input("Data", Orange.data.Table)
+
+    class Outputs:
+        data = Output("Data", Orange.data.Table,
+                      doc="Table with discretized features")
 
     settingsHandler = settings.DomainContextHandler()
     saved_var_states = settings.ContextSetting({})
@@ -237,7 +240,7 @@ class OWDiscretize(widget.OWWidget):
         box.layout().insertWidget(0, self.report_button)
         self._update_spin_positions()
 
-
+    @Inputs.data
     def set_data(self, data):
         self.closeContext()
         self.data = data
@@ -468,7 +471,7 @@ class OWDiscretize(widget.OWWidget):
         if self.data is not None and len(self.data):
             domain = self.discretized_domain()
             output = self.data.from_table(domain, self.data)
-        self.send("Data", output)
+        self.Outputs.data.send(output)
 
     def storeSpecificSettings(self):
         super().storeSpecificSettings()

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -369,8 +369,8 @@ class OWPythonScript(widget.OWWidget):
     outputs = [("out_data", Orange.data.Table, ),
 #                ("out_distance", Orange.misc.SymMatrix, ),
                ("out_learner", Learner, ),
-               ("out_classifier", Model, widget.Dynamic),
-               ("out_object", object, widget.Dynamic)]
+               ("out_classifier", Model),
+               ("out_object", object)]
 
     libraryListSource = \
         Setting([Script("Hello world", "print('Hello world')\n")])

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -23,10 +23,10 @@ from Orange.preprocess.preprocess import Preprocess
 from Orange.preprocess import RemoveNaNClasses
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.itemmodels import DomainModel
-from Orange.widgets.widget import OWWidget, Msg
+from Orange.widgets.widget import OWWidget, Msg, Input, Output
 
-Input = namedtuple(
-    "Input",
+InputLearner = namedtuple(
+    "InputLearner",
     ["learner",  # :: Orange.base.Learner
      "results",  # :: Option[Try[Orange.evaluation.Results]]
      "stats"]    # :: Option[Sequence[Try[float]]]
@@ -130,13 +130,16 @@ class OWTestLearners(OWWidget):
     icon = "icons/TestLearners1.svg"
     priority = 100
 
-    inputs = [("Learner", Learner, "set_learner", widget.Multiple),
-              ("Data", Table, "set_train_data", widget.Default),
-              ("Test Data", Table, "set_test_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    class Inputs:
+        train_data = Input("Data", Table, flags=widget.Default)
+        test_data = Input("Test Data", Table)
+        learner = Input("Learner", Learner, flags=widget.Multiple)
+        preprocessor = Input("Preprocessor", Preprocess)
 
-    outputs = [("Predictions", Table),
-               ("Evaluation Results", Results)]
+    class Outputs:
+        predictions = Output("Predictions", Table)
+        evalutions_results = Output("Evaluation Results", Results)
+
 
     settings_version = 3
     settingsHandler = settings.PerfectDomainContextHandler(metas_in_res=True)
@@ -293,6 +296,7 @@ class OWTestLearners(OWWidget):
         if self.resampling == OWTestLearners.FeatureFold and not enabled:
             self.resampling = OWTestLearners.KFold
 
+    @Inputs.learner
     def set_learner(self, learner, key):
         """
         Set the input `learner` for `key`.
@@ -301,9 +305,10 @@ class OWTestLearners(OWWidget):
             # Removed
             del self.learners[key]
         else:
-            self.learners[key] = Input(learner, None, None)
+            self.learners[key] = InputLearner(learner, None, None)
             self._invalidate([key])
 
+    @Inputs.train_data
     def set_train_data(self, data):
         """
         Set the input training dataset.
@@ -351,6 +356,7 @@ class OWTestLearners(OWWidget):
                 self.resampling = OWTestLearners.FeatureFold
         self._invalidate()
 
+    @Inputs.test_data
     def set_test_data(self, data):
         """
         Set the input separate testing dataset.
@@ -394,6 +400,7 @@ class OWTestLearners(OWWidget):
                 (False, True): " test "}[(self.train_data_missing_vals,
                                           self.test_data_missing_vals)]
 
+    @Inputs.preprocessor
     def set_preprocessor(self, preproc):
         """
         Set the input preprocessor to apply on the training data.
@@ -716,8 +723,8 @@ class OWTestLearners(OWWidget):
         else:
             combined = None
             predictions = None
-        self.send("Evaluation Results", combined)
-        self.send("Predictions", predictions)
+        self.Outputs.evalutions_results.send(combined)
+        self.Outputs.predictions.send(predictions)
 
     def send_report(self):
         """Report on the testing schema and results"""

--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -21,7 +21,7 @@ class OWLoadModel(widget.OWWidget):
     replaces = ["Orange.widgets.classify.owloadclassifier.OWLoadClassifier"]
     icon = "icons/LoadModel.svg"
 
-    outputs = [("Model", Model, widget.Dynamic)]
+    outputs = [("Model", Model)]
 
     #: List of recent filenames.
     history = Setting([])

--- a/Orange/widgets/utils/signals.py
+++ b/Orange/widgets/utils/signals.py
@@ -1,0 +1,228 @@
+import copy
+import warnings
+
+from Orange.util import OrangeDeprecationWarning
+
+
+class SignalSpecificationError(Exception):
+    pass
+
+
+# Input/output signal (channel) description
+
+#: Input/Output flags.
+#: -------------------
+#:
+#: The input/output is the default for its type.
+#: When there are multiple IO signals with the same type the
+#: one with the default flag takes precedence when adding a new
+#: link in the canvas.
+Default = 8
+NonDefault = 16
+#: Single input signal (default)
+Single = 2
+#: Multiple outputs can be linked to this signal.
+#: Signal handlers with this flag have (object, id: object) -> None signature.
+Multiple = 4
+#: Applies to user interaction only.
+#: Only connected if specifically requested (in a dedicated "Links" dialog)
+#: or it is the only possible connection.
+Explicit = 32
+#: Dynamic output type (obsolete and ignored).
+#: Specifies that the instances on the output will in general be
+#: subtypes of the declared type and that the output can be connected
+#: to any input signal which can accept a subtype of the declared output
+#: type.
+Dynamic = 64
+#: Only applies to output. Specifies that this output can be connected only
+#: to inputs that expect this type of its supertypes. Otherwise, the output
+#: can be connected to any input which can accept a subtype of the
+#: declared output type.
+Strict = 128
+
+
+class _Signal:
+    """
+    Description of a signal.
+
+    Parameters
+    ----------
+    name : str
+        Name of the channel.
+    type : str or `type`
+        Type of the accepted signals.
+    flags : int, optional
+        Channel flags.
+    id : str
+        A unique id of the input signal.
+    doc : str, optional
+        A docstring documenting the channel.
+    replaces : List[str]
+        A list of names this input replaces.
+    """
+
+    def __init__(self, name, type, flags=Single + NonDefault,
+                 id=None, doc=None, replaces=[]):
+        self.name = name
+        self.type = type
+        self.id = id
+        self.doc = doc
+        self.replaces = list(replaces)
+        self.widget = None
+
+        if not (flags & Single or flags & Multiple):
+            flags += Single
+        if not (flags & Default or flags & NonDefault):
+            flags += NonDefault
+
+        self.single = flags & Single
+        self.default = flags & Default
+        self.explicit = flags & Explicit
+        self.flags = flags
+
+
+class Input(_Signal):
+    """
+    Input has additional argument `handler` for providing a handler in
+    old-style signal declarations.
+    """
+    def __init__(self, name, type, handler="", flags=Single + NonDefault,
+                 id=None, doc=None, replaces=[]):
+        super().__init__(name, type, flags, id, doc, replaces)
+        self.handler = handler
+
+    def __str__(self):
+        return "{}(name='{}', type={}, handler={})".format(
+            type(self).__name__, self.name, self.type, self.handler)
+
+    __repr__ = __str__
+
+    def __call__(self, method):
+        """
+        The call implements decorator-like behaviour. The decorator stores
+        the decorated method's name in the signal's `handler` attribute.
+        The method is returned unchanged.
+        """
+        if self.handler:
+            raise ValueError("Input {} is already bound to method {}".
+                             format(self.name, self.handler))
+        self.handler = method.__name__
+        return method
+
+
+class Output(_Signal):
+    def __init__(self, name, type, flags=Single + NonDefault,
+                 id=None, doc=None, replaces=[]):
+        super().__init__(name, type, flags, id, doc, replaces)
+        self.widget = None
+        self.dynamic = not (flags & Strict)
+
+        if self.dynamic and not self.single:
+            raise SignalSpecificationError(
+                "Output signal can not be 'Multiple' and 'Dynamic'.")
+        if flags & Dynamic:
+            warnings.warn("all outputs are dynamic; flag Dynamic is deprecated",
+                          OrangeDeprecationWarning)
+
+    def __str__(self):
+        is_bound = "bound" if self.widget else "unbound"
+        return "{} {}(name='{}', type={})".format(
+            is_bound, type(self).__name__, self.name, self.type)
+
+    __repr__ = __str__
+
+    def bound_signal(self, widget):
+        """Return a copy of the signal bound to a widget."""
+        new_signal = copy.copy(self)
+        new_signal.widget = widget
+        return new_signal
+
+    def send(self, value, id=None):
+        assert self.widget is not None
+        signal_manager = self.widget.signalManager
+        if signal_manager is not None:
+            signal_manager.send(self.widget, self.name, value, id)
+
+
+class WidgetSignalsMixin:
+    class Inputs:
+        pass
+
+    class Outputs:
+        pass
+
+    def __init__(self):
+        self._bind_outputs()
+
+    def _bind_outputs(self):
+        bound_cls = self.Outputs()
+        for name, signal in self.Outputs.__dict__.items():
+            if isinstance(signal, Output):
+                bound_cls.__dict__[name] = signal.bound_signal(self)
+        setattr(self, "Outputs", bound_cls)
+
+    def send(self, signal_name, value, id=None):
+        """
+        Send a `value` on the `signalName` widget output.
+
+        An output with `signalName` must be defined in the class ``outputs``
+        list.
+        """
+        signal = getattr(self.Outputs, signal_name, None)
+        if signal is None:
+            raise ValueError('{} is not a valid output signal for widget {}'.
+                             format(signal_name, self.name))
+        signal.send(value, id)
+
+    def handleNewSignals(self):
+        """
+        Invoked by the workflow signal propagation manager after all
+        signals handlers have been called.
+
+        Reimplement this method in order to coalesce updates from
+        multiple updated inputs.
+        """
+        pass
+
+    # Methods used by the meta class
+    @classmethod
+    def patch_signals(cls):
+        cls._migrate_signals(Input)
+        cls._check_input_handlers()
+        cls._migrate_signals(Output)
+
+    @classmethod
+    def _migrate_signals(cls, signal_type):
+        """
+        Copy signals from `inputs`/`outputs` attribute to group.
+        Then, remove the attribute to unshadow the property.
+
+        Args:
+            signal_type (type): `Input` or `Output`
+        """
+        attr_name = signal_type.__name__ + 's'
+        signals = cls.__dict__.get(attr_name.lower())
+        if isinstance(signals, (list, tuple)):
+            group = type(attr_name, (), {})
+            setattr(cls, attr_name, group)
+            for signal in signals:
+                if isinstance(signal, tuple):
+                    signal = signal_type(*signal)
+                setattr(group, signal.name, signal)
+            #delattr(cls, attr_name.lower())
+
+    @classmethod
+    def _check_input_handlers(cls):
+        unbound = [signal.name for signal in cls.inputs
+                   if not signal.handler]
+        if unbound:
+            raise ValueError("unbound signal(s) in {}: {}".
+                             format(cls.__name__, ", ".join(unbound)))
+
+
+class AttributeList(list):
+    """Signal type for lists of attributes (variables)"""
+
+# Temporary compatibility fix
+InputSignal = Input
+OutputSignal = Output

--- a/doc/development/source/widget.rst
+++ b/doc/development/source/widget.rst
@@ -106,12 +106,17 @@ Input/Output flags:
    Multiple signal (more then one input on the channel). Input with this
    flag receive a second parameter `id`.
 
-.. attribute:: Dynamic
+.. attribute:: Strict
 
-   Only applies to output. Specifies that the instances on the output
-   will in general be subtypes of the declared type and that the output
+   Only applies to output. Specifies that this output can be connected only
+   to inputs that expect this type of its supertypes. Otherwise, the output
    can be connected to any input which can accept a subtype of the
    declared output type.
+
+.. attribute:: Dynamic (obsolete and ignored)
+
+   Opposite of `Strict`. All output signals are now dynamic by default.
+   Non-dynamic signals can be specified by using the flag `Strict`.
 
 .. attribute:: Explicit
 


### PR DESCRIPTION
This is something I wanted to try for a long time. After doing it I'm no longer so sure, but I'd like to see your comments (@ales-erjavec, @astaric, @lanzagar, @kernc).

1. I like the new classes for Error/Warning/Info messages that treat messages as objects that can be activated/deactivated.
2. I don't like using string literals.
3. I like the new-style PyQt's signals: you emit a signal by calling emit on a signal object.

First, see the changes I made to [owtestlearners.py](https://github.com/biolab/orange3/pull/2292/files#diff-bfe1378d373a089b1906fa7c0e28e9a8).

**Output signals** can be declared and emitted in a similar fashion as PyQt's signals, like

    predictions_signal = OutputSignal("Predictions", Table)
    evalutions_results_signal = OutputSignal("Evaluation Results", Results)

and emitted by

    self.predictions_signal.send(predictions)

We can no longer make a mistake of emitting a signal with a wrong name. On the other hand, this hasn't been much of a problem lately. Disadvantage: I haven't been able to come up with good names for objects representing output signals. `evalutions_results_signal` is not too convincing.

**Input signals** are declared by decorating handlers, like in

     @InputSignal("Data", Table, flags=widget.Default)
     def set_train_data(self, data):

This is convenient since we don't have to write handlers' names (as string literals); any errors doing this were however already catched in the widget's metaclass. Disadvantage: inputs are not longer listed out in the beginning. Advantage: the sole reason for looking at those lists was to find handler names (and then searching for the corresponding method). Now you can just search for "InputSignal".

Implementation is not complicated. A bit of the work is done in the meta class, which catches the declaration, and part is in the signal mixin's `__init__`, which binds signals to widgets. Two widget's methods are moved into a mixin, which is good. Some other code from widget.py is moved, too. Moving classes `InputSignal` and `OutputSignal` from canvas registry modules to widgets requires that canvas imports some modules from widgets. If this is undesirable, they can be moved back. A more likely direction, though, will be to move the widget base class into canvas, IMHO.

The change is compatible with the existing signal declaration; it in fact moves the new-style declaration into old lists internally.

Feel free to criticize at will or reject. :) Or propose improvements.