### PR TITLE
Move creation of widget description to widgets; Reimplement signal definition lists

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,7 +3,9 @@ engines:
    enabled: true
    config:
      languages:
-     - python
+       - python
+   exclude_paths:
+     - doc/
  pep8:
    enabled: false
  radon:

--- a/Orange/canvas/registry/description.py
+++ b/Orange/canvas/registry/description.py
@@ -5,7 +5,6 @@ Widget meta description classes
 """
 
 import sys
-import warnings
 
 # Exceptions
 from itertools import chain
@@ -73,20 +72,13 @@ class InputSignal(object):
         A list of names this input replaces.
     """
     def __init__(self, name, type, handler, flags=Single + NonDefault,
-                 id=None, doc=None, replaces=[]):
+                 id=None, doc=None, replaces=()):
         self.name = name
         self.type = type
         self.handler = handler
         self.id = id
         self.doc = doc
         self.replaces = list(replaces)
-
-        if isinstance(flags, str):
-            # flags are stored as strings
-            warnings.warn("Passing 'flags' as string is deprecated, use "
-                          "integer constants instead",
-                          PendingDeprecationWarning)
-            flags = eval(flags)
 
         if not (flags & Single or flags & Multiple):
             flags += Single
@@ -127,19 +119,12 @@ class OutputSignal(object):
         A list of names this output replaces.
     """
     def __init__(self, name, type, flags=Single + NonDefault,
-                 id=None, doc=None, replaces=[]):
+                 id=None, doc=None, replaces=()):
         self.name = name
         self.type = type
         self.id = id
         self.doc = doc
         self.replaces = list(replaces)
-
-        if isinstance(flags, str):
-            # flags are stored as strings
-            warnings.warn("Passing 'flags' as string is deprecated, use "
-                          "integer constants instead",
-                          PendingDeprecationWarning)
-            flags = eval(flags)
 
         if not (flags & Single or flags & Multiple):
             flags += Single
@@ -214,12 +199,11 @@ class WidgetDescription(object):
     def __init__(self, name, id, category=None, version=None,
                  description=None,
                  qualified_name=None, package=None, project_name=None,
-                 inputs=[], outputs=[],
+                 inputs=(), outputs=(),
                  help=None, help_ref=None, url=None, keywords=None,
                  priority=sys.maxsize,
                  icon=None, background=None,
-                 replaces=None,
-                 ):
+                 replaces=None):
 
         if not qualified_name:
             # TODO: Should also check that the name is real.
@@ -285,7 +269,7 @@ class WidgetDescription(object):
 
         default_cat_name = package_name if package_name else ""
 
-        for widget_cls_name, widget_class in module.__dict__.items():
+        for widget_class in module.__dict__.values():
             if not hasattr(widget_class, "get_widget_description"):
                 continue
             description = widget_class.get_widget_description()
@@ -298,8 +282,8 @@ class WidgetDescription(object):
             description.package = module.__package__
             description.category = widget_class.category or default_cat_name
             return description
-        else:
-            raise WidgetSpecificationError
+
+        raise WidgetSpecificationError
 
 class CategoryDescription(object):
     """
@@ -335,8 +319,7 @@ class CategoryDescription(object):
                  project_name=None,
                  url=None, help=None, keywords=None,
                  widgets=None, priority=sys.maxsize,
-                 icon=None, background=None
-                 ):
+                 icon=None, background=None):
 
         self.name = name
         self.version = version

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -36,16 +36,15 @@ from Orange.base import Learner
 from Orange.evaluation import scoring, Results
 from Orange.preprocess.preprocess import Preprocess
 from Orange.preprocess import RemoveNaNClasses
-from Orange.widgets import widget, gui, settings
+from Orange.widgets import gui, settings
 from Orange.widgets.utils.itemmodels import DomainModel
-from Orange.widgets.widget import OWWidget, Msg
+from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.widgets.utils.concurrent import ThreadExecutor
 
 log = logging.getLogger(__name__)
 
-
-Input = namedtuple(
-    "Input",
+InputLearner = namedtuple(
+    "InputLearner",
     ["learner",  # :: Orange.base.Learner
      "results",  # :: Option[Try[Orange.evaluation.Results]]
      "stats"]    # :: Option[Sequence[Try[float]]]
@@ -163,13 +162,15 @@ class OWTestLearners(OWWidget):
     icon = "icons/TestLearners1.svg"
     priority = 100
 
-    inputs = [("Learner", Learner, "set_learner", widget.Multiple),
-              ("Data", Table, "set_train_data", widget.Default),
-              ("Test Data", Table, "set_test_data"),
-              ("Preprocessor", Preprocess, "set_preprocessor")]
+    class Inputs:
+        train_data = Input("Data", Table, flags=widget.Default)
+        test_data = Input("Test Data", Table)
+        learner = Input("Learner", Learner, flags=widget.Multiple)
+        preprocessor = Input("Preprocessor", Preprocess)
 
-    outputs = [("Predictions", Table),
-               ("Evaluation Results", Results)]
+    class Outputs:
+        predictions = Output("Predictions", Table)
+        evaluations_results = Output("Evaluation Results", Results)
 
     settings_version = 3
     settingsHandler = settings.PerfectDomainContextHandler(metas_in_res=True)
@@ -332,6 +333,7 @@ class OWTestLearners(OWWidget):
         if self.resampling == OWTestLearners.FeatureFold and not enabled:
             self.resampling = OWTestLearners.KFold
 
+    @Inputs.learner
     def set_learner(self, learner, key):
         """
         Set the input `learner` for `key`.
@@ -346,9 +348,10 @@ class OWTestLearners(OWWidget):
             self._invalidate([key])
             del self.learners[key]
         else:
-            self.learners[key] = Input(learner, None, None)
+            self.learners[key] = InputLearner(learner, None, None)
             self._invalidate([key])
 
+    @Inputs.train_data
     def set_train_data(self, data):
         """
         Set the input training dataset.
@@ -400,6 +403,7 @@ class OWTestLearners(OWWidget):
                 self.resampling = OWTestLearners.FeatureFold
         self._invalidate()
 
+    @Inputs.test_data
     def set_test_data(self, data):
         # type: (Orange.data.Table) -> None
         """
@@ -448,6 +452,7 @@ class OWTestLearners(OWWidget):
                 (False, True): " test "}[(self.train_data_missing_vals,
                                           self.test_data_missing_vals)]
 
+    @Inputs.preprocessor
     def set_preprocessor(self, preproc):
         """
         Set the input preprocessor to apply on the training data.
@@ -656,8 +661,8 @@ class OWTestLearners(OWWidget):
         else:
             combined = None
             predictions = None
-        self.send("Evaluation Results", combined)
-        self.send("Predictions", predictions)
+        self.Outputs.evaluations_results.send(combined)
+        self.Outputs.predictions.send(predictions)
 
     def send_report(self):
         """Report on the testing schema and results"""

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -163,9 +163,9 @@ class OWTestLearners(OWWidget):
     priority = 100
 
     class Inputs:
-        train_data = Input("Data", Table, flags=widget.Default)
+        train_data = Input("Data", Table, default=True)
         test_data = Input("Test Data", Table)
-        learner = Input("Learner", Learner, flags=widget.Multiple)
+        learner = Input("Learner", Learner, multiple=True)
         preprocessor = Input("Preprocessor", Preprocess)
 
     class Outputs:

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -28,7 +28,7 @@ class TestOWTestLearners(WidgetTest):
         data = Table("iris")[::3]
         self.send_signal("Data", data)
         self.send_signal("Learner", MajorityLearner(), 0, wait=5000)
-        res = self.get_output("Evaluation Results")
+        res = self.get_output(self.widget.Outputs.evaluations_results)
         self.assertIsInstance(res, Results)
         self.assertIsNotNone(res.domain)
         self.assertIsNotNone(res.data)
@@ -48,7 +48,7 @@ class TestOWTestLearners(WidgetTest):
 
     def test_testOnTest(self):
         data = Table("iris")
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.train_data, data)
         self.widget.resampling = OWTestLearners.TestOnTest
         self.send_signal("Test Data", data)
 
@@ -168,3 +168,6 @@ class TestHelpers(unittest.TestCase):
         np.testing.assert_equal(r1.row_indices, res.row_indices)
         np.testing.assert_equal(r2.row_indices, res.row_indices)
         np.testing.assert_equal(r3.row_indices, res.row_indices)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/utils/signals.py
+++ b/Orange/widgets/utils/signals.py
@@ -105,6 +105,7 @@ class Output(OutputSignal, _Signal):
                  default=False, explicit=False, dynamic=True):
         flags = self.get_flags(False, default, explicit, dynamic)
         super().__init__(name, type, flags, id, doc, replaces or [])
+        self.widget = None
 
     def bound_signal(self, widget):
         """
@@ -189,11 +190,17 @@ class WidgetSignalsMixin:
 
     @classmethod
     def _check_input_handlers(cls):
-        unbound = [signal.name for signal in cls.inputs
-                   if not signal.handler]
+        unbound = [signal.name for signal in cls.Inputs.__dict__.values()
+                   if isinstance(signal, Input) and not signal.handler]
         if unbound:
             raise ValueError("unbound signal(s) in {}: {}".
                              format(cls.__name__, ", ".join(unbound)))
+
+        missing_handlers = [signal.handler for signal in cls.inputs
+                            if not hasattr(cls, signal.handler)]
+        if missing_handlers:
+            raise ValueError("missing handlers in {}: {}".
+                             format(cls.__name__, ", ".join(missing_handlers)))
 
     @classmethod
     def get_signals(cls, direction):

--- a/Orange/widgets/utils/signals.py
+++ b/Orange/widgets/utils/signals.py
@@ -37,19 +37,25 @@ class Input(InputSignal, _Signal):
 
     Parameters
     ----------
-    name (str): signal name
-    type (type): signal type
-    id (str): a unique id of the signal
-    doc (str, optional): signal documentation
-    replaces (list of str): a list with names of signals replaced by this signal
-    multiple (bool, optional): if set, multiple signals can be connected
-        to this output (default: `False`)
-    default (bool, optional): when the widget accepts multiple signals of the
-        same type, one of them can set this flag to act as the default
+    name (str):
+        signal name
+    type (type):
+        signal type
+    id (str):
+        a unique id of the signal
+    doc (str, optional):
+        signal documentation
+    replaces (list of str):
+        a list with names of signals replaced by this signal
+    multiple (bool, optional):
+        if set, multiple signals can be connected to this output
         (default: `False`)
-    explicit (bool, optional): if set, this signal is only used when it is
-        the only option or when explicitly connected in the dialog
-        (default: `False`)
+    default (bool, optional):
+        when the widget accepts multiple signals of the same type, one of them
+        can set this flag to act as the default (default: `False`)
+    explicit (bool, optional):
+        if set, this signal is only used when it is the only option or when
+        explicitly connected in the dialog (default: `False`)
     """
     def __init__(self, name, type, id=None, doc=None, replaces=None, *,
                  multiple=False, default=False, explicit=False):
@@ -85,21 +91,27 @@ class Output(OutputSignal, _Signal):
 
     Parameters
     ----------
-    name (str): signal name
-    type (type): signal type
-    id (str): a unique id of the signal
-    doc (str, optional): signal documentation
-    replaces (list of str): a list with names of signals replaced by this signal
-    default (bool, optional): when the widget outputs multiple signals of the
-        same type, one of them can set this flag to act as the default
-        (default: `False`)
-    explicit (bool, optional): if set, this signal is only used when it is
-        the only option or when explicitly connected in the dialog
-        (default: `False`)
-    dynamic (bool, optional): Specifies that the instances on the output will
-        in general be subtypes of the declared type and that the output can
-        be connected to any input signal which can accept a subtype of the
-        declared output type.
+    name (str):
+        signal name
+    type (type):
+        signal type
+    id (str):
+        a unique id of the signal
+    doc (str, optional):
+        signal documentation
+    replaces (list of str):
+        a list with names of signals replaced by this signal
+    default (bool, optional):
+        when the widget accepts multiple signals of the same type, one of them
+        can set this flag to act as the default (default: `False`)
+    explicit (bool, optional):
+        if set, this signal is only used when it is the only option or when
+        explicitly connected in the dialog (default: `False`)
+    dynamic (bool, optional):
+        Specifies that the instances on the output will in general be subtypes
+        of the declared type and that the output can be connected to any input
+        signal which can accept a subtype of the declared output type
+        (default: `True`)
     """
     def __init__(self, name, type, id=None, doc=None, replaces=None, *,
                  default=False, explicit=False, dynamic=True):

--- a/Orange/widgets/utils/signals.py
+++ b/Orange/widgets/utils/signals.py
@@ -126,7 +126,7 @@ class WidgetSignalsMixin:
             return [copy.copy(signal) for signal in old_style]
         signal_class = getattr(cls, direction.title())
         return [signal for signal in signal_class.__dict__.values()
-                if isinstance(signal, (InputSignal, OutputSignal))]
+                if isinstance(signal, (Input, Output))]
 
 
 class AttributeList(list):

--- a/Orange/widgets/utils/signals.py
+++ b/Orange/widgets/utils/signals.py
@@ -1,0 +1,133 @@
+import copy
+
+from Orange.canvas.registry.description import \
+    InputSignal, OutputSignal, \
+    Single, Multiple, Default, NonDefault, Explicit, Dynamic
+
+
+class Input(InputSignal):
+    def __init__(self, name, type, flags=None, id=None, doc=None, replaces=[],
+                 single=True, multiple=False, default=False, explicit=False,
+                 dynamic=True):
+        if flags is None:
+            flags = (single and Single) | \
+                    (multiple and Multiple) | \
+                    (default and Default or NonDefault) | \
+                    (explicit and Explicit) | \
+                    (dynamic and Dynamic)
+        super().__init__(name, type, "", flags, id, doc, replaces)
+
+    def __call__(self, method):
+        """
+        Decorator that stores decorated method's name in the signal's
+        `handler` attribute. The method is returned unchanged.
+        """
+        if self.handler:
+            raise ValueError("Input {} is already bound to method {}".
+                             format(self.name, self.handler))
+        self.handler = method.__name__
+        return method
+
+
+class Output(OutputSignal):
+    def __init__(self, name, type, flags=None, id=None, doc=None, replaces=[],
+                 single=True, multiple=False, default=False, explicit=False,
+                 dynamic=True):
+        if flags is None:
+            flags = (single and Single) | \
+                    (multiple and Multiple) | \
+                    (default and Default or NonDefault) | \
+                    (explicit and Explicit) | \
+                    (dynamic and not multiple and Dynamic)
+        super().__init__(name, type, flags, id, doc, replaces)
+
+    def bound_signal(self, widget):
+        """Return a copy of the signal bound to a widget."""
+        new_signal = copy.copy(self)
+        new_signal.widget = widget
+        return new_signal
+
+    def send(self, value, id=None):
+        assert self.widget is not None
+        signal_manager = self.widget.signalManager
+        if signal_manager is not None:
+            signal_manager.send(self.widget, self.name, value, id)
+
+
+class WidgetSignalsMixin:
+    class Inputs:
+        pass
+
+    class Outputs:
+        pass
+
+    def __init__(self):
+        self._bind_outputs()
+
+    def _bind_outputs(self):
+        bound_cls = self.Outputs()
+        for name, signal in self.Outputs.__dict__.items():
+            if isinstance(signal, Output):
+                bound_cls.__dict__[name] = signal.bound_signal(self)
+        setattr(self, "Outputs", bound_cls)
+
+    def send(self, signalName, value, id=None):
+        """
+        Send a `value` on the `signalName` widget output.
+
+        An output with `signalName` must be defined in the class ``outputs``
+        list.
+        """
+        if not any(s.name == signalName for s in self.outputs):
+            raise ValueError('{} is not a valid output signal for widget {}'.format(
+                signalName, self.name))
+        if self.signalManager is not None:
+            self.signalManager.send(self, signalName, value, id)
+
+    def handleNewSignals(self):
+        """
+        Invoked by the workflow signal propagation manager after all
+        signals handlers have been called.
+        Reimplement this method in order to coalesce updates from
+        multiple updated inputs.
+        """
+        pass
+
+    # Methods used by the meta class
+    @classmethod
+    def convert_signals(cls):
+        def signal_from_args(args, signal_type):
+            if isinstance(args, tuple):
+                return signal_type(*args)
+            elif isinstance(args, signal_type):
+                return copy.copy(args)
+
+        if hasattr(cls, "inputs") and cls.inputs:
+            cls.inputs = [signal_from_args(input_, InputSignal)
+                          for input_ in cls.inputs]
+        if hasattr(cls, "outputs") and cls.outputs:
+            cls.outputs = [signal_from_args(output, OutputSignal)
+                           for output in cls.outputs]
+
+        cls._check_input_handlers()
+
+    @classmethod
+    def _check_input_handlers(cls):
+        unbound = [signal.name for signal in cls.inputs
+                   if not signal.handler]
+        if unbound:
+            raise ValueError("unbound signal(s) in {}: {}".
+                             format(cls.__name__, ", ".join(unbound)))
+
+    @classmethod
+    def get_signals(cls, direction):
+        old_style = cls.__dict__.get(direction, None)
+        if old_style:
+            return [copy.copy(signal) for signal in old_style]
+        signal_class = getattr(cls, direction.title())
+        return [signal for signal in signal_class.__dict__.values()
+                if isinstance(signal, (InputSignal, OutputSignal))]
+
+
+class AttributeList(list):
+    """Signal type for lists of attributes (variables)"""

--- a/Orange/widgets/utils/signals.py
+++ b/Orange/widgets/utils/signals.py
@@ -51,10 +51,10 @@ class Input(InputSignal, _Signal):
         the only option or when explicitly connected in the dialog
         (default: `False`)
     """
-    def __init__(self, name, type, id=None, doc=None, replaces=[], *,
+    def __init__(self, name, type, id=None, doc=None, replaces=None, *,
                  multiple=False, default=False, explicit=False):
         flags = self.get_flags(multiple, default, explicit, False)
-        super().__init__(name, type, "", flags, id, doc, replaces)
+        super().__init__(name, type, "", flags, id, doc, replaces or [])
 
     def __call__(self, method):
         """
@@ -101,10 +101,10 @@ class Output(OutputSignal, _Signal):
         be connected to any input signal which can accept a subtype of the
         declared output type.
     """
-    def __init__(self, name, type, id=None, doc=None, replaces=[], *,
+    def __init__(self, name, type, id=None, doc=None, replaces=None, *,
                  default=False, explicit=False, dynamic=True):
         flags = self.get_flags(False, default, explicit, dynamic)
-        super().__init__(name, type, flags, id, doc, replaces)
+        super().__init__(name, type, flags, id, doc, replaces or [])
 
     def bound_signal(self, widget):
         """

--- a/Orange/widgets/utils/tests/test_signals.py
+++ b/Orange/widgets/utils/tests/test_signals.py
@@ -1,0 +1,191 @@
+# Tests construct several MockWidget classes with different signals
+# pylint: disable=function-redefined
+# pylint: disable=unused-variable
+
+# It is our constitutional right to use foo and bar as fake handler names
+# pylint: disable=blacklisted-name
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from Orange.canvas.registry.description import \
+    Single, Multiple, Default, NonDefault, Explicit, Dynamic, InputSignal, \
+    OutputSignal
+from Orange.widgets.tests.base import GuiTest
+from Orange.widgets.utils.signals import _Signal, Input, Output
+from Orange.widgets.widget import OWWidget
+
+
+class SignalTest(unittest.TestCase):
+    def test_get_flags(self):
+        self.assertEqual(_Signal.get_flags(False, False, False, False),
+                         Single | NonDefault)
+        self.assertEqual(_Signal.get_flags(True, False, False, False),
+                         Multiple | NonDefault)
+        self.assertEqual(_Signal.get_flags(False, True, False, False),
+                         Single | Default)
+        self.assertEqual(_Signal.get_flags(False, False, True, False),
+                         Single | NonDefault | Explicit)
+        self.assertEqual(_Signal.get_flags(False, False, False, True),
+                         Single | NonDefault | Dynamic)
+
+
+class InputTest(unittest.TestCase):
+    def test_init(self):
+        with patch("Orange.widgets.utils.signals._Signal.get_flags",
+                   return_value=42) as getflags:
+            signal = Input("a name", int, "an id", "a doc", ["x"])
+            self.assertEqual(signal.name, "a name")
+            self.assertEqual(signal.type, int)
+            self.assertEqual(signal.id, "an id")
+            self.assertEqual(signal.doc, "a doc")
+            self.assertEqual(signal.replaces, ["x"])
+            self.assertEqual(signal.flags, 42)
+            getflags.assert_called_with(False, False, False, False)
+
+            Input("a name", int, "an id", "a doc", ["x"], multiple=True)
+            getflags.assert_called_with(True, False, False, False)
+
+            Input("a name", int, "an id", "a doc", ["x"], default=True)
+            getflags.assert_called_with(False, True, False, False)
+
+            Input("a name", int, "an id", "a doc", ["x"], explicit=True)
+            getflags.assert_called_with(False, False, True, False)
+
+    def test_decorate(self):
+        input = Input("a name", int)
+        self.assertEqual(input.handler, "")
+
+        @input
+        def foo():
+            pass
+        self.assertEqual(input.handler, "foo")
+
+        with self.assertRaises(ValueError):
+            @input
+            def bar():
+                pass
+
+
+class OutputTest(unittest.TestCase):
+    def test_init(self):
+        with patch("Orange.widgets.utils.signals._Signal.get_flags",
+                   return_value=42) as getflags:
+            signal = Output("a name", int, "an id", "a doc", ["x"])
+            self.assertEqual(signal.name, "a name")
+            self.assertEqual(signal.type, int)
+            self.assertEqual(signal.id, "an id")
+            self.assertEqual(signal.doc, "a doc")
+            self.assertEqual(signal.replaces, ["x"])
+            self.assertEqual(signal.flags, 42)
+            getflags.assert_called_with(False, False, False, True)
+
+            Output("a name", int, "an id", "a doc", ["x"], default=True)
+            getflags.assert_called_with(False, True, False, True)
+
+            Output("a name", int, "an id", "a doc", ["x"], explicit=True)
+            getflags.assert_called_with(False, False, True, True)
+
+            Output("a name", int, "an id", "a doc", ["x"], dynamic=False)
+            getflags.assert_called_with(False, False, False, False)
+
+    def test_bind_and_send(self):
+        widget = MagicMock()
+        output = Output("a name", int, "an id", "a doc", ["x"])
+        bound = output.bound_signal(widget)
+        value = object()
+        id = 42
+        bound.send(value, id)
+        widget.signalManager.send.assert_called_with(
+            widget, "a name", value, id)
+
+
+class WidgetSignalsMixinTest(GuiTest):
+    def test_init_binds_outputs(self):
+        class MockWidget(OWWidget):
+            name = "foo"
+            class Outputs:
+                an_output = Output("a name", int)
+
+        widget = MockWidget()
+        self.assertEqual(widget.Outputs.an_output.widget, widget)
+        self.assertIsNone(MockWidget.Outputs.an_output.widget)
+
+    def test_checking_invalid_inputs(self):
+        with self.assertRaises(ValueError):
+            class MockWidget(OWWidget):
+                name = "foo"
+
+                class Inputs:
+                    an_input = Input("a name", int)
+
+        with self.assertRaises(ValueError):
+            class MockWidget(OWWidget):
+                name = "foo"
+                inputs = [("a name", int, "no_such_handler")]
+
+        # Now, don't crash
+        class MockWidget(OWWidget):
+            name = "foo"
+            inputs = [("a name", int, "handler")]
+
+            def handler(self):
+                pass
+
+    def test_signal_conversion(self):
+        class MockWidget(OWWidget):
+            name = "foo"
+            inputs = [("name 1", int, "foo"), InputSignal("name 2", int, "foo")]
+            outputs = [("name 3", int), OutputSignal("name 4", int)]
+
+            def foo(self):
+                pass
+
+        input1, input2 = MockWidget.inputs
+        self.assertIsInstance(input1, InputSignal)
+        self.assertEqual(input1.name, "name 1")
+        self.assertIsInstance(input2, InputSignal)
+        self.assertEqual(input2.name, "name 2")
+
+        output1, output2 = MockWidget.outputs
+        self.assertIsInstance(output1, OutputSignal)
+        self.assertEqual(output1.name, "name 3")
+        self.assertIsInstance(output2, OutputSignal)
+        self.assertEqual(output2.name, "name 4")
+
+    def test_get_signals(self):
+        class MockWidget(OWWidget):
+            name = "foo"
+            inputs = [("a name", int, "foo")]
+            outputs = [("another name", float)]
+
+            def foo(self):
+                pass
+
+        self.assertIs(MockWidget.get_signals("inputs"), MockWidget.inputs)
+        self.assertIs(MockWidget.get_signals("outputs"), MockWidget.outputs)
+
+        class MockWidget(OWWidget):
+            name = "foo"
+
+            class Inputs:
+                an_input = Input("a name", int)
+
+            class Outputs:
+                an_output = Output("another name", int)
+
+            @Inputs.an_input
+            def foo(self):
+                pass
+
+        input, = MockWidget.get_signals("inputs")
+        self.assertIsInstance(input, InputSignal)
+        self.assertEqual(input.name, "a name")
+
+        output, = MockWidget.get_signals("outputs")
+        self.assertIsInstance(output, OutputSignal)
+        self.assertEqual(output.name, "another name")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -1,3 +1,6 @@
+# Module imports Input, Output and AttributeList to be used in widgets
+# pylint: disable=unused-import
+
 import sys
 import os
 import types
@@ -12,6 +15,8 @@ from AnyQt.QtGui import QIcon, QKeySequence, QDesktopServices
 
 from Orange.data import FileFormat
 from Orange.widgets import settings, gui
+# OutputSignal and InputSignal are imported for compatibility, but shouldn't
+# be used; use Input and Output instead
 from Orange.canvas.registry import description as widget_description, \
     WidgetDescription, OutputSignal, InputSignal
 from Orange.canvas.report import Report
@@ -52,16 +57,9 @@ class WidgetMetaClass(type(QDialog)):
         cls = super().__new__(mcs, name, bases, kwargs)
         if not cls.name: # not a widget
             return cls
-
         cls.convert_signals()
-        # TODO Remove this when all widgets are migrated to Orange 3.0
-        if (hasattr(cls, "settingsToWidgetCallback") or
-                hasattr(cls, "settingsFromWidgetCallback")):
-            raise TypeError("Reimplement settingsToWidgetCallback and "
-                            "settingsFromWidgetCallback")
-
-        cls.settingsHandler = SettingsHandler.create(cls, template=cls.settingsHandler)
-
+        cls.settingsHandler = \
+            SettingsHandler.create(cls, template=cls.settingsHandler)
         return cls
 
 

--- a/doc/development/source/code/owNumber.py
+++ b/doc/development/source/code/owNumber.py
@@ -1,17 +1,18 @@
-from Orange.widgets import widget, gui
+from Orange.widgets import gui
+from Orange.widgets.widget import OWWidget, Output
 from Orange.widgets.settings import Setting
 from PyQt4.QtGui import QIntValidator
 
 
-class OWWidgetNumber(widget.OWWidget):
+class OWWidgetNumber(OWWidget):
     name = "Number"
-    id = "orange.widgets.data.number"
     description = "Lets the user input a number"
     icon = "icons/Unknown.svg"
     priority = 10
     category = ""
-    keywords = ["list", "of", "keywords"]
-    outputs = [("Number", int)]
+
+    class Outputs:
+        number = Output("Number", int)
 
     want_main_area = False
 
@@ -27,4 +28,4 @@ class OWWidgetNumber(widget.OWWidget):
         self.number_changed()
 
     def number_changed(self):
-        self.send("Number", self.number)
+        self.Outputs.number.send(self.number)

--- a/doc/development/source/orange-demo/orangedemo/OWDataSamplerA.py
+++ b/doc/development/source/orange-demo/orangedemo/OWDataSamplerA.py
@@ -3,16 +3,20 @@ import sys
 import numpy
 
 import Orange.data
-from Orange.widgets import widget, gui
+from Orange.widgets.widget import OWWidget, Input, Output
+from Orange.widgets import gui
 
-class OWDataSamplerA(widget.OWWidget):
+class OWDataSamplerA(OWWidget):
     name = "Data Sampler"
     description = "Randomly selects a subset of instances from the data set"
     icon = "icons/DataSamplerA.svg"
     priority = 10
 
-    inputs = [("Data", Orange.data.Table, "set_data")]
-    outputs = [("Sampled Data", Orange.data.Table)]
+    class Inputs:
+        data = Input("Data", Orange.data.Table)
+
+    class Outputs:
+        sample = Output("Sampled Data", Orange.data.Table)
 
     want_main_area = False
 
@@ -26,6 +30,7 @@ class OWDataSamplerA(widget.OWWidget):
 # [end-snippet-1]
 
 # [start-snippet-2]
+    @Inputs.data
     def set_data(self, dataset):
         if dataset is not None:
             self.infoa.setText('%d instances in input data set' % len(dataset))
@@ -33,18 +38,17 @@ class OWDataSamplerA(widget.OWWidget):
             indices = indices[:int(numpy.ceil(len(dataset) * 0.1))]
             sample = dataset[indices]
             self.infob.setText('%d sampled instances' % len(sample))
-            self.send("Sampled Data", sample)
+            self.Outputs.sample.send(sample)
         else:
             self.infoa.setText('No data on input yet, waiting to get something.')
             self.infob.setText('')
-            self.send("Sampled Data", None)
+            self.Outputs.sample.send("Sampled Data")
 # [end-snippet-2]
 
 # [start-snippet-3]
 def main(argv=sys.argv):
     from PyQt4.QtGui import QApplication
     app = QApplication(list(argv))
-    args = app.argv()
     if len(argv) > 1:
         filename = argv[1]
     else:

--- a/doc/development/source/orange-demo/orangedemo/OWDataSamplerB.py
+++ b/doc/development/source/orange-demo/orangedemo/OWDataSamplerB.py
@@ -2,17 +2,21 @@ import sys
 import numpy
 
 import Orange.data
-from Orange.widgets import widget, gui, settings
+from Orange.widgets.widget import OWWidget, Input, Output, settings
+from Orange.widgets import gui
 
 # [start-snippet-1]
-class OWDataSamplerB(widget.OWWidget):
+class OWDataSamplerB(OWWidget):
     name = "Data Sampler (B)"
     description = "Randomly selects a subset of instances from the data set."
     icon = "icons/DataSamplerB.svg"
     priority = 20
 
-    inputs = [("Data", Orange.data.Table, "set_data")]
-    outputs = [("Sampled Data", Orange.data.Table)]
+    class Inputs:
+        data = Input("Data", Orange.data.Table)
+
+    class Outputs:
+        sample = Output("Sampled Data", Orange.data.Table)
 
     proportion = settings.Setting(50)
     commitOnChange = settings.Setting(0)
@@ -44,6 +48,7 @@ class OWDataSamplerB(widget.OWWidget):
 # [end-snippet-3]
 
 # [start-snippet-4]
+    @Inputs.data
     def set_data(self, dataset):
         if dataset is not None:
             self.dataset = dataset
@@ -69,7 +74,7 @@ class OWDataSamplerB(widget.OWWidget):
         self.infob.setText('%d sampled instances' % len(self.sample))
 
     def commit(self):
-        self.send("Sampled Data", self.sample)
+        self.Outputs.sample.send(self.sample)
 
     def checkCommit(self):
         if self.commitOnChange:
@@ -79,7 +84,6 @@ class OWDataSamplerB(widget.OWWidget):
 def main(argv=sys.argv):
     from PyQt4.QtGui import QApplication
     app = QApplication(list(argv))
-    args = app.argv()
     if len(argv) > 1:
         filename = argv[1]
     else:

--- a/doc/development/source/orange-demo/orangedemo/OWDataSamplerC.py
+++ b/doc/development/source/orange-demo/orangedemo/OWDataSamplerC.py
@@ -2,19 +2,22 @@ import sys
 import numpy
 
 import Orange.data
-from Orange.widgets import widget, gui, settings
+from Orange.widgets.widget import OWWidget, Input, Output, settings
+from Orange.widgets import gui
 
 
-class OWDataSamplerC(widget.OWWidget):
+class OWDataSamplerC(OWWidget):
     name = "Data Sampler (C)"
     description = "Randomly selects a subset of instances from the data set."
     icon = "icons/DataSamplerC.svg"
     priority = 30
 
-    inputs = [("Data", Orange.data.Table, "set_data")]
+    class Inputs:
+        data = Input("Data", Orange.data.Table)
 # [start-snippet-1]
-    outputs = [("Sampled Data", Orange.data.Table),
-               ("Other Data", Orange.data.Table)]
+    class Outputs:
+        sample = Output("Sampled Data", Orange.data.Table)
+        other = Output("Other Data", Orange.data.Table)
 # [end-snippet-1]
     proportion = settings.Setting(50)
     commitOnChange = settings.Setting(0)
@@ -46,6 +49,7 @@ class OWDataSamplerC(widget.OWWidget):
 
         self.resize(100,50)
 
+    @Input.data
     def set_data(self, dataset):
         if dataset is not None:
             self.dataset = dataset
@@ -73,8 +77,8 @@ class OWDataSamplerC(widget.OWWidget):
         self.infob.setText('%d sampled instances' % len(self.sample))
 
     def commit(self):
-        self.send("Sampled Data", self.sample)
-        self.send("Other Data", self.otherdata)
+        self.Outputs.sample.send(self.sample)
+        self.Outputs.sample.send(self.otherdata)
 
     def checkCommit(self):
         if self.commitOnChange:
@@ -83,7 +87,6 @@ class OWDataSamplerC(widget.OWWidget):
 def main(argv=sys.argv):
     from PyQt4.QtGui import QApplication
     app = QApplication(list(argv))
-    args = app.argv()
     if len(argv) > 1:
         filename = argv[1]
     else:

--- a/doc/development/source/orange-demo/orangedemo/OWLearningCurveA.py
+++ b/doc/development/source/orange-demo/orangedemo/OWLearningCurveA.py
@@ -7,11 +7,12 @@ from PyQt4.QtGui import QTableWidget, QTableWidgetItem
 import Orange.data
 import Orange.classification
 
-from Orange.widgets import widget, gui, settings
+from Orange.widgets import gui, settings
+from Orange.widgets.widget import OWWidget, Input
 from Orange.evaluation.testing import Results
 
 
-class OWLearningCurveA(widget.OWWidget):
+class OWLearningCurveA(OWWidget):
     name = "Learning Curve (A)"
     description = ("Takes a data set and a set of learners and shows a "
                    "learning curve in a table")
@@ -19,9 +20,10 @@ class OWLearningCurveA(widget.OWWidget):
     priority = 1000
 
 # [start-snippet-1]
-    inputs = [("Data", Orange.data.Table, "set_dataset"),
-              ("Learner", Orange.classification.Learner, "set_learner",
-               widget.Multiple + widget.Default)]
+    class Inputs:
+        data = Input("Data", Orange.data.Table)
+        learner = Input("Learner", Orange.classification.Learner,
+                        multiple=True)
 # [end-snippet-1]
 
     #: cross validation folds
@@ -97,6 +99,7 @@ class OWLearningCurveA(widget.OWWidget):
     ##########################################################################
     # slots: handle input signals
 
+    @Inputs.data
     def set_dataset(self, data):
         """Set the input train dataset."""
         # Clear all results/scores
@@ -114,6 +117,7 @@ class OWLearningCurveA(widget.OWWidget):
 
         self.commitBtn.setEnabled(self.data is not None)
 
+    @Inputs.learner
     def set_learner(self, learner, id):
         """Set the input learner for channel id."""
         if id in self.learners:

--- a/doc/development/source/orange-demo/orangedemo/OWLearningCurveB.py
+++ b/doc/development/source/orange-demo/orangedemo/OWLearningCurveB.py
@@ -10,11 +10,12 @@ from PyQt4.QtGui import QTableWidget, QTableWidgetItem
 import Orange.data
 import Orange.classification
 
-from Orange.widgets import widget, gui, settings
+from Orange.widgets import gui, settings
+from Orange.widgets.widget import OWWidget, Input
 from Orange.evaluation.testing import Results
 
 
-class OWLearningCurveB(widget.OWWidget):
+class OWLearningCurveB(OWWidget):
     name = "Learning Curve (B)"
     description = ("Takes a data set and a set of learners and shows a "
                    "learning curve in a table")
@@ -22,10 +23,11 @@ class OWLearningCurveB(widget.OWWidget):
     priority = 1010
 
 # [start-snippet-1]
-    inputs = [("Data", Orange.data.Table, "set_dataset", widget.Default),
-              ("Test Data", Orange.data.Table, "set_testdataset"),
-              ("Learner", Orange.classification.Learner, "set_learner",
-               widget.Multiple + widget.Default)]
+    class Inputs:
+        data = Input("Data", Orange.data.Table, default=True)
+        test_data = Input("Test Data", Orange.data.Table)
+        learner = Input("Learner", Orange.classification.Learner,
+                        multiple=True)
 # [end-snippet-1]
 
     #: cross validation folds
@@ -101,6 +103,7 @@ class OWLearningCurveB(widget.OWWidget):
     ##########################################################################
     # slots: handle input signals
 
+    @Inputs.data
     def set_dataset(self, data):
         """Set the input train dataset."""
         # Clear all results/scores
@@ -118,6 +121,7 @@ class OWLearningCurveB(widget.OWWidget):
 
         self.commitBtn.setEnabled(self.data is not None)
 
+    @Inputs.test_data
     def set_testdataset(self, testdata):
         """Set a separate test dataset."""
         # Clear all results/scores
@@ -128,6 +132,7 @@ class OWLearningCurveB(widget.OWWidget):
 
         self.testdata = testdata
 
+    @Inputs.learner
     def set_learner(self, learner, id):
         """Set the input learner for channel id."""
         if id in self.learners:

--- a/doc/development/source/tutorial-channels.rst
+++ b/doc/development/source/tutorial-channels.rst
@@ -55,28 +55,12 @@ widget are defined by
 
 
 Notice that everything is pretty much the same as it was with
-widgets from previous lessons, the only difference being
-``widget.Multiple + widget.Default`` (from the
-:mod:`Orange.widgets.widget` namespace) as the last value in the list
-that defines the :obj:`Learner` channel. This
-``widget.Multiple + widget.Default`` says that this
-is a multi-input channel and is the default input for its type.
-If it would be unspecified then by default value of
-``widget.Single`` would be used. That would mean that the
-widget can receive the input only from one widget and is not
-the default input channel for its type (more on default channels later).
+widgets from previous lessons, the only difference being the additional argument
+``multiple=True``, which says that this input can be connected to outputs of
+multiple widgets.
 
-.. note::
-   :obj:`Default` flag here is used for illustration. Since *"Learner"*
-   channel is the only channel for a :class:`Orange.classification.Learner`
-   type it is also the default.
-
-In Orange, tokens are sent around with an id of a widget that is
-sending the token, and having a multi-input channel only tells Orange to
-send a token together with sending widget id, the two arguments with
-which the receiving function is called. For our *"Learner"*
-channel the receiving function is :func:`set_learner`, and this looks
-like the following
+Handlers of multiple-input signals must accept two arguments: the sent object
+and the id of the sending widget.
 
 .. literalinclude:: orange-demo/orangedemo/OWLearningCurveA.py
    :pyobject: OWLearningCurveA.set_learner
@@ -100,27 +84,6 @@ link was removed/closed) or invalidates the cross validation results
 and curve point for that channel id, marking for update in
 :func:`~Orange.widgets.widget.OWWidget.handleNewSignals`. A similar case is
 when we receive a learner for a new channel id.
-
-.. 
-
-   The function above first checks if the learner sent is empty
-   (:obj:`None`). Remember that sending an empty learner
-   essentially means that the link with the sending widget was removed,
-   hence we need to remove such learner from our list. If a non-empty
-   learner was sent, then it is either a new learner (say, from a widget
-   we have just linked to our learning curve widget), or an update
-   version of the previously sent learner. If the later is the case, then
-   there is an *id* which we already have in the learners list, and we
-   need to replace previous information on that learner. If a new learner
-   was sent, the case is somehow simpler, and we just add this learner
-   and its learning curve to the corresponding variables that hold this
-   information.
-
-   The function that handles :obj:`learners` as shown above is
-   the most complicated function in our learning curve widget. In fact,
-   the rest of the widget does some simple GUI management, and calls
-   learning curve routines from testing and performance scoring functions
-   from :mod:`~Orange.evaluation`.
 
 Note that in this widget the evaluation (k-fold cross
 validation) is carried out just once given the learner, data set and
@@ -214,10 +177,9 @@ open, as the default *"Train Data"* was selected.
 Explicit Channels
 *****************
 
-
-Some times when a widget has multiple outputs of different types, some
+Sometimes when a widget has multiple outputs of different types, some
 of them should not be subject to this automatic default connection selection.
 An example of this is in Orange's `Logistic Regression` widget that outputs
-a suplimentary 'Coefficients' data table. Such outputs can be marked with
-and :attr:`~Orange.widgets.widget.Explicit` flag ensuring they are never
+a supplementary 'Coefficients' data table. Such outputs can be marked with
+and :attr:`~Orange.widgets.widget.Explicit` flag, which ensures they are never
 selected for a default connection.

--- a/doc/development/source/tutorial-cont.rst
+++ b/doc/development/source/tutorial-cont.rst
@@ -3,7 +3,7 @@ Getting Started (Continued)
 ###########################
 
 After learning what an Orange Widget is and how to define them on
-a toy example, we will build an semi-usefull widgets that can
+a toy example, we will build an semi-useful widgets that can
 work together with the existing Orange Widgets.
 
 We will start with a very simple one, that will receive a data set
@@ -13,8 +13,8 @@ DataSampler since this is what widget will be doing, and A since we
 prototype a number of this widgets in our tutorial).
 
 
-A package named Demo
---------------------
+A 'Demo' package
+----------------
 
 First in order to include our new widgets in the Orange Canvas's
 toolbox we will create a dummy `python project
@@ -49,18 +49,15 @@ widget starts out as:
    :start-after: start-snippet-1
    :end-before: end-snippet-1
 
-Widget defines one input and one output channel. For input, this is a *Data*
-channel, accepting objects of the type :class:`Orange.data.Table` and
-specifying that :func:`set_data` method will be used to handle them.
-For now, we will use a single output channel called "Sampled Data",
-which will be of the same type (:class:`Orange.data.Table`).
+The widget defines an input channel "Data" and an output channel called
+"Sampled Data". Both will carry tokens of the type :class:`Orange.data.Table`.
+In the code, we will refer to the signals as `Inputs.data` and `Outputs.sample`.
 
-Notice that the types of the channels are specified by a class;
-you can use any class here, but if your widgets need to talk with
-other widgets in Orange, you will need to check which classes are
-used there. Luckily, and as one of the main design principles,
-there are just a few channel types that current Orange widgets are
-using.
+Channels can carry tokens of arbitrary types. However, the purpose of widgets
+is to talk with other widgets, so as one of the main design principles we try
+to maximize the flexibility of widgets by minimizing the number of different
+channel types. Do not invent new signal types before checking whether you cannot
+reuse the existing.
 
 As our widget won't display anything apart from some info, we will
 place the two labels in the control area and surround it with the box
@@ -72,11 +69,11 @@ will happen, the first line will report on "no data yet", and second
 line will be empty.
 
 
-In order to complete our widget, we now need to define how will it
-handle the input data. This is done in a method called :func:`set_data`
-(remember, we did introduce this name in the specification of the
-input channel)
-
+In order to complete our widget, we now need to define a method that will
+handle the input data. We will call it :func:`set_data`; the name is arbitrary,
+but calling the method `set_<the name of the input>` seems like a good practice.
+To designate it as the method that accepts the signal defined in `Inputs.data`,
+we decorate it with `@Inputs.data`.
 
 .. literalinclude:: orange-demo/orangedemo/OWDataSamplerA.py
    :start-after: start-snippet-2
@@ -85,17 +82,18 @@ input channel)
 The :obj:`dataset` argument is the token sent through the input
 channel which our method needs to handle.
 
-To handle the non-empty token, the widget updates the interface
+To handle a non-empty token, the widget updates the interface
 reporting on number of data items on the input, then does the data
 sampling using Orange's routines for these, and updates the
 interface reporting on the number of sampled instances. Finally, the
-sampled data is sent as a token to the output channel with a name
-"Sampled Data".
+sampled data is sent as a token to the output channel defined as
+`Output.sample`.
 
 Although our widget is now ready to test, for a final touch, let's
 design an icon for our widget. As specified in the widget header, we
-will call it :download:`DataSamplerA.svg <orange-demo/orangedemo/icons/DataSamplerA.svg>` and will
-put it in `icons` subdirectory of `orangedemo` directory.
+will call it
+:download:`DataSamplerA.svg <orange-demo/orangedemo/icons/DataSamplerA.svg>`
+and put it in `icons` subdirectory of `orangedemo` directory.
 
 
 With this we can now go ahead and install the orangedemo package. We

--- a/doc/development/source/tutorial-settings.rst
+++ b/doc/development/source/tutorial-settings.rst
@@ -167,6 +167,7 @@ that handles the data signal. This is how it looks in the scatter plot
 
 .. code-block:: python
 
+    @Input.data
     def set_data(self, data):
         self.closeContext()
         self.data = data

--- a/doc/development/source/widget.rst
+++ b/doc/development/source/widget.rst
@@ -14,8 +14,7 @@ Widget Meta Description
 
 Every widget in the canvas framework needs to define it's meta definition.
 This includes the widget's name and text descriptions but more
-importantly also its input/output specification. This is done by defining
-constants in the widget's class namespace:
+importantly also its input/output specification.
 
 .. code-block:: python
 
@@ -23,22 +22,21 @@ constants in the widget's class namespace:
         name = "Integer Constant"
         description = "A simple integer constant"
 
-        outputs = [("Constant", int)]
+        class Outputs:
+            constant = Output("Constant", int)
 
         ...
 
         def commit(self):
-            """
-            Commit/send the outputs.
-            """
-            self.send("Constant", 42)
+            """Commit/send the outputs."""
+            self.Outputs.constant.send(42)
 
 Omitting the implementation details, this defines a simple node named
 *Integer Constant* which outputs (on a signal called *Constant*) a single
 object of type :class:`int`.
 
-The node's inputs are defined similarly but with and extra field naming
-the widget instance method which accepts the inputs at runtime:
+The node's inputs are defined similarly. Each input is then used as a decorator
+of its corresponding handler method, which accepts the inputs at runtime:
 
 .. code-block:: python
 
@@ -46,17 +44,21 @@ the widget instance method which accepts the inputs at runtime:
         name = "Add two integers"
         description = "Add two numbers"
 
-        inputs = [("A", int, "set_A"),
-                  ("B", int, "set_B")]
+        class Inputs:
+            a = Input("A", int)
+            b = Input("B", int)
 
-        outputs = [("A + B", int")]
+        class Outputs:
+            sum = Input("A + B", int)
 
         ...
 
+        @Inputs.a
         def set_A(self, a):
             """Set the `A` input."""
             self.A = a
 
+        @Inputs.b
         def set_B(self, b):
             """Set the `B` input."""
             self.B = b
@@ -66,10 +68,8 @@ the widget instance method which accepts the inputs at runtime:
             self.commit()
 
         def commit(self):
-            """
-            Commit/send the outputs.
-            """
-            sef.send("result", self.A + self.B)
+            """Commit/send the outputs"""
+            sef.Outputs.sum.send("self.A + self.B)
 
 
 .. seealso:: :doc:`Getting Started Tutorial <tutorial>`
@@ -79,78 +79,34 @@ Input/Output Signal Definitions
 -------------------------------
 
 Widgets specify their input/output capabilities in their class definitions
-by means of a ``inputs`` and ``outputs`` class attributes which are lists of
-tuples or lists of :class:`InputSignal`/:class:`OutputSignal`.
+by defining classes named `Inputs` and `Outputs`, which contain class
+attributes of type `Input` and `Output`, correspondingly. `Input` and `Output`
+require at least two arguments, the signal's name (as shown in canvas) and
+type. Optional arguments further define the behaviour of the signal.
 
-   * An input is defined by a ``(name, type, methodname [, flags])`` tuple
-     or an :class:`InputSignal`.
+**Note**: old-style signals define the input and output signals using class
+attributes `inputs` and `outputs` instead of classes `Input` and `Output`.
+The two attributes contain a list of tuples with the name and type and,
+for inputs, the name of the handler method. The optional last argument
+is an integer constant giving the flags. This style of signal definition
+is deprecated.
 
-     The `name` is the input's descriptive name, `type` the type of objects
-     received, `methodname` a `str` naming a widget member method that will
-     receive the input, and optional `flags`.
+.. autoclass:: Input
 
-   * An output is defined by a ``(name, type, flags)`` tuple or an
-     :class:`OutputSignal`
-
-Input/Output flags:
-
-.. attribute:: Default
-
-   This input is the default for it's type.
-   When there are multiple IO signals with the same type the
-   one with the default flag takes precedence when adding a new
-   link in the canvas.
-
-.. attribute:: Multiple
-
-   Multiple signal (more then one input on the channel). Input with this
-   flag receive a second parameter `id`.
-
-.. attribute:: Dynamic
-
-   Only applies to output. Specifies that the instances on the output
-   will in general be subtypes of the declared type and that the output
-   can be connected to any input which can accept a subtype of the
-   declared output type.
-
-.. attribute:: Explicit
-
-   Outputs with an explicit flag are never selected (auto connected) among
-   candidate connections. Connections are only established when there is
-   one unambiguous connection possible or through a dedicated 'Links'
-   dialog.
-
-.. autoclass:: InputSignal
-
-.. autoclass:: OutputSignal
-
+.. autoclass:: Output
 
 Sending/Receiving
 -----------------
 
-The widgets receive inputs at runtime with the designated handler method
-(specified in the :const:`OWWidget.inputs` class member).
+The widgets receive inputs at runtime with the handler method decorated with
+the signal, as shown in the above examples.
 
-If a widget defines multiple inputs it can coalesce updates by reimplementing
-:func:`OWWidget.handleNewSignals` method.
-
-.. code-block:: python
-
-   def set_foo(self, foo):
-      self.foo = foo
-
-   def set_bar(self, bar):
-      self.bar = bar
-
-   def handleNewSignals(self)
-      dosomething(self.foo, self.bar)
-
-
-If an input is defined with the :const:`Multiple`, then the input handler
-method also receives an connection `id` uniquely identifying a
+If an input is defined with the flag `multiple` set, the input handler
+method also receives a connection `id` uniquely identifying a
 connection/link on which the value was sent (see also :doc:`tutorial-channels`)
 
-The widgets publish their outputs using :meth:`OWWidget.send` method.
+The widget sends an output by calling the signal's `send` method, as shown
+above.
 
 Accessing Controls though Attribute Names
 -----------------------------------------

--- a/pylintrc
+++ b/pylintrc
@@ -342,7 +342,7 @@ max-branches=12
 max-statements=200
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=9
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20


### PR DESCRIPTION
A different take on #2292 and #2290.

## Widget discovery

Widget discovery code used to search for classes with metatype `WidgetMetaClass`, and then it extracted information contained in class attributes into `WidgetDescription`. The canvas thus had to import `WidgetMetaClass` and dug into the widget's attributes.

In this PR, the widget must describe itself. Discovery searches for any class that implements `get_widget_description`, which returns a `WidgetDescription`. Signals are described with `InputSignal` and `OutputSignal`; the widget can represent them internally in any way it wants.

The idea here is that canvas knows less about widget implementation. The entire API would be (more or less) that canvas exposes descriptive classes (`WidgetDescription`, `InputSignal`, `OutputSignal`) and requires that objects driven by the canvas implement a single method (`get_widget_description`). Ideally, canvas would no longer import any widget modules or assume anything else about widgets. This would be a step towards entirely separating the canvas from widgets.

## New-style Signals

Signals are changed as already proposed in #2292 but without touching canvas. Signals can be declared as follows.

```
class OWTestLearners:
    ...
    class Inputs:
        train_data = Input("Data", Table, default=True)
        test_data = Input("Test Data", Table)
        learner = Input("Learner", Learner, multiple=True)
        preprocessor = Input("Preprocessor", Preprocess)

    class Outputs:
        predictions = Output("Predictions", Table)
        evaluations_results = Output("Evaluation Results", Results)
```

Input handlers are than marked with

    @Inputs.train_data
    def set_train_data(self, data):

and outputs are sent by

    Outputs.predictions.send(predictions)

This is convenient since we don't have to write handlers' names (as string literals); any errors doing this were however already catched in the widget's metaclass. Disadvantage: inputs are not longer listed out in the beginning. Advantage: the sole reason for looking at those lists was to find handler names (and then searching for the corresponding method). Now you can just search for "InputSignal".

The code is compatible with the existing code.

##### Includes
- [X] Code changes
- [X] Tests
- [x] Documentation