### PR TITLE
[Fix] Scatter Plot: Reset the axis width only when needed

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -496,8 +496,6 @@ class OWScatterPlot(OWWidget):
         self.update_graph(reset_view=False)
 
     def update_graph(self, reset_view=True, **_):
-        axis = self.graph.plot_widget.getAxis("left")
-        axis.textWidth = 0
         self.graph.zoomStack = []
         if self.graph.data is None:
             return

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -633,6 +633,12 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         self.master.Information.missing_coords.clear()
         self._clear_plot_widget()
 
+        if self.shown_y != attr_y:
+            # 'reset' the axis text width estimation. Without this the left
+            # axis tick labels space only ever expands
+            yaxis = self.plot_widget.getAxis("left")
+            yaxis.textWidth = 30
+
         self.shown_x, self.shown_y = attr_x, attr_y
 
         if self.jittered_data is None or not len(self.jittered_data):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The left axis can observably jump when the widget receives new data on the 'Data Subset' input. This is observable only when the input data contains unknowns in currently displayed X, Y, color or size variables.

Example (load brown-selected in File widget, select rows in Data Table while Scatter Plot is visible):

<img width="376" alt="screen shot 2017-06-27 at 10 33 57" src="https://user-images.githubusercontent.com/4716745/27578351-272330d6-5b24-11e7-8275-06de7463f007.png">

##### Description of changes

Reset the axis text width hint only when switching between displayed variables.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
