### PR TITLE
owsvm: Fit probabilities by default in SVM widget

### DIFF
--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -199,6 +199,7 @@ class OWSVM(OWBaseLearner):
             'degree': self.degree,
             'gamma': self.gamma or self._default_gamma,
             'coef0': self.coef0,
+            'probability': True,
             'tol': self.tol,
             'max_iter': self.max_iter if self.limit_iter else -1,
             'preprocessors': self.preprocessors


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #2251

##### Description of changes
SVM widget should set `probability=True` by default.
This allows probabilities to be fitted and is more useful (e.g. when checking results in Predictions, ROC etc.)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
