### PR TITLE
[FIX] Fix asynchronous widget tests

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -26,24 +26,28 @@ class TestOWTestLearners(WidgetTest):
         super().setUp()
         self.widget = self.create_widget(OWTestLearners)  # type: OWTestLearners
 
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
+
     def test_basic(self):
-        data = Table("iris")[::3]
+        data = Table("iris")[::15]
         self.send_signal(self.widget.Inputs.train_data, data)
-        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0, wait=5000)
-        res = self.get_output(self.widget.Outputs.evaluations_results)
+        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0)
+        res = self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
         self.assertIsInstance(res, Results)
         self.assertIsNotNone(res.domain)
         self.assertIsNotNone(res.data)
         self.assertIsNotNone(res.probabilities)
 
-        self.send_signal(self.widget.Inputs.learner, None, 0, wait=5000)
-        res = self.get_output(self.widget.Outputs.evaluations_results)
+        self.send_signal(self.widget.Inputs.learner, None, 0)
+        res = self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
         self.assertIsNone(res)
 
         data = Table("housing")[::10]
         self.send_signal(self.widget.Inputs.train_data, data)
-        self.send_signal(self.widget.Inputs.learner, MeanLearner(), 0, wait=5000)
-        res = self.get_output(self.widget.Outputs.evaluations_results)
+        self.send_signal(self.widget.Inputs.learner, MeanLearner(), 0)
+        res = self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
         self.assertIsInstance(res, Results)
         self.assertIsNotNone(res.domain)
         self.assertIsNotNone(res.data)
@@ -65,6 +69,7 @@ class TestOWTestLearners(WidgetTest):
         self.send_signal(self.widget.Inputs.train_data, data)
         self.assertFalse(rb.isEnabled())
         self.assertFalse(self.widget.features_combo.isEnabled())
+        self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
 
         self.send_signal(self.widget.Inputs.train_data, data_with_disc_metas)
         self.assertTrue(rb.isEnabled())
@@ -73,6 +78,7 @@ class TestOWTestLearners(WidgetTest):
         self.assertTrue(self.widget.features_combo.isEnabled())
         self.assertEqual(self.widget.features_combo.currentText(), "iris")
         self.assertEqual(len(self.widget.features_combo.model()), 1)
+        self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
 
         self.send_signal(self.widget.Inputs.train_data, None)
         self.assertFalse(rb.isEnabled())
@@ -148,7 +154,7 @@ class TestOWTestLearners(WidgetTest):
         Handling memory error.
         GH-2316
         """
-        data = Table("iris")[::3]
+        data = Table("iris")[::15]
         self.send_signal(self.widget.Inputs.train_data, data)
         self.assertFalse(self.widget.Error.memory_error.is_shown())
 
@@ -216,6 +222,7 @@ class TestOWTestLearners(WidgetTest):
             del Score.registry["NewScore"]
             del Score.registry["NewClassificationScore"]
             del Score.registry["NewRegressionScore"]
+
 
 class TestHelpers(unittest.TestCase):
     def test_results_one_vs_rest(self):

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -3,6 +3,8 @@ import os
 import time
 import unittest
 from unittest.mock import Mock
+# pylint: disable=unused-import
+from typing import List, Optional, Type, TypeVar
 
 import numpy as np
 import sip
@@ -28,6 +30,7 @@ from Orange.regression.base_regression import (
 from Orange.widgets.utils.annotated_data import (
     ANNOTATED_DATA_FEATURE_NAME, ANNOTATED_DATA_SIGNAL_NAME
 )
+from Orange.widgets.widget import OWWidget
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 
 sip.setdestroyonexit(False)
@@ -35,6 +38,9 @@ sip.setdestroyonexit(False)
 app = None
 
 DEFAULT_TIMEOUT = 5000
+
+# pylint: disable=invalid-name
+T = TypeVar("T")
 
 
 class DummySignalManager:
@@ -70,8 +76,7 @@ class WidgetTest(GuiTest):
     will ensure they are created correctly.
     """
 
-    #: list[OwWidget]
-    widgets = []
+    widgets = []  # type: List[OWWidget]
 
     @classmethod
     def setUpClass(cls):
@@ -95,6 +100,7 @@ class WidgetTest(GuiTest):
         self.process_events()
 
     def create_widget(self, cls, stored_settings=None, reset_default_settings=True):
+        # type: (Type[T], Optional[dict], bool) -> T
         """Create a widget instance using mock signal_manager.
 
         When used with default parameters, it also overrides settings stored

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -215,6 +215,9 @@ class WidgetTest(GuiTest):
             else:
                 raise ValueError("'{}' is not an input name for widget {}"
                                  .format(input, type(widget).__name__))
+        if widget.isBlocking():
+            raise RuntimeError("'send_signal' called but the widget is in "
+                               "blocking state and does not accept inputs.")
         getattr(widget, input.handler)(value, *args)
         widget.handleNewSignals()
         if wait >= 0 and widget.isBlocking():

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -224,7 +224,7 @@ class WidgetTest(GuiTest):
             spy = QSignalSpy(widget.blockingStateChanged)
             self.assertTrue(spy.wait(timeout=wait))
 
-    def get_output(self, output, widget=None):
+    def get_output(self, output, widget=None, wait=5000):
         """Return the last output that has been sent from the widget.
 
         Parameters
@@ -232,6 +232,8 @@ class WidgetTest(GuiTest):
         output_name : str
         widget : Optional[OWWidget]
             widget whose output is returned. If not set, self.widget is used
+        wait : int
+            The amount of time (in milliseconds) to wait for widget to complete.
 
         Returns
         -------
@@ -239,9 +241,15 @@ class WidgetTest(GuiTest):
         """
         if widget is None:
             widget = self.widget
+
+        if widget.isBlocking() and wait >= 0:
+            spy = QSignalSpy(widget.blockingStateChanged)
+            self.assertTrue(spy.wait(wait),
+                            "Failed to get output in the specified timeout")
         if not isinstance(output, str):
             output = output.name
         return self.signal_manager.outputs.get((widget, output), None)
+
 
     @contextmanager
     def modifiers(self, modifiers):

--- a/Orange/widgets/unsupervised/tests/test_owmds.py
+++ b/Orange/widgets/unsupervised/tests/test_owmds.py
@@ -29,6 +29,10 @@ class TestOWMDS(WidgetTest, WidgetOutputsTestMixin):
             }
         )  # type: OWMDS
 
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
+
     def _select_data(self):
         random.seed(42)
         points = random.sample(range(0, len(self.data)), 20)
@@ -37,8 +41,8 @@ class TestOWMDS(WidgetTest, WidgetOutputsTestMixin):
         return sorted(points)
 
     def test_pca_init(self):
-        self.send_signal(self.signal_name, self.signal_data, wait=1000)
-        output = self.get_output(self.widget.Outputs.annotated_data)
+        self.send_signal(self.signal_name, self.signal_data)
+        output = self.get_output(self.widget.Outputs.annotated_data, wait=1000)
         expected = np.array(
             [[-2.69304803, 0.32676458],
              [-2.7246721, -0.20921726],
@@ -49,7 +53,7 @@ class TestOWMDS(WidgetTest, WidgetOutputsTestMixin):
 
     def test_nan_plot(self):
         data = datasets.missing_data_1()
-        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.data, data, wait=1000)
 
         simulate.combobox_run_through_all(self.widget.cb_color_value)
         simulate.combobox_run_through_all(self.widget.cb_color_value)
@@ -63,7 +67,7 @@ class TestOWMDS(WidgetTest, WidgetOutputsTestMixin):
         data.Y[:] = np.nan
         data.metas[:, 1] = np.nan
 
-        self.send_signal("Data", data)
+        self.send_signal("Data", data, wait=1000)
 
         simulate.combobox_run_through_all(self.widget.cb_color_value)
         simulate.combobox_run_through_all(self.widget.cb_shape_value)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Asynchronous tests for owmds and owtestlearners set inputs to their respective widgets when they should not (a per `OWWidget.isBlocking`).
 
##### Description of changes

* Raise RuntimeError in `WidgetTest.send_signal` if the target widget is not ready to receive inputs.
* Add `wait` parameter to `WidgetTest.get_output`.
* Fix test_owmds and test_owtestlearners.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
