### PR TITLE
[MNT] Run tests from subpackages

### DIFF
--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -78,13 +78,19 @@ def suite(loader=None, pattern='test*.py'):
         loader = unittest.TestLoader()
     if pattern is None:
         pattern = 'test*.py'
-    top_level_dir = os.path.dirname(os.path.dirname(Orange.__file__))
-    all_tests = [
-        loader.discover(test_dir, pattern, top_level_dir),
-    ]
-
+    orange_dir = os.path.dirname(Orange.__file__)
+    top_level_dir = os.path.dirname(orange_dir)
+    all_tests = [loader.discover(test_dir, pattern, top_level_dir)]
+    if not suite.in_tests:  # prevent recursion
+        suite.in_tests = True
+        all_tests += (loader.discover(dir, pattern, dir)
+                      for dir in (os.path.join(orange_dir, fn, "tests")
+                                  for fn in os.listdir(orange_dir)
+                                  if fn != "widgets")
+                      if os.path.exists(dir))
     return unittest.TestSuite(all_tests)
 
+suite.in_tests = False
 
 def load_tests(loader, tests, pattern):
     return suite(loader, pattern)


### PR DESCRIPTION
##### Issue

Orange currently does not run unit tests placed in subpackage directories, e.g. Orange/distance/tests.

##### Description of changes

Discovery is patched so that it does. The trick to prevent the recursion similar to that in widget tests (https://github.com/biolab/orange3/blob/master/Orange/widgets/tests/__init__.py).

##### Includes
- [X] Code changes