### PR TITLE
[FIX] Change Variable Icons: Discrete -> Categorical, Continuous -> Numeric

### DIFF
--- a/Orange/classification/majority.py
+++ b/Orange/classification/majority.py
@@ -22,7 +22,7 @@ class MajorityLearner(Learner):
     def fit_storage(self, dat):
         if not dat.domain.has_discrete_class:
             raise ValueError("classification.MajorityLearner expects a domain "
-                             "with a (single) discrete variable")
+                             "with a (single) categorical variable")
         dist = distribution.get_distribution(dat, dat.domain.class_var)
         N = dist.sum()
         if N > 0:

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -452,7 +452,7 @@ class ContinuousVariable(Variable):
     set to 0 to prevent changes by `to_val`.
     """
 
-    TYPE_HEADERS = ('continuous', 'c')
+    TYPE_HEADERS = ('continuous', 'c', 'numeric', 'n')
 
     def __init__(self, name="", number_of_decimals=None, compute_value=None):
         """
@@ -549,7 +549,7 @@ class DiscreteVariable(Variable):
         for regression.
     """
 
-    TYPE_HEADERS = ('discrete', 'd')
+    TYPE_HEADERS = ('discrete', 'd', 'categorical')
 
     _all_vars = collections.defaultdict(list)
     presorted_values = []

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -141,9 +141,9 @@ class OWContinuize(widget.OWWidget):
     def send_report(self):
         self.report_items(
             "Settings",
-            [("Multinominal attributes",
+            [("Categorical features",
               self.multinomial_treats[self.multinomial_treatment][0]),
-             ("Continuous attributes",
+             ("Numeric features",
               self.continuous_treats[self.continuous_treatment][0]),
              ("Class", self.class_treats[self.class_treatment][0]),
              ("Value range", self.value_ranges[self.zero_based])])

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -20,8 +20,8 @@ from Orange.widgets.widget import Input, Output
 
 class OWContinuize(widget.OWWidget):
     name = "Continuize"
-    description = ("Transform discrete attributes into continuous and, " +
-                   "optionally, normalize the continuous values.")
+    description = ("Transform categorical attributes into numeric and, " +
+                   "optionally, normalize numeric values.")
     icon = "icons/Continuize.svg"
     category = "Data"
     keywords = ["data", "continuize"]
@@ -50,7 +50,7 @@ class OWContinuize(widget.OWWidget):
         ("Most frequent value as base", Continuize.FrequentAsBase),
         ("One attribute per value", Continuize.Indicators),
         ("Ignore multinomial attributes", Continuize.RemoveMultinomial),
-        ("Remove all discrete attributes", Continuize.Remove),
+        ("Remove categorical attributes", Continuize.Remove),
         ("Treat as ordinal", Continuize.AsOrdinal),
         ("Divide by number of values", Continuize.AsNormalizedOrdinal))
 
@@ -71,19 +71,19 @@ class OWContinuize(widget.OWWidget):
     def __init__(self):
         super().__init__()
 
-        box = gui.vBox(self.controlArea, "Multinomial Attributes")
+        box = gui.vBox(self.controlArea, "Categorical Features")
         gui.radioButtonsInBox(
             box, self, "multinomial_treatment",
             btnLabels=[x[0] for x in self.multinomial_treats],
             callback=self.settings_changed)
 
-        box = gui.vBox(self.controlArea, "Continuous Attributes")
+        box = gui.vBox(self.controlArea, "Numeric Features")
         gui.radioButtonsInBox(
             box, self, "continuous_treatment",
             btnLabels=[x[0] for x in self.continuous_treats],
             callback=self.settings_changed)
 
-        box = gui.vBox(self.controlArea, "Discrete Class Attribute")
+        box = gui.vBox(self.controlArea, "Categorical Outcomes")
         gui.radioButtonsInBox(
             box, self, "class_treatment",
             btnLabels=[t[0] for t in self.class_treats],

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -131,14 +131,14 @@ class OWDataInfo(widget.OWWidget):
             disc_class = count(domain.class_vars, DiscreteVariable)
             cont_class = count(domain.class_vars, ContinuousVariable)
             if not cont_class:
-                self.targets = "Multitarget data,\n%i discrete targets" % \
+                self.targets = "Multitarget data,\n%i categorical targets" % \
                                n_or_none(disc_class)
             elif not disc_class:
                 self.targets = "Multitarget data,\n%i numeric targets" % \
                                n_or_none(cont_class)
             else:
                 self.targets = "<p>Multi target data</p>\n" + pack_table(
-                    (("Discrete", disc_class), ("Numeric", cont_class)))
+                    (("Categorical", disc_class), ("Numeric", cont_class)))
 
         self.data_desc = dd = OrderedDict()
 
@@ -158,23 +158,23 @@ class OWDataInfo(widget.OWWidget):
             return ", ".join(s.format(n) for s, n in items if n)
 
         dd["Features"] = len(domain.attributes) and join_if((
-            ("{} discrete", disc_features),
+            ("{} categorical", disc_features),
             ("{} numeric", cont_features)
         ))
         if domain.class_var:
             name = domain.class_var.name
             if domain.class_var.is_discrete:
-                dd["Target"] = "discrete outcome '{}'".format(name)
+                dd["Target"] = "categorical outcome '{}'".format(name)
             else:
                 dd["Target"] = "numeric target '{}'".format(name)
         elif domain.class_vars:
             tt = ""
             if disc_class:
-                tt += report.plural("{number} discrete outcome{s}", disc_class)
+                tt += report.plural("{number} categorical outcome{s}", disc_class)
             if cont_class:
                 tt += report.plural("{number} numeric target{s}", cont_class)
         dd["Meta attributes"] = len(domain.metas) > 0 and join_if((
-            ("{} discrete", disc_metas),
+            ("{} categorical", disc_metas),
             ("{} numeric", cont_metas),
             ("{} textual", str_metas)
         ))

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -618,7 +618,7 @@ class OWFeatureConstructor(OWWidget):
         items = OrderedDict()
         for feature in self.featuremodel:
             if isinstance(feature, DiscreteDescriptor):
-                items[feature.name] = "{} (discrete with values {}{})".format(
+                items[feature.name] = "{} (categorical with values {}{})".format(
                     feature.expression, feature.values,
                     "; ordered" * feature.ordered)
             elif isinstance(feature, ContinuousDescriptor):

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -341,7 +341,7 @@ class OWFeatureConstructor(OWWidget):
     ]
 
     class Error(OWWidget.Error):
-        more_values_needed = Msg("Discrete feature {} needs more values.")
+        more_values_needed = Msg("Categorical feature {} needs more values.")
         invalid_expressions = Msg("Invalid expressions: {}.")
 
     def __init__(self):

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -371,7 +371,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         if domain.has_continuous_class:
             text += "<br/>Regression; numerical class."
         elif domain.has_discrete_class:
-            text += "<br/>Classification; discrete class with {} values.".\
+            text += "<br/>Classification; categorical class with {} values.".\
                 format(len(domain.class_var.values))
         elif table.domain.class_vars:
             text += "<br/>Multi-target; {} target variables.".format(

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -67,7 +67,7 @@ class DiscretizeEditor(BaseEditor):
         NoDisc: "None",
         EqualWidth: "Equal width discretization",
         EqualFreq: "Equal frequency discretization",
-        Drop: "Remove continuous attributes",
+        Drop: "Remove numeric features",
         EntropyMDL: "Entropy-MDL discretization"
     }
 
@@ -194,9 +194,9 @@ class ContinuizeEditor(BaseEditor):
 
     Continuizers = OrderedDict([
         (Continuize.FrequentAsBase, "Most frequent is base"),
-        (Continuize.Indicators, "One attribute per value"),
-        (Continuize.RemoveMultinomial, "Remove multinomial attributes"),
-        (Continuize.Remove, "Remove all discrete attributes"),
+        (Continuize.Indicators, "One feature per value"),
+        (Continuize.RemoveMultinomial, "Remove non-binary features"),
+        (Continuize.Remove, "Remove categorical features"),
         (Continuize.AsOrdinal, "Treat as ordinal"),
         (Continuize.AsNormalizedOrdinal, "Divide by number of values")
     ])

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -35,11 +35,11 @@ class OWPurgeDomain(widget.OWWidget):
     resizing_enabled = False
     buttons_area_orientation = Qt.Vertical
 
-    feature_options = (('sortValues', 'Sort discrete feature values'),
+    feature_options = (('sortValues', 'Sort categorical feature values'),
                        ('removeValues', 'Remove unused feature values'),
                        ('removeAttributes', 'Remove constant features'))
 
-    class_options = (('sortClasses', 'Sort discrete class variable values'),
+    class_options = (('sortClasses', 'Sort categorical class values'),
                      ('removeClasses', 'Remove unused class variable values'),
                      ('removeClassAttribute', 'Remove constant class variables'))
 

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -159,7 +159,7 @@ class OWSql(OWWidget):
         box.layout().addWidget(self.custom_sql)
 
         gui.checkBox(box, self, "guess_values",
-                     "Auto-discover discrete variables",
+                     "Auto-discover categorical variables",
                      callback=self.open_table)
 
         gui.checkBox(box, self, "download",

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -413,7 +413,7 @@ class OWDataTable(widget.OWWidget):
             callback=self._on_show_variable_labels_changed)
 
         gui.checkBox(box, self, "show_distributions",
-                     'Visualize continuous values',
+                     'Visualize numeric values',
                      callback=self._on_distribution_color_changed)
         gui.checkBox(box, self, "color_by_class", 'Color by instance classes',
                      callback=self._on_distribution_color_changed)

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1024,9 +1024,9 @@ class __AttributeIconDict(dict):
     def __getitem__(self, key):
         if not self:
             for tpe, char, col in ((vartype(ContinuousVariable()),
-                                    "C", (202, 0, 32)),
+                                    "N", (202, 0, 32)),
                                    (vartype(DiscreteVariable()),
-                                    "D", (26, 150, 65)),
+                                    "C", (26, 150, 65)),
                                    (vartype(StringVariable()),
                                     "S", (0, 0, 0)),
                                    (vartype(TimeVariable()),

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -46,7 +46,7 @@ class OWDistances(OWWidget):
     buttons_area_orientation = Qt.Vertical
 
     class Error(OWWidget.Error):
-        no_continuous_features = Msg("No continuous features")
+        no_continuous_features = Msg("No numeric features")
         dense_metric_sparse_data = Msg("Selected metric does not support sparse data")
         empty_data = Msg("Empty data set")
         mahalanobis_error = Msg("{}")
@@ -54,7 +54,7 @@ class OWDistances(OWWidget):
         distances_value_error = Msg("Error occurred while calculating distances\n{}")
 
     class Warning(OWWidget.Warning):
-        ignoring_discrete = Msg("Ignoring discrete features")
+        ignoring_discrete = Msg("Ignoring categorical features")
         imputing_data = Msg("Imputing missing values")
 
     def __init__(self):

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -1191,7 +1191,7 @@ class Mdsplotutils(plotutils):
                 color_data = plotutils.continuous_colors(
                     col, palette=plotstyle.continuous_palette)
         else:
-            raise TypeError("Discrete/Continuous variable or None expected.")
+            raise TypeError("Categorical/Numeric variable or None expected.")
 
         return color_data
 

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -35,7 +35,7 @@ class VarTableModel(QAbstractTableModel):
     DISCRETE_VALUE_DISPLAY_LIMIT = 20
 
     places = "feature", "target", "meta", "skip"
-    typenames = "nominal", "numeric", "string", "datetime"
+    typenames = "categorical", "numeric", "string", "datetime"
     vartypes = DiscreteVariable, ContinuousVariable, StringVariable, TimeVariable
     name2type = dict(zip(typenames, vartypes))
     type2name = dict(zip(vartypes, typenames))

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -631,6 +631,8 @@ class VariableListModel(PyListModel):
     def variable_tooltip(self, var):
         if var.is_discrete:
             return self.discrete_variable_tooltip(var)
+        elif var.is_time:
+            return self.time_variable_toltip(var)
         elif var.is_continuous:
             return self.continuous_variable_toltip(var)
         elif var.is_string:
@@ -647,14 +649,19 @@ class VariableListModel(PyListModel):
         return text
 
     def discrete_variable_tooltip(self, var):
-        text = "<b>%s</b><br/>Discrete with %i values: " %\
+        text = "<b>%s</b><br/>Categorical with %i values: " %\
                (safe_text(var.name), len(var.values))
         text += ", ".join("%r" % safe_text(v) for v in var.values)
         text += self.variable_labels_tooltip(var)
         return text
 
+    def time_variable_toltip(self, var):
+        text = "<b>%s</b><br/>Time" % safe_text(var.name)
+        text += self.variable_labels_tooltip(var)
+        return text
+
     def continuous_variable_toltip(self, var):
-        text = "<b>%s</b><br/>Continuous" % safe_text(var.name)
+        text = "<b>%s</b><br/>Numeric" % safe_text(var.name)
         text += self.variable_labels_tooltip(var)
         return text
 

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -146,7 +146,7 @@ class OWDistributions(widget.OWWidget):
             gui.indentedBox(box, sep=4),
             self, "disc_cont", "Bin continuous variables",
             callback=self._on_groupvar_idx_changed,
-            tooltip="Show continuous variables as discrete.")
+            tooltip="Show numeric variables as categorical.")
 
         box = gui.vBox(self.controlArea, "Group by")
         self.icons = gui.attributeIconDict

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -144,7 +144,7 @@ class OWDistributions(widget.OWWidget):
 
         self.cb_disc_cont = gui.checkBox(
             gui.indentedBox(box, sep=4),
-            self, "disc_cont", "Bin continuous variables",
+            self, "disc_cont", "Bin numeric variables",
             callback=self._on_groupvar_idx_changed,
             tooltip="Show numeric variables as categorical.")
 
@@ -260,11 +260,11 @@ class OWDistributions(widget.OWWidget):
 
     def _setup_smoothing(self):
         if not self.disc_cont and self.var and self.var.is_continuous:
-            self.cb_disc_cont.setText("Bin continuous variables")
+            self.cb_disc_cont.setText("Bin numeric variables")
             self.l_smoothing_l.setText("Smooth")
             self.l_smoothing_r.setText("Precise")
         else:
-            self.cb_disc_cont.setText("Bin continuous variables into {} bins".
+            self.cb_disc_cont.setText("Bin numeric variables into {} bins".
                                       format(self.bins[self.smoothing_index]))
             self.l_smoothing_l.setText(" " + str(self.bins[0]))
             self.l_smoothing_r.setText(" " + str(self.bins[-1]))

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -436,7 +436,7 @@ class OWHeatMap(widget.OWWidget):
         sparse_densified = Msg("Showing this data may require a lot of memory")
 
     class Error(widget.OWWidget.Error):
-        no_continuous = Msg("No continuous feature columns")
+        no_continuous = Msg("No numeric features")
         not_enough_features = Msg("Not enough features for column clustering")
         not_enough_instances = Msg("Not enough instances for clustering")
         not_enough_instances_k_means = Msg(

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -430,7 +430,7 @@ class OWHeatMap(widget.OWWidget):
 
     class Information(widget.OWWidget.Information):
         sampled = Msg("Data has been sampled")
-        discrete_ignored = Msg("{} discrete column{} ignored")
+        discrete_ignored = Msg("{} categorical feature{} ignored")
         row_clust = Msg("{}")
         col_clust = Msg("{}")
         sparse_densified = Msg("Showing this data may require a lot of memory")

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -584,7 +584,7 @@ class OWLinearProjection(widget.OWWidget):
         # Initialize the GUI controls from data's domain.
         cont_vars = [var for var in data.domain.variables
                      if var.is_continuous]
-        self.warning("Plotting requires continuous features.",
+        self.warning("Plotting requires numeric features.",
                      shown=not len(cont_vars))
         self.varmodel_selected[:] = cont_vars[:3]
         self.varmodel_other[:] = cont_vars[3:]

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -303,7 +303,7 @@ class OWMosaicDisplay(OWWidget):
         incompatible_subset = Msg("Data subset is incompatible with Data")
         no_valid_data = Msg("No valid data")
         no_cont_selection_sql = \
-            Msg("Selection of continuous variables on SQL is not supported")
+            Msg("Selection of numeric features on SQL is not supported")
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -650,7 +650,7 @@ class OWNomogram(OWWidget):
             orientation=Qt.Horizontal, callback=self.update_scene)
 
         self.cont_feature_dim_combo = gui.comboBox(
-            box, self, "cont_feature_dim_index", label="Continuous features: ",
+            box, self, "cont_feature_dim_index", label="Numeric features: ",
             items=["1D projection", "2D curve"], orientation=Qt.Horizontal,
             callback=self.update_scene)
 

--- a/Orange/widgets/visualize/owparallelcoordinates.py
+++ b/Orange/widgets/visualize/owparallelcoordinates.py
@@ -93,7 +93,8 @@ class OWParallelCoordinates(OWVisWidget):
                      items=["No statistics", "Means, deviations", "Median, quartiles"], callback=self.update_graph,
                      sendSelectedValue=False, valueType=int)
         gui.checkBox(box, self, 'graph.show_distributions', 'Show distributions', callback=self.update_graph,
-                     tooltip="Show bars with distribution of class values (only for discrete attributes)")
+                     tooltip="Show bars with distribution of class values "
+                             "(only for categorical attributes)")
 
     def add_group_settings(self, parent):
         box = gui.vBox(parent, "Groups")

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -188,7 +188,7 @@ class OWScatterPlot(OWWidget):
             "None" if x == 0 else ("%.1f %%" if x < 1 else "%d %%") % x)
         gui.checkBox(
             gui.indentedBox(box), self, 'graph.jitter_continuous',
-            'Jitter continuous values', callback=self.reset_graph_data)
+            'Jitter numeric values', callback=self.reset_graph_data)
 
         self.sampling = gui.auto_commit(
             self.controlArea, self, "auto_sample", "Sample", box="Sampling",

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -189,7 +189,7 @@ class OWSilhouettePlot(widget.OWWidget):
                 data = None
                 error_msg = "No continuous columns"
             elif ncont < len(data.domain.attributes):
-                warning_msg = "{0} discrete columns will not be used for " \
+                warning_msg = "{0} categorical columns will not be used for " \
                               "distance computation".format(ndiscrete)
 
         self.data = data


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Variable icons do not match names used in the File widget, which is usually where people set/check variable types now. Many places in Orange use the same icons and use various names inconsistently.

**Proposal**
We use:
- "categorical" marked with a "C" icon
- "numeric" marked with an "N" icon

##### Description of changes
Moving towards consistency will be a long (Sisyphean) struggle.
This PR makes the file widget consistent, using categorical (C) and numeric (N). It also updates the icons' tooltips. The same icons are used across all Orange.
If/When other labels and descriptions are found using different terms, they should be adapted to use the same names.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
