### PR TITLE
owpca: fix normalize checkbox

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -257,6 +257,8 @@ class OWPCA(widget.OWWidget):
         if self.data is None:
             return
         data = self.data
+        self._pca_projector.preprocessors = \
+            self._pca_preprocessors + ([Normalize()] if self.normalize else [])
         if not isinstance(data, SqlTable):
             pca = self._pca_projector(data)
             variance_ratio = pca.explained_variance_ratio_
@@ -407,11 +409,6 @@ class OWPCA(widget.OWWidget):
         self._invalidate_selection()
 
     def _update_normalize(self):
-        if self.normalize:
-            pp = self._pca_preprocessors + [Normalize()]
-        else:
-            pp = self._pca_preprocessors
-        self._pca_projector.preprocessors = pp
         self.fit()
         if self.data is None:
             self._invalidate_selection()

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -103,3 +103,19 @@ class TestOWPCA(WidgetTest):
         self.assertTrue(all(type(a) is ContinuousVariable   # pylint: disable=unidiomatic-typecheck
                             for a in components.domain.attributes),
                         "Some variables aren't of type ContinuousVariable")
+
+    def test_normalization(self):
+        data = Table("iris.tab")
+        self.widget.ncomponents = 2
+        self.assertTrue(self.widget.normalize)
+        self.widget.set_data(data)
+        norm1 = self.get_output(self.widget.Outputs.transformed_data)
+        self.widget.controls.normalize.toggle()
+        nonnorm1 = self.get_output(self.widget.Outputs.transformed_data)
+        self.widget.controls.normalize.toggle()
+        norm2 = self.get_output(self.widget.Outputs.transformed_data)
+        self.widget.controls.normalize.toggle()
+        nonnorm2 = self.get_output(self.widget.Outputs.transformed_data)
+        np.testing.assert_equal(nonnorm1.X, nonnorm2.X)
+        np.testing.assert_equal(norm1.X, norm2.X)
+        self.assertTrue(np.any(norm1.X - nonnorm1.X))  # nonnorm and norm are different


### PR DESCRIPTION
##### Issue
Even though Normalize was set the data were not normalized, unless
the checkbox was unchecked and checked.

##### Description of changes
Moved preprocessor creating code to fit.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
