### PR TITLE
[FIX] Correspondence Analysis: do not crash when no categorical

### DIFF
--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -61,6 +61,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
 
     class Error(widget.OWWidget.Error):
         empty_data = widget.Msg("Empty data set")
+        no_disc_vars = widget.Msg("Correspondence Analysis needs categorical variables")
 
     def __init__(self):
         super().__init__()
@@ -102,6 +103,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     def set_data(self, data):
         self.closeContext()
         self.clear()
+        self.Error.no_disc_vars.clear()
 
         if data is not None and not len(data):
             self.Error.empty_data()
@@ -113,12 +115,14 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
         if data is not None:
             self.varlist[:] = [var for var in data.domain.variables
                                if var.is_discrete]
-            self.selected_var_indices = [0, 1][:len(self.varlist)]
-            self.component_x = 0
-            self.component_y = int(len(self.varlist[self.selected_var_indices[-1]].values) > 1)
-            self.openContext(data)
-            self._restore_selection()
-#             self._invalidate()
+            if not len(self.varlist[:]):
+                self.Error.no_disc_vars()
+            else:
+                self.selected_var_indices = [0, 1][:len(self.varlist)]
+                self.component_x = 0
+                self.component_y = int(len(self.varlist[self.selected_var_indices[-1]].values) > 1)
+                self.openContext(data)
+                self._restore_selection()
         self._update_CA()
 
     def clear(self):

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -61,7 +61,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
 
     class Error(widget.OWWidget.Error):
         empty_data = widget.Msg("Empty data set")
-        no_disc_vars = widget.Msg("Correspondence Analysis needs categorical variables")
+        no_disc_vars = widget.Msg("No categorical data")
 
     def __init__(self):
         super().__init__()
@@ -103,13 +103,11 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     def set_data(self, data):
         self.closeContext()
         self.clear()
-        self.Error.no_disc_vars.clear()
+        self.Error.clear()
 
         if data is not None and not len(data):
             self.Error.empty_data()
             data = None
-        else:
-            self.Error.empty_data.clear()
 
         self.data = data
         if data is not None:
@@ -117,6 +115,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
                                if var.is_discrete]
             if not len(self.varlist[:]):
                 self.Error.no_disc_vars()
+                self.data = None
             else:
                 self.selected_var_indices = [0, 1][:len(self.varlist)]
                 self.component_x = 0

--- a/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
+++ b/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
@@ -51,3 +51,20 @@ class TestOWCorrespondence(WidgetTest):
             [(0,), (0,), (0,)]
         )
         self.send_signal(self.widget.Inputs.data, table)
+
+    def test_no_discrete_variables(self):
+        """
+        Do not crash when there are no discrete (categorical) variable(s).
+        GH-2723
+        """
+        table = Table(
+            Domain(
+                [ContinuousVariable("a")]
+            ),
+            [(1,), (2,), (3,)]
+        )
+        self.assertFalse(self.widget.Error.no_disc_vars.is_shown())
+        self.send_signal(self.widget.Inputs.data, table)
+        self.assertTrue(self.widget.Error.no_disc_vars.is_shown())
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertFalse(self.widget.Error.no_disc_vars.is_shown())

--- a/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
+++ b/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
@@ -68,3 +68,8 @@ class TestOWCorrespondence(WidgetTest):
         self.assertTrue(self.widget.Error.no_disc_vars.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.no_disc_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, table)
+        self.assertTrue(self.widget.Error.no_disc_vars.is_shown())
+        self.send_signal(self.widget.Inputs.data, Table("iris"))
+        self.assertFalse(self.widget.Error.no_disc_vars.is_shown())


### PR DESCRIPTION
##### Issue
Widget crashes when there are no categorical variables in a data.

##### Description of changes
Check and show error.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
