### PR TITLE
[FIX] Test & Learn: do not crash on a data with class only nans

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -206,6 +206,7 @@ class OWTestLearners(OWWidget):
         class_inconsistent = Msg("Test and train data sets "
                                  "have different target variables.")
         memory_error = Msg("Not enough memory.")
+        no_class_values = Msg("Target variable has no values.")
         only_one_class_var_value = Msg("Target variable has only one value.")
 
     class Warning(OWWidget.Warning):
@@ -356,6 +357,7 @@ class OWTestLearners(OWWidget):
         self.Error.train_data_empty.clear()
         self.Error.class_required.clear()
         self.Error.too_many_classes.clear()
+        self.Error.no_class_values.clear()
         self.Error.only_one_class_var_value.clear()
         if data is not None and not len(data):
             self.Error.train_data_empty()
@@ -363,9 +365,11 @@ class OWTestLearners(OWWidget):
         if data:
             conds = [not data.domain.class_vars,
                      len(data.domain.class_vars) > 1,
+                     np.isnan(data.Y).all(),
                      data.domain.has_discrete_class and len(data.domain.class_var.values) == 1]
             errors = [self.Error.class_required,
                       self.Error.too_many_classes,
+                      self.Error.no_class_values,
                       self.Error.only_one_class_var_value]
             for cond, error in zip(conds, errors):
                 if cond:

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -195,6 +195,21 @@ class TestOWTestLearners(WidgetTest):
         self.send_signal("Learner", MajorityLearner(), 0, wait=1000)
         self.assertTrue(self.widget.Error.only_one_class_var_value.is_shown())
 
+    def test_nan_class(self):
+        """
+        Do not crash on a data with only nan class values.
+        GH-2751
+        """
+        def assertErrorShown(data, is_shown):
+            self.send_signal("Data", data)
+            self.assertEqual(is_shown, self.widget.Error.no_class_values.is_shown())
+
+        data = Table("iris")[::30]
+        data.Y[:] = np.nan
+
+        for data, is_shown in zip([None, data, Table("iris")[:30]], [False, True, False]):
+            assertErrorShown(data, is_shown)
+
     def test_addon_scorers(self):
         try:
             class NewScore(Score):


### PR DESCRIPTION
##### Issue
Widget **Test & Learn** crashes when receives data with a class which has only `nan` values. This is because all data is removed and `Table` suddenly has length `0`.

##### Description of changes
The data is set to `None` when its length is `0`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
