### PR TITLE
[FIX] OWColor: Use DiscreteVariable's values for matching contexts

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -286,7 +286,8 @@ class OWColor(widget.OWWidget):
     inputs = [("Data", Orange.data.Table, "set_data")]
     outputs = [("Data", Orange.data.Table)]
 
-    settingsHandler = settings.PerfectDomainContextHandler()
+    settingsHandler = settings.PerfectDomainContextHandler(
+        match_values=settings.PerfectDomainContextHandler.MATCH_VALUES_ALL)
     disc_data = settings.ContextSetting([])
     cont_data = settings.ContextSetting([])
     color_settings = settings.Setting(None)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #2375.

##### Description of changes
`PerfectDomainContextHandler` matches by `PerfectDomainContextHandler.MATCH_VALUES_ALL`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation