### PR TITLE
[FIX] owpreproces: Stable order of continuizers

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -191,13 +191,14 @@ class DiscretizeEditor(BaseEditor):
 class ContinuizeEditor(BaseEditor):
     _Type = type(Continuize.FirstAsBase)
 
-    Continuizers = OrderedDict({
-        Continuize.FrequentAsBase: "Most frequent is base",
-        Continuize.Indicators: "One attribute per value",
-        Continuize.RemoveMultinomial: "Remove multinomial attributes",
-        Continuize.Remove: "Remove all discrete attributes",
-        Continuize.AsOrdinal: "Treat as ordinal",
-        Continuize.AsNormalizedOrdinal: "Divide by number of values"})
+    Continuizers = OrderedDict([
+        (Continuize.FrequentAsBase, "Most frequent is base"),
+        (Continuize.Indicators, "One attribute per value"),
+        (Continuize.RemoveMultinomial, "Remove multinomial attributes"),
+        (Continuize.Remove, "Remove all discrete attributes"),
+        (Continuize.AsOrdinal, "Treat as ordinal"),
+        (Continuize.AsNormalizedOrdinal, "Divide by number of values")
+    ])
 
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The order of methods presented in the "Continuize Discrete Variables" is random

##### Description of changes

* Fix OrderedDict initialization.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
