### PR TITLE
Replace string with text as variable type (in GUI only)

### DIFF
--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -95,7 +95,7 @@ class TestOWFile(WidgetTest):
 
         self.open_dataset("iris")
         idx = self.widget.domain_editor.model().createIndex(4, 1)
-        self.widget.domain_editor.model().setData(idx, "string", Qt.EditRole)
+        self.widget.domain_editor.model().setData(idx, "text", Qt.EditRole)
         self.widget.apply_button.click()
         data = self.get_output(self.widget.Outputs.data)
         self.assertIsInstance(data.domain["iris"], StringVariable)
@@ -263,7 +263,7 @@ a
                 self.assertEqual(str(a), model.data(model.createIndex(i, 0), Qt.DisplayRole))
             # make conversions
             model.setData(model.createIndex(0, 1), "categorical", Qt.EditRole)
-            model.setData(model.createIndex(1, 1), "string", Qt.EditRole)
+            model.setData(model.createIndex(1, 1), "text", Qt.EditRole)
             model.setData(model.createIndex(2, 1), "numeric", Qt.EditRole)
             model.setData(model.createIndex(3, 1), "numeric", Qt.EditRole)
             model.setData(model.createIndex(6, 1), "numeric", Qt.EditRole)

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -35,7 +35,7 @@ class VarTableModel(QAbstractTableModel):
     DISCRETE_VALUE_DISPLAY_LIMIT = 20
 
     places = "feature", "target", "meta", "skip"
-    typenames = "categorical", "numeric", "string", "datetime"
+    typenames = "categorical", "numeric", "text", "datetime"
     vartypes = DiscreteVariable, ContinuousVariable, StringVariable, TimeVariable
     name2type = dict(zip(typenames, vartypes))
     type2name = dict(zip(vartypes, typenames))

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -850,7 +850,7 @@ class VariableListModel(PyListModel):
         return text
 
     def string_variable_tooltip(self, var):
-        text = "<b>%s</b><br/>String" % safe_text(var.name)
+        text = "<b>%s</b><br/>Text" % safe_text(var.name)
         text += self.variable_labels_tooltip(var)
         return text
 


### PR DESCRIPTION
##### Issue

Many muggles don't understand what's a *string*. They know what's *text*, though.

##### Description of changes

It seems that this appears only in Domain editor, and in icons. Fixing the former is trivial. <strike>For icons, "T" is already used for time variables. However, I think it's better to have the same letter (in an icon of a different color) then having the cryptic "string".

This follows the earlier change in which discrete and continuous were replaced by categorical and numeric.</strike> Icons are not changed to avoid confusion.

##### Includes
- [X] Code changes
