### PR TITLE
[ENH] SimpleTreeLearner: Release GIL & thread safety

### DIFF
--- a/Orange/classification/simple_tree.py
+++ b/Orange/classification/simple_tree.py
@@ -6,7 +6,7 @@ from Orange.base import Learner, Model
 __all__ = ['SimpleTreeLearner']
 
 from . import _simple_tree
-_tree = ct.pydll.LoadLibrary(_simple_tree.__file__)
+_tree = ct.cdll.LoadLibrary(_simple_tree.__file__)
 
 DiscreteNode = 0
 ContinuousNode = 1


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

SimpleTreeLearner does not release the GIL (as it is not thread safe)

##### Description of changes

* Remove use of global `compar_attr` variable. Use `qsort_(r|s)` with explicit context passing.
* Use GIL releasing ctypes call.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
