### PR TITLE
owpca: prevent caching features of components output

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -467,7 +467,8 @@ class OWPCA(widget.OWWidget):
                 self.data.domain.metas
             )
             transformed = transformed.from_table(domain, transformed)
-            dom = Domain([ContinuousVariable(a.name)
+            # prevent caching new features by defining compute_value
+            dom = Domain([ContinuousVariable(a.name, compute_value=lambda _: None)
                           for a in self._pca.orig_domain.attributes],
                          metas=[StringVariable(name='component')])
             metas = numpy.array([['PC{}'.format(i + 1)

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -114,3 +114,11 @@ class TestOWPCA(WidgetTest):
         varnonnorm = self.widget.variance_covered
         # normalized data will have lower covered variance
         self.assertLess(varnorm, varnonnorm)
+
+    def test_do_not_mask_features(self):
+        # the widget used to replace cached variables when creating the
+        # components output (until 20170726)
+        data = Table("iris.tab")
+        self.widget.set_data(data)
+        ndata = Table("iris.tab")
+        self.assertIs(data.domain[0], ndata.domain[0])


### PR DESCRIPTION
##### Issue

Fixes an instance of #2500 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
