### PR TITLE
[ENH] Canvas Annotations: Text markup editing

### DIFF
--- a/Orange/canvas/canvas/items/annotationitem.py
+++ b/Orange/canvas/canvas/items/annotationitem.py
@@ -90,6 +90,29 @@ class GraphicsTextEdit(QGraphicsTextItem):
             painter.setPen(QPen(color))
             painter.drawText(brect, Qt.AlignTop | Qt.AlignLeft, text)
 
+    def hoverMoveEvent(self, event):
+        layout = self.document().documentLayout()
+        if layout.anchorAt(event.pos()):
+            self.setCursor(Qt.PointingHandCursor)
+        else:
+            self.unsetCursor()
+        super().hoverMoveEvent(event)
+
+    def mousePressEvent(self, event):
+        flags = self.textInteractionFlags()
+        if flags & Qt.LinksAccessibleByMouse \
+                and not flags & Qt.TextSelectableByMouse \
+                and self.document().documentLayout().anchorAt(event.pos()):
+            # QGraphicsTextItem ignores the press event without
+            # Qt.TextSelectableByMouse flag set. This causes the
+            # corresponding mouse release to never get to this item
+            # and therefore no linkActivated/openUrl ...
+            super().mousePressEvent(event)
+            if not event.isAccepted():
+                event.accept()
+        else:
+            super().mousePressEvent(event)
+
 
 def render_plain(content):
     """

--- a/Orange/canvas/canvas/scene.py
+++ b/Orange/canvas/canvas/scene.py
@@ -550,7 +550,6 @@ class CanvasScene(QGraphicsScene):
 
         if isinstance(scheme_annot, scheme.SchemeTextAnnotation):
             item = items.TextAnnotation()
-            item.setPlainText(scheme_annot.text)
             x, y, w, h = scheme_annot.rect
             item.setPos(x, y)
             item.resize(w, h)
@@ -558,8 +557,8 @@ class CanvasScene(QGraphicsScene):
 
             font = font_from_dict(scheme_annot.font, item.font())
             item.setFont(font)
-            scheme_annot.text_changed.connect(item.setPlainText)
-
+            item.setContent(scheme_annot.content, scheme_annot.content_type)
+            scheme_annot.content_changed.connect(item.setContent)
         elif isinstance(scheme_annot, scheme.SchemeArrowAnnotation):
             item = items.ArrowAnnotation()
             start, end = scheme_annot.start_pos, scheme_annot.end_pos
@@ -597,10 +596,7 @@ class CanvasScene(QGraphicsScene):
         )
 
         if isinstance(scheme_annotation, scheme.SchemeTextAnnotation):
-            scheme_annotation.text_changed.disconnect(
-                item.setPlainText
-            )
-
+            scheme_annotation.content_changed.disconnect(item.setContent)
         self.remove_annotation_item(item)
 
     def annotation_items(self):
@@ -813,7 +809,7 @@ class CanvasScene(QGraphicsScene):
 
         # Right (context) click on the node item. If the widget is not
         # in the current selection then select the widget (only the widget).
-        # Else simply return and let customContextMenuReqested signal
+        # Else simply return and let customContextMenuRequested signal
         # handle it
         shape_item = self.item_at(event.scenePos(), items.NodeItem)
         if shape_item and event.button() == Qt.RightButton and \
@@ -855,6 +851,12 @@ class CanvasScene(QGraphicsScene):
                 self.user_interaction_handler.keyReleaseEvent(event):
             return
         return QGraphicsScene.keyReleaseEvent(self, event)
+
+    def contextMenuEvent(self, event):
+        if self.user_interaction_handler and \
+                self.user_interaction_handler.contextMenuEvent(event):
+            return
+        super().contextMenuEvent(event)
 
     def set_user_interaction_handler(self, handler):
         if self.user_interaction_handler and \

--- a/Orange/canvas/document/commands.py
+++ b/Orange/canvas/document/commands.py
@@ -170,18 +170,22 @@ class RenameNodeCommand(QUndoCommand):
 
 
 class TextChangeCommand(QUndoCommand):
-    def __init__(self, scheme, annotation, old, new, parent=None):
+    def __init__(self, scheme, annotation,
+                 old_content, old_content_type,
+                 new_content, new_content_type, parent=None):
         QUndoCommand.__init__(self, "Change text", parent)
         self.scheme = scheme
         self.annotation = annotation
-        self.old = old
-        self.new = new
+        self.old_content = old_content
+        self.old_content_type = old_content_type
+        self.new_content = new_content
+        self.new_content_type = new_content_type
 
     def redo(self):
-        self.annotation.text = self.new
+        self.annotation.set_content(self.new_content, self.new_content_type)
 
     def undo(self):
-        self.annotation.text = self.old
+        self.annotation.set_content(self.old_content, self.old_content_type)
 
 
 class SetAttrCommand(QUndoCommand):

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -188,6 +188,12 @@ class UserInteraction(QObject):
         """
         return False
 
+    def contextMenuEvent(self, event):
+        """
+        Handle a `QGraphicsScene.contextMenuEvent`
+        """
+        return False
+
 
 class NoPossibleLinksError(ValueError):
     pass
@@ -1262,7 +1268,7 @@ class ResizeTextAnnotation(UserInteraction):
 
     def mousePressEvent(self, event):
         pos = event.scenePos()
-        if self.item is None:
+        if event.button() & Qt.LeftButton and self.item is None:
             item = self.scene.item_at(pos, items.TextAnnotation)
             if item is not None and not item.hasFocus():
                 self.editItem(item)
@@ -1317,7 +1323,7 @@ class ResizeTextAnnotation(UserInteraction):
             self.control.setRect(rect)
 
     def cancel(self, reason=UserInteraction.OtherReason):
-        log.debug("ResizeArrowAnnotation.cancel(%s)", reason)
+        log.debug("ResizeTextAnnotation.cancel(%s)", reason)
         if self.item is not None and self.savedRect is not None:
             self.item.setGeometry(self.savedRect)
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,6 +49,7 @@ requirements:
     - joblib
     - python.app    # [osx]
     - dill          # pickle anything
+    - commonmark
 
 test:
   # Python imports

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -5,3 +5,5 @@ pyqtgraph>=0.10.0
 
 # For add-ons' descriptions
 docutils
+
+CommonMark>=0.5.5

--- a/scripts/macos/requirements.txt
+++ b/scripts/macos/requirements.txt
@@ -20,3 +20,4 @@ scipy==0.19.0
 sip==4.19.2
 six==1.10.0
 xlrd==1.0.0
+CommonMark==0.7.3


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Implements inline text markup editing for canvas annotations. Html, rst and markdown are supported.

Use alt-right click on the annotation to change how the content should be interpreted.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
