### PR TITLE
allows_cycle flag

### DIFF
--- a/Orange/canvas/registry/description.py
+++ b/Orange/canvas/registry/description.py
@@ -195,6 +195,7 @@ class WidgetDescription(object):
         Widget's background color (in the canvas GUI).
     replaces : list-of-str, optional
         A list of `id`s this widget replaces (optional).
+    allows_cycle: True if the widget allows cycle creation on her
 
     """
     def __init__(self, name, id, category=None, version=None,
@@ -204,7 +205,8 @@ class WidgetDescription(object):
                  help=None, help_ref=None, url=None, keywords=None,
                  priority=sys.maxsize,
                  icon=None, background=None,
-                 replaces=None):
+                 replaces=None,
+                 allows_cycle=False):
 
         if not qualified_name:
             # TODO: Should also check that the name is real.
@@ -228,6 +230,7 @@ class WidgetDescription(object):
         self.icon = icon
         self.background = background
         self.replaces = replaces
+        self.allows_cycle = allows_cycle
 
     def __str__(self):
         return ("WidgetDescription(name=%(name)r, id=%(id)r), "

--- a/Orange/canvas/scheme/node.py
+++ b/Orange/canvas/scheme/node.py
@@ -70,6 +70,9 @@ class SchemeNode(QObject):
         self.__state_messages = {}
         self.properties = properties or {}
 
+    def allows_cycle(self):
+        return self.description.allows_cycle
+
     def input_channels(self):
         """
         Return a list of input channels (:class:`InputSignal`) for the node.

--- a/Orange/canvas/scheme/scheme.py
+++ b/Orange/canvas/scheme/scheme.py
@@ -860,6 +860,6 @@ class Scheme(QObject):
         """
         return types.MappingProxyType(self.__env)
 
-    def dump_settings(self, node: SchemeNode):
+    def dump_settings(self, node, SchemeNode):
         """Dump current settings of the `node` to the standard output"""
         print(node.properties)

--- a/Orange/canvas/scheme/signalmanager.py
+++ b/Orange/canvas/scheme/signalmanager.py
@@ -13,10 +13,10 @@ import itertools
 import warnings
 
 from collections import namedtuple, defaultdict, deque
-from operator import attrgetter, add
+from operator import attrgetter
 from functools import partial
 
-from AnyQt.QtCore import QObject, QCoreApplication, QEvent, QTimer
+from AnyQt.QtCore import QObject, QTimer
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
 
@@ -435,9 +435,9 @@ class SignalManager(QObject):
         scheme = self.scheme()
 
         def expand(node):
-            return [link.sink_node for
-                link in scheme.find_links(source_node=node) if
-                link.enabled]
+            return [link.sink_node
+                    for link in scheme.find_links(source_node=node)
+                    if link.enabled]
 
         components = strongly_connected_components(scheme.nodes, expand)
         node_scc = {node: scc for scc in components for node in scc}

--- a/Orange/canvas/scheme/tests/test_scheme.py
+++ b/Orange/canvas/scheme/tests/test_scheme.py
@@ -2,6 +2,7 @@
 Tests for Scheme
 """
 
+import unittest
 from ...gui import test
 from ...registry.tests import small_testing_registry
 from ...registry import WidgetRegistry
@@ -14,7 +15,6 @@ from .. import (
 
 from ...registry.description import WidgetDescription, CategoryDescription
 from ...registry.description import InputSignal, OutputSignal
-import unittest
 
 
 class TestScheme(test.QCoreAppTestCase):

--- a/Orange/canvas/scheme/tests/test_scheme.py
+++ b/Orange/canvas/scheme/tests/test_scheme.py
@@ -4,12 +4,17 @@ Tests for Scheme
 
 from ...gui import test
 from ...registry.tests import small_testing_registry
+from ...registry import WidgetRegistry
 
 from .. import (
     Scheme, SchemeNode, SchemeLink, SchemeTextAnnotation,
-    SchemeArrowAnnotation, SchemeTopologyError, SinkChannelError,
-    DuplicatedLinkError, IncompatibleChannelTypeError
+    SchemeTopologyError, SinkChannelError,
+    DuplicatedLinkError, IncompatibleChannelTypeError, SchemeCycleError
 )
+
+from ...registry.description import WidgetDescription, CategoryDescription
+from ...registry.description import InputSignal, OutputSignal
+import unittest
 
 
 class TestScheme(test.QCoreAppTestCase):
@@ -111,3 +116,160 @@ class TestScheme(test.QCoreAppTestCase):
         scheme.remove_annotation(text_annot)
         self.assertSequenceEqual(annotations_added, [arrow_annot])
         self.assertSequenceEqual(scheme.annotations, annotations_added)
+
+
+class TestSchemeCycleDetection(unittest.TestCase):
+    """
+    Test class dedicated to check that the cycle detection and the management
+    of the :attr:`allows_cycle` of the :class:`WidgetDescription` is well
+    managed
+    """
+    iNewDesc = 0
+
+    def setUp(self):
+        self.reg = WidgetRegistry()
+
+        # Create the scheme
+        self.scheme = Scheme()
+
+        self.reg.register_category(
+            CategoryDescription(name='test',
+                                qualified_name="Orange.widgets.test")
+        )
+
+    def test_simplecycle(self):
+        """Make sure we succeed to create a cycle with one widget having
+        the 'allows_cycle' flag and we fail if this flag is not here"""
+
+        def create_simple_cycle(allows_cycle):
+            desc_node_1 = self.create_node_desc(allows_cycle=False)
+            self.reg.register_widget(desc_node_1)
+            desc_1 = self.reg.widget(desc_node_1.qualified_name)
+
+            desc_node_2 = self.create_node_desc(allows_cycle=allows_cycle)
+            self.reg.register_widget(desc_node_2)
+            desc_2 = self.reg.widget(desc_node_2.qualified_name)
+            n1 = self.scheme.new_node(desc_1)
+            n2 = self.scheme.new_node(desc_2)
+            source_channel = n1.output_channel("Data")
+            sink_channel = n2.input_channel("Data")
+            lupstream = SchemeLink(n1, source_channel, n2, sink_channel)
+            self.scheme.add_link(lupstream)
+            ldownstream = SchemeLink(n2, "Data", n1, "Data")
+            self.scheme.add_link(ldownstream)
+
+        create_simple_cycle(allows_cycle=True)
+        with self.assertRaises(SchemeCycleError):
+            create_simple_cycle(allows_cycle=False)
+
+    def create_node_desc(self, allows_cycle):
+        """Create a simple widget taking a string in input and returning a
+        string.
+
+        :param allows_cycle: true if the node allow cycle
+        """
+
+        inputs = [
+            InputSignal("Data", "builtins.str", "processing"),
+            InputSignal("Data2", "builtins.str", "processing"),
+            InputSignal("Data3", "builtins.str", "processing")
+        ]
+
+        outputs = [
+            OutputSignal("Data", "builtins.str"),
+            OutputSignal("Data2", "builtins.str"),
+            OutputSignal("Data3", "builtins.str")
+        ]
+        name = 'desc_' + str(self.iNewDesc)
+        node_desc = WidgetDescription(name=name,
+                                      id='id_' + name,
+                                      inputs=inputs,
+                                      outputs=outputs,
+                                      qualified_name='Orange.widgets.test.' + name,
+                                      allows_cycle=allows_cycle,
+                                      category='test')
+        self.iNewDesc = self.iNewDesc + 1
+        return node_desc
+
+    def create_node(self):
+        desc_node_1 = self.create_node_desc(allows_cycle=True)
+        self.reg.register_widget(desc_node_1)
+        desc_1 = self.reg.widget(desc_node_1.qualified_name)
+        return self.scheme.new_node(desc_1)
+
+    def link(self, node1, node2, channel):
+        src_channel_1 = node1.output_channel(channel)
+        sink_channel_2 = node2.input_channel(channel)
+        link = SchemeLink(node1, src_channel_1, node2, sink_channel_2)
+        self.scheme.add_link(link)
+
+    def test_cycle_case_8(self):
+        """Make sure under no condition we can create a '8 cycle'.
+        Such as defined in the issue #2629
+        """
+        n0 = self.create_node()
+        n1 = self.create_node()
+        n2 = self.create_node()
+
+        self.link(n0, n1, "Data")
+        self.link(n1, n2, "Data")
+        self.link(n2, n1, "Data2")
+        with self.assertRaises(SchemeCycleError):
+            self.link(n1, n0, "Data2")
+
+    def test_extrapolate_cycles(self):
+        """Make sure the algorithm of cycle detection is working"""
+        n0 = self.create_node()
+        n1 = self.create_node()
+        n2 = self.create_node()
+        n3 = self.create_node()
+        n4 = self.create_node()
+        n5 = self.create_node()
+        n6 = self.create_node()
+
+        self.link(n0, n1, "Data")
+        self.link(n1, n2, "Data")
+        self.link(n2, n1, "Data2")
+        self.link(n2, n3, "Data")
+        self.link(n3, n4, "Data")
+        self.link(n4, n5, "Data")
+        self.link(n5, n3, "Data2")
+
+        source_channel = n5.output_channel("Data")
+        sink_channel = n6.input_channel("Data")
+        link = SchemeLink(n5, source_channel, n6, sink_channel)
+        cycles = self.scheme.extrapolate_cycles(link)
+        self.assertTrue(len(cycles) == 2)
+        if len(cycles[0]) == 2:
+            cyclen1n2 = cycles[0]
+            cyclen3n4n5 = cycles[1]
+        else:
+            cyclen1n2 = cycles[1]
+            cyclen3n4n5 = cycles[0]
+
+        self.assertTrue(len(cyclen1n2) == 2)
+        self.assertTrue(len(cyclen3n4n5) == 3)
+        self.assertTrue(n1 in cyclen1n2 and n2 in cyclen1n2)
+        self.assertTrue(n3 in cyclen3n4n5 and n4 in cyclen3n4n5 and n5 in cyclen3n4n5)
+        self.scheme.add_link(link)
+
+    def test_simple_cycle_with_subcycle(self):
+        """Make sure we cannot create a 'simple cycle' containing at one
+        'sub-cycle'. Such as defined in the issue #2629
+        """
+        n0 = self.create_node()
+        n1 = self.create_node()
+        n2 = self.create_node()
+
+        self.link(n0, n1, "Data")
+        self.link(n1, n2, "Data")
+        self.link(n2, n1, "Data2")
+
+        sourceChannel = n2.output_channel("Data")
+        sinkChannel = n0.input_channel("Data")
+        link = SchemeLink(n2, sourceChannel, n0, sinkChannel)
+
+        cycles = self.scheme.extrapolate_cycles(link)
+        self.assertTrue(len(cycles) == 2)
+        with self.assertRaises(SchemeCycleError):
+            self.scheme.add_link(link)

--- a/Orange/canvas/scheme/tests/test_signalmanager.py
+++ b/Orange/canvas/scheme/tests/test_signalmanager.py
@@ -1,0 +1,54 @@
+import unittest
+
+from Orange.canvas.scheme import signalmanager
+
+
+class TestSCC(unittest.TestCase):
+    def test_scc(self):
+        E1 = {}
+        scc = signalmanager.strongly_connected_components(E1, E1.__getitem__)
+        self.assertEqual(scc, [])
+
+        E2 = {1: []}
+        scc = signalmanager.strongly_connected_components(E2, E2.__getitem__)
+        self.assertEqual(scc, [[1]])
+
+        T1 = {1: [2, 3], 2: [4, 5], 3: [6, 7], 4: [], 5: [], 6: [], 7: []}
+        scc = signalmanager.strongly_connected_components(T1, T1.__getitem__)
+        self.assertEqual(scc, [[4], [5], [2], [6], [7], [3], [1]])
+
+        C1 = {1: [2], 2: [3], 3: [1]}
+        scc = signalmanager.strongly_connected_components(C1, C1.__getitem__)
+        self.assertEqual(scc, [[1, 2, 3]])
+
+        G1 = {1: [2, 3], 2: [3, 5], 3: [], 5: [2]}
+        scc = signalmanager.strongly_connected_components(G1, G1.__getitem__)
+        self.assertEqual(scc, [[3], [2, 5], [1]])
+
+        DAG1 = {1: [2, 3], 2: [3], 3: [4], 4: []}
+        scc = signalmanager.strongly_connected_components(
+            DAG1, DAG1.__getitem__)
+        self.assertEqual(scc, [[4], [3], [2], [1]])
+
+        G2 = {1: [2], 2: [1, 5], 3: [4], 4: [3, 5], 5: [6],
+              6: [7], 7: [8], 8: [6, 9], 9: []}
+        scc = signalmanager.strongly_connected_components(G2, G2.__getitem__)
+        self.assertEqual(scc, [[9], [6, 7, 8], [5], [1, 2], [3, 4]])
+
+        G3 = {1: [2], 2: [3], 3: [1],
+              4: [5, 3], 5: [4, 6],
+              6: [3, 7], 7: [6],
+              8: [8]}
+        scc = signalmanager.strongly_connected_components(G3, G3.__getitem__)
+        self.assertEqual(scc, [[1, 2, 3], [6, 7], [4, 5], [8]])
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    for ui in (TestSCC, ):
+        test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(ui))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -137,6 +137,9 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: static size contents.
     resizing_enabled = True
 
+    #: Is the widget allowing connections bringing cycling in the workflow.
+    allows_cycle = False
+
     blockingStateChanged = Signal(bool)
     processingStateChanged = Signal(int)
 
@@ -254,7 +257,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         properties = {name: getattr(cls, name) for name in
                       ("name", "icon", "description", "priority", "keywords",
                        "help", "help_ref", "url",
-                       "version", "background", "replaces")}
+                       "version", "background", "replaces", "allows_cycle")}
         properties["id"] = cls.id or cls.__module__
         properties["inputs"] = cls.get_signals("inputs")
         properties["outputs"] = cls.get_signals("outputs")


### PR DESCRIPTION
##### Issue
Can't create loop inside a workflow


##### Description of changes
Add the 'allows_cycle' flag into `OWWidget`.

- If `False` won't change the current behavior.
- If `True` then the widget will allow connection bringing cycle in the workflow. This is why if set to True, the widget/user has to know how to handle cycling on his workflow.

##### Includes
- [X] Code changes
- [x] add unit test
- [x] check for 8 cycle
- [x] check for sub cycle
