### PR TITLE
[FIX] Fix saving reports on Python 3.6

### DIFF
--- a/Orange/canvas/report/owreport.py
+++ b/Orange/canvas/report/owreport.py
@@ -56,6 +56,10 @@ class ReportItem(QStandardItem):
         self.id = id(icon)
         super().__init__(icon, name)
 
+    def __getnewargs__(self):
+        return (self.name, self.html, self.scheme, self.module, self.icon_name,
+                self.comment)
+
 
 class ReportItemModel(QStandardItemModel):
     def __init__(self, rows, columns, parent=None):


### PR DESCRIPTION
##### Issue

This is urgent. The current release is broken: Reports cannot be saved because `ReportItems` (derived from `QStandardItem`) can't be pickled.

##### Description of changes

Add `ReportItem.__getnewargs__`.

I don't have Python 3.6 env on this machine so I ran tests from a bundle. Can somebody with "real" Python 3.6 check this?

##### Includes
- [X] Code changes
- [X] Tests
