### PR TITLE
DomainContextHandler: Fix check for empty domains

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -1024,7 +1024,7 @@ class DomainContextHandler(ContextHandler):
     def decode_setting(self, setting, value, domain=None):
         if isinstance(value, tuple):
             if 100 <= value[1]:
-                if not domain:
+                if domain is None:
                     raise ValueError("Cannot decode variable without domain")
                 return domain[value[0]]
             return value[0]

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -270,7 +270,13 @@ class TestDomainContextHandler(TestCase):
         setting = ContextSetting(None)
 
         var = self.domain[0]
-        val = self.handler.decode_setting(setting, (var.name, 100 + vartype(var)), self.domain)
+        val = self.handler.decode_setting(setting, (var.name, 100 + vartype(var)),
+                                          self.domain)
+        self.assertIs(val, var)
+
+        all_metas_domain = Domain([], metas=[var])
+        val = self.handler.decode_setting(setting, (var.name, 100 + vartype(var)),
+                                          all_metas_domain)
         self.assertIs(val, var)
 
     def create_context(self, domain, values):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When domain is empty (but not None!) an if check was executed that should not have been.

##### Description of changes
Correctly check with `is None`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
