### PR TITLE
DomainModel: Prevent modification except through set_domain

### DIFF
--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -352,7 +352,7 @@ class DiscreteVariableEditor(VariableEditor):
         """Clear the model state.
         """
         VariableEditor.clear(self)
-        self.values_model.wrap([])
+        self.values_model.clear()
 
     @Slot()
     def on_values_changed(self):

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -716,7 +716,7 @@ class ColoredListModel(itemmodels.PyListModel):
             len(colorpalette.DefaultRGBColors))
 
     def data(self, index, role=Qt.DisplayRole):
-        if self._is_index_valid_for(index, self) and \
+        if self._is_index_valid(index) and \
                 role == Qt.DecorationRole and \
                 0 <= index.row() < self.colors.number_of_colors:
             return gui.createAttributePixmap("", self.colors[index.row()])

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -216,6 +216,8 @@ class OWMDS(OWWidget):
         g = self.graph.gui
         box = g.point_properties_box(self.controlArea)
         self.models = g.points_models
+        self.models[2].order = \
+            self.models[2].order[:1] + ("Stress", ) + self.models[2].order[1:]
 
         gui.hSlider(box, self, "connected_pairs", label="Show similar pairs:", minValue=0,
                     maxValue=20, createLabel=False, callback=self._on_connected_changed)
@@ -270,7 +272,6 @@ class OWMDS(OWWidget):
         self.graph.attr_shape = None
         self.graph.attr_size = None
         self.graph.attr_label = None
-        self.models[2][:] = self.models[2][0:1] + ["Stress"] + self.models[2][1:]
 
     def prepare_data(self):
         pass

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -867,11 +867,6 @@ class VariableListModel(PyListModel):
         text += self.variable_labels_tooltip(var)
         return text
 
-    def python_variable_tooltip(self, var):
-        text = "<b>%s</b><br/>Python" % safe_text(var.name)
-        text += self.variable_labels_tooltip(var)
-        return text
-
 
 class DomainModel(VariableListModel):
     ATTRIBUTES, CLASSES, METAS = 1, 2, 4

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -10,7 +10,7 @@ from warnings import warn
 from xml.sax.saxutils import escape
 
 from AnyQt.QtCore import (
-    Qt, QAbstractListModel, QAbstractTableModel, QModelIndex,
+    Qt, QObject, QAbstractListModel, QAbstractTableModel, QModelIndex,
     QItemSelectionModel
 )
 from AnyQt.QtCore import pyqtSignal as Signal
@@ -668,7 +668,8 @@ class PyListModel(QAbstractListModel):
 
     def __add__(self, iterable):
         new_list = PyListModel(list(self._list),
-                               self.parent(),
+                               # method parent is overloaded in Model
+                               QObject.parent(self),
                                flags=self._flags,
                                list_item_role=self.list_item_role,
                                supportedDropActions=self.supportedDropActions())
@@ -679,6 +680,7 @@ class PyListModel(QAbstractListModel):
 
     def __iadd__(self, iterable):
         self.extend(iterable)
+        return self
 
     def __delitem__(self, s):
         if isinstance(s, slice):

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -344,3 +344,32 @@ class TestDomainModel(TestCase):
         self.assertEqual(
             list(model),
             classes + [PyListModel.Separator] + metas + [PyListModel.Separator] + attrs)
+
+    def test_read_only(self):
+        model = DomainModel()
+        domain = Domain([ContinuousVariable(x) for x in "abc"])
+        model.set_domain(domain)
+        index = model.index(0, 0)
+
+        self.assertRaises(TypeError, model.append, 42)
+        self.assertRaises(TypeError, model.extend, [42])
+        self.assertRaises(TypeError, model.insert, 0, 42)
+        self.assertRaises(TypeError, model.remove, 0)
+        self.assertRaises(TypeError, model.pop)
+        self.assertRaises(TypeError, model.clear)
+        self.assertRaises(TypeError, model.reverse)
+        self.assertRaises(TypeError, model.sort)
+        with self.assertRaises(TypeError):
+            model[0] = 1
+        with self.assertRaises(TypeError):
+            del model[0]
+
+        self.assertRaises(TypeError, model.setData, index, domain[0])
+        self.assertTrue(model.setData(index, "foo", Qt.ToolTipRole))
+
+        self.assertRaises(TypeError, model.setItemData, index,
+                          {Qt.EditRole: domain[0], Qt.ToolTipRole: "foo"})
+        self.assertTrue(model.setItemData(index, {Qt.ToolTipRole: "foo"}))
+
+        self.assertRaises(TypeError, model.insertRows, 0, 0)
+        self.assertRaises(TypeError, model.removeRows, 0, 0)

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -1,18 +1,24 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
-from unittest import TestCase
+import unittest
+from unittest.mock import patch
 
 import numpy as np
 
 from AnyQt.QtCore import Qt
 
-from Orange.data import Domain, ContinuousVariable, DiscreteVariable
+from Orange.data import \
+    Domain, \
+    ContinuousVariable, DiscreteVariable, StringVariable, TimeVariable
 from Orange.widgets.utils.itemmodels import \
-    AbstractSortTableModel, PyTableModel, PyListModel, DomainModel, _argsort
+    AbstractSortTableModel, PyTableModel,\
+    PyListModel, VariableListModel, DomainModel,\
+    _argsort, _as_contiguous_range
+from Orange.widgets.gui import TableVariable
 
 
-class TestArgsort(TestCase):
+class TestArgsort(unittest.TestCase):
     def test_argsort(self):
         self.assertEqual(_argsort("dacb"), [1, 3, 2, 0])
         self.assertEqual(_argsort("dacb", reverse=True), [0, 2, 3, 1])
@@ -29,8 +35,18 @@ class TestArgsort(TestCase):
                      reverse=True),
             [0, 3, 1, 2])
 
+class TestUtils(unittest.TestCase):
+    def test_as_contiguous_range(self):
+        self.assertEqual(_as_contiguous_range(slice(1, 8), 20), (1, 8, 1))
+        self.assertEqual(_as_contiguous_range(slice(1, 8), 6), (1, 6, 1))
+        self.assertEqual(_as_contiguous_range(slice(8, 1, -1), 6), (2, 6, 1))
+        self.assertEqual(_as_contiguous_range(slice(8), 6), (0, 6, 1))
+        self.assertEqual(_as_contiguous_range(slice(8, None, -1), 6), (0, 6, 1))
+        self.assertEqual(_as_contiguous_range(slice(7, None, -1), 9), (0, 8, 1))
+        self.assertEqual(_as_contiguous_range(slice(None, None, -1), 9),
+                         (0, 9, 1))
 
-class TestPyTableModel(TestCase):
+class TestPyTableModel(unittest.TestCase):
     def setUp(self):
         self.model = PyTableModel([[1, 4],
                                    [2, 3]])
@@ -122,7 +138,7 @@ class TestPyTableModel(TestCase):
                                         Qt.TextAlignmentRole))
 
 
-class TestAbstractSortTableModel(TestCase):
+class TestAbstractSortTableModel(unittest.TestCase):
     def test_sorting(self):
         assert issubclass(PyTableModel, AbstractSortTableModel)
         model = PyTableModel([[1, 4],
@@ -150,10 +166,55 @@ class TestAbstractSortTableModel(TestCase):
         self.assertSequenceEqual(model.mapFromSourceRows(...).tolist(), [0, 2, 1])
 
 
-class TestPyListModel(TestCase):
+# Tests test _is_index_valid and access model._other_data. The latter tests
+# implementation, but it would be cumbersome and less readable to test function
+# pylint: disable=protected-access
+class TestPyListModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model = PyListModel([1, 2, 3, 4])
+
+    def test_wrap(self):
+        model = PyListModel()
+        s = [1, 2]
+        model.wrap(s)
+        self.assertSequenceEqual(model, [1, 2])
+        model.append(3)
+        self.assertEqual(s, [1, 2, 3])
+        self.assertEqual(len(model._other_data), 3)
+
+        s.append(5)
+        self.assertRaises(RuntimeError, model._is_index_valid, 0)
+
+    def test_is_index_valid(self):
+        self.assertTrue(self.model._is_index_valid(0))
+        self.assertTrue(self.model._is_index_valid(2))
+        self.assertTrue(self.model._is_index_valid(-1))
+        self.assertTrue(self.model._is_index_valid(-4))
+
+        self.assertFalse(self.model._is_index_valid(-5))
+        self.assertFalse(self.model._is_index_valid(5))
+
+    def test_index(self):
+        index = self.model.index(2, 0)
+        self.assertTrue(index.isValid())
+        self.assertEqual(index.row(), 2)
+        self.assertEqual(index.column(), 0)
+
+        self.assertFalse(self.model.index(5, 0).isValid())
+        self.assertFalse(self.model.index(-5, 0).isValid())
+        self.assertFalse(self.model.index(0, 1).isValid())
+
+    def test_headerData(self):
+        self.assertEqual(self.model.headerData(3, Qt.Vertical), "3")
+
+    def test_rowCount(self):
+        self.assertEqual(self.model.rowCount(), len(self.model))
+        self.assertEqual(self.model.rowCount(self.model.index(2, 0)), 0)
+
+    def test_columnCount(self):
+        self.assertEqual(self.model.columnCount(), 1)
+        self.assertEqual(self.model.columnCount(self.model.index(2, 0)), 0)
 
     def test_indexOf(self):
         self.assertEqual(self.model.indexOf(3), 2)
@@ -163,6 +224,19 @@ class TestPyListModel(TestCase):
         self.assertEqual(self.model.data(mi), 3)
         self.assertEqual(self.model.data(mi, Qt.EditRole), 3)
 
+        self.assertIsNone(self.model.data(self.model.index(5)))
+
+    def test_itemData(self):
+        model = PyListModel([1, 2, 3, 4])
+        mi = model.index(2)
+        model.setItemData(mi, {Qt.ToolTipRole: "foo"})
+        self.assertEqual(model.itemData(mi)[Qt.ToolTipRole], "foo")
+
+        self.assertEqual(model.itemData(model.index(5)), {})
+
+    def test_parent(self):
+        self.assertFalse(self.model.parent(self.model.index(2)).isValid())
+
     def test_set_data(self):
         model = PyListModel([1, 2, 3, 4])
         model.setData(model.index(0), None, Qt.EditRole)
@@ -171,6 +245,8 @@ class TestPyListModel(TestCase):
         model.setData(model.index(1), "This is two", Qt.ToolTipRole)
         self.assertEqual(model.data(model.index(1), Qt.ToolTipRole),
                          "This is two",)
+
+        self.assertFalse(model.setData(model.index(5), "foo"))
 
     def test_setitem(self):
         model = PyListModel([1, 2, 3, 4])
@@ -194,7 +270,7 @@ class TestPyListModel(TestCase):
         self.assertSequenceEqual(model, [1, 2, 3, 4, 5, 6])
 
         model = PyListModel([1, 2, 3, 4])
-        model[0:2] = [-1, -2]
+        model[0:2] = (-1, -2)
         self.assertSequenceEqual(model, [-1, -2, 3, 4])
 
         model = PyListModel([1, 2, 3, 4])
@@ -206,23 +282,70 @@ class TestPyListModel(TestCase):
             # non unit strides currently not supported
             model[0:-1:2] = [3, 3]
 
+    def test_getitem(self):
+        self.assertEqual(self.model[0], 1)
+        self.assertEqual(self.model[2], 3)
+        self.assertEqual(self.model[-1], 4)
+        self.assertEqual(self.model[-4], 1)
+
+        with self.assertRaises(IndexError):
+            self.model[4]    # pylint: disable=pointless-statement
+
+        with self.assertRaises(IndexError):
+            self.model[-5]  # pylint: disable=pointless-statement
+
     def test_delitem(self):
         model = PyListModel([1, 2, 3, 4])
+        model._other_data = list("abcd")
         del model[1]
         self.assertSequenceEqual(model, [1, 3, 4])
+        self.assertSequenceEqual(model._other_data, "acd")
 
         model = PyListModel([1, 2, 3, 4])
+        model._other_data = list("abcd")
         del model[1:3]
 
         self.assertSequenceEqual(model, [1, 4])
+        self.assertSequenceEqual(model._other_data, "ad")
+
         model = PyListModel([1, 2, 3, 4])
+        model._other_data = list("abcd")
         del model[:]
         self.assertSequenceEqual(model, [])
+        self.assertEqual(len(model._other_data), 0)
 
         model = PyListModel([1, 2, 3, 4])
         with self.assertRaises(IndexError):
             # non unit strides currently not supported
             del model[0:-1:2]
+        self.assertEqual(len(model), len(model._other_data))
+
+    def test_add(self):
+        model2 = self.model + [5, 6]
+        self.assertSequenceEqual(model2, [1, 2, 3, 4, 5, 6])
+        self.assertEqual(len(model2), len(model2._other_data))
+
+    def test_iadd(self):
+        model = PyListModel([1, 2, 3, 4])
+        model += [5, 6]
+        self.assertSequenceEqual(model, [1, 2, 3, 4, 5, 6])
+        self.assertEqual(len(model), len(model._other_data))
+
+    def test_list_specials(self):
+        # Essentially tested in other tests, but let's do it explicitly, too
+        # __len__
+        self.assertEqual(len(self.model), 4)
+
+        # __contains__
+        self.assertTrue(2 in self.model)
+        self.assertFalse(5 in self.model)
+
+        # __iter__
+        self.assertSequenceEqual(self.model, [1, 2, 3, 4])
+
+        # __bool__
+        self.assertTrue(bool(self.model))
+        self.assertFalse(bool(PyListModel()))
 
     def test_insert_delete_rows(self):
         model = PyListModel([1, 2, 3, 4])
@@ -235,8 +358,184 @@ class TestPyListModel(TestCase):
         self.assertIs(success, True)
         self.assertSequenceEqual(model, [None, None, None])
 
+        self.assertFalse(model.insertRows(0, 1, model.index(0)))
+        self.assertFalse(model.removeRows(0, 1, model.index(0)))
 
-class TestDomainModel(TestCase):
+    def test_extend(self):
+        model = PyListModel([])
+        model.extend([1, 2, 3, 4])
+        self.assertSequenceEqual(model, [1, 2, 3, 4])
+
+        model.extend([5, 6])
+        self.assertSequenceEqual(model, [1, 2, 3, 4, 5, 6])
+
+        self.assertEqual(len(model), len(model._other_data))
+
+    def test_append(self):
+        model = PyListModel([])
+        model.append(1)
+        self.assertSequenceEqual(model, [1])
+
+        model.append(2)
+        self.assertSequenceEqual(model, [1, 2])
+
+        self.assertEqual(len(model), len(model._other_data))
+
+    def test_insert(self):
+        model = PyListModel()
+        model.insert(0, 1)
+        self.assertSequenceEqual(model, [1])
+        self.assertEqual(len(model._other_data), 1)
+        model._other_data = ["a"]
+
+        model.insert(0, 2)
+        self.assertSequenceEqual(model, [2, 1])
+        self.assertEqual(model._other_data[1], "a")
+        self.assertNotEqual(model._other_data[0], "a")
+        model._other_data[0] = "b"
+
+        model.insert(1, 3)
+        self.assertSequenceEqual(model, [2, 3, 1])
+        self.assertEqual(model._other_data[0], "b")
+        self.assertEqual(model._other_data[2], "a")
+        self.assertNotEqual(model._other_data[1], "b")
+        self.assertNotEqual(model._other_data[1], "a")
+        model._other_data[1] = "c"
+
+        model.insert(3, 4)
+        self.assertSequenceEqual(model, [2, 3, 1, 4])
+        self.assertSequenceEqual(model._other_data[:3], ["b", "c", "a"])
+        model._other_data[3] = "d"
+
+        model.insert(-1, 5)
+        self.assertSequenceEqual(model, [2, 3, 1, 5, 4])
+        self.assertSequenceEqual(model._other_data[:3], ["b", "c", "a"])
+        self.assertEqual(model._other_data[4], "d")
+        self.assertEqual(len(model), len(model._other_data))
+
+    def test_remove(self):
+        model = PyListModel([1, 2, 3, 2, 4])
+        model._other_data = list("abcde")
+        model.remove(2)
+        self.assertSequenceEqual(model, [1, 3, 2, 4])
+        self.assertSequenceEqual(model._other_data, "acde")
+
+    def test_pop(self):
+        model = PyListModel([1, 2, 3, 2, 4])
+        model._other_data = list("abcde")
+        model.pop(1)
+        self.assertSequenceEqual(model, [1, 3, 2, 4])
+        self.assertSequenceEqual(model._other_data, "acde")
+
+    def test_clear(self):
+        model = PyListModel([1, 2, 3, 2, 4])
+        model.clear()
+        self.assertSequenceEqual(model, [])
+        self.assertEqual(len(model), len(model._other_data))
+
+        model.clear()
+        self.assertSequenceEqual(model, [])
+        self.assertEqual(len(model), len(model._other_data))
+
+    def test_reverse(self):
+        model = PyListModel([1, 2, 3, 4])
+        model._other_data = list("abcd")
+        model.reverse()
+        self.assertSequenceEqual(model, [4, 3, 2, 1])
+        self.assertSequenceEqual(model._other_data, "dcba")
+
+    def test_sort(self):
+        model = PyListModel([3, 1, 4, 2])
+        model._other_data = list("abcd")
+        model.sort()
+        self.assertSequenceEqual(model, [1, 2, 3, 4])
+        self.assertSequenceEqual(model._other_data, "bdac")
+
+
+class TestVariableListModel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.disc = DiscreteVariable("gender", values=("M", "F"))
+        cls.cont = ContinuousVariable("age")
+        cls.string = StringVariable("name")
+        cls.time = TimeVariable("birth")
+        cls.model = VariableListModel([
+            cls.cont, None, "Foo", cls.disc, cls.string, cls.time])
+
+    def test_placeholder(self):
+        model = self.model
+        self.assertEqual(model.data(model.index(1)), "None")
+        model.placeholder = "Bar"
+        self.assertEqual(model.data(model.index(1)), "Bar")
+        model.placeholder = "None"
+
+    def test_displayrole(self):
+        data, index = self.model.data, self.model.index
+        self.assertEqual(data(index(0)), "age")
+        self.assertEqual(data(index(1)), "None")
+        self.assertEqual(data(index(2)), "Foo")
+        self.assertEqual(data(index(3)), "gender")
+        self.assertEqual(data(index(4)), "name")
+        self.assertEqual(data(index(5)), "birth")
+
+    def test_tooltip(self):
+        def get_tooltip(i):
+            return self.model.data(self.model.index(i), Qt.ToolTipRole)
+
+        text = get_tooltip(0)
+        self.assertIn("age", text)
+        self.assertIn("Numeric", text)
+
+        self.assertIsNone(get_tooltip(1))
+        self.assertIsNone(get_tooltip(2))
+
+        text = get_tooltip(3)
+        self.assertIn("gender", text)
+        self.assertIn("M", text)
+        self.assertIn("F", text)
+        self.assertIn("2", text)
+        self.assertIn("Categorical", text)
+
+        text = get_tooltip(4)
+        self.assertIn("name", text)
+        self.assertIn("Text", text)
+
+        text = get_tooltip(5)
+        self.assertIn("birth", text)
+        self.assertIn("Time", text)
+
+        self.cont.attributes = {"foo": "bar"}
+        text = get_tooltip(0)
+        self.assertIn("foo", text)
+        self.assertIn("bar", text)
+
+    @unittest.skip
+    def test_decoration(self):
+        decorations = [self.model.data(self.model.index(i), Qt.DecorationRole)
+                       for i in range(self.model.rowCount())]
+        self.assertIs(decorations[1], decorations[2])
+        del decorations[2]
+        for i, dec1 in enumerate(decorations):
+            for dec2 in decoreations[i]:
+                self.assertIsNot(dec1, dec2)
+
+    def test_table_variable(self):
+        self.assertEqual(
+            [self.model.data(self.model.index(i), TableVariable)
+             for i in range(self.model.rowCount())],
+            [self.cont, None, None, self.disc, self.string, self.time])
+
+    def test_other_roles(self):
+        with patch.object(PyListModel, "data") as data:
+            index = self.model.index(0)
+            _ = self.model.data(index, Qt.BackgroundRole)
+            print(data.call_args[1:])
+            self.assertEqual(data.call_args[0][1:], (index, Qt.BackgroundRole))
+
+    def test_invalid_index(self):
+        self.assertIsNone(self.model.data(self.model.index(0).parent()))
+
+class TestDomainModel(unittest.TestCase):
     def test_init_with_single_section(self):
         model = DomainModel(order=DomainModel.CLASSES)
         self.assertEqual(model.order, (DomainModel.CLASSES, ))
@@ -373,3 +672,6 @@ class TestDomainModel(TestCase):
 
         self.assertRaises(TypeError, model.insertRows, 0, 0)
         self.assertRaises(TypeError, model.removeRows, 0, 0)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -180,10 +180,10 @@ class TestPyListModel(TestCase):
         self.assertSequenceEqual(model, [1, 42, 3, 42])
 
         with self.assertRaises(IndexError):
-            model[4]
+            model[4]  # pylint: disable=pointless-statement
 
         with self.assertRaises(IndexError):
-            model[-5]
+            model[-5]  # pylint: disable=pointless-statement
 
         model = PyListModel([1, 2, 3, 4])
         model[0:0] = [-1, 0]

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -22,7 +22,7 @@ from Orange.statistics import contingency, distribution
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import (Setting, DomainContextHandler,
                                      ContextSetting)
-from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.utils.itemmodels import DomainModel, VariableListModel
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
 from Orange.widgets.widget import Input, Output
@@ -183,10 +183,7 @@ class OWBoxPlot(widget.OWWidget):
         self.scale_x = self.scene_min_x = self.scene_width = 0
         self.label_width = 0
 
-        order = (DomainModel.CLASSES, DomainModel.METAS, DomainModel.ATTRIBUTES)
-        self.attrs = DomainModel(
-            order=order,
-            valid_types=DomainModel.PRIMITIVE)
+        self.attrs = VariableListModel()
         view = gui.listView(
             self.controlArea, self, "attribute", box="Variable",
             model=self.attrs, callback=self.attr_changed)
@@ -202,13 +199,12 @@ class OWBoxPlot(widget.OWWidget):
             tooltip="Order by 𝜒² or ANOVA over the subgroups",
             callback=self.apply_sorting)
         self.group_vars = DomainModel(
-            order=order,
-            placeholder="None",
+            placeholder="None", separators=False,
             valid_types=Orange.data.DiscreteVariable)
-        self.group_vars.clear()  # Remove 'None' from the list view
-        view = gui.listView(
+        self.group_view = view = gui.listView(
             self.controlArea, self, "group_var", box="Subgroups",
             model=self.group_vars, callback=self.grouping_changed)
+        view.setEnabled(False)
         view.setMinimumSize(QSize(30, 30))
         # See the comment above
         view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Ignored)
@@ -270,6 +266,12 @@ class OWBoxPlot(widget.OWWidget):
 
         return super().eventFilter(obj, event)
 
+    def reset_attrs(self, domain):
+        self.attrs[:] = [
+            var for var in chain(
+                domain.class_vars, domain.metas, domain.attributes)
+            if var.is_primitive()]
+
     # noinspection PyTypeChecker
     @Inputs.data
     def set_data(self, dataset):
@@ -284,7 +286,8 @@ class OWBoxPlot(widget.OWWidget):
         if dataset:
             domain = dataset.domain
             self.group_vars.set_domain(domain)
-            self.attrs.set_domain(domain)
+            self.group_view.setEnabled(len(self.group_vars) > 1)
+            self.reset_attrs(domain)
             self.select_default_variables(domain)
             self.openContext(self.dataset)
             self.grouping_changed()
@@ -348,15 +351,15 @@ class OWBoxPlot(widget.OWWidget):
                     include_class=True, include_metas=True) else None
             self.attrs.sort(key=compute_score)
         else:
-            self.attrs.set_domain(domain)
+            self.reset_attrs(domain)
         self.attribute = attribute
 
     def reset_all_data(self):
         self.clear_scene()
         self.infot1.setText("")
-        self.attrs.set_domain(None)
+        self.attrs.clear()
         self.group_vars.set_domain(None)
-        self.group_vars.clear()  # Remove 'None' from the list view
+        self.group_view.setEnabled(False)
         self.is_continuous = False
         self.update_display_box()
 

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -33,11 +33,16 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(len(self.widget.group_vars), 2)
         self.assertFalse(self.widget.display_box.isHidden())
         self.assertTrue(self.widget.stretching_box.isHidden())
+
         self.send_signal(self.widget.Inputs.data, None)
         self.assertEqual(len(self.widget.attrs), 0)
-        self.assertEqual(len(self.widget.group_vars), 0)
+        self.assertEqual(len(self.widget.group_vars), 1)
+        self.assertFalse(self.widget.group_view.isEnabled())
         self.assertTrue(self.widget.display_box.isHidden())
         self.assertFalse(self.widget.stretching_box.isHidden())
+
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.assertTrue(self.widget.group_view.isEnabled())
 
     def test_input_data_missings_cont_group_var(self):
         """Check widget with continuous data with missing values and group variable"""


### PR DESCRIPTION
##### Issue

`DomainModel` should not allow modifying the underlying list, except through `set_domain`.

##### Description of changes

- Decorate all list methods that would modify the underlying list to raise an exception, unless they are called from within `set_domain`. This also prevents modifying the model through `setData`, `setItemData`, `insertRows` and `removeRows`.
- Fix widgets that directly changed the model: MDS, Box plot
- Add tests for `DomainModel` and `PyListModel`
- Fix detected problems in `PyListModel`:
-- fix `__add__` and `__iadd__` which didn't work at all
-- remove a bug in `_is_index_valid`, refactor it, add checks to detect models broken by misuse of `wrap` (see #2771); current implementation used an additional argument to circumvent the potential bugs
-- remove unnecessary use of `wrap` in Edit domain

##### Includes
- [X] Code changes
- [X] Tests