### PR TITLE
[FIX] owhierarchicalclustering: Explicit geometry transform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,10 @@ INSTALL_REQUIRES = sorted(set(
 ) - {''})
 
 
+EXTRAS_REQUIRE = {
+    ':python_version<="3.4"': ["typing"],
+}
+
 ENTRY_POINTS = {
     "orange.canvas.help": (
         "html-index = Orange.widgets:WIDGET_HELP_PATH",
@@ -268,6 +272,7 @@ def setup_package():
         packages=PACKAGES,
         package_data=PACKAGE_DATA,
         install_requires=INSTALL_REQUIRES,
+        extras_require=EXTRAS_REQUIRE,
         entry_points=ENTRY_POINTS,
         zip_safe=False,
         test_suite='Orange.tests.suite',


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-2297

The cause of the broken PDF export was a non aspect preserving implicit dendrogram scaling and use of cosmetic pen to implement fast resize in response to user interaction. QPDFWriter however cannot handle cosmetic pens.

##### Description of changes

Explicit transform/scale the dendrogram geometry to scene display coordinates and avoid use of cosmetic pens.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
