### PR TITLE
[FIX] Scatter Plot Graph: crash on metas column with all 0 values

### DIFF
--- a/Orange/widgets/utils/scaling.py
+++ b/Orange/widgets/utils/scaling.py
@@ -49,11 +49,7 @@ class ScaleData:
             return
 
         Y = data.Y if data.Y.ndim == 2 else np.atleast_2d(data.Y).T
-        if np.any(data.metas):
-            all_data = (data.X, Y, data.metas)
-        else:
-            all_data = (data.X, Y)
-        all_data = np.hstack(all_data).T
+        all_data = np.hstack((data.X, Y, data.metas)).T
         self.scaled_data = self.data.copy()
         self.valid_data_array = np.isfinite(all_data)
         domain = self.domain

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -526,6 +526,20 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(w.Inputs.data_subset, data[::30])
         self.assertEqual(len(w.graph.subset_indices), 5)
 
+    def test_metas_zero_column(self):
+        """
+        Prevent crash when metas column is zero.
+        GH-2775
+        """
+        data = Table("iris")
+        domain = data.domain
+        domain = Domain(domain.attributes[:3], domain.class_vars, domain.attributes[3:])
+        data = data.transform(domain)
+        data.metas[:, 0] = 0
+        w = self.widget
+        self.send_signal(w.Inputs.data, data)
+        simulate.combobox_activate_item(w.controls.attr_x, domain.metas[0].name)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
##### Issue
**Scaling** does not stack metas with other arrays when metas array has all values set to zero.

##### Description of changes
Another check for metas array.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
