### PR TITLE
Fix owtestlearner random coverage

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -52,6 +52,15 @@ class TestOWTestLearners(WidgetTest):
         self.assertIsNotNone(res.domain)
         self.assertIsNotNone(res.data)
 
+    def test_more_learners(self):
+        data = Table("iris")[::15]
+        self.send_signal(self.widget.Inputs.train_data, data)
+        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0)
+        self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
+        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 1)
+        res = self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
+        np.testing.assert_equal(res.probabilities[0], res.probabilities[1])
+
     def test_testOnTest(self):
         data = Table("iris")
         self.send_signal(self.widget.Inputs.train_data, data)


### PR DESCRIPTION
##### Issue

Random coverage: https://codecov.io/gh/biolab/orange3/compare/1a4652ab07fb1d4e4246f87c7f716d4783abea92...959a79e14344856da534d7dc1bc0b4f1f92aaaa4/src/Orange/widgets/evaluate/owtestlearners.py

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
