### PR TITLE
[FIX] score.FCBF: don't segfault on continuous variables w/ <0 values

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -230,13 +230,11 @@ def _gini(D):
                   np.sum(D, axis=0) / np.sum(D))
 
 
-def _symmetrical_uncertainty(X, Y):
+def _symmetrical_uncertainty(data, attr1, attr2):
     """Symmetrical uncertainty, Press et al., 1988."""
-    from Orange.preprocess._relieff import contingency_table
-    X, Y = np.around(X), np.around(Y)
-    cont = contingency_table(X, Y)
+    cont = np.asarray(contingency.Discrete(data, attr1, attr2), dtype=float)
     ig = InfoGain().from_contingency(cont, 1)
-    return 2 * ig / (_entropy(cont.sum(0)) + _entropy(cont.sum(1)))
+    return 2 * ig / (_entropy(cont) + _entropy(cont.T))
 
 
 class FCBF(ClassificationScorer):
@@ -248,9 +246,10 @@ class FCBF(ClassificationScorer):
     2003. http://www.aaai.org/Papers/ICML/2003/ICML03-111.pdf
     """
     def score_data(self, data, feature=None):
+        attributes = data.domain.attributes
         S = []
-        for i, a in enumerate(data.X.T):
-            S.append((_symmetrical_uncertainty(a, data.Y), i))
+        for i, attr in enumerate(attributes):
+            S.append((_symmetrical_uncertainty(data, attr, data.domain.class_var), i))
         S.sort()
         worst = []
 
@@ -262,9 +261,7 @@ class FCBF(ClassificationScorer):
             while True:
                 try: SUqc, Fq = S[-q]
                 except IndexError: break
-                # TODO: cache
-                if _symmetrical_uncertainty(data.X.T[Fp],
-                                            data.X.T[Fq]) >= SUqc:
+                if _symmetrical_uncertainty(data, attributes[Fp], attributes[Fq]) >= SUqc:
                     del S[-q]
                     worst.append((1e-4*SUqc, Fq))
                 else:

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from Orange.data import Table, Domain, DiscreteVariable
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange import preprocess
 from Orange.preprocess.score import InfoGain, GainRatio, Gini, Chi2, ANOVA,\
     UnivariateLinearRegression, ReliefF, FCBF, RReliefF
@@ -129,5 +129,13 @@ class FeatureScoringTest(unittest.TestCase):
         scorer = FCBF()
         weights = scorer(self.zoo, None)
         found = [self.zoo.domain[attr].name for attr in reversed(weights.argsort()[-5:])]
-        reference = ['legs', 'backbone', 'toothed', 'hair', 'aquatic']
+        reference = ['legs', 'milk', 'toothed', 'feathers', 'backbone']
         self.assertEqual(found, reference)
+
+        # GH-1916
+        data = Table(Domain([ContinuousVariable('1'), ContinuousVariable('2')],
+                            DiscreteVariable('target')),
+                     np.full((2, 2), np.nan),
+                     np.r_[0., 1])
+        weights = scorer(data, None)
+        np.testing.assert_equal(weights, np.nan)


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3/issues/1916

##### Description of changes
Previously, FCBF always computed contingency as if the variable were discrete. Now uses Orange's Discrete contingency, which discretizes as necessary.
This should, hopefully, also fix segfault on OSX when all values are missing.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
