### PR TITLE
Added pip to requirements-core.txt

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,3 +1,4 @@
+pip>=9.0
 numpy>=1.9.0
 scipy>=0.16.1
 scikit-learn>=0.18.1


### PR DESCRIPTION
Following instructions failed to install Orange on Ubuntu 14.04 with:
ValueError: ("Expected ',' or end-of-list in", 'Orange3==3.6.0.dev0+1278e52', 'at', '+1278e52')

This should fix similar issues.