### PR TITLE
[FIX] OWBaseLearner: Save learner name in workflow

### DIFF
--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -67,6 +67,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
     LEARNER = None
     supports_sparse = True
 
+    learner_name = Setting(None, schema_only=True)
     want_main_area = False
     resizing_enabled = False
     auto_apply = Setting(True)
@@ -96,7 +97,8 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
         self.data = None
         self.valid_data = False
         self.learner = None
-        self.learner_name = self.name
+        if self.learner_name is None:
+            self.learner_name = self.name
         self.model = None
         self.preprocessors = None
         self.outdated_settings = False

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -96,3 +96,16 @@ class TestOWBaseLearner(WidgetTest):
         self.assertIn(WidgetA.Inputs.data.name, inputs)
         self.assertIn(WidgetA.Inputs.preprocessor.name, inputs)
         self.assertIn("A", inputs)
+
+    def test_persists_learner_name_in_settings(self):
+        class WidgetA(OWBaseLearner):
+            name = "A"
+            LEARNER = KNNLearner
+
+        w1 = self.create_widget(WidgetA)
+        self.assertEqual(w1.learner_name, "A")
+        w1.learner_name = "MyWidget"
+
+        settings = w1.settingsHandler.pack_data(w1)
+        w2 = self.create_widget(WidgetA, settings)
+        self.assertEqual(w2.learner_name, w1.learner_name)


### PR DESCRIPTION
##### Issue
Learner names are not saved in workflows (Fixes #2601)

##### Description of changes
Declare learner_name as a schema_only setting. Fill default value in __init__ when not loading from workflow.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
