### PR TITLE
[ENH] Improve support for HiDPI displays

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -20,7 +20,9 @@ import pkg_resources
 
 from AnyQt.QtGui import QFont, QColor, QDesktopServices
 from AnyQt.QtWidgets import QMessageBox
-from AnyQt.QtCore import Qt, QDir, QUrl, QSettings, QThread, pyqtSignal
+from AnyQt.QtCore import (
+    Qt, QDir, QUrl, QSettings, QThread, pyqtSignal, QT_VERSION
+)
 
 from Orange import canvas
 from Orange.canvas.application.application import CanvasApplication
@@ -240,6 +242,9 @@ def main(argv=None):
         qt_argv += shlex.split(options.qt)
 
     qt_argv += args
+
+    if QT_VERSION >= 0x50600:
+        CanvasApplication.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
     log.debug("Starting CanvasApplicaiton with argv = %r.", qt_argv)
     app = CanvasApplication(qt_argv)

--- a/Orange/canvas/application/welcomedialog.py
+++ b/Orange/canvas/application/welcomedialog.py
@@ -8,7 +8,7 @@ from AnyQt.QtWidgets import (
     QHBoxLayout, QVBoxLayout, QSizePolicy, QLabel
 )
 from AnyQt.QtGui import QFont, QIcon, QPixmap, QPainter, QColor, QBrush
-from AnyQt.QtCore import Qt, QRect, QPoint
+from AnyQt.QtCore import Qt, QRect, QSize, QPoint, QT_VERSION
 from AnyQt.QtCore import pyqtSignal as Signal
 
 from ..canvas.items.utils import radial_gradient
@@ -19,17 +19,15 @@ def decorate_welcome_icon(icon, background_color):
     """Return a `QIcon` with a circle shaped background.
     """
     welcome_icon = QIcon()
-    sizes = [32, 48, 64, 80]
+    sizes = [32, 48, 64, 80, 128, 256]
     background_color = NAMED_COLORS.get(background_color, background_color)
     background_color = QColor(background_color)
     grad = radial_gradient(background_color)
     for size in sizes:
-        icon_pixmap = icon.pixmap(5 * size / 8, 5 * size / 8)
-        icon_size = icon_pixmap.size()
+        icon_size = QSize(5 * size / 8, 5 * size / 8)
         icon_rect = QRect(QPoint(0, 0), icon_size)
-
         pixmap = QPixmap(size, size)
-        pixmap.fill(QColor(0, 0, 0, 0))
+        pixmap.fill(Qt.transparent)
         p = QPainter(pixmap)
         p.setRenderHint(QPainter.Antialiasing, True)
         p.setBrush(QBrush(grad))
@@ -37,7 +35,7 @@ def decorate_welcome_icon(icon, background_color):
         ellipse_rect = QRect(0, 0, size, size)
         p.drawEllipse(ellipse_rect)
         icon_rect.moveCenter(ellipse_rect.center())
-        p.drawPixmap(icon_rect.topLeft(), icon_pixmap)
+        icon.paint(p, icon_rect, Qt.AlignCenter, )
         p.end()
 
         welcome_icon.addPixmap(pixmap)

--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -100,11 +100,19 @@ class NodeBodyItem(GraphicsPathObject):
             blurRadius=3,
             color=QColor(SHADOW_COLOR),
             offset=QPointF(0, 0),
-            )
-
-        self.setGraphicsEffect(self.shadow)
+        )
         self.shadow.setEnabled(True)
 
+        # An item with the same shape as this object, stacked behind this
+        # item as a source for QGraphicsDropShadowEffect. Cannot attach
+        # the effect to this item directly as QGraphicsEffect makes the item
+        # non devicePixelRatio aware.
+        shadowitem = GraphicsPathObject(self, objectName="shadow-shape-item")
+        shadowitem.setPen(Qt.NoPen)
+        shadowitem.setBrush(QBrush(QColor(SHADOW_COLOR).lighter()))
+        shadowitem.setGraphicsEffect(self.shadow)
+        shadowitem.setFlag(QGraphicsItem.ItemStacksBehindParent)
+        self.__shadow = shadowitem
         self.__blurAnimation = QPropertyAnimation(self.shadow, b"blurRadius",
                                                   self)
         self.__blurAnimation.setDuration(100)
@@ -125,6 +133,7 @@ class NodeBodyItem(GraphicsPathObject):
         path = QPainterPath()
         path.addEllipse(rect)
         self.setPath(path)
+        self.__shadow.setPath(path)
         self.__shapeRect = rect
 
     def setPalette(self, palette):

--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -10,13 +10,15 @@ from xml.sax.saxutils import escape
 
 from AnyQt.QtWidgets import (
     QGraphicsItem, QGraphicsObject, QGraphicsTextItem,
-    QGraphicsDropShadowEffect, QGraphicsView, QStyle, QApplication
+    QGraphicsDropShadowEffect, QStyle, QApplication
 )
 from AnyQt.QtGui import (
     QPen, QBrush, QColor, QPalette, QIcon, QPainter, QPainterPath,
     QPainterPathStroker
 )
-from AnyQt.QtCore import Qt, QPointF, QRectF, QSize, QTimer, QPropertyAnimation
+from AnyQt.QtCore import (
+    Qt, QPointF, QRectF, QRect, QSize, QTimer, QPropertyAnimation
+)
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtProperty as Property
 
 from .graphicspathobject import GraphicsPathObject
@@ -656,34 +658,13 @@ class GraphicsIconItem(QGraphicsItem):
             else:
                 mode = QIcon.Disabled
 
-            transform = self.sceneTransform()
-
-            if widget is not None:
-                # 'widget' is the QGraphicsView.viewport()
-                view = widget.parent()
-                if isinstance(view, QGraphicsView):
-                    # Combine the scene transform with the view transform.
-                    view_transform = view.transform()
-                    transform = view_transform * view_transform
-
-            lod = option.levelOfDetailFromTransform(transform)
-
             w, h = self.__iconSize.width(), self.__iconSize.height()
-            target = QRectF(0, 0, w, h)
-            source = QRectF(0, 0, w * lod, w * lod).toRect()
-
-            # The actual size of the requested pixmap can be smaller.
-            size = self.__icon.actualSize(source.size(), mode=mode)
-            source.setSize(size)
-
-            pixmap = self.__icon.pixmap(source.size(), mode=mode)
-
+            target = QRect(0, 0, w, h)
             painter.setRenderHint(
                 QPainter.SmoothPixmapTransform,
                 self.__transformationMode == Qt.SmoothTransformation
             )
-
-            painter.drawPixmap(target, pixmap, QRectF(source))
+            self.__icon.paint(painter, target, Qt.AlignCenter, mode)
 
 
 class NameTextItem(QGraphicsTextItem):

--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -196,10 +196,10 @@ class NodeBodyItem(GraphicsPathObject):
         if self.__progress >= 0:
             # Draw the progress meter over the shape.
             # Set the clip to shape so the meter does not overflow the shape.
+            painter.save()
             painter.setClipPath(self.shape(), Qt.ReplaceClip)
             color = self.palette.color(QPalette.ButtonText)
             pen = QPen(color, 5)
-            painter.save()
             painter.setPen(pen)
             painter.setRenderHints(QPainter.Antialiasing)
             span = max(1, int(self.__progress * 57.60))

--- a/Orange/canvas/gui/toolbox.py
+++ b/Orange/canvas/gui/toolbox.py
@@ -100,21 +100,6 @@ class ToolBoxTabButton(QToolButton):
             background_brush = palette.button()
 
         rect = opt.rect
-        icon = opt.icon
-        icon_size = opt.iconSize
-
-        # TODO: add shift for pressed as set by the style (PM_ButtonShift...)
-
-        pm = None
-        if not icon.isNull():
-            if opt.state & QStyle.State_Enabled:
-                mode = QIcon.Normal
-            else:
-                mode = QIcon.Disabled
-
-            pm = opt.icon.pixmap(
-                    rect.size().boundedTo(icon_size), mode,
-                    QIcon.On if opt.state & QStyle.State_On else QIcon.Off)
 
         icon_area_rect = QRect(rect)
         icon_area_rect.setRight(int(icon_area_rect.height() * 1.26))
@@ -176,11 +161,20 @@ class ToolBoxTabButton(QToolButton):
                    int(Qt.AlignVCenter | Qt.AlignLeft) | \
                    int(Qt.TextSingleLine),
                    text)
-        if pm:
-            pm_rect = QRect(QPoint(0, 0), pm.size())
-            centered_rect = QRect(pm_rect)
-            centered_rect.moveCenter(icon_area_rect.center())
-            p.drawPixmap(centered_rect, pm, pm_rect)
+
+        if not opt.icon.isNull():
+            if opt.state & QStyle.State_Enabled:
+                mode = QIcon.Normal
+            else:
+                mode = QIcon.Disabled
+            if opt.state & QStyle.State_On:
+                state = QIcon.On
+            else:
+                state = QIcon.Off
+            icon_area_rect = icon_area_rect
+            icon_rect = QRect(QPoint(0, 0), opt.iconSize)
+            icon_rect.moveCenter(icon_area_rect.center())
+            opt.icon.paint(p, icon_rect, Qt.AlignCenter, mode, state)
         p.restore()
 
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -995,20 +995,29 @@ def createAttributePixmap(char, background=Qt.black, color=Qt.white):
     :type color: QColor
     :rtype: QIcon
     """
-    pixmap = QtGui.QPixmap(13, 13)
-    pixmap.fill(QtGui.QColor(0, 0, 0, 0))
-    painter = QtGui.QPainter()
-    painter.begin(pixmap)
-    painter.setRenderHints(painter.Antialiasing | painter.TextAntialiasing |
-                           painter.SmoothPixmapTransform)
-    painter.setPen(background)
-    painter.setBrush(background)
-    rect = QtCore.QRectF(0, 0, 13, 13)
-    painter.drawRoundedRect(rect, 4, 4)
-    painter.setPen(color)
-    painter.drawText(2, 11, char)
-    painter.end()
-    return QtGui.QIcon(pixmap)
+    icon = QtGui.QIcon()
+    for size in (13, 16, 18, 20, 22, 24, 28, 32, 64):
+        pixmap = QtGui.QPixmap(size, size)
+        pixmap.fill(Qt.transparent)
+        painter = QtGui.QPainter()
+        painter.begin(pixmap)
+        painter.setRenderHints(painter.Antialiasing | painter.TextAntialiasing |
+                               painter.SmoothPixmapTransform)
+        painter.setPen(background)
+        painter.setBrush(background)
+        margin = 1 + size // 16
+        text_margin = size // 20
+        rect = QtCore.QRectF(margin, margin,
+                             size - 2 * margin, size - 2 * margin)
+        painter.drawRoundedRect(rect, 30.0, 30.0, Qt.RelativeSize)
+        painter.setPen(color)
+        font = painter.font()  # type: QtGui.QFont
+        font.setPixelSize(size - 2 * margin - 2 * text_margin)
+        painter.setFont(font)
+        painter.drawText(rect, Qt.AlignCenter, char)
+        painter.end()
+        icon.addPixmap(pixmap)
+    return icon
 
 
 class __AttributeIconDict(dict):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Parts of the canvas are unaware of QPaintDevice.devicePixelRatio.

##### Description of changes

* Enable use of high dpi pixmaps if available. 
* Provide larger generated icons where applicable.
* Use QIcon.paint instead of going through QIcon.pixmap -> drawPixmap.
* Workaround for QGraphicsEffect lack of devicePixelRatio support.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
