### PR TITLE
preprocess.randomize: Fix randomization for sparse matrices

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -368,14 +368,12 @@ class Randomize(Preprocess):
     def randomize(self, table, rand_state=None):
         rstate = np.random.RandomState(rand_state)
         if sp.issparse(table):
-            table = table.tocsc()
-            rnd_indices = np.arange(table.shape[0], dtype=table.indices.dtype)
+            table = table.tocsc()  # type: sp.spmatrix
             for i in range(table.shape[1]):
+                permutation = rstate.permutation(table.shape[0])
                 col_indices = \
                     table.indices[table.indptr[i]: table.indptr[i + 1]]
-                new_indices = rnd_indices[:len(col_indices)]
-                rstate.shuffle(new_indices)
-                col_indices[:] = new_indices
+                col_indices[:] = permutation[col_indices]
         elif len(table.shape) > 1:
             for i in range(table.shape[1]):
                 rstate.shuffle(table[:, i])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The choice of non-zero indices was dependent on the sparsity and
did not take the full index space into consideration.

For instance an input matrix with non-zero elements only in the first row would never be changed.

##### Description of changes

Actually permute the input's non-zero indices.  This is slower as the full random permutation is required for each column.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
