### PR TITLE
[FIX] Distances: prevent inf numbers

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -5,7 +5,7 @@ from collections import namedtuple, OrderedDict
 from itertools import chain
 from contextlib import contextmanager
 
-import numpy
+import numpy as np
 
 from AnyQt.QtWidgets import (
     QGraphicsWidget, QGraphicsObject, QGraphicsLinearLayout, QGraphicsPathItem,
@@ -605,7 +605,7 @@ class DendrogramWidget(QGraphicsWidget):
         else:
             drect = QSizeF(leaf_count, self._root.value.height)
 
-        eps = numpy.finfo(numpy.float64).eps
+        eps = np.finfo(np.float64).eps
 
         if abs(drect.width()) < eps:
             sx = 1.0
@@ -1135,7 +1135,7 @@ class OWHierarchicalClustering(widget.OWWidget):
 
         if isinstance(items, Orange.data.Table) and self.matrix.axis == 1:
             # Select rows
-            c = numpy.zeros(self.matrix.shape[0])
+            c = np.zeros(self.matrix.shape[0])
 
             for i, indices in enumerate(maps):
                 c[indices] = i

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -1,6 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-import numpy
+import numpy as np
 import Orange.misc
 from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -53,7 +53,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         self.assertIsNone(self.get_output(self.widget.Outputs.annotated_data))
 
     def test_all_zero_inputs(self):
-        d = Orange.misc.DistMatrix(numpy.zeros((10, 10)))
+        d = Orange.misc.DistMatrix(np.zeros((10, 10)))
         self.widget.set_distances(d)
 
     def test_annotation_settings_retrieval(self):
@@ -61,8 +61,8 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         widget = self.widget
 
         dist_names = Orange.misc.DistMatrix(
-            numpy.zeros((4, 4)), self.data, axis=0)
-        dist_no_names = Orange.misc.DistMatrix(numpy.zeros((10, 10)), axis=1)
+            np.zeros((4, 4)), self.data, axis=0)
+        dist_no_names = Orange.misc.DistMatrix(np.zeros((10, 10)), axis=1)
 
         self.send_signal(self.widget.Inputs.distances, self.distances)
         # Check that default is set (class variable)


### PR DESCRIPTION
##### Issue
![screenshot_20170606_112022](https://cloud.githubusercontent.com/assets/22157215/26822407/2fa81c6a-4aaa-11e7-968d-8c1b52dbd554.png)

> ---------------------------- ValueError Exception -----------------------------
> Traceback (most recent call last):
>   File "pyqtgraph/graphicsItems/AxisItem.py", line 525, in paint specs = self.generateDrawSpecs(painter)
>   File "pyqtgraph/graphicsItems/AxisItem.py", line 819, in generateDrawSpecs tickLevels = self.tickValues(self.range[0], self.range[1], lengthInPixels)
>   File "pyqtgraph/graphicsItems/AxisItem.py", line 691, in tickValues num = int((maxVal-start) / spacing) + 1
> ValueError: cannot convert float NaN to integer
> -------------------------------------------------------------------------------


##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
