### PR TITLE
Variable: Allow using is_* as predicates

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -107,6 +107,19 @@ class TestVariable(unittest.TestCase):
         self.assertTrue(a.is_string)
         self.assertFalse(a.is_primitive())
 
+    def test_properties_as_predicates(self):
+        a = ContinuousVariable()
+        self.assertTrue(Variable.is_continuous(a))
+        self.assertFalse(Variable.is_discrete(a))
+        self.assertFalse(Variable.is_string(a))
+        self.assertTrue(Variable.is_primitive(a))
+
+        a = StringVariable()
+        self.assertFalse(Variable.is_continuous(a))
+        self.assertFalse(Variable.is_discrete(a))
+        self.assertTrue(Variable.is_string(a))
+        self.assertFalse(Variable.is_primitive(a))
+
     def test_strange_eq(self):
         a = ContinuousVariable()
         b = ContinuousVariable()


### PR DESCRIPTION
##### Issue

Fixes #2719.

##### Description of changes

Implement `is_discrete` etc. as descriptors for instance and class attribute access to allow using them in e.g. `filter(Variable.is_discrete, domain)`.

Add an optional argument to `is_primitive`. `is_primitive` is needed a different treatment because it's a class method and not a property.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
