### PR TITLE
Rename Selection Group to Selected

### DIFF
--- a/Orange/widgets/utils/annotated_data.py
+++ b/Orange/widgets/utils/annotated_data.py
@@ -73,7 +73,7 @@ def create_groups_table(data, selection):
     if data is None:
         return None
     names = [var.name for var in data.domain.variables + data.domain.metas]
-    name = get_next_name(names, "Selection group")
+    name = get_next_name(names, ANNOTATED_DATA_FEATURE_NAME)
     metas = data.domain.metas + (
         DiscreteVariable(
             name,


### PR DESCRIPTION
##### Issue

If Scatter plot's Data is connected to another widget, the column name in the output signal depends upon whether the user selects more groups or only one. If it is, for instance, connected to another scatter plot, the user has to change the name of the variable used for coloring.

##### Description of changes

Rename *Selection group* to *Selected*.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
