### PR TITLE
[FIX] schemeedit: Clear edit focus before removing items

### DIFF
--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -815,7 +815,7 @@ class SchemeEditWidget(QWidget):
         selected = self.scene().selectedItems()
         if not selected:
             return
-
+        scene = self.scene()
         self.__undoStack.beginMacro(self.tr("Remove"))
         for item in selected:
             if isinstance(item, items.NodeItem):
@@ -824,6 +824,9 @@ class SchemeEditWidget(QWidget):
                     commands.RemoveNodeCommand(self.__scheme, node)
                 )
             elif isinstance(item, items.annotationitem.Annotation):
+                if item.hasFocus() or item.isAncestorOf(scene.focusItem()):
+                    # Clear input focus from the item to be removed.
+                    scene.focusItem().clearFocus()
                 annot = self.scene().annotation_for_item(item)
                 self.__undoStack.push(
                     commands.RemoveAnnotationCommand(self.__scheme, annot)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When the canvas text annotation is selected and has edit focus, pressing *(Control|Command) + Backspace* raises an error
```
----------------------------- KeyError Exception ------------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/document/schemeedit.py", line 1339, in __onEditingFinished
    annot = self.__scene.annotation_for_item(item)
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/canvas/scene.py", line 618, in annotation_for_item
    return rev[item]
KeyError: <Orange.canvas.canvas.items.annotationitem.TextAnnotation object at 0x1246ee318>
-------------------------------------------------------------------------------
```
##### Description of changes

Clear item's keyboard focus before removing it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
