### PR TITLE
[FIX] Windows installers: Python lookup

### DIFF
--- a/scripts/windows/PythonHelpers.nsh
+++ b/scripts/windows/PythonHelpers.nsh
@@ -119,6 +119,8 @@
             ReadRegStr $2 ${ROOT_KEY} \
                        "${__CONDA_REG_PREFIX}\$1\InstallPath" ""
             ${If} $2 != ""
+            ${AndIf} ${FileExists} "$2\python.exe"
+            ${AndIf} ${FileExists} "$2\Scripts\conda.exe"
                 ${LogWrite} "${ROOT_KEY} ${__CONDA_REG_PREFIX}\$1\InstallPath: $2"
                 Exch $2  # <stack> $0, $1, $2, "prefix"
             ${EndIf}

--- a/scripts/windows/PythonHelpers.nsh
+++ b/scripts/windows/PythonHelpers.nsh
@@ -80,7 +80,7 @@
 #
 # Retrive the registered install prefix for Python
 # - input: VERSIONTAG is a MajorMinor version number (no dots)
-# - input: BITS 34 or 64 (constant!)
+# - input: BITS 34 or 64 (constant)
 # - output: INSTALL_PREFIX installation path (e.g C:\Python35)
 # - output: INSTALL_MODE
 #           1 if Python was installed for all users or 0 if
@@ -88,41 +88,12 @@
 #
 # Example
 # -------
-# ${GetAnacondaInstall} 3.5 64 $PythonDir $InstallMode
+# ${GetAnacondaInstall} 35 64 $PythonDir $InstallMode
 
 !macro __GET_CONDA_INSTALL VERSION_TAG BITS INSTALL_PREFIX INSTALL_MODE
-    !define __CONDA_REG_PREFIX \
-        Software\Python\ContinuumAnalytics\Anaconda${VERSION_TAG}-${BITS}
-
-    !if "${BITS}" != 32
-    !if "${BITS}" != 64
-        !error "BITS must be a 32 or 64 constant"
-    !endif
-    !endif
-    ReadRegStr ${INSTALL_PREFIX} HKCU ${__CONDA_REG_PREFIX}\InstallPath ""
-    ${If} ${INSTALL_PREFIX} != ""
-        StrCpy ${INSTALL_MODE} 0
-    ${Else}
-        ReadRegStr ${INSTALL_PREFIX} HKLM ${__CONDA_REG_PREFIX}\InstallPath ""
-        ${If} ${INSTALL_PREFIX} != ""
-            StrCpy ${INSTALL_MODE} 1
-        ${Else}
-            StrCpy ${INSTALL_MODE} 0
-        ${EndIf}
-    ${EndIf}
-
-    ${If} ${INSTALL_PREFIX} != ""
-        # Strip (single) trailing '\' if present
-        Push $0
-        StrCpy $0 ${INSTALL_PREFIX} "" -1
-        ${If} $0 == "\"
-            StrLen $0 ${INSTALL_PREFIX}
-            IntOp $0 $0 - 1
-            StrCpy ${INSTALL_PREFIX} ${INSTALL_PREFIX} $0 0
-        ${EndIf}
-        Pop $0
-     ${EndIf}
-    !undef __CONDA_REG_PREFIX
+    !define __TAG Anaconda${VERSION_TAG}-${BITS}
+    ${GetPythonInstallPEP514} ContinuumAnalytics ${__TAG} ${INSTALL_PREFIX} ${INSTALL_MODE}
+    !undef __TAG
 !macroend
 !define GetAnacondaInstall "!insertmacro __GET_CONDA_INSTALL"
 

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -30,6 +30,13 @@ rem # with a local package, we need to create it manually.
 echo @echo off           > "%PREFIX%\Scripts\conda.bat"
 echo call "%CONDA%" %%* >> "%PREFIX%\Scripts\conda.bat"
 
+rem # same for activate.bat
+rem #
+for %%f in ( "%CONDA%" ) do ( set "CONDA_DIR=%%~dpf" )
+echo @echo off                           > "%PREFIX%\Scripts\activate.bat"
+echo call "%CONDA_DIR%\activate.bat" %%* >> "%PREFIX%\Scripts\activate.bat"
+set CONDA_DIR=
+
 rem # Create .condarc file that includes conda-forge channel
 rem # We need it so add-ons can be installed from conda-forge
 echo Appending conda-forge channel

--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -171,6 +171,10 @@ Var StartMenuFolder
 # - no check box to enable/disable start menu creation
 #   (is controled by the Components Page)
 !define MUI_STARTMENUPAGE_NODISABLE
+# Registry key path where the selected start folder name is stored
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT SHELL_CONTEXT
+!define MUI_STARTMENUPAGE_REGISTRY_KEY ${INSTALL_SETTINGS_KEY}
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME StartMenuFolder
 !insertmacro MUI_PAGE_STARTMENU StartMenuPageID $StartMenuFolder
 
 # Install Files page:
@@ -749,8 +753,8 @@ Section Uninstall
     ${LogWrite} "    PythonPrefix: $PythonPrefix"
     ${LogWrite} "    BasePythonPrefix: $BasePythonPrefix"
 
-    Call un.Register
     Call un.Shortcuts
+    Call un.Register
     Call un.Launchers
     Call un.InstallPackages
     Call un.Environment

--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -574,6 +574,11 @@ Section "Start Menu Shortcuts" SectionStartMenu
             "$SMPROGRAMS\$StartMenuFolder\${LAUNCHER_SHORTCUT_NAME}.lnk" \
             "$PythonExecPrefix\pythonw.exe" "-m Orange.canvas" \
             "$PythonPrefix\share\orange3\icons\orange.ico" 0
+
+        # A utility shortcut for activating the environment
+        CreateShortCut \
+            "$SMPROGRAMS\$StartMenuFolder\${APPNAME} Command Prompt.lnk" \
+            "%COMSPEC%" '/S /K ""$PythonScriptsPrefix\activate.bat" "$InstDir""'
     ${EndIf}
     !insertmacro MUI_STARTMENU_WRITE_END
 SectionEnd
@@ -604,6 +609,7 @@ Function un.Shortcuts
         ${LogWrite} "Removing Start Menu Shortcuts (from $SMPROGRAMS\$0)"
         DetailPrint "Removing Start Menu shortcuts"
         Delete "$SMPROGRAMS\$0\${LAUNCHER_SHORTCUT_NAME}.lnk"
+        Delete "$SMPROGRAMS\$0\${APPNAME} Command Prompt.lnk"
         RMDir "$SMPROGRAMS\$0"
     ${EndIf}
     ${LogWrite} "Removing Desktop shortcurt"

--- a/scripts/windows/orange-install.nsi
+++ b/scripts/windows/orange-install.nsi
@@ -446,7 +446,7 @@ Section "Python ${PYTHON_VERSION} (${BITS} bit)" SectionPython
         Abort "Python installation failed (error value: $0)"
     ${EndIf}
     ${GetPythonInstall} \
-        "${PYMAJOR}.${PYMINOR}" $BasePythonPrefix $PythonInstallMode
+        "${PYMAJOR}.${PYMINOR}" ${BITS} $BasePythonPrefix $PythonInstallMode
     ${If} $BasePythonPrefix == ""
         Abort "Python installation failed (cannot determine Python \
                installation prefix)."
@@ -811,7 +811,8 @@ Function .onInit
     !insertmacro MULTIUSER_INIT
 
 !if ${PYINSTALL_TYPE} == Normal
-    ${GetPythonInstall} ${PYMAJOR}.${PYMINOR} $BasePythonPrefix $PythonInstallMode
+    ${GetPythonInstall} ${PYMAJOR}.${PYMINOR} ${BITS} \
+        $BasePythonPrefix $PythonInstallMode
     ${LogWrite} "Python Prefix: $BasePythonPrefix"
     ${LogWrite} "Python Install Type: $PythonInstallMode"
     ${If} $BasePythonPrefix != ""

--- a/scripts/windows/orange-install.nsi
+++ b/scripts/windows/orange-install.nsi
@@ -189,6 +189,10 @@ Var StartMenuFolder
 # - no check box to enable/disable start menu creation
 #   (is controled by the Components Page)
 !define MUI_STARTMENUPAGE_NODISABLE
+# Registry key path where the selected start folder name is stored
+!define MUI_STARTMENUPAGE_REGISTRY_ROOT SHELL_CONTEXT
+!define MUI_STARTMENUPAGE_REGISTRY_KEY ${INSTALL_SETTINGS_KEY}
+!define MUI_STARTMENUPAGE_REGISTRY_VALUENAME StartMenuFolder
 !insertmacro MUI_PAGE_STARTMENU StartMenuPageID $StartMenuFolder
 
 # Install Files page:
@@ -783,8 +787,8 @@ Section Uninstall
     ${LogWrite} "    PythonPrefix: $PythonPrefix"
     ${LogWrite} "    BasePythonPrefix: $BasePythonPrefix"
 
-    Call un.Register
     Call un.Shortcuts
+    Call un.Register
     Call un.Launchers
     Call un.InstallPackages
     Call un.Environment

--- a/scripts/windows/orange-install.nsi
+++ b/scripts/windows/orange-install.nsi
@@ -639,6 +639,9 @@ Function un.Shortcuts
         ${LogWrite} "Removing Start Menu Shortcuts (from $SMPROGRAMS\$0)"
         DetailPrint "Removing Start Menu shortcuts"
         Delete "$SMPROGRAMS\$0\${LAUNCHER_SHORTCUT_NAME}.lnk"
+!if ${PYINSTALL_TYPE} == Normal
+        Delete "$SMPROGRAMS\$0\${APPNAME} Command Prompt.lnk"
+!endif
         RMDir "$SMPROGRAMS\$0"
     ${EndIf}
     ${LogWrite} "Removing Desktop shortcurt"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

* gh-2826
* Regular 32-bit installer for Python >= 3.5 would fail to find the correct Python installation (looks for 64 bit python instead)

##### Description of changes

* Validate conda install layout
* Fix registry key lookup for 32 bit python >= 3.5

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
