### PR TITLE
[FIX] Mosaic Vizrank: compute_attr_order is called every step

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -137,12 +137,6 @@ class MosaicVizRank(VizRankDialog, OWComponent):
                 attrs = sorted(zip(weights, data.domain.attributes),
                                key=lambda x: (-x[0], x[1].name))
                 self.attr_ordering = [a for _, a in attrs]
-        if class_var is not None:
-            if self._compute_class_dists():
-                if self.attr_ordering[0] is class_var:
-                    del self.attr_ordering[0]
-            elif self.attr_ordering[0] is not class_var:
-                self.attr_ordering.insert(0, class_var)
 
     def _compute_class_dists(self):
         return self.master.interior_coloring == self.master.CLASS_DISTRIBUTION
@@ -152,8 +146,7 @@ class MosaicVizRank(VizRankDialog, OWComponent):
         Return the number of combinations, starting with a single attribute
         if Mosaic is colored by class distributions, and two if by Pearson
         """
-        self.compute_attr_order()
-        n_attrs = len(self.attr_ordering)
+        n_attrs = len(self.master.discrete_data.domain.attributes)
         min_attrs = 1 if self._compute_class_dists() else 2
         max_attrs = min(n_attrs, self.max_attrs)
         return sum(comb(n_attrs, k, exact=True)
@@ -498,9 +491,9 @@ class OWMosaicDisplay(OWWidget):
             color_var = self.data.domain[self.cb_attr_color.currentText()]
             self.interior_coloring = self.CLASS_DISTRIBUTION
             self.bar_button.setEnabled(True)
-        attributes = [v for v in self.data.domain if v != color_var]
-        metas = [v for v in self.data.domain.metas if v != color_var]
-        domain = Domain(attributes, color_var, metas)
+        attributes = [v for v in self.data.domain.attributes + self.data.domain.class_vars
+                      + self.data.domain.metas if v != color_var and v.is_primitive()]
+        domain = Domain(attributes, color_var, None)
         self.color_data = color_data = self.data.from_table(domain, self.data)
         self.discrete_data = self._get_discrete_data(color_data)
         self.vizrank.stop_and_reset()

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -118,31 +118,43 @@ class MosaicVizRankTests(WidgetTest):
         """MosaicVizrank correctly computes the number of combinations"""
         widget = self.widget
         vizrank = self.vizrank
-        widget.set_data(self.iris)
 
-        widget.interior_coloring = widget.PEARSON
-        vizrank.max_attrs = 2
-        self.assertEqual(vizrank.state_count(), 10)  # 5x4 / 2
-        vizrank.max_attrs = 3
-        self.assertEqual(vizrank.state_count(), 20)  # above + 5x4x3 / 2x3
-        vizrank.max_attrs = 4
-        self.assertEqual(vizrank.state_count(), 25)  # above + 5x4x3x2 / 2x3x4
+        data = self.iris
+        attributes = [v for v in data.domain.attributes[1:]]
+        metas = [data.domain.attributes[0]]
+        domain = Domain(attributes, data.domain.class_var, metas)
+        new_data = data.from_table(domain, data)
+        widget.set_data(new_data)
 
-        widget.interior_coloring = widget.CLASS_DISTRIBUTION
-        vizrank.max_attrs = 2
-        self.assertEqual(vizrank.state_count(), 10)  # 4 + 4x3 / 2
-        vizrank.max_attrs = 3
-        self.assertEqual(vizrank.state_count(), 14)  # above + 4x3x2 / 3x2
-        vizrank.max_attrs = 4
-        self.assertEqual(vizrank.state_count(), 15)  # above + 4x3x2x1 / 2x3x4
+        for data in [self.iris, new_data]:
+            widget.set_data(data)
 
-        widget.set_data(self.iris_no_class)
-        vizrank.max_attrs = 2
-        self.assertEqual(vizrank.state_count(), 6)  # 4x3 / 2
-        vizrank.max_attrs = 3
-        self.assertEqual(vizrank.state_count(), 10)  # above + 4x3x2 / 3x2
-        vizrank.max_attrs = 4
-        self.assertEqual(vizrank.state_count(), 11)  # above + 4x3x2x1 / 2x3x4
+            simulate.combobox_activate_index(self.widget.controls.variable_color, 0, 0)
+            self.assertTrue(widget.interior_coloring == widget.PEARSON)
+            vizrank.max_attrs = 2
+            self.assertEqual(vizrank.state_count(), 10)  # 5x4 / 2
+            vizrank.max_attrs = 3
+            self.assertEqual(vizrank.state_count(), 20)  # above + 5x4x3 / 2x3
+            vizrank.max_attrs = 4
+            self.assertEqual(vizrank.state_count(), 25)  # above + 5x4x3x2 / 2x3x4
+
+            simulate.combobox_activate_index(self.widget.controls.variable_color, 2, 0)
+            self.assertTrue(widget.interior_coloring == widget.CLASS_DISTRIBUTION)
+            vizrank.max_attrs = 2
+            self.assertEqual(vizrank.state_count(), 10)  # 4 + 4x3 / 2
+            vizrank.max_attrs = 3
+            self.assertEqual(vizrank.state_count(), 14)  # above + 4x3x2 / 3x2
+            vizrank.max_attrs = 4
+            self.assertEqual(vizrank.state_count(), 15)  # above + 4x3x2x1 / 2x3x4
+
+            widget.set_data(self.iris_no_class)
+            simulate.combobox_activate_index(self.widget.controls.variable_color, 0, 0)
+            vizrank.max_attrs = 2
+            self.assertEqual(vizrank.state_count(), 6)  # 4x3 / 2
+            vizrank.max_attrs = 3
+            self.assertEqual(vizrank.state_count(), 10)  # above + 4x3x2 / 3x2
+            vizrank.max_attrs = 4
+            self.assertEqual(vizrank.state_count(), 11)  # above + 4x3x2x1 / 2x3x4
 
     def test_iteration(self):
         """MosaicVizrank correctly iterates through states"""


### PR DESCRIPTION
##### Issue
`compute_attr_order` is called every step. It does not need to be.


##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
