### PR TITLE
[TST] WidgetTest.send_signal: assert signal value of correct type

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -488,7 +488,7 @@ class Scale(Preprocess):
         return data.transform(domain)
 
 
-class PreprocessorList(Reprable):
+class PreprocessorList(Preprocess):
     """
     Store a list of preprocessors and on call apply them to the data set.
 

--- a/Orange/widgets/data/tests/test_owoutliers.py
+++ b/Orange/widgets/data/tests/test_owoutliers.py
@@ -23,7 +23,7 @@ class TestOWOutliers(WidgetTest):
         self.assertEqual(len(self.get_output(self.widget.Outputs.outliers)), 74)
         self.send_signal(self.widget.Inputs.data, None)
         self.assertEqual(self.widget.data, None)
-        self.assertIsNone(self.get_output("Data"))
+        self.assertIsNone(self.get_output(self.widget.Outputs.inliers))
 
     def test_multiclass(self):
         """Check widget for multiclass dataset"""

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -67,7 +67,7 @@ class TestOWPythonScript(WidgetTest):
             self.send_signal(signal, data, (1, ))
             self.widget.text.setPlainText("out_{} = 42".format(lsignal))
             self.widget.execute_button.click()
-            self.assertEqual(self.get_output(lsignal), None)
+            self.assertEqual(self.get_output(signal), None)
             self.assertTrue(hasattr(self.widget.Error, lsignal))
             self.assertTrue(getattr(self.widget.Error, lsignal).is_shown())
 

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -231,6 +231,11 @@ class WidgetTest(GuiTest):
             raise RuntimeError("'send_signal' called but the widget is in "
                                "blocking state and does not accept inputs.")
         handler = getattr(widget, input.handler)
+
+        # Assert sent input is of correct class
+        assert isinstance(value, (input.type, type(None))), \
+            '{} should be {}'.format(value.__class__.__mro__, input.type)
+
         handler(value, *args)
         widget.handleNewSignals()
         if wait >= 0 and widget.isBlocking():

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -500,18 +500,19 @@ class WidgetLearnerTestMixin:
 
     def test_input_preprocessor(self):
         """Check learner's preprocessors with an extra pp on input"""
-        self.send_signal("Preprocessor", Randomize)
+        randomize = Randomize()
+        self.send_signal("Preprocessor", randomize)
         self.assertEqual(
-            Randomize, self.widget.preprocessors,
+            randomize, self.widget.preprocessors,
             'Preprocessor not added to widget preprocessors')
         self.widget.apply_button.button.click()
         self.assertEqual(
-            (Randomize,), self.widget.learner.preprocessors,
+            (randomize,), self.widget.learner.preprocessors,
             'Preprocessors were not passed to the learner')
 
     def test_input_preprocessors(self):
         """Check multiple preprocessors on input"""
-        pp_list = PreprocessorList([Randomize, RemoveNaNColumns])
+        pp_list = PreprocessorList([Randomize(), RemoveNaNColumns()])
         self.send_signal("Preprocessor", pp_list)
         self.widget.apply_button.button.click()
         self.assertEqual(
@@ -520,9 +521,10 @@ class WidgetLearnerTestMixin:
 
     def test_input_preprocessor_disconnect(self):
         """Check learner's preprocessors after disconnecting pp from input"""
-        self.send_signal("Preprocessor", Randomize)
+        randomize = Randomize()
+        self.send_signal("Preprocessor", randomize)
         self.widget.apply_button.button.click()
-        self.assertEqual(Randomize, self.widget.preprocessors)
+        self.assertEqual(randomize, self.widget.preprocessors)
 
         self.send_signal("Preprocessor", None)
         self.widget.apply_button.button.click()

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -266,6 +266,10 @@ class WidgetTest(GuiTest):
                             "Failed to get output in the specified timeout")
         if not isinstance(output, str):
             output = output.name
+        # widget.outputs are old-style signals; if empty, use new style
+        outputs = widget.outputs or widget.Outputs.__dict__.values()
+        assert output in (out.name for out in outputs), \
+            "widget {} has no output {}".format(widget.name, output)
         return self.signal_manager.outputs.get((widget, output), None)
 
 

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -7,6 +7,7 @@ import scipy.sparse as sp
 from AnyQt.QtCore import QRectF, Qt
 
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
+from Orange.widgets.widget import AttributeList
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin, datasets
 from Orange.widgets.visualize.owscatterplot import \
     OWScatterPlot, ScatterPlotVizRank
@@ -302,13 +303,14 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         GH-2384
         """
         domain = Table("iris").domain
-        self.send_signal(self.widget.Inputs.features, domain)
+        self.send_signal(self.widget.Inputs.features, AttributeList(domain))
         self.send_signal(self.widget.Inputs.features, None)
 
     def test_features_and_data(self):
         data = Table("iris")
         self.send_signal(self.widget.Inputs.data, data)
-        self.send_signal(self.widget.Inputs.features, data.domain[2:])
+        self.send_signal(self.widget.Inputs.features,
+                         AttributeList(data.domain[2:]))
         self.assertIs(self.widget.attr_x, data.domain[2])
         self.assertIs(self.widget.attr_y, data.domain[3])
 


### PR DESCRIPTION
##### Issue
`send_signal` didn't check the type of sent value. Sending around a Learner class instead of an instance led me to a behavior that took much too long to debug. In general, widget implementors aren't expected to validate types as canvas does it for them. So should the tests.

##### Description of changes
Assert passed signal value is of correct type.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
