### PR TITLE
owconcatenate: Fix an AttributeError when widget has no input

### DIFF
--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -161,7 +161,8 @@ class OWConcatenate(widget.OWWidget):
                 domain = reduce(domain_intersection,
                                 (table.domain for table in tables))
 
-        if self.append_source_column:
+        if tables and self.append_source_column:
+            assert domain is not None
             source_var = Orange.data.DiscreteVariable(
                 self.source_attr_name,
                 values=["{}".format(i) for i in range(len(tables))]

--- a/Orange/widgets/data/tests/test_owconcatenate.py
+++ b/Orange/widgets/data/tests/test_owconcatenate.py
@@ -21,6 +21,12 @@ class TestOWConcatenate(WidgetTest):
         self.iris = Table("iris")
         self.titanic = Table("titanic")
 
+    def test_no_input(self):
+        self.widget.apply()
+        self.widget.controls.append_source_column.toggle()
+        self.widget.apply()
+        self.assertIsNone(self.get_output(self.widget.Outputs.data))
+
     def test_single_input(self):
         self.assertIsNone(self.get_output(self.widget.Outputs.data))
         self.send_signal(self.widget.Inputs.primary_data, self.iris)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

If the widget had no input and the `append_source_columns` was True,
it would crash in `apply` method with an

```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 2009, in do_commit
    commit()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owconcatenate.py", line 183, in apply
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/annotated_data.py", line 27, in add_columns
    attributes = domain.attributes + tuple(attributes)
AttributeError: 'NoneType' object has no attribute 'attributes'
-------------------------------------------------------------------------------
```

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
