### PR TITLE
[FIX] Bincount: Fix crash on array with all nans

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -144,7 +144,11 @@ def bincount(x, weights=None, max_val=None, minlength=None):
         # zeros, we must count implicit zeros separately and add them to the
         # explicit ones found before
         if sp.issparse(x_original):
-            bc[0] += zero_weights
+            # If x contains only NaNs, then bc will be an empty array
+            if zero_weights and bc.size == 0:
+                bc = [zero_weights]
+            elif zero_weights:
+                bc[0] += zero_weights
 
     return bc, nans
 

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -417,6 +417,15 @@ class TestBincount(unittest.TestCase):
 
         np.testing.assert_equal(bincount(x)[0], expected)
 
+    @dense_sparse
+    def test_all_zeros_or_nans(self, array):
+        """Sparse arrays with only nans with no explicit zeros will have no non
+        zero indices. Check that this counts the zeros properly."""
+        x = array([np.nan] * 5 + [0] * 5)
+        expected = [5]
+
+        np.testing.assert_equal(bincount(x)[0], expected)
+
 
 class TestUnique(unittest.TestCase):
     @dense_sparse

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -408,6 +408,13 @@ class TestBincount(unittest.TestCase):
         expected = [3, 0, 2, 1]
         np.testing.assert_equal(bincount(x, w)[0], expected)
 
+    @dense_sparse
+    def test_all_nans(self, array):
+        x = array([np.nan] * 5)
+        expected = []
+
+        np.testing.assert_equal(bincount(x)[0], expected)
+
 
 class TestUnique(unittest.TestCase):
     @dense_sparse

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -26,7 +26,9 @@ def dense_sparse(test_case):
 
             return sp_array
 
-        test_case(self, lambda x: np.array(x))
+        test_case(self, np.array)
+        test_case(self, csr_matrix)
+        test_case(self, csc_matrix)
         test_case(self, partial(sparse_with_explicit_zero, array=csr_matrix))
         test_case(self, partial(sparse_with_explicit_zero, array=csc_matrix))
 


### PR DESCRIPTION
##### Issue
Utility version of `bincount` crashed on sparse vector of all NaNs. 


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
