### PR TITLE
[FIX] table: Update `ids` in `Table.__del__`

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -819,6 +819,7 @@ class Table(MutableSequence, Storage):
         self.Y = np.delete(self._Y, key, axis=0)
         self.metas = np.delete(self.metas, key, axis=0)
         self.W = np.delete(self.W, key, axis=0)
+        self.ids = np.delete(self.ids, key, axis=0)
 
     def __len__(self):
         return self.X.shape[0]

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -356,6 +356,13 @@ class TableTestCase(unittest.TestCase):
             del d[:]
             self.assertEqual(len(d), 0)
 
+    def test_del_slice_ids(self):
+        # __del__ updates `ids` member
+        d = data.Table("test2")
+        ids = d.ids.copy()
+        del d[2:4]
+        np.testing.assert_array_equal(d.ids, np.delete(ids, slice(2, 4)))
+
     def test_set_slice_example(self):
         import warnings
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

```
import Orange.data
d = Orange.data.Table("iris")
del d[2:]
d[[True, False]]
```
fails with
```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 694, in __getitem__
    return self.from_table_rows(self, key)
  File "/Users/aleserjavec/workspace/orange3/Orange/data/table.py", line 449, in from_table_rows
    self.ids = np.array(source.ids[row_indices])
IndexError: boolean index did not match indexed array along dimension 0; dimension is 150 but corresponding boolean dimension is 2
```
##### Description of changes

Update `ids` in `Table.__del__`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
