### PR TITLE
[FIX] Predictions: space added before bracket in meta name.

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -499,7 +499,7 @@ class OWPredictions(OWWidget):
             newcolumns += [p.results[0].reshape((-1, 1)) for p in slots]
 
         if self.output_probabilities:
-            newmetas += [ContinuousVariable(name="%s(%s)" % (p.name, value))
+            newmetas += [ContinuousVariable(name="%s (%s)" % (p.name, value))
                          for p in slots for value in self.class_values]
             newcolumns += [p.results[1] for p in slots]
         return newmetas, newcolumns


### PR DESCRIPTION
##### Issue

Missing space before "(" in the name of the meta variable when concatenating the classifier name and the class name.

##### Description of changes

Space added before "("

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
