### PR TITLE
[FIX] Select Rows: do not crash when string to discrete

### DIFF
--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -5,7 +5,7 @@ from AnyQt.QtTest import QTest
 from AnyQt.QtWidgets import QLineEdit
 
 from Orange.data import (
-    Table, ContinuousVariable, StringVariable, DiscreteVariable)
+    Table, ContinuousVariable, StringVariable, DiscreteVariable, Domain)
 from Orange.widgets.data.owselectrows import (
     OWSelectRows, FilterDiscreteType, SelectRowsContextHandler)
 from Orange.widgets.tests.base import WidgetTest, datasets
@@ -242,3 +242,31 @@ class TestOWSelectRows(WidgetTest):
         settings = dict(context_settings=[context])
 
         return self.create_widget(OWSelectRows, settings)
+
+    def test_metas_string_2_discrete(self):
+        """
+        Widget crashes when StringVariable is changed to DiscreteVariable.
+        GH-2353
+        """
+        domain = Domain([], metas=[StringVariable("meta")])
+        data_list = ["b", "a", "3.14", "42"]
+        data = Table(domain, list(zip(data_list)))
+        self.send_signal("Data", data)
+        self.enterFilter(data.domain["meta"], "contains", "a")
+        domain = Domain([], metas=[DiscreteVariable("meta", values=data_list)])
+        data = Table(domain, list(zip(data_list)))
+        self.send_signal("Data", data)
+
+    def test_metas_string_2_discrete_2(self):
+        """
+        Widget crashes when StringVariable is changed to DiscreteVariable.
+        GH-2353
+        """
+        domain = Domain([], metas=[StringVariable("meta")])
+        data_list = ["1", "2", "3.14", "42"]
+        data = Table(domain, list(zip(data_list)))
+        self.send_signal("Data", data)
+        self.enterFilter(data.domain["meta"], "is outside", "1", "2")
+        domain = Domain([], metas=[DiscreteVariable("meta", values=data_list)])
+        data = Table(domain, list(zip(data_list)))
+        self.send_signal("Data", data)


### PR DESCRIPTION
##### Issue 1
![screenshot_20170530_104408](https://cloud.githubusercontent.com/assets/22157215/26575325/09853462-4525-11e7-89c5-c3b43bde2ffc.png)
![screenshot_20170530_104445](https://cloud.githubusercontent.com/assets/22157215/26575327/0c6105b2-4525-11e7-9aa2-d03cb5202a61.png)

##### Steps to reproduce the behavior 1
Put _File_ widget on a canvas and open _iris_. Skip all attributes except first for instance _sepal length_. Set it to **string** and **meta**. Connect _File_ widget and _Select Rows_. In _Select Rows_ select **contains** and write a letter in a box. And lastly in _File_ widget change **string** to **nominal** and click **Apply** button.

##### Issue 2
![screenshot_20170530_124330](https://cloud.githubusercontent.com/assets/22157215/26579800/bdd3d81e-4535-11e7-9db3-513bdc8a0892.png)
![screenshot_20170530_124402](https://cloud.githubusercontent.com/assets/22157215/26579805/c077b270-4535-11e7-8bb9-cb1c8ec74dac.png)

##### Steps to reproduce the behavior 2
Put _File_ widget on a canvas and open _iris_. Skip all attributes except first for instance _sepal length_. Set it to **string** and **meta**. Connect _File_ widget and _Select Rows_. In _Select Rows_ select **is outside** and write numbers in boxes. For instance, write **1** and **2**. And lastly in _File_ widget change **string** to **nominal** and click **Apply** button.

##### Description of changes
Work in progress.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
