### PR TITLE
[FIX] Some preprocessors couldn't be pickled

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -33,12 +33,14 @@ class Preprocess(_RefuseDataInConstructor, Reprable):
 
 
 class Continuize(Preprocess):
+    MultinomialTreatment = Enum(
+        "Continuize",
+        ("Indicators", "FirstAsBase", "FrequentAsBase", "Remove",
+         "RemoveMultinomial", "ReportError", "AsOrdinal", "AsNormalizedOrdinal",
+         "Leave"),
+        qualname="Continuize.MultinomialTreatment")
     (Indicators, FirstAsBase, FrequentAsBase, Remove, RemoveMultinomial,
-     ReportError, AsOrdinal, AsNormalizedOrdinal, Leave) = Enum(
-         "Continuize",
-         "Indicators, FirstAsBase, FrequentAsBase,"
-         "Remove, RemoveMultinomial, ReportError, AsOrdinal,"
-         "AsNormalizedOrdinal, Leave")
+     ReportError, AsOrdinal, AsNormalizedOrdinal, Leave) = MultinomialTreatment
 
     def __init__(self, zero_based=True,
                  multinomial_treatment=Indicators):
@@ -255,8 +257,8 @@ class Normalize(Preprocess):
     >>> normalizer = Normalize(norm_type=Normalize.NormalizeBySpan)
     >>> normalized_data = normalizer(data)
     """
-    Type = Enum("Normalize",
-                "NormalizeBySpan, NormalizeBySD")
+    Type = Enum("Normalize", ("NormalizeBySpan", "NormalizeBySD"),
+                qualname="Normalize.Type")
     NormalizeBySpan, NormalizeBySD = Type
 
     def __init__(self,
@@ -326,8 +328,12 @@ class Randomize(Preprocess):
     >>> randomizer = Randomize(Randomize.RandomizeClasses)
     >>> randomized_data = randomizer(data)
     """
-    Type = Enum("Randomize", dict(RandomizeClasses=1, RandomizeAttributes=2,
-                                  RandomizeMetas=4), type=int)
+    Type = Enum("Randomize",
+                dict(RandomizeClasses=1,
+                     RandomizeAttributes=2,
+                     RandomizeMetas=4),
+                type=int,
+                qualname="Randomize.Type")
     RandomizeClasses, RandomizeAttributes, RandomizeMetas = Type
 
     def __init__(self, rand_type=RandomizeClasses, rand_seed=None):
@@ -396,8 +402,10 @@ class Scale(Preprocess):
         def __call__(self, *args, **kwargs):
             return getattr(Scale, '_' + self.name)(*args, **kwargs)
 
-    CenteringType = _MethodEnum('Scale', 'NoCentering, Mean, Median')
-    ScalingType = _MethodEnum('Scale', 'NoScaling, Std, Span')
+    CenteringType = _MethodEnum("Scale", ("NoCentering", "Mean", "Median"),
+                                qualname="Scale.CenteringType")
+    ScalingType = _MethodEnum("Scale", ("NoScaling", "Std", "Span"),
+                              qualname="Scale.ScalingType")
     NoCentering, Mean, Median = CenteringType
     NoScaling, Std, Span = ScalingType
 

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 
 import os
+import pickle
 import unittest
 from unittest.mock import Mock, MagicMock, patch
 import numpy as np
@@ -130,3 +131,23 @@ class TestReprs(unittest.TestCase):
             repr_str = repr(preproc())
             new_preproc = eval(repr_str)
             self.assertEqual(repr(new_preproc), repr_str)
+
+class TestEnumPickling(unittest.TestCase):
+    def test_continuize_pickling(self):
+        c = Continuize(multinomial_treatment=Continuize.FirstAsBase)
+        s = pickle.dumps(c, -1)
+        c1 = pickle.loads(s)
+        self.assertIs(c1.multinomial_treatment, c.multinomial_treatment)
+
+    def test_randomize_pickling(self):
+        c = Randomize(rand_type=Randomize.RandomizeMetas)
+        s = pickle.dumps(c, -1)
+        c1 = pickle.loads(s)
+        self.assertIs(c1.rand_type, c.rand_type)
+
+    def test_scaling_pickling(self):
+        c = Scale(center=Scale.Median, scale=Scale.Span)
+        s = pickle.dumps(c, -1)
+        c1 = pickle.loads(s)
+        self.assertIs(c1.center, c.center)
+        self.assertIs(c1.scale, c.scale)


### PR DESCRIPTION
##### Issue

Randomize, Scale, Continuize were not picklable since the corresponding Enums were not global.

##### Description of changes

Add `qualname`.

##### Includes
- [X] Code changes
- [X] Tests