### PR TITLE
owconcatenate: Use table names for values of source var

### DIFF
--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -164,9 +164,13 @@ class OWConcatenate(widget.OWWidget):
 
         if tables and self.append_source_column:
             assert domain is not None
+            names = [getattr(t, 'name', '') for t in tables]
+            if len(names) != len(set(names)):
+                names = ['{} ({})'.format(name, i)
+                         for i, name in enumerate(names)]
             source_var = Orange.data.DiscreteVariable(
                 self.source_attr_name,
-                values=["{}".format(i) for i in range(len(tables))]
+                values=names
             )
             places = ["class_vars", "attributes", "metas"]
             domain = add_columns(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since loading a workflow doesn't produce a consistent ordering, indices aren't reliable.

##### Description of changes
Use names of the tables as values of the new (optional) source variable.
(Append indices if not unique)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
