### PR TITLE
Revert "WebEngineView: delay showing the widget a bit"

### DIFF
--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -100,7 +100,6 @@ if HAVE_WEBENGINE:
                              sizeHint=QSize(500, 400),
                              sizePolicy=QSizePolicy(QSizePolicy.Expanding,
                                                     QSizePolicy.Expanding),
-                             visible=False,
                              **kwargs)
             self.bridge = bridge
             self.debug = debug
@@ -139,10 +138,6 @@ if HAVE_WEBENGINE:
             channel.registerObject('__bridge', _QWidgetJavaScriptWrapper(self))
 
             self.page().setWebChannel(channel)
-
-            # Delay showing the widget. Observation indicate this results in
-            # fewer window resizes.
-            QTimer.singleShot(1, self.show)
 
         def _onloadJS(self, code, name='', injection_point=QWebEngineScript.DocumentReady):
             script = QWebEngineScript()


### PR DESCRIPTION
This reverts commit 6f7c4392b23374ebde88ade62a9457dd5972d30f.


##### Issue
Fixes https://github.com/biolab/orange3-prototypes/issues/113


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
