### PR TITLE
[FIX] Error Reporting: send report even when recursion error is raised

### DIFF
--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -25,6 +25,8 @@ from AnyQt.QtWidgets import (
     QVBoxLayout, QWidget
 )
 
+from Orange.util import try_
+
 try:
     from Orange.widgets.widget import OWWidget
     from Orange.version import full_version as VERSION_STR
@@ -193,7 +195,8 @@ class ErrorReporting(QDialog):
             err_module = '{}:{}'.format(
                 frame.tb_frame.f_globals.get('__name__', frame.tb_frame.f_code.co_filename),
                 frame.tb_lineno)
-            err_locals = pformat(OrderedDict(sorted(frame.tb_frame.f_locals.items())))
+            err_locals = OrderedDict(sorted(frame.tb_frame.f_locals.items()))
+            err_locals = try_(lambda: pformat(err_locals), try_(lambda: str(err_locals)))
 
         def _find_widget_frame(tb):
             while tb:

--- a/Orange/canvas/application/errorreporting.py
+++ b/Orange/canvas/application/errorreporting.py
@@ -30,7 +30,8 @@ try:
     from Orange.version import full_version as VERSION_STR
 except ImportError:
     # OWWidget (etc.) is not available because this is not Orange
-    class OWWidget: pass
+    class OWWidget:
+        pass
     VERSION_STR = '???'
 
 
@@ -74,8 +75,10 @@ class ErrorReporting(QDialog):
                               data.get(F.WIDGET_MODULE)),
                       filename=data.get(F.WIDGET_SCHEME)):
             self._cache.add(key)
-            try: os.remove(filename)
-            except Exception: pass
+            try:
+                os.remove(filename)
+            except Exception:
+                pass
 
         super().__init__(None, Qt.Window, modal=True,
                          sizeGripEnabled=True, windowIcon=icon,
@@ -134,7 +137,8 @@ class ErrorReporting(QDialog):
         buttons = QWidget(self)
         buttons_layout = QHBoxLayout(self)
         buttons.setLayout(buttons_layout)
-        buttons_layout.addWidget(QPushButton('Send Report (Thanks!)', default=True, clicked=self.accept))
+        buttons_layout.addWidget(
+            QPushButton('Send Report (Thanks!)', default=True, clicked=self.accept))
         buttons_layout.addWidget(QPushButton("Don't Send", default=False, clicked=self.reject))
         layout.addWidget(buttons)
 


### PR DESCRIPTION
##### Issue
Sometimes error reporting crashes when trying to prepare a string with local variables. `RecursionError` is raised. Instead of the actual error this error is sent.


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
