### PR TITLE
Add Show Settings to widget context menu

### DIFF
--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -858,8 +858,8 @@ class SchemeEditWidget(QWidget):
         """
         Print widget settings to log.
         """
-        import pprint
-        pp = pprint.PrettyPrinter(indent=4)
+        from Orange.widgets.settings import SettingsPrinter
+        pp = SettingsPrinter(indent=4)
         selected = self.scene().selectedItems()
         for item in selected:
             node = self.__scene.node_for_item(item)

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -160,6 +160,9 @@ class SchemeEditWidget(QWidget):
         self.__widgetMenu.addAction(self.__removeSelectedAction)
         self.__widgetMenu.addSeparator()
         self.__widgetMenu.addAction(self.__helpAction)
+        if log.isEnabledFor(logging.DEBUG):
+            self.__widgetMenu.addSeparator()
+            self.__widgetMenu.addAction(self.__showSettingsAction)
 
         self.__linkMenu = QMenu(self.tr("Link"), self)
         self.__linkMenu.addAction(self.__linkEnableAction)
@@ -284,6 +287,13 @@ class SchemeEditWidget(QWidget):
                     triggered=self.removeSelected,
                     enabled=False
                     )
+
+        self.__showSettingsAction = \
+            QAction(self.tr("Show settings"), self,
+                    objectName="show-settings",
+                    toolTip=self.tr("Show widget settings"),
+                    triggered=self.showSettings,
+                    enabled=False)
 
         shortcuts = [Qt.Key_Delete,
                      Qt.ControlModifier + Qt.Key_Backspace]
@@ -844,6 +854,18 @@ class SchemeEditWidget(QWidget):
                 )
         self.__undoStack.endMacro()
 
+    def showSettings(self):
+        """
+        Print widget settings to log.
+        """
+        import pprint
+        pp = pprint.PrettyPrinter(indent=4)
+        selected = self.scene().selectedItems()
+        for item in selected:
+            node = self.__scene.node_for_item(item)
+            widget = self.scheme().widget_for_node(node)
+            pp.pprint(widget.settingsHandler.pack_data(widget))
+
     def selectAll(self):
         """
         Select all selectable items in the scheme.
@@ -1264,6 +1286,7 @@ class SchemeEditWidget(QWidget):
         self.__helpAction.setEnabled(len(nodes) == 1)
         self.__renameAction.setEnabled(len(nodes) == 1)
         self.__duplicateSelectedAction.setEnabled(bool(nodes))
+        self.__showSettingsAction.setEnabled(len(nodes) == 1)
 
         if len(nodes) > 1:
             self.__openSelectedAction.setText(self.tr("Open All"))

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -856,15 +856,12 @@ class SchemeEditWidget(QWidget):
 
     def showSettings(self):
         """
-        Print widget settings to log.
+        Dump settings of selected items to the standard output.
         """
-        from Orange.widgets.settings import SettingsPrinter
-        pp = SettingsPrinter(indent=4)
         selected = self.scene().selectedItems()
         for item in selected:
-            node = self.__scene.node_for_item(item)
-            widget = self.scheme().widget_for_node(node)
-            pp.pprint(widget.settingsHandler.pack_data(widget))
+            node = self.scene().node_for_item(item)
+            self.scheme().dump_settings(node)
 
     def selectAll(self):
         """

--- a/Orange/canvas/scheme/scheme.py
+++ b/Orange/canvas/scheme/scheme.py
@@ -672,3 +672,7 @@ class Scheme(QObject):
         will be reflected in it.
         """
         return types.MappingProxyType(self.__env)
+
+    def dump_settings(self, node: SchemeNode):
+        """Dump current settings of the `node` to the standard output"""
+        print(node.properties)

--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -101,6 +101,13 @@ class WidgetsScheme(Scheme):
         inst.show()
         inst.raise_()
 
+    def dump_settings(self, node: SchemeNode):
+        from Orange.widgets.settings import SettingsPrinter
+        widget = self.widget_for_node(node)
+
+        pp = SettingsPrinter(indent=4)
+        pp.pprint(widget.settingsHandler.pack_data(widget))
+
 
 class WidgetManager(QObject):
     """

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -34,8 +34,10 @@ import itertools
 import os
 import logging
 import pickle
+import pprint
 import time
 import warnings
+from operator import itemgetter
 
 from Orange.data import Domain, Variable
 from Orange.misc.environ import widget_settings_dir
@@ -1207,6 +1209,30 @@ class PerfectDomainContextHandler(DomainContextHandler):
             return value, -1
         else:
             return super().encode_setting(context, setting, value)
+
+
+class SettingsPrinter(pprint.PrettyPrinter):
+    """Pretty Printer that knows how to properly format Contexts."""
+
+    def _format(self, obj, stream, indent, allowance, context, level):
+        if not isinstance(obj, Context):
+            return super()._format(obj, stream, indent,
+                                   allowance, context, level)
+
+        stream.write("Context(")
+        for key, value in sorted(obj.__dict__.items(), key=itemgetter(0)):
+            if key == "values":
+                continue
+            stream.write(key)
+            stream.write("=")
+            stream.write(self._repr(value, context, level + 1))
+            stream.write(",\n")
+            stream.write(" " * (indent + 8))
+        stream.write("values=")
+        stream.write(" ")
+        self._format(obj.values, stream, indent+15,
+                     allowance+1, context, level + 1)
+        stream.write(")")
 
 
 def rename_setting(settings, old_name, new_name):

--- a/Orange/widgets/tests/test_context_handler.py
+++ b/Orange/widgets/tests/test_context_handler.py
@@ -3,7 +3,10 @@ from copy import copy, deepcopy
 from io import BytesIO
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
-from Orange.widgets.settings import ContextHandler, Setting, ContextSetting, Context, VERSION_KEY
+from Orange.widgets.settings import (
+    ContextHandler, ContextSetting, Context, Setting, SettingsPrinter,
+    VERSION_KEY
+)
 
 __author__ = 'anze'
 
@@ -159,3 +162,24 @@ class TestContextHandler(TestCase):
         self.assertIn("context_settings", settings)
         for c in settings["context_settings"]:
             self.assertIn(VERSION_KEY, c.values)
+
+
+class TestSettingsPrinter(TestCase):
+    def test_formats_contexts(self):
+        settings = dict(key1=1, key2=2,
+                        context_settings=[
+                            Context(param1=1, param2=2,
+                                    values=dict(value1=1,
+                                                value2=2)),
+                            Context(param1=3, param2=4,
+                                    values=dict(value1=5,
+                                                value2=6))
+                        ])
+        pp = SettingsPrinter()
+
+        output = pp.pformat(settings)
+        # parameter of all contexts should be visible in the output
+        self.assertIn("param1=1", output)
+        self.assertIn("param2=2", output)
+        self.assertIn("param1=3", output)
+        self.assertIn("param2=4", output)


### PR DESCRIPTION
##### Issue
It is hard to see widget's settings

##### Description of changes
Add an action to the widget's context menu that is shown when canvas is run in debug mode (debug log level), which prints the current widget's settings to the log.

##### Includes
- [X] Code changes
- [X] Tests