### PR TITLE
[FIX] settings: Store settings version in the serialized defaults

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -630,7 +630,15 @@ class ContextHandler(SettingsHandler):
     def write_defaults_file(self, settings_file):
         """Call the inherited method, then add global context to the pickle."""
         super().write_defaults_file(settings_file)
-        pickle.dump(self.global_contexts, settings_file, -1)
+
+        def add_version(context):
+            context = copy.copy(context)
+            context.values = dict(context.values)
+            context.values[VERSION_KEY] = self.widget_class.settings_version
+            return context
+
+        pickle.dump([add_version(context) for context in self.global_contexts],
+                    settings_file, -1)
 
     def pack_data(self, widget):
         """Call the inherited method, then add local contexts to the dict."""

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -424,7 +424,9 @@ class SettingsHandler:
         ----------
         settings_file : file-like object
         """
-        pickle.dump(self.defaults, settings_file, -1)
+        defaults = dict(self.defaults)
+        defaults[VERSION_KEY] = self.widget_class.settings_version
+        pickle.dump(defaults, settings_file, -1)
 
     def _get_settings_filename(self):
         """Return the name of the file with default settings for the widget"""

--- a/Orange/widgets/tests/test_settings_handler.py
+++ b/Orange/widgets/tests/test_settings_handler.py
@@ -56,6 +56,7 @@ class SettingHandlerTestCase(unittest.TestCase):
         fd, settings_file = mkstemp(suffix='.ini')
 
         handler = SettingsHandler()
+        handler.widget_class = SimpleWidget
         handler.defaults = {'a': 5, 'b': {1: 5}}
         handler._get_settings_filename = lambda: settings_file
         handler.write_defaults()
@@ -64,7 +65,9 @@ class SettingHandlerTestCase(unittest.TestCase):
             default_settings = pickle.load(f)
         os.close(fd)
 
-        self.assertEqual(handler.defaults, default_settings)
+        self.assertEqual(default_settings.pop(VERSION_KEY, -0xBAD),
+                         handler.widget_class.settings_version,)
+        self.assertEqual(default_settings, handler.defaults)
 
         os.remove(settings_file)
 
@@ -327,7 +330,10 @@ class SettingHandlerTestCase(unittest.TestCase):
         h.widget_class = widget
         h.defaults = defaults
         filename = h._get_settings_filename()
-        h.write_defaults()
+
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "wb") as f:
+            pickle.dump(defaults, f)
 
         yield
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Widget settings version were not stored in the serialized defaults, but were still passed to  OWWidget.migrate_settings with an incorrect version of 0.

One example where this caused an error (due to wrong migration)

* Open canvas, add 'Test & Score', change the *Sampling* option to *Test on test data*, close canvas
* Open again, add 'Test & Score', observe that no *Sampling* option is selected at all. Without changing anything add a single file and learner input to the widget.
```
-------------------------- AssertionError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/canvas/scheme/widgetsscheme.py", line 839, in process_signals_for_widget
    widget.handleNewSignals()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/evaluate/owtestlearners.py", line 486, in handleNewSignals
    self.__update()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/evaluate/owtestlearners.py", line 826, in __update
    assert False, "self.resampling %s" % self.resampling
AssertionError: self.resampling 6
```

##### Description of changes

Store settings version in the serialized defaults.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
