### PR TITLE
[FIX] Fix and improve Precision, Recall, F1

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -293,8 +293,8 @@ def compute_CD(avranks, N, alpha="0.05", test="nemenyi"):
     return cd
 
 
-def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, width=6, textspace=1,
-                reverse=False, filename=None, **kwargs):
+def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None,
+                width=6, textspace=1, reverse=False, filename=None, **kwargs):
     """
     Draws a CD graph, which is used to display  the differences in methods' performance.
     See Janez Demsar, Statistical Comparisons of Classifiers over Multiple Data Sets, 7(Jan):1--30, 2006.
@@ -324,7 +324,8 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, w
         import matplotlib.pyplot as plt
         from matplotlib.backends.backend_agg import FigureCanvasAgg
     except ImportError:
-        print("Function requires matplotlib. Please install it.", file=sys.stderr)
+        print("Function requires matplotlib. Please install it.",
+              file=sys.stderr)
         return
 
     width = float(width)
@@ -414,7 +415,8 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, w
             lsums = len(sums)
             allpairs = [(i, j) for i, j in mxrange([[lsums], [lsums]]) if j > i]
             # remove not significant
-            notSig = [(i, j) for i, j in allpairs if abs(sums[i] - sums[j]) <= hsd]
+            notSig = [(i, j) for i, j in allpairs
+                      if abs(sums[i] - sums[j]) <= hsd]
             # keep only longest
 
             def no_longer(ij_tuple, notSig):
@@ -478,23 +480,27 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, w
         tick = smalltick
         if a == int(a):
             tick = bigtick
-        line([(rankpos(a), cline - tick / 2), (rankpos(a), cline)], linewidth=0.7)
+        line([(rankpos(a), cline - tick / 2), (rankpos(a), cline)],
+             linewidth=0.7)
 
     for a in range(lowv, highv + 1):
-        text(rankpos(a), cline - tick / 2 - 0.05, str(a), ha="center", va="bottom")
+        text(rankpos(a), cline - tick / 2 - 0.05, str(a),
+             ha="center", va="bottom")
 
     k = len(ssums)
 
     for i in range(math.ceil(k / 2)):
         chei = cline + minnotsignificant + i * 0.2
-        line([(rankpos(ssums[i]), cline), (rankpos(ssums[i]), chei), (textspace - 0.1, chei)], linewidth=0.7)
+        line([(rankpos(ssums[i]), cline), (rankpos(ssums[i]), chei),
+              (textspace - 0.1, chei)], linewidth=0.7)
         text(textspace - 0.2, chei, nnames[i], ha="right", va="center")
 
     for i in range(math.ceil(k / 2), k):
         chei = cline + minnotsignificant + (k - i - 1) * 0.2
-        line([(rankpos(ssums[i]), cline), (rankpos(ssums[i]), chei), (textspace + scalewidth + 0.1, chei)],
-             linewidth=0.7)
-        text(textspace + scalewidth + 0.2, chei, nnames[i], ha="left", va="center")
+        line([(rankpos(ssums[i]), cline), (rankpos(ssums[i]), chei),
+              (textspace + scalewidth + 0.1, chei)], linewidth=0.7)
+        text(textspace + scalewidth + 0.2, chei, nnames[i],
+             ha="left", va="center")
 
     if cd and cdmethod is None:
         # upper scale
@@ -504,15 +510,19 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, w
             begin, end = rankpos(highv), rankpos(highv - cd)
 
         line([(begin, distanceh), (end, distanceh)], linewidth=0.7)
-        line([(begin, distanceh + bigtick / 2), (begin, distanceh - bigtick / 2)], linewidth=0.7)
-        line([(end, distanceh + bigtick / 2), (end, distanceh - bigtick / 2)], linewidth=0.7)
-        text((begin + end) / 2, distanceh - 0.05, "CD", ha="center", va="bottom")
+        line([(begin, distanceh + bigtick / 2),
+              (begin, distanceh - bigtick / 2)], linewidth=0.7)
+        line([(end, distanceh + bigtick / 2),
+              (end, distanceh - bigtick / 2)], linewidth=0.7)
+        text((begin + end) / 2, distanceh - 0.05, "CD",
+             ha="center", va="bottom")
 
         # non significance lines
         def draw_lines(lines, side=0.05, height=0.1):
             start = cline + 0.2
             for l, r in lines:
-                line([(rankpos(ssums[l]) - side, start), (rankpos(ssums[r]) + side, start)], linewidth=2.5)
+                line([(rankpos(ssums[l]) - side, start),
+                      (rankpos(ssums[r]) + side, start)], linewidth=2.5)
                 start += height
 
         draw_lines(lines)
@@ -521,8 +531,10 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None, w
         begin = rankpos(avranks[cdmethod] - cd)
         end = rankpos(avranks[cdmethod] + cd)
         line([(begin, cline), (end, cline)], linewidth=2.5)
-        line([(begin, cline + bigtick / 2), (begin, cline - bigtick / 2)], linewidth=2.5)
-        line([(end, cline + bigtick / 2), (end, cline - bigtick / 2)], linewidth=2.5)
+        line([(begin, cline + bigtick / 2), (begin, cline - bigtick / 2)],
+             linewidth=2.5)
+        line([(end, cline + bigtick / 2), (end, cline - bigtick / 2)],
+             linewidth=2.5)
 
     if filename:
         print_figure(fig, filename, **kwargs)

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -56,10 +56,13 @@ def classification_stats(results):
 
 classification_stats.headers, classification_stats.scores = zip(*(
     ("AUC", scoring.AUC),
-    ("CA", scoring.CA),
-    ("F1", scoring.F1),
-    ("Precision", scoring.Precision),
-    ("Recall", scoring.Recall),
+    ("CA", lambda res, *args, **kwargs: scoring.CA(res)),
+    ("F1", (lambda res, target=None:
+            scoring.F1(res, target=target, average='weighted'))),
+    ("Precision", (lambda res, target=None:
+                   scoring.Precision(res, target=target, average='weighted'))),
+    ("Recall", (lambda res, target=None:
+                scoring.Recall(res, target=target, average='weighted'))),
 ))
 
 
@@ -559,7 +562,7 @@ class OWTestLearners(OWWidget):
                     ovr_results = results_one_vs_rest(
                         slot.results.value, target_index)
 
-                    stats = [Try(lambda: score(ovr_results))
+                    stats = [Try(lambda: score(ovr_results, target=1))
                              for score in classification_stats.scores]
                 else:
                     stats = None


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Precision, Recall and F1 scores in Test & Score were showing incorrect results and not using the selected target class correctly.

##### Description of changes
Refactor scores by adding the TargetScore base class for Precision, Recall and F1. Call them correctly from the Test & Score widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
