### PR TITLE
[ENH] Distances: Optimize PearsonR/SpearmanR

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -507,6 +507,9 @@ def _corrcoef2(a, b, axis=0):
     numpy.corrcoef
     """
     a, b = np.atleast_2d(a, b)
+    if not (axis == 0 or axis == 1):
+        raise ValueError("Invalid axis {} (only 0 or 1 accepted)".format(axis))
+
     mean_a = np.mean(a, axis=axis, keepdims=True)
     mean_b = np.mean(b, axis=axis, keepdims=True)
     assert a.shape[axis] == b.shape[axis]
@@ -523,8 +526,6 @@ def _corrcoef2(a, b, axis=0):
     elif axis == 1:
         C = a.dot(b.T)
         assert C.shape == (n, m)
-    else:
-        raise ValueError()
 
     ss_a = np.sum(a ** 2, axis=axis, keepdims=True)
     ss_b = np.sum(b ** 2, axis=axis, keepdims=True)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

* PearsonR is poorly implemented by a double for loop in python.
* SpearmanR quadruples it's workload only to throw most of it away. 

##### Description of changes

* Use `numpy.corrcoef` for PearsonR
* Implement a variants of corrcoef/spearmanr which compute correlations between two arrays more efficiently (without also computing all correlations within the two arrays).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
