### PR TITLE
OWDataTable: don't crash on empty selection

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -775,7 +775,7 @@ class OWDataTable(widget.OWWidget):
 
         indexes = selection.indexes()
 
-        rows = numpy.unique([ind.row() for ind in indexes])
+        rows = numpy.unique([ind.row() for ind in indexes]).astype(int)
         # map the rows through the applied sorting (if any)
         rows = model.mapToSourceRows(rows)
         rows.sort()


### PR DESCRIPTION
##### Issue
Fixes https://github.com/biolab/orange3/issues/2728
Closes https://github.com/biolab/orange3/pull/2730

##### Description of changes
Don't pass float row indexes to `AbstractSortTableModel`.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
