### PR TITLE
OWImpute & OWPreprocess: Add forward backward fill for missing values

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -13,6 +13,7 @@ import builtins
 import math
 import random
 import logging
+import numpy as np
 
 from traceback import format_exception_only
 from collections import namedtuple, OrderedDict
@@ -878,9 +879,9 @@ __ALLOWED = [
     "bin", "bool", "bytearray", "bytes", "chr", "complex", "dict",
     "divmod", "enumerate", "filter", "float", "format", "frozenset",
     "getattr", "hasattr", "hash", "hex", "id", "int", "iter", "len",
-    "list", "map", "max", "memoryview", "min", "next", "object",
+    "list", "map", "memoryview", "next", "object",
     "oct", "ord", "pow", "range", "repr", "reversed", "round",
-    "set", "slice", "sorted", "str", "sum", "tuple", "type",
+    "set", "slice", "sorted", "str", "tuple", "type",
     "zip"
 ]
 
@@ -901,7 +902,19 @@ __GLOBALS.update({
     "vonmisesvariate": random.vonmisesvariate,
     "weibullvariate": random.weibullvariate,
     "triangular": random.triangular,
-    "uniform": random.uniform}
+    "uniform": random.uniform,
+    "mean": lambda *args: np.nanmean(args),
+    "min": lambda *args: np.nanmin(args),
+    "max": lambda *args: np.nanmax(args),
+    "sum": lambda *args: np.nansum(args),
+    "std": lambda *args: np.nanstd(args),
+    "median": lambda *args: np.nanmedian(args),
+    "cumsum": lambda *args: np.nancumsum(args),
+    "cumprod": lambda *args: np.nancumprod(args),
+    "argmax": lambda *args: np.nanargmax(args),
+    "argmin": lambda *args: np.nanargmin(args),
+    "var": lambda *args: np.nanvar(args)
+}
 )
 
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -70,7 +70,8 @@ class OWImpute(OWWidget):
     DEFAULT_LEARNER = SimpleTreeLearner()
     METHODS = [AsDefault(), impute.DoNotImpute(), impute.Average(),
                impute.AsValue(), impute.Model(DEFAULT_LEARNER), impute.Random(),
-               impute.DropInstances(), impute.Default()]
+               impute.DropInstances(), impute.Default(),
+               impute.FillForward(), impute.FillBackward()]
     DEFAULT, DO_NOT_IMPUTE, MODEL_BASED_IMPUTER, AS_INPUT = 0, 1, 4, 7
 
     settingsHandler = settings.DomainContextHandler()

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -262,7 +262,8 @@ class _RemoveNaNRows(preprocess.preprocess.Preprocess):
 
 class ImputeEditor(BaseEditor):
     (NoImputation, Constant, Average,
-     Model, Random, DropRows, DropColumns) = 0, 1, 2, 3, 4, 5, 6
+     Model, Random, DropRows, DropColumns,
+     ForwardFill, BackwardFill) = 0, 1, 2, 3, 4, 5, 6, 7, 8
 
     Imputers = {
         NoImputation: (None, {}),
@@ -270,7 +271,9 @@ class ImputeEditor(BaseEditor):
         Average: (preprocess.impute.Average(), {}),
         #         Model: (preprocess.impute.Model, {}),
         Random: (preprocess.impute.Random(), {}),
-        DropRows: (None, {})
+        DropRows: (None, {}),
+        ForwardFill: (preprocess.impute.FillForward(), {}),
+        BackwardFill: (preprocess.impute.FillBackward(), {})
     }
     Names = {
         NoImputation: "Don't impute.",
@@ -279,6 +282,8 @@ class ImputeEditor(BaseEditor):
         Model: "Model based imputer",
         Random: "Replace with random value",
         DropRows: "Remove rows with missing values.",
+        ForwardFill: preprocess.impute.FillForward.description,
+        BackwardFill: preprocess.impute.FillBackward.description
     }
 
     def __init__(self, parent=None, **kwargs):
@@ -289,7 +294,7 @@ class ImputeEditor(BaseEditor):
         self.__group = group = QButtonGroup(self, exclusive=True)
         group.buttonClicked.connect(self.__on_buttonClicked)
 
-        for methodid in [self.Average, self.Random, self.DropRows]:
+        for methodid in [self.Average, self.Random, self.DropRows, self.ForwardFill, self.BackwardFill]:
             text = self.Names[methodid]
             rb = QRadioButton(text=text, checked=self.__method == methodid)
             group.addButton(rb, methodid)


### PR DESCRIPTION
##### Issue
Add forward backward fill for missing values

##### Description of changes
* Add `FillForward(BaseImputer)`
* Add `FillBackward(BaseImputer)`
* Add `ReplaceUnknownsPreviousOrNext(Transformation)`



##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
