### PR TITLE
[FIX] Scatter Plot: two minor errors

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -323,8 +323,9 @@ class OWScatterPlot(OWWidget):
         self.vizrank.initialize()
         self.vizrank.attrs = self.data.domain.attributes if self.data is not None else []
         self.vizrank_button.setEnabled(
-            self.data is not None and self.data.domain.class_var is not None
-            and len(self.data.domain.attributes) > 1 and len(self.data) > 1)
+            self.data is not None and not self.data.is_sparse() and
+            self.data.domain.class_var is not None and
+            len(self.data.domain.attributes) > 1 and len(self.data) > 1)
         if self.data is not None and self.data.domain.class_var is None \
             and len(self.data.domain.attributes) > 1 and len(self.data) > 1:
             self.vizrank_button.setToolTip(
@@ -423,7 +424,6 @@ class OWScatterPlot(OWWidget):
                             new=False)
 
     def sparse_to_dense(self, input_data=None):
-        self.vizrank_button.setEnabled(not (self.data and self.data.is_sparse()))
         if input_data is None or not input_data.is_sparse():
             return input_data
         keys = []

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -989,7 +989,7 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         self.make_legend()
 
     def assure_attribute_present(self, attr):
-        if attr not in self.data.domain:
+        if self.data is not None and attr not in self.data.domain:
             self.master.prepare_data()
 
     def update_grid(self):


### PR DESCRIPTION
##### Issue
![screenshot_20170606_120406](https://cloud.githubusercontent.com/assets/22157215/26824140/71e63f34-4ab0-11e7-8f14-92c60751ea30.png)

##### Steps to reproduce the behavior
Put _Scatter Plot_ widget on the canvas. Then try to change shape. Select **(Same shape)**.

![screenshot_20170606_120429](https://cloud.githubusercontent.com/assets/22157215/26824145/752c7244-4ab0-11e7-8ecb-30fb13f32c9a.png)

##### Steps to reproduce the behavior
Put _Scatter Plot_ widget on the canvas.  Then do something. For instance, try to change color. **Find Informative Projections** button enables and it crashes when an user starts vizrank.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
