### PR TITLE
FileWidget: Fix conversion for integer floating-point values.

### DIFF
--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -247,13 +247,13 @@ a
         self.assertTrue(".123" in formats)
 
     def test_domain_editor_conversions(self):
-        dat = """V0\tV1\tV2\tV3\tV4\tV5
-                 c\tc\td\td\tc\td
-                  \t \t \t \t \t
-                 3.0\t1.0\t4\ta\t0.0\tx
-                 1.0\t2.0\t4\tb\t0.0\ty
-                 2.0\t1.0\t7\ta\t0.0\ty
-                 0.0\t2.0\t7\ta\t0.0\tz"""
+        dat = """V0\tV1\tV2\tV3\tV4\tV5\tV6
+                 c\tc\td\td\tc\td\td
+                  \t \t \t \t \t \t
+                 3.0\t1.0\t4\ta\t0.0\tx\t1.0
+                 1.0\t2.0\t4\tb\t0.0\ty\t2.0
+                 2.0\t1.0\t7\ta\t0.0\ty\t2.0
+                 0.0\t2.0\t7\ta\t0.0\tz\t2.0"""
         with named_file(dat, suffix=".tab") as filename:
             self.open_dataset(filename)
             data1 = self.get_output(self.widget.Outputs.data)
@@ -266,6 +266,7 @@ a
             model.setData(model.createIndex(1, 1), "string", Qt.EditRole)
             model.setData(model.createIndex(2, 1), "numeric", Qt.EditRole)
             model.setData(model.createIndex(3, 1), "numeric", Qt.EditRole)
+            model.setData(model.createIndex(6, 1), "numeric", Qt.EditRole)
             self.widget.apply_button.click()
             data2 = self.get_output(self.widget.Outputs.data)
             # round continuous values should be converted to integers (3.0 -> 3, "3")
@@ -273,6 +274,8 @@ a
             self.assertEqual(len(data2[0].metas[0]), 1)
             # discrete integer values should stay the same after conversion to continuous
             self.assertAlmostEqual(float(data1[0][2].value), data2[0][1])
+            # discrete round floats should stay the same after conversion to continuous
+            self.assertAlmostEqual(float(data1[0][6].value), data2[0][5])
 
     def test_url_no_scheme(self):
         mock_urlreader = Mock(side_effect=ValueError())

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -248,7 +248,7 @@ class DomainEditor(QTableView):
         places = [[], [], []]  # attributes, class_vars, metas
         cols = [[], [], []]  # Xcols, Ycols, Mcols
 
-        for (name, tpe, place, _, _), (orig_var, orig_plc) in \
+        for (name, tpe, place, _, may_be_numeric), (orig_var, orig_plc) in \
                 zip(variables,
                         chain([(at, Place.feature) for at in domain.attributes],
                               [(cl, Place.class_var) for cl in domain.class_vars],
@@ -261,8 +261,6 @@ class DomainEditor(QTableView):
 
             cont_ints = type(orig_var) == ContinuousVariable and \
                         all(x.is_integer() for x in self._iter_vals(col_data) if not np.isnan(x))
-            disc_ints = type(orig_var) == DiscreteVariable and \
-                        all(x.isdecimal() for x in orig_var.values)
 
             if name == orig_var.name and tpe == type(orig_var):
                 var = orig_var
@@ -292,7 +290,7 @@ class DomainEditor(QTableView):
                 col_data = self._to_column(col_data, False, dtype=object)
             elif tpe == ContinuousVariable and type(orig_var) == DiscreteVariable:
                 var = tpe(name)
-                if disc_ints:
+                if may_be_numeric:
                     col_data = [np.nan if self._is_missing(x) else float(orig_var.values[int(x)])
                                 for x in self._iter_vals(col_data)]
                 col_data = self._to_column(col_data, is_sparse)


### PR DESCRIPTION
##### Issue
Fixes #2424
See https://github.com/biolab/orange3/pull/2518#issuecomment-323717377

##### Description of changes
Problem: ExcelReader creates a Discrete variable with a list of integer floats.
Solution: Change the check for conversion of list of categorical values to floats. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
