### PR TITLE
Statistics.stack: Move to statistics module

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -17,10 +17,11 @@ from Orange.data import (
     Domain, Variable, Storage, StringVariable, Unknown, Value, Instance,
     ContinuousVariable, DiscreteVariable, MISSING_VALUES
 )
-from Orange.data.util import SharedComputeValue, vstack, hstack
+from Orange.data.util import SharedComputeValue
 from Orange.statistics.util import bincount, countnans, contingency, \
-    stats as fast_stats, sparse_has_implicit_zeros, sparse_count_implicit_zeros, \
-    sparse_implicit_zero_weights
+    stats as fast_stats, sparse_has_implicit_zeros, \
+    sparse_count_implicit_zeros, \
+    sparse_implicit_zero_weights, vstack, hstack
 from Orange.util import flatten
 
 __all__ = ["dataset_dirs", "get_sample_datasets_dir", "RowInstance", "Table"]

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -1,9 +1,10 @@
 """
 Data-manipulation utilities.
 """
-import numpy as np
 import bottleneck as bn
-from scipy import sparse as sp
+import numpy as np
+# Backwards compatibility
+from Orange.statistics.util import hstack, vstack  # pylint: disable=unused-import
 
 
 def one_hot(values, dtype=float):
@@ -63,29 +64,3 @@ class SharedComputeValue:
         """Given precomputed shared data, perform variable-specific
         part of computation and return new variable values."""
         raise NotImplementedError
-
-
-def vstack(arrays):
-    """vstack that supports sparse and dense arrays
-
-    If all arrays are dense, result is dense. Otherwise,
-    result is a sparse (csr) array.
-    """
-    if any(sp.issparse(arr) for arr in arrays):
-        arrays = [sp.csr_matrix(arr) for arr in arrays]
-        return sp.vstack(arrays)
-    else:
-        return np.vstack(arrays)
-
-
-def hstack(arrays):
-    """hstack that supports sparse and dense arrays
-
-    If all arrays are dense, result is dense. Otherwise,
-    result is a sparse (csc) array.
-    """
-    if any(sp.issparse(arr) for arr in arrays):
-        arrays = [sp.csc_matrix(arr) for arr in arrays]
-        return sp.hstack(arrays)
-    else:
-        return np.hstack(arrays)

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -519,3 +519,29 @@ def var(x, axis=None):
     result = x.multiply(x).mean(axis) - np.square(x.mean(axis))
     result = np.squeeze(np.asarray(result))
     return result
+
+
+def vstack(arrays):
+    """vstack that supports sparse and dense arrays
+
+    If all arrays are dense, result is dense. Otherwise,
+    result is a sparse (csr) array.
+    """
+    if any(sp.issparse(arr) for arr in arrays):
+        arrays = [sp.csr_matrix(arr) for arr in arrays]
+        return sp.vstack(arrays)
+    else:
+        return np.vstack(arrays)
+
+
+def hstack(arrays):
+    """hstack that supports sparse and dense arrays
+
+    If all arrays are dense, result is dense. Otherwise,
+    result is a sparse (csc) array.
+    """
+    if any(sp.issparse(arr) for arr in arrays):
+        arrays = [sp.csc_matrix(arr) for arr in arrays]
+        return sp.hstack(arrays)
+    else:
+        return np.hstack(arrays)

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -8,7 +8,8 @@ import scipy as sp
 from scipy.sparse import csr_matrix, issparse, csc_matrix
 
 from Orange.statistics.util import bincount, countnans, contingency, stats, \
-    nanmin, nanmax, unique, nanunique, mean, nanmean, digitize, var
+    nanmin, nanmax, unique, nanunique, mean, nanmean, digitize, var, vstack, \
+    hstack
 
 
 def dense_sparse(test_case):
@@ -191,6 +192,46 @@ class TestUtil(unittest.TestCase):
                     var(csr_matrix(data), axis=axis),
                     np.var(data, axis=axis)
                 )
+
+    def assert_correct_array_type(self, array, shape, sparsity):
+        self.assertEqual(array.shape, shape)
+        self.assertEqual(["dense", "sparse"][issparse(array)], sparsity)
+
+    def test_vstack(self):
+        numpy = np.array([[1., 2.], [3., 4.]])
+        csr = csr_matrix(numpy)
+        csc = csc_matrix(numpy)
+
+        self.assert_correct_array_type(
+            vstack([numpy, numpy]),
+            shape=(4, 2), sparsity="dense")
+        self.assert_correct_array_type(
+            vstack([csr, numpy]),
+            shape=(4, 2), sparsity="sparse")
+        self.assert_correct_array_type(
+            vstack([numpy, csc]),
+            shape=(4, 2), sparsity="sparse")
+        self.assert_correct_array_type(
+            vstack([csc, csr]),
+            shape=(4, 2), sparsity="sparse")
+
+    def test_hstack(self):
+        numpy = np.array([[1., 2.], [3., 4.]])
+        csr = csr_matrix(numpy)
+        csc = csc_matrix(numpy)
+
+        self.assert_correct_array_type(
+            hstack([numpy, numpy]),
+            shape=(2, 4), sparsity="dense")
+        self.assert_correct_array_type(
+            hstack([csr, numpy]),
+            shape=(2, 4), sparsity="sparse")
+        self.assert_correct_array_type(
+            hstack([numpy, csc]),
+            shape=(2, 4), sparsity="sparse")
+        self.assert_correct_array_type(
+            hstack([csc, csr]),
+            shape=(2, 4), sparsity="sparse")
 
 
 class TestDigitize(unittest.TestCase):

--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -8,7 +8,6 @@ import scipy.sparse as sp
 from Orange.util import export_globals, flatten, deprecated, try_, deepgetattr, \
     OrangeDeprecationWarning
 from Orange.data import Table
-from Orange.data.util import vstack, hstack
 from Orange.statistics.util import stats
 
 SOMETHING = 0xf00babe
@@ -62,46 +61,6 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(deepgetattr(a, 'l.__len__.__call__'), a.l.__len__.__call__)
         self.assertTrue(deepgetattr(a, 'l.__nx__.__x__', 42), 42)
         self.assertRaises(AttributeError, lambda: deepgetattr(a, 'l.__nx__.__x__'))
-
-    def test_vstack(self):
-        numpy = np.array([[1., 2.], [3., 4.]])
-        csr = sp.csr_matrix(numpy)
-        csc = sp.csc_matrix(numpy)
-
-        self.assertCorrectArrayType(
-            vstack([numpy, numpy]),
-            shape=(4, 2), sparsity="dense")
-        self.assertCorrectArrayType(
-            vstack([csr, numpy]),
-            shape=(4, 2), sparsity="sparse")
-        self.assertCorrectArrayType(
-            vstack([numpy, csc]),
-            shape=(4, 2), sparsity="sparse")
-        self.assertCorrectArrayType(
-            vstack([csc, csr]),
-            shape=(4, 2), sparsity="sparse")
-
-    def test_hstack(self):
-        numpy = np.array([[1., 2.], [3., 4.]])
-        csr = sp.csr_matrix(numpy)
-        csc = sp.csc_matrix(numpy)
-
-        self.assertCorrectArrayType(
-            hstack([numpy, numpy]),
-            shape=(2, 4), sparsity="dense")
-        self.assertCorrectArrayType(
-            hstack([csr, numpy]),
-            shape=(2, 4), sparsity="sparse")
-        self.assertCorrectArrayType(
-            hstack([numpy, csc]),
-            shape=(2, 4), sparsity="sparse")
-        self.assertCorrectArrayType(
-            hstack([csc, csr]),
-            shape=(2, 4), sparsity="sparse")
-
-    def assertCorrectArrayType(self, array, shape, sparsity):
-        self.assertEqual(array.shape, shape)
-        self.assertEqual(["dense", "sparse"][sp.issparse(array)], sparsity)
 
     @unittest.skipUnless(os.environ.get('ORANGE_DEPRECATIONS_ERROR'),
                          'ORANGE_DEPRECATIONS_ERROR not set')

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -8,7 +8,7 @@ import scipy.sparse as sp
 
 import Orange
 from Orange.data import StringVariable, ContinuousVariable
-from Orange.data.util import hstack
+from Orange.statistics.util import hstack
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils import itemmodels
 from Orange.widgets.utils.sql import check_sql_input


### PR DESCRIPTION
##### Issue
`hstack` and `vstack` existed in `Orange.data.util`, however all the other functions that handle sparse and dense data are situated in `Orange.statistics.util`.

##### Description of changes
Move functions and tests to `Orange.statistics.util` module to keep all functions that deal with sparse/dense compatibility in same module.

Based on #2572.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
