### PR TITLE
[FIX] errorreporting: Remove use of pip internal api

### DIFF
--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -39,6 +39,17 @@ REPORT_POST_URL = 'https://qa.orange.biolab.si/error_report/v1/'
 log = logging.getLogger()
 
 
+def get_installed_distributions():
+    for dist in pkg_resources.working_set:  # type: pkg_resources.Distribution
+        name = dist.project_name
+        try:
+            version = dist.version
+        except ValueError:
+            # PKG-INFO/METADATA is not available or parsable.
+            version = "Unknown"
+        yield "{name}=={version}".format(name=name, version=version)
+
+
 class ErrorReporting(QDialog):
     _cache = set()  # For errors already handled during one session
 
@@ -191,8 +202,7 @@ class ErrorReporting(QDialog):
             widget = frame.tb_frame.f_locals['self'].__class__
             widget_module = '{}:{}'.format(widget.__module__, frame.tb_lineno)
 
-        packages = ', '.join(sorted("%s==%s" % (dist.project_name, dist.version)
-                                    for dist in pkg_resources.working_set))
+        packages = ', '.join(sorted(get_installed_distributions()))
 
         machine_id = QSettings().value('error-reporting/machine-id', '', type=str)
 

--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -1,5 +1,4 @@
 import os
-import pip
 import sys
 import time
 import logging
@@ -15,6 +14,8 @@ from collections import OrderedDict
 from urllib.parse import urljoin, urlencode
 from urllib.request import pathname2url, urlopen, build_opener
 from unittest.mock import patch
+
+import pkg_resources
 
 from AnyQt.QtCore import pyqtSlot, QSettings, Qt
 from AnyQt.QtGui import QDesktopServices, QFont
@@ -190,8 +191,8 @@ class ErrorReporting(QDialog):
             widget = frame.tb_frame.f_locals['self'].__class__
             widget_module = '{}:{}'.format(widget.__module__, frame.tb_lineno)
 
-        packages = ', '.join(sorted("%s==%s" % (i.project_name, i.version)
-                                    for i in pip.get_installed_distributions()))
+        packages = ', '.join(sorted("%s==%s" % (dist.project_name, dist.version)
+                                    for dist in pkg_resources.working_set))
 
         machine_id = QSettings().value('error-reporting/machine-id', '', type=str)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Error reporting uses internal pip api, which will be [moved in Pip 10](https://mail.python.org/pipermail/distutils-sig/2017-October/031642.html).

##### Description of changes

Remove use of pip internal api

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
