### PR TITLE
Requirements: scipy version bump to 0.16.1

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,5 +1,5 @@
 numpy>=1.9.0
-scipy>=0.11.0
+scipy>=0.16.1
 scikit-learn>=0.18.1
 bottleneck>=1.0.0
 # Reading Excel files


### PR DESCRIPTION
Scipy 0.16.1 is installed with the 32-bit Windows installer. Bumping
as we do not test with older scipy anyway.