### PR TITLE
[FIX] Paint Data: Fix crash on empty data

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -797,7 +797,7 @@ class OWPaintData(OWWidget):
         self.class_model.rowsInserted.connect(self._class_count_changed)
         self.class_model.rowsRemoved.connect(self._class_count_changed)
 
-        if self.data is None:
+        if self.data is None or not len(self.data):
             self.data = []
             self.__buffer = np.zeros((0, 3))
         elif isinstance(self.data, np.ndarray):

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -797,7 +797,7 @@ class OWPaintData(OWWidget):
         self.class_model.rowsInserted.connect(self._class_count_changed)
         self.class_model.rowsRemoved.connect(self._class_count_changed)
 
-        if self.data is None or not len(self.data):
+        if not self.data:
             self.data = []
             self.__buffer = np.zeros((0, 3))
         elif isinstance(self.data, np.ndarray):

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -71,3 +71,10 @@ class TestOWPaintData(WidgetTest):
         self.assertTrue(self.widget.Warning.sparse_not_supported.is_shown())
         self.send_signal("Data", None)
         self.assertFalse(self.widget.Warning.sparse_not_supported.is_shown())
+
+    def test_load_empty_data(self):
+        """
+        It should not crash when old workflow with no data is loaded.
+        GH-2399
+        """
+        self.create_widget(OWPaintData, stored_settings={"data": []})


### PR DESCRIPTION
##### Issue
We create Paint Data widget, draw nothing, and save created workflow.
![screenshot_20170613_100755](https://user-images.githubusercontent.com/22157215/27072331-6ac463d2-5020-11e7-854f-cdec1e9f57b8.png)

Then we open it:
![screenshot_20170613_100840](https://user-images.githubusercontent.com/22157215/27072339-71a1938c-5020-11e7-9439-0631a8306e78.png)

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation

