### PR TITLE
[FIX] FreeViz: 2 issues when no data

### DIFF
--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -815,6 +815,8 @@ class OWFreeViz(widget.OWWidget):
         self.graph.update_data(self.variable_x, self.variable_y, reset_view)
 
     def update_density(self):
+        if self.graph.data is None:
+            return
         self._update_graph(reset_view=False)
 
     def selection_changed(self):

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -453,6 +453,8 @@ class OWFreeViz(widget.OWWidget):
     def update_radius(self):
         # Update the anchor/axes visibility
         assert not self.plotdata is None
+        if self.plotdata.hidecircle is None:
+            return
 
         minradius = self.radius / 100 + 1e-5
         for anchor, item in zip(self.plotdata.anchors,

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -115,3 +115,12 @@ class TestOWFreeViz(WidgetTest, WidgetOutputsTestMixin):
         w = self.widget
         self.send_signal(w.Inputs.data, None)
         w.rslider.setSliderPosition(3)
+
+    def test_update_graph_no_data(self):
+        """
+        Widget should not crash when there is no data and one wants to change class density etc.
+        GH-2780
+        """
+        w = self.widget
+        self.send_signal(w.Inputs.data, None)
+        w.cb_class_density.click()

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -106,3 +106,12 @@ class TestOWFreeViz(WidgetTest, WidgetOutputsTestMixin):
     def test_class_density(self):
         self.send_signal(self.widget.Inputs.data, Table("iris"))
         self.widget.cb_class_density.click()
+
+    def test_set_radius_no_data(self):
+        """
+        Widget should not crash when there is no data and radius slider is moved.
+        GH-2780
+        """
+        w = self.widget
+        self.send_signal(w.Inputs.data, None)
+        w.rslider.setSliderPosition(3)


### PR DESCRIPTION
##### Issue
Widget crashes when there is no data and
1) Radius slider is moved
2) Class density, etc. is changed


##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
