### PR TITLE
[FIX] widgets/model: Restore 'explicit' hint flag for 'Coefficients' output

### DIFF
--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -26,7 +26,7 @@ class OWLinearRegression(OWBaseLearner):
     LEARNER = LinearRegressionLearner
 
     class Outputs(OWBaseLearner.Outputs):
-        coefficients = Output("Coefficients", Table)
+        coefficients = Output("Coefficients", Table, explicit=True)
 
     #: Types
     REGULARIZATION_TYPES = ["No regularization", "Ridge regression (L2)",

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -23,7 +23,7 @@ class OWLogisticRegression(OWBaseLearner):
     LEARNER = LogisticRegressionLearner
 
     class Outputs(OWBaseLearner.Outputs):
-        coefficients = Output("Coefficients", Table)
+        coefficients = Output("Coefficients", Table, explicit=True)
 
     penalty_type = settings.Setting(1)
     C_index = settings.Setting(61)

--- a/Orange/widgets/model/owsgd.py
+++ b/Orange/widgets/model/owsgd.py
@@ -27,7 +27,7 @@ class OWSGD(OWBaseLearner):
     LEARNER = SGDLearner
 
     class Outputs(OWBaseLearner.Outputs):
-        coefficients = Output("Coefficients", Table)
+        coefficients = Output("Coefficients", Table, explicit=True)
 
     reg_losses = (
         ('Squared Loss', 'squared_loss'),

--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -25,7 +25,7 @@ class OWSVM(OWBaseLearner):
     LEARNER = SVMLearner
 
     class Outputs(OWBaseLearner.Outputs):
-        support_vectors = Output("Support vectors", Table)
+        support_vectors = Output("Support vectors", Table, explicit=True)
 
     #: Different types of SVMs
     SVM, Nu_SVM = range(2)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Connect Logistic Regression -> Test & Score

Coefficients -> Train connection is established, but Learner -> Learner would be expected.

##### Description of changes

Restore the 'explicit' hint flag on output declarations for Table outputs.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
