### PR TITLE
Variable: Add sparse flag

### DIFF
--- a/Orange/preprocess/continuize.py
+++ b/Orange/preprocess/continuize.py
@@ -25,14 +25,19 @@ class DomainContinuizer(_RefuseDataInConstructor, Reprable):
                 return []
             if treat == Continuize.AsOrdinal:
                 new_var = ContinuousVariable(var.name,
-                                             compute_value=Identity(var))
+                                             compute_value=Identity(var),
+                                             sparse=var.sparse)
                 return [new_var]
             if treat == Continuize.AsNormalizedOrdinal:
                 n_values = max(1, len(var.values))
                 if self.zero_based:
-                    return [ContinuousVariable(var.name, compute_value=Normalizer(var, 0, 1 / (n_values - 1)))]
+                    return [ContinuousVariable(var.name,
+                                               compute_value=Normalizer(var, 0, 1 / (n_values - 1)),
+                                               sparse=var.sparse)]
                 else:
-                    return [ContinuousVariable(var.name, compute_value=Normalizer(var, (n_values - 1) / 2, 2 / (n_values - 1)))]
+                    return [ContinuousVariable(var.name,
+                                               compute_value=Normalizer(var, (n_values - 1) / 2, 2 / (n_values - 1)),
+                                               sparse=var.sparse)]
 
             new_vars = []
             if treat == Continuize.Indicators:
@@ -48,7 +53,8 @@ class DomainContinuizer(_RefuseDataInConstructor, Reprable):
                     continue
                 new_var = ContinuousVariable(
                     "{}={}".format(var.name, val),
-                    compute_value=ind_class(var, i))
+                    compute_value=ind_class(var, i),
+                    sparse=var.sparse)
                 new_vars.append(new_var)
             return new_vars
 

--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -73,7 +73,8 @@ class Discretizer(Transformation):
             to_sql = SingleValueSql(values[0])
 
         dvar = DiscreteVariable(name=var.name, values=values,
-                                compute_value=cls(var, points))
+                                compute_value=cls(var, points),
+                                sparse=var.sparse)
         dvar.source_variable = var
         dvar.to_sql = to_sql
         return dvar

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -246,7 +246,8 @@ class AsValue(BaseImputeMethod):
                 compute_value=Lookup(
                     variable,
                     np.arange(len(variable.values), dtype=int),
-                    unknown=len(variable.values))
+                    unknown=len(variable.values)),
+                sparse=variable.sparse,
                 )
             return var
 
@@ -255,7 +256,9 @@ class AsValue(BaseImputeMethod):
             indicator_var = Orange.data.DiscreteVariable(
                 fmt.format(var=variable),
                 values=("undef", "def"),
-                compute_value=IsDefined(variable))
+                compute_value=IsDefined(variable),
+                sparse=variable.sparse,
+            )
             stats = basic_stats.BasicStats(data, variable)
             return (variable.copy(compute_value=ReplaceUnknowns(variable,
                                                                 stats.mean)),

--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -42,7 +42,7 @@ class Normalizer(Reprable):
         avg, sd = (dist.mean(), dist.standard_deviation()) if dist.size else (0, 1)
         if sd == 0:
             sd = 1
-        return ContinuousVariable(var.name, compute_value=Norm(var, avg, 1 / sd))
+        return ContinuousVariable(var.name, compute_value=Norm(var, avg, 1 / sd), sparse=var.sparse)
 
     def normalize_by_span(self, dist, var):
         dma, dmi = dist.max(), dist.min()
@@ -50,6 +50,6 @@ class Normalizer(Reprable):
         if diff < 1e-15:
             diff = 1
         if self.zero_based:
-            return ContinuousVariable(var.name, compute_value=Norm(var, dmi, 1 / diff))
+            return ContinuousVariable(var.name, compute_value=Norm(var, dmi, 1 / diff), sparse=var.sparse)
         else:
-            return ContinuousVariable(var.name, compute_value=Norm(var, (dma + dmi) / 2, 2 / diff))
+            return ContinuousVariable(var.name, compute_value=Norm(var, (dma + dmi) / 2, 2 / diff), sparse=var.sparse)

--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -1,9 +1,8 @@
 from Orange.data import ContinuousVariable, Domain
 from Orange.statistics import distribution
-from .transformation import Normalizer as Norm
-from .preprocess import Normalize
 from Orange.util import Reprable
-import warnings
+from .preprocess import Normalize
+from .transformation import Normalizer as Norm
 
 __all__ = ["Normalizer"]
 

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -170,7 +170,9 @@ def merge_transforms(exp):
                 exp.var.name,
                 values=exp.var.values,
                 ordered=exp.var.ordered,
-                compute_value=merge_lookup(A, B))
+                compute_value=merge_lookup(A, B),
+                sparse=exp.var.sparse,
+            )
             assert isinstance(prev.sub, Var)
             return Transformed(prev.sub, new_var)
         else:
@@ -253,7 +255,8 @@ def remove_unused_values(var, data):
     return DiscreteVariable("{}".format(var.name),
                             values=used_values,
                             base_value=base_value,
-                            compute_value=Lookup(var, translation_table)
+                            compute_value=Lookup(var, translation_table),
+                            sparse=var.sparse,
                             )
 
 
@@ -268,7 +271,8 @@ def sort_var_values(var):
     )
 
     return DiscreteVariable(var.name, values=newvalues,
-                            compute_value=Lookup(var, translation_table))
+                            compute_value=Lookup(var, translation_table),
+                            sparse=var.sparse)
 
 
 def merge_lookup(A, B):

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -118,6 +118,7 @@ class TestDiscretizer(TestCase):
     def setUp(self):
         self.var = Mock(data.ContinuousVariable, number_of_decimals=1)
         self.var.name = "x"
+        self.var.sparse = False
 
     def test_create_discretized_var(self):
         dvar = discretize.Discretizer.create_discretized_var(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

In order to properly support sparse features, this PR introduces the `Variable.sparse` flag, which indicates that the variable suggests to be stored in sparse format.

##### Description of changes
* Add `sparse` flag to variables.
* When copying variables, copy the sparse flag as well. This is far from correct, but it should do for a start.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
