### PR TITLE
[FIX] simple_tree.c: Fix mingw compiler compatibility

### DIFF
--- a/Orange/classification/_simple_tree.c
+++ b/Orange/classification/_simple_tree.c
@@ -61,7 +61,7 @@ enum { IntVar, FloatVar };
 #define QSORT_R_STYLE_GNU
 #define QSORT_R_FUNC(base, nel, size, thunk, compar) \
 	qsort_r(base, nel, size, compar, thunk)
-#elif (defined _MSC_VER)
+#elif (defined _MSC_VER || defined __MINGW32__)
 #define QSORT_R_STYLE_MSVC
 #define QSORT_R_FUNC(base, nel, size, thunk, compar) \
 	qsort_s(base, nel, size, compar, thunk)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

*_simple_tree.c* did not compile using mingw compiler toolchain.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
