### PR TITLE
[FIX] utils/concurrent: Handle an empty futures list

### DIFF
--- a/Orange/widgets/utils/concurrent.py
+++ b/Orange/widgets/utils/concurrent.py
@@ -570,10 +570,11 @@ class FutureSetWatcher(QObject):
     doneAll = Signal()
 
     def __init__(self, futures=None, *args, **kwargs):
+        # type: (List[Future], ...) -> None
         super().__init__(*args, **kwargs)
         self.__futures = None
         self.__countdone = 0
-        if futures:
+        if futures is not None:
             self.setFutures(futures)
 
     def setFutures(self, futures):
@@ -608,6 +609,9 @@ class FutureSetWatcher(QObject):
                     pass
 
             future.add_done_callback(partial(on_done, i))
+        if not self.__futures:
+            # `futures` was an empty sequence.
+            methodinvoke(self, "doneAll", ())()
 
     @Slot(int, Future)
     def __emitpending(self, index, future):
@@ -643,6 +647,10 @@ class FutureSetWatcher(QObject):
         """
         assert QThread.currentThread() is self.thread()
         QCoreApplication.sendPostedEvents(self, QEvent.MetaCall)
+
+    def wait(self):
+        assert self.__futures is not None
+        concurrent.futures.wait(self.__futures)
 
 
 class methodinvoke(object):

--- a/Orange/widgets/utils/tests/test_concurrent.py
+++ b/Orange/widgets/utils/tests/test_concurrent.py
@@ -201,6 +201,31 @@ class TestFutureSetWatcher(CoreAppTestCase):
         self.assertSetEqual(as_set(spy.resultAt), {(0, True)})
         self.assertSetEqual(as_set(spy.exceptionAt), set())
 
+        # doneAll must always be emitted after the doneAt signals.
+        executor = ThreadPoolExecutor(max_workers=2)
+        futures = [executor.submit(pow, 1000, 1000) for _ in range(100)]
+        watcher = FutureSetWatcher(futures)
+        emithistory = []
+        watcher.doneAt.connect(lambda i, f: emithistory.append(("doneAt", i, f)))
+        watcher.doneAll.connect(lambda: emithistory.append(("doneAll", )))
+
+        spy = spies(watcher)
+        watcher.wait()
+        self.assertEqual(len(spy.doneAll), 0)
+        self.assertEqual(len(spy.doneAt), 0)
+        watcher.flush()
+        self.assertEqual(len(spy.doneAt), 100)
+        self.assertEqual(list(spy.doneAll), [[]])
+        self.assertSetEqual(set(emithistory[:-1]),
+                            {("doneAt", i, f) for i, f in enumerate(futures)})
+        self.assertEqual(emithistory[-1], ("doneAll",))
+
+        # doneAll must be emitted even when on an empty futures list
+        watcher = FutureSetWatcher()
+        watcher.setFutures([])
+        spy = spies(watcher)
+        self.assertTrue(spy.doneAll.wait())
+
 
 class TestTask(CoreAppTestCase):
 

--- a/Orange/widgets/utils/tests/test_concurrent.py
+++ b/Orange/widgets/utils/tests/test_concurrent.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 import threading
 import random
 
@@ -225,6 +226,18 @@ class TestFutureSetWatcher(CoreAppTestCase):
         watcher.setFutures([])
         spy = spies(watcher)
         self.assertTrue(spy.doneAll.wait())
+
+        watcher = FutureSetWatcher()
+        watcher.setFutures([])
+        watcher.wait()
+
+        watcher = FutureSetWatcher()
+        with self.assertRaises(RuntimeError):
+            watcher.wait()
+
+        with unittest.mock.patch.object(watcher, "thread", lambda: 42), \
+                self.assertRaises(RuntimeError):
+            watcher.flush()
 
 
 class TestTask(CoreAppTestCase):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

It is possible that a client passes a empty futures list to `FutureSetWatcher`. In this case the `doneAll` signal is not emitted which might cause the client to never resume progress it it does not handle the empty futures list.

##### Description of changes

Ensure a `doneAll` signal is emitted even for an empty futures list.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
