### PR TITLE
Refactor Lookup & Support Sparse Data

### DIFF
--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -4,7 +4,7 @@ from scipy.sparse import issparse
 import Orange.data
 from Orange.statistics import distribution, basic_stats
 from Orange.util import Reprable
-from .transformation import Transformation, Lookup as BaseLookup
+from .transformation import Transformation, Lookup
 
 __all__ = ["ReplaceUnknowns", "Average", "DoNotImpute", "DropInstances",
            "Model", "AsValue", "Random", "Default"]
@@ -225,23 +225,6 @@ def domain_with_class_var(domain, class_var):
 class IsDefined(Transformation):
     def transform(self, c):
         return ~numpy.isnan(c)
-
-
-class Lookup(BaseLookup):
-    def __init__(self, variable, lookup_table, unknown=None):
-        super().__init__(variable, lookup_table)
-        self.unknown = unknown
-
-    def transform(self, column):
-        if self.unknown is None:
-            unknown = numpy.nan
-        else:
-            unknown = self.unknown
-
-        mask = numpy.isnan(column)
-        column_valid = numpy.where(mask, 0, column)
-        values = self.lookup_table[numpy.array(column_valid, dtype=int)]
-        return numpy.where(mask, unknown, values)
 
 
 class AsValue(BaseImputeMethod):

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -272,15 +272,6 @@ def sort_var_values(var):
                             compute_value=Lookup(var, translation_table))
 
 
-class Lookup(Lookup):
-    def transform(self, column):
-        column = np.array(column, dtype=np.float64)
-        mask = np.isnan(column)
-        column_valid = np.where(mask, 0, column)
-        values = self.lookup_table[np.array(column_valid, dtype=int)]
-        return np.where(mask, np.nan, values)
-
-
 def merge_lookup(A, B):
     """
     Merge two consecutive Lookup transforms into one.

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -129,19 +129,22 @@ class Lookup(Transformation):
     """
     Transform a discrete variable according to lookup table (`self.lookup`).
     """
-    def __init__(self, variable, lookup_table):
+    def __init__(self, variable, lookup_table, unknown=np.nan):
         """
         :param variable: The variable whose transformed value is returned.
         :type variable: int or str or :obj:`~Orange.data.DiscreteVariable`
         :param lookup_table: transformations for each value of `self.variable`
         :type lookup_table: np.array or list or tuple
+        :param unknown: The value to be used as unknown value.
+        :type unknown: float or int 
         """
         super().__init__(variable)
         self.lookup_table = lookup_table
+        self.unknown = unknown
 
     def transform(self, column):
         mask = np.isnan(column)
         column = column.astype(int)
         column[mask] = 0
         values = self.lookup_table[column]
-        return np.where(mask, np.nan, values)
+        return np.where(mask, self.unknown, values)

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -143,6 +143,9 @@ class Lookup(Transformation):
         self.unknown = unknown
 
     def transform(self, column):
+        # Densify DiscreteVariable values coming from sparse data sets.
+        if sp.issparse(column):
+            column = column.toarray().ravel()
         mask = np.isnan(column)
         column = column.astype(int)
         column[mask] = 0

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import scipy.sparse as sp
 
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable, \
     StringVariable
@@ -66,6 +67,7 @@ class LookupTest(unittest.TestCase):
     def test_transform(self):
         lookup = Lookup(None, np.array([1, 2, 0, 2]))
         column = np.array([1, 2, 3, 0, np.nan, 0], dtype=np.float64)
-        np.testing.assert_array_equal(
-            lookup.transform(column),
-            np.array([2, 0, 2, 1, np.nan, 1], dtype=np.float64))
+        for col in [column, sp.csr_matrix(column)]:
+            np.testing.assert_array_equal(
+                lookup.transform(col),
+                np.array([2, 0, 2, 1, np.nan, 1], dtype=np.float64))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
We had three almost identical implementations of Lookup. None of them supported sparse data.

##### Description of changes
Remove two redundant implementations. Support sparse data by densifying it first.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
