### PR TITLE
[FIX] Rank widget supports Scorer inputs

### DIFF
--- a/Orange/modelling/linear.py
+++ b/Orange/modelling/linear.py
@@ -1,11 +1,24 @@
+import numpy as np
+
 from Orange.classification.sgd import SGDClassificationLearner
+from Orange.data import Variable
 from Orange.modelling import SklFitter
+from Orange.preprocess.score import LearnerScorer
 from Orange.regression import SGDRegressionLearner
 
 __all__ = ['SGDLearner']
 
 
-class SGDLearner(SklFitter):
+class _FeatureScorerMixin(LearnerScorer):
+    feature_type = Variable
+    class_type = Variable
+
+    def score(self, data):
+        model = self.get_learner(data)(data)
+        return np.atleast_2d(np.abs(model.skl_model.coef_)).mean(0)
+
+
+class SGDLearner(SklFitter, _FeatureScorerMixin):
     name = 'sgd'
 
     __fits__ = {'classification': SGDClassificationLearner,

--- a/Orange/modelling/randomforest.py
+++ b/Orange/modelling/randomforest.py
@@ -1,12 +1,23 @@
 from Orange.base import RandomForestModel
 from Orange.classification import RandomForestLearner as RFClassification
+from Orange.data import Variable
 from Orange.modelling import SklFitter
+from Orange.preprocess.score import LearnerScorer
 from Orange.regression import RandomForestRegressionLearner as RFRegression
 
 __all__ = ['RandomForestLearner']
 
 
-class RandomForestLearner(SklFitter):
+class _FeatureScorerMixin(LearnerScorer):
+    feature_type = Variable
+    class_type = Variable
+
+    def score(self, data):
+        model = self.get_learner(data)(data)
+        return model.skl_model.feature_importances_
+
+
+class RandomForestLearner(SklFitter, _FeatureScorerMixin):
     name = 'random forest'
 
     __fits__ = {'classification': RFClassification,

--- a/doc/visual-programming/source/widgets/data/rank.rst
+++ b/doc/visual-programming/source/widgets/data/rank.rst
@@ -14,6 +14,11 @@ Signals
 
    An input data set.
 
+- **Scorer**  (multiple)
+
+  Models that implement the feature scoring interface, such as linear /
+  logistic regression, random forest, stochastic gradient descent, etc.
+
 **Outputs**:
 
 -  **Reduced Data**
@@ -46,6 +51,12 @@ Scoring methods
 5. `Chi2 <https://en.wikipedia.org/wiki/Chi-squared_distribution>`_: dependence between the feature and the class as measure by the chi-square statistice
 6. `ReliefF <https://en.wikipedia.org/wiki/Relief_(feature_selection)>`_: the ability of an attribute to distinguish between classes on similar data instances
 7. `FCBF (Fast Correlation Based Filter) <https://www.aaai.org/Papers/ICML/2003/ICML03-111.pdf>`_: entropy-based measure, which also identifies redundancy due to pairwise correlations between features
+
+Additionally, you can connect certain learners that enable scoring the features
+according to how important they are in models that the learners build (e.g.
+:ref:`Linear <model.lr>` / :ref:`Logistic Regression <model.logit>`,
+:ref:`Random Forest <model.rf>`, :ref:`SGD <model.sgd>`, …).
+
 
 Example: Attribute Ranking and Selection
 ----------------------------------------

--- a/doc/visual-programming/source/widgets/model/linearregression.rst
+++ b/doc/visual-programming/source/widgets/model/linearregression.rst
@@ -1,3 +1,5 @@
+.. _model.lr:
+
 Linear Regression
 =================
 

--- a/doc/visual-programming/source/widgets/model/logisticregression.rst
+++ b/doc/visual-programming/source/widgets/model/logisticregression.rst
@@ -1,3 +1,5 @@
+.. _model.logit:
+
 Logistic Regression
 ===================
 

--- a/doc/visual-programming/source/widgets/model/randomforest.rst
+++ b/doc/visual-programming/source/widgets/model/randomforest.rst
@@ -1,3 +1,5 @@
+.. _model.rf:
+
 Random Forest
 =============
 

--- a/doc/visual-programming/source/widgets/model/stochasticgradient.rst
+++ b/doc/visual-programming/source/widgets/model/stochasticgradient.rst
@@ -1,3 +1,5 @@
+.. _model.sgd:
+
 Stochastic Gradient Descent
 ===========================
 


### PR DESCRIPTION
##### Issue
Rank didn't support Scorer (e.g Random Forest) inputs since the introduction of Fitters.

##### Description of changes
Have Rank support Random Forest as an input Scorer. Also SGD.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
