### PR TITLE
[ENH] Improved Sparsity Handling

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1649,6 +1649,40 @@ class Table(MutableSequence, Storage):
         self.attributes["old_domain"] = table.domain
         return self
 
+    def to_sparse(self, sparse_attributes=True, sparse_class=False,
+                  sparse_metas=False):
+        def sparsify(features):
+            for f in features:
+                f.sparse = True
+
+        new_domain = self.domain.copy()
+
+        if sparse_attributes:
+            sparsify(new_domain.attributes)
+        if sparse_class:
+            sparsify(new_domain.class_vars)
+        if sparse_metas:
+            sparsify(new_domain.metas)
+        return self.transform(new_domain)
+
+    def to_dense(self, dense_attributes=True, dense_class=True,
+                 dense_metas=True):
+        def densify(features):
+            for f in features:
+                f.sparse = False
+
+        new_domain = self.domain.copy()
+
+        if dense_attributes:
+            densify(new_domain.attributes)
+        if dense_class:
+            densify(new_domain.class_vars)
+        if dense_metas:
+            densify(new_domain.metas)
+        t = self.transform(new_domain)
+        t.ids = self.ids    # preserve indices
+        return t
+
 
 def _check_arrays(*arrays, dtype=None):
     checked = []

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1704,7 +1704,7 @@ def _check_arrays(*arrays, dtype=None):
 
         if ninstances(array) != shape_1:
             raise ValueError("Leading dimension mismatch (%d != %d)"
-                             % (len(array), shape_1))
+                             % (ninstances(array), shape_1))
 
         if sp.issparse(array):
             array.data = np.asarray(array.data)

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -382,18 +382,19 @@ class Table(MutableSequence, Storage):
                 self.domain = domain
                 conversion = domain.get_conversion(source.domain)
                 self.X = get_columns(row_indices, conversion.attributes, n_rows,
-                                     is_sparse=sp.issparse(source.X))
+                                     is_sparse=conversion.sparse_X)
                 if self.X.ndim == 1:
                     self.X = self.X.reshape(-1, len(self.domain.attributes))
+
                 self.Y = get_columns(row_indices, conversion.class_vars, n_rows,
-                                     is_sparse=sp.issparse(source.Y))
+                                     is_sparse=conversion.sparse_Y)
 
                 dtype = np.float64
                 if any(isinstance(var, StringVariable) for var in domain.metas):
                     dtype = np.object
                 self.metas = get_columns(row_indices, conversion.metas,
                                          n_rows, dtype,
-                                         is_sparse=sp.issparse(source.metas))
+                                         is_sparse=conversion.sparse_metas)
                 if self.metas.ndim == 1:
                     self.metas = self.metas.reshape(-1, len(self.domain.metas))
                 if source.has_weights():

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -89,3 +89,34 @@ def hstack(arrays):
         return sp.hstack(arrays)
     else:
         return np.hstack(arrays)
+
+
+def assure_array_dense(a):
+    if sp.issparse(a):
+        a = a.toarray()
+    return a
+
+
+def assure_array_sparse(a):
+    if not sp.issparse(a):
+        # since x can be a list, cast to np.array
+        # since x can come from metas with string, cast to float
+        a = np.asarray(a).astype(np.float)
+        return sp.csc_matrix(a)
+    return a
+
+
+def assure_column_sparse(a):
+    a = assure_array_sparse(a)
+    # if x of shape (n, ) is passed to csc_matrix constructor,
+    # the resulting matrix is of shape (1, n) and hence we
+    # need to transpose it to make it a column
+    if a.shape[0] == 1:
+        a = a.T
+    return a
+
+
+def assure_column_dense(a):
+    a = assure_array_dense(a)
+    # column assignments must be of shape (n,) and not (n, 1)
+    return np.ravel(a)

--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sp
 
-from Orange.data import DiscreteVariable, Domain, Table
+from Orange.data import DiscreteVariable, Domain
 from Orange.data.sql.table import SqlTable
 from Orange.preprocess.util import _RefuseDataInConstructor
 from Orange.statistics import distribution, contingency

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -157,7 +157,7 @@ class ReplaceUnknownsModel(Reprable):
             column = np.array([float(data[self.variable])])
         else:
             column = np.array(data.get_column_view(self.variable)[0],
-                                 copy=True)
+                              copy=True)
 
         mask = np.isnan(column)
         if not np.any(mask):

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from Orange.data import (
-    ContinuousVariable, DiscreteVariable,  StringVariable, TimeVariable,
+    ContinuousVariable, DiscreteVariable, StringVariable, TimeVariable,
     Variable, Domain, Table, DomainConversion)
 from Orange.data.domain import filter_visible
 from Orange.preprocess import Continuize, Impute
@@ -165,7 +165,8 @@ class TestDomainInit(unittest.TestCase):
                                             (0, 2, DiscreteVariable),
                                             (18, 23, ContinuousVariable)]:
             n_rows, n_cols, = aran_max - aran_min, 1
-            d = Domain.from_numpy(np.zeros((1, 1)), np.arange(aran_min, aran_max).reshape(n_rows, n_cols))
+            d = Domain.from_numpy(np.zeros((1, 1)),
+                                  np.arange(aran_min, aran_max).reshape(n_rows, n_cols))
             self.assertTrue(d.anonymous)
             self.assertIsInstance(d.class_var, vartype)
             if isinstance(vartype, DiscreteVariable):
@@ -402,14 +403,14 @@ class TestDomainInit(unittest.TestCase):
         assert_array_equal(y, np.array([0]))
         metas_exp = [gender.Unknown, education.Unknown, ssn.Unknown]
 
-        def eq(a, b):
+        def equal(a, b):
             if isinstance(a, Real) and isinstance(b, Real) and \
                     np.isnan(a) and np.isnan(b):
                 return True
             else:
                 return a == b
 
-        self.assertTrue(all(starmap(eq, zip(metas, metas_exp))))
+        self.assertTrue(all(starmap(equal, zip(metas, metas_exp))))
 
         x, y, metas = domain.convert([42, 13, "White", "M", "HS", "1234567"])
         assert_array_equal(x, np.array([42, 13]))

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -3,7 +3,7 @@
 import warnings
 from time import time
 from numbers import Real
-from itertools import starmap
+from itertools import starmap, chain
 import unittest
 import pickle
 
@@ -501,6 +501,42 @@ class TestDomainInit(unittest.TestCase):
 
         self.assertEqual(domain[age].number_of_decimals, 5)
         self.assertEqual(new_domain[age].number_of_decimals, 10)
+
+    def test_domain_conversion_sparsity(self):
+        destination = Domain(
+            attributes=[
+                ContinuousVariable(name='a'),
+                ContinuousVariable(name='b'),
+                ContinuousVariable(name='c'),
+            ],
+            class_vars=[DiscreteVariable('d', values=['e'])],
+            metas=[StringVariable('f')]
+        )
+
+        # all dense
+        source = Domain(attributes=[])
+        conversion = DomainConversion(source, destination)
+        self.assertFalse(conversion.sparse_X)
+        self.assertFalse(conversion.sparse_Y)
+        self.assertFalse(conversion.sparse_metas)
+
+        # set destination attributes as sparse
+        for a in destination.attributes:
+            a.sparse = True
+        source = Domain(attributes=[])
+        conversion = DomainConversion(source, destination)
+        self.assertTrue(conversion.sparse_X)
+        self.assertFalse(conversion.sparse_Y)
+        self.assertFalse(conversion.sparse_metas)
+
+        # set all destination variable as sparse
+        for a in chain(destination.variables, destination.metas):
+            a.sparse = True
+        source = Domain(attributes=[])
+        conversion = DomainConversion(source, destination)
+        self.assertTrue(conversion.sparse_X)
+        self.assertTrue(conversion.sparse_Y)
+        self.assertFalse(conversion.sparse_metas)
 
 
 class TestDomainFilter(unittest.TestCase):

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -98,11 +98,11 @@ class TestNormalizer(unittest.TestCase):
     def test_normalize_sparse(self):
         domain = Domain([ContinuousVariable(str(i)) for i in range(3)])
         # pylint: disable=bad-whitespace
-        X = sp.csr_matrix(np.array([
+        X = np.array([
             [0, -1, -2],
             [0,  1,  2],
-        ]))
-        data = Table.from_numpy(domain, X)
+        ])
+        data = Table.from_numpy(domain, X).to_sparse()
 
         # pylint: disable=bad-whitespace
         solution = sp.csr_matrix(np.array([

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -9,6 +9,7 @@ from Orange.data import Table
 from Orange.preprocess import Remove
 from Orange.tests import test_filename
 
+
 class TestRemover(unittest.TestCase):
 
     @classmethod

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -4,7 +4,6 @@
 import unittest
 
 import numpy as np
-import scipy.sparse as sp
 
 from Orange.data import Table
 from Orange.preprocess import Remove
@@ -138,8 +137,7 @@ class TestRemover(unittest.TestCase):
 
     def test_remove_unused_values_attr_sparse(self):
         data = self.test8
-        data = data[1:]
-        data.X = sp.csr_matrix(data.X)
+        data = data[1:].to_sparse()
         remover = Remove(Remove.RemoveUnusedValues)
         new_data = remover(data)
         attr_res = remover.attr_results

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2705,6 +2705,28 @@ class TestTableTranspose(unittest.TestCase):
                           for x in table2.domain.metas])
 
 
+class TestTableSparseDenseTransformations(unittest.TestCase):
+    def setUp(self):
+        self.iris = Table('iris')
+
+    def test_conversion(self):
+        iris = Table('iris')
+        iris_sparse = iris.to_sparse(sparse_attributes=True)
+        self.assertTrue(sp.issparse(iris_sparse.X))
+        self.assertFalse(sp.issparse(iris_sparse.Y))
+        self.assertFalse(sp.issparse(iris_sparse.metas))
+
+        iris_sparse = iris.to_sparse(sparse_attributes=True, sparse_class=True)
+        self.assertTrue(sp.issparse(iris_sparse.X))
+        self.assertTrue(sp.issparse(iris_sparse.Y))
+        self.assertFalse(sp.issparse(iris_sparse.metas))
+
+        dense_iris = iris_sparse.to_dense()
+        self.assertFalse(sp.issparse(dense_iris.X))
+        self.assertFalse(sp.issparse(dense_iris.Y))
+        self.assertFalse(sp.issparse(dense_iris.metas))
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1777,7 +1777,7 @@ class CreateTableWithDomainAndTable(TableTests):
                 new_table, self.table, rows=slice_)
 
     def test_can_use_attributes_as_new_columns(self):
-        a, c, m = column_sizes(self.table)
+        a, _, _ = column_sizes(self.table)
         order = [random.randrange(a) for _ in self.domain.attributes]
         new_attributes = [self.domain.attributes[i] for i in order]
         new_domain = self.create_domain(
@@ -1788,7 +1788,7 @@ class CreateTableWithDomainAndTable(TableTests):
             new_table, self.table, xcols=order, ycols=order, mcols=order)
 
     def test_can_use_class_vars_as_new_columns(self):
-        a, c, m = column_sizes(self.table)
+        a, c, _ = column_sizes(self.table)
         order = [random.randrange(a, a + c) for _ in self.domain.class_vars]
         new_classes = [self.domain.class_vars[i - a] for i in order]
         new_domain = self.create_domain(new_classes, new_classes, new_classes)
@@ -1798,7 +1798,7 @@ class CreateTableWithDomainAndTable(TableTests):
             new_table, self.table, xcols=order, ycols=order, mcols=order)
 
     def test_can_use_metas_as_new_columns(self):
-        a, c, m = column_sizes(self.table)
+        _, _, m = column_sizes(self.table)
         order = [random.randrange(-m + 1, 0) for _ in self.domain.metas]
         new_metas = [self.domain.metas[::-1][i] for i in order]
         new_domain = self.create_domain(new_metas, new_metas, new_metas)
@@ -2049,7 +2049,7 @@ class TableElementAssignmentTest(TableTests):
         self.assertAlmostEqual(self.table.X[0, 0], 42.)
 
     def test_can_assign_values_to_classes(self):
-        a, c, m = column_sizes(self.table)
+        a, _, _ = column_sizes(self.table)
         self.table[0, a] = 42.
         self.assertAlmostEqual(self.table.Y[0], 42.)
 
@@ -2067,7 +2067,7 @@ class TableElementAssignmentTest(TableTests):
             self.table.metas[0], self.table.metas[1])
 
     def test_can_assign_lists(self):
-        a, c, m = column_sizes(self.table)
+        a, _, _ = column_sizes(self.table)
         new_example = [float(i)
                        for i in range(len(self.attributes + self.class_vars))]
         self.table[0] = new_example
@@ -2077,7 +2077,7 @@ class TableElementAssignmentTest(TableTests):
             self.table.Y[0], np.array(new_example[a:]))
 
     def test_can_assign_np_array(self):
-        a, c, m = column_sizes(self.table)
+        a, _, _ = column_sizes(self.table)
         new_example = \
             np.array([float(i)
                       for i in range(len(self.attributes + self.class_vars))])
@@ -2199,7 +2199,7 @@ class InterfaceTest(unittest.TestCase):
     def test_clear(self):
         self.table.clear()
         self.assertEqual(len(self.table), 0)
-        for i in self.table:
+        for _ in self.table:
             self.fail("Table should not contain any rows.")
 
     def test_subclasses(self):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -640,8 +640,7 @@ class TableTestCase(unittest.TestCase):
         self.assertFalse(np.all(t.metas == copy.metas))
 
     def test_copy_sparse(self):
-        t = data.Table('iris')
-        t.X = sp.csr_matrix(t.X)
+        t = data.Table('iris').to_sparse()
         copy = t.copy()
 
         self.assertEqual((t.X != copy.X).nnz, 0)      # sparse matrices match by content
@@ -1845,8 +1844,7 @@ class CreateTableWithDomainAndTable(TableTests):
             new_table, self.table[:0], xcols=order, ycols=order, mcols=order)
 
     def test_from_table_sparse_move_some_to_empty_metas(self):
-        iris = data.Table("iris")
-        iris.X = sp.csr_matrix(iris.X)
+        iris = data.Table("iris").to_sparse()
         new_domain = data.domain.Domain(
             iris.domain.attributes[:2], iris.domain.class_vars,
             iris.domain.attributes[2:], source=iris.domain)
@@ -1861,19 +1859,18 @@ class CreateTableWithDomainAndTable(TableTests):
         back_iris = data.Table.from_table(iris.domain, new_iris)
         self.assertEqual(back_iris.domain, iris.domain)
         self.assertTrue(sp.issparse(back_iris.X))
-        self.assertTrue(sp.issparse(back_iris.metas))
+        self.assertFalse(sp.issparse(back_iris.metas))
         self.assertEqual(back_iris.X.shape, iris.X.shape)
         self.assertEqual(back_iris.metas.shape, iris.metas.shape)
 
     def test_from_table_sparse_move_all_to_empty_metas(self):
-        iris = data.Table("iris")
-        iris.X = sp.csr_matrix(iris.X)
+        iris = data.Table("iris").to_sparse()
         new_domain = data.domain.Domain(
             [], iris.domain.class_vars, iris.domain.attributes,
             source=iris.domain)
         new_iris = data.Table.from_table(new_domain, iris)
 
-        self.assertTrue(sp.issparse(new_iris.X))
+        self.assertFalse(sp.issparse(new_iris.X))
         self.assertTrue(sp.issparse(new_iris.metas))
         self.assertEqual(new_iris.X.shape, (len(iris), 0))
         self.assertEqual(new_iris.metas.shape, (len(iris), 4))
@@ -1882,13 +1879,12 @@ class CreateTableWithDomainAndTable(TableTests):
         back_iris = data.Table.from_table(iris.domain, new_iris)
         self.assertEqual(back_iris.domain, iris.domain)
         self.assertTrue(sp.issparse(back_iris.X))
-        self.assertTrue(sp.issparse(back_iris.metas))
+        self.assertFalse(sp.issparse(back_iris.metas))
         self.assertEqual(back_iris.X.shape, iris.X.shape)
         self.assertEqual(back_iris.metas.shape, iris.metas.shape)
 
     def test_from_table_sparse_move_to_nonempty_metas(self):
-        brown = data.Table("brown-selected")
-        brown.X = sp.csr_matrix(brown.X)
+        brown = data.Table("brown-selected").to_sparse()
         n_attr = len(brown.domain.attributes)
         n_metas = len(brown.domain.metas)
         new_domain = data.domain.Domain(

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1848,7 +1848,7 @@ class CreateTableWithDomainAndTable(TableTests):
         new_domain = data.domain.Domain(
             iris.domain.attributes[:2], iris.domain.class_vars,
             iris.domain.attributes[2:], source=iris.domain)
-        new_iris = data.Table.from_table(new_domain, iris)
+        new_iris = iris.transform(new_domain)
 
         self.assertTrue(sp.issparse(new_iris.X))
         self.assertTrue(sp.issparse(new_iris.metas))
@@ -1856,7 +1856,7 @@ class CreateTableWithDomainAndTable(TableTests):
         self.assertEqual(new_iris.metas.shape, (len(iris), 2))
 
         # move back
-        back_iris = data.Table.from_table(iris.domain, new_iris)
+        back_iris = new_iris.transform(iris.domain)
         self.assertEqual(back_iris.domain, iris.domain)
         self.assertTrue(sp.issparse(back_iris.X))
         self.assertFalse(sp.issparse(back_iris.metas))
@@ -1868,7 +1868,7 @@ class CreateTableWithDomainAndTable(TableTests):
         new_domain = data.domain.Domain(
             [], iris.domain.class_vars, iris.domain.attributes,
             source=iris.domain)
-        new_iris = data.Table.from_table(new_domain, iris)
+        new_iris = iris.transform(new_domain)
 
         self.assertFalse(sp.issparse(new_iris.X))
         self.assertTrue(sp.issparse(new_iris.metas))
@@ -1876,7 +1876,7 @@ class CreateTableWithDomainAndTable(TableTests):
         self.assertEqual(new_iris.metas.shape, (len(iris), 4))
 
         # move back
-        back_iris = data.Table.from_table(iris.domain, new_iris)
+        back_iris = new_iris.transform(iris.domain)
         self.assertEqual(back_iris.domain, iris.domain)
         self.assertTrue(sp.issparse(back_iris.X))
         self.assertFalse(sp.issparse(back_iris.metas))

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -308,8 +308,7 @@ a
         self.assertTrue(self.widget.Error.missing_reader.is_shown())
 
     def test_domain_edit_on_sparse_data(self):
-        iris = Table("iris")
-        iris.X = sp.csr_matrix(iris.X)
+        iris = Table("iris").to_sparse()
 
         f = tempfile.NamedTemporaryFile(suffix='.pickle', delete=False)
         pickle.dump(iris, f)

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -435,8 +435,7 @@ class TestOWMergeData(WidgetTest):
         """
         data = Table("iris")[::25]
         data_ed_dense = Table("titanic")[::300]
-        data_ed_sparse = Table("titanic")[::300]
-        data_ed_sparse.X = sp.csr_matrix(data_ed_sparse.X)
+        data_ed_sparse = Table("titanic")[::300].to_sparse()
         self.send_signal("Data", data)
 
         self.send_signal("Extra Data", data_ed_dense)

--- a/Orange/widgets/model/tests/test_tree.py
+++ b/Orange/widgets/model/tests/test_tree.py
@@ -1,6 +1,5 @@
 # pylint: disable=protected-access
 import numpy as np
-import scipy.sparse as sp
 
 from Orange.base import Model
 from Orange.data import Table
@@ -49,8 +48,7 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         table1 = Table("iris")
         self.send_signal("Data", table1)
         model_dense = self.get_output("Model")
-        table2 = Table("iris")
-        table2.X = sp.csr_matrix(table2.X)
+        table2 = Table("iris").to_sparse()
         self.send_signal("Data", table2)
         model_sparse = self.get_output("Model")
         self.assertTrue(np.array_equal(model_dense._code, model_sparse._code))
@@ -64,8 +62,7 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         table1 = Table("housing")
         self.send_signal("Data", table1)
         model_dense = self.get_output("Model")
-        table2 = Table("housing")
-        table2.X = sp.csr_matrix(table2.X)
+        table2 = Table("housing").to_sparse()
         self.send_signal("Data", table2)
         model_sparse = self.get_output("Model")
         self.assertTrue(np.array_equal(model_dense._code, model_sparse._code))

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -24,7 +24,8 @@ from Orange.canvas.report.owreport import OWReport
 from Orange.classification.base_classification import (
     LearnerClassification, ModelClassification
 )
-from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable,\
+    Variable
 from Orange.modelling import Fitter
 from Orange.preprocess import RemoveNaNColumns, Randomize
 from Orange.preprocess.preprocess import PreprocessorList
@@ -100,6 +101,7 @@ class WidgetTest(GuiTest):
         report = OWReport()
         cls.widgets.append(report)
         OWReport.get_instance = lambda: report
+        Variable._clear_all_caches()
 
     def tearDown(self):
         """Process any pending events before the next test is executed."""
@@ -687,6 +689,7 @@ class WidgetOutputsTestMixin:
     """
 
     def init(self):
+        Variable._clear_all_caches()
         self.data = Table("iris")
         self.same_input_output_domain = True
 

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -66,8 +66,7 @@ class TestOWManifoldLearning(WidgetTest):
         np.testing.assert_array_equal(self.iris.metas, _output.metas)
 
     def test_sparse_data(self):
-        data = Table("iris")
-        data.X = sparse.csr_matrix(data.X)
+        data = Table("iris").to_sparse()
         self.assertTrue(sparse.issparse(data.X))
         self.widget.manifold_method_index = 2
         self.send_signal(self.widget.Inputs.data, data)

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -1105,7 +1105,7 @@ class TableModel(AbstractSortTableModel):
             elif role == TableModel.ClassVar:
                 getter = operator.attrgetter("sparse_y")
             elif role == TableModel.Meta:
-                getter = operator.attrgetter("sparse_meta")
+                getter = operator.attrgetter("sparse_metas")
             return partial(formater, vars, getter)
 
         def make_basket(vars, density, role):

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -663,8 +663,7 @@ class OWHeatMap(widget.OWWidget):
 
         if data is not None and sp.issparse(data.X):
             try:
-                data = data.copy()
-                data.X = data.X.toarray()
+                data = data.to_dense()
             except MemoryError:
                 data = None
                 self.Error.not_enough_memory()

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -623,13 +623,7 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         domain = data.domain
         all_attrs = domain.variables + domain.metas
         attrs = list(set(all_attrs) & attrs)
-        selected_data = data[:, attrs]
-        if sp.issparse(selected_data.X):
-            selected_data.X = selected_data.X.toarray()
-        if sp.issparse(selected_data.Y):
-            selected_data.Y = selected_data.Y.toarray()
-        if sp.issparse(selected_data.metas):
-            selected_data.metas = selected_data.metas.toarray()
+        selected_data = data[:, attrs].to_dense()
         return selected_data
 
     def _clear_plot_widget(self):

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -209,7 +209,7 @@ class OWSieveDiagram(OWWidget):
                 discretize = Discretize(
                     method=EqualFreq(n=4), remove_const=False,
                     discretize_classes=True, discretize_metas=True)
-                return discretize(data)
+                return discretize(data).to_dense()
             return data
 
         if not data.is_sparse() and not init:
@@ -219,7 +219,6 @@ class OWSieveDiagram(OWWidget):
                      self.attr_y}
             new_domain = data.domain.select_columns(attrs)
             data = Table.from_table(new_domain, data)
-            data.X = data.X.toarray()
         return discretizer(data)
 
     @Inputs.features

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -317,11 +317,8 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         GH-2152
         GH-2157
         """
-        table = Table("iris")
-        table.X = sp.csr_matrix(table.X)
-        self.assertTrue(sp.issparse(table.X))
-        table.Y = sp.csr_matrix(table._Y)  # pylint: disable=protected-access
-        self.assertTrue(sp.issparse(table.Y))
+        table = Table("iris").to_sparse(sparse_attributes=True,
+                                        sparse_class=True)
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.set_subset_data(table[:30])
         data = self.get_output("Data")

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -3,7 +3,6 @@
 from math import isnan
 from unittest.mock import patch
 import numpy as np
-import scipy.sparse as sp
 
 from AnyQt.QtCore import QEvent, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
@@ -100,7 +99,7 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         output = self.get_output("Data")
         self.assertFalse(output.is_sparse())
 
-        table.X = sp.csr_matrix(table.X)
+        table = table.to_sparse()
         self.send_signal(self.widget.Inputs.data, table)
         self.assertEqual(len(self.widget.discrete_data.domain), 2)
         output = self.get_output("Data")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #2322.

Blocked on #2734. Blocked on #2736.

##### Description of changes
* `DomainConversion` now has three extra attributes telling whether X, Y, or metas should be sparse according to the features inside of them. Metas can only be sparse if no StringVariables are present.
* `Table.from_table` determines the density of X, Y, and metas according to domain conversion.
* Add `to_sparse` and `to_dense` methods to `Table`.
* Reset variables caches to alleviate interdependencies between test files.
* Fix showing sparse metas in Table widget.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation