### PR TITLE
[ENH] DomainModel: Don't Show Hidden Variables by Default

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -1,4 +1,3 @@
-import pickle
 from numbers import Number, Integral
 from math import isnan, isinf
 
@@ -23,6 +22,7 @@ from AnyQt.QtWidgets import (
 import numpy
 
 from Orange.data import Variable, Storage, DiscreteVariable, ContinuousVariable
+from Orange.data.domain import filter_visible
 from Orange.widgets import gui
 from Orange.widgets.utils import datacaching
 from Orange.statistics import basic_stats
@@ -870,7 +870,7 @@ class DomainModel(VariableListModel):
     PRIMITIVE = (DiscreteVariable, ContinuousVariable)
 
     def __init__(self, order=SEPARATED, placeholder=None,
-                 valid_types=None, alphabetical=False, **kwargs):
+                 valid_types=None, alphabetical=False, skip_hidden_vars=True, **kwargs):
         super().__init__(placeholder=placeholder, **kwargs)
         if isinstance(order, int):
             order = (order,)
@@ -883,6 +883,7 @@ class DomainModel(VariableListModel):
         self.order = order
         self.valid_types = valid_types
         self.alphabetical = alphabetical
+        self.skip_hidden_vars = skip_hidden_vars
         self.set_domain(None)
 
     def set_domain(self, domain):
@@ -903,6 +904,8 @@ class DomainModel(VariableListModel):
                     *(vars for i, vars in enumerate(
                         (domain.attributes, domain.class_vars, domain.metas))
                       if (1 << i) & section)))
+                if self.skip_hidden_vars:
+                    to_add = list(filter_visible(to_add))
                 if self.valid_types is not None:
                     to_add = [var for var in to_add
                               if isinstance(var, self.valid_types)]

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from AnyQt.QtCore import Qt
 
-from Orange.data import Domain, ContinuousVariable
+from Orange.data import Domain, ContinuousVariable, DiscreteVariable
 from Orange.widgets.utils.itemmodels import \
     AbstractSortTableModel, PyTableModel, PyListModel, DomainModel, _argsort
 
@@ -288,3 +288,25 @@ class TestDomainModel(TestCase):
                          sorted(attrs + metas, key=lambda x: x.name) +
                          [sep] +
                          sorted(classes, key=lambda x: x.name))
+
+    def test_filtering(self):
+        cont = [ContinuousVariable(n) for n in "abc"]
+        disc = [DiscreteVariable(n) for n in "def"]
+        attrs = cont + disc
+
+        model = DomainModel(valid_types=(ContinuousVariable, ))
+        model.set_domain(Domain(attrs))
+        self.assertEqual(list(model), cont)
+
+        model = DomainModel(valid_types=(DiscreteVariable, ))
+        model.set_domain(Domain(attrs))
+        self.assertEqual(list(model), disc)
+
+        disc[0].attributes["hidden"] = True
+        model.set_domain(Domain(attrs))
+        self.assertEqual(list(model), disc[1:])
+
+        model = DomainModel(valid_types=(DiscreteVariable, ),
+                            skip_hidden_vars=False)
+        model.set_domain(Domain(attrs))
+        self.assertEqual(list(model), disc)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
DomainModel shows all variables, even those, that are marked as hidden. 

##### Description of changes
DomainModel shows only non-hidden variables by default. If `skip_hidden_vars` is set to `False`, all variables are shown.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation