### PR TITLE
Update chardet requirement

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -6,7 +6,7 @@ bottleneck>=1.0.0
 # Reading Excel files
 xlrd>=0.9.2
 # Encoding detection
-chardet>=2.3.0
+chardet>=3.0.2
 # Multiprocessing abstraction
 joblib>=0.9.4
 keyring


### PR DESCRIPTION
chardet>=3.0.2 is required by requests library