### PR TITLE
[FIX] Hierarchical Clustering: Fix size constraints

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1319,16 +1319,16 @@ class OWHierarchicalClustering(widget.OWWidget):
 
     def _set_slider_value(self, value, span):
         with blocked(self.cut_line):
-            self.cut_line.setValue(value)
             self.cut_line.setRange(0, span)
+            self.cut_line.setValue(value)
 
         with blocked(self.top_axis.line):
-            self.top_axis.line.setValue(value)
             self.top_axis.line.setRange(0, span)
+            self.top_axis.line.setValue(value)
 
         with blocked(self.bottom_axis.line):
-            self.bottom_axis.line.setValue(value)
             self.bottom_axis.line.setRange(0, span)
+            self.bottom_axis.line.setValue(value)
 
     def set_cutoff_height(self, height):
         self.cutoff_height = height

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -885,7 +885,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.zoom_slider = gui.hSlider(
             self.controlArea, self, "zoom_factor", box="Zoom",
             minValue=-6, maxValue=3, step=1, ticks=True, createLabel=False,
-            callback=self.__zoom_factor_changed)
+            callback=self.__update_font_scale)
 
         zoom_in = QAction(
             "Zoom in", self, shortcut=QKeySequence.ZoomIn,
@@ -1003,6 +1003,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.top_axis.line.valueChanged.connect(self._axis_slider_changed)
         self.dendrogram.geometryChanged.connect(self._dendrogram_geom_changed)
         self._set_cut_line_visible(self.selection_method == 1)
+        self.__update_font_scale()
 
     @Inputs.distances
     def set_distances(self, matrix):
@@ -1384,7 +1385,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.zoom_factor = clip(self.zoom_slider.minimum(),
                                 self.zoom_slider.maximum(),
                                 self.zoom_factor + 1)
-        self.__zoom_factor_changed()
+        self.__update_font_scale()
 
     def __zoom_out(self):
         def clip(minval, maxval, val):
@@ -1392,11 +1393,11 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.zoom_factor = clip(self.zoom_slider.minimum(),
                                 self.zoom_slider.maximum(),
                                 self.zoom_factor - 1)
-        self.__zoom_factor_changed()
+        self.__update_font_scale()
 
     def __zoom_reset(self):
         self.zoom_factor = 0
-        self.__zoom_factor_changed()
+        self.__update_font_scale()
 
     def __layout_main_graphics(self, width=-1):
         if width < 0:
@@ -1408,12 +1409,11 @@ class OWHierarchicalClustering(widget.OWWidget):
         mw = self._main_graphics.minimumWidth() + 4
         self.view.setMinimumWidth(mw + self.view.verticalScrollBar().width())
 
-    def __zoom_factor_changed(self):
+    def __update_font_scale(self):
         font = self.scene.font()
         factor = (1.25 ** self.zoom_factor)
         font = qfont_scaled(font, factor)
-        self.labels.setFont(font)
-        self.dendrogram.setFont(font)
+        self._main_graphics.setFont(font)
 
     def send_report(self):
         annot = self.label_cb.currentText()

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1255,7 +1255,15 @@ class OWHierarchicalClustering(widget.OWWidget):
 
     def eventFilter(self, obj, event):
         if obj is self.view.viewport() and event.type() == QEvent.Resize:
-            width = self.view.viewport().width() - 2
+            # NOTE: not using viewport.width(), due to 'transient' scroll bars
+            # (macOS). Viewport covers the whole view, but QGraphicsView still
+            # scrolls left, right with scroll bar extent (other
+            # QAbstractScrollArea widgets behave as expected).
+            w_frame = self.view.frameWidth()
+            margin = self.view.viewportMargins()
+            w_scroll = self.view.verticalScrollBar().width()
+            width = (self.view.width() - w_frame * 2 -
+                     margin.left() - margin.right() - w_scroll)
             # layout with new width constraint
             self.__layout_main_graphics(width=width)
         elif obj is self._main_graphics and \


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The dendrogram can be resized below its minimum width (without horizontal scroll bars shown).

##### Description of changes

* Set minimum width constraint in the graphics view to ensure scroll bars would not be needed.
* Improve size hinting.
* Fix cutoff line/slider updates.
* Fix dendrogram font scale (zoom) initialization.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
