### PR TITLE
[FIX] setup: Increase required setuptools version

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -12,4 +12,4 @@ joblib>=0.9.4
 keyring
 keyrings.alt    # for alternative keyring implementations
 dill
-setuptools>=11.3
+setuptools>=36.3


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-2600

##### Description of changes

Increase required setuptools version to 36.3 

This is required for installing namespace packages from wheels
build with newer versions of setuptools (see setuptools issue 885)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
