### PR TITLE
postgres: Use make to reuse existing variables

### DIFF
--- a/Orange/data/sql/backend/postgres.py
+++ b/Orange/data/sql/backend/postgres.py
@@ -144,10 +144,10 @@ class Psycopg2Backend(Backend):
         TIME_TYPES = (1083, 1114, 1184, 1266,)
 
         if type_code in FLOATISH_TYPES:
-            return ContinuousVariable(field_name)
+            return ContinuousVariable.make(field_name)
 
         if type_code in TIME_TYPES + DATE_TYPES:
-            tv = TimeVariable(field_name)
+            tv = TimeVariable.make(field_name)
             tv.have_date |= type_code in DATE_TYPES
             tv.have_time |= type_code in TIME_TYPES
             return tv
@@ -156,19 +156,19 @@ class Psycopg2Backend(Backend):
             if inspect_table:
                 values = self.get_distinct_values(field_name, inspect_table)
                 if values:
-                    return DiscreteVariable(field_name, values)
-            return ContinuousVariable(field_name)
+                    return DiscreteVariable.make(field_name, values)
+            return ContinuousVariable.make(field_name)
 
         if type_code in BOOLEAN_TYPES:
-            return DiscreteVariable(field_name, ['false', 'true'])
+            return DiscreteVariable.make(field_name, ['false', 'true'])
 
         if type_code in CHAR_TYPES:
             if inspect_table:
                 values = self.get_distinct_values(field_name, inspect_table)
                 if values:
-                    return DiscreteVariable(field_name, values)
+                    return DiscreteVariable.make(field_name, values)
 
-        return StringVariable(field_name)
+        return StringVariable.make(field_name)
 
     def count_approx(self, query):
         sql = "EXPLAIN " + query

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -830,6 +830,7 @@ class TimeVariable(ContinuousVariable):
 
     If time is specified wihout an UTC offset, localtime is assumed.
     """
+    _all_vars = {}
     TYPE_HEADERS = ('time', 't')
     UNIX_EPOCH = datetime(1970, 1, 1)
     _ISO_FORMATS = [

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -46,6 +46,11 @@ class TestSqlTable(PostgresTest):
             self.assertEqual(string_attr.name, "col2")
             self.assertTrue('"col2"' in string_attr.to_sql())
 
+    def test_make_attributes(self):
+        table1 = SqlTable(self.conn, self.iris)
+        table2 = SqlTable(self.conn, self.iris)
+        self.assertIs(table1.domain[0], table2.domain[0])
+
     def test_len(self):
         with self.sql_table_from_data(zip(self.float_variable(26))) as table:
             self.assertEqual(len(table), 26)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
SqlTable does not reuse existing variable objects.

##### Description of changes
Use Variable.make instead of creating new ones.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
