### PR TITLE
doc: Mention schema_only settings in doc

### DIFF
--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1368,12 +1368,6 @@ class CreateTableWithFilename(TableTests):
 
 
 class CreateTableWithUrl(TableTests):
-    def test_load_from_url(self):
-        d1 = data.Table('iris')
-        d2 = data.Table('https://raw.githubusercontent.com/biolab/orange3/master/Orange/datasets/iris.tab')
-        np.testing.assert_array_equal(d1.X, d2.X)
-        np.testing.assert_array_equal(d1.Y, d2.Y)
-
     class _MockUrlOpen(MagicMock):
         headers = {'content-disposition': 'attachment; filename="Something-FormResponses.tsv"; '
                                           'filename*=UTF-8''Something%20%28Responses%29.tsv'}

--- a/doc/development/source/tutorial-settings.rst
+++ b/doc/development/source/tutorial-settings.rst
@@ -130,6 +130,29 @@ Well-behaved widgets remember their settings - the state of their
 checkboxes and radio-buttons, the text in their line edits, the
 selections in their combo boxes and similar.
 
+Persisting defaults
+*******************
+When a widget is removed, its settings are stored to be used as defaults
+for future instances of this widget.
+
+Updated defaults are stored in user's profile. It's location depends
+on the operating system:
+(%APPDATA%\Orange\<version>\widgets on windows,
+~/Library/Application\ Support/orange/<version>/widgets on macOS,
+~/.local/share/Orange/<version>/widgets on linux)
+Original default values can be restored by deleting files from this folder,
+by running Orange from command line with `--clear-widget-settings` option,
+or through Options/Reset Widget Settings menu action.
+
+Schema-only settings
+--------------------
+Some settings have defaults that should not change. For instance, when using
+a Paint Data widget, drawn points should be saved in a workflow, but a new
+widget should always start with a blank page - modified value should not
+be remembered.
+
+This can be achieved by declaring a setting with a `schema_only` flag. Such
+setting is saved with a workflow, but its default value never changes.
 
 Context dependent settings
 **************************


### PR DESCRIPTION
##### Issue
The fact that default values of settings are updated was not mentioned in the documentation. Now it is, along with a way to disable this behavior for a specific setting.

As promised in gh-2535

##### Includes
- [X] Documentation
