### PR TITLE
FileWidget: DomainEditor update of type conversions.

### DIFF
--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -247,6 +247,30 @@ a
         formats = dialog_formats()
         self.assertTrue(".123" in formats)
 
-
-class TestDomainEditor(TestCase):
-    pass
+    def test_domain_editor_conversions(self):
+        dat = """V0\tV1\tV2\tV3\tV4\tV5
+                 c\tc\td\td\tc\td
+                  \t \t \t \t \t
+                 3.0\t1.0\t4\ta\t0.0\tx
+                 1.0\t2.0\t4\tb\t0.0\ty
+                 2.0\t1.0\t7\ta\t0.0\ty
+                 0.0\t2.0\t7\ta\t0.0\tz"""
+        with named_file(dat, suffix=".tab") as filename:
+            self.open_dataset(filename)
+            data1 = self.get_output(self.widget.Outputs.data)
+            model = self.widget.domain_editor.model()
+            # check the ordering of attributes
+            for i, a in enumerate(data1.domain.attributes):
+                self.assertEqual(str(a), model.data(model.createIndex(i, 0), Qt.DisplayRole))
+            # make conversions
+            model.setData(model.createIndex(0, 1), "categorical", Qt.EditRole)
+            model.setData(model.createIndex(1, 1), "string", Qt.EditRole)
+            model.setData(model.createIndex(2, 1), "numeric", Qt.EditRole)
+            model.setData(model.createIndex(3, 1), "numeric", Qt.EditRole)
+            self.widget.apply_button.click()
+            data2 = self.get_output(self.widget.Outputs.data)
+            # round continuous values should be converted to integers (3.0 -> 3, "3")
+            self.assertEqual(len(data2.domain.attributes[0].values[0]), 1)
+            self.assertEqual(len(data2[0].metas[0]), 1)
+            # discrete integer values should stay the same after conversion to continuous
+            self.assertAlmostEqual(float(data1[0][2].value), data2[0][1])

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 from os import path, remove
 from unittest.mock import Mock
+from unittest import TestCase
 import pickle
 import tempfile
 
@@ -245,3 +246,7 @@ a
         # test adding file formats after registering the widget
         formats = dialog_formats()
         self.assertTrue(".123" in formats)
+
+
+class TestDomainEditor(TestCase):
+    pass

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -261,6 +261,8 @@ class DomainEditor(QTableView):
 
             cont_ints = type(orig_var) == ContinuousVariable and \
                         all(x.is_integer() for x in self._iter_vals(col_data) if not np.isnan(x))
+            disc_ints = type(orig_var) == DiscreteVariable and \
+                        all(x.isdecimal() for x in orig_var.values)
 
             if name == orig_var.name and tpe == type(orig_var):
                 var = orig_var
@@ -290,8 +292,9 @@ class DomainEditor(QTableView):
                 col_data = self._to_column(col_data, False, dtype=object)
             elif tpe == ContinuousVariable and type(orig_var) == DiscreteVariable:
                 var = tpe(name)
-                col_data = [np.nan if self._is_missing(x) else float(orig_var.values[int(x)])
-                            for x in self._iter_vals(col_data)]
+                if disc_ints:
+                    col_data = [np.nan if self._is_missing(x) else float(orig_var.values[int(x)])
+                                for x in self._iter_vals(col_data)]
                 col_data = self._to_column(col_data, is_sparse)
             else:
                 var = tpe(name)

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -241,6 +241,9 @@ class DomainEditor(QTableView):
         -------
         (new_domain, [attribute_columns, class_var_columns, meta_columns])
         """
+        # Allow type-checking with type() instead of isinstance() for exact comparison
+        # pylint: disable=unidiomatic-typecheck
+
         variables = self.model().variables
         places = [[], [], []]  # attributes, class_vars, metas
         cols = [[], [], []]  # Xcols, Ycols, Mcols

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -274,6 +274,11 @@ class DomainEditor(QTableView):
                 # don't obey sparsity for StringVariable since they are
                 # in metas which are transformed to dense below
                 col_data = self._to_column(col_data, False, dtype=object)
+            elif tpe == ContinuousVariable and type(orig_var) == DiscreteVariable:
+                var = tpe(name)
+                col_data = [np.nan if self._is_missing(x) else float(orig_var.values[int(x)])
+                            for x in self._iter_vals(col_data)]
+                col_data = self._to_column(col_data, is_sparse)
             else:
                 var = tpe(name)
             places[place].append(var)


### PR DESCRIPTION
##### Issue
Fixes #2424 and #2423.

##### Description of changes
Conversion nominal -> numeric now retains the actual values (bugfix).
Conversion numeric -> * drops decimal places (e.g. 18.0 -> 18) if all entries are integer.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
