### PR TITLE
domain: Add deprecation warning in __iter__

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -10,6 +10,7 @@ import numpy as np
 from Orange.data import (
     Unknown, Variable, ContinuousVariable, DiscreteVariable, StringVariable
 )
+from Orange.util import deprecated
 
 __all__ = ["DomainConversion", "Domain"]
 
@@ -242,9 +243,16 @@ class Domain:
         """
         return item in self._indices
 
+    @deprecated("Domain.variables")
     def __iter__(self):
         """
         Return an iterator through variables (features and class attributes).
+
+        The current behaviour is confusing, as `x in domain` returns True
+        for meta variables, but iter(domain) does not yield them.
+        This will be consolidated eventually (in 3.12?), the code that
+        currently iterates over domain should iterate over domain.variables
+        instead.
         """
         return iter(self._variables)
 

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -355,9 +355,9 @@ class SqlTable(Table):
         if columns is not None:
             columns = [self.domain[col] for col in columns]
         else:
-            columns = list(self.domain)
+            columns = self.domain.variables
             if include_metas:
-                columns += list(self.domain.metas)
+                columns += self.domain.metas
         return self._get_stats(columns)
 
     def _get_stats(self, columns):
@@ -387,7 +387,7 @@ class SqlTable(Table):
         if columns is not None:
             columns = [self.domain[col] for col in columns]
         else:
-            columns = list(self.domain)
+            columns = self.domain.variables
         return self._get_distributions(columns)
 
     def _get_distributions(self, columns):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -158,7 +158,7 @@ class RowInstance(Instance):
 
 class Columns:
     def __init__(self, domain):
-        for v in chain(domain, domain.metas):
+        for v in chain(domain.variables, domain.metas):
             setattr(self, v.name.replace(" ", "_"), v)
 
 

--- a/Orange/preprocess/continuize.py
+++ b/Orange/preprocess/continuize.py
@@ -73,7 +73,7 @@ class DomainContinuizer(_RefuseDataInConstructor, Reprable):
 
         domain = data if isinstance(data, Domain) else data.domain
         if (treat == Continuize.ReportError and
-                any(var.is_discrete and len(var.values) > 2 for var in domain)):
+                any(var.is_discrete and len(var.values) > 2 for var in domain.variables)):
             raise ValueError("data has multinomial attributes")
         needs_discrete = (treat == Continuize.FrequentAsBase and
                           domain.has_discrete_attributes(transform_class))

--- a/Orange/tests/sql/test_misc.py
+++ b/Orange/tests/sql/test_misc.py
@@ -29,7 +29,7 @@ class MiscSqlTests(PostgresTest):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
         sepal_length = iris.domain["sepal length"]
         get_conditional_distribution(iris, [sepal_length])
-        get_conditional_distribution(iris, list(iris.domain))
+        get_conditional_distribution(iris, list(iris.domain.variables))
 
     @unittest.skipIf(no_widgets, "Cannot import widgets")
     def test_create_sql_contingency(self):

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -30,7 +30,7 @@ class TestSqlTable(PostgresTest):
             self.assertEqual(len(table.domain), 2)
             self.assertEqual(len(table.domain.metas), 1)
 
-            float_attr, discrete_attr = table.domain
+            float_attr, discrete_attr = table.domain.variables
             string_attr, = table.domain.metas
 
             self.assertIsInstance(float_attr, ContinuousVariable)

--- a/Orange/tests/test_continuize.py
+++ b/Orange/tests/test_continuize.py
@@ -39,7 +39,7 @@ class TestDomainContinuizer(unittest.TestCase):
             dom = DomainContinuizer(transform_class=True)
             dom = dom(inp)
             self.assertTrue(all(attr.is_continuous
-                                for attr in dom))
+                                for attr in dom.variables))
             self.assertIsNot(dom.class_var, self.data.domain.class_var)
             self.assertIs(dom[0], self.data.domain[0])
             self.assertIs(dom[1], self.data.domain[1])
@@ -140,7 +140,7 @@ class TestDomainContinuizer(unittest.TestCase):
         dom = dom(self.data.domain)
         self.assertTrue(all(attr.is_continuous
                             for attr in dom.attributes))
-        self.assertEqual([attr.name for attr in dom],
+        self.assertEqual([attr.name for attr in dom.variables],
                          ["c1", "c2", "d2=b", "cl1"])
 
     def test_multi_ignore_class(self):
@@ -170,7 +170,7 @@ class TestDomainContinuizer(unittest.TestCase):
             self.assertIs(dom.class_var, self.data.domain.class_var)
             self.assertIs(dom[0], self.data.domain[0])
             self.assertIs(dom[1], self.data.domain[1])
-            self.assertEqual([attr.name for attr in dom],
+            self.assertEqual([attr.name for attr in dom.variables],
                              ["c1", "c2", "d2", "d3", "cl1"])
 
             dat2 = Table(dom, self.data)
@@ -189,7 +189,7 @@ class TestDomainContinuizer(unittest.TestCase):
             self.assertTrue(dom.has_continuous_class)
             self.assertIs(dom[0], self.data.domain[0])
             self.assertIs(dom[1], self.data.domain[1])
-            self.assertEqual([attr.name for attr in dom],
+            self.assertEqual([attr.name for attr in dom.variables],
                              ["c1", "c2", "d2", "d3", "cl1"])
 
             dat2 = Table(dom, self.data)
@@ -207,7 +207,7 @@ class TestDomainContinuizer(unittest.TestCase):
             self.assertIs(dom.class_var, self.data.domain.class_var)
             self.assertIs(dom[0], self.data.domain[0])
             self.assertIs(dom[1], self.data.domain[1])
-            self.assertEqual([attr.name for attr in dom],
+            self.assertEqual([attr.name for attr in dom.variables],
                              ["c1", "c2", "d2", "d3", "cl1"])
 
             dat2 = Table(dom, self.data)

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -1,6 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-
+import warnings
 from time import time
 from numbers import Real
 from itertools import starmap
@@ -16,6 +16,7 @@ from Orange.data import (
 from Orange.data.domain import filter_visible
 from Orange.preprocess import Continuize, Impute
 from Orange.tests.base import create_pickling_tests
+from Orange.util import OrangeDeprecationWarning
 
 
 def create_domain(*ss):
@@ -266,14 +267,21 @@ class TestDomainInit(unittest.TestCase):
             [] in d
 
     def test_iter(self):
-        d = Domain((age, gender, income), metas=(ssn,))
-        self.assertEqual([var for var in d], [age, gender, income])
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("error")
 
-        d = Domain((age, ), metas=(ssn,))
-        self.assertEqual([var for var in d], [age])
+            d = Domain((age, gender, income), metas=(ssn,))
+            with self.assertRaises(OrangeDeprecationWarning):
+                list(d)
 
-        d = Domain((), metas=(ssn,))
-        self.assertEqual([var for var in d], [])
+            warnings.simplefilter("ignore")
+            self.assertEqual([var for var in d], [age, gender, income])
+
+            d = Domain((age, ), metas=(ssn,))
+            self.assertEqual([var for var in d], [age])
+
+            d = Domain((), metas=(ssn,))
+            self.assertEqual([var for var in d], [])
 
     def test_str(self):
         cases = (

--- a/Orange/tests/test_impute.py
+++ b/Orange/tests/test_impute.py
@@ -192,7 +192,7 @@ class TestAsValue(unittest.TestCase):
         vars = reduce(lambda acc, v:
                       acc + (list(v) if isinstance(v, (tuple, list))
                              else [v]),
-                      [impute.AsValue()(table, var) for var in table.domain],
+                      [impute.AsValue()(table, var) for var in table.domain.variables],
                       [])
         domain = data.Domain(vars)
         idata = table.from_table(domain, table)

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -262,7 +262,7 @@ class TestInstance(unittest.TestCase):
             "[{}]".format(", ".join("{:.3f}".format(x)
                                     for x in range(len(self.attributes)))))
 
-        for attr in domain:
+        for attr in domain.variables:
             attr.number_of_decimals = 0
         self.assertEqual(
             str(inst),
@@ -274,7 +274,7 @@ class TestInstance(unittest.TestCase):
         inst = Instance(domain, range(len(self.attributes)))
         self.assertEqual(repr(inst), "[0.000, 1.000, 2.000, 3.000, 4.000, ...]")
 
-        for attr in domain:
+        for attr in domain.variables:
             attr.number_of_decimals = 0
         self.assertEqual(repr(inst), "[0, 1, 2, 3, 4, ...]")
 

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -36,7 +36,7 @@ class TestTabReader(unittest.TestCase):
         file = io.StringIO(simplefile)
         table = read_tab_file(file)
 
-        f1, f2, c1, c2 = table.domain
+        f1, f2, c1, c2 = table.domain.variables
         self.assertIsInstance(f1, DiscreteVariable)
         self.assertEqual(f1.name, "Feature 1")
         self.assertIsInstance(f2, DiscreteVariable)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -727,7 +727,7 @@ class TableTestCase(unittest.TestCase):
         d = data.Table("iris")
         dom = data.Domain(["petal length", "sepal length", "iris"],
                           source=d.domain)
-        d_ref = d[:10, dom]
+        d_ref = d[:10, dom.variables]
         self.assertEqual(d_ref.domain.class_var, d.domain.class_var)
         self.assertEqual(d_ref[0, "petal length"], d[0, "petal length"])
         self.assertEqual(d_ref[0, "sepal length"], d[0, "sepal length"])

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -50,7 +50,7 @@ class TestTabReader(unittest.TestCase):
             file.close()
             table = CSVReader(filename).read()
 
-            f1, f2, f3 = table.domain
+            f1, f2, f3 = table.domain.variables
             self.assertIsInstance(f1, DiscreteVariable)
             self.assertEqual(f1.name, name + "1")
             self.assertIsInstance(f2, ContinuousVariable)

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -65,7 +65,7 @@ class TestExcelHeader1(unittest.TestCase):
         self.assertIsInstance(domain[1], ContinuousVariable)
         self.assertIsInstance(domain[2], DiscreteVariable)
         self.assertIsInstance(domain[3], ContinuousVariable)
-        for i, var in enumerate(domain):
+        for i, var in enumerate(domain.variables):
             self.assertEqual(var.name, chr(97 + i))
         self.assertEqual(domain[0].values, ["green", "red"])
         np.testing.assert_almost_equal(table.X,

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -257,7 +257,8 @@ class OWDiscretize(widget.OWWidget):
     def _initialize(self, data):
         # Initialize the default variable states for new data.
         self.class_var = data.domain.class_var
-        cvars = [var for var in data.domain if var.is_continuous]
+        cvars = [var for var in data.domain.variables
+                 if var.is_continuous]
         self.varmodel[:] = cvars
 
         class_var = data.domain.class_var

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -473,7 +473,7 @@ class OWEditDomain(widget.OWWidget):
 
     def _initialize(self):
         domain = self.data.domain
-        self.input_vars = tuple(domain) + domain.metas
+        self.input_vars = domain.variables + domain.metas
         self.domain_model[:] = list(self.input_vars)
 
     def _restore(self):

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -591,7 +591,7 @@ class OWFeatureConstructor(OWWidget):
 
         desc = list(self.featuremodel)
         desc = self._validate_descriptors(desc)
-        source_vars = tuple(self.data.domain) + self.data.domain.metas
+        source_vars = self.data.domain.variables + self.data.domain.metas
         new_variables = construct_variables(desc, source_vars)
 
         attrs = [var for var in new_variables if var.is_primitive()]

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -143,7 +143,7 @@ class OWMergeData(widget.OWWidget):
         if data is None:
             model[:] = []
             return
-        model[:] = list(chain([INDEX], data.domain, data.domain.metas))
+        model[:] = list(chain([INDEX], data.domain.variables, data.domain.metas))
 
     def _add_instanceid_to_models(self):
         needs_id = self.data is not None and self.extra_data is not None and \

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -657,7 +657,7 @@ class OWDataTable(widget.OWWidget):
                 RichTableDecorator.Labels | RichTableDecorator.Name)
 
             labelnames = set()
-            for a in model.source.domain:
+            for a in model.source.domain.variables:
                 labelnames.update(a.attributes.keys())
             labelnames = sorted(
                 [label for label in labelnames if not label.startswith("_")])

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -31,7 +31,7 @@ class FeatureConstructorTest(unittest.TestCase):
                                 values=values, base_value=-1, ordered=False)]
         )
         data = Table(Domain(list(data.domain.attributes) +
-                            construct_variables(desc, data.domain),
+                            construct_variables(desc, data.domain.variables),
                             data.domain.class_vars,
                             data.domain.metas), data)
         self.assertTrue(isinstance(data.domain[name], DiscreteVariable))
@@ -48,7 +48,7 @@ class FeatureConstructorTest(unittest.TestCase):
                                   number_of_decimals=2)]
         )
         data = Table(Domain(list(data.domain.attributes) +
-                            construct_variables(featuremodel, data.domain),
+                            construct_variables(featuremodel, data.domain.variables),
                             data.domain.class_vars,
                             data.domain.metas), data)
         self.assertTrue(isinstance(data.domain[name], ContinuousVariable))
@@ -66,7 +66,7 @@ class FeatureConstructorTest(unittest.TestCase):
         data = Table(Domain(data.domain.attributes,
                             data.domain.class_vars,
                             list(data.domain.metas) +
-                            construct_variables(desc, data.domain)),
+                            construct_variables(desc, data.domain.variables)),
                      data)
         self.assertTrue(isinstance(data.domain[name], StringVariable))
         for i in range(3):
@@ -82,7 +82,7 @@ class FeatureConstructorTest(unittest.TestCase):
                                   expression="_0_1 + _1",
                                   number_of_decimals=3)]
         )
-        nv = construct_variables(desc, data.domain)
+        nv = construct_variables(desc, data.domain.variables)
         ndata = Table(Domain(nv, None), data)
         np.testing.assert_array_equal(ndata.X[:, 0],
                                       data.X[:, :2].sum(axis=1))

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -53,19 +53,19 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataA)
-        data_items = list(chain([INDEX], domainA, domainA.metas))
+        data_items = list(chain([INDEX], domainA.variables, domainA.metas))
         extra_items = list(chain(
             [INDEX], domainA.variables[::2], domainA.metas[1:]))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        extra_items = list(chain([INDEX], domainB, domainB.metas))
+        extra_items = list(chain([INDEX], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
         self.send_signal(self.widget.Inputs.data, self.dataB)
-        data_items = list(chain([INDEX], domainB, domainB.metas))
+        data_items = list(chain([INDEX], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
@@ -87,13 +87,13 @@ class TestOWMergeData(WidgetTest):
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
         data_items = list(chain(
             [INDEX], domainA.variables[::2], domainA.metas[1:]))
-        extra_items = list(chain([INDEX], domainB, domainB.metas))
+        extra_items = list(chain([INDEX], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
         self.send_signal(self.widget.Inputs.data, self.dataB)
         data_items = extra_items = list(chain(
-            [INSTANCEID, INDEX], domainB, domainB.metas))
+            [INSTANCEID, INDEX], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
@@ -115,13 +115,13 @@ class TestOWMergeData(WidgetTest):
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
         data_items = list(chain(
             [INDEX], domainA.variables[::2], domainA.metas[1:]))
-        extra_items = list(chain([INDEX], domainB, domainB.metas))
+        extra_items = list(chain([INDEX], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
         self.send_signal(self.widget.Inputs.data, self.dataB)
         data_items = extra_items = list(chain(
-            [INSTANCEID, INDEX], domainB, domainB.metas))
+            [INSTANCEID, INDEX], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -891,7 +891,7 @@ class DomainContextHandler(ContextHandler):
             attributes = encode(domain.attributes, False)
             attributes.update(encode(domain.class_vars, True))
         else:
-            attributes = encode(domain, match == self.MATCH_VALUES_ALL)
+            attributes = encode(domain.variables, match == self.MATCH_VALUES_ALL)
 
         metas = encode(domain.metas, match == self.MATCH_VALUES_ALL)
 

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -447,7 +447,7 @@ class OWDistanceMap(widget.OWWidget):
         elif not axis:
             model[:] = ["None", "Enumeration", "Attribute names"]
         elif isinstance(items, Orange.data.Table):
-            annot_vars = list(filter_visible(items.domain)) + list(items.domain.metas)
+            annot_vars = list(filter_visible(items.domain.variables)) + list(items.domain.metas)
             model[:] = ["None", "Enumeration"] + annot_vars
             self.annotation_idx = 0
             self.openContext(items.domain)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -277,7 +277,7 @@ class OWDistanceMatrix(widget.OWWidget):
             self.annotation_idx = 2
         elif isinstance(items, Table):
             annotations.extend(
-                itertools.chain(items.domain, items.domain.metas))
+                itertools.chain(items.domain.variables, items.domain.metas))
             if items.domain.class_var:
                 self.annotation_idx = 2 + len(items.domain.attributes)
         self.annot_combo.model()[:] = annotations

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -305,7 +305,7 @@ class OWKMeans(widget.OWWidget):
             return
 
         domain = self.data.domain
-        existing_vars = [var.name for var in chain(domain, domain.metas)]
+        existing_vars = [var.name for var in chain(domain.variables, domain.metas)]
         clust_var = DiscreteVariable(
             get_next_name(existing_vars, "Cluster"),
             values=["C%d" % (x + 1) for x in range(km.k)])

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -675,7 +675,8 @@ class OWMDS(OWWidget):
 
     def commit(self):
         if self.embedding is not None:
-            names = get_unique_names([v.name for v in self.data.domain], ["mds-x", "mds-y"])
+            names = get_unique_names([v.name for v in self.data.domain.variables],
+                                     ["mds-x", "mds-y"])
             output = embedding = Orange.data.Table.from_numpy(
                 Orange.data.Domain([ContinuousVariable(names[0]), ContinuousVariable(names[1])]),
                 self.embedding

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -227,12 +227,12 @@ class OWDistributions(widget.OWWidget):
                 self.warning("Empty input data cannot be visualized")
                 return
             domain = self.data.domain
-            self.varmodel[:] = list(domain) + \
+            self.varmodel[:] = list(domain.variables) + \
                                [meta for meta in domain.metas
                                 if meta.is_continuous or meta.is_discrete]
             self.groupvarview.clear()
             self.groupvarmodel = \
-                ["(None)"] + [var for var in domain if var.is_discrete] + \
+                ["(None)"] + [var for var in domain.variables if var.is_discrete] + \
                 [meta for meta in domain.metas if meta.is_discrete]
             self.groupvarview.addItem("(None)")
             for var in self.groupvarmodel[1:]:

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -362,9 +362,9 @@ class OWMosaicDisplay(OWWidget):
         if (data is None or
                 not len(data) or
                 not any(attr.is_discrete or attr.is_continuous
-                        for attr in chain(data.domain, data.domain.metas))):
+                        for attr in chain(data.domain.variables, data.domain.metas))):
             return None
-        elif any(attr.is_continuous for attr in data.domain):
+        elif any(attr.is_continuous for attr in data.domain.variables):
             return Discretize(
                 method=EqualFreq(n=4), remove_const=False, discretize_classes=True,
                 discretize_metas=True)(data)
@@ -382,7 +382,7 @@ class OWMosaicDisplay(OWWidget):
             combo.addItem("(None)")
 
         icons = gui.attributeIconDict
-        for attr in chain(data.domain, data.domain.metas):
+        for attr in chain(data.domain.variables, data.domain.metas):
             if attr.is_primitive:
                 for combo in self.attr_combos:
                     combo.addItem(icons[attr], attr.name)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -205,7 +205,7 @@ class OWSieveDiagram(OWWidget):
         GH-2260
         """
         def discretizer(data):
-            if any(attr.is_continuous for attr in chain(data.domain, data.domain.metas)):
+            if any(attr.is_continuous for attr in chain(data.domain.variables, data.domain.metas)):
                 discretize = Discretize(
                     method=EqualFreq(n=4), remove_const=False,
                     discretize_classes=True, discretize_metas=True)

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -659,7 +659,7 @@ def pairwise(iterable):
 # even if they have exactly the same variables).
 # TODO: What about metas.
 def domain_eq(d1, d2):
-    return tuple(d1) == tuple(d2)
+    return d1.variables == d2.variables
 
 
 # Comparing/hashing Orange.data.Instance across domains ignoring metas.

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -290,7 +290,7 @@ class MosaicVizRankTests(WidgetTest):
                    [1, 2, 6], [1, 3, 7], [1, 4, 7]]
         table = Table("titanic")
         self.send_signal(self.widget.Inputs.data, table)
-        color_vars = ["(Pearson residuals)"] + [str(x) for x in table.domain]
+        color_vars = ["(Pearson residuals)"] + [str(x) for x in table.domain.variables]
         for i, cv in enumerate(color_vars):
             idx = self.widget.cb_attr_color.findText(cv)
             self.widget.cb_attr_color.setCurrentIndex(idx)

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -335,7 +335,8 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         GH-2384
         """
         domain = Table("iris").domain
-        self.send_signal(self.widget.Inputs.features, AttributeList(domain))
+        self.send_signal(self.widget.Inputs.features,
+                         AttributeList(domain.variables))
         self.send_signal(self.widget.Inputs.features, None)
 
     def test_features_and_data(self):

--- a/Orange/widgets/visualize/utils/lac.py
+++ b/Orange/widgets/visualize/utils/lac.py
@@ -196,7 +196,7 @@ def create_contingencies(X, callback=None):
 
 def get_bin_centers(X_):
     m = []
-    for i, var in enumerate(X_.domain):
+    for i, var in enumerate(X_.domain.variables):
         cleaned_values = [tuple(map(str.strip, v.strip('[]()<>=≥').split('-')))
                           for v in var.values]
         try:


### PR DESCRIPTION
The current behaviour is confusing, as `x in domain` returns True for meta variables, but iter(domain) does not yield them.

This PR adds a deprecation warning, points users to iterate over domain.variables instead.