### PR TITLE
[FIX] Nomogram on PyQt4

### DIFF
--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -8,7 +8,7 @@ from AnyQt.QtWidgets import (
     QGraphicsView, QGraphicsScene, QGraphicsItem, QGraphicsSimpleTextItem,
     QGraphicsTextItem, QGraphicsLineItem, QGraphicsWidget, QGraphicsRectItem,
     QGraphicsEllipseItem, QGraphicsLinearLayout, QGridLayout, QLabel, QFrame,
-    QSizePolicy, QApplication,
+    QSizePolicy, QApplication, QDesktopWidget,
 )
 from AnyQt.QtGui import QColor, QPainter, QFont, QPen, QBrush
 from AnyQt.QtCore import Qt, QRectF, QSize
@@ -50,7 +50,7 @@ class MovableToolTip(QLabel):
         self.adjustSize()
 
         x, y = pos.x(), (pos.y() + 15 if change_y else self.y())
-        avail = QApplication.focusWindow().screen().availableGeometry()
+        avail = QDesktopWidget().availableGeometry(self)
         if x + self.width() > avail.right():
             x -= self.width()
         if y + self.height() > avail.bottom():
@@ -113,7 +113,7 @@ class ProbabilitiesDotItem(DotItem):
         self.setBrush(QColor(150, 150, 150, 255))
         self.setPen(QPen(QBrush(QColor(75, 75, 75, 255)), 2))
 
-    def move_to_sum(self, invisible_sum: float=None):
+    def move_to_sum(self, invisible_sum: float = None):
         total = sum(item.value for item in self.movable_dot_items)
 
         if invisible_sum is not None:

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -2,13 +2,16 @@
 # pylint: disable=missing-docstring
 import numpy as np
 
+from AnyQt.QtCore import QPoint
+
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.classification import (
     NaiveBayesLearner, LogisticRegressionLearner, MajorityLearner
 )
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.visualize.ownomogram import (
-    OWNomogram, DiscreteFeatureItem, ContinuousFeatureItem, ProbabilitiesDotItem
+    OWNomogram, DiscreteFeatureItem, ContinuousFeatureItem, ProbabilitiesDotItem,
+    MovableToolTip
 )
 
 
@@ -201,3 +204,8 @@ class TestOWNomogram(WidgetTest):
             ordered = [self.widget.nomogram_main.layout().itemAt(i).childItems()[0].toPlainText()
                        for i in range(self.widget.nomogram_main.layout().count())]
             self.assertListEqual(names[i], ordered)
+
+    def test_tooltip(self):
+        # had problems on PyQt4
+        m = MovableToolTip()
+        m.show(QPoint(0, 0), "Some text.")


### PR DESCRIPTION
##### Issue
* Nomogram tooltips crashing on PyQt4.


##### Description of changes
Fixed.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
