### PR TITLE
Outlier multi-class minor fix.

### DIFF
--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -170,7 +170,7 @@ class OWOutliers(widget.OWWidget):
         inliers = outliers = None
         self.n_inliers = self.n_outliers = None
         if self.data is not None and len(self.data) > 0:
-            if self.data.Y.ndim > 1:
+            if self.data.Y.ndim > 1 and self.data.Y.shape[1] > 1:
                 self.Error.multiclass_error()
             else:
                 inliers, outliers = self._get_outliers()


### PR DESCRIPTION
##### Issue
Multi-class check fails when data.Y is of dimension (n, 1) or (n, 0).

##### Description of changes
Small fix of Outliers widget checking for multi-class data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
