### PR TITLE
[FIX] Test and Score: Show default columns

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -196,7 +196,7 @@ class OWTestLearners(OWWidget):
         ContinuousVariable: ("MSE", "RMSE", "MAE", "R2")}
 
     shown_scores = \
-        settings.Setting(set(chain(BUILTIN_ORDER.values())))
+        settings.Setting(set(chain(*BUILTIN_ORDER.values())))
 
     class Error(OWWidget.Error):
         train_data_empty = Msg("Train data set is empty.")


### PR DESCRIPTION
##### Issue

Test & Score does not show any columns by default.

##### Description of changes

An extensive list of changes (see below) makes sure that the settings are initially filled with the list of columns showed by default.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
