### PR TITLE
[FIX] preprocess: Fix RemoveNaNClasses / Use existing HasClass

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -8,10 +8,10 @@ import numpy as np
 import scipy
 
 from Orange.data import Table, Storage, Instance, Value
+from Orange.data.filter import HasClass
 from Orange.data.util import one_hot
 from Orange.misc.wrapper_meta import WrapperMeta
-from Orange.preprocess import (RemoveNaNClasses, Continuize,
-                               RemoveNaNColumns, SklImpute, Normalize)
+from Orange.preprocess import Continuize, RemoveNaNColumns, SklImpute, Normalize
 from Orange.util import Reprable
 
 __all__ = ["Learner", "Model", "SklLearner", "SklModel"]
@@ -341,7 +341,7 @@ class SklLearner(Learner, metaclass=WrapperMeta):
     _params = {}
 
     preprocessors = default_preprocessors = [
-        RemoveNaNClasses(),
+        HasClass(),
         Continuize(),
         RemoveNaNColumns(),
         SklImpute()]

--- a/Orange/classification/rules.py
+++ b/Orange/classification/rules.py
@@ -15,10 +15,11 @@ import bottleneck as bn
 import numpy as np
 from scipy.stats import chi2
 
-from Orange.data import Table, _contingency
 from Orange.classification import Learner, Model
+from Orange.data import Table, _contingency
+from Orange.data.filter import HasClass
 from Orange.preprocess.discretize import EntropyMDL
-from Orange.preprocess import RemoveNaNColumns, RemoveNaNClasses, Impute
+from Orange.preprocess import RemoveNaNColumns, Impute
 
 __all__ = ["CN2Learner", "CN2UnorderedLearner", "CN2SDLearner",
            "CN2SDUnorderedLearner"]
@@ -901,7 +902,7 @@ class _RuleLearner(Learner):
     .. [1] "Separate-and-Conquer Rule Learning", Johannes Fürnkranz,
            Artificial Intelligence Review 13, 3-54, 1999
     """
-    preprocessors = [RemoveNaNColumns(), RemoveNaNClasses(), Impute()]
+    preprocessors = [RemoveNaNColumns(), HasClass(), Impute()]
 
     def __init__(self, preprocessors=None, base_rules=None):
         """

--- a/Orange/classification/softmax_regression.py
+++ b/Orange/classification/softmax_regression.py
@@ -2,8 +2,8 @@ import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 
 from Orange.classification import Learner, Model
-from Orange.preprocess import (RemoveNaNClasses, Continuize, RemoveNaNColumns,
-                               Impute, Normalize)
+from Orange.data.filter import HasClass
+from Orange.preprocess import Continuize, RemoveNaNColumns, Impute, Normalize
 
 __all__ = ["SoftmaxRegressionLearner"]
 
@@ -40,7 +40,7 @@ class SoftmaxRegressionLearner(Learner):
         Parameters for L-BFGS algorithm.
     """
     name = 'softmax'
-    preprocessors = [RemoveNaNClasses(),
+    preprocessors = [HasClass(),
                      RemoveNaNColumns(),
                      Impute(),
                      Continuize(),

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -12,7 +12,7 @@ import Orange.data
 from Orange.data.filter import HasClass
 from Orange.preprocess.util import _RefuseDataInConstructor
 from Orange.statistics import distribution
-from Orange.util import Reprable, Enum
+from Orange.util import Reprable, Enum, deprecated
 from . import impute, discretize, transformation
 
 __all__ = ["Continuize", "Discretize", "Impute",
@@ -198,6 +198,7 @@ class RemoveConstant(Preprocess):
         return data.transform(domain)
 
 
+@deprecated
 class RemoveNaNClasses(Preprocess):
     """
     Construct preprocessor that removes examples with missing class

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -9,6 +9,7 @@ from sklearn.utils import shuffle as skl_shuffle
 import bottleneck as bn
 
 import Orange.data
+from Orange.data.filter import HasClass
 from Orange.preprocess.util import _RefuseDataInConstructor
 from Orange.statistics import distribution
 from Orange.util import Reprable, Enum
@@ -216,11 +217,7 @@ class RemoveNaNClasses(Preprocess):
         -------
         data : data set without rows with missing classes
         """
-        if len(data.Y.shape) > 1:
-            nan_cls = np.any(np.isnan(data.Y), axis=1)
-        else:
-            nan_cls = np.isnan(data.Y)
-        return data[~nan_cls]
+        return HasClass()(data)
 
 
 class Normalize(Preprocess):

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -198,7 +198,7 @@ class RemoveConstant(Preprocess):
         return data.transform(domain)
 
 
-@deprecated
+@deprecated("Orange.data.filter.HasClas")
 class RemoveNaNClasses(Preprocess):
     """
     Construct preprocessor that removes examples with missing class

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -4,12 +4,13 @@ from itertools import chain
 
 import numpy as np
 from sklearn import feature_selection as skl_fss
-from Orange.misc.wrapper_meta import WrapperMeta
 
-from Orange.statistics import contingency, distribution
 from Orange.data import Domain, Variable, DiscreteVariable, ContinuousVariable
-from Orange.preprocess.preprocess import Discretize, Impute, RemoveNaNClasses
+from Orange.data.filter import HasClass
+from Orange.misc.wrapper_meta import WrapperMeta
+from Orange.preprocess.preprocess import Discretize, Impute
 from Orange.preprocess.util import _RefuseDataInConstructor
+from Orange.statistics import contingency, distribution
 from Orange.util import Reprable
 
 __all__ = ["Chi2",
@@ -27,9 +28,7 @@ class Scorer(_RefuseDataInConstructor, Reprable):
     feature_type = None
     class_type = None
     supports_sparse_data = None
-    preprocessors = [
-        RemoveNaNClasses()
-    ]
+    preprocessors = [HasClass()]
 
     @property
     def friendly_name(self):

--- a/Orange/regression/linear_bfgs.py
+++ b/Orange/regression/linear_bfgs.py
@@ -1,9 +1,9 @@
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 
+from Orange.data.filter import HasClass
+from Orange.preprocess import Normalize, Continuize, Impute, RemoveNaNColumns
 from Orange.regression import Learner, Model
-from Orange.preprocess import (RemoveNaNClasses, Normalize, Continuize,
-                               Impute, RemoveNaNColumns)
 
 __all__ = ["LinearRegressionLearner"]
 
@@ -51,7 +51,7 @@ class LinearRegressionLearner(Learner):
         print(c(data)) # predict
     '''
     name = 'linear_bfgs'
-    preprocessors = [RemoveNaNClasses(),
+    preprocessors = [HasClass(),
                      Normalize(),
                      Continuize(),
                      Impute(),

--- a/Orange/tests/test_filter.py
+++ b/Orange/tests/test_filter.py
@@ -92,6 +92,19 @@ class TestHasClassFilter(unittest.TestCase):
         self.assertEqual(len(without_class), self.n_missing)
         self.assertTrue(without_class.has_missing_class())
 
+    def test_has_class_multiclass(self):
+        domain = Domain([DiscreteVariable("x", values="01")],
+                        [DiscreteVariable("y1", values="01"),
+                        DiscreteVariable("y2", values="01")])
+        table = Table(domain, [[0, 1, np.nan],
+                               [1, np.nan, 0],
+                               [1, 0, 1],
+                               [1, np.nan, np.nan]])
+        table = HasClass()(table)
+        self.assertTrue(not np.isnan(table).any())
+        self.assertEqual(table.domain, domain)
+        self.assertEqual(len(table), 1)
+
     def test_has_class_filter_instance(self):
         class_missing = self.table[9]
         class_present = self.table[0]

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -78,27 +78,6 @@ class RemoveConstant(unittest.TestCase):
         self.assertEqual(len(d.domain.attributes), 4)
 
 
-class TestRemoveNanClass(unittest.TestCase):
-    def test_remove_nan_classes(self):
-        table = Table("imports-85")
-        self.assertTrue(np.isnan(table.Y).any())
-        table = RemoveNaNClasses()(table)
-        self.assertTrue(not np.isnan(table.Y).any())
-
-    def test_remove_nan_classes_multiclass(self):
-        domain = Domain([DiscreteVariable("a", values="01")],
-                        [DiscreteVariable("b", values="01"),
-                        DiscreteVariable("c", values="01")])
-        table = Table(domain, [[0, 1, np.nan],
-                               [1, np.nan, 0],
-                               [1, 0, 1],
-                               [1, np.nan, np.nan]])
-        table = RemoveNaNClasses()(table)
-        self.assertTrue(not np.isnan(table).any())
-        self.assertEqual(table.domain, domain)
-        self.assertEqual(len(table), 1)
-
-
 class TestScaling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -122,7 +101,7 @@ class TestScaling(unittest.TestCase):
 class TestReprs(unittest.TestCase):
     def test_reprs(self):
         preprocs = [Continuize, Discretize, Impute, SklImpute, Normalize,
-                    Randomize, RemoveNaNClasses, ProjectPCA, ProjectCUR, Scale,
+                    Randomize, ProjectPCA, ProjectCUR, Scale,
                     EqualFreq, EqualWidth, EntropyMDL, SelectBestFeatures,
                     SelectRandomFeatures, RemoveNaNColumns, DoNotImpute, DropInstances,
                     Average, Default]

--- a/Orange/tests/test_rules.py
+++ b/Orange/tests/test_rules.py
@@ -3,18 +3,17 @@
 
 import unittest
 import numpy as np
-from Orange.data import Table
-from Orange.preprocess import RemoveNaNClasses, Impute
 
-from Orange.classification.rules import main as rules_main
+from Orange.classification import (CN2Learner, CN2UnorderedLearner,
+                                   CN2SDLearner, CN2SDUnorderedLearner)
 from Orange.classification.rules import (_RuleLearner, _RuleClassifier,
                                          RuleHunter, Rule, EntropyEvaluator,
                                          LaplaceAccuracyEvaluator,
                                          WeightedRelativeAccuracyEvaluator,
                                          argmaxrnd, hash_dist)
-
-from Orange.classification import (CN2Learner, CN2UnorderedLearner,
-                                   CN2SDLearner, CN2SDUnorderedLearner)
+from Orange.data import Table
+from Orange.data.filter import HasClass
+from Orange.preprocess import Impute
 
 
 class TestRuleInduction(unittest.TestCase):
@@ -41,7 +40,7 @@ class TestRuleInduction(unittest.TestCase):
         self.assertEqual(len(list(base_rule_learner.active_preprocessors)), 3)
         # preprocessor types
         preprocessor_types = [type(x) for x in base_rule_learner.active_preprocessors]
-        self.assertIn(RemoveNaNClasses, preprocessor_types)
+        self.assertIn(HasClass, preprocessor_types)
         self.assertIn(Impute, preprocessor_types)
 
         # test find_rules

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -2,7 +2,6 @@
 # pylint: disable=invalid-sequence-index
 
 import sys
-import functools
 from itertools import chain
 import abc
 import enum
@@ -13,7 +12,6 @@ from functools import partial, reduce
 
 import concurrent.futures
 from concurrent.futures import Future
-
 from collections import OrderedDict, namedtuple
 
 try:
@@ -31,20 +29,20 @@ from AnyQt.QtGui import QStandardItemModel, QStandardItem
 from AnyQt.QtCore import Qt, QSize, QThread, QMetaObject, Q_ARG
 from AnyQt.QtCore import pyqtSlot as Slot
 
+from Orange.base import Learner
+import Orange.classification
 from Orange.data import Table, DiscreteVariable, ContinuousVariable
+from Orange.data.filter import HasClass
 from Orange.data.sql.table import SqlTable, AUTO_DL_LIMIT
 import Orange.evaluation
-import Orange.classification
-import Orange.regression
-
-from Orange.base import Learner
 from Orange.evaluation import scoring, Results
 from Orange.preprocess.preprocess import Preprocess
-from Orange.preprocess import RemoveNaNClasses
+import Orange.regression
 from Orange.widgets import gui, settings, widget
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.widgets.utils.concurrent import ThreadExecutor
+
 
 log = logging.getLogger(__name__)
 
@@ -389,7 +387,7 @@ class OWTestLearners(OWWidget):
         if self.train_data_missing_vals or self.test_data_missing_vals:
             self.Warning.missing_data(self._which_missing_data())
             if data:
-                data = RemoveNaNClasses(data)
+                data = HasClass()(data)
         else:
             self.Warning.missing_data.clear()
 
@@ -439,7 +437,7 @@ class OWTestLearners(OWWidget):
         if self.train_data_missing_vals or self.test_data_missing_vals:
             self.Warning.missing_data(self._which_missing_data())
             if data:
-                data = RemoveNaNClasses()(data)
+                data = HasClass()(data)
         else:
             self.Warning.missing_data.clear()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
SklLearner methods do not work on SqlTable data because of the RemoveNaNClasses preprocessor.

##### Description of changes
Use an existing (more general) implementation of the RemoveNaNClasses preprocessor - the HasClass filter.
Why do we even have both (functionality looks exactly the same)?

Before merging, we should check whether the RemoveNaNClasses preprocessor can be removed completely and HasClass filter used in its place.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
