### PR TITLE
[ENH] Canvas: Add zoom

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -291,10 +291,9 @@ class CanvasMainWindow(QMainWindow):
 
         tool_actions = self.current_document().toolbarActions()
 
-        (self.canvas_zoom_action, self.canvas_align_to_grid_action,
+        (self.canvas_align_to_grid_action,
          self.canvas_text_action, self.canvas_arrow_action,) = tool_actions
 
-        self.canvas_zoom_action.setIcon(canvas_icons("Search.svg"))
         self.canvas_align_to_grid_action.setIcon(canvas_icons("Grid.svg"))
         self.canvas_text_action.setIcon(canvas_icons("Text Size.svg"))
         self.canvas_arrow_action.setIcon(canvas_icons("Arrow.svg"))
@@ -535,6 +534,21 @@ class CanvasMainWindow(QMainWindow):
                     shortcut=QKeySequence(Qt.ShiftModifier | Qt.Key_R)
                     )
 
+        self.zoom_in_action = \
+            QAction(self.tr("Zoom in"), self,
+                    triggered=self.zoom_in,
+                    shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_Plus))
+
+        self.zoom_out_action = \
+            QAction(self.tr("Zoom out"), self,
+                    triggered=self.zoom_out,
+                    shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_Minus))
+
+        self.zoom_reset_action = \
+            QAction(self.tr("Reset Zoom"), self,
+                    triggered=self.zoom_reset,
+                    shortcut=QKeySequence(Qt.ControlModifier | Qt.Key_0))
+
         if sys.platform == "darwin":
             # Actions for native Mac OSX look and feel.
             self.minimize_action = \
@@ -649,6 +663,12 @@ class CanvasMainWindow(QMainWindow):
         self.view_menu.addAction(self.show_report_action)
 
         self.view_menu.addSeparator()
+        self.view_menu.addAction(self.zoom_in_action)
+        self.view_menu.addAction(self.zoom_out_action)
+        self.view_menu.addAction(self.zoom_reset_action)
+
+        self.view_menu.addSeparator()
+
         self.view_menu.addAction(self.toogle_margins_action)
         menu_bar.addMenu(self.view_menu)
 
@@ -1892,6 +1912,15 @@ class CanvasMainWindow(QMainWindow):
                     self.window_menu.setEnabled(not self.isMinimized())
 
             QMainWindow.changeEvent(self, event)
+
+    def zoom_in(self):
+        self.scheme_widget.view().change_zoom(1)
+
+    def zoom_out(self):
+        self.scheme_widget.view().change_zoom(-1)
+
+    def zoom_reset(self):
+        self.scheme_widget.view().reset_zoom()
 
     def sizeHint(self):
         """

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -171,16 +171,6 @@ class SchemeEditWidget(QWidget):
         self.__linkMenu.addAction(self.__linkResetAction)
 
     def __setupActions(self):
-
-        self.__zoomAction = \
-            QAction(self.tr("Zoom"), self,
-                    objectName="zoom-action",
-                    checkable=True,
-                    shortcut=QKeySequence.ZoomIn,
-                    toolTip=self.tr("Zoom in the workflow."),
-                    toggled=self.toggleZoom,
-                    )
-
         self.__cleanUpAction = \
             QAction(self.tr("Clean Up"), self,
                     objectName="cleanup-action",
@@ -467,14 +457,12 @@ class SchemeEditWidget(QWidget):
         Return a list of actions that can be inserted into a toolbar.
         At the moment these are:
 
-            - 'Zoom' action
             - 'Clean up' action (align to grid)
             - 'New text annotation' action (with a size menu)
             - 'New arrow annotation' action (with a color menu)
 
         """
-        return [self.__zoomAction,
-                self.__cleanUpAction,
+        return [self.__cleanUpAction,
                 self.__newTextAnnotationAction,
                 self.__newArrowAnnotationAction]
 
@@ -866,18 +854,6 @@ class SchemeEditWidget(QWidget):
         for item in self.__scene.items():
             if item.flags() & QGraphicsItem.ItemIsSelectable:
                 item.setSelected(True)
-
-    def toggleZoom(self, zoom):
-        """
-        Toggle view zoom. If `zoom` is True the scheme is displayed
-        scaled to 150%.
-
-        """
-        view = self.view()
-        if zoom:
-            view.scale(1.5, 1.5)
-        else:
-            view.resetTransform()
 
     def alignToGrid(self):
         """


### PR DESCRIPTION
##### Issue

Zooming is currently rather rigid. There is also no zooming out.

##### Description of changes

Add zooming by ⌘+scroll; zooming is continuous on trackpads, and discrete with mouse.
Add zooming by ⌘+ and ⌘- ,and reset by ⌘0.
Remove the zoom toggle button from the toolbar.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation