### PR TITLE
[FIX] VizRank (Linear Projection, Radviz): spin disabled/enabled

### DIFF
--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -78,6 +78,10 @@ class LinearProjectionVizRank(VizRankDialog, OWComponent):
             self.scores = []
             self.rank_model.clear()
         self.last_run_n_attrs = self.n_attrs
+        self.n_attrs_spin.setDisabled(True)
+
+    def stopped(self):
+        self.n_attrs_spin.setDisabled(False)
 
     def check_preconditions(self):
         master = self.master

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -199,6 +199,10 @@ class RadvizVizRank(VizRankDialog, OWComponent):
             self.scores = []
             self.rank_model.clear()
         self.last_run_n_attrs = self.n_attrs
+        self.n_attrs_spin.setDisabled(True)
+
+    def stopped(self):
+        self.n_attrs_spin.setDisabled(False)
 
 
 class RadvizInteractiveViewBox(InteractiveViewBox):


### PR DESCRIPTION
##### Issue
See https://github.com/biolab/orange3/pull/2480#issuecomment-353300444

##### Description of changes
Changing number of vars disabled when running.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
