### PR TITLE
DiscreteVariable: make 'values' a read-only property

### DIFF
--- a/Orange/canvas/scheme/scheme.py
+++ b/Orange/canvas/scheme/scheme.py
@@ -19,7 +19,7 @@ from .node import SchemeNode
 from .link import SchemeLink, compatible_channels
 from .annotations import BaseSchemeAnnotation
 
-from ..utils import check_arg, check_type
+from ..utils import check_arg, check_typevar
 
 from .errors import (
     SchemeCycleError, IncompatibleChannelTypeError, SinkChannelError,

--- a/Orange/canvas/scheme/scheme.py
+++ b/Orange/canvas/scheme/scheme.py
@@ -19,7 +19,7 @@ from .node import SchemeNode
 from .link import SchemeLink, compatible_channels
 from .annotations import BaseSchemeAnnotation
 
-from ..utils import check_arg, check_typevar
+from ..utils import check_arg, check_type
 
 from .errors import (
     SchemeCycleError, IncompatibleChannelTypeError, SinkChannelError,

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -614,7 +614,7 @@ class FileFormat(metaclass=FileFormatMeta):
             elif type_flag in ContinuousVariable.TYPE_HEADERS:
                 coltype = ContinuousVariable
                 try:
-                    values = [float(i) for i in orig_values]
+                    values = tuple(float(i) for i in orig_values)
                 except ValueError:
                     for row, num in enumerate(orig_values):
                         try:

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -552,12 +552,12 @@ class DiscreteVariable(Variable):
 
     def __init__(self, name="", values=(), ordered=False, base_value=-1, compute_value=None):
         """ Construct a discrete variable descriptor with the given values. """
-        self.values = list(values)
-        if not all(isinstance(value, str) for value in self.values):
+        values = tuple(values)
+        if not all(isinstance(value, str) for value in values):
             raise TypeError("values of DiscreteVariables must be strings")
         super().__init__(name, compute_value)
+        self._values = values
         self.ordered = ordered
-        self._values = tuple(values)
         self.base_value = base_value
 
     @property

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -241,7 +241,7 @@ class AsValue(BaseImputeMethod):
             value = "N/A"
             var = Orange.data.DiscreteVariable(
                 fmt.format(var=variable),
-                values=variable.values + [value],
+                values=variable.values + (value, ),
                 base_value=variable.base_value,
                 compute_value=Lookup(
                     variable,

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -67,7 +67,7 @@ class TestSqlTable(PostgresTest):
             filtered_table = filter.SameValue(table.domain[0], 'm')(table)
             self.assertEqual(len(filtered_table), 13)
 
-            table.domain[0].values += ('x', )
+            table.domain[0]._values += ('x', )
             filtered_table = filter.SameValue(table.domain[0], 'x')(table)
             self.assertEqual(len(filtered_table), 0)
 

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -40,7 +40,7 @@ class TestSqlTable(PostgresTest):
             self.assertIsInstance(discrete_attr, DiscreteVariable)
             self.assertEqual(discrete_attr.name, "col1")
             self.assertTrue('"col1"' in discrete_attr.to_sql())
-            self.assertEqual(discrete_attr.values, ['f', 'm'])
+            self.assertEqual(discrete_attr.values, ('f', 'm'))
 
             self.assertIsInstance(string_attr, StringVariable)
             self.assertEqual(string_attr.name, "col2")
@@ -67,7 +67,7 @@ class TestSqlTable(PostgresTest):
             filtered_table = filter.SameValue(table.domain[0], 'm')(table)
             self.assertEqual(len(filtered_table), 13)
 
-            table.domain[0].values.append('x')
+            table.domain[0].values += ('x', )
             filtered_table = filter.SameValue(table.domain[0], 'x')(table)
             self.assertEqual(len(filtered_table), 0)
 

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -130,21 +130,21 @@ class TestDiscretizer(TestCase):
     def test_create_discretized_var_formatting(self):
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [1, 2, 3])
-        self.assertEqual(dvar.values, ["< 1", "1 - 2", "2 - 3", "≥ 3"])
+        self.assertEqual(dvar.values, ("< 1", "1 - 2", "2 - 3", "≥ 3"))
 
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [10])
-        self.assertEqual(dvar.values, ["< 10", "≥ 10"])
+        self.assertEqual(dvar.values, ("< 10", "≥ 10"))
 
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [10.1234])
-        self.assertEqual(dvar.values, ["< 10.1", "≥ 10.1"])
+        self.assertEqual(dvar.values, ("< 10.1", "≥ 10.1"))
 
         self.var.number_of_decimals = 3
 
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [5, 10.1234])
-        self.assertEqual(dvar.values, ["< 5", "5 - 10.123", "≥ 10.123"])
+        self.assertEqual(dvar.values, ("< 5", "5 - 10.123", "≥ 10.123"))
 
     def test_discretizer_computation(self):
         dvar = discretize.Discretizer.create_discretized_var(

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -48,9 +48,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['4', '6']])
+                          if a.is_discrete], [('4', '6')])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3'], ['2']])
+                          if c.is_discrete], [('1', '2', '3'), ('2')])
         self.assertDictEqual(attr_res,
                              {'removed': 2, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -70,9 +70,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4', '6']])
+                          if a.is_discrete], [('1'), ('4', '6')])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3']])
+                          if c.is_discrete], [('1', '2', '3')])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -92,9 +92,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4']])
+                          if a.is_discrete], [('1', ), ('4', )])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3'], ['2']])
+                          if c.is_discrete], [('1', '2', '3'), ('2', )])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 1, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -116,9 +116,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4', '6']])
+                          if a.is_discrete], [('1', ), ('4', '6')])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['2', '3'], ['2']])
+                          if c.is_discrete], [('2', '3'), ('2', )])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -131,5 +131,5 @@ class TestRemover(unittest.TestCase):
                      meta_flags=Remove.RemoveUnusedValues)(subset)
 
         self.assertEqual(res.domain["b"].values, res.domain["c"].values)
-        self.assertEqual(res.domain["d"].values, ["1", "2"])
-        self.assertEqual(res.domain["f"].values, ['1', 'hey'])
+        self.assertEqual(res.domain["d"].values, ("1", "2"))
+        self.assertEqual(res.domain["f"].values, ('1', 'hey'))

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1577,7 +1577,7 @@ class CreateTableWithData(TableTests):
         np.testing.assert_almost_equal(table.Y, Y)
         self.assertIsInstance(table.domain.class_vars[0],
                               data.DiscreteVariable)
-        self.assertEqual(table.domain.class_vars[0].values, ["v1", "v2"])
+        self.assertEqual(table.domain.class_vars[0].values, ("v1", "v2"))
 
     def test_creates_a_table_with_given_domain(self):
         domain = self.mock_domain()

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -250,7 +250,7 @@ class TestDiscreteVariable(VariableTest):
     def test_no_nonstringvalues(self):
         self.assertRaises(TypeError, DiscreteVariable, "foo", values=["a", 42])
         a = DiscreteVariable("foo", values=["a", "b", "c"])
-        self.assertRaises(TypeError, a.add_value, 42)
+        self.assertRaises(TypeError, a._add_value, 42)
 
 
 @variabletest(ContinuousVariable)

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -158,7 +158,7 @@ class TestDiscreteVariable(VariableTest):
 
         # Compatible, adds values
         self.assertIs(find_comp("gend", values=["F", "N", "R"]), gend)
-        self.assertEqual(gend.values, ["F", "M", "N", "R"])
+        self.assertEqual(gend.values, ("F", "M", "N", "R"))
 
     def test_find_compatible_ordered(self):
         abc = DiscreteVariable("abc", values="abc", ordered=True)
@@ -188,7 +188,7 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertIsInstance(var, DiscreteVariable)
         self.assertEqual(var.name, "a")
-        self.assertEqual(var.values, ["F", "M"])
+        self.assertEqual(var.values, ("F", "M"))
 
     def test_val_from_str(self):
         var = DiscreteVariable.make("a", values=["F", "M"])
@@ -199,15 +199,15 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'])")
+            "DiscreteVariable(name='a', values=('F', 'M'))")
         var.base_value = 1
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'], base_value=1)")
+            "DiscreteVariable(name='a', values=('F', 'M'), base_value=1)")
         var.ordered = True
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'], "
+            "DiscreteVariable(name='a', values=('F', 'M'), "
             "ordered=True, base_value=1)")
 
         var = DiscreteVariable.make("a", values="1234567")

--- a/Orange/tests/test_variable.py
+++ b/Orange/tests/test_variable.py
@@ -239,11 +239,11 @@ class TestDiscreteVariable(VariableTest):
         # Test ncolors adapts to nvalues
         var = DiscreteVariable.make('foo', values=['d', 'r'])
         self.assertEqual(len(var.colors), 2)
-        var.add_value('e')
+        var._add_value('e')
         self.assertEqual(len(var.colors), 3)
         user_defined = (0, 0, 0)
         var.set_color(2, user_defined)
-        var.add_value('k')
+        var._add_value('k')
         self.assertEqual(len(var.colors), 4)
         np.testing.assert_array_equal(var.colors[2], user_defined)
 
@@ -271,11 +271,11 @@ class TestContinuousVariable(VariableTest):
     def test_adjust_decimals(self):
         a = ContinuousVariable("a")
         self.assertEqual(a.str_val(4.654321), "4.654")
-        a.val_from_str_add("5")
+        a._val_from_str_add("5")
         self.assertEqual(a.str_val(4.654321), "5")
-        a.val_from_str_add("  5.12    ")
+        a._val_from_str_add("  5.12    ")
         self.assertEqual(a.str_val(4.654321), "4.65")
-        a.val_from_str_add("5.1234")
+        a._val_from_str_add("5.1234")
         self.assertEqual(a.str_val(4.654321), "4.6543")
 
     def test_colors(self):

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -67,7 +67,7 @@ class TestExcelHeader1(unittest.TestCase):
         self.assertIsInstance(domain[3], ContinuousVariable)
         for i, var in enumerate(domain):
             self.assertEqual(var.name, chr(97 + i))
-        self.assertEqual(domain[0].values, ["green", "red"])
+        self.assertEqual(domain[0].values, ("green", "red"))
         np.testing.assert_almost_equal(table.X,
                                        np.array([[1, 0.5, 0, 21],
                                                  [1, 0.1, 0, 123],
@@ -95,7 +95,7 @@ class TestExcelHeader1(unittest.TestCase):
         for n, var in zip("acf", domain.metas):
             self.assertEqual(var.name, n)
         self.assertIsInstance(domain.metas[0], DiscreteVariable)
-        self.assertEqual(domain.metas[0].values, ["green", "red"])
+        self.assertEqual(domain.metas[0].values, ("green", "red"))
         self.assertIsInstance(domain.metas[1], ContinuousVariable)
         np.testing.assert_almost_equal(
             table.metas[:, 0], np.array([1, 1, 0] * 7 + [1, 1]))
@@ -130,7 +130,7 @@ class TestExcelHeader3(unittest.TestCase):
         for n, var in zip("acf", domain.metas):
             self.assertEqual(var.name, n)
         self.assertIsInstance(domain.metas[0], DiscreteVariable)
-        self.assertEqual(domain.metas[0].values, ["green", "red"])
+        self.assertEqual(domain.metas[0].values, ("green", "red"))
         self.assertIsInstance(domain.metas[1], ContinuousVariable)
         np.testing.assert_almost_equal(
             table.metas[:, 0], np.array([1, 1, 0] * 7 + [1, 1]))

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -329,7 +329,7 @@ class OWColor(widget.OWWidget):
             if var.is_discrete or var.is_continuous:
                 var = var.make_proxy()
                 if var.is_discrete:
-                    var.values = var.values[:]
+                    var._values = var.values[:]
                     self.disc_colors.append(var)
                 else:
                     self.cont_colors.append(var)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -363,7 +363,7 @@ class OWSelectRows(widget.OWWidget):
                 self.cond_list.setCellWidget(oper_combo.row, 2, button)
             else:
                 combo = QComboBox()
-                combo.addItems([""] + var.values)
+                combo.addItems(("", ) + var.values)
                 if lc[0]:
                     combo.setCurrentIndex(int(lc[0]))
                 else:

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -279,7 +279,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
             nmodels = results.predicted.shape[0]
             self.headers = class_values + \
-                           [unicodedata.lookup("N-ARY SUMMATION")]
+                           (unicodedata.lookup("N-ARY SUMMATION"), )
 
             # NOTE: The 'learner_names' is set in 'Test Learners' widget.
             if hasattr(results, "learner_names"):

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -593,7 +593,7 @@ class OWTestLearners(OWWidget):
         if self.data.domain.has_discrete_class:
             self.cbox.setVisible(True)
             class_var = self.data.domain.class_var
-            items = [self.TARGET_AVERAGE] + class_var.values
+            items = (self.TARGET_AVERAGE, ) + class_var.values
             self.class_selection_combo.addItems(items)
 
             class_index = 0

--- a/Orange/widgets/tests/test_class_values_context_handler.py
+++ b/Orange/widgets/tests/test_class_values_context_handler.py
@@ -59,7 +59,7 @@ class TestClassValuesContextHandler(TestCase):
         self.handler.open_context(widget, self.args[0][1])
 
         context = widget.current_context
-        self.assertEqual(context.classes, ['a', 'b', 'c'])
+        self.assertEqual(context.classes, ('a', 'b', 'c'))
         self.assertEqual(widget.text, 'u')
         self.assertEqual(widget.with_metas, [])
 

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -47,7 +47,7 @@ class TestDomainContextHandler(TestCase):
 
         self.assertEqual(encoded_attributes,
                          {'c1': Continuous, 'd1': Discrete, 'd2': Discrete,
-                          'd3': list('ghi')})
+                          'd3': tuple('ghi')})
         self.assertEqual(encoded_metas, {'c2': Continuous, 'd4': Discrete})
 
     def test_encode_domain_with_match_all(self):
@@ -58,10 +58,10 @@ class TestDomainContextHandler(TestCase):
         encoded_attributes, encoded_metas = handler.encode_domain(self.domain)
 
         self.assertEqual(encoded_attributes,
-                         {'c1': Continuous, 'd1': list('abc'),
-                          'd2': list('def'), 'd3': list('ghi')})
+                         {'c1': Continuous, 'd1': tuple('abc'),
+                          'd2': tuple('def'), 'd3': tuple('ghi')})
         self.assertEqual(encoded_metas,
-                         {'c2': Continuous, 'd4': list('jkl')})
+                         {'c2': Continuous, 'd4': tuple('jkl')})
 
     def test_encode_domain_with_false_attributes_in_res(self):
         handler = DomainContextHandler(attributes_in_res=False,

--- a/doc/data-mining-library/source/reference/data.variable.rst
+++ b/doc/data-mining-library/source/reference/data.variable.rst
@@ -86,7 +86,6 @@ Base class
     .. automethod:: is_primitive
     .. automethod:: str_val
     .. automethod:: to_val
-    .. automethod:: val_from_str_add
     .. autoattribute:: compute_value
 
     Method `compute_value` is usually invoked behind the scenes in
@@ -146,7 +145,6 @@ Continuous variables
     .. automethod:: is_primitive
     .. automethod:: str_val
     .. automethod:: to_val
-    .. automethod:: val_from_str_add
 
 Discrete variables
 ------------------
@@ -157,7 +155,6 @@ Discrete variables
     .. automethod:: is_primitive
     .. automethod:: str_val
     .. automethod:: to_val
-    .. automethod:: val_from_str_add
 
 String variables
 ----------------
@@ -168,7 +165,6 @@ String variables
     .. automethod:: is_primitive
     .. automethod:: str_val
     .. automethod:: to_val
-    .. automethod:: val_from_str_add
 
 Time variables
 --------------


### PR DESCRIPTION
Make `Discrete.values` a read-only property.

Methods for adding to `values` are made private and they are only used in `find_compatible`, which is called by `make`. This is currently unavoidable.

This is related to #2277, but deserves a separate PR since it is more general.

##### Includes
- [X] Code changes
