### PR TITLE
[FIX] tests: Fix test errors when running with numpy 1.13.0

### DIFF
--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -3,6 +3,7 @@ import unittest
 import tempfile
 from contextlib import contextmanager
 
+import numpy as np
 import Orange
 
 
@@ -17,6 +18,31 @@ def named_file(content, encoding=None, suffix=''):
         yield name
     finally:
         os.remove(name)
+
+
+@np.vectorize
+def naneq(a, b):
+    try:
+        return (np.isnan(a) and np.isnan(b)) or a == b
+    except TypeError:
+        return a == b
+
+
+def assert_array_nanequal(a, b, *args, **kwargs):
+    """
+    Similar as np.testing.assert_array_equal but with better handling of
+    object arrays.
+
+    Note
+    ----
+    Is not fast!
+
+    Parameters
+    ----------
+    a : array-like
+    b : array-like
+    """
+    return np.testing.utils.assert_array_compare(naneq, a, b, *args, **kwargs)
 
 
 def test_dirname():

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_array_equal
 from Orange.data import \
     Instance, Domain, Unknown, Value, \
     DiscreteVariable, ContinuousVariable, StringVariable
+from Orange.tests import assert_array_nanequal
 
 
 class TestInstance(unittest.TestCase):
@@ -75,11 +76,10 @@ class TestInstance(unittest.TestCase):
         self.assertEqual(inst._metas.shape, (3, ))
         self.assertTrue(all(isnan(x) for x in inst._x))
         self.assertTrue(all(isnan(x) for x in inst._y))
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert_array_equal(inst._metas,
-                               np.array([var.Unknown for var in domain.metas],
-                                        dtype=object))
+
+        assert_array_nanequal(inst._metas,
+                              np.array([var.Unknown for var in domain.metas],
+                                       dtype=object))
 
     def test_init_x_arr(self):
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")])
@@ -162,12 +162,11 @@ class TestInstance(unittest.TestCase):
                                      domain.class_vars,
                                      [self.metas[0], "w", domain[0]])
         inst2 = Instance(domain2, inst)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", FutureWarning)
-            assert_array_equal(inst2._x, np.array([Unknown, 0, 43]))
-            self.assertEqual(inst2._y[0], 1)
-            assert_array_equal(inst2._metas, np.array([0, Unknown, 42],
-                                                      dtype=object))
+
+        assert_array_nanequal(inst2._x, np.array([Unknown, 0, 43]))
+        self.assertEqual(inst2._y[0], 1)
+        assert_array_nanequal(inst2._metas, np.array([0, Unknown, 42],
+                                                     dtype=object))
 
     def test_get_item(self):
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")],

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -14,21 +14,7 @@ import numpy as np
 from Orange import data
 from Orange.data import (filter, Unknown, Variable, Table, DiscreteVariable,
                          ContinuousVariable, Domain, StringVariable)
-from Orange.tests import test_dirname
-
-
-@np.vectorize
-def naneq(a, b):
-    try:
-        return (isnan(a) and isnan(b)) or a == b
-    except TypeError:
-        return a == b
-
-
-def assert_array_nanequal(*args, **kwargs):
-    # similar as np.testing.assert_array_equal but with better handling of
-    # object arrays
-    return np.testing.utils.assert_array_compare(naneq, *args, **kwargs)
+from Orange.tests import test_dirname, assert_array_nanequal
 
 
 class TableTestCase(unittest.TestCase):

--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -46,10 +46,10 @@ class TestUtil(unittest.TestCase):
         var = ContinuousVariable('x')
         transform = ReplaceUnknownsRandom(var, Continuous(1, var))
 
-        self.assertEqual(repr(transform).replace('\n       ', ' '),
+        self.assertEqual(repr(transform).replace('\n', '').replace(' ', ''),
                          "ReplaceUnknownsRandom("
-                         "variable=ContinuousVariable(name='x', number_of_decimals=3), "
-                         "distribution=Continuous([[ 0.], [ 0.]]))")
+                         "variable=ContinuousVariable(name='x',number_of_decimals=3),"
+                         "distribution=Continuous([[0.],[0.]]))")
 
         # GH 2275
         logit = LogisticRegressionLearner()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

3 test failures when running with numpy 1.13.0
```
======================================================================
FAIL: test_init_inst (Orange.tests.test_instance.TestInstance)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\Orange\tests\test_instance.py", line 170, in test_init_inst
    dtype=object))
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\numpy\testing\utils.py", line 854, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\numpy\testing\utils.py", line 778, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Arrays are not equal
(mismatch 33.33333333333333%)
 x: array([0, nan, 42.0], dtype=object)
 y: array([0, nan, 42], dtype=object)
======================================================================
FAIL: test_init_xym_no_data (Orange.tests.test_instance.TestInstance)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\Orange\tests\test_instance.py", line 82, in test_init_xym_no_data
    dtype=object))
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\numpy\testing\utils.py", line 854, in assert_array_equal
    verbose=verbose, header='Arrays are not equal')
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\numpy\testing\utils.py", line 778, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Arrays are not equal
(mismatch 66.66666666666666%)
 x: array([nan, nan, ''], dtype=object)
 y: array([nan, nan, ''], dtype=object)
======================================================================
FAIL: test_reprable (Orange.tests.test_util.TestUtil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Miniconda35\conda-bld\orange3_1497021380284\_t_env\lib\site-packages\Orange\tests\test_util.py", line 50, in test_reprable
    "ReplaceUnknownsRandom("
AssertionError: "Repl[62 chars]_of_decimals=3), distribution=Continuous([[ 0.],      [ 0.]]))" != "Repl[62 chars]_of_decimals=3), distribution=Continuous([[ 0.], [ 0.]]))"
- ReplaceUnknownsRandom(variable=ContinuousVariable(name='x', number_of_decimals=3), distribution=Continuous([[ 0.],      [ 0.]]))
?                                                                                                                    -----
+ ReplaceUnknownsRandom(variable=ContinuousVariable(name='x', number_of_decimals=3), distribution=Continuous([[ 0.], [ 0.]]))
```


##### Description of changes

* Remove use of `assert_array_equal` for object arrays
* Compare the `Reprable` output ignoring whitespace.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
