### PR TITLE
[FIX] RowInstance: Fix sparse check

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1,15 +1,14 @@
 import operator
 import os
 import zlib
-
 from collections import MutableSequence, Iterable, Sequence, Sized
+from functools import reduce
 from itertools import chain
 from numbers import Real, Integral
-from functools import reduce
 from threading import Lock, RLock
 
-import numpy as np
 import bottleneck as bn
+import numpy as np
 from scipy import sparse as sp
 
 import Orange.data  # import for io.py
@@ -19,7 +18,8 @@ from Orange.data import (
     ContinuousVariable, DiscreteVariable, MISSING_VALUES
 )
 from Orange.data.util import SharedComputeValue, vstack, hstack
-from Orange.statistics.util import bincount, countnans, contingency, stats as fast_stats
+from Orange.statistics.util import bincount, countnans, contingency, \
+    stats as fast_stats
 from Orange.util import flatten
 
 __all__ = ["dataset_dirs", "get_sample_datasets_dir", "RowInstance", "Table"]
@@ -312,7 +312,8 @@ class Table(MutableSequence, Storage):
                 elif not isinstance(col, Integral):
                     if isinstance(col, SharedComputeValue):
                         if (id(col.compute_shared), id(source)) not in shared_cache:
-                            shared_cache[id(col.compute_shared), id(source)] = col.compute_shared(source)
+                            shared_cache[id(col.compute_shared), id(source)] = \
+                                col.compute_shared(source)
                         shared = shared_cache[id(col.compute_shared), id(source)]
                         if row_indices is not ...:
                             a[:, i] = match_type(
@@ -564,8 +565,8 @@ class Table(MutableSequence, Storage):
         if not writer:
             desc = FileFormat.names.get(ext)
             if desc:
-                raise IOError("Writing of {}s is not supported".
-                    format(desc.lower()))
+                raise IOError(
+                    "Writing of {}s is not supported".format(desc.lower()))
             else:
                 raise IOError("Unknown file name extension.")
         writer.write_file(filename, self)
@@ -1493,10 +1494,10 @@ class Table(MutableSequence, Storage):
 
                 for col_i, arr_i, _ in cont_vars:
                     if sp.issparse(arr):
-                        col_data = arr.data[arr.indptr[arr_i]:
-                        arr.indptr[arr_i + 1]]
-                        rows = arr.indices[arr.indptr[arr_i]:
-                        arr.indptr[arr_i + 1]]
+                        col_data = arr.data[
+                                   arr.indptr[arr_i]:arr.indptr[arr_i + 1]]
+                        rows = arr.indices[
+                               arr.indptr[arr_i]:arr.indptr[arr_i + 1]]
                         W_ = None if W is None else W[rows]
                         classes_ = classes[rows]
                     else:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -100,11 +100,11 @@ class RowInstance(Instance):
                                 type(value).__name__)
             if key < len(self._x):
                 self._x[key] = value
-                if self.sparse_x:
+                if self.sparse_x is not None:
                     self.table.X[self.row_index, key] = value
             else:
                 self._y[key - len(self._x)] = value
-                if self.sparse_y:
+                if self.sparse_y is not None:
                     self.table._Y[self.row_index, key - len(self._x)] = value
         else:
             self._metas[-1 - key] = value

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2219,6 +2219,28 @@ class TestRowInstance(unittest.TestCase):
             row[0] = i
         np.testing.assert_array_equal(table.X[:, 0], np.arange(len(table)))
 
+    def test_sparse_assignment(self):
+        X = np.eye(4)
+        Y = X[2]
+        table = data.Table(X, Y)
+        row = table[1]
+        self.assertFalse(sp.issparse(row.sparse_x))
+        self.assertEqual(row[0], 0)
+        self.assertEqual(row[1], 1)
+
+        table.X = sp.csr_matrix(table.X)
+        table._Y = sp.csr_matrix(table._Y)
+        sparse_row = table[1]
+        self.assertTrue(sp.issparse(sparse_row.sparse_x))
+        self.assertEqual(sparse_row[0], 0)
+        self.assertEqual(sparse_row[1], 1)
+        sparse_row[1] = 0
+        self.assertEqual(sparse_row[1], 0)
+        self.assertEqual(table.X[1, 1], 0)
+        self.assertEqual(table[2][4], 1)
+        table[2][4] = 0
+        self.assertEqual(table[2][4], 0)
+
 
 class TestTableTranspose(unittest.TestCase):
     def test_transpose_no_class(self):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -662,14 +662,17 @@ class TableTestCase(unittest.TestCase):
         d1 = data.Domain([data.ContinuousVariable('a1')])
         t1 = data.Table.from_numpy(d1, [[1],
                                         [2]])
-        d2 = data.Domain([data.ContinuousVariable('a2')], metas=[data.StringVariable('s')])
+        d2 = data.Domain([data.ContinuousVariable('a2')],
+                         metas=[data.StringVariable('s')])
         t2 = data.Table.from_numpy(d2, [[3],
                                         [4]], metas=[['foo'],
                                                      ['fuu']])
-        self.assertRaises(ValueError, lambda: data.Table.concatenate((t1, t2), axis=5))
+        self.assertRaises(ValueError,
+                          lambda: data.Table.concatenate((t1, t2), axis=5))
 
         t3 = data.Table.concatenate((t1, t2))
-        self.assertEqual(t3.domain.attributes, t1.domain.attributes + t2.domain.attributes)
+        self.assertEqual(t3.domain.attributes,
+                         t1.domain.attributes + t2.domain.attributes)
         self.assertEqual(len(t3.domain.metas), 1)
         self.assertEqual(t3.X.shape, (2, 2))
         self.assertRaises(ValueError, lambda: data.Table.concatenate((t3, t1)))
@@ -777,10 +780,13 @@ class TableTestCase(unittest.TestCase):
         d.save("test-zoo.tab")
         dd = data.Table("test-zoo")
         try:
-            self.assertTupleEqual(d.domain.metas, dd.domain.metas, msg="Meta attributes don't match.")
-            self.assertTupleEqual(d.domain.variables, dd.domain.variables, msg="Attributes don't match.")
+            self.assertTupleEqual(d.domain.metas, dd.domain.metas,
+                                  msg="Meta attributes don't match.")
+            self.assertTupleEqual(d.domain.variables, dd.domain.variables,
+                                  msg="Attributes don't match.")
 
-            np.testing.assert_almost_equal(d.W, dd.W, err_msg="Weights don't match.")
+            np.testing.assert_almost_equal(d.W, dd.W,
+                                           err_msg="Weights don't match.")
             for i in range(10):
                 for j in d.domain.variables:
                     self.assertEqual(d[i][j], dd[i][j])
@@ -792,10 +798,13 @@ class TableTestCase(unittest.TestCase):
         d.save("test-zoo-weights.tab")
         dd = data.Table("test-zoo-weights")
         try:
-            self.assertTupleEqual(d.domain.metas, dd.domain.metas, msg="Meta attributes don't match.")
-            self.assertTupleEqual(d.domain.variables, dd.domain.variables, msg="Attributes don't match.")
+            self.assertTupleEqual(d.domain.metas, dd.domain.metas,
+                                  msg="Meta attributes don't match.")
+            self.assertTupleEqual(d.domain.variables, dd.domain.variables,
+                                  msg="Attributes don't match.")
 
-            np.testing.assert_almost_equal(d.W, dd.W, err_msg="Weights don't match.")
+            np.testing.assert_almost_equal(d.W, dd.W,
+                                           err_msg="Weights don't match.")
             for i in range(10):
                 for j in d.domain.variables:
                     self.assertEqual(d[i][j], dd[i][j])
@@ -1593,7 +1602,8 @@ class CreateTableWithData(TableTests):
         table = data.Table.from_numpy(domain, self.data, W=self.weight_data)
 
         np.testing.assert_equal(table.W.shape, (len(self.data), ))
-        np.testing.assert_almost_equal(table.W.flatten(), self.weight_data.flatten())
+        np.testing.assert_almost_equal(table.W.flatten(),
+                                       self.weight_data.flatten())
 
     def test_splits_X_and_Y_if_given_in_same_array(self):
         joined_data = np.column_stack((self.data, self.class_data))
@@ -1827,8 +1837,9 @@ class CreateTableWithDomainAndTable(TableTests):
     def test_from_table_sparse_move_some_to_empty_metas(self):
         iris = data.Table("iris")
         iris.X = sp.csr_matrix(iris.X)
-        new_domain = data.domain.Domain(iris.domain.attributes[:2], iris.domain.class_vars,
-                                        iris.domain.attributes[2:], source=iris.domain)
+        new_domain = data.domain.Domain(
+            iris.domain.attributes[:2], iris.domain.class_vars,
+            iris.domain.attributes[2:], source=iris.domain)
         new_iris = data.Table.from_table(new_domain, iris)
 
         self.assertTrue(sp.issparse(new_iris.X))
@@ -1847,8 +1858,9 @@ class CreateTableWithDomainAndTable(TableTests):
     def test_from_table_sparse_move_all_to_empty_metas(self):
         iris = data.Table("iris")
         iris.X = sp.csr_matrix(iris.X)
-        new_domain = data.domain.Domain([], iris.domain.class_vars,
-                                        iris.domain.attributes, source=iris.domain)
+        new_domain = data.domain.Domain(
+            [], iris.domain.class_vars, iris.domain.attributes,
+            source=iris.domain)
         new_iris = data.Table.from_table(new_domain, iris)
 
         self.assertTrue(sp.issparse(new_iris.X))
@@ -1869,9 +1881,11 @@ class CreateTableWithDomainAndTable(TableTests):
         brown.X = sp.csr_matrix(brown.X)
         n_attr = len(brown.domain.attributes)
         n_metas = len(brown.domain.metas)
-        new_domain = data.domain.Domain(brown.domain.attributes[:-10], brown.domain.class_vars,
-                                        brown.domain.attributes[-10:] + brown.domain.metas,
-                                        source=brown.domain)
+        new_domain = data.domain.Domain(
+            brown.domain.attributes[:-10],
+            brown.domain.class_vars,
+            brown.domain.attributes[-10:] + brown.domain.metas,
+            source=brown.domain)
         new_brown = data.Table.from_table(new_domain, brown)
 
         self.assertTrue(sp.issparse(new_brown.X))
@@ -2073,7 +2087,8 @@ class InterfaceTest(unittest.TestCase):
         data.ContinuousVariable(name="Continuous Feature 1"),
         data.ContinuousVariable(name="Continuous Feature 2"),
         data.DiscreteVariable(name="Discrete Feature 1", values=[0, 1]),
-        data.DiscreteVariable(name="Discrete Feature 2", values=["value1", "value2"]),
+        data.DiscreteVariable(name="Discrete Feature 2",
+                              values=["value1", "value2"]),
     )
 
     class_vars = (
@@ -2100,7 +2115,8 @@ class InterfaceTest(unittest.TestCase):
     nrows = 4
 
     def setUp(self):
-        self.domain = data.Domain(attributes=self.features, class_vars=self.class_vars)
+        self.domain = data.Domain(attributes=self.features,
+                                  class_vars=self.class_vars)
         self.table = data.Table.from_numpy(
             self.domain,
             np.array(self.feature_data),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The condition `if self.sparse_x` works when it is false (`sparse_x == None`). But crashed when it was actually a sparse array since "The truth value of an array ... is ambiguous"

##### Description of changes
Test with `is not None`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
