### PR TITLE
BoxPlot: Reorder the attributes to put the class at the top

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -204,6 +204,7 @@ class OWBoxPlot(widget.OWWidget):
             order=order,
             placeholder="None",
             valid_types=Orange.data.DiscreteVariable)
+        self.group_vars.clear()  # Remove 'None' from the list view
         view = gui.listView(
             self.controlArea, self, "group_var", box="Subgroups",
             model=self.group_vars, callback=self.grouping_changed)
@@ -345,6 +346,7 @@ class OWBoxPlot(widget.OWWidget):
         self.infot1.setText("")
         self.attrs.set_domain(None)
         self.group_vars.set_domain(None)
+        self.group_vars.clear()  # Remove 'None' from the list view
         self.is_continuous = False
         self.update_display_box()
 

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -279,20 +279,24 @@ class OWBoxPlot(widget.OWWidget):
             domain = dataset.domain
             self.group_vars.set_domain(domain)
             self.attrs.set_domain(domain)
-            if self.attrs:
-                # Select the first non-class variable; if all are classes,
-                # select the first class
-                self.attribute = \
-                    self.attrs[len(domain.class_vars) % len(self.attrs)]
-            if domain.class_var and domain.class_var.is_discrete:
-                self.group_var = domain.class_var
-            else:
-                self.group_var = None  # Reset to trigger selection via callback
+            self.select_default_variables(domain)
             self.openContext(self.dataset)
             self.grouping_changed()
         else:
             self.reset_all_data()
         self.commit()
+
+    def select_default_variables(self, domain):
+        # visualize first non-class variable, group by class (if present)
+        if len(self.attrs) > len(domain.class_vars):
+            self.attribute = self.attrs[len(domain.class_vars)]
+        elif self.attrs:
+            self.attribute = self.attrs[0]
+
+        if domain.class_var and domain.class_var.is_discrete:
+            self.group_var = domain.class_var
+        else:
+            self.group_var = None  # Reset to trigger selection via callback
 
     def apply_sorting(self):
         def compute_score(attr):

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -22,7 +22,7 @@ from Orange.statistics import contingency, distribution
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import (Setting, DomainContextHandler,
                                      ContextSetting)
-from Orange.widgets.utils.itemmodels import VariableListModel
+from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
 from Orange.widgets.widget import Input, Output
@@ -182,7 +182,10 @@ class OWBoxPlot(widget.OWWidget):
         self.scale_x = self.scene_min_x = self.scene_width = 0
         self.label_width = 0
 
-        self.attrs = VariableListModel()
+        order = (DomainModel.CLASSES, DomainModel.METAS, DomainModel.ATTRIBUTES)
+        self.attrs = DomainModel(
+            order=order,
+            valid_types=DomainModel.PRIMITIVE)
         view = gui.listView(
             self.controlArea, self, "attribute", box="Variable",
             model=self.attrs, callback=self.attr_changed)
@@ -197,7 +200,10 @@ class OWBoxPlot(widget.OWWidget):
             "Order by relevance",
             tooltip="Order by 𝜒² or ANOVA over the subgroups",
             callback=self.apply_sorting)
-        self.group_vars = VariableListModel()
+        self.group_vars = DomainModel(
+            order=order,
+            placeholder="None",
+            valid_types=Orange.data.DiscreteVariable)
         view = gui.listView(
             self.controlArea, self, "group_var", box="Subgroups",
             model=self.group_vars, callback=self.grouping_changed)
@@ -270,14 +276,13 @@ class OWBoxPlot(widget.OWWidget):
         self.attribute = None
         if dataset:
             domain = dataset.domain
-            self.group_vars[:] = \
-                [None] + \
-                [a for a in chain(domain.variables, domain.metas)
-                 if a.is_discrete]
-            self.attrs[:] = chain(domain.variables,
-                                  (a for a in domain.metas if a.is_primitive()))
+            self.group_vars.set_domain(domain)
+            self.attrs.set_domain(domain)
             if self.attrs:
-                self.attribute = self.attrs[0]
+                # Select the first non-class variable; if all are classes,
+                # select the first class
+                self.attribute = \
+                    self.attrs[len(domain.class_vars) % len(self.attrs)]
             if domain.class_var and domain.class_var.is_discrete:
                 self.group_var = domain.class_var
             else:
@@ -332,16 +337,14 @@ class OWBoxPlot(widget.OWWidget):
                     include_class=True, include_metas=True) else None
             self.attrs.sort(key=compute_score)
         else:
-            self.attrs[:] = chain(
-                domain.variables,
-                (a for a in data.domain.metas if a.is_primitive()))
+            self.attrs.set_domain(domain)
         self.attribute = attribute
 
     def reset_all_data(self):
         self.clear_scene()
         self.infot1.setText("")
-        self.attrs[:] = []
-        self.group_vars[:] = []
+        self.attrs.set_domain(None)
+        self.group_vars.set_domain(None)
         self.is_continuous = False
         self.update_display_box()
 

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -105,21 +105,22 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
 
         select_group(0)
         self.assertFalse(order_check.isEnabled())
-        select_group(1)
+        select_group(2)  # First attribute
         self.assertTrue(order_check.isEnabled())
 
         order_check.setChecked(False)
-        self.assertEqual(tuple(attributes), data.domain.variables)
+        self.assertEqual(tuple(attributes),
+                         data.domain.class_vars + data.domain.attributes)
         order_check.setChecked(True)
         self.assertEqual([x.name for x in attributes],
                          ['sex', 'survived', 'age', 'status'])
-        select_group(4)
+        select_group(1)  # Class
         self.assertEqual([x.name for x in attributes],
                          ['sex', 'status', 'age', 'survived'])
 
         data = self.heart
         self.send_signal("Data", data)
-        select_group(len(group_list.model()) - 1)
+        select_group(1)  # Class
         order_check.setChecked(True)
         self.assertEqual([x.name for x in attributes],
                          ['thal', 'major vessels colored', 'chest pain',


### PR DESCRIPTION
##### Issue

The class is selected as the default grouping attribute, yet it's hidden on the bottom of the list.

Furthermore, we have pushed classed to the top in other widgets.

##### Description of changes

Reorder to put the class at the top.

##### Includes
- [X] Code changes
