### PR TITLE
Statistics.util.var: Implement variance

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -375,3 +375,13 @@ def digitize(x, bins, right=False):
         r = r.tocsr()
 
     return r
+
+
+def var(x, axis=None):
+    """ Equivalent of np.var that supports sparse and dense matrices. """
+    if not sp.issparse(x):
+        return np.var(x, axis)
+
+    result = x.multiply(x).mean(axis) - np.square(x.mean(axis))
+    result = np.squeeze(np.asarray(result))
+    return result

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -1,11 +1,13 @@
 import unittest
 import warnings
+from itertools import chain
+
 import numpy as np
 import scipy as sp
 from scipy.sparse import csr_matrix, issparse
 
 from Orange.statistics.util import bincount, countnans, contingency, stats, \
-    nanmin, nanmax, unique, mean, nanmean, digitize
+    nanmin, nanmax, unique, mean, nanmean, digitize, var
 
 
 class TestUtil(unittest.TestCase):
@@ -223,3 +225,12 @@ class TestUtil(unittest.TestCase):
         bins = np.array([1])
         # Then digitize should return a sparse matrix
         self.assertTrue(issparse(digitize(data, bins)))
+
+    def test_var(self):
+        for data in self.data:
+            for axis in chain((None,), range(len(data.shape))):
+                # Can't use array_equal here due to differences on 1e-16 level
+                np.testing.assert_array_almost_equal(
+                    var(csr_matrix(data), axis=axis),
+                    np.var(data, axis=axis)
+                )


### PR DESCRIPTION
##### Issue
The statistics module did not have an implementation of [`var`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.var.html) to compute the variance.

##### Description of changes
Add implementation of `var` which supports dense and sparse data.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
