### PR TITLE
[FIX] Add-ons: Fix Installation of Official Add-ons Through Drag & Drop

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -588,7 +588,7 @@ class AddonManagerDialog(QDialog):
             if path.endswith(self.ADDON_EXTENSIONS):
                 name, vers, summary, descr = (get_meta_from_archive(path) or
                                               (os.path.basename(path), '', '', ''))
-                names.append(name)
+                names.append(cleanup(name))
                 packages.append(
                     Installable(name, vers, summary,
                                 descr or summary, path, [path]))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Installing official add-ons through drag & drop doesn't work from cleaning the add-ons names onwards (3.4.0 onwards?). The mismatch occurs when we compare cleaned addon name with the zip file name. Since the official addon name was cleaned it doesn't match the uncleaned zip filename.


##### Description of changes
Clean the drag & drop file name in the same manner as official addons.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
