### PR TITLE
[FIX] Disable menu and mouse zoom in all evaluate's ploting widgets.

### DIFF
--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -75,15 +75,18 @@ class OWCalibrationPlot(widget.OWWidget):
                      callback=self._on_display_rug_changed)
 
         self.plotview = pg.GraphicsView(background="w")
-        self.plot = pg.PlotItem()
+        self.plot = pg.PlotItem(enableMenu=False)
+        self.plot.setMouseEnabled(False, False)
+        self.plot.hideButtons()
 
         axis = self.plot.getAxis("bottom")
         axis.setLabel("Predicted Probability")
 
         axis = self.plot.getAxis("left")
         axis.setLabel("Observed Average")
-        self.plotview.setCentralItem(self.plot)
 
+        self.plot.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0), padding=0.05)
+        self.plotview.setCentralItem(self.plot)
         self.mainArea.layout().addWidget(self.plotview)
 
     def set_results(self, results):

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -101,8 +101,9 @@ class OWLiftCurve(widget.OWWidget):
         self.plotview = pg.GraphicsView(background="w")
         self.plotview.setFrameStyle(QtWidgets.QFrame.StyledPanel)
 
-        self.plot = pg.PlotItem()
-        self.plot.getViewBox().setMenuEnabled(False)
+        self.plot = pg.PlotItem(enableMenu=False)
+        self.plot.setMouseEnabled(False, False)
+        self.plot.hideButtons()
 
         pen = QPen(self.palette().color(QPalette.Text))
 
@@ -120,7 +121,7 @@ class OWLiftCurve(widget.OWWidget):
         axis.setLabel("TP Rate")
 
         self.plot.showGrid(True, True, alpha=0.1)
-        self.plot.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0))
+        self.plot.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0), padding=0.05)
 
         self.plotview.setCentralItem(self.plot)
         self.mainArea.layout().addWidget(self.plotview)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -392,9 +392,9 @@ class OWROCAnalysis(widget.OWWidget):
         self.plotview = pg.GraphicsView(background="w")
         self.plotview.setFrameStyle(QFrame.StyledPanel)
 
-        self.plot = pg.PlotItem()
-        self.plot.getViewBox().setMenuEnabled(False)
-        self.plot.getViewBox().setMouseEnabled(False, False)
+        self.plot = pg.PlotItem(enableMenu=False)
+        self.plot.setMouseEnabled(False, False)
+        self.plot.hideButtons()
 
         pen = QPen(self.palette().color(QPalette.Text))
 
@@ -412,7 +412,7 @@ class OWROCAnalysis(widget.OWWidget):
         axis.setLabel("TP Rate (Sensitivity)")
 
         self.plot.showGrid(True, True, alpha=0.1)
-        self.plot.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0))
+        self.plot.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0), padding=0.05)
 
         self.plotview.setCentralItem(self.plot)
         self.mainArea.layout().addWidget(self.plotview)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Disable menu and mouse zoom in all evaluate's plotting widgets.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
