### PR TITLE
[FIX] Report Table: Make Table Headers Bold

### DIFF
--- a/Orange/canvas/report/index.html
+++ b/Orange/canvas/report/index.html
@@ -70,6 +70,10 @@
         padding: 2px 6px 2px 6px;
     }
 
+    th {
+        font-weight: bold;
+    }
+
     @media screen {
         td, th {
             white-space: nowrap;

--- a/Orange/canvas/report/report.py
+++ b/Orange/canvas/report/report.py
@@ -241,7 +241,7 @@ class Report:
                     bgcolor = 'transparent'
 
                 font = data(Qt.FontRole)
-                weight = 'bold' if font and font.bold() else 'normal'
+                weight = 'font-weight: bold;' if font and font.bold() else ''
 
                 alignment = data(Qt.TextAlignmentRole) or Qt.AlignLeft
                 halign = ('left' if alignment & Qt.AlignLeft else
@@ -254,7 +254,7 @@ class Report:
                         'color:{fgcolor};'
                         'border:{border};'
                         'background:{bgcolor};'
-                        'font-weight:{weight};'
+                        '{weight}'
                         'text-align:{halign};'
                         'vertical-align:{valign};">{text}</{tag}>'.format(
                             tag='th' if row is None or col is None else 'td',


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When reporting a view (or model?) through `report_table` header column and row is printed in the same format as the data values. Although there is a code that mark header columns as `<th>` (and not as `<td>`) this is invalidated by the `font-weight` attribute.

 E.g. in `Test & Score` before:

![screen shot 2017-10-10 at 16 33 43](https://user-images.githubusercontent.com/713026/31392256-13000360-add9-11e7-825b-e90116a8a11b.png)
and after:
![screen shot 2017-10-10 at 16 33 07](https://user-images.githubusercontent.com/713026/31392235-08f7b430-add9-11e7-92d8-a4b3e2e46944.png)

##### Description of changes
Set `font-weight` to `bold` when inside header so `<th>` is not invalidated.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation