### PR TITLE
Quick menu: always open with search bar focus.

### DIFF
--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -1079,10 +1079,7 @@ class QuickMenu(FramelessWindow):
 
         self.show()
 
-        if searchText:
-            self.setFocusProxy(self.__search)
-        else:
-            self.setFocusProxy(None)
+        self.setFocusProxy(self.__search)
 
     def exec_(self, pos=None, searchText=""):
         """


### PR DESCRIPTION
Now Keyboard shortcuts (up, down, enter) work immediately, but search
line edit placeholder text is not shown anymore.

##### Issue

Pressing enter when quick menu opened only focused the search bar instead of putting the widget onto canvas. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
