### PR TITLE
preprocess.randomize: Don't shuffle entire rows

### DIFF
--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -6,7 +6,6 @@ import pickle
 import unittest
 from unittest.mock import Mock
 import numpy as np
-import scipy.sparse as sp
 
 from Orange.data import Table
 from Orange.preprocess import EntropyMDL, DoNotImpute, Default, Average, SelectRandomFeatures, EqualFreq, \
@@ -77,35 +76,6 @@ class TestRemoveConstant(unittest.TestCase):
         data = Table("iris")
         d = RemoveConstant()(data)
         self.assertEqual(len(d.domain.attributes), 4)
-
-
-class TestRandomize(unittest.TestCase):
-    def test_randomize(self):
-        x = np.arange(10000, dtype=int).reshape((100, 100))
-        randomized = Randomize().randomize(x.copy())
-
-        # Do not mix data between columns
-        np.testing.assert_equal(randomized % 100, x % 100)
-
-        # Do not shuffle entire rows: lexical sorting of rows should equal the
-        # original table
-        randomized = np.array(sorted(list(map(list, randomized))), dtype=int)
-        self.assertFalse(np.all(randomized == x))
-
-    def test_randomize_sparse(self):
-        x = np.array([[0, 0, 3, 0],
-                      [1, 0, 2, 0],
-                      [4, 5, 6, 7]])
-        randomized = Randomize(rand_seed=1).randomize(sp.csr_matrix(x))
-        randomized = randomized.toarray()
-        # Data is shuffled (rand_seed=1 should always shuffle it)
-        self.assertFalse(np.all(x == randomized))
-        # Data remains within a column
-        self.assertTrue(all(sorted(x[:, i]) == sorted(randomized[:, i])
-                            for i in range(4)))
-        # Do not shuffle entire rows
-        randomized = np.array(sorted(list(map(list, randomized))), dtype=int)
-        self.assertFalse(np.all(randomized == x))
 
 
 class TestScaling(unittest.TestCase):

--- a/Orange/tests/test_randomize.py
+++ b/Orange/tests/test_randomize.py
@@ -4,6 +4,7 @@
 import unittest
 
 import numpy as np
+import scipy.sparse as sp
 from Orange.data import Table
 from Orange.preprocess import Randomize
 
@@ -88,3 +89,30 @@ class TestRandomizer(unittest.TestCase):
         rand_data2 = randomizer2(self.zoo)
         np.testing.assert_array_equal(rand_data11.Y, rand_data12.Y)
         np.testing.assert_array_equal(rand_data11.Y, rand_data2.Y)
+
+    def test_randomize(self):
+        x = np.arange(10000, dtype=int).reshape((100, 100))
+        randomized = Randomize().randomize(x.copy())
+
+        # Do not mix data between columns
+        np.testing.assert_equal(randomized % 100, x % 100)
+
+        # Do not shuffle entire rows:
+        # lexical sorting of rows should not equal the original table
+        randomized = np.array(sorted(list(map(list, randomized))), dtype=int)
+        self.assertFalse(np.all(randomized == x))
+
+    def test_randomize_sparse(self):
+        x = np.array([[0, 0, 3, 0],
+                      [1, 0, 2, 0],
+                      [4, 5, 6, 7]])
+        randomized = Randomize(rand_seed=1).randomize(sp.csr_matrix(x))
+        randomized = randomized.toarray()
+        # Data is shuffled (rand_seed=1 should always shuffle it)
+        self.assertFalse(np.all(x == randomized))
+        # Data remains within a column
+        self.assertTrue(all(sorted(x[:, i]) == sorted(randomized[:, i])
+                            for i in range(4)))
+        # Do not shuffle entire rows
+        randomized = np.array(sorted(list(map(list, randomized))), dtype=int)
+        self.assertFalse(np.all(randomized == x))


### PR DESCRIPTION
### Issue

9b5d6c4d57b0e47627b2e185d85e19b606131bef has broken shuffling of attributes in Randomize widget: `skl_shuffle` shuffles whole rows, so the effect of shuffling attributes is the same as of shuffling the class.

### Fix

Dense data is handled as before 9b5d6c4d57b0e47627b2e185d85e19b606131bef.

Sparse data is converted to csc and indices are replaced with random indices. These indices are unique within each row.

The new method for randomization is now tested. I haven't added any other tests for this (otherwise untested) class.

##### Includes
- [X] Code changes
- [X] Tests
