### PR TITLE
[FIX] OWColor: Fix propagating changes to the output

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -349,7 +349,10 @@ class Table(MutableSequence, Storage):
                     if cached:
                         return cached
                 if domain == source.domain:
-                    return cls.from_table_rows(source, row_indices)
+                    table = cls.from_table_rows(source, row_indices)
+                    # assure resulting domain is the instance passed on input
+                    table.domain = domain
+                    return table
 
                 if isinstance(row_indices, slice):
                     start, stop, stride = row_indices.indices(source.X.shape[0])

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
+import copy
 import os
 import unittest
 from itertools import chain
@@ -1734,6 +1735,12 @@ class CreateTableWithDomainAndTable(TableTests):
         self.assertIsInstance(new_table, MyTableClass)
         self.assertIsNot(table, new_table)
         self.assertIs(new_table.domain, new_domain)
+
+    def test_transform_same_domain(self):
+        iris = data.Table("iris")
+        new_domain = copy.copy(iris.domain)
+        new_data = iris.transform(new_domain)
+        self.assertIs(new_data.domain, new_domain)
 
     def test_can_copy_table(self):
         new_table = data.Table.from_table(self.domain, self.table)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -3,14 +3,14 @@
 
 import copy
 import os
+import random
 import unittest
 from itertools import chain
 from math import isnan
-import random
-
 from unittest.mock import Mock, MagicMock, patch
-import scipy.sparse as sp
+
 import numpy as np
+import scipy.sparse as sp
 
 from Orange import data
 from Orange.data import (filter, Unknown, Variable, Table, DiscreteVariable,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #2378 

##### Description of changes
Assure that when domains are equal, `from_tables` sets the resulting table's domain to the instance that was passed on the input.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation