### PR TITLE
[FIX] MDS: primitive metas, init_attr_values

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -310,16 +310,10 @@ class OWMDS(OWWidget):
         if self.matrix is not None and data is not None and len(self.matrix) == len(data):
             self.closeContext()
             self.data = data
+            self.init_attr_values()
             self.openContext(data)
         else:
             self._invalidated = True
-        if data is not None:
-            self._primitive_metas = tuple(a for a in data.domain.metas if a.is_primitive())
-            keys = [k for k, a in enumerate(data.domain.metas) if a.is_primitive()]
-            self._data_metas = data.metas[:, keys]
-        else:
-            self._primitive_metas = ()
-            self._data_metas = None
 
     @Inputs.distances
     def set_disimilarity(self, matrix):
@@ -653,12 +647,19 @@ class OWMDS(OWWidget):
     def _setup_plot(self, new=False):
         emb_x, emb_y = self.embedding[:, 0], self.embedding[:, 1]
         coords = np.vstack((emb_x, emb_y)).T
+
+        data = self.data
+
+        primitive_metas = tuple(a for a in data.domain.metas if a.is_primitive())
+        keys = [k for k, a in enumerate(data.domain.metas) if a.is_primitive()]
+        data_metas = data.metas[:, keys]
+
         attributes = self.data.domain.attributes + (self.variable_x, self.variable_y) + \
-                     self._primitive_metas
+                     primitive_metas
         domain = Domain(attributes=attributes,
                         class_vars=self.data.domain.class_vars)
-        if self._data_metas is not None:
-            data_x = (self.data.X, coords, self._data_metas)
+        if data_metas is not None:
+            data_x = (self.data.X, coords, data_metas)
         else:
             data_x = (self.data.X, coords)
         data = Table.from_numpy(domain, X=np.hstack(data_x),


### PR DESCRIPTION
##### Issue


##### Description of changes
Move to primitive metas moved to `_setup_plot`.

`init_attr_data` called alwasy when new data.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
