### PR TITLE
canvas: always set http_proxy environment variables if proxy detected

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -719,20 +719,6 @@ def unique(iterable):
     return (el for el in iterable if not observed(el))
 
 
-def _env_with_proxies():
-    """
-    Return system environment with proxies obtained from urllib so that
-    they can be used with pip.
-    """
-    proxies = urllib.request.getproxies()
-    env = dict(os.environ)
-    if "http" in proxies:
-        env["HTTP_PROXY"] = proxies["http"]
-    if "https" in proxies:
-        env["HTTPS_PROXY"] = proxies["https"]
-    return env
-
-
 Install, Upgrade, Uninstall = 1, 2, 3
 
 
@@ -988,7 +974,6 @@ def create_process(cmd, executable=None, **kwargs):
         cmd,
         executable=executable,
         cwd=None,
-        env=_env_with_proxies(),
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         bufsize=-1,


### PR DESCRIPTION
##### Issue
Some clients (like requests, pip) don't detect proxy configuration that is not set via `http_proxy` environment variables.

##### Description of changes
We set proxy via environment for add-ons before, but it shouldn't hurt to just set it always? According to [getproxies()](https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies), if env vars are set, this is no-op. But on Windows/macOS, it ~~should~~might make a difference.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
