### PR TITLE
[FIX] OWWidget: Move 'splitter' to private members

### DIFF
--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -220,7 +220,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         self.left_side = None
         self.controlArea = self.mainArea = self.buttonsArea = None
-        self.splitter = None
+        self.__splitter = None
         if self.want_basic_layout:
             self.set_basic_layout()
 
@@ -234,13 +234,13 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             # Otherwise, the first control has focus
             self.controlArea.setFocus(Qt.ActiveWindowFocusReason)
 
-        if self.splitter is not None:
-            self.splitter.controlAreaVisibilityChanged.connect(
+        if self.__splitter is not None:
+            self.__splitter.controlAreaVisibilityChanged.connect(
                 self.storeControlAreaVisibility)
             sc = QShortcut(
                 QKeySequence(Qt.ControlModifier | Qt.ShiftModifier | Qt.Key_D),
                 self)
-            sc.activated.connect(self.splitter.flip)
+            sc.activated.connect(self.__splitter.flip)
         return self
 
     # pylint: disable=super-init-not-called
@@ -316,12 +316,12 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
                 return
 
     def _insert_splitter(self):
-        self.splitter = self._Splitter(Qt.Horizontal, self)
-        self.layout().addWidget(self.splitter)
+        self.__splitter = self._Splitter(Qt.Horizontal, self)
+        self.layout().addWidget(self.__splitter)
 
     def _insert_control_area(self):
-        self.left_side = gui.vBox(self.splitter, spacing=0)
-        self.splitter.setSizes([1])  # Smallest size allowed by policy
+        self.left_side = gui.vBox(self.__splitter, spacing=0)
+        self.__splitter.setSizes([1])  # Smallest size allowed by policy
         if self.buttons_area_orientation is not None:
             self.controlArea = gui.vBox(self.left_side, addSpace=0)
             self._insert_buttons_area()
@@ -342,12 +342,12 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     def _insert_main_area(self):
         self.mainArea = gui.vBox(
-            self.splitter, margin=4,
+            self.__splitter, margin=4,
             sizePolicy=QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         )
-        self.splitter.addWidget(self.mainArea)
-        self.splitter.setCollapsible(
-            self.splitter.indexOf(self.mainArea), False)
+        self.__splitter.addWidget(self.mainArea)
+        self.__splitter.setCollapsible(
+            self.__splitter.indexOf(self.mainArea), False)
         self.mainArea.layout().setContentsMargins(
             0 if self.want_control_area else 4, 4, 4, 4)
 
@@ -572,7 +572,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         QDialog.showEvent(self, event)
         if self.save_position and not self.__was_restored:
             # Restore saved geometry on (first) show
-            self.splitter.setControlAreaVisible(self.controlAreaVisible)
+            self.__splitter.setControlAreaVisible(self.controlAreaVisible)
             self.__restoreWidgetGeometry()
             self.__was_restored = True
         self.__quicktipOnce()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since gh-2743 *Data Sets*, *Predictions* and *GO Browser* (from Bioinformatics add-on) raise a
```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/widget.py", line 575, in showEvent
    self.splitter.setControlAreaVisible(self.controlAreaVisible)
AttributeError: 'QSplitter' object has no attribute 'setControlAreaVisible'
-------------------------------------------------------------------------------
```
Because they assign `self.splitter = ...`


##### Description of changes

Rename `OWWidget.splitter` to `OWWidget.__splitter`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
