### PR TITLE
Test & Score: Offload evaluations to a separate thread

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -246,4 +246,16 @@ class MahalanobisDistance(Distance):
             dist = DistMatrix(dist)
         return dist
 
-Mahalanobis = MahalanobisDistance()
+
+# Only retain this to raise errors on use. Remove in some future version.
+class __MahalanobisDistanceError(MahalanobisDistance):
+    def _raise_error(self, *args, **kwargs):
+        raise RuntimeError(
+            "Invalid use of MahalanobisDistance.\n"
+            "Create a new MahalanobisDistance instance first, e.g.\n"
+            ">>> metric = MahalanobisDistance(data)\n"
+            ">>> dist = metric(data)"
+        )
+    fit = _raise_error
+    __call__ = _raise_error
+Mahalanobis = __MahalanobisDistanceError()

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -153,15 +153,15 @@ class SklImpute(Preprocess):
         from Orange.data.sql.table import SqlTable
         if isinstance(data, SqlTable):
             return Impute()(data)
-        self.imputer = skl_preprocessing.Imputer(strategy=self.strategy)
-        X = self.imputer.fit_transform(data.X)
+        imputer = skl_preprocessing.Imputer(strategy=self.strategy)
+        X = imputer.fit_transform(data.X)
         # Create new variables with appropriate `compute_value`, but
         # drop the ones which do not have valid `imputer.statistics_`
         # (i.e. all NaN columns). `sklearn.preprocessing.Imputer` already
         # drops them from the transformed X.
         features = [impute.Average()(data, var, value)
                     for var, value in zip(data.domain.attributes,
-                                          self.imputer.statistics_)
+                                          imputer.statistics_)
                     if not np.isnan(value)]
         assert X.shape[1] == len(features)
         domain = Orange.data.Domain(features, data.domain.class_vars,

--- a/Orange/projection/base.py
+++ b/Orange/projection/base.py
@@ -1,7 +1,7 @@
 import inspect
 
 import Orange.data
-from Orange.base import _ReprableWithPreprocessors, _ReprableWithParams
+from Orange.base import _ReprableWithPreprocessors
 from Orange.misc.wrapper_meta import WrapperMeta
 from Orange.misc.cache import single_cache
 import Orange.preprocess
@@ -53,7 +53,7 @@ class Projection:
         return self.name
 
 
-class SklProjector(_ReprableWithParams, Projector, metaclass=WrapperMeta):
+class SklProjector(Projector, metaclass=WrapperMeta):
     __wraps__ = None
     _params = {}
     name = 'skl projection'
@@ -91,3 +91,12 @@ class SklProjector(_ReprableWithParams, Projector, metaclass=WrapperMeta):
     def fit(self, X, Y=None):
         proj = self.__wraps__(**self.params)
         return proj.fit(X, Y)
+
+    def __getattr__(self, item):
+        try:
+            return self.params[item]
+        except (AttributeError, KeyError):
+            raise AttributeError(item) from None
+
+    def __dir__(self):
+        return list(sorted(set(super().__dir__()) | set(self.params.keys())))

--- a/Orange/projection/base.py
+++ b/Orange/projection/base.py
@@ -4,7 +4,6 @@ import threading
 import Orange.data
 from Orange.base import _ReprableWithPreprocessors
 from Orange.misc.wrapper_meta import WrapperMeta
-from Orange.misc.cache import single_cache
 import Orange.preprocess
 
 __all__ = ["Projector", "Projection", "SklProjector"]
@@ -69,7 +68,6 @@ class Projection:
         self.__dict__.update(proj.__dict__)
         self.proj = proj
 
-    @single_cache
     def transform(self, X):
         return self.proj.transform(X)
 

--- a/Orange/projection/cur.py
+++ b/Orange/projection/cur.py
@@ -95,7 +95,14 @@ class CUR(Projector):
             self.U_ = np.dot(np.dot(pinvC, X), pinvR)
         else:
             self.U_ = None
-        return CURModel(self)
+
+        # TODO: FIX - do not retain state and ref for this instance
+        # The only use pattern admissble by this implementation is
+        # `model = CUR(**param)(data)`
+        # i.e. CUR instance cannot be used after calling fit once.
+        m = CURModel(self)
+        m.domain = self.domain
+        return m
 
     def transform(self, X, axis):
         if axis == 0:
@@ -152,9 +159,12 @@ class Projector:
         self.transformed = None
 
     def __call__(self, data):
-        if data is not self.transformed:
-            self.transformed = self.projection.transform(data.X)
-        return self.transformed[:, self.feature]
+        transformed = self.transformed
+        # ?? This does not seem right ? Is 'cached' by result ?
+        if data is not transformed:
+            transformed = self.projection.transform(data.X)
+            self.transformed = transformed
+        return transformed[:, self.feature]
 
     def __getstate__(self):
         d = dict(self.__dict__)

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -13,7 +13,7 @@ from Orange.data import (Table, Domain, ContinuousVariable,
                          DiscreteVariable, StringVariable, Instance)
 from Orange.distance import (Euclidean, SpearmanR, SpearmanRAbsolute,
                              PearsonR, PearsonRAbsolute, Manhattan, Cosine,
-                             Jaccard, _preprocess, Mahalanobis, MahalanobisDistance)
+                             Jaccard, _preprocess, MahalanobisDistance)
 from Orange.misc import DistMatrix
 from Orange.tests import named_file, test_filename
 from Orange.util import OrangeDeprecationWarning
@@ -753,23 +753,23 @@ class TestMahalanobis(TestCase):
                 self.assertAlmostEqual(d[i][j], mah(self.x[i], self.x[j]), delta=1e-5)
 
     def test_attributes(self):
-        Mahalanobis.fit(self.x)
-        self.assertEqual(Mahalanobis(self.x[0], self.x[1]).shape, (1, 1))
-        self.assertEqual(Mahalanobis(self.x).shape, (self.n, self.n))
-        self.assertEqual(Mahalanobis(self.x[0:3], self.x[5:7]).shape, (3, 2))
-        self.assertEqual(Mahalanobis(self.x1, self.x2).shape, (1, 1))
-        Mahalanobis(self.x, impute=True)
-        Mahalanobis(self.x[:-1, :])
-        self.assertRaises(ValueError, Mahalanobis, self.x[:, :-1])
-        self.assertRaises(ValueError, Mahalanobis, self.x1[:-1], self.x2)
-        self.assertRaises(ValueError, Mahalanobis, self.x1, self.x2[:-1])
-        self.assertRaises(ValueError, Mahalanobis, self.x.T)
+        metric = MahalanobisDistance(self.x)
+        self.assertEqual(metric(self.x[0], self.x[1]).shape, (1, 1))
+        self.assertEqual(metric(self.x).shape, (self.n, self.n))
+        self.assertEqual(metric(self.x[0:3], self.x[5:7]).shape, (3, 2))
+        self.assertEqual(metric(self.x1, self.x2).shape, (1, 1))
+        metric(self.x, impute=True)
+        metric(self.x[:-1, :])
+        self.assertRaises(ValueError, metric, self.x[:, :-1])
+        self.assertRaises(ValueError, metric, self.x1[:-1], self.x2)
+        self.assertRaises(ValueError, metric, self.x1, self.x2[:-1])
+        self.assertRaises(ValueError, metric, self.x.T)
 
     def test_iris(self):
         tab = Table('iris')
-        Mahalanobis.fit(tab)
-        self.assertEqual(Mahalanobis(tab).shape, (150, 150))
-        self.assertEqual(Mahalanobis(tab[0], tab[1]).shape, (1, 1))
+        metric = MahalanobisDistance(tab)
+        self.assertEqual(metric(tab).shape, (150, 150))
+        self.assertEqual(metric(tab[0], tab[1]).shape, (1, 1))
 
     def test_axis(self):
         mah = MahalanobisDistance(self.x, axis=1)
@@ -786,6 +786,17 @@ class TestMahalanobis(TestCase):
         mah(x[0], x[1])
         mah = MahalanobisDistance(xt)
         mah(xt[0], xt[1])
+
+    def test_global_is_borked(self):
+        """
+        Test that the global state retaining non-safe Mahalanobis instance
+        raises RuntimeErrors on all invocations
+        """
+        from Orange.distance import Mahalanobis
+        with self.assertRaises(RuntimeError):
+            Mahalanobis.fit(self.x)
+        with self.assertRaises(RuntimeError):
+            Mahalanobis(self.x)
 
 
 class TestDistances(TestCase):

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -2,9 +2,6 @@
 # pylint: disable=missing-docstring
 
 import unittest
-import multiprocessing as mp
-from unittest.mock import patch
-
 import numpy as np
 
 from Orange.classification import NaiveBayesLearner, MajorityLearner
@@ -14,7 +11,6 @@ from Orange.evaluation import (Results, CrossValidation, LeaveOneOut, TestOnTrai
                                TestOnTestData, ShuffleSplit, sample, RMSE,
                                CrossValidationFeature)
 from Orange.preprocess import discretize, preprocess
-from Orange.util import OrangeWarning
 
 
 def random_data(nrows, ncols):
@@ -255,28 +251,6 @@ class TestCrossValidation(TestSampling):
         self.assertEqual(len(table.domain.class_vars), len(data.domain.class_vars))
         # +2 for class, +1 for fold
         self.assertEqual(len(table.domain.metas), len(data.domain.metas) + 2 + 1)
-
-    def test_unpicklable_params(self):
-
-        class NonPicklableLearner(MajorityLearner):
-            pass
-
-        self.assertWarns(OrangeWarning,
-                         CrossValidation, self.iris, [NonPicklableLearner()], k=3, n_jobs=3)
-
-    def test_internal_cv(self):
-        # This test just covers; can't catch warnings from subprocesses
-        proc = mp.current_process()
-        was_daemon = proc.daemon
-        proc.daemon = True
-        self.assertWarns(OrangeWarning,
-                         CrossValidation, self.iris, [_ParameterTuningLearner()], k=2, n_jobs=3)
-        proc.daemon = was_daemon
-
-    def test_njobs(self):
-        with patch('Orange.evaluation.testing.CrossValidation._MIN_NJOBS_X_SIZE', 1):
-            res = CrossValidation(self.random_table, [NaiveBayesLearner()], k=5, n_jobs=3)
-        self.check_folds(res, 5, self.nrows)
 
 
 class TestCrossValidationFeature(TestSampling):

--- a/Orange/tests/test_fitter.py
+++ b/Orange/tests/test_fitter.py
@@ -1,9 +1,8 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from Orange.classification.base_classification import LearnerClassification
 from Orange.data import Table, ContinuousVariable
-from Orange.evaluation import CrossValidation
 from Orange.modelling import Fitter
 from Orange.preprocess import Randomize, Discretize
 from Orange.regression.base_regression import LearnerRegression
@@ -107,10 +106,6 @@ class FitterTest(unittest.TestCase):
         self.assertEqual(
             tuple(learner.active_preprocessors), (pp,),
             'Fitter did not properly pass its preprocessors to its learners')
-
-    def test_n_jobs_fitting(self):
-        with patch('Orange.evaluation.testing.CrossValidation._MIN_NJOBS_X_SIZE', 1):
-            CrossValidation(self.heart_disease, [DummyFitter()], k=5, n_jobs=5)
 
     def test_properly_delegates_preprocessing(self):
         class DummyClassificationLearner(LearnerClassification):

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -27,18 +27,20 @@ class TestOWTestLearners(WidgetTest):
     def test_basic(self):
         data = Table("iris")[::3]
         self.send_signal("Data", data)
-        self.send_signal("Learner", MajorityLearner(), 0)
+        self.send_signal("Learner", MajorityLearner(), 0, wait=5000)
         res = self.get_output("Evaluation Results")
         self.assertIsInstance(res, Results)
         self.assertIsNotNone(res.domain)
         self.assertIsNotNone(res.data)
         self.assertIsNotNone(res.probabilities)
 
-        self.send_signal("Learner", None, 0)
+        self.send_signal("Learner", None, 0, wait=5000)
+        res = self.get_output("Evaluation Results")
+        self.assertIsNone(res)
 
         data = Table("housing")[::10]
         self.send_signal("Data", data)
-        self.send_signal("Learner", MeanLearner(), 0)
+        self.send_signal("Learner", MeanLearner(), 0, wait=5000)
         res = self.get_output("Evaluation Results")
         self.assertIsInstance(res, Results)
         self.assertIsNotNone(res.domain)

--- a/Orange/widgets/model/owrules.py
+++ b/Orange/widgets/model/owrules.py
@@ -319,15 +319,10 @@ class OWRuleLearner(OWBaseLearner):
 
     def update_model(self):
         """
-        Ensure that the progress bar is updated only if the generated
-        learner is used within this widget (for example, it must not be
-        accessed from test&score widget).
+        Reimplemented from OWBaseLearner.
         """
         if self.check_data():
-            with self.progressBar() as progress:
-                self.learner.set_progress_advance_callback(progress.advance)
-                self.model = self.learner(self.data)
-                self.learner.clear_progress_advance_callback()
+            self.model = self.learner(self.data)
             self.model.name = self.learner_name
             self.model.instances = self.data
             self.valid_data = True
@@ -336,6 +331,9 @@ class OWRuleLearner(OWBaseLearner):
         self.send(self.OUTPUT_MODEL_NAME, self.model)
 
     def create_learner(self):
+        """
+        Reimplemented from OWBaseLearner.
+        """
         return self.LEARNER(
             preprocessors=self.preprocessors,
             base_rules=self.base_rules,

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -10,10 +10,15 @@ from Orange.widgets import gui, settings
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.widget import OWWidget, Msg
 
+# A placeholder. This metric is handled specially in commit method.
+__Mahalanobis = distance.MahalanobisDistance()
+__Mahalanobis.fit = None
+
+
 METRICS = [
     distance.Euclidean,
     distance.Manhattan,
-    distance.Mahalanobis,
+    __Mahalanobis,
     distance.Cosine,
     distance.Jaccard,
     distance.SpearmanR,
@@ -131,15 +136,10 @@ class OWDistances(OWWidget):
             return
 
         if isinstance(metric, distance.MahalanobisDistance):
-            n, m = data.X.shape
-            if self.axis == 1:
-                n, m = m, n
-
-        if isinstance(metric, distance.MahalanobisDistance):
             # Mahalanobis distance has to be trained before it can be used
             # to compute distances
             try:
-                metric.fit(data, axis=1 - self.axis)
+                metric = distance.MahalanobisDistance(data, axis=1 - self.axis)
             except (ValueError, MemoryError) as e:
                 self.Error.mahalanobis_error(e)
                 return

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from Orange.data import Table
-from Orange.distance import MahalanobisDistance, Mahalanobis
+from Orange.distance import MahalanobisDistance
 from Orange.widgets.unsupervised.owdistances import OWDistances, METRICS
 from Orange.widgets.tests.base import WidgetTest
 
@@ -12,8 +12,8 @@ class TestOWDistances(WidgetTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.iris = Table("iris")
-        cls.titanic = Table("titanic")
+        cls.iris = Table("iris")[::5]
+        cls.titanic = Table("titanic")[::10]
 
     def setUp(self):
         self.widget = self.create_widget(OWDistances)
@@ -24,7 +24,7 @@ class TestOWDistances(WidgetTest):
         self.send_signal("Data", self.iris)
         for i, metric in enumerate(METRICS):
             if isinstance(metric, MahalanobisDistance):
-                metric.fit(self.iris)
+                metric = MahalanobisDistance(self.iris)
             self.widget.metrics_combo.activated.emit(i)
             self.widget.metrics_combo.setCurrentIndex(i)
             self.send_signal("Data", self.iris)
@@ -42,7 +42,9 @@ class TestOWDistances(WidgetTest):
         self.assertFalse(self.widget.Error.no_continuous_features.is_shown())
 
     def test_mahalanobis_error(self):
-        self.widget.metric_idx = METRICS.index(Mahalanobis)
+        mah_index = [i for i, d in enumerate(METRICS)
+                     if isinstance(d, MahalanobisDistance)][0]
+        self.widget.metric_idx = mah_index
         self.widget.autocommit = True
 
         invalid = self.iris[:]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Test & Score is non-interactive

##### Description of changes

Run the evaluations in a thread (not that Orange would be particularly thread-safe - at the very least DiscreteVariable's values can change during a run)

Other changes:
* Make SklImpute thread safe.
* Change Reprable implementation to allow thread safe use (remove all uses of `mock.patch` (??))
* Remove inplace modification of the learner sent from owrules (after already being sent)
* Remove instance modifications in manifold.py to make it thread safe (in some cases even just for repeated sequential use).
* Make the {Learner,Projector}.domain a property utilizing thread local storage behind the scenes. This is to work around a non thread-safe API design.
* Disable the global `distance.Mahalanobis` instance. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation

