### PR TITLE
[ENH] Add-on installation with Conda

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -38,8 +38,8 @@ from AnyQt.QtGui import (
 
 from AnyQt.QtCore import (
     QSortFilterProxyModel, QItemSelectionModel,
-    Qt, QObject, QMetaObject, QEvent, QSize, QTimer, QThread, Q_ARG
-)
+    Qt, QObject, QMetaObject, QEvent, QSize, QTimer, QThread, Q_ARG,
+    QSettings)
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 from ..gui.utils import message_warning, message_information, \
@@ -861,7 +861,12 @@ class PipInstaller:
 
 class CondaInstaller:
     def __init__(self):
-        self.conda = self._find_conda()
+        enabled = QSettings().value('add-ons/allow-conda-experimental',
+                                    False, type=bool)
+        if enabled:
+            self.conda = self._find_conda()
+        else:
+            self.conda = None
 
     def _find_conda(self):
         executable = sys.executable

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -942,16 +942,6 @@ def python_process(args, script_name=None, **kwargs):
         # Don't run the script with a 'gui' (detached) process.
         dirname = os.path.dirname(executable)
         executable = os.path.join(dirname, "python.exe")
-        # by default a new console window would show up when executing the
-        # script
-        startupinfo = subprocess.STARTUPINFO()
-        if hasattr(subprocess, "STARTF_USESHOWWINDOW"):
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        else:
-            # This flag was missing in inital releases of 2.7
-            startupinfo.dwFlags |= subprocess._subprocess.STARTF_USESHOWWINDOW
-
-        kwargs["startupinfo"] = startupinfo
 
     if script_name is not None:
         script = script_name
@@ -965,6 +955,12 @@ def python_process(args, script_name=None, **kwargs):
 
 
 def create_process(cmd, executable=None, **kwargs):
+    if hasattr(subprocess, "STARTUPINFO"):
+        # do not open a new console window for command on windows
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        kwargs["startupinfo"] = startupinfo
+
     return subprocess.Popen(
         cmd,
         executable=executable,

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -861,10 +861,24 @@ class PipInstaller:
 
 class CondaInstaller:
     def __init__(self):
+        self.conda = self._find_conda()
+
+    def _find_conda(self):
         executable = sys.executable
         bin = os.path.dirname(executable)
+
+        # posix
         conda = os.path.join(bin, "conda")
-        self.conda = conda if os.path.exists(conda) else None
+        if os.path.exists(conda):
+            return conda
+
+        # windows
+        conda = os.path.join(bin, "Scripts", "conda.bat")
+        if os.path.exists(conda):
+            # "activate" conda environment orange is running in
+            os.environ["CONDA_PREFIX"] = bin
+            os.environ["CONDA_DEFAULT_ENV"] = bin
+            return conda
 
     def install(self, pkg):
         cmd = ["conda", "install", "--yes", pkg.name]

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -886,11 +886,11 @@ class CondaInstaller:
             return conda
 
     def install(self, pkg):
-        cmd = ["conda", "install", "--yes", pkg.name]
+        cmd = ["conda", "install", "--yes", "--quiet", pkg.name]
         run_command(cmd, raise_on_fail=False)
 
     def upgrade(self, pkg):
-        cmd = ["conda", "upgrade", "--yes", pkg.name]
+        cmd = ["conda", "upgrade", "--yes", "--quiet", pkg.name]
         run_command(cmd, raise_on_fail=False)
 
     def uninstall(self, dist):
@@ -932,6 +932,7 @@ def run_command(command, raise_on_fail=True):
     if process.returncode != 0:
         log.info("Command %s failed with %s",
                  " ".join(command), process.returncode)
+        log.debug("Output:\n%s", "\n".join(output))
         if raise_on_fail:
             raise CommandFailed(command, process.returncode, output)
 

--- a/Orange/canvas/application/settings.py
+++ b/Orange/canvas/application/settings.py
@@ -375,6 +375,24 @@ class UserSettingsDialog(QMainWindow):
         form.addRow("Machine ID:", line_edit_mid)
         tab.setLayout(form)
 
+        # Add-ons Tab
+        tab = QWidget()
+        self.addTab(tab, self.tr("Add-ons"),
+                    toolTip="Settings related to add-on installation")
+
+        form = QFormLayout()
+        conda = QWidget(self, objectName="conda-group")
+        conda.setLayout(QVBoxLayout())
+        conda.layout().setContentsMargins(0, 0, 0, 0)
+
+        cb_conda_install = QCheckBox(self.tr("Install add-ons with conda"), self,
+                                     objectName="allow-conda-experimental")
+        self.bind(cb_conda_install, "checked", "add-ons/allow-conda-experimental")
+        conda.layout().addWidget(cb_conda_install)
+
+        form.addRow(self.tr("Conda"), conda)
+        tab.setLayout(form)
+
         if self.__macUnified:
             # Need some sensible size otherwise mac unified toolbar 'takes'
             # the space that should be used for layout of the contents

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -121,6 +121,9 @@ spec = \
 
      ("error-reporting/machine-id", str, '',
      "Report custom name instead of machine ID"),
+
+     ("add-ons/allow-conda-experimental", bool, False,
+      "Install add-ons with conda"),
      ]
 
 spec = [config_slot(*t) for t in spec]

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -23,19 +23,19 @@ if not exist "%PREFIX%\python.exe" (
         "%CONDA%" install --yes --copy --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
             || exit /b !ERRORLEVEL!
     )
-
-    rem # `conda create` does not add a conda.bat script when used
-    rem # with a local package, we need to create it manually.
-    echo @echo off           > "%PREFIX%\Scripts\conda.bat"
-    echo call "%CONDA%" %%* >> "%PREFIX%\Scripts\conda.bat"
-
-    rem # Create .condarc file that includes conda-forge channel
-    rem # We need it so add-ons can be installed from conda-forge
-    echo Appending conda-forge channel
-    echo channels:         > "%PREFIX%\.condarc"
-    echo   - defaults     >> "%PREFIX%\.condarc"
-    echo   - conda-forge  >> "%PREFIX%\.condarc"
 )
+
+rem # `conda create` does not add a conda.bat script when used
+rem # with a local package, we need to create it manually.
+echo @echo off           > "%PREFIX%\Scripts\conda.bat"
+echo call "%CONDA%" %%* >> "%PREFIX%\Scripts\conda.bat"
+
+rem # Create .condarc file that includes conda-forge channel
+rem # We need it so add-ons can be installed from conda-forge
+echo Appending conda-forge channel
+echo channels:         > "%PREFIX%\.condarc"
+echo   - conda-forge  >> "%PREFIX%\.condarc"
+echo   - defaults     >> "%PREFIX%\.condarc"
 
 for %%f in ( *.tar.bz2 ) do (
     echo Installing: %%f


### PR DESCRIPTION
##### Issue
Some add-ons have dependencies that are a pain to install on windows. Conda makes this easier


##### Description of changes
Add-on installation/upgrading/uninstallation calls conda commands before pip. If conda command succeeds, pip says that everything is up to date/uninstalled and does nothing.

Needs testing on win/linux, with different configurations (orange installed in conda root/conda environment, orange installed beside conda, ...)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
