### PR TITLE
Remove explicit Report button, improve widget layouts

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -323,11 +323,14 @@ class OWColor(widget.OWWidget):
         self.cont_model.dataChanged.connect(self._on_data_changed)
         box.layout().addWidget(cont_view)
 
-        box = gui.auto_commit(self.controlArea, self, "auto_apply", "Apply",
-                              orientation=Qt.Horizontal,
-                              checkbox_label="Apply automatically")
-        box.layout().insertSpacing(0, 20)
-        box.layout().insertWidget(0, self.report_button)
+        box = gui.auto_commit(
+            self.controlArea, self, "auto_apply", "Apply",
+            orientation=Qt.Horizontal, checkbox_label="Apply automatically")
+        box.button.setFixedWidth(180)
+        box.layout().insertStretch(0)
+
+    def sizeHint(self):
+        return QSize(500, 570)
 
     def _create_proxies(self, variables):
         part_vars = []

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -126,9 +126,10 @@ class OWConcatenate(widget.OWWidget):
         cb.makeConsistent()
 
         box = gui.auto_commit(
-            self.controlArea, self, "auto_commit", "Apply", commit=self.apply)
-        box.layout().insertWidget(0, self.report_button)
-        box.layout().insertSpacing(1, 20)
+            self.controlArea, self, "auto_commit", "Apply", commit=self.apply,
+            orientation=Qt.Horizontal, checkbox_label="Apply automatically")
+        box.button.setFixedWidth(180)
+        box.layout().insertStretch(0)
 
     @Inputs.primary_data
     @check_sql_input

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -213,14 +213,10 @@ class OWCreateClass(widget.OWWidget):
             optionsbox, self, "case_sensitive", "Case sensitive",
             callback=self.options_changed)
 
-        layout = QGridLayout()
-        gui.widgetBox(self.controlArea, orientation=layout)
-        for i in range(3):
-            layout.setColumnStretch(i, 1)
-        layout.addWidget(self.report_button, 0, 0)
-        apply = gui.button(None, self, "Apply", autoDefault=False,
-                           callback=self.apply)
-        layout.addWidget(apply, 0, 2)
+        box = gui.hBox(self.controlArea)
+        gui.rubber(box)
+        gui.button(box, self, "Apply", autoDefault=False, width=180,
+                   callback=self.apply)
 
         # TODO: Resizing upon changing the number of rules does not work
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -1,8 +1,7 @@
 from collections import namedtuple
 
 from AnyQt.QtWidgets import (
-    QListView, QHBoxLayout, QStyledItemDelegate, QDialogButtonBox,
-    QApplication
+    QListView, QHBoxLayout, QStyledItemDelegate, QApplication
 )
 from AnyQt.QtCore import Qt
 
@@ -231,12 +230,12 @@ class OWDiscretize(widget.OWWidget):
 
         self.controlbox = controlbox
 
-        box = gui.auto_commit(
-            self.controlArea, self, "autosend", "Apply",
-            orientation=Qt.Horizontal,
-            checkbox_label="Apply automatically")
-        box.layout().insertSpacing(0, 20)
-        box.layout().insertWidget(0, self.report_button)
+        box = gui.auto_commit(self.controlArea, self, "autosend", "Apply",
+                              orientation=Qt.Horizontal,
+                              checkbox_label="Apply automatically")
+        box.button.setFixedWidth(180)
+        box.layout().insertStretch(0)
+
         self._update_spin_positions()
 
 

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -455,8 +455,6 @@ class OWFeatureConstructor(OWWidget):
         box.layout().addLayout(layout, 1)
 
         box = gui.hBox(self.controlArea)
-        box.layout().addWidget(self.report_button)
-        self.report_button.setMinimumWidth(180)
         gui.rubber(box)
         commit = gui.button(box, self, "Send", callback=self.apply,
                             default=True)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -204,8 +204,6 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             box, self, "Browse documentation data sets",
             callback=lambda: self.browse_file(True), autoDefault=False)
         gui.rubber(box)
-        box.layout().addWidget(self.report_button)
-        self.report_button.setFixedWidth(170)
 
         self.apply_button = gui.button(
             box, self, "Apply", callback=self.apply_domain_edit)

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -201,9 +201,10 @@ class OWImpute(OWWidget):
 
         box = gui.auto_commit(
             self.controlArea, self, "autocommit", "Apply",
-            orientation=Qt.Horizontal, checkbox_label="Apply automatically")
-        box.layout().insertSpacing(0, 80)
-        box.layout().insertWidget(0, self.report_button)
+            orientation=Qt.Horizontal,
+            checkbox_label="Apply automatically")
+        box.button.setFixedWidth(180)
+        box.layout().insertStretch(0)
 
         self.data = None
         self.learner = None

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -2,7 +2,7 @@ import sys
 from functools import partial
 
 from AnyQt.QtWidgets import (
-    QWidget, QListView, QLineEdit, QCompleter, QSizePolicy, QGridLayout)
+    QWidget, QListView, QLineEdit, QCompleter, QGridLayout)
 from AnyQt.QtGui import QDrag
 from AnyQt.QtCore import (
     Qt, QObject, QEvent, QModelIndex,
@@ -388,12 +388,9 @@ class OWSelectAttributes(widget.OWWidget):
 
         autobox = gui.auto_commit(None, self, "auto_commit", "Send")
         layout.addWidget(autobox, 3, 0, 1, 3)
-        reset = gui.button(None, self, "Reset", callback=self.reset)
-        autobox.layout().insertWidget(0, self.report_button)
-        autobox.layout().insertWidget(1, reset)
-        autobox.layout().insertSpacing(2, 10)
-        reset.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-        self.report_button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        reset = gui.button(None, self, "Reset", callback=self.reset, width=120)
+        autobox.layout().insertWidget(0, reset)
+        autobox.layout().insertStretch(1, 20)
 
         layout.setRowStretch(0, 4)
         layout.setRowStretch(1, 0)

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -58,9 +58,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
         gui.button(
             box, self, "Browse documentation data sets",
             callback=lambda: self.browse_file(True), autoDefault=False)
-        gui.rubber(box)
-        box.layout().addWidget(self.report_button)
-        self.report_button.setFixedWidth(170)
+        box.layout().addSpacing(200)
 
         self.set_file_list()
         QTimer.singleShot(0, self.open_file)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -248,8 +248,6 @@ class OWDistanceMatrix(widget.OWWidget):
         self.annot_combo.setModel(VariableListModel())
         self.annot_combo.model()[:] = ["None", "Enumeration"]
         gui.rubber(settings_box)
-        settings_box.layout().addWidget(self.report_button)
-        gui.separator(settings_box, 40)
         acb = gui.auto_commit(settings_box, self, "auto_commit",
                               "Send Selected", "Send Automatically", box=None)
         acb.setFixedWidth(200)

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -64,11 +64,7 @@ class OWDistances(OWWidget):
                                           items=[m[0] for m in METRICS],
                                           callback=self._invalidate
                                          )
-        box = gui.auto_commit(self.buttonsArea, self, "autocommit", "Apply",
-                              box=False, checkbox_label="Apply automatically")
-        box.layout().insertWidget(0, self.report_button)
-        box.layout().insertSpacing(1, 8)
-
+        gui.auto_commit(self.controlArea, self, "autocommit", "Apply")
         self.layout().setSizeConstraint(self.layout().SetFixedSize)
 
     @Inputs.data

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -56,10 +56,7 @@ class OWDistanceTransformation(widget.OWWidget):
                          btnLabels=[x[0] for x in self.inversion_options],
                          callback=self._invalidate)
 
-        box = gui.auto_commit(self.buttonsArea, self, "autocommit", "Apply",
-                              checkbox_label="Apply automatically", box=None)
-        box.layout().insertWidget(0, self.report_button)
-        box.layout().insertSpacing(1, 8)
+        gui.auto_commit(self.controlArea, self, "autocommit", "Apply")
 
     @Inputs.distances
     def set_data(self, data):

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -150,7 +150,6 @@ class OWKMeans(widget.OWWidget):
         self.apply_button = gui.auto_commit(
             self.buttonsArea, self, "auto_run", "Apply", box=None,
             commit=self.apply)
-        self.buttonsArea.layout().addWidget(self.report_button)
         gui.rubber(self.controlArea)
 
         box = gui.vBox(self.mainArea, box="Silhouette Scores")

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -269,11 +269,9 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
             orientation=Qt.Horizontal, callback=self.learner_name_changed)
 
     def add_bottom_buttons(self):
-        box = gui.hBox(self.controlArea, True)
-        box.layout().addWidget(self.report_button)
-        gui.separator(box, 15)
-        self.apply_button = gui.auto_commit(box, self, 'auto_apply', '&Apply',
-                                            box=False, commit=self.apply)
+        self.apply_button = gui.auto_commit(
+            self.controlArea, self, 'auto_apply', '&Apply',
+            box=True, commit=self.apply)
 
     def send(self, signalName, value, id=None):
         # A subclass might still use the old syntax to send outputs

--- a/Orange/widgets/visualize/owruleviewer.py
+++ b/Orange/widgets/visualize/owruleviewer.py
@@ -74,9 +74,6 @@ class OWRuleViewer(widget.OWWidget):
         gui.checkBox(widget=bottom_box, master=self, value="compact_view",
                      label="Compact view", callback=self.on_update)
 
-        self.report_button.setFixedWidth(180)
-        bottom_box.layout().addWidget(self.report_button)
-
     @Inputs.data
     def set_data(self, data):
         self.data = data

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -122,10 +122,6 @@ class OWSieveDiagram(OWWidget):
         self.canvasView.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.canvasView.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
 
-        box = gui.hBox(self.mainArea)
-        box.layout().addWidget(self.graphButton)
-        box.layout().addWidget(self.report_button)
-
     def sizeHint(self):
         return QSize(450, 550)
 


### PR DESCRIPTION
##### Issue

#2514 moved Report button to the status bar.

- Widgets that explicitly positioned the button still show it.
- The layout of widgets without the Report button is changed, and sometimes doesn't look good.

##### Description of changes

Remove Report button, check and fix layouts.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
