### PR TITLE
[FIX] mssql: Catch errors due to incorrect connection params

### DIFF
--- a/Orange/data/sql/backend/mssql.py
+++ b/Orange/data/sql/backend/mssql.py
@@ -24,6 +24,9 @@ class PymssqlBackend(Backend):
             self.connection = pymssql.connect(login_timeout=5, **connection_params)
         except pymssql.Error as ex:
             raise BackendError(str(ex)) from ex
+        except ValueError:
+            # ValueError is raised when 'server' contains "\\"
+            raise BackendError("Incorrect format of connection details")
 
     def list_tables_query(self, schema=None):
         return """


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Using a string like `foo\\bar` for the server parameter crashed the widget (with an uncaught ValueError).

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
