### PR TITLE
[FIX] Broken installation of Installation of wheels

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -815,7 +815,11 @@ class PipInstaller:
         cmd = ["python", "-m", "pip", "install"]
         if self.user_install:
             cmd.append("--user")
-        cmd.append(pkg.name)
+        if pkg.package_url.startswith("http://"):
+            cmd.append(pkg.name)
+        else:
+            # Package url is path to the (local) wheel
+            cmd.append(pkg.package_url)
 
         run_command(cmd)
 


### PR DESCRIPTION
##### Issue
Installation of add-ons with dragging of wheels to the add-ons dialog broke in 3.7


##### Description of changes
Fix it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
