### PR TITLE
Feature Constructor: Add some builtin functions

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -93,7 +93,9 @@ def selected_row(view):
 class FeatureEditor(QFrame):
     FUNCTIONS = dict(chain([(key, val) for key, val in math.__dict__.items()
                             if not key.startswith("_")],
-                           [("str", str)]))
+                           [(key, val) for key, val in builtins.__dict__.items()
+                            if key in {"str", "float", "int", "len",
+                                       "abs", "max", "min"}]))
     featureChanged = Signal()
     featureEdited = Signal()
 

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -1,6 +1,7 @@
 import unittest
 import ast
 import sys
+import math
 
 import numpy as np
 
@@ -8,11 +9,10 @@ from Orange.data import (Table, Domain, StringVariable,
                          ContinuousVariable, DiscreteVariable)
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.itemmodels import PyListModel
-from Orange.widgets.data.owfeatureconstructor import (DiscreteDescriptor,
-                                                      ContinuousDescriptor,
-                                                      StringDescriptor,
-                                                      construct_variables, OWFeatureConstructor,
-                                                      DiscreteFeatureEditor)
+from Orange.widgets.data.owfeatureconstructor import (
+    DiscreteDescriptor, ContinuousDescriptor, StringDescriptor,
+    construct_variables, OWFeatureConstructor,
+    FeatureEditor, DiscreteFeatureEditor)
 
 from Orange.widgets.data.owfeatureconstructor import freevars, validate_exp
 
@@ -258,3 +258,9 @@ class OWFeatureConstructorTests(WidgetTest):
         self.assertFalse(self.widget.Error.more_values_needed.is_shown())
         self.widget.apply()
         self.assertTrue(self.widget.Error.more_values_needed.is_shown())
+
+
+class TestFeatureEditor(unittest.TestCase):
+    def test_has_functions(self):
+        self.assertIs(FeatureEditor.FUNCTIONS["abs"], abs)
+        self.assertIs(FeatureEditor.FUNCTIONS["sqrt"], math.sqrt)


### PR DESCRIPTION
##### Issue

Feature Constructor widget does not offer `abs` in the combo.

##### Description of changes

I added `abs` and, while at it, also some other builtin function that could be useful.

##### Includes
- [X] Code changes
- [X] Tests