### PR TITLE
[FIX] widgets/tests: Compatibility with Python 3.5.{0,1}

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -4,7 +4,11 @@ import time
 import unittest
 from unittest.mock import Mock
 # pylint: disable=unused-import
-from typing import List, Optional, Type, TypeVar
+from typing import List, Optional, TypeVar
+try:
+    from typing import Type  # typing.Type was added in 3.5.2
+except ImportError:  # pragma: no cover
+    pass
 
 import numpy as np
 import sip


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

typing.Type was introduced only in Python 3.5.2 

##### Description of changes

try-except the import.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
