### PR TITLE
[FIX] Statistics.countnans/bincount: Fix NaN Counting, Consider Implicit Zeros

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1399,7 +1399,7 @@ class Table(MutableSequence, Storage):
             else:
                 m = self._Y[:, col - self.X.shape[1]]
             if var.is_discrete:
-                dist, unknowns = bincount(m, len(var.values) - 1, W)
+                dist, unknowns = bincount(m, weights=W, max_val=len(var.values) - 1)
             elif not m.shape[0]:
                 dist, unknowns = np.zeros((2, 0)), 0
             else:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -19,7 +19,8 @@ from Orange.data import (
 )
 from Orange.data.util import SharedComputeValue, vstack, hstack
 from Orange.statistics.util import bincount, countnans, contingency, \
-    stats as fast_stats, sparse_has_zeros, sparse_count_zeros
+    stats as fast_stats, sparse_has_zeros, sparse_count_zeros, \
+    sparse_zero_weights
 from Orange.util import flatten
 
 __all__ = ["dataset_dirs", "get_sample_datasets_dir", "RowInstance", "Table"]
@@ -1427,10 +1428,15 @@ class Table(MutableSequence, Storage):
                 # If sparse, then 0s will not be counted with `valuecount`, so
                 # we have to add them to the result manually.
                 if sp.issparse(x) and sparse_has_zeros(x):
-                    zero_vec = [0, sparse_count_zeros(x)]
+                    if W is not None:
+                        zero_weights = sparse_zero_weights(x, W).sum()
+                    else:
+                        zero_weights = sparse_count_zeros(x)
+                    zero_vec = [0, zero_weights]
                     dist = np.insert(dist, np.searchsorted(dist[0], 0), zero_vec, axis=1)
-
-                unknowns = countnans(x, W)
+                # Since `countnans` assumes vector shape to be (1, n) and `x`
+                # shape is (n, 1), we pass the transpose
+                unknowns = countnans(x.T, W)
             distributions.append((dist, unknowns))
 
         return distributions

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -19,8 +19,8 @@ from Orange.data import (
 )
 from Orange.data.util import SharedComputeValue, vstack, hstack
 from Orange.statistics.util import bincount, countnans, contingency, \
-    stats as fast_stats, sparse_has_zeros, sparse_count_zeros, \
-    sparse_zero_weights
+    stats as fast_stats, sparse_has_implicit_zeros, sparse_count_implicit_zeros, \
+    sparse_implicit_zero_weights
 from Orange.util import flatten
 
 __all__ = ["dataset_dirs", "get_sample_datasets_dir", "RowInstance", "Table"]
@@ -1427,11 +1427,11 @@ class Table(MutableSequence, Storage):
                 dist = np.array(_valuecount.valuecount(vals))
                 # If sparse, then 0s will not be counted with `valuecount`, so
                 # we have to add them to the result manually.
-                if sp.issparse(x) and sparse_has_zeros(x):
+                if sp.issparse(x) and sparse_has_implicit_zeros(x):
                     if W is not None:
-                        zero_weights = sparse_zero_weights(x, W).sum()
+                        zero_weights = sparse_implicit_zero_weights(x, W).sum()
                     else:
-                        zero_weights = sparse_count_zeros(x)
+                        zero_weights = sparse_count_implicit_zeros(x)
                     zero_vec = [0, zero_weights]
                     dist = np.insert(dist, np.searchsorted(dist[0], 0), zero_vec, axis=1)
                 # Since `countnans` assumes vector shape to be (1, n) and `x`

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -272,8 +272,8 @@ class Continuous(np.ndarray):
         return np.average(np.asarray(self[0]), weights=np.asarray(self[1]))
 
     def variance(self):
-        avg = self.mean()
-        return sum([((x-avg)**2)*w for x, w in zip(self[0], self[1])])/sum(self[1])
+        mean = self.mean()
+        return sum(((x - mean) ** 2) * w for x, w in zip(self[0], self[1])) / sum(self[1])
 
     def standard_deviation(self):
         return math.sqrt(self.variance())

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -44,6 +44,22 @@ def sparse_has_zeros(x):
     return np.prod(x.shape) != x.nnz
 
 
+def sparse_zero_weights(x, weights):
+    """ Extract the weight values of all zeros in a sparse matrix. """
+    if not sp.issparse(x):
+        raise TypeError('The matrix provided was not sparse.')
+
+    if weights.ndim == 1:
+        n_items = np.prod(x.shape)
+        zero_indices = np.setdiff1d(np.arange(n_items), x.indices, assume_unique=True)
+        return weights[zero_indices]
+    else:
+        # Can easily be implemented using a coo_matrix
+        raise NotImplemented(
+            'Computing zero weights on ndimensinal weight matrix is not implemented'
+        )
+
+
 def bincount(x, weights=None, max_val=None, minlength=None):
     """Return counts of values in array X.
 
@@ -83,11 +99,8 @@ def bincount(x, weights=None, max_val=None, minlength=None):
     # Store the original matrix before any manipulation to check for sparse
     x_original = x
     if sp.issparse(x):
-        n_items = np.prod(x_original.shape)
-        zero_indices = np.setdiff1d(np.arange(n_items), x.indices, assume_unique=True)
-
         if weights is not None:
-            zero_weights = weights[zero_indices].sum()
+            zero_weights = sparse_zero_weights(x, weights).sum()
             weights = weights[x.indices]
         else:
             zero_weights = sparse_count_zeros(x)

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -31,10 +31,17 @@ def _count_nans_per_row_sparse(X, weights, dtype=None):
 
 
 def sparse_count_zeros(x):
-    """ Count the number of zeros in a sparse matrix. """
+    """ Count the number of implicit zeros in a sparse matrix. """
     if not sp.issparse(x):
         raise TypeError('The matrix provided was not sparse.')
     return np.prod(x.shape) - x.nnz
+
+
+def sparse_has_zeros(x):
+    """ Check if sparse matrix contains any implicit zeros. """
+    if not sp.issparse(x):
+        raise TypeError('The matrix provided was not sparse.')
+    return np.prod(x.shape) != x.nnz
 
 
 def bincount(x, weights=None, max_val=None, minlength=None):
@@ -315,17 +322,12 @@ def stats(X, weights=None, compute_variance=False):
             X.shape[0] - nans))
 
 
-def _sparse_has_zeros(x):
-    """ Check if sparse matrix contains any implicit zeros. """
-    return np.prod(x.shape) != x.nnz
-
-
 def _nan_min_max(x, func, axis=0):
     if not sp.issparse(x):
         return func(x, axis=axis)
     if axis is None:
         extreme = func(x.data, axis=axis) if x.nnz else float('nan')
-        if _sparse_has_zeros(x):
+        if sparse_has_zeros(x):
             extreme = func([0, extreme])
         return extreme
     if axis == 0:
@@ -338,7 +340,7 @@ def _nan_min_max(x, func, axis=0):
     for row in x:
         values = row.data
         extreme = func(values) if values.size else float('nan')
-        if _sparse_has_zeros(row):
+        if sparse_has_zeros(row):
             extreme = func([0, extreme])
         r.append(extreme)
     return np.array(r)

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -55,7 +55,7 @@ def sparse_zero_weights(x, weights):
         return weights[zero_indices]
     else:
         # Can easily be implemented using a coo_matrix
-        raise NotImplemented(
+        raise NotImplementedError(
             'Computing zero weights on ndimensinal weight matrix is not implemented'
         )
 

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -30,6 +30,13 @@ def _count_nans_per_row_sparse(X, weights):
     return np.fromiter((np.isnan(row.data).sum() for row in X), dtype=np.float)
 
 
+def sparse_count_zeros(x):
+    """ Count the number of zeros in a sparse matrix. """
+    if not sp.issparse(x):
+        raise TypeError('The matrix provided was not sparse.')
+    return np.prod(x.shape) - x.nnz
+
+
 def bincount(x, weights=None, max_val=None, minlength=None):
     """Return counts of values in array X.
 
@@ -76,7 +83,7 @@ def bincount(x, weights=None, max_val=None, minlength=None):
             zero_weights = weights[zero_indices].sum()
             weights = weights[x.indices]
         else:
-            zero_weights = np.prod(x_original.shape) - x_original.nnz
+            zero_weights = sparse_count_zeros(x)
 
         x = x.data
 
@@ -395,7 +402,7 @@ def unique(x, return_counts=False):
     if not sp.issparse(x):
         return np.unique(x, return_counts=return_counts)
 
-    implicit_zeros = np.prod(x.shape) - x.nnz
+    implicit_zeros = sparse_count_zeros(x)
     explicit_zeros = not np.all(x.data)
     r = np.unique(x.data, return_counts=return_counts)
     if not implicit_zeros:

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -23,7 +23,7 @@ def _count_nans_per_row_sparse(X, weights, dtype=None):
             data_weights = weights[nan_rows, nan_cols]
 
         w = sp.coo_matrix((data_weights, (nan_rows, nan_cols)), shape=X.shape)
-        w = w.tocsr(copy=False)
+        w = w.tocsr()
 
         return np.fromiter((np.sum(row.data) for row in w), dtype=dtype)
 

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -131,10 +131,11 @@ def bincount(x, weights=None, max_val=None, minlength=None):
         bc = np.bincount(
             x.astype(np.int32, copy=False), weights=weights, minlength=minlength
         ).astype(float)
-        # Since `csr_matrix.values` only contain non-zero values, we must count
-        # those separately and set the appropriate bin
+        # Since `csr_matrix.values` only contain non-zero values or explicit
+        # zeros, we must count implicit zeros separately and add them to the
+        # explicit ones found before
         if sp.issparse(x_original):
-            bc[0] = zero_weights
+            bc[0] += zero_weights
 
     return bc, nans
 

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -49,6 +49,8 @@ def sparse_zero_weights(x, weights):
     if not sp.issparse(x):
         raise TypeError('The matrix provided was not sparse.')
 
+    x = x.tocsr()
+
     if weights.ndim == 1:
         n_items = np.prod(x.shape)
         zero_indices = np.setdiff1d(np.arange(n_items), x.indices, assume_unique=True)
@@ -99,6 +101,7 @@ def bincount(x, weights=None, max_val=None, minlength=None):
     # Store the original matrix before any manipulation to check for sparse
     x_original = x
     if sp.issparse(x):
+        x = x.tocsr()
         if weights is not None:
             zero_weights = sparse_zero_weights(x, weights).sum()
             weights = weights[x.indices]

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -49,7 +49,7 @@ def sparse_implicit_zero_weights(x, weights):
     if not sp.issparse(x):
         raise TypeError('The matrix provided was not sparse.')
 
-    x = x.tocsr()
+    x = x.tocsc()
 
     if weights.ndim == 1:
         n_items = np.prod(x.shape)
@@ -101,7 +101,7 @@ def bincount(x, weights=None, max_val=None, minlength=None):
     # Store the original matrix before any manipulation to check for sparse
     x_original = x
     if sp.issparse(x):
-        x = x.tocsr()
+        x = x.tocsc()
         if weights is not None:
             zero_weights = sparse_implicit_zero_weights(x, weights).sum()
             weights = weights[x.indices]

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -353,6 +353,7 @@ class TestDomainDistribution(unittest.TestCase):
             [data.DiscreteVariable("d%i" % i, values=list("abc")) for i in range(10)] +
             [data.ContinuousVariable("c%i" % i) for i in range(10)])
 
+        # pylint: disable=bad-whitespace
         X = sp.csr_matrix(
             # 0  1  2  3       4       5       6  7  8  9 10 11 12   13 14 15 16      17 18 19
             # --------------------------------------------------------------------------------
@@ -433,6 +434,7 @@ class TestDomainDistribution(unittest.TestCase):
 
 class TestContinuous(unittest.TestCase):
     def test_mean(self):
+        # pylint: disable=bad-whitespace
         x = np.array([[0, 5, 10],
                       [9, 0,  1]])
         dist = distribution.Continuous(x)
@@ -440,6 +442,7 @@ class TestContinuous(unittest.TestCase):
         self.assertEqual(dist.mean(), np.mean(([0] * 9) + [10]))
 
     def test_variance(self):
+        # pylint: disable=bad-whitespace
         x = np.array([[0, 5, 10],
                       [9, 0,  1]])
         dist = distribution.Continuous(x)
@@ -447,6 +450,7 @@ class TestContinuous(unittest.TestCase):
         self.assertEqual(dist.variance(), np.var(([0] * 9) + [10]))
 
     def test_standard_deviation(self):
+        # pylint: disable=bad-whitespace
         x = np.array([[0, 5, 10],
                       [9, 0,  1]])
         dist = distribution.Continuous(x)

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -12,6 +12,7 @@ from Orange.statistics import distribution
 from Orange import data
 from Orange.tests import test_filename
 
+
 class Distribution_DiscreteTestCase(unittest.TestCase):
     def setUp(self):
         self.freqs = [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0]
@@ -291,6 +292,7 @@ class TestClassDistribution(unittest.TestCase):
         np.testing.assert_array_equal(disc,
                                       [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0])
 
+
 class TestGetDistribution(unittest.TestCase):
     def test_get_distribution(self):
         d = data.Table("iris")
@@ -427,6 +429,30 @@ class TestDomainDistribution(unittest.TestCase):
         dist, nanc = d._compute_distributions([variable])[0]
         np.testing.assert_almost_equal(dist, [2, 3, 2])
         self.assertEqual(nanc, 1)
+
+
+class TestContinuous(unittest.TestCase):
+    def test_mean(self):
+        x = np.array([[0, 5, 10],
+                      [9, 0,  1]])
+        dist = distribution.Continuous(x)
+
+        self.assertEqual(dist.mean(), np.mean(([0] * 9) + [10]))
+
+    def test_variance(self):
+        x = np.array([[0, 5, 10],
+                      [9, 0,  1]])
+        dist = distribution.Continuous(x)
+
+        self.assertEqual(dist.variance(), np.var(([0] * 9) + [10]))
+
+    def test_standard_deviation(self):
+        x = np.array([[0, 5, 10],
+                      [9, 0,  1]])
+        dist = distribution.Continuous(x)
+
+        self.assertEqual(dist.standard_deviation(), np.std(([0] * 9) + [10]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -363,6 +363,8 @@ class TestDomainDistribution(unittest.TestCase):
              [0, 0, 0, 0,      0,      0,      0, 0, 0, 0, 0, 0, 0,   0, 0, 0, 0,      0, 0, 0],
              [0, 0, 2, 0,      0,      0,      1, 0, 0, 0, 0, 0, 0, 1.1, 0, 0, 0,      0, 0, 0]]
         )
+        X[0, 0] = 0
+
         d = data.Table.from_numpy(domain, X)
         ddist = distribution.get_distributions(d)
 

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -98,16 +98,14 @@ class TestNormalizer(unittest.TestCase):
     def test_normalize_sparse(self):
         domain = Domain([ContinuousVariable(str(i)) for i in range(3)])
         X = sp.csr_matrix(np.array([
-            [0, 0, 0,],
             [0, -1, -2],
-            [0, 1, 2],
+            [0,  1,  2],
         ]))
         data = Table.from_numpy(domain, X)
 
         solution = sp.csr_matrix(np.array([
-            [0, 0, 0,],
             [0, -1, -1],
-            [0, 1, 1],
+            [0,  1,  1],
         ]))
 
         normalizer = Normalize()
@@ -116,7 +114,7 @@ class TestNormalizer(unittest.TestCase):
 
         # raise error for non-zero offsets
         data.X = sp.csr_matrix(np.array([
-            [0, 0, 0, ],
+            [0, 0, 0],
             [0, 1, 3],
             [0, 2, 4],
         ]))

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -97,12 +97,14 @@ class TestNormalizer(unittest.TestCase):
 
     def test_normalize_sparse(self):
         domain = Domain([ContinuousVariable(str(i)) for i in range(3)])
+        # pylint: disable=bad-whitespace
         X = sp.csr_matrix(np.array([
             [0, -1, -2],
             [0,  1,  2],
         ]))
         data = Table.from_numpy(domain, X)
 
+        # pylint: disable=bad-whitespace
         solution = sp.csr_matrix(np.array([
             [0, -1, -1],
             [0,  1,  1],

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -324,14 +324,16 @@ class TestCountnans(unittest.TestCase):
 
         np.testing.assert_equal(countnans(x, w, axis=1), [.5, 1])
 
-    def test_2d_weights(self):
-        x = [[0, np.nan, 1, 1],
-             [0, np.nan, 2, 2]]
+    @dense_sparse
+    def test_2d_weights(self, array):
+        x = array([[np.nan, np.nan, 1,      1 ],
+                   [     0, np.nan, 2, np.nan ]])
         w = np.array([[1, 2, 3, 4],
                       [5, 6, 7, 8]])
 
-        np.testing.assert_equal(countnans(x, w, axis=0), [0, 8, 0, 0])
-        np.testing.assert_equal(countnans(x, w, axis=1), [2, 6])
+        np.testing.assert_equal(countnans(x, w), 17)
+        np.testing.assert_equal(countnans(x, w, axis=0), [1, 8, 0, 8])
+        np.testing.assert_equal(countnans(x, w, axis=1), [3, 14])
 
 
 class TestBincount(unittest.TestCase):

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -22,15 +22,6 @@ class TestUtil(unittest.TestCase):
             np.ones((2, 3)),
         ]
 
-    def test_bincount(self):
-        hist, n_nans = bincount([0., 1., np.nan, 3])
-        self.assertEqual(n_nans, 1)
-        np.testing.assert_equal(hist, [1, 1, 0, 1])
-
-        hist, n_nans = bincount([0., 1., 3], max_val=3)
-        self.assertEqual(n_nans, 0)
-        np.testing.assert_equal(hist, [1, 1, 0, 1])
-
     def test_contingency(self):
         x = np.array([0, 1, 0, 2, np.nan])
         y = np.array([0, 0, 1, np.nan, 0])
@@ -324,3 +315,29 @@ class TestCountnans(unittest.TestCase):
         np.testing.assert_equal(countnans(x, weights=w, axis=1), [2, 6])
 
 
+class TestBincount(unittest.TestCase):
+    def test_count_nans(self):
+        dense = [0, 0, 1, 2, np.nan, 2]
+        sparse = csr_matrix(dense)
+        expected = 1
+
+        np.testing.assert_equal(bincount(dense)[1], expected)
+        np.testing.assert_equal(bincount(sparse)[1], expected)
+
+    def test_adds_empty_bins(self):
+        dense = np.array([0, 1, 3, 5])
+        sparse = csr_matrix(dense)
+        expected = [1, 1, 0, 1, 0, 1]
+
+        np.testing.assert_equal(bincount(dense)[0], expected)
+        np.testing.assert_equal(bincount(sparse)[0], expected)
+
+    def test_maxval_adds_empty_bins(self):
+        dense = [1, 1, 1, 2, 3, 2]
+        sparse = csr_matrix(dense)
+
+        max_val = 5
+        expected = [0, 3, 2, 1, 0, 0]
+
+        np.testing.assert_equal(bincount(dense, max_val=max_val)[0], expected)
+        np.testing.assert_equal(bincount(sparse, max_val=max_val)[0], expected)

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -332,6 +332,16 @@ class TestCountnans(unittest.TestCase):
         np.testing.assert_equal(countnans(x, w, axis=0), [1, 8, 0, 8])
         np.testing.assert_equal(countnans(x, w, axis=1), [3, 14])
 
+    @dense_sparse
+    def test_dtype(self, array):
+        x = array([0, np.nan, 2, 3])
+        w = np.array([0, 1.5, 0, 0])
+
+        self.assertIsInstance(countnans(x, w, dtype=np.int32), np.int32)
+        self.assertEqual(countnans(x, w, dtype=np.int32), 1)
+        self.assertIsInstance(countnans(x, w, dtype=np.float64), np.float64)
+        self.assertEqual(countnans(x, w, dtype=np.float64), 1.5)
+
 
 class TestBincount(unittest.TestCase):
     @dense_sparse

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -1,6 +1,5 @@
 import unittest
 import warnings
-
 from functools import wraps
 from itertools import chain
 
@@ -13,6 +12,7 @@ from Orange.statistics.util import bincount, countnans, contingency, stats, \
 
 
 def dense_sparse(test_case):
+    # type: (Callable) -> Callable
     """Run a single test case on both dense and sparse data."""
     @wraps(test_case)
     def _wrapper(self):
@@ -182,6 +182,7 @@ class TestUtil(unittest.TestCase):
 
 class TestDigitize(unittest.TestCase):
     def setUp(self):
+        # pylint: disable=bad-whitespace
         self.data = [
             np.array([
                 [0., 1.,     0., np.nan, 3.,     5.],
@@ -323,6 +324,7 @@ class TestCountnans(unittest.TestCase):
 
     @dense_sparse
     def test_2d_weights(self, array):
+        # pylint: disable=bad-whitespace
         x = array([[np.nan, np.nan, 1,      1 ],
                    [     0, np.nan, 2, np.nan ]])
         w = np.array([[1, 2, 3, 4],

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -355,3 +355,35 @@ class TestBincount(unittest.TestCase):
         expected = [0, 3, 2, 1, 0, 0]
 
         np.testing.assert_equal(bincount(x, max_val=max_val)[0], expected)
+
+    @dense_sparse
+    def test_maxval_doesnt_truncate_values_when_too_small(self, array):
+        x = array([1, 1, 1, 2, 3, 2])
+        max_val = 1
+        expected = [0, 3, 2, 1]
+
+        np.testing.assert_equal(bincount(x, max_val=max_val)[0], expected)
+
+    @dense_sparse
+    def test_minlength_adds_empty_bins(self, array):
+        x = array([1, 1, 1, 2, 3, 2])
+        minlength = 5
+        expected = [0, 3, 2, 1, 0]
+
+        np.testing.assert_equal(bincount(x, minlength=minlength)[0], expected)
+
+    @dense_sparse
+    def test_weights(self, array):
+        x = array([0, 0, 1, 1, 2, 2, 3, 3])
+        w = np.array([1, 2, 0, 0, 1, 1, 0, 1])
+
+        expected = [3, 0, 2, 1]
+        np.testing.assert_equal(bincount(x, w)[0], expected)
+
+    @dense_sparse
+    def test_weights_with_nans(self, array):
+        x = array([0, 0, 1, 1, np.nan, 2, np.nan, 3])
+        w = np.array([1, 2, 0, 0, 1, 1, 0, 1])
+
+        expected = [3, 0, 1, 1]
+        np.testing.assert_equal(bincount(x, w)[0], expected)

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -5,7 +5,7 @@ from itertools import chain
 
 import numpy as np
 import scipy as sp
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import csr_matrix, issparse, csc_matrix
 
 from Orange.statistics.util import bincount, countnans, contingency, stats, \
     nanmin, nanmax, unique, nanunique, mean, nanmean, digitize, var
@@ -18,6 +18,7 @@ def dense_sparse(test_case):
     def _wrapper(self):
         test_case(self, lambda x: np.array(x))
         test_case(self, lambda x: csr_matrix(x))
+        test_case(self, lambda x: csc_matrix(x))
 
     return _wrapper
 

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -412,3 +412,11 @@ class TestBincount(unittest.TestCase):
 
         expected = [3, 0, 1, 1]
         np.testing.assert_equal(bincount(x, w)[0], expected)
+
+    @dense_sparse
+    def test_weights_with_transposed_x(self, array):
+        x = array([0, 0, 1, 1, 2, 2, 3, 3]).T
+        w = np.array([1, 2, 0, 0, 1, 1, 0, 1])
+
+        expected = [3, 0, 2, 1]
+        np.testing.assert_equal(bincount(x, w)[0], expected)


### PR DESCRIPTION
##### Issue

The statistics module implementation of `countnans` did not support the `axis` argument. Moreover, it appeared to have been computing number of NaNs incorrectly on sparse data in general.


##### Description of changes
- Refactor `bincount` to properly count implicit and explicit zeros, with full weight support.
- Add implementation of `countnans` which correctly counts NaNs and supports the axis keyword.
- Add `dense_sparse` decorator for facilitating testing.

See #2558 for discussion.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
