### PR TITLE
[FIX] canvas: Fix link runtime state modeling

### DIFF
--- a/Orange/canvas/canvas/items/linkitem.py
+++ b/Orange/canvas/canvas/items/linkitem.py
@@ -290,6 +290,8 @@ class LinkItem(QGraphicsObject):
     #: These are pulled from SchemeLink.State for ease of binding to it's
     #: state
     State = SchemeLink.State
+    #: The link has no associated state.
+    NoState = SchemeLink.NoState
     #: Link is empty; the source node does not have any value on output
     Empty = SchemeLink.Empty
     #: Link is active; the source node has a valid value on output
@@ -326,7 +328,7 @@ class LinkItem(QGraphicsObject):
 
         self.__dynamic = False
         self.__dynamicEnabled = False
-        self.__state = LinkItem.Empty
+        self.__state = LinkItem.NoState
         self.hover = False
 
         self.prepareGeometryChange()
@@ -707,10 +709,10 @@ class LinkItem(QGraphicsObject):
             normal = QPen(QBrush(QColor("#9CACB4")), 2.0)
             hover = QPen(QBrush(QColor("#7D7D7D")), 2.1)
 
-        if self.__state & LinkItem.Active:
-            pen_style = Qt.SolidLine
-        else:
+        if self.__state & LinkItem.Empty:
             pen_style = Qt.DashLine
+        else:
+            pen_style = Qt.SolidLine
 
         normal.setStyle(pen_style)
         hover.setStyle(pen_style)

--- a/Orange/canvas/scheme/link.py
+++ b/Orange/canvas/scheme/link.py
@@ -83,15 +83,17 @@ class SchemeLink(QObject):
         """
         Flags indicating the runtime state of a link
         """
+        #: The link has no associated state.
+        NoState = 0
         #: A link is empty when it has no value on it
-        Empty = 0
+        Empty = 1
         #: A link is active when the source node provides a value on output
-        Active = 1
+        Active = 2
         #: A link is pending when it's sink node has not yet been notified
         #: of a change (note that Empty|Pending is a valid state)
-        Pending = 2
+        Pending = 4
 
-    Empty, Active, Pending = State
+    NoState, Empty, Active, Pending = State
 
     def __init__(self, source_node, source_channel,
                  sink_node, sink_channel, enabled=True, properties=None,
@@ -125,7 +127,7 @@ class SchemeLink(QObject):
 
         self.__enabled = enabled
         self.__dynamic_enabled = False
-        self.__state = SchemeLink.Empty
+        self.__state = SchemeLink.NoState
         self.__tool_tip = ""
         self.properties = properties or {}
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Links in workflow previews are rendered as dotted lines. This is due to workflow mode's inability to account for the possibility that it has no associated runtime execution state.

##### Description of changes

Add (and use as default) a `NoState` flag to account for no runtime execution state. Style the graphical presentation accordingly.
 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
