### PR TITLE
[FIX] Table: Fix printing data with sparse Y

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -189,6 +189,8 @@ class Table(MutableSequence, Storage):
     def Y(self, value):
         if len(value.shape) == 1:
             value = value[:, None]
+        if sp.issparse(value) and len(self) != value.shape[0]:
+            value = value.T
         self._Y = value
 
     def __new__(cls, *args, **kwargs):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -114,6 +114,8 @@ class RowInstance(Instance):
     def _str(self, limit):
         def sp_values(matrix, variables):
             if not sp.issparse(matrix):
+                if matrix.ndim == 1:
+                    matrix = matrix[:, np.newaxis]
                 return Instance.str_values(matrix[row], variables, limit)
 
             row_entries, idx = [], 0
@@ -140,7 +142,7 @@ class RowInstance(Instance):
         row = self.row_index
         s = "[" + sp_values(table.X, domain.attributes)
         if domain.class_vars:
-            s += " | " + sp_values(table._Y, domain.class_vars)
+            s += " | " + sp_values(table.Y, domain.class_vars)
         s += "]"
         if self._domain.metas:
             s += " {" + sp_values(table.metas, domain.metas) + "}"
@@ -1507,10 +1509,8 @@ class Table(MutableSequence, Storage):
 
                 for col_i, arr_i, _ in cont_vars:
                     if sp.issparse(arr):
-                        col_data = arr.data[
-                                   arr.indptr[arr_i]:arr.indptr[arr_i + 1]]
-                        rows = arr.indices[
-                               arr.indptr[arr_i]:arr.indptr[arr_i + 1]]
+                        col_data = arr.data[arr.indptr[arr_i]:arr.indptr[arr_i + 1]]
+                        rows = arr.indices[arr.indptr[arr_i]:arr.indptr[arr_i + 1]]
                         W_ = None if W is None else W[rows]
                         classes_ = classes[rows]
                     else:

--- a/Orange/tests/test_sparse_table.py
+++ b/Orange/tests/test_sparse_table.py
@@ -48,3 +48,29 @@ class InterfaceTest(tabletests.InterfaceTest):
         iris = Table('iris')
         iris.X, iris.Y = csr_matrix(iris.X), csr_matrix(iris.Y)
         str(iris)
+
+    def test_Y_setter_1d(self):
+        iris = Table('iris')
+        assert iris.Y.shape == (150,)
+        iris.Y = csr_matrix(iris.Y)
+        # We expect the Y shape to match the X shape, which is (150, 4) in iris
+        self.assertEqual(iris.Y.shape, (150, 1))
+
+    def test_Y_setter_2d(self):
+        iris = Table('iris')
+        assert iris.Y.shape == (150,)
+        # Convert iris.Y to (150, 1) shape
+        new_y = iris.Y[:, np.newaxis]
+        iris.Y = np.hstack((new_y, new_y))
+        iris.Y = csr_matrix(iris.Y)
+        # We expect the Y shape to match the X shape, which is (150, 4) in iris
+        self.assertEqual(iris.Y.shape, (150, 2))
+
+    def test_Y_setter_2d_single_instance(self):
+        iris = Table('iris')[:1]
+        # Convert iris.Y to (1, 1) shape
+        new_y = iris.Y[:, np.newaxis]
+        iris.Y = np.hstack((new_y, new_y))
+        iris.Y = csr_matrix(iris.Y)
+        # We expect the Y shape to match the X shape, which is (1, 4) in iris
+        self.assertEqual(iris.Y.shape, (1, 2))

--- a/Orange/tests/test_sparse_table.py
+++ b/Orange/tests/test_sparse_table.py
@@ -1,9 +1,11 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
+import numpy as np
 from scipy.sparse import csr_matrix
 
 from Orange import data
+from Orange.data import Table
 from Orange.tests import test_table as tabletests
 
 
@@ -41,3 +43,8 @@ class InterfaceTest(tabletests.InterfaceTest):
 
     def test_value_assignment(self):
         super().test_value_assignment()
+
+    def test_str(self):
+        iris = Table('iris')
+        iris.X, iris.Y = csr_matrix(iris.X), csr_matrix(iris.Y)
+        str(iris)


### PR DESCRIPTION
##### Issue
Table `__str__` method crashed when the Y was sparse.

_Steps to reproduce:_
```
data = Table('iris')
data.X = sp.csr_matrix(data.X)
# Transpose is needed due to the way sparse converts 1d arrays into sparse matrices
data.Y = sp.csr_matrix(data.Y).T
print(data)
```

Also, printing any Table would be missing the final closing `]` e.g.
```
[[0, 1],
 [1, 0]
```
I've fixed this to
```
[[0, 1],
 [1, 0]]
```

##### Description of changes
The `__str__` method no longer crashes on a sparse Y. Also, I've made it so `var_name=value` is printed for any non-zero value and all discrete values. The `var_name` is now also hidden for any target variable (the reasoning being that there are usually not that many target variables, and showing the variable name wouldn't add any clarity to the output).

@nikicc could you please check if this is ok?

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
