### PR TITLE
[RFC][WIP] OWWidget: Add a menu bar

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -13,7 +13,7 @@ from AnyQt.QtGui import (
 )
 from AnyQt.QtWidgets import (
     QSizePolicy, QAction, QUndoCommand, QUndoStack, QGridLayout,
-    QFormLayout, QToolButton, QActionGroup
+    QFormLayout, QToolButton, QActionGroup, QMenu
 )
 
 from AnyQt.QtCore import Qt, QObject, QTimer, QSize, QSizeF, QPointF, QRectF
@@ -895,6 +895,11 @@ class OWPaintData(OWWidget):
         redo.setShortcut(QKeySequence.Redo)
 
         self.addActions([undo, redo])
+        mb = self.menuBar()
+        editm = mb.findChild(QMenu, "menu-edit")
+        if editm is not None:
+            editm.addActions([undo, redo])
+
         self.undo_stack.indexChanged.connect(lambda _: self.invalidate())
 
         gui.separator(tBox)

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -14,10 +14,10 @@ import numpy
 from scipy.sparse import issparse
 
 from AnyQt.QtWidgets import (
-    QTableView, QHeaderView, QAbstractButton, QApplication, QStyleOptionHeader,
-    QStyle, QStylePainter, QStyledItemDelegate
+    QTableView, QHeaderView, QAbstractButton, QAction, QMenu, QApplication,
+    QStyleOptionHeader, QStyle, QStylePainter, QStyledItemDelegate
 )
-from AnyQt.QtGui import QColor, QClipboard
+from AnyQt.QtGui import QColor, QKeySequence, QClipboard
 from AnyQt.QtCore import (
     Qt, QSize, QEvent, QByteArray, QMimeData, QObject, QMetaObject,
     QAbstractProxyModel, QIdentityProxyModel, QModelIndex,
@@ -446,8 +446,14 @@ class OWDataTable(widget.OWWidget):
         self.tabs = gui.tabWidget(self.mainArea)
         self.tabs.currentChanged.connect(self._on_current_tab_changed)
 
-    def copy_to_clipboard(self):
-        self.copy()
+        copy = QAction(
+            "Copy Selection to Clipboard", self,
+            shortcut=QKeySequence.Copy, triggered=self.copy)
+        self.addAction(copy)
+        mb = self.menuBar()
+        editm = mb.findChild(QMenu, "menu-edit")
+        if editm is not None:
+            editm.addAction(copy)
 
     def sizeHint(self):
         return QSize(800, 500)

--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -100,17 +100,19 @@ class WidgetTestCase(WidgetTest):
 
         w = Widget()
         w._OWWidget__setControlAreaVisible(False)
-        w.setGeometry(QRect(51, 52, 53, 54))
+        geom = QRect(51, 52, 53, 54)
+        geom.setSize(geom.size().expandedTo(w.minimumSize()))
+        w.setGeometry(geom)
         state = w.saveGeometryAndLayoutState()
         w1 = Widget()
         self.assertTrue(w1.restoreGeometryAndLayoutState(state))
-        self.assertEqual(w1.geometry(), QRect(51, 52, 53, 54))
+        self.assertEqual(w1.geometry(), geom)
         self.assertFalse(w1.controlAreaVisible)
 
         Widget.want_control_area = False
         w2 = Widget()
         self.assertTrue(w2.restoreGeometryAndLayoutState(state))
-        self.assertEqual(w1.geometry(), QRect(51, 52, 53, 54))
+        self.assertEqual(w1.geometry(), geom)
 
         self.assertFalse((w2.restoreGeometryAndLayoutState(QByteArray())))
         self.assertFalse(w2.restoreGeometryAndLayoutState(QByteArray(b'ab')))

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -10,7 +10,7 @@ import numpy as np
 from AnyQt.QtWidgets import (
     QGraphicsWidget, QGraphicsObject, QGraphicsLinearLayout, QGraphicsPathItem,
     QGraphicsScene, QGraphicsView, QGridLayout, QFormLayout, QSizePolicy,
-    QGraphicsSimpleTextItem, QGraphicsLayoutItem, QAction, QComboBox
+    QGraphicsSimpleTextItem, QGraphicsLayoutItem, QAction, QMenu, QComboBox
 )
 from AnyQt.QtGui import (
     QTransform, QPainterPath, QPainterPathStroker, QColor, QBrush, QPen,
@@ -936,19 +936,29 @@ class OWHierarchicalClustering(widget.OWWidget):
             callback=self.__update_font_scale)
 
         zoom_in = QAction(
-            "Zoom in", self, shortcut=QKeySequence.ZoomIn,
+            "Increase Font Size", self, shortcut=QKeySequence.ZoomIn,
             triggered=self.__zoom_in
         )
         zoom_out = QAction(
-            "Zoom out", self, shortcut=QKeySequence.ZoomOut,
+            "Decrease Front Size", self, shortcut=QKeySequence.ZoomOut,
             triggered=self.__zoom_out
         )
         zoom_reset = QAction(
-            "Reset zoom", self,
+            "Reset Font Size", self,
             shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_0),
             triggered=self.__zoom_reset
         )
         self.addActions([zoom_in, zoom_out, zoom_reset])
+        mb = self.menuBar()
+        viewmenu = mb.findChild(QMenu, "menu-view")
+        if viewmenu is not None:
+            zoommenu = QMenu("Zoom", viewmenu)
+            zoommenu.addActions([zoom_in, zoom_out, zoom_reset])
+            zoommenu.insertSeparator(zoom_reset)
+            if viewmenu.actions():
+                viewmenu.insertMenu(viewmenu.actions()[0], zoommenu)
+            else:
+                viewmenu.addMenu(zoommenu)
 
         self.controlArea.layout().addStretch()
 

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -227,7 +227,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         self.__help_action = QAction(
             "Help", self, objectName="action-help", toolTip="Show help",
-            enabled=False, visible=False, shortcut=QKeySequence(Qt.Key_F1)
+            enabled=False, shortcut=QKeySequence(Qt.Key_F1)
         )
         self.addAction(self.__help_action)
 

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -12,8 +12,9 @@ from typing import Optional, Union
 
 from AnyQt.QtWidgets import (
     QWidget, QDialog, QVBoxLayout, QSizePolicy, QApplication, QStyle,
-    QShortcut, QSplitter, QSplitterHandle, QPushButton, QStatusBar,
-    QProgressBar, QAction, QFrame, QStyleOption, QWIDGETSIZE_MAX
+    QSplitter, QSplitterHandle, QPushButton, QStatusBar,
+    QProgressBar, QAction, QFrame, QStyleOption, QMenuBar, QMenu,
+    QWIDGETSIZE_MAX
 )
 from AnyQt.QtCore import (
     Qt, QObject, QEvent, QRect, QMargins, QByteArray, QDataStream, QBuffer,
@@ -218,18 +219,81 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.__was_shown = False
 
         self.__statusMessage = ""
-
-        self.__msgwidget = None
+        self.__info_ns = None  # type: Optional[StateInfo]
+        self.__msgwidget = None  # type: Optional[MessageOverlayWidget]
         self.__msgchoice = 0
+        self.__statusbar = None  # type: Optional[QStatusBar]
+        self.__statusbar_action = None  # type: Optional[QAction]
 
         self.__help_action = QAction(
             "Help", self, objectName="action-help", toolTip="Show help",
             enabled=False, visible=False, shortcut=QKeySequence(Qt.Key_F1)
         )
         self.addAction(self.__help_action)
-        self.__statusbar = None  # type: Optional[QStatusBar]
-        self.__statusbar_action = None  # type: Optional[QAction]
-        self.__info_ns = None  # type: Optional[StateInfo]
+
+        self.__report_action = QAction(
+            "Report", self, objectName="action-report", toolTip="Report",
+            enabled=False, visible=False,
+            shortcut=QKeySequence(Qt.AltModifier | Qt.Key_R)
+        )
+        if hasattr(self, "send_report"):
+            self.__report_action.triggered.connect(self.show_report)
+            self.__report_action.setEnabled(True)
+            self.__report_action.setVisible(True)
+
+        self.__save_image_action = QAction(
+            "Save Image", self, objectName="action-save-image",
+            toolTip="Save image",
+            shortcut=QKeySequence(Qt.AltModifier | Qt.Key_S),
+        )
+        self.__save_image_action.triggered.connect(self.save_graph)
+        self.__save_image_action.setEnabled(bool(self.graph_name))
+        self.__save_image_action.setVisible(bool(self.graph_name))
+
+        self.__copy_action = QAction(
+            "Copy to Clipboard", self, objectName="action-copy-to-clipboard",
+            shortcut=QKeySequence.Copy, enabled=False, visible=False
+        )
+        self.__copy_action.triggered.connect(self.copy_to_clipboard)
+        if bool(self.graph_name):
+            self.__copy_action.setEnabled(True)
+            self.__copy_action.setVisible(True)
+            self.__copy_action.setText("Copy Image to Clipboard")
+
+        # macOS Minimize action
+        self.__minimize_action = QAction(
+            "Minimize", self, shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_M)
+        )
+        self.__minimize_action.triggered.connect(self.showMinimized)
+        # macOS Zoom close window action
+        self.__close_action = QAction(
+            "Close", self, objectName="action-close-window",
+            shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_W)
+        )
+        self.__close_action.triggered.connect(self.hide)
+
+        self.__menubar = mb = QMenuBar(self)
+        fileaction = mb.addMenu(_Menu("&File", mb, objectName="menu-file"))
+        fileaction.setVisible(False)
+        fileaction.menu().addSeparator()
+        fileaction.menu().addAction(self.__report_action)
+        fileaction.menu().addAction(self.__save_image_action)
+        editaction = mb.addMenu(_Menu("&Edit", mb, objectName="menu-edit"))
+        editaction.setVisible(False)
+
+        editaction.menu().addAction(self.__copy_action)
+        viewaction = mb.addMenu(_Menu("&View", mb, objectName="menu-view"))
+        viewaction.setVisible(False)
+        windowaction = mb.addMenu(_Menu("&Window", mb, objectName="menu-window"))
+        windowaction.setVisible(False)
+
+        if sys.platform == "darwin":
+            windowaction.menu().addAction(self.__close_action)
+            windowaction.menu().addAction(self.__minimize_action)
+            windowaction.menu().addSeparator()
+
+        helpaction = mb.addMenu(_Menu("&Help", mb, objectName="help-menu"))
+        helpaction.menu().addAction(self.__help_action)
 
         self.left_side = None
         self.controlArea = self.mainArea = self.buttonsArea = None
@@ -237,26 +301,36 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         self.__splitter = None
         if self.want_basic_layout:
             self.set_basic_layout()
+            self.layout().setMenuBar(mb)
 
-        sc = QShortcut(QKeySequence(Qt.ShiftModifier | Qt.Key_F1), self)
-        sc.activated.connect(self.__quicktip)
-
-        sc = QShortcut(QKeySequence.Copy, self)
-        sc.activated.connect(self.copy_to_clipboard)
+        self.__quick_help_action = QAction(
+            "Quick Help Tip", self, objectName="action-quick-help-tip",
+            shortcut=QKeySequence(Qt.ShiftModifier | Qt.Key_F1)
+        )
+        self.__quick_help_action.setEnabled(bool(self.UserAdviceMessages))
+        self.__quick_help_action.setVisible(bool(self.UserAdviceMessages))
+        self.__quick_help_action.triggered.connect(self.__quicktip)
+        helpaction.menu().addAction(self.__quick_help_action)
 
         if self.controlArea is not None:
             # Otherwise, the first control has focus
             self.controlArea.setFocus(Qt.ActiveWindowFocusReason)
 
-        if self.__splitter is not None:
-            self.__splitter.handleClicked.connect(
-                self.__toggleControlArea
+        if self.__splitter is not None and self.__splitter.count() > 1:
+            action = QAction(
+                "Show Control Area", self, objectName="action-show-control-area",
+                shortcut=QKeySequence(Qt.ControlModifier | Qt.ShiftModifier |
+                                      Qt.Key_D),
+                checkable=True,
             )
-            sc = QShortcut(
-                QKeySequence(Qt.ControlModifier | Qt.ShiftModifier | Qt.Key_D),
-                self, autoRepeat=False)
-            sc.activated.connect(self.__toggleControlArea)
+            action.setChecked(True)
+            action.triggered[bool].connect(self.__setControlAreaVisible)
+            self.__splitter.handleClicked.connect(self.__toggleControlArea)
+            viewaction.menu().addAction(action)
         return self
+
+    def menuBar(self):
+        return self.__menubar
 
     # pylint: disable=super-init-not-called
     def __init__(self, *args, **kwargs):
@@ -623,6 +697,9 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if self.__splitter is None or self.__splitter.count() < 2:
             return
         self.controlAreaVisible = visible
+        action = self.findChild(QAction, "action-show-control-area")
+        if action is not None:
+            action.setChecked(visible)
         splitter = self.__splitter  # type: QSplitter
         w = splitter.widget(0)
         # Set minimum width to 1 (overrides minimumSizeHint) when control area
@@ -947,16 +1024,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         else:
             QDialog.keyPressEvent(self, e)
 
-
     defaultKeyActions = {}
-
-    if sys.platform == "darwin":
-        defaultKeyActions = {
-            (Qt.ControlModifier, Qt.Key_M):
-                lambda self: self.showMaximized
-                if self.isMinimized() else self.showMinimized(),
-            (Qt.ControlModifier, Qt.Key_W):
-                lambda self: self.setVisible(not self.isVisible())}
 
     def setBlocking(self, state=True):
         """
@@ -1204,6 +1272,22 @@ class _StatusBar(QStatusBar):
         style.drawPrimitive(QStyle.PE_PanelStatusBar, opt, painter, None)
         # Do not draw any PE_FrameStatusBarItem frames.
         painter.end()
+
+
+class _Menu(QMenu):
+    """
+    A QMenu managing self-visibility in a parent menu or menu bar.
+
+    The menu is visible if it has at least one visible action.
+    """
+    def actionEvent(self, event):
+        super().actionEvent(event)
+        ma = self.menuAction()
+        if ma is not None:
+            ma.setVisible(
+                any(ac.isVisible() and not ac.isSeparator()
+                    for ac in self.actions())
+            )
 
 
 class Message(object):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -570,12 +570,26 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.__statusbar_action = statusbar_action = QAction(
                 "Show status bar", self, objectName="action-show-status-bar",
                 toolTip="Show status bar", checkable=True,
-                enabled=False, visible=False,
                 shortcut=QKeySequence(
                     Qt.ShiftModifier | Qt.ControlModifier | Qt.Key_Backslash)
             )
             statusbar_action.toggled[bool].connect(statusbar.setVisible)
             self.addAction(statusbar_action)
+
+            # Ensure the status bar and the message widget are visible on
+            # warning and errors.
+            def message_activated(msg):
+                # type: (Msg) -> None
+                if msg.group.severity >= 2:
+                    statusbar.setVisible(True)
+            self.messageActivated.connect(message_activated)
+
+            self.addAction(statusbar_action)
+            if self.__menubar is not None:
+                viewm = self.findChild(QMenu, "menu-view")
+                if viewm is not None:
+                    viewm.addAction(statusbar_action)
+
         return statusbar
 
     def __updateStatusBarOnChange(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Menu bar is a more appropriate place for the  Help / Report / Save image actions.

##### Description of changes

Move the Help/Report/Save actions to the menu bar. Extend with other useful actions.

Subclasses can/should also use the menu to add their own actions. This is done for 'Data Table' and 'Paint Data'

Other widgets that should use the menu:
- Scatter Plot: Zoom In/ Out, Zoom reset
- Silhouette Plot, Hierarchical Clustering (all with s zoom slider/actions) Zoom In/Out or Increase/Decrease Font size.
...

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
