### PR TITLE
owdatasets: Support file paths of depth other than 1

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -241,17 +241,19 @@ class OWDataSets(widget.OWWidget):
             allkeys = allkeys | set(allinforemote)
         allkeys = sorted(allkeys)
 
-        def info(prefix, filename):
-            if (prefix, filename) in allinforemote:
-                info = allinforemote[prefix, filename]
+        def info(file_path):
+            if file_path in allinforemote:
+                info = allinforemote[file_path]
             else:
-                info = allinfolocal[prefix, filename]
-            islocal = (prefix, filename) in allinfolocal
-            isremote = (prefix, filename) in allinforemote
+                info = allinfolocal[file_path]
+            islocal = file_path in allinfolocal
+            isremote = file_path in allinforemote
             outdated = islocal and isremote and (
-                allinforemote[prefix, filename].get('version', '') !=
-                allinfolocal[prefix, filename].get('version', ''))
+                allinforemote[file_path].get('version', '') !=
+                allinfolocal[file_path].get('version', ''))
             islocal &= not outdated
+            prefix = os.path.join('', *file_path[:-1])
+            filename = file_path[-1]
 
             return namespace(
                 prefix=prefix, filename=filename,
@@ -276,8 +278,8 @@ class OWDataSets(widget.OWWidget):
         model.setHorizontalHeaderLabels(HEADER)
 
         current_index = -1
-        for i, (prefix, filename) in enumerate(allkeys):
-            datainfo = info(prefix, filename)
+        for i, file_path in enumerate(allkeys):
+            datainfo = info(file_path)
             item1 = QStandardItem()
             item1.setData(" " if datainfo.islocal else "", Qt.DisplayRole)
             item1.setData(datainfo, Qt.UserRole)
@@ -298,7 +300,7 @@ class OWDataSets(widget.OWWidget):
             row = [item1, item2, item3, item4, item5, item6, item7]
             model.appendRow(row)
 
-            if (prefix, filename) == self.selected_id:
+            if os.path.join(*file_path) == self.selected_id:
                 current_index = i
 
         hs = self.view.header().saveState()
@@ -367,7 +369,7 @@ class OWDataSets(widget.OWWidget):
             di = current.data(Qt.UserRole)
             text = description_html(di)
             self.descriptionlabel.setText(text)
-            self.selected_id = (di.prefix, di.filename)
+            self.selected_id = os.path.join(di.prefix, di.filename)
         else:
             self.descriptionlabel.setText("")
             self.selected_id = None


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The code assumed a key in the llocal/remote index could be unpacked into `prefix, filename` i.e. that the file was in a single dir one level deeper than the index url.
This currently works with our architecture, but prevents us from reusing the code for other repositories with a flat of deeper dir structure.

##### Description of changes
Leave `file_path` unpacked (a tuple) and extract prefix and filename in a more general way.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
