### PR TITLE
Change the color of the sinkIndicator while LinkItem is pending

### DIFF
--- a/Orange/canvas/canvas/items/linkitem.py
+++ b/Orange/canvas/canvas/items/linkitem.py
@@ -684,7 +684,7 @@ class LinkItem(QGraphicsObject):
             self.__state = state
 
             if state & LinkItem.Pending:
-                self.sinkIndicator.setBrush(QBrush(Qt.yellow))
+                self.sinkIndicator.setBrush(QBrush(Qt.red))
             else:
                 self.sinkIndicator.setBrush(QBrush(QColor("#9CACB4")))
             self.__updatePen()


### PR DESCRIPTION
##### Issue
I think displaying the actual position of the data flow is very useful, but the yellow color was so hard to notice that many people didn't even know about this feature. Red is definitely visible (although not colorblind friendly), but now it looks a bit funny because the sinkIndicator layer is below the shield. It could be considered to change the color of the whole input shield while the flow is pending or move the sinkIndicator layer above the shield.

##### Description of changes
Change the Qt.yellow color to Qt.red

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
