### PR TITLE
[FIX] Select Rows: None on output when no data

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -530,8 +530,11 @@ class OWSelectRows(widget.OWWidget):
                 matching_output = remover(matching_output)
                 non_matching_output = remover(non_matching_output)
 
-        self.Outputs.matching_data.send(matching_output)
-        self.Outputs.unmatched_data.send(non_matching_output)
+        def output_filter(output):
+            return output if output is not None and len(output) else None
+
+        self.Outputs.matching_data.send(output_filter(matching_output))
+        self.Outputs.unmatched_data.send(output_filter(non_matching_output))
 
         self.match_desc = report.describe_data_brief(matching_output)
         self.nonmatch_desc = report.describe_data_brief(non_matching_output)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -530,11 +530,13 @@ class OWSelectRows(widget.OWWidget):
                 matching_output = remover(matching_output)
                 non_matching_output = remover(non_matching_output)
 
-        def output_filter(output):
-            return output if output is not None and len(output) else None
+        if matching_output is not None and not len(matching_output):
+            matching_output = None
+        if non_matching_output is not None and not len(non_matching_output):
+            non_matching_output = None
 
-        self.Outputs.matching_data.send(output_filter(matching_output))
-        self.Outputs.unmatched_data.send(output_filter(non_matching_output))
+        self.Outputs.matching_data.send(matching_output)
+        self.Outputs.unmatched_data.send(non_matching_output)
 
         self.match_desc = report.describe_data_brief(matching_output)
         self.nonmatch_desc = report.describe_data_brief(non_matching_output)

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -242,3 +242,20 @@ class TestOWSelectRows(WidgetTest):
         settings = dict(context_settings=[context])
 
         return self.create_widget(OWSelectRows, settings)
+
+    def test_output_filter(self):
+        """
+        None on output when there is no data.
+        GH-2726
+        """
+        data = Table("iris")[:10]
+        len_data = len(data)
+        self.send_signal(self.widget.Inputs.data, data)
+
+        self.enterFilter(data.domain[0], "is below", "-1")
+        self.assertIsNone(self.get_output("Matching Data"))
+        self.assertEqual(len(self.get_output("Unmatched Data")), len_data)
+        self.widget.remove_all_button.click()
+        self.enterFilter(data.domain[0], "is below", "10")
+        self.assertIsNone(self.get_output("Unmatched Data"))
+        self.assertEqual(len(self.get_output("Matching Data")), len_data)


### PR DESCRIPTION
##### Issue
**Rank** widget crashes because receives empty `Table` and empty `Domain` which is created by **Select Rows**.

##### Description of changes
**Select Rows** commits `None`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
