### PR TITLE
[FIX] Table: classes (Y) must be float

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -492,7 +492,7 @@ class Table(MutableSequence, Storage):
 
         if Y is None:
             if sp.issparse(X):
-                Y = np.empty((X.shape[0], 0), object)
+                Y = np.empty((X.shape[0], 0), dtype=np.float64)
             else:
                 Y = X[:, len(domain.attributes):]
                 X = X[:, :len(domain.attributes)]


### PR DESCRIPTION
##### Issue
Y must be type `float`, not `object`.


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
