### PR TITLE
[FIX] Disable pyqtgraph's exit cleanup handler

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -46,6 +46,10 @@ log = logging.getLogger(__name__)
 import signal
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+# Disable pyqtgraph's atexit and QApplication.aboutToQuit cleanup handlers.
+import pyqtgraph
+pyqtgraph.setConfigOption("exitCleanup", False)
+
 
 def fix_osx_10_9_private_font():
     # Fix fonts on Os X (QTBUG 47206, 40833, 32789)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-2596

##### Description of changes

Disable pyqtgraph's atexit and QApplication.aboutToQuit cleanup handlers.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
