### PR TITLE
[FIX] owhierarchicalclustering: Fix performance on deselection

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -439,6 +439,7 @@ class DendrogramWidget(QGraphicsWidget):
         if item in self._selection:
             if state == False:
                 self._remove_selection(item)
+                self._re_enumerate_selections()
                 self.selectionChanged.emit()
         else:
             # If item is already inside another selected item,
@@ -455,11 +456,11 @@ class DendrogramWidget(QGraphicsWidget):
 
             if state:
                 self._add_selection(item)
-                self._re_enumerate_selections()
 
             elif item in self._selection:
                 self._remove_selection(item)
 
+            self._re_enumerate_selections()
             self.selectionChanged.emit()
 
     def _add_selection(self, item):
@@ -498,8 +499,6 @@ class DendrogramWidget(QGraphicsWidget):
             self.scene().removeItem(selection_item)
 
         del self._selection[item]
-
-        self._re_enumerate_selections()
 
     def _selected_sub_items(self, item):
         """Return all selected subclusters under item."""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The widget is slow to respond when the selection is changed in such a way that the number of groups diminishes significantly.

Example:

File (vehicle.tab) -> Distances (Euclidean) -> Hierarchical clustering (Average)

In the *Selection* box select and set *Height ratio: 0.1%*. Switch between that and *Top N: 3* Going from Height ratio to top N is significantly slower then the other way.


##### Description of changes

The code (`set_selected_items`) had quadratic time complexity in the number of deselected items.
Fixed by a more judicious placement of calls to `_re_enumerate_selections`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
