### PR TITLE
[FIX] Test & Learn: class with only one value

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -364,6 +364,9 @@ class OWTestLearners(OWWidget):
         """
         self.Information.data_sampled.clear()
         self.Error.train_data_empty.clear()
+        self.Error.class_required.clear()
+        self.Error.too_many_classes.clear()
+        self.Error.only_one_class_var_value.clear()
         if data is not None and not len(data):
             self.Error.train_data_empty()
             data = None
@@ -376,10 +379,6 @@ class OWTestLearners(OWWidget):
         elif data and data.domain.has_discrete_class and len(data.domain.class_var.values) == 1:
             self.Error.only_one_class_var_value()
             data = None
-        else:
-            self.Error.class_required.clear()
-            self.Error.too_many_classes.clear()
-            self.Error.only_one_class_var_value.clear()
 
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -370,15 +370,18 @@ class OWTestLearners(OWWidget):
         if data is not None and not len(data):
             self.Error.train_data_empty()
             data = None
-        if data and not data.domain.class_vars:
-            self.Error.class_required()
-            data = None
-        elif data and len(data.domain.class_vars) > 1:
-            self.Error.too_many_classes()
-            data = None
-        elif data and data.domain.has_discrete_class and len(data.domain.class_var.values) == 1:
-            self.Error.only_one_class_var_value()
-            data = None
+        if data:
+            conds = [not data.domain.class_vars,
+                     len(data.domain.class_vars) > 1,
+                     data.domain.has_discrete_class and len(data.domain.class_var.values) == 1]
+            errors = [self.Error.class_required,
+                      self.Error.too_many_classes,
+                      self.Error.only_one_class_var_value]
+            for cond, error in zip(conds, errors):
+                if cond:
+                    error()
+                    data = None
+                    break
 
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -218,6 +218,7 @@ class OWTestLearners(OWWidget):
         class_inconsistent = Msg("Test and train data sets "
                                  "have different target variables.")
         memory_error = Msg("Not enough memory.")
+        only_one_class_var_value = Msg("Target variable has only one value.")
 
     class Warning(OWWidget.Warning):
         missing_data = \
@@ -372,9 +373,13 @@ class OWTestLearners(OWWidget):
         elif data and len(data.domain.class_vars) > 1:
             self.Error.too_many_classes()
             data = None
+        elif data and data.domain.has_discrete_class and len(data.domain.class_var.values) == 1:
+            self.Error.only_one_class_var_value()
+            data = None
         else:
             self.Error.class_required.clear()
             self.Error.too_many_classes.clear()
+            self.Error.only_one_class_var_value.clear()
 
         if isinstance(data, SqlTable):
             if data.approx_len() < AUTO_DL_LIMIT:


### PR DESCRIPTION
##### Issue
_Iris_ table with only one class value (_Iris-setosa_). _Iris-setosa_ is selected in _Target Class_ box in Test & Score widget.
![screenshot_20170529_175407](https://cloud.githubusercontent.com/assets/22157215/26555917/d0a64e2a-4497-11e7-91de-8dce56bffc8e.png)


##### Description of changes
Work in progress.

##### Includes
- [x] Code changes
- [X] Tests
- [ ] Documentation
