### PR TITLE
Canvas: Update checker should never crash

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -135,7 +135,8 @@ def check_for_updates():
                 try:
                     self.resultReady.emit(
                         urlopen('https://orange.biolab.si/version/', timeout=10).read().decode())
-                except OSError:
+                # Nothing that this fails with should make Orange crash
+                except Exception:  # pylint: disable=broad-except
                     log.exception('Failed to check for updates')
 
         def compare_versions(latest):


### PR DESCRIPTION
##### Issue
Update checker crashed with (probably) SSLError on Windos with insufficient / outdated cert store.

##### Description of changes
Catch all exceptions.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
