### PR TITLE
TableModel: Add old style mappings as deprecated

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -1144,6 +1144,10 @@ class TableModel(AbstractSortTableModel):
     def sortColumnData(self, column):
         return self._columnSortKeyData(column, TableModel.ValueRole)
 
+    @deprecated('Orange.widgets.utils.itemmodels.TableModel.sortColumnData')
+    def columnSortKeyData(self, column, role):
+        return self._columnSortKeyData(column, role)
+
     def _columnSortKeyData(self, column, role):
         """
         Return a sequence of source table objects which can be used as

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -26,6 +26,7 @@ from Orange.data import Variable, Storage, DiscreteVariable, ContinuousVariable
 from Orange.widgets import gui
 from Orange.widgets.utils import datacaching
 from Orange.statistics import basic_stats
+from Orange.util import deprecated
 
 
 class _store(dict):
@@ -152,6 +153,14 @@ class AbstractSortTableModel(QAbstractTableModel):
                 new_rows.setflags(write=False)
             rows = new_rows
         return rows
+
+    @deprecated('Orange.widgets.utils.itemmodels.AbstractSortTableModel.mapFromSourceRows')
+    def mapFromTableRows(self, rows):
+        return self.mapFromSourceRows(rows)
+
+    @deprecated('Orange.widgets.utils.itemmodels.AbstractSortTableModel.mapToSourceRows')
+    def mapToTableRows(self, rows):
+        return self.mapToSourceRows(rows)
 
     def resetSorting(self):
         """Invalidates the current sorting"""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The methods for mapping from/to source table rows in `TableModel` were renamed from _mapFrom**Table**Rows_ to _mapFrom**Source**Rows_ as of https://github.com/biolab/orange3/pull/2494. Hence mapping for all models extending `TableModel` in addons now crash with:
```
AttributeError: '*TableModel' object has no attribute 'mapToTableRows'
```

##### Description of changes
Add old style methods names and mark them as deprecated.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation