### PR TITLE
[FIX] Select Rows: Removing Unused Values for Discrete Variables in Sparse Data

### DIFF
--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -1,9 +1,11 @@
 from collections import namedtuple
+
 import numpy as np
 
-from .preprocess import Preprocess
 from Orange.data import Domain, DiscreteVariable, Table
 from Orange.preprocess.transformation import Lookup
+from Orange.statistics.util import nanunique
+from .preprocess import Preprocess
 
 __all__ = ["Remove"]
 
@@ -234,10 +236,7 @@ def remove_unused_values(var, data):
         Domain([var]),
         data
     )
-    array = column_data.X.ravel()
-    mask = np.isfinite(array)
-    unique = np.array(np.unique(array[mask]), dtype=int)
-
+    unique = nanunique(column_data.X).astype(int)
     if len(unique) == len(var.values):
         return var
 

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -26,14 +26,14 @@ class Remove(Preprocess):
     attr_flags : int (default: 0)
         If SortValues, values of discrete attributes are sorted.
         If RemoveConstant, unused attributes are removed.
-        If RemoveUnusedValues, unused values are removed from descrete
+        If RemoveUnusedValues, unused values are removed from discrete
         attributes.
         It is possible to merge operations in one by summing several types.
 
     class_flags: int (default: 0)
         If SortValues, values of discrete class attributes are sorted.
         If RemoveConstant, unused class attributes are removed.
-        If RemoveUnusedValues, unused values are removed from descrete
+        If RemoveUnusedValues, unused values are removed from discrete
         class attributes.
         It is possible to merge operations in one by summing several types.
 

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -283,6 +283,7 @@ def mean(x):
              'you meant nanmean?', stacklevel=2)
     return m
 
+
 def nanmean(x, axis=None):
     """ Equivalent of np.nanmean that supports sparse or dense matrices. """
     def nanmean_sparse(x):
@@ -299,6 +300,7 @@ def nanmean(x, axis=None):
         return np.array([nanmean_sparse(row) for row in arr])
     else:
         raise NotImplementedError
+
 
 def unique(x, return_counts=False):
     """ Equivalent of np.unique that supports sparse or dense matrices. """
@@ -319,6 +321,13 @@ def unique(x, return_counts=False):
         if explicit_zeros:
             return r
         return np.insert(r, 0, 0)
+
+
+def nanunique(x):
+    """ Return unique values while disregarding missing (np.nan) values.
+    Supports sparse or dense matrices. """
+    r = unique(x)
+    return r[~np.isnan(r)]
 
 
 def digitize(x, bins, right=False):

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -7,7 +7,7 @@ import scipy as sp
 from scipy.sparse import csr_matrix, issparse
 
 from Orange.statistics.util import bincount, countnans, contingency, stats, \
-    nanmin, nanmax, unique, mean, nanmean, digitize, var
+    nanmin, nanmax, unique, nanunique, mean, nanmean, digitize, var
 
 
 class TestUtil(unittest.TestCase):
@@ -145,6 +145,13 @@ class TestUtil(unittest.TestCase):
         np.testing.assert_array_equal(
             unique(x1, return_counts=True),
             unique(x2, return_counts=True),
+        )
+
+    def test_nanunique(self):
+        x = csr_matrix(np.array([0, 1, 1, np.nan]))
+        np.testing.assert_array_equal(
+            nanunique(x),
+            np.array([0, 1])
         )
 
     def test_mean(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When `remove unused features` is checked in Select Rows and some discrete variable comes from sparse data, Orange crashes with `AttributeError: ravel not found` error.

The problem is in the `remove_unused_values` method (`Orange/preprocess/remove.py`) which cannot handle sparse matrices.

Issue: https://sentry.io/biolab/orange3/issues/269413491/

##### Description of changes
* Implement `nanunique` function. `nanunique` returns unique values without missing (`np.nan`) values and works on sparse and dense matrices. 
* Fix `remove_unused_values` to use `nanunique ` and hance support sparse discrete columns.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation