### PR TITLE
[FIX] Update checker: LooseVersion doesn't handle str parts

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -124,7 +124,6 @@ def check_for_updates():
         settings.setValue('startup/last-update-check-time', int(time.time()))
 
         from urllib.request import urlopen
-        from distutils.version import LooseVersion
         from Orange.version import version as current
 
         class GetLatestVersion(QThread):
@@ -133,12 +132,13 @@ def check_for_updates():
             def run(self):
                 try:
                     self.resultReady.emit(
-                        urlopen('https://orange.biolab.si/version', timeout=10).read().decode())
+                        urlopen('https://orange.biolab.si/version/', timeout=10).read().decode())
                 except OSError:
                     log.exception('Failed to check for updates')
 
         def compare_versions(latest):
-            if LooseVersion(latest) <= LooseVersion(current):
+            version = pkg_resources.parse_version
+            if version(latest) <= version(current):
                 return
             question = QMessageBox(
                 QMessageBox.Information,

--- a/Orange/tests/test_third_party.py
+++ b/Orange/tests/test_third_party.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from pkg_resources import parse_version
+
+
+class TestPkgResources(TestCase):
+    def test_parse_version(self):
+        self.assertGreater(parse_version('3.4.1'), parse_version('3.4.0'))
+        self.assertGreater(parse_version('3.4.1'), parse_version('3.4.dev'))
+        self.assertGreater(parse_version('3.4.0'), parse_version('3.4~1'))


### PR DESCRIPTION
##### Issue
```py
>>> from distutils.version import LooseVersion
>>> LooseVersion('3.4.dev') <= LooseVersion('3.4.1')
--------------------------------------------------------------------------------
TypeError: unorderable types: str() < int()
```

##### Description of changes
Use newer `package_resources.SetuptoolsVersion` which doesn't exhibit this problem.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
