### PR TITLE
Scripts: prepare signed macos binary

### DIFF
--- a/scripts/macos/build-macos-app.sh
+++ b/scripts/macos/build-macos-app.sh
@@ -152,6 +152,7 @@ VERSION=$("${PYTHON}" -m pip show orange3 | grep -E '^Version:' |
 
 m4 -D__VERSION__="${VERSION:?}" "${APPDIR}"/Contents/Info.plist.in \
     > "${APPDIR}"/Contents/Info.plist
+rm "${APPDIR}"/Contents/Info.plist.in
 
 # Sanity check
 (

--- a/scripts/macos/create-dmg-installer.sh
+++ b/scripts/macos/create-dmg-installer.sh
@@ -75,9 +75,6 @@ ln -s /Applications/ "${TMP_TEMPLATE}"/Applications
 # Copy the .app directory in place
 cp -a "${APP}" "${TMP_TEMPLATE}"/Orange3.app
 
-# Remove unnecesary files.
-find "${TMP_TEMPLATE}"/Orange3.app/Contents/ \( -name '*.pyc' -or -name '*.pyo' \) -delete
-
 # Create a regular .fseventsd/no_log file
 # (see http://hostilefork.com/2009/12/02/trashes-fseventsd-and-spotlight-v100/ )
 

--- a/scripts/macos/sign-app.sh
+++ b/scripts/macos/sign-app.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Build app
+rm -rf ~/dev/orange3/dist/Orange3.app
+./build-macos-app.sh ~/dev/orange3/dist/Orange3.app
+# Missing symlink Current messes with code signing
+ln -s 3.6 ../../dist/Orange3.app/Contents/Frameworks/Python.framework/Versions/Current
+# sign bundle
+codesign -s "Developer ID" /Users/anze/dev/orange3/dist/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6
+codesign -s "Developer ID" /Users/anze/dev/orange3/dist/Orange3.app/Contents/MacOS/pip 
+codesign -s "Developer ID" /Users/anze/dev/orange3/dist/Orange3.app
+
+# Create disk image
+./create-dmg-installer.sh --app ../../dist/Orange3.app ../../dist/Orange3-3.4.5-signed.dmg
+# Sign disk image
+codesign -s "Developer ID" /Users/anze/dev/orange3/dist/Orange3-3.4.5-signed.dmg 


### PR DESCRIPTION
This is a script I use to prepare a signed macos release. I had to modify the mac build process a bit in order to be able to sign the resulting app.

The script could (should?) be rewritten in a way that does not hardcode version and paths, but that would require some bash programming skills I do not possess.