### PR TITLE
[FIX] owmanifoldlearning: Remove `n_jobs=-2` parameter

### DIFF
--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -276,8 +276,7 @@ class OWManifoldLearning(OWWidget):
         self.Outputs.transformed_data.send(out)
 
     def get_method_parameters(self, data, method):
-        parameters = dict(n_components=self.n_components,
-                          n_jobs=-2)
+        parameters = dict(n_components=self.n_components)
         parameters.update(self.params_widget.parameters)
         if data is not None and data.is_sparse() and method == TSNE:
             parameters.update(method='exact',


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Manifold Learning frequently deadlocks with the forking multiprocessing backend and a
threaded blas library.


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
