### PR TITLE
[MNT] Travis: Stop running radon in favor of codeclimate

### DIFF
--- a/.travis/stage_script.sh
+++ b/.travis/stage_script.sh
@@ -2,6 +2,7 @@
 if [ "$RUN_PYLINT" ]; then
     cd $TRAVIS_BUILD_DIR
     foldable pip install -r requirements-dev.txt
+    foldable pip uninstall -y radon     # disable radon in favor of codeclimate
     cp pylintrc ~/.pylintrc
     .travis/check_pylint_diff
     exit $?


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Radon requirements occasionally cannot be met while a pass on Travis is required for all PRs.

##### Description of changes
Stop running radon on Travis and check codeclimate instead.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
