### PR TITLE
OWFile: dialog formats not set in class

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -17,7 +17,7 @@ from Orange.widgets.settings import Setting, ContextSetting, \
     PerfectDomainContextHandler, SettingProvider
 from Orange.widgets.utils.domaineditor import DomainEditor
 from Orange.widgets.utils.itemmodels import PyListModel
-from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
+from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin, dialog_formats
 
 # Backward compatibility: class RecentPath used to be defined in this module,
 # and it is used in saved (pickled) settings. It must be imported into the
@@ -104,13 +104,6 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     url = Setting("")
 
     variables = ContextSetting([])
-
-    dlg_formats = (
-        "All readable files ({});;".format(
-            '*' + ' *'.join(FileFormat.readers.keys())) +
-        ";;".join("{} (*{})".format(f.DESCRIPTION, ' *'.join(f.EXTENSIONS))
-                  for f in sorted(set(FileFormat.readers.values()),
-                                  key=list(FileFormat.readers.values()).index)))
 
     domain_editor = SettingProvider(DomainEditor)
 
@@ -261,7 +254,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             start_file = self.last_path() or os.path.expanduser("~/")
 
         filename, _ = QFileDialog.getOpenFileName(
-            self, 'Open Orange Data File', start_file, self.dlg_formats)
+            self, 'Open Orange Data File', start_file, dialog_formats())
         if not filename:
             return
         self.add_path(filename)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -18,10 +18,19 @@ from Orange.data import FileFormat, dataset_dirs, StringVariable, Table, \
     Domain, DiscreteVariable
 from Orange.tests import named_file
 from Orange.widgets.data.owfile import OWFile
+from Orange.widgets.utils.filedialogs import dialog_formats
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.domaineditor import ComboDelegate, VarTypeDelegate, VarTableModel
 
 TITANIC_PATH = path.join(path.dirname(Orange.__file__), 'datasets', 'titanic.tab')
+
+
+class AddedFormat(FileFormat):
+    EXTENSIONS = ('.123',)
+    DESCRIPTION = "Test if a dialog format works after reading OWFile"
+
+    def read(self):
+        pass
 
 
 class TestOWFile(WidgetTest):
@@ -231,3 +240,8 @@ a
         self.widget.apply_button.click()
         data = self.get_output("Data")
         self.assertIsNone(data)
+
+    def test_add_new_format(self):
+        # test adding file formats after registering the widget
+        formats = dialog_formats()
+        self.assertTrue(".123" in formats)

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -5,6 +5,7 @@ from AnyQt.QtGui import QBrush
 from AnyQt.QtWidgets import \
     QMessageBox, QFileDialog, QFileIconProvider, QComboBox
 
+from Orange.data.io import FileFormat
 from Orange.widgets.settings import Setting
 
 
@@ -38,6 +39,17 @@ fix_extension.CANCEL = 2
 
 def format_filter(writer):
     return '{} (*{})'.format(writer.DESCRIPTION, ' *'.join(writer.EXTENSIONS))
+
+
+def dialog_formats():
+    """
+    Return readable file types for QFileDialogs.
+    """
+    return ("All readable files ({});;".format(
+        '*' + ' *'.join(FileFormat.readers.keys())) +
+            ";;".join("{} (*{})".format(f.DESCRIPTION, ' *'.join(f.EXTENSIONS))
+                      for f in sorted(set(FileFormat.readers.values()),
+                                      key=list(FileFormat.readers.values()).index)))
 
 
 def get_file_name(start_dir, start_filter, file_formats):


### PR DESCRIPTION
If dlg_formats were set before an object was created, new file formats
from the add-ons were not detected unless OWFile was already cached in
the widget registry.

##### Issue

Fixes https://github.com/markotoplak/orange-infrared/issues/74

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
