### PR TITLE
[FIX] Rank: should not fail on data with no attributes

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -285,7 +285,7 @@ class OWRank(OWWidget):
 
     @Inputs.data
     @check_sql_input
-    def setData(self, data):
+    def set_data(self, data):
         self.closeContext()
         self.selected_rows = []
         self.ranksModel.clear()

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -193,6 +193,7 @@ class OWRank(OWWidget):
     class Error(OWWidget.Error):
         invalid_type = Msg("Cannot handle target variable type {}")
         inadequate_learner = Msg("Scorer {} inadequate: {}")
+        no_attributes = Msg("Data does not have a single attribute.")
 
     def __init__(self):
         super().__init__()
@@ -299,6 +300,9 @@ class OWRank(OWWidget):
         self.Information.missings_imputed(
             shown=data is not None and data.has_missing())
 
+        if data is not None and not len(data.domain.attributes):
+            data = None
+            self.Error.no_attributes()
         self.data = data
         self.switchProblemType(ProblemType.CLASSIFICATION)
         if self.data is not None:

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -325,3 +325,17 @@ class TestOWRank(WidgetTest):
         reduced_data = self.get_output(widget.Outputs.reduced_data)
         self.assertEqual(reduced_data.domain.attributes,
                          (self.iris.domain["petal length"], ))
+
+    def test_no_attributes(self):
+        """
+        Rank should not fail on data with no attributes.
+        GH-2745
+        """
+        data = Table("iris")[::30]
+        domain = Domain(attributes=[], class_vars=data.domain.class_vars)
+        new_data = data.transform(domain)
+        self.assertFalse(self.widget.Error.no_attributes.is_shown())
+        self.send_signal(self.widget.Inputs.data, new_data)
+        self.assertTrue(self.widget.Error.no_attributes.is_shown())
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertFalse(self.widget.Error.no_attributes.is_shown())


### PR DESCRIPTION
##### Issue
Sending data without attributes results in a crashed **Rank** widget.

##### Description of changes
Error is shown.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
