### PR TITLE
[FIX] tree: Fix min_samples_leaf check

### DIFF
--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -94,7 +94,7 @@ class TreeLearner(Learner):
             cont = _tree_scorers.contingency(col_x, len(data.domain.attributes[attr_no].values),
                                              data.Y, len(data.domain.class_var.values))
             attr_distr = np.sum(cont, axis=0)
-            null_nodes = attr_distr <= self.min_samples_leaf
+            null_nodes = attr_distr < self.min_samples_leaf
             # This is just for speed. If there is only a single non-null-node,
             # entropy wouldn't decrease anyway.
             if sum(null_nodes) >= n_values - 1:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Setting "Min. number of instances in leaves" (or `min_samples_leaf` in the code) to K actually enforced leaves to have K + 1 instances.

##### Description of changes
Change the check for invalid nodes from `<= min_samples_leaf` to strict `< min_samples_leaf`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
