### PR TITLE
[RFC] Domain: return all variables

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -211,6 +211,9 @@ class Domain:
     def metas(self):
         return self._metas
 
+    def filter(self, pred):
+        return [v for v in chain(self, self.metas) if pred(v)]
+
     def __len__(self):
         """The number of variables (features and class attributes)."""
         return len(self._variables)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -12,7 +12,7 @@ from Orange.data import _variable
 from Orange.util import Registry, color_to_hex, hex_to_color, Reprable
 
 __all__ = ["Unknown", "MISSING_VALUES", "make_variable", "is_discrete_values",
-           "Value", "Variable", "ContinuousVariable", "DiscreteVariable",
+           "Value", "Variable", "PrimitiveVariable", "ContinuousVariable", "DiscreteVariable",
            "StringVariable", "TimeVariable"]
 
 
@@ -348,7 +348,7 @@ class Variable(Reprable, metaclass=VariableMeta):
         `True` if the variable's values are stored as floats.
         Non-primitive variables can appear in the data only as meta attributes.
         """
-        return issubclass(cls, (DiscreteVariable, ContinuousVariable))
+        return issubclass(cls, PrimitiveVariable)
 
     @property
     def is_discrete(self):
@@ -439,7 +439,11 @@ class Variable(Reprable, metaclass=VariableMeta):
         return var
 
 
-class ContinuousVariable(Variable):
+class PrimitiveVariable(Variable):
+    TYPE_HEADERS = ()
+
+
+class ContinuousVariable(PrimitiveVariable):
     """
     Descriptor for continuous variables.
 
@@ -536,7 +540,7 @@ class ContinuousVariable(Variable):
         return var
 
 
-class DiscreteVariable(Variable):
+class DiscreteVariable(PrimitiveVariable):
     """
     Descriptor for symbolic, discrete variables. Values of discrete variables
     are stored as floats; the numbers corresponds to indices in the list of


### PR DESCRIPTION
##### Issue
Due to historical background Orange Data Mining has issues:

1. `domain.variables` are attributes and classes but not metas
2. There is no such thing as `domain.something` where that would be attributes, classes, and metas.
3. Yes, `some_meta in domain` may return `True`, but when one would iterate over `domain` it does not iterate over metas.
4. Iteration over attributes, classes, and metas or over all primitive features including metas would be useful in many widgets.

See also:
https://github.com/biolab/orange3/pull/2699#discussion_r146087213
https://github.com/biolab/orange3/pull/2699#discussion_r146343078



##### Description of changes

- PrimitiveVariable (created only to be used for separating primitive and non primitive variables).

- Domain method which returns list of all features. This method can be called with an argument which specifies which features to return (all by default).


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
