### PR TITLE
[ENH] DomainEditor: Add horizontal header

### DIFF
--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -97,6 +97,13 @@ class VarTableModel(QAbstractTableModel):
             self.dataChanged.emit(index.sibling(row, 0), index.sibling(row, 3))
             return True
 
+    def headerData(self, i, orientation, role=Qt.DisplayRole):
+        if orientation == Qt.Horizontal and role == Qt.DisplayRole and i < 4:
+            return ("Name", "Type", "Role", "Values")[i]
+        if role == Qt.TextAlignmentRole:
+            return Qt.AlignLeft
+        return super().headerData(i, orientation, role)
+
     def flags(self, index):
         if index.column() == Column.values:
             return super().flags(index)
@@ -181,7 +188,6 @@ class DomainEditor(QTableView):
 
         self.setModel(VarTableModel(self.variables))
         self.setSelectionMode(QTableView.NoSelection)
-        self.horizontalHeader().hide()
         self.horizontalHeader().setStretchLastSection(True)
         self.setShowGrid(False)
         self.setEditTriggers(


### PR DESCRIPTION
##### Issue

DomainEditor (e.g. in the File Widget) does not have horizontal header and hence doesn't allow the user to resize the columns. This is a problem when the features have longer names.

##### Description of changes

I added the header. While it is better in terms of functionality, the previous design may have been less cluttered. @BlazZupan, what do you think?

<img width="600" alt="screen shot 2017-09-11 at 21 57 27" src="https://user-images.githubusercontent.com/2387315/30306248-c0f21908-973c-11e7-8e2e-7ac15bf4d97b.png">

##### Includes
- [X] Code changes
