### PR TITLE
OWRank: sort NaNs last; fix sort indicator

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -549,7 +549,7 @@ class OWRank(OWWidget):
         # Saved selected_rows will likely be incorrect
         if version is None or version < 2:
             column, order = 0, Qt.DescendingOrder
-            headerState = settings.pop("headerState")
+            headerState = settings.pop("headerState", None)
 
             # Lacking knowledge of last problemType, use discrete ranks view's ordering
             if isinstance(headerState, (tuple, list)):

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -147,6 +147,13 @@ class TableModel(PyTableModel):
         if yes_reset:
             super().resetSorting()
 
+    def _argsortData(self, data, order):
+        """Always sort NaNs last"""
+        indices = np.argsort(data, kind='mergesort')
+        if order == Qt.DescendingOrder:
+            return np.roll(indices[::-1], -np.isnan(data).sum())
+        return indices
+
 
 class OWRank(OWWidget):
     name = "Rank"

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -424,13 +424,14 @@ class OWRank(OWWidget):
 
         self.ranksModel.wrap(model_array.tolist())
         self.ranksModel.setHorizontalHeaderLabels(('#',) + labels)
-        self.ranksView.setColumnWidth(0, 30)
+        self.ranksView.setColumnWidth(0, 40)
 
         # Re-apply sort
         try:
             sort_column, sort_order = self.sorting
             if sort_column < len(labels):
                 self.ranksModel.sort(sort_column + 1, sort_order)  # +1 for '#' (discrete count) column
+                self.ranksView.horizontalHeader().setSortIndicator(sort_column + 1, sort_order)
         except ValueError:
             pass
 

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -231,6 +231,19 @@ class TestOWRank(WidgetTest):
         order2 = self.widget.ranksModel.mapToSourceRows(...).tolist()
         self.assertNotEqual(order1, order2)
 
+    def test_scores_nan_sorting(self):
+        """Check NaNs are sorted last"""
+        data = self.iris.copy()
+        data.get_column_view('petal length')[0][:] = np.nan
+        self.send_signal(self.widget.Inputs.data, data)
+
+        # Assert last row is all nan
+        for order in (Qt.AscendingOrder,
+                      Qt.DescendingOrder):
+            self.widget.ranksView.horizontalHeader().setSortIndicator(1, order)
+            last_row = self.widget.ranksModel[self.widget.ranksModel.mapToSourceRows(...)[-1]]
+            np.testing.assert_array_equal(last_row, np.repeat(np.nan, 3))
+
     def test_data_which_make_scorer_nan(self):
         """
         Tests if widget crashes due to too high (Infinite) calculated values.

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -244,6 +244,11 @@ class TestOWRank(WidgetTest):
             last_row = self.widget.ranksModel[self.widget.ranksModel.mapToSourceRows(...)[-1]]
             np.testing.assert_array_equal(last_row, np.repeat(np.nan, 3))
 
+    def test_default_sort_indicator(self):
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.assertNotEqual(
+            0, self.widget.ranksView.horizontalHeader().sortIndicatorSection())
+
     def test_data_which_make_scorer_nan(self):
         """
         Tests if widget crashes due to too high (Infinite) calculated values.

--- a/Orange/widgets/tests/test_itemmodels.py
+++ b/Orange/widgets/tests/test_itemmodels.py
@@ -7,7 +7,7 @@ from AnyQt.QtCore import Qt
 
 from Orange.data import Domain, ContinuousVariable
 from Orange.widgets.utils.itemmodels import \
-    PyTableModel, PyListModel, DomainModel, _argsort
+    AbstractSortTableModel, PyTableModel, PyListModel, DomainModel, _argsort
 
 
 class TestArgsort(TestCase):
@@ -118,6 +118,20 @@ class TestPyTableModel(TestCase):
         self.assertTrue(Qt.AlignCenter &
                         self.model.data(self.model.index(1, 0),
                                         Qt.TextAlignmentRole))
+
+
+class TestAbstractSortTableModel(TestCase):
+    def setUp(self):
+        assert issubclass(PyTableModel, AbstractSortTableModel)
+        self.model = PyTableModel([[1, 4],
+                                   [2, 3]])
+
+    def test_sorting(self):
+        self.model.sort(1, Qt.AscendingOrder)
+        self.assertSequenceEqual(self.model.mapToSourceRows(...).tolist(), [1, 0])
+
+        self.model.sort(1, Qt.DescendingOrder)
+        self.assertSequenceEqual(self.model.mapToSourceRows(...).tolist(), [0, 1])
 
 
 class TestPyListModel(TestCase):


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3/issues/2617

##### Description of changes
Always sort NaNs last. Implemented by exposing reimplementable `AbstractSortTableModel._argsortData()`. Also fix header indicator by sorting via `view.horizontalHeader().setSortIdicator()` instead of its model.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
