### PR TITLE
[FIX] Ensure visible nodes after openning a workflow.

### DIFF
--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -632,12 +632,27 @@ class SchemeEditWidget(QWidget):
             self.__scene.setItemIndexMethod(CanvasScene.NoIndex)
             self.__setupScene(self.__scene)
 
-            self.__view.setScene(self.__scene)
-
             self.__scene.set_scheme(scheme)
+            self.__view.setScene(self.__scene)
 
             if self.__scheme:
                 self.__scheme.installEventFilter(self)
+                nodes = self.__scheme.nodes
+                if nodes:
+                    self.ensureVisible(nodes[0])
+
+    def ensureVisible(self, node):
+        """
+        Scroll the contents of the viewport so that `node` is visible.
+
+        Parameters
+        ----------
+        node: SchemeNode
+        """
+        if self.__scheme is None:
+            return
+        item = self.__scene.item_for_node(node)
+        self.__view.ensureVisible(item)
 
     def scheme(self):
         """

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -361,7 +361,7 @@ class SchemeEditWidget(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        scene = CanvasScene()
+        scene = CanvasScene(self)
         scene.setItemIndexMethod(CanvasScene.NoIndex)
         self.__setupScene(scene)
 
@@ -628,7 +628,7 @@ class SchemeEditWidget(QWidget):
 
             self.__undoStack.clear()
 
-            self.__scene = CanvasScene()
+            self.__scene = CanvasScene(self)
             self.__scene.setItemIndexMethod(CanvasScene.NoIndex)
             self.__setupScene(self.__scene)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

In case the user opens a workflow whose nodes are very far from coordinate origin there is nothing visible in the viewport.

Example:
```xml
<?xml version='1.0' encoding='utf-8'?>
<scheme description="" title="" version="2.0">
	<nodes>
		<node id="0" name="Constant" position="(3779.0, 2765.0)" project_name="Orange3" qualified_name="Orange.widgets.model.owconstant.OWConstant" title="Constant" version="" />
	</nodes>
	<links />
	<annotations />
	<thumbnail />
</scheme>
```
##### Description of changes

Scroll the viewport to the first node.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
