### PR TITLE
Update checker: more informative User-Agent string

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -125,7 +125,7 @@ def check_for_updates():
     if check_updates and time.time() - last_check_time > ONE_DAY:
         settings.setValue('startup/last-update-check-time', int(time.time()))
 
-        from urllib.request import urlopen
+        from urllib.request import urlopen, Request
         from Orange.version import version as current
 
         class GetLatestVersion(QThread):
@@ -133,11 +133,28 @@ def check_for_updates():
 
             def run(self):
                 try:
-                    self.resultReady.emit(
-                        urlopen('https://orange.biolab.si/version/', timeout=10).read().decode())
+                    request = Request('https://orange.biolab.si/version/',
+                                      headers={
+                                          'Accept': 'text/plain',
+                                          'Accept-Encoding': 'gzip, deflate',
+                                          'Connection': 'close',
+                                          'User-Agent': self.ua_string()})
+                    contents = urlopen(request, timeout=10).read().decode()
                 # Nothing that this fails with should make Orange crash
                 except Exception:  # pylint: disable=broad-except
                     log.exception('Failed to check for updates')
+                else:
+                    self.resultReady.emit(contents)
+
+            @staticmethod
+            def ua_string():
+                is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
+                return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}'.format(
+                    orange_version=current,
+                    py_version='.'.join(sys.version[:3]),
+                    platform=sys.platform,
+                    conda='Anaconda' if is_anaconda else '',
+                )
 
         def compare_versions(latest):
             version = pkg_resources.parse_version


### PR DESCRIPTION
##### Issue
Don't have enough usage stats.

##### Description of changes
Increase verbosity of client's user-agent string when connecting to check for updates. The expectation is this shall prove there are about as many Orange users on Loonix as there are Sheep.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
