### PR TITLE
[ENH] PCA on sparse data

### DIFF
--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -65,12 +65,6 @@ class SelectBestFeatures(Reprable):
             else:
                 method = UnivariateLinearRegression()
 
-        if not isinstance(data.domain.class_var, method.class_type):
-            raise ValueError(("Scoring method {} requires a class variable " +
-                              "of type {}.").format(
-                (method if type(method) == type else type(method)).__name__,
-                method.class_type.__name__)
-            )
         features = data.domain.attributes
         try:
             scores = method(data)

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from itertools import chain
 
@@ -30,12 +31,37 @@ class Scorer(_RefuseDataInConstructor, Reprable):
         RemoveNaNClasses()
     ]
 
+    @property
+    def friendly_name(self):
+        """Return type name with camel-case separated into words.
+        Derived classes can provide a better property or a class attribute.
+        """
+        return re.sub("([a-z])([A-Z])",
+                      lambda mo: mo.group(1) + " " + mo.group(2).lower(),
+                      type(self).__name__)
+
+    @staticmethod
+    def _friendly_vartype_name(vartype):
+        if vartype == DiscreteVariable:
+            return "categorical"
+        if vartype == ContinuousVariable:
+            return "numeric"
+        # Fallbacks
+        name = vartype.__name__
+        if name.endswith("Variable"):
+            return name.lower()[:-8]
+        return name
+
     def __call__(self, data, feature=None):
         if not data.domain.class_var:
-            raise ValueError("Data with class labels required.")
+            raise ValueError(
+                "{} requires data with a target variable."
+                .format(self.friendly_name))
         if not isinstance(data.domain.class_var, self.class_type):
-            raise ValueError("Scoring method %s requires a class variable of type %s." %
-                             (type(self).__name__, self.class_type.__name__))
+            raise ValueError(
+                "{} requires a {} target variable."
+                .format(self.friendly_name,
+                        self._friendly_vartype_name(self.class_type)))
 
         if feature is not None:
             f = data.domain[feature]
@@ -44,9 +70,12 @@ class Scorer(_RefuseDataInConstructor, Reprable):
         for pp in self.preprocessors:
             data = pp(data)
 
-        if any(not isinstance(a, self.feature_type)
-               for a in data.domain.attributes):
-            raise ValueError('Only %ss are supported' % self.feature_type)
+        for var in data.domain.attributes:
+            if not isinstance(var, self.feature_type):
+                raise ValueError(
+                    "{} cannot score {} variables."
+                    .format(self.friendly_name,
+                            self._friendly_vartype_name(type(var))))
 
         return self.score_data(data, feature)
 
@@ -299,6 +328,7 @@ class ReliefF(Scorer):
     feature_type = Variable
     class_type = DiscreteVariable
     supports_sparse_data = False
+    friendly_name = "ReliefF"
 
     def __init__(self, n_iterations=50, k_nearest=10):
         self.n_iterations = n_iterations
@@ -326,6 +356,7 @@ class RReliefF(Scorer):
     feature_type = Variable
     class_type = ContinuousVariable
     supports_sparse_data = False
+    friendly_name = "RReliefF"
 
     def __init__(self, n_iterations=50, k_nearest=50):
         self.n_iterations = n_iterations

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -18,7 +18,7 @@ from Orange.preprocess import Continuize
 from Orange.projection import SklProjector, Projection
 from Orange.preprocess.score import LearnerScorer
 
-__all__ = ["PCA", "SparsePCA", "IncrementalPCA"]
+__all__ = ["PCA", "SparsePCA", "IncrementalPCA", "TruncatedSVD"]
 
 
 class _FeatureScorerMixin(LearnerScorer):
@@ -150,6 +150,35 @@ class IncrementalPCAModel(PCAModel):
             self.proj.partial_fit(data)
         self.__dict__.update(self.proj.__dict__)
         return self
+
+
+class TruncatedSVD(SklProjector, _FeatureScorerMixin):
+    __wraps__ = skl_decomposition.TruncatedSVD
+    name = 'truncated svd'
+
+    def __init__(self, n_components=None, copy=True, whiten=False,
+                 svd_solver='auto', tol=0.0, iterated_power='auto',
+                 random_state=None, preprocessors=None, max_components=None):
+        super().__init__(preprocessors=preprocessors)
+        if n_components is not None and max_components is not None:
+            raise ValueError("n_components and max_components can not both be defined.")
+        # max_components limits the number of PCA components if the minimum
+        # shape of the X matrix (after preprocessing) is higher than
+        # max_components, so that sklearn does not always compute the full
+        # transform, which is faster and uses less memory for big data.
+        self.max_components = max_components
+        self.params = vars()
+
+    def fit(self, X, Y=None):
+        params = self.params.copy()
+        if params["n_components"] is None and self.max_components is not None:
+            # shape of X after preprocessing
+            # Add -1 to avoid error in scikit fit_transform
+            # ValueError: n_components must be < n_features (strict)
+            params["n_components"] = min(min(X.shape) - 1, self.max_components)
+        proj = self.__wraps__(**params)
+        proj = proj.fit(X, Y)
+        return PCAModel(proj, self.domain)
 
 
 class Projector(SharedComputeValue):

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -137,7 +137,14 @@ class VariableEditor(QWidget):
         self._setup_gui_labels()
 
     def _setup_gui_name(self):
-        self.name_edit = QLineEdit()
+        class OrangeLineEdit(QLineEdit):
+            def keyPressEvent(self, event):
+                if event.key() in [Qt.Key_Return, Qt.Key_Enter]:
+                    self.parent().on_name_changed()
+                else:
+                    super().keyPressEvent(event)
+
+        self.name_edit = OrangeLineEdit()
         self.main_form.addRow("Name:", self.name_edit)
         self.name_edit.editingFinished.connect(self.on_name_changed)
 

--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,7 @@ disable=
     parameter-unpacking,long-suffix,cmp-method,using-cmp-argument,
     useless-suppression,import-error,
     empty-docstring,missing-docstring,redefined-outer-name,redefined-builtin,
-    attribute-defined-outside-init
+    attribute-defined-outside-init, no-else-return, len-as-condition
 
 
 [REPORTS]


### PR DESCRIPTION
##### Issue
Implements Issue #2255.
Use TruncatedSVD (LSA) on sparse data instead of PCA, since PCA does not work on sparse data. The difference is that TruncatedSVD truncates the vectors and does not center the data before calling svd. For dense data, functionality remains the same.

##### Description of changes
Workflow:
Corpus (Select bookexcerpts.tab) -> Bag of Words -> PCA
![pca](https://cloud.githubusercontent.com/assets/8665160/25993026/e5d3bb26-3708-11e7-8a4a-83bae8b5452e.png)

- widgets/unsupervised/owpca.py: Data centering checkbox (true = PCA, false = TruncatedSVD)
- projection/pca.py: TruncatedSVD model
- tests: test_pca.py

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
