### PR TITLE
owcalibrationplot: Specify output type for the smoother

### DIFF
--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -220,7 +220,7 @@ def gaussian_smoother(x, y, sigma=1.0):
         W = a * numpy.exp(-gamma * ((xs - x) ** 2))
         return numpy.average(y, weights=W)
 
-    return numpy.frompyfunc(smoother, 1, 1)
+    return numpy.vectorize(smoother, otypes=[numpy.float])
 
 
 def main():


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Python 3.6, numpy 1.13.0:
```
======================================================================
ERROR: test_basic (Orange.widgets.evaluate.tests.test_owcalibrationplot.TestOWCalibrationPlot)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\test-install\lib\site-packages\Orange\widgets\evaluate\tests\test_owcalibrationplot.py", line 30, in test_basic
    self.send_signal("Evaluation Results", self.res)
  File "C:\test-install\lib\site-packages\Orange\widgets\tests\base.py", line 218, in send_signal
    getattr(widget, input.handler)(value, *args)
  File "C:\test-install\lib\site-packages\Orange\widgets\evaluate\owcalibrationplot.py", line 99, in set_results
    self._replot()
  File "C:\test-install\lib\site-packages\Orange\widgets\evaluate\owcalibrationplot.py", line 191, in _replot
    self._setup_plot()
  File "C:\test-install\lib\site-packages\Orange\widgets\evaluate\owcalibrationplot.py", line 181, in _setup_plot
    self.plot.addItem(curve.curve_item)
  File "C:\test-install\lib\site-packages\pyqtgraph\graphicsItems\PlotItem\PlotItem.py", line 512, in addItem
    self.vb.addItem(item, *args, **vbargs)
  File "C:\test-install\lib\site-packages\pyqtgraph\graphicsItems\ViewBox\ViewBox.py", line 407, in addItem
    self.updateAutoRange()
  File "C:\test-install\lib\site-packages\pyqtgraph\graphicsItems\ViewBox\ViewBox.py", line 886, in updateAutoRange
    childRange = self.childrenBounds(frac=fractionVisible)
  File "C:\test-install\lib\site-packages\pyqtgraph\graphicsItems\ViewBox\ViewBox.py", line 1388, in childrenBounds
    yr = item.dataBounds(1, frac=frac[1], orthoRange=orthoRange[1])
  File "C:\test-install\lib\site-packages\pyqtgraph\graphicsItems\PlotDataItem.py", line 620, in dataBounds
    range = self.curve.dataBounds(ax, frac, orthoRange)
  File "C:\test-install\lib\site-packages\pyqtgraph\graphicsItems\PlotCurveItem.py", line 131, in dataBounds
    b = (np.nanmin(d), np.nanmax(d))
  File "C:\test-install\lib\site-packages\numpy\lib\nanfunctions.py", line 253, in nanmin
    res = _copyto(res, np.nan, mask)
  File "C:\test-install\lib\site-packages\numpy\lib\nanfunctions.py", line 105, in _copyto
    a = a.dtype.type(val)
AttributeError: 'float' object has no attribute 'dtype'
----------------------------------------------------------------------
```
(as seen [here](https://ci.appveyor.com/project/ales-erjavec/orange3-installers/build/job/fhatba2ubm9wtfvl))

##### Description of changes

Specify output type for the smoother.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
