### PR TITLE
DOC: fix RTFD via append instead of inserting project root to sys.path

### DIFF
--- a/doc/data-mining-library/source/conf.py
+++ b/doc/data-mining-library/source/conf.py
@@ -22,7 +22,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-sys.path.insert(0, os.path.abspath('../../..'))
+sys.path.append(os.path.abspath('../../..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/development/source/conf.py
+++ b/doc/development/source/conf.py
@@ -22,7 +22,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-sys.path.insert(0, os.path.abspath('../../..'))
+sys.path.append(os.path.abspath('../../..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/visual-programming/source/conf.py
+++ b/doc/visual-programming/source/conf.py
@@ -22,7 +22,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-sys.path.insert(0, os.path.abspath('../../..'))
+sys.path.append(os.path.abspath('../../..'))
 sys.path.append(os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
##### Issue
Doc builds on RTFS don't contain API (docstrings) docs due to unable to import Orange.

##### Description of changes
Instead of inserting at position 0, _append_ project root to `sys.path` to prefer importing _installed_ Orange version.


##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
