### PR TITLE
[NOMERGE] Revert "itemmodels.AbstractSortTableModel: Fix mapFromSourceRows"

### DIFF
--- a/Orange/canvas/report/tests/test_report.py
+++ b/Orange/canvas/report/tests/test_report.py
@@ -65,6 +65,7 @@ VISUALIZATION_WIDGETS = get_owwidgets('Orange.widgets.visualize')
 MODEL_WIDGETS = get_owwidgets('Orange.widgets.model')
 
 
+@unittest.skipIf(os.environ.get('APPVEYOR'), 'Segfaults on Appveyor')
 class TestReport(WidgetTest):
     def test_report(self):
         count = 5
@@ -152,6 +153,7 @@ class TestReport(WidgetTest):
             os.rmdir(temp_dir)
 
 
+@unittest.skipIf(os.environ.get('APPVEYOR'), 'Segfaults on Appveyor')
 class TestReportWidgets(WidgetTest):
     model_widgets = MODEL_WIDGETS
     data_widgets = DATA_WIDGETS

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -118,7 +118,7 @@ class AbstractSortTableModel(QAbstractTableModel):
 
         Parameters
         ----------
-        rows : int or list of int or numpy.ndarray of dtype=int or Ellipsis
+        rows : int or list of int or numpy.ndarray or Ellipsis
             View (sorted) rows.
 
         Returns
@@ -127,10 +127,7 @@ class AbstractSortTableModel(QAbstractTableModel):
             Source rows matching input rows. If they are the same,
             simply input `rows` is returned.
         """
-        # self.__sortInd[rows] fails if `rows` is an empty list or array
-        if self.__sortInd is not None \
-                and (isinstance(rows, (Integral, type(Ellipsis)))
-                     or len(rows)):
+        if self.__sortInd is not None:
             new_rows = self.__sortInd[rows]
             if rows is Ellipsis:
                 new_rows.setflags(write=False)
@@ -142,7 +139,7 @@ class AbstractSortTableModel(QAbstractTableModel):
 
         Parameters
         ----------
-        rows : int or list of int or numpy.ndarray of dtype=int or Ellipsis
+        rows : int or list of int or numpy.ndarray or Ellipsis
             Source model rows.
 
         Returns
@@ -151,10 +148,7 @@ class AbstractSortTableModel(QAbstractTableModel):
             ModelIndex (sorted) rows matching input source rows.
             If they are the same, simply input `rows` is returned.
         """
-        # self.__sortInd[rows] fails if `rows` is an empty list or array
-        if self.__sortIndInv is not None \
-                and (isinstance(rows, (Integral, type(Ellipsis)))
-                     or len(rows)):
+        if self.__sortIndInv is not None:
             new_rows = self.__sortIndInv[rows]
             if rows is Ellipsis:
                 new_rows.setflags(write=False)

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -3,8 +3,6 @@
 
 from unittest import TestCase
 
-import numpy as np
-
 from AnyQt.QtCore import Qt
 
 from Orange.data import Domain, ContinuousVariable, DiscreteVariable
@@ -123,31 +121,17 @@ class TestPyTableModel(TestCase):
 
 
 class TestAbstractSortTableModel(TestCase):
-    def test_sorting(self):
+    def setUp(self):
         assert issubclass(PyTableModel, AbstractSortTableModel)
-        model = PyTableModel([[1, 4],
-                              [2, 2],
-                              [3, 3]])
-        model.sort(1, Qt.AscendingOrder)
-        # mapToSourceRows
-        self.assertSequenceEqual(model.mapToSourceRows(...).tolist(), [1, 2, 0])
-        self.assertEqual(model.mapToSourceRows(1).tolist(), 2)
-        self.assertSequenceEqual(model.mapToSourceRows([1, 2]).tolist(), [2, 0])
-        self.assertSequenceEqual(model.mapToSourceRows([]), [])
-        self.assertSequenceEqual(model.mapToSourceRows(np.array([], dtype=int)).tolist(), [])
-        self.assertRaises(IndexError, model.mapToSourceRows, np.r_[0.])
+        self.model = PyTableModel([[1, 4],
+                                   [2, 3]])
 
-        # mapFromSourceRows
-        self.assertSequenceEqual(model.mapFromSourceRows(...).tolist(), [2, 0, 1])
-        self.assertEqual(model.mapFromSourceRows(1).tolist(), 0)
-        self.assertSequenceEqual(model.mapFromSourceRows([1, 2]).tolist(), [0, 1])
-        self.assertSequenceEqual(model.mapFromSourceRows([]), [])
-        self.assertSequenceEqual(model.mapFromSourceRows(np.array([], dtype=int)).tolist(), [])
-        self.assertRaises(IndexError, model.mapFromSourceRows, np.r_[0.])
+    def test_sorting(self):
+        self.model.sort(1, Qt.AscendingOrder)
+        self.assertSequenceEqual(self.model.mapToSourceRows(...).tolist(), [1, 0])
 
-        model.sort(1, Qt.DescendingOrder)
-        self.assertSequenceEqual(model.mapToSourceRows(...).tolist(), [0, 2, 1])
-        self.assertSequenceEqual(model.mapFromSourceRows(...).tolist(), [0, 2, 1])
+        self.model.sort(1, Qt.DescendingOrder)
+        self.assertSequenceEqual(self.model.mapToSourceRows(...).tolist(), [0, 1])
 
 
 class TestPyListModel(TestCase):

--- a/Orange/widgets/utils/tests/test_webview.py
+++ b/Orange/widgets/utils/tests/test_webview.py
@@ -1,4 +1,6 @@
 import time
+import unittest
+import os
 from os.path import dirname
 
 from AnyQt.QtCore import Qt, QObject, pyqtSlot
@@ -11,6 +13,7 @@ from Orange.widgets.utils.webview import WebviewWidget, HAVE_WEBKIT, wait
 SOME_URL = WebviewWidget.toFileURL(dirname(__file__))
 
 
+@unittest.skipIf(os.environ.get('APPVEYOR'), 'Segfaults on Appveyor')
 class WebviewWidgetTest(WidgetTest):
     def test_base(self):
         w = WebviewWidget()

--- a/Orange/widgets/visualize/tests/test_owmap.py
+++ b/Orange/widgets/visualize/tests/test_owmap.py
@@ -1,3 +1,4 @@
+import os
 import time
 import unittest
 import numpy as np
@@ -16,6 +17,7 @@ except RuntimeError:
 
 
 @unittest.skipIf(QT_TOO_OLD, "not supported in Qt <5.3")
+@unittest.skipIf(os.environ.get('APPVEYOR'), 'Segfaults on Appveyor')
 class TestOWMap(WidgetTest):
     @classmethod
     def setUpClass(cls):

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import os
 import time
 import unittest
 
@@ -96,12 +97,14 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, None)
         assertCount(1, [0, 0, 0, 0], 0)
 
+
 # Derive from WidgetTest to simplify creation of the Mosaic widget, although
 # we are actually testing the MosaicVizRank dialog and not the widget
 
 # These tests are rather crude: the main challenge of this widget is to handle
 # user interactions and interrupts, e.g. changing the widget settings or
 # getting new data while the computation is running.
+@unittest.skipIf(os.environ.get('APPVEYOR'), 'Segfaults on Appveyor')
 class MosaicVizRankTests(WidgetTest):
     @classmethod
     def setUpClass(cls):
@@ -219,7 +222,7 @@ class MosaicVizRankTests(WidgetTest):
             item.data(self.vizrank._AttrRole),
             tuple(self.vizrank.attr_ordering[i] for i in [0, 1, 3]))
 
-    @unittest.skip("Appveyor sometimes fails.")
+    @unittest.skip("This fails.")  # FIXME
     def test_does_not_crash(self):
         """MosaicVizrank computes rankings without crashing"""
         widget = self.widget

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -1,6 +1,8 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import os
 from math import isnan
+import unittest
 from unittest.mock import patch
 import numpy as np
 import scipy.sparse as sp
@@ -15,6 +17,7 @@ from Orange.widgets.visualize.owsieve import ChiSqStats
 from Orange.widgets.visualize.owsieve import Discretize
 
 
+@unittest.skipIf(os.environ.get('APPVEYOR'), 'Segfaults on Appveyor')
 class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
5854208ff56968218b13431784cb8fb1eb1b17cb is the first commit where AppVeyor started consistently failing. Submitted against my better judgment, this should wholly exclude that commit being at fault.