### PR TITLE
[FIX] Outliers widget no longer checks classes and doesn't crash on singular covariances matrices

### DIFF
--- a/Orange/classification/elliptic_envelope.py
+++ b/Orange/classification/elliptic_envelope.py
@@ -2,6 +2,7 @@ import sklearn.covariance as skl_covariance
 
 from Orange.base import SklLearner, SklModel
 from Orange.data import Table
+from Orange.preprocess import Continuize, RemoveNaNColumns, SklImpute
 
 __all__ = ["EllipticEnvelopeLearner"]
 
@@ -27,6 +28,7 @@ class EllipticEnvelopeClassifier(SklModel):
 class EllipticEnvelopeLearner(SklLearner):
     __wraps__ = skl_covariance.EllipticEnvelope
     __returns__ = EllipticEnvelopeClassifier
+    preprocessors = [Continuize(), RemoveNaNColumns(), SklImpute()]
 
     def __init__(self, store_precision=True, assume_centered=False,
                  support_fraction=None, contamination=0.1,

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -149,6 +149,7 @@ class OWOutliers(widget.OWWidget):
         except ValueError:
             self.Error.singular_cov()
             self.in_out_info_label.setText(self.in_out_info_default)
+            return None, None
         except MemoryError:
             self.Error.memory_error()
             return None, None

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -43,7 +43,6 @@ class OWOutliers(widget.OWWidget):
 
     class Error(widget.OWWidget.Error):
         singular_cov = Msg("Singular covariance matrix.")
-        multiclass_error = Msg("Multiple class data is not supported")
         memory_error = Msg("Not enough memory")
 
     def __init__(self):
@@ -171,10 +170,7 @@ class OWOutliers(widget.OWWidget):
         inliers = outliers = None
         self.n_inliers = self.n_outliers = None
         if self.data is not None and len(self.data) > 0:
-            if self.data.Y.ndim > 1 and self.data.Y.shape[1] > 1:
-                self.Error.multiclass_error()
-            else:
-                inliers, outliers = self._get_outliers()
+            inliers, outliers = self._get_outliers()
 
         self.Outputs.inliers.send(inliers)
         self.Outputs.outliers.send(outliers)
@@ -189,8 +185,9 @@ class OWOutliers(widget.OWWidget):
                 support_fraction=self.support_fraction
                 if self.empirical_covariance else None,
                 contamination=self.cont / 100.)
-        model = learner(self.data)
-        y_pred = model(self.data)
+        data = self.data.transform(Domain(self.data.domain.attributes))
+        model = learner(data)
+        y_pred = model(data)
         self.add_metas(model)
         return np.array(y_pred)
 

--- a/Orange/widgets/data/tests/test_owoutliers.py
+++ b/Orange/widgets/data/tests/test_owoutliers.py
@@ -37,3 +37,11 @@ class TestOWOutliers(WidgetTest):
             side_effect=MemoryError):
             self.send_signal("Data", data)
             self.assertTrue(self.widget.Error.memory_error.is_shown())
+
+    def test_nans(self):
+        """Widget does not crash with nans"""
+        a = np.arange(20, dtype=float).reshape(4, 5)
+        a[0, 0] = np.nan
+        data = Table(a)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertIsNot(self.get_output(self.widget.Outputs.inliers), None)

--- a/Orange/widgets/data/tests/test_owoutliers.py
+++ b/Orange/widgets/data/tests/test_owoutliers.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 
-from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
+from Orange.data import Table
 from Orange.widgets.data.owoutliers import OWOutliers
 from Orange.widgets.tests.base import WidgetTest
 
@@ -24,20 +24,6 @@ class TestOWOutliers(WidgetTest):
         self.send_signal(self.widget.Inputs.data, None)
         self.assertEqual(self.widget.data, None)
         self.assertIsNone(self.get_output("Data"))
-
-    def test_multiclass(self):
-        """Check widget for multiclass dataset"""
-        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
-        class_vars = [DiscreteVariable("cls", ["a", "b", "c"]),
-                      DiscreteVariable("cls", ["aa", "bb", "cc"])]
-        domain = Domain(attrs, class_vars)
-        X = np.arange(12).reshape(6, 2)
-        Y = np.array([[0, 1], [2, 1], [0, 2], [1, 1], [1, 2], [2, 0]])
-        data = Table(domain, X, Y)
-        self.send_signal(self.widget.Inputs.data, data)
-        self.assertTrue(self.widget.Error.multiclass_error.is_shown())
-        self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Error.multiclass_error.is_shown())
 
     def test_memory_error(self):
         """


### PR DESCRIPTION
##### Issue

- Outliers widget does not work with multiple classes.
- ... and crashes when variance matrices is singular, instead of reporting an error.
- `EllipticEnvelopeLearner` removes instances without classes.

Fixes #2588.

##### Description of changes

- Remove tests for classes
- Fix the crash for singular data
- Set proper preprocessors for `EllipticEnvelopeLearner`

Tests do not add much new; they passed before, too. The PR actually removes tests that checked for what shouldn't had been checked.

##### Includes
- [X] Code changes
- [X] Tests