### PR TITLE
[FIX] Canvas: Palette propagation

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -250,8 +250,8 @@ class CanvasMainWindow(QMainWindow):
 
         # Bottom tool bar
         self.canvas_toolbar = canvas_tool_dock.toolbar
-        self.canvas_toolbar.setIconSize(QSize(25, 25))
-        self.canvas_toolbar.setFixedHeight(28)
+        self.canvas_toolbar.setIconSize(QSize(24, 24))
+        self.canvas_toolbar.setMinimumHeight(28)
         self.canvas_toolbar.layout().setSpacing(1)
 
         # Widgets tool box

--- a/Orange/canvas/application/widgettoolbox.py
+++ b/Orange/canvas/application/widgettoolbox.py
@@ -381,20 +381,26 @@ class WidgetToolBox(ToolBox):
         self.insertItem(index, grid, text, icon, tooltip)
         button = self.tabButton(index)
 
-        # Set the 'highlight' color
+        # Set the 'highlight' color if applicable
+        highlight = None
+        highlight_foreground = None
         if item.data(Qt.BackgroundRole) is not None:
-            brush = item.background()
+            highlight = item.background()
         elif item.data(QtWidgetRegistry.BACKGROUND_ROLE) is not None:
-            brush = item.data(QtWidgetRegistry.BACKGROUND_ROLE)
-        else:
-            brush = self.palette().brush(QPalette.Button)
+            highlight = item.data(QtWidgetRegistry.BACKGROUND_ROLE)
 
-        if not brush.gradient():
-            gradient = create_gradient(brush.color())
-            brush = QBrush(gradient)
+        if isinstance(highlight, QBrush) and highlight.style() != Qt.NoBrush:
+            if not highlight.gradient():
+                value = highlight.color().value()
+                gradient = create_gradient(highlight.color())
+                highlight = QBrush(gradient)
+                highlight_foreground = Qt.black if value > 128 else Qt.white
 
         palette = button.palette()
-        palette.setBrush(QPalette.Highlight, brush)
+        if highlight is not None:
+            palette.setBrush(QPalette.Highlight, highlight)
+        if highlight_foreground is not None:
+            palette.setBrush(QPalette.HighlightedText, highlight_foreground)
         button.setPalette(palette)
 
     def __on_itemChanged(self, item):

--- a/Orange/canvas/canvas/items/annotationitem.py
+++ b/Orange/canvas/canvas/items/annotationitem.py
@@ -11,7 +11,8 @@ from AnyQt.QtWidgets import (
     QGraphicsDropShadowEffect, QMenu, QAction, QActionGroup
 )
 from AnyQt.QtGui import (
-    QPainterPath, QPainterPathStroker, QPolygonF, QColor, QPen, QBrush
+    QPainterPath, QPainterPathStroker, QPolygonF, QColor, QPen, QBrush,
+    QPalette
 )
 from AnyQt.QtCore import (
     Qt, QPointF, QSizeF, QRectF, QLineF, QEvent, QMetaObject, QT_VERSION
@@ -269,6 +270,9 @@ class TextAnnotation(Annotation):
         self.__textItem.setTextInteractionFlags(self.__defaultInteractionFlags)
         self.__textItem.setFont(self.font())
         self.__textItem.editingFinished.connect(self.__textEditingFinished)
+        self.__textItem.setDefaultTextColor(
+            self.palette().color(QPalette.Text)
+        )
         if self.__textItem.scene() is not None:
             self.__textItem.installSceneEventFilter(self)
         layout = self.__textItem.document().documentLayout()
@@ -481,7 +485,10 @@ class TextAnnotation(Annotation):
     def changeEvent(self, event):
         if event.type() == QEvent.FontChange:
             self.__textItem.setFont(self.font())
-
+        elif event.type() == QEvent.PaletteChange:
+            self.__textItem.setDefaultTextColor(
+                self.palette().color(QPalette.Text)
+            )
         Annotation.changeEvent(self, event)
 
     @Slot()

--- a/Orange/canvas/canvas/scene.py
+++ b/Orange/canvas/canvas/scene.py
@@ -12,10 +12,12 @@ from operator import attrgetter
 
 from xml.sax.saxutils import escape
 
-from AnyQt.QtWidgets import QGraphicsScene, QGraphicsItem, QGraphicsObject
-from AnyQt.QtGui import QPainter, QBrush, QColor, QFont
-from AnyQt.QtCore import Qt, QPointF, QRectF, QSizeF, QLineF, QBuffer, \
-                         QEvent, QObject, QSignalMapper, QT_VERSION
+from AnyQt.QtWidgets import QGraphicsScene, QGraphicsItem
+from AnyQt.QtGui import QPainter, QColor, QFont
+from AnyQt.QtCore import (
+    Qt, QPointF, QRectF, QSizeF, QLineF, QBuffer, QObject, QSignalMapper,
+    QT_VERSION
+)
 from AnyQt.QtSvg import QSvgGenerator
 from AnyQt.QtCore import pyqtSignal as Signal
 try:
@@ -938,7 +940,7 @@ def grab_svg(scene):
     painter = QPainter(gen)
 
     # Draw background.
-    painter.setBrush(QBrush(Qt.white))
+    painter.setBrush(scene.palette().base())
     painter.drawRect(target_rect)
 
     # Render the scene

--- a/Orange/canvas/canvas/scene.py
+++ b/Orange/canvas/canvas/scene.py
@@ -869,19 +869,6 @@ class CanvasScene(QGraphicsScene):
         if handler:
             handler.start()
 
-    def event(self, event):
-        # TODO: change the base class of Node/LinkItem to QGraphicsWidget.
-        # It already handles font changes.
-        if event.type() == QEvent.FontChange:
-            self.__update_font()
-
-        return QGraphicsScene.event(self, event)
-
-    def __update_font(self):
-        font = self.font()
-        for item in self.__node_items + self.__link_items:
-            item.setFont(font)
-
     def __str__(self):
         return "%s(objectName=%r, ...)" % \
                 (type(self).__name__, str(self.objectName()))

--- a/Orange/canvas/document/editlinksdialog.py
+++ b/Orange/canvas/document/editlinksdialog.py
@@ -283,7 +283,7 @@ class LinksEditWidget(QGraphicsWidget):
                 line.setLine(start.x(), start.y(),
                              event.pos().x(), event.pos().y())
 
-                pen = QPen(Qt.black, 4)
+                pen = QPen(self.palette().color(QPalette.Foreground), 4)
                 pen.setCapStyle(Qt.RoundCap)
                 line.setPen(pen)
                 line.show()
@@ -361,7 +361,7 @@ class LinksEditWidget(QGraphicsWidget):
         sink_pos = self.mapFromItem(sink_anchor, sink_pos)
         line.setLine(source_pos.x(), source_pos.y(),
                      sink_pos.x(), sink_pos.y())
-        pen = QPen(Qt.black, 4)
+        pen = QPen(self.palette().color(QPalette.Foreground), 4)
         pen.setCapStyle(Qt.RoundCap)
         line.setPen(pen)
 

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -22,7 +22,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtGui import (
     QKeySequence, QCursor, QFont, QPainter, QPixmap, QColor, QBrush, QIcon,
-    QWhatsThisClickedEvent
+    QWhatsThisClickedEvent, QPalette
 )
 
 from AnyQt.QtCore import (
@@ -399,7 +399,7 @@ class SchemeEditWidget(QWidget):
         )
 
         scene.setFont(self.font())
-
+        scene.setPalette(self.palette())
         scene.installEventFilter(self)
 
         scene.set_registry(self.__registry)
@@ -977,6 +977,9 @@ class SchemeEditWidget(QWidget):
     def changeEvent(self, event):
         if event.type() == QEvent.FontChange:
             self.__updateFont()
+        elif event.type() == QEvent.PaletteChange:
+            if self.__scene is not None:
+                self.__scene.setPalette(self.palette())
 
         QWidget.changeEvent(self, event)
 

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -21,7 +21,7 @@ from AnyQt.QtWidgets import (
     QGraphicsTextItem
 )
 from AnyQt.QtGui import (
-    QKeySequence, QCursor, QFont, QPainter, QPixmap, QColor, QBrush, QIcon,
+    QKeySequence, QCursor, QFont, QPainter, QPixmap, QColor, QIcon,
     QWhatsThisClickedEvent, QPalette
 )
 
@@ -1657,11 +1657,10 @@ class SchemeEditWidget(QWidget):
 
     def __signalManagerStateChanged(self, state):
         if state == signalmanager.SignalManager.Running:
-            self.__view.setBackgroundBrush(QBrush(Qt.NoBrush))
-#            self.__view.setBackgroundIcon(QIcon())
-        elif state == signalmanager.SignalManager.Paused:
-            self.__view.setBackgroundBrush(QBrush(QColor(235, 235, 235)))
-#            self.__view.setBackgroundIcon(QIcon("canvas_icons:Pause.svg"))
+            role = QPalette.Base
+        else:
+            role = QPalette.Window
+        self.__view.viewport().setBackgroundRole(role)
 
 
 def geometry_from_annotation_item(item):

--- a/Orange/canvas/gui/dropshadow.py
+++ b/Orange/canvas/gui/dropshadow.py
@@ -58,17 +58,14 @@ class DropShadowFrame(QWidget):
         Shadow radius.
 
     """
-    def __init__(self, parent=None, color=None, radius=5,
+    def __init__(self, parent=None, color=QColor(), radius=5,
                  **kwargs):
         QWidget.__init__(self, parent, **kwargs)
         self.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         self.setAttribute(Qt.WA_NoChildEventsForParent, True)
         self.setFocusPolicy(Qt.NoFocus)
 
-        if color is None:
-            color = self.palette().color(QPalette.Dark)
-
-        self.__color = color
+        self.__color = QColor(color)
         self.__radius = radius
 
         self.__widget = None
@@ -89,8 +86,14 @@ class DropShadowFrame(QWidget):
     def color(self):
         """
         Return the color of the drop shadow.
+
+        By default this is a color from the `palette` (for
+        `self.foregroundRole()`)
         """
-        return QColor(self.__color)
+        if self.__color.isValid():
+            return QColor(self.__color)
+        else:
+            return self.palette().color(self.foregroundRole())
 
     color_ = Property(QColor, fget=color, fset=setColor, designable=True,
                       doc="Drop shadow color")

--- a/Orange/canvas/gui/toolbox.py
+++ b/Orange/canvas/gui/toolbox.py
@@ -84,6 +84,14 @@ class ToolBoxTabButton(QToolButton):
         else:
             self.setPalette(palette)
 
+    def enterEvent(self, event):
+        super().enterEvent(event)
+        self.update()
+
+    def leaveEvent(self, event):
+        super().leaveEvent(event)
+        self.update()
+
     def paintEvent(self, event):
         if self.__nativeStyling:
             QToolButton.paintEvent(self, event)
@@ -101,13 +109,17 @@ class ToolBoxTabButton(QToolButton):
         # highlight brush is used as the background for the icon and background
         # when the tab is expanded and as mouse hover color (lighter).
         brush_highlight = palette.highlight()
+        foregroundrole = QPalette.ButtonText
         if opt.state & QStyle.State_Sunken:
             # State 'down' pressed during a mouse press (slightly darker).
             background_brush = brush_darker(brush_highlight, 110)
+            foregroundrole = QPalette.HighlightedText
         elif opt.state & QStyle.State_MouseOver:
             background_brush = brush_darker(brush_highlight, 95)
+            foregroundrole = QPalette.HighlightedText
         elif opt.state & QStyle.State_On:
             background_brush = brush_highlight
+            foregroundrole = QPalette.HighlightedText
         else:
             # The default button brush.
             background_brush = palette.button()
@@ -167,7 +179,7 @@ class ToolBoxTabButton(QToolButton):
 
         p.save()
         text = fm.elidedText(opt.text, Qt.ElideRight, text_rect.width())
-        p.setPen(QPen(palette.color(QPalette.ButtonText)))
+        p.setPen(QPen(palette.color(foregroundrole)))
         p.setFont(opt.font)
 
         p.drawText(text_rect,

--- a/Orange/canvas/gui/toolbox.py
+++ b/Orange/canvas/gui/toolbox.py
@@ -14,7 +14,7 @@ from operator import eq, attrgetter
 from AnyQt.QtWidgets import (
     QWidget, QFrame, QSizePolicy, QStyle, QStyleOptionToolButton,
     QStyleOptionToolBox, QScrollArea, QVBoxLayout, QToolButton,
-    QAction, QActionGroup
+    QAction, QActionGroup, QApplication
 )
 from AnyQt.QtGui import (
     QIcon, QFontMetrics, QPainter, QPalette, QBrush, QPen, QColor,
@@ -68,8 +68,21 @@ class ToolBoxTabButton(QToolButton):
         self.__nativeStyling = False
         self.position = QStyleOptionToolBox.OnlyOneTab
         self.selected = QStyleOptionToolBox.NotAdjacent
+        font = kwargs.pop("font", None)
+        palette = kwargs.pop("palette", None)
 
         QToolButton.__init__(self, *args, **kwargs)
+
+        if font is None:
+            self.setFont(QApplication.font("QAbstractButton"))
+            self.setAttribute(Qt.WA_SetFont, False)
+        else:
+            self.setFont(font)
+        if palette is None:
+            self.setPalette(QApplication.palette("QAbstractButton"))
+            self.setAttribute(Qt.WA_SetPalette, False)
+        else:
+            self.setPalette(palette)
 
     def paintEvent(self, event):
         if self.__nativeStyling:

--- a/Orange/canvas/styles/darkorange.qss
+++ b/Orange/canvas/styles/darkorange.qss
@@ -1,0 +1,9 @@
+
+@canvas_icons: orange;
+
+CanvasToolDock QToolBar QToolButton:menu-indicator {
+    image: url(canvas_icons:/Dropdown.svg);
+    subcontrol-position: top right;
+    height: 8px;
+    width: 8px;
+}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Canvas conflicts with dark theme/styles, e.g:

<img width="1012" alt="screen shot 2017-11-09 at 17 51 11" src="https://user-images.githubusercontent.com/4716745/32618391-e76a23d2-c577-11e7-9f74-45fe942d9540.png">

##### Description of changes

* Propagate the palette in the canvas where applicable
* Use palette's colors instead of hardcoded ones
* Add an option to specify --style=fusion:breeze-dark (the palette's colors are taken from KDE's t 'Breeze Dark' theme). **This is mostly just for testing, the fusion style is not a good with dark color themes**
* Suppress the default 'orange' styling in the main window if the application palette is to dark.

<s>If deemed necessary a GUI option in the preferences dialog can also be added to select the style.</s>


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
