### PR TITLE
OWRank: Eliminate alternating colors, add grid

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -73,9 +73,9 @@ class TableView(QTableView):
                          selectionBehavior=QTableView.SelectRows,
                          selectionMode=QTableView.ExtendedSelection,
                          sortingEnabled=True,
-                         showGrid=False,
+                         showGrid=True,
                          cornerButtonEnabled=False,
-                         alternatingRowColors=True,
+                         alternatingRowColors=False,
                          **kwargs)
         self.setItemDelegate(gui.ColoredBarItemDelegate(self))
         self.setItemDelegateForColumn(0, QItemDelegate())


### PR DESCRIPTION
##### Issue

Rank widgets now has alternating row colors, but they don't go together well with the monotone header.

##### Description of changes

I tried and failed to color the header. `QHeaderView.paint` calls `QStyle.drawControl` which is OS-specific and overrides the background color, at least on Mac. Hence I reverted the table view so that it has grid instead of alternating colors.

An alternative would be to eliminate the header, like in Confusion matrix. This requires some additional work to support selections etc. I don't think alternating colors look nice here anyway, so I vote for a grid.

Fixes #2609.

##### Includes
- [X] Code changes
