### PR TITLE
[MNT]  Fix appveyor tests

### DIFF
--- a/.ci_tools/appveyor/step-test.ps1
+++ b/.ci_tools/appveyor/step-test.ps1
@@ -18,12 +18,13 @@ pushd
 try {
     cd build/testdir
 
-    # Install numpy/scipy from staging index (contains numpy and scipy
+    # Install scipy from staging index (contains scipy
     # extracted form the legacy superpack installers (sse2 builds))
 
     python -m pip install `
-        --index-url "$env:STAGING_INDEX" `
-        --only-binary "numpy,scipy" numpy scipy
+        --extra-index-url "$env:STAGING_INDEX" `
+        --only-binary "numpy,scipy,scikit-learn,bottleneck" `
+        numpy~=1.12.1 scipy scikit-learn==0.18.1
 
     if ($LastExitCode -ne 0) { throw "Last command exited with non-zero code." }
 

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -30,11 +30,13 @@ class TestSklAdaBoostLearner(unittest.TestCase):
         np.random.seed(0)
         stump_estimator = SklTreeLearner(max_depth=1)
         tree_estimator = SklTreeLearner()
-        stump = SklAdaBoostClassificationLearner(base_estimator=stump_estimator)
-        tree = SklAdaBoostClassificationLearner(base_estimator=tree_estimator)
+        stump = SklAdaBoostClassificationLearner(
+            base_estimator=stump_estimator, n_estimators=5)
+        tree = SklAdaBoostClassificationLearner(
+            base_estimator=tree_estimator, n_estimators=5)
         results = CrossValidation(self.iris, [stump, tree], k=4)
         ca = CA(results)
-        self.assertLess(ca[0], ca[1])
+        self.assertLessEqual(ca[0], ca[1])
 
     def test_predict_single_instance(self):
         learn = SklAdaBoostClassificationLearner()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

* scikit-learn 0.19 wheels on PyPI are no binary compatible with our testing numpy.
* TestSklAdaBoostLearner.test_adaboost_base_estimator fails with scikit-learn 0.19
```
Failure
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 600, in run
    testMethod()
  File "/Users/aleserjavec/workspace/orange3/Orange/tests/test_ada_boost.py", line 37, in test_adaboost_base_estimator
    self.assertLess(ca[0], ca[1])
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 1199, in assertLess
    self.fail(self._formatMessage(msg, standardMsg))
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 665, in fail
    raise self.failureException(msg)
AssertionError: 0.92666666666666664 not less than 0.92666666666666664
```
##### Description of changes

* use scikit-learn 0.18.1 for testing (where applicable).
* Fix ada boost test.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
