### PR TITLE
Statistics.util: Implement digitize

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -342,7 +342,11 @@ def digitize(x, bins, right=False):
 
     """
     if not sp.issparse(x):
+        # TODO Remove reshaping logic when support for numpy==1.9 is dropped
+        original_shape = x.shape
+        x = x.flatten()
         result = np.digitize(x, bins, right)
+        result = result.reshape(original_shape)
         # In order to keep the return shape consistent, and sparse matrices
         # don't support 1d matrices, make sure to convert 1d to 2d matrices
         if result.ndim == 1:
@@ -358,7 +362,9 @@ def digitize(x, bins, right=False):
         r = zero_bin * np.ones(x.shape, dtype=np.int64)
 
     for idx, row in enumerate(x.tocsr()):
-        r[idx, row.indices] = np.digitize(row.data, bins, right)
+        # TODO Remove this check when support for numpy==1.9 is dropped
+        if row.nnz > 0:
+            r[idx, row.indices] = np.digitize(row.data, bins, right)
 
     # Orange mainly deals with `csr_matrix`, but `lil_matrix` is more efficient
     # for incremental building

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -2,10 +2,10 @@ import unittest
 import warnings
 import numpy as np
 import scipy as sp
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, issparse
 
 from Orange.statistics.util import bincount, countnans, contingency, stats, \
-    nanmin, nanmax, unique, mean, nanmean
+    nanmin, nanmax, unique, mean, nanmean, digitize
 
 
 class TestUtil(unittest.TestCase):
@@ -158,3 +158,62 @@ class TestUtil(unittest.TestCase):
             np.testing.assert_array_equal(
                 nanmean(X_sparse),
                 np.nanmean(X))
+
+    def test_digitize(self):
+        for x in self.data:
+            x_sparse = csr_matrix(x)
+            bins = np.arange(-2, 2)
+
+            np.testing.assert_array_equal(
+                np.digitize(x, bins),
+                digitize(x, bins),
+                'Digitize fails on dense data'
+            )
+            np.testing.assert_array_equal(
+                np.digitize(x, bins),
+                digitize(x_sparse, bins),
+                'Digitize fails on sparse data'
+            )
+
+    def test_digitize_right(self):
+        for x in self.data:
+            x_sparse = csr_matrix(x)
+            bins = np.arange(-2, 2)
+
+            np.testing.assert_array_equal(
+                np.digitize(x, bins, right=True),
+                digitize(x, bins, right=True),
+                'Digitize fails on dense data'
+            )
+            np.testing.assert_array_equal(
+                np.digitize(x, bins, right=True),
+                digitize(x_sparse, bins, right=True),
+                'Digitize fails on sparse data'
+            )
+
+    def test_digitize_1d_array(self):
+        """A consistent return shape must be returned for both sparse and dense."""
+        x = np.array([0, 1, 1, 0, np.nan, 0, 1])
+        x_sparse = csr_matrix(x)
+        bins = np.arange(-2, 2)
+
+        np.testing.assert_array_equal(
+            [np.digitize(x, bins)],
+            digitize(x, bins),
+            'Digitize fails on 1d dense data'
+        )
+        np.testing.assert_array_equal(
+            [np.digitize(x, bins)],
+            digitize(x_sparse, bins),
+            'Digitize fails on 1d sparse data'
+        )
+
+    def test_digitize_sparse_zeroth_bin(self):
+        # Setup the data so that the '0's will fit into the '0'th bin.
+        data = csr_matrix([
+            [0, 0, 0, 1, 1, 0, 0, 1, 0],
+            [0, 0, 1, 1, 0, 0, 1, 0, 0],
+        ])
+        bins = np.array([1])
+        # Then digitize should return a sparse matrix
+        self.assertTrue(issparse(digitize(data, bins)))

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -164,13 +164,14 @@ class TestUtil(unittest.TestCase):
             x_sparse = csr_matrix(x)
             bins = np.arange(-2, 2)
 
+            x_shape = x.shape
             np.testing.assert_array_equal(
-                np.digitize(x, bins),
+                np.digitize(x.flatten(), bins).reshape(x_shape),
                 digitize(x, bins),
                 'Digitize fails on dense data'
             )
             np.testing.assert_array_equal(
-                np.digitize(x, bins),
+                np.digitize(x.flatten(), bins).reshape(x_shape),
                 digitize(x_sparse, bins),
                 'Digitize fails on sparse data'
             )
@@ -180,13 +181,14 @@ class TestUtil(unittest.TestCase):
             x_sparse = csr_matrix(x)
             bins = np.arange(-2, 2)
 
+            x_shape = x.shape
             np.testing.assert_array_equal(
-                np.digitize(x, bins, right=True),
+                np.digitize(x.flatten(), bins, right=True).reshape(x_shape),
                 digitize(x, bins, right=True),
                 'Digitize fails on dense data'
             )
             np.testing.assert_array_equal(
-                np.digitize(x, bins, right=True),
+                np.digitize(x.flatten(), bins, right=True).reshape(x_shape),
                 digitize(x_sparse, bins, right=True),
                 'Digitize fails on sparse data'
             )
@@ -197,13 +199,14 @@ class TestUtil(unittest.TestCase):
         x_sparse = csr_matrix(x)
         bins = np.arange(-2, 2)
 
+        x_shape = x.shape
         np.testing.assert_array_equal(
-            [np.digitize(x, bins)],
+            [np.digitize(x.flatten(), bins).reshape(x_shape)],
             digitize(x, bins),
             'Digitize fails on 1d dense data'
         )
         np.testing.assert_array_equal(
-            [np.digitize(x, bins)],
+            [np.digitize(x.flatten(), bins).reshape(x_shape)],
             digitize(x_sparse, bins),
             'Digitize fails on 1d sparse data'
         )


### PR DESCRIPTION
##### Issue
The statistics module did not have an implementation of [`digitize`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.digitize.html).


##### Description of changes
Add implementation of `digitize` which supports dense and sparse data.

@nikicc Would it perhaps make sense to return a sparse matrix if a sparse matrix is passed? Assuming that a large sparse matrix would be passed, and that all the "0"s would belong to the "0" bin, then it would be more efficient to return a sparse matrix instead of a dense numpy array. However there is absolutely no guarantee that the "0"s would indeed belong to the "0" bin, so this may not make sense, as it would just complicate the API. Is this of any concern, or is the current implementation ok?


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
