### PR TITLE
Python Script: Check for types of output variables

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -121,7 +121,7 @@ class PythonScriptEditor(QPlainTextEdit):
             text = self.lastLine()
             if text and not text.strip():
                 cursor = self.textCursor()
-                for i in range(min(self.INDENT, len(text))):
+                for _ in range(min(self.INDENT, len(text))):
                     cursor.deletePreviousChar()
             else:
                 super().keyPressEvent(event)
@@ -359,8 +359,8 @@ class OWPythonScript(widget.OWWidget):
 
     inputs = [("in_data", Orange.data.Table, "setExampleTable",
                widget.Default),
-#               ("in_distance", Orange.misc.SymMatrix, "setDistanceMatrix",
-#                widget.Default),
+              # ("in_distance", Orange.misc.SymMatrix, "setDistanceMatrix",
+              # widget.Default),
               ("in_learner", Learner, "setLearner",
                widget.Default),
               ("in_classifier", Model, "setClassifier",
@@ -368,7 +368,7 @@ class OWPythonScript(widget.OWWidget):
               ("in_object", object, "setObject")]
 
     outputs = [("out_data", Orange.data.Table, ),
-#                ("out_distance", Orange.misc.SymMatrix, ),
+               # ("out_distance", Orange.misc.SymMatrix, ),
                ("out_learner", Learner, ),
                ("out_classifier", Model, widget.Dynamic),
                ("out_object", object, widget.Dynamic)]
@@ -417,7 +417,7 @@ class OWPythonScript(widget.OWWidget):
 
         self.libraryView = QListView(
             editTriggers=QListView.DoubleClicked |
-                         QListView.EditKeyPressed,
+            QListView.EditKeyPressed,
             sizePolicy=QSizePolicy(QSizePolicy.Ignored,
                                    QSizePolicy.Preferred)
         )

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -30,7 +30,7 @@ class TestOWPythonScript(WidgetTest):
         for _input, _output, data in (
                 ("in_data", "out_data", self.iris),
                 ("in_learner", "out_learner", self.learner),
-                ("in_classifier", "out_data", self.model),
+                ("in_classifier", "out_classifier", self.model),
                 ("in_object", "out_object", "object")):
             self.widget.text.setPlainText("{} = {}".format(_output, _input))
             self.send_signal(_input, data)
@@ -50,3 +50,21 @@ class TestOWPythonScript(WidgetTest):
         self.widget.execute_button.button.click()
         self.assertNotIn("NameError: name 'temp' is not defined",
                          self.widget.console.toPlainText())
+
+    def test_wrong_outputs(self):
+        """
+        Error is shown when output variables are filled with wrong variable types.
+        And also output variable is set to None.
+        GH-2308
+        """
+        self.assertEqual(len(self.widget.Error.active), 0)
+        for _input, _output, data in (
+                ("in_data", "out_data", self.iris),
+                ("in_learner", "out_learner", self.learner),
+                ("in_classifier", "out_classifier", self.model)):
+            self.widget.text.setPlainText("{} = {}".format(_output, _input))
+            self.send_signal(_input, "42")
+            self.assertEqual(self.get_output(_output), None)
+            self.assertTrue(getattr(self.widget.Error, _output).is_shown())
+            self.send_signal(_input, data)
+            self.assertFalse(getattr(self.widget.Error, _output).is_shown())


### PR DESCRIPTION
##### Issue
Various errors reported by sentry. A user can write a code which sends data in incompatible or inappropriate variables. For instance it can send `String` instead of `Table` and that causes some other widget to crash.

##### Description of changes
Only proper variables are sent.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
