### PR TITLE
[FIX] Silhouette Plot: another memory error

### DIFF
--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -84,6 +84,7 @@ class OWSilhouettePlot(widget.OWWidget):
         need_two_clusters = Msg("Need at least two non-empty clusters")
         singleton_clusters_all = Msg("All clusters are singletons")
         memory_error = Msg("Not enough memory")
+        value_error = Msg("Distances could not be computed: '{}'")
 
     class Warning(widget.OWWidget.Warning):
         missing_cluster_assignment = Msg(
@@ -267,6 +268,9 @@ class OWSilhouettePlot(widget.OWWidget):
             except MemoryError:
                 self.Error.memory_error()
                 return
+            except ValueError as err:
+                self.Error.value_error(str(err))
+                return
 
         self._update_labels()
 
@@ -278,9 +282,7 @@ class OWSilhouettePlot(widget.OWWidget):
         self._clear_scene()
 
     def _clear_messages(self):
-        self.Error.memory_error.clear()
-        self.Error.singleton_clusters_all.clear()
-        self.Error.need_two_clusters.clear()
+        self.Error.clear()
         self.Warning.missing_cluster_assignment.clear()
 
     def _update_labels(self):


### PR DESCRIPTION
##### Issue
Related to #2336.

Silhouette Plot already catches a memory error. However that error might be caught but another error is thrown. That is 

> ValueError array is too big; 'arr.size * arr.dtype.itemsize' is larger than the maximum possible size.

See: https://sentry.io/biolab/orange3/issues/196744070/events/6454328021/

##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
