### PR TITLE
[FIX] MDS: similar pairs and combos not cleared

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -360,6 +360,7 @@ class OWMDS(OWWidget):
         self.data = None
         self.effective_matrix = None
         self.embedding = None
+        self.init_attr_values()
 
         # if no data nor matrix is present reset plot
         if self.signal_data is None and self.matrix is None:

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -341,6 +341,7 @@ class OWMDS(OWWidget):
         # invalidate the pen/brush when the subset is changed
         self._subset_mask = None  # type: Optional[np.ndarray]
         self.controls.graph.alpha_value.setEnabled(subset_data is None)
+        self._invalidated = True
 
     def _clear(self):
         self._similar_pairs = None


### PR DESCRIPTION
##### Issue
1) Combos do not clear when data connection is removed.
2) Adding or removing subset data clears connections between similar pairs.


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
