### PR TITLE
DomainContextSetting: don't skip meta-only domains

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -916,7 +916,7 @@ class DomainContextHandler(ContextHandler):
         return context
 
     def open_context(self, widget, domain):
-        if not domain:
+        if domain is None:
             return None, False
 
         if not isinstance(domain, Domain):


### PR DESCRIPTION
##### Issue

If a domain has just meta attributes, `DomainContextHandler` does not open a context.

I encountered this when converting the Distance map widget to use variables instead of ints. I loaded 'conferences.dst' with Distance File, and connected it to Distance map, which failed since the widget had no current context. I no longer have this problem since I had to change the widget for other reasons, but the bug may reappear elsewhere.

I can write a test if @astaric agrees with the change.

##### Description of changes

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
