### PR TITLE
[ENH] Multiple inputs for OWPythonScript

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -475,9 +475,9 @@ class OWPythonScript(widget.OWWidget):
 
         self.controlBox.layout().addWidget(w)
 
-        self.execute_button = gui.auto_commit(
-            self.controlArea, self, "auto_execute", "Run",
-            checkbox_label="Autorun on new data").button
+        auto = gui.auto_commit(self.controlArea, self, "auto_execute", "Run",
+                               checkbox_label="Autorun on new data")
+        self.execute_button, self.autobox = auto.button, auto.checkbox
 
         self.splitCanvas = QSplitter(Qt.Vertical, self.mainArea)
         self.mainArea.layout().addWidget(self.splitCanvas)
@@ -677,7 +677,7 @@ class OWPythonScript(widget.OWWidget):
 
     def commit(self):
         if self.auto_execute:
-           self.execute_button.setEnabled(False)
+            self.execute_button.setEnabled(False)
         self.Error.clear()
         self._script = str(self.text.toPlainText())
         lcls = self.initial_locals_state()

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -17,9 +17,9 @@ class TestOWPythonScript(WidgetTest):
     def test_inputs(self):
         """Check widget's inputs"""
         for input, data in (("Data", self.iris),
-                             ("Learner", self.learner),
-                             ("Classifier", self.model),
-                             ("Object", "object")):
+                            ("Learner", self.learner),
+                            ("Classifier", self.model),
+                            ("Object", "object")):
             self.assertEqual(getattr(self.widget, input.lower()), {})
             self.send_signal(input, data, (1,))
             self.assertEqual(getattr(self.widget, input.lower()), {1: data})
@@ -38,17 +38,17 @@ class TestOWPythonScript(WidgetTest):
             self.assertIs(self.get_output(signal), data)
             self.send_signal(signal, None, (1,))
             self.widget.text.setPlainText("print(in_{})".format(lsignal))
-            self.widget.execute_button.button.click()
+            self.widget.execute_button.click()
             self.assertIsNone(self.get_output(signal))
 
     def test_local_variable(self):
         """Check if variable remains in locals after removed from script"""
-        self.widget.execute_button.checkbox.setCheckState(False)
+        self.widget.autobox.setCheckState(False)
         self.widget.text.setPlainText("temp = 42\nprint(temp)")
-        self.widget.execute_button.button.click()
+        self.widget.execute_button.click()
         self.assertIn("42", self.widget.console.toPlainText())
         self.widget.text.setPlainText("print(temp)")
-        self.widget.execute_button.button.click()
+        self.widget.execute_button.click()
         self.assertNotIn("NameError: name 'temp' is not defined",
                          self.widget.console.toPlainText())
 
@@ -57,7 +57,7 @@ class TestOWPythonScript(WidgetTest):
         Error is shown when output variables are filled with wrong variable
         types and also output variable is set to None. (GH-2308)
         """
-        self.widget.execute_button.checkbox.setCheckState(False)
+        self.widget.autobox.setCheckState(False)
         self.assertEqual(len(self.widget.Error.active), 0)
         for signal, data in (
                 ("Data", self.iris),
@@ -66,13 +66,13 @@ class TestOWPythonScript(WidgetTest):
             lsignal = signal.lower()
             self.send_signal(signal, data, (1, ))
             self.widget.text.setPlainText("out_{} = 42".format(lsignal))
-            self.widget.execute_button.button.click()
+            self.widget.execute_button.click()
             self.assertEqual(self.get_output(lsignal), None)
             self.assertTrue(hasattr(self.widget.Error, lsignal))
             self.assertTrue(getattr(self.widget.Error, lsignal).is_shown())
 
             self.widget.text.setPlainText("out_{0} = in_{0}".format(lsignal))
-            self.widget.execute_button.button.click()
+            self.widget.execute_button.click()
             self.assertIs(self.get_output(signal), data)
             self.assertFalse(getattr(self.widget.Error, lsignal).is_shown())
 
@@ -80,8 +80,8 @@ class TestOWPythonScript(WidgetTest):
         self.assertIsNot(self.widget.Error, OWWidget.Error)
 
     def test_multiple_signals(self):
-        self.widget.execute_button.checkbox.setCheckState(False)
-        click = self.widget.execute_button.button.click
+        self.widget.autobox.setCheckState(False)
+        click = self.widget.execute_button.click
         console_locals = self.widget.console.locals
 
         titanic = Table("titanic")

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -4,6 +4,7 @@ from Orange.data import Table
 from Orange.classification import LogisticRegressionLearner
 from Orange.widgets.data.owpythonscript import OWPythonScript
 from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.widget import OWWidget
 
 
 class TestOWPythonScript(WidgetTest):
@@ -15,30 +16,30 @@ class TestOWPythonScript(WidgetTest):
 
     def test_inputs(self):
         """Check widget's inputs"""
-        for _input, data in (("in_data", self.iris),
-                             ("in_learner", self.learner),
-                             ("in_classifier", self.model),
-                             ("in_object", "object")):
-            self.assertEqual(getattr(self.widget, _input), None)
-            self.send_signal(_input, data)
-            self.assertEqual(getattr(self.widget, _input), data)
-            self.send_signal(_input, None)
-            self.assertEqual(getattr(self.widget, _input), None)
+        for input, data in (("Data", self.iris),
+                             ("Learner", self.learner),
+                             ("Classifier", self.model),
+                             ("Object", "object")):
+            self.assertEqual(getattr(self.widget, input.lower()), {})
+            self.send_signal(input, data, (1,))
+            self.assertEqual(getattr(self.widget, input.lower()), {1: data})
+            self.send_signal(input, None, (1,))
+            self.assertEqual(getattr(self.widget, input.lower()), {})
 
     def test_outputs(self):
         """Check widget's outputs"""
-        for _input, _output, data in (
-                ("in_data", "out_data", self.iris),
-                ("in_learner", "out_learner", self.learner),
-                ("in_classifier", "out_classifier", self.model),
-                ("in_object", "out_object", "object")):
-            self.widget.text.setPlainText("{} = {}".format(_output, _input))
-            self.send_signal(_input, data)
-            self.assertEqual(self.get_output(_output), data)
-            self.send_signal(_input, None)
-            self.widget.text.setPlainText("print({})".format(_output))
+        for signal, data in (
+                ("Data", self.iris),
+                ("Learner", self.learner),
+                ("Classifier", self.model)):
+            lsignal = signal.lower()
+            self.widget.text.setPlainText("out_{0} = in_{0}".format(lsignal))
+            self.send_signal(signal, data, (1,))
+            self.assertIs(self.get_output(signal), data)
+            self.send_signal(signal, None, (1,))
+            self.widget.text.setPlainText("print(in_{})".format(lsignal))
             self.widget.execute_button.button.click()
-            self.assertEqual(self.get_output(_output), None)
+            self.assertIsNone(self.get_output(signal))
 
     def test_local_variable(self):
         """Check if variable remains in locals after removed from script"""
@@ -53,18 +54,63 @@ class TestOWPythonScript(WidgetTest):
 
     def test_wrong_outputs(self):
         """
-        Error is shown when output variables are filled with wrong variable types.
-        And also output variable is set to None.
-        GH-2308
+        Error is shown when output variables are filled with wrong variable
+        types and also output variable is set to None. (GH-2308)
         """
+        self.widget.execute_button.checkbox.setCheckState(False)
         self.assertEqual(len(self.widget.Error.active), 0)
-        for _input, _output, data in (
-                ("in_data", "out_data", self.iris),
-                ("in_learner", "out_learner", self.learner),
-                ("in_classifier", "out_classifier", self.model)):
-            self.widget.text.setPlainText("{} = {}".format(_output, _input))
-            self.send_signal(_input, "42")
-            self.assertEqual(self.get_output(_output), None)
-            self.assertTrue(getattr(self.widget.Error, _output).is_shown())
-            self.send_signal(_input, data)
-            self.assertFalse(getattr(self.widget.Error, _output).is_shown())
+        for signal, data in (
+                ("Data", self.iris),
+                ("Learner", self.learner),
+                ("Classifier", self.model)):
+            lsignal = signal.lower()
+            self.send_signal(signal, data, (1, ))
+            self.widget.text.setPlainText("out_{} = 42".format(lsignal))
+            self.widget.execute_button.button.click()
+            self.assertEqual(self.get_output(lsignal), None)
+            self.assertTrue(hasattr(self.widget.Error, lsignal))
+            self.assertTrue(getattr(self.widget.Error, lsignal).is_shown())
+
+            self.widget.text.setPlainText("out_{0} = in_{0}".format(lsignal))
+            self.widget.execute_button.button.click()
+            self.assertIs(self.get_output(signal), data)
+            self.assertFalse(getattr(self.widget.Error, lsignal).is_shown())
+
+    def test_owns_errors(self):
+        self.assertIsNot(self.widget.Error, OWWidget.Error)
+
+    def test_multiple_signals(self):
+        self.widget.execute_button.checkbox.setCheckState(False)
+        click = self.widget.execute_button.button.click
+        console_locals = self.widget.console.locals
+
+        titanic = Table("titanic")
+
+        click()
+        self.assertIsNone(console_locals["in_data"])
+        self.assertEqual(console_locals["in_datas"], [])
+
+        self.send_signal("Data", self.iris, (1, ))
+        click()
+        self.assertIs(console_locals["in_data"], self.iris)
+        datas = console_locals["in_datas"]
+        self.assertEqual(len(datas), 1)
+        self.assertIs(datas[0], self.iris)
+
+        self.send_signal("Data", titanic, (2, ))
+        click()
+        self.assertIsNone(console_locals["in_data"])
+        self.assertEqual({id(obj) for obj in console_locals["in_datas"]},
+                         {id(self.iris), id(titanic)})
+
+        self.send_signal("Data", None, (2, ))
+        click()
+        self.assertIs(console_locals["in_data"], self.iris)
+        datas = console_locals["in_datas"]
+        self.assertEqual(len(datas), 1)
+        self.assertIs(datas[0], self.iris)
+
+        self.send_signal("Data", None, (1, ))
+        click()
+        self.assertIsNone(console_locals["in_data"])
+        self.assertEqual(console_locals["in_datas"], [])

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -48,6 +48,8 @@ class DummySignalManager:
         self.outputs = {}
 
     def send(self, widget, signal_name, value, id):
+        if not isinstance(signal_name, str):
+            signal_name = signal_name.name
         self.outputs[(widget, signal_name)] = value
 
 
@@ -202,7 +204,7 @@ class WidgetTest(GuiTest):
 
         Parameters
         ----------
-        input_name : str
+        input : str
         value : Object
         id : int
             channel id, used for inputs with flag Multiple
@@ -224,7 +226,8 @@ class WidgetTest(GuiTest):
         if widget.isBlocking():
             raise RuntimeError("'send_signal' called but the widget is in "
                                "blocking state and does not accept inputs.")
-        getattr(widget, input.handler)(value, *args)
+        handler = getattr(widget, input.handler)
+        handler(value, *args)
         widget.handleNewSignals()
         if wait >= 0 and widget.isBlocking():
             spy = QSignalSpy(widget.blockingStateChanged)


### PR DESCRIPTION
##### Issue

Alternative to #2418.

##### Description of changes

Allow multiple inputs, store them in dictionaries and expose them under their existing names (e.g. `in_data`) in case there is only a single signal, and with plural names (e.g. `in_datas`) bound to lists of inputs (zero, one or more).

Creation of inputs and outputs is automatized through a meta class. The advantage of this is, beside easier adding of new inputs and outputs, sharing the common code for all inputs. For instance, when testing multiple inputs, we only need to test `in_data` (`in_datas`) since other inputs work the same way.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
