### PR TITLE
Add Domain.empty, add warning to Domain.__bool__

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -1,3 +1,4 @@
+import warnings
 import weakref
 
 from math import log
@@ -10,7 +11,7 @@ import numpy as np
 from Orange.data import (
     Unknown, Variable, ContinuousVariable, DiscreteVariable, StringVariable
 )
-from Orange.util import deprecated
+from Orange.util import deprecated, OrangeDeprecationWarning
 
 __all__ = ["DomainConversion", "Domain"]
 
@@ -242,6 +243,16 @@ class Domain:
     def __len__(self):
         """The number of variables (features and class attributes)."""
         return len(self._variables)
+
+    def __bool__(self):
+        warnings.warn(
+            "Domain.__bool__ is ambiguous; use 'is None' or 'empty' instead",
+            OrangeDeprecationWarning, stacklevel=2)
+        return len(self) > 0  # Keep the obsolete behaviour
+
+    def empty(self):
+        """True if the domain has no variables of any kind"""
+        return not self.variables and not self.metas
 
     def __getitem__(self, idx):
         """

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1567,7 +1567,7 @@ class Table(MutableSequence, Storage):
                       for row in table] if feature_names_column else \
             [ContinuousVariable(feature_name + " " + str(i + 1).zfill(
                 int(np.ceil(np.log10(n_cols))))) for i in range(n_cols)]
-        if old_domain and feature_names_column:
+        if old_domain is not None and feature_names_column:
             for i, _ in enumerate(attributes):
                 if attributes[i].name in old_domain:
                     var = old_domain[attributes[i].name]
@@ -1608,7 +1608,7 @@ class Table(MutableSequence, Storage):
 
         # class_vars - attributes of attributes to class - from old domain
         class_vars = []
-        if old_domain:
+        if old_domain is not None:
             class_vars = old_domain.class_vars
         self.Y = get_table_from_attributes_of_attributes(class_vars)
 
@@ -1635,10 +1635,10 @@ class Table(MutableSequence, Storage):
             return variable
 
         _metas = [StringVariable(n) for n in names]
-        if old_domain:
+        if old_domain is not None:
             _metas = [m for m in old_domain.metas if m.name != meta_attr_name]
         M = get_table_from_attributes_of_attributes(_metas, _dtype=object)
-        if not old_domain:
+        if old_domain is None:
             _metas = [guessed_var(i, m.name) for i, m in enumerate(_metas)]
         if _metas:
             self.metas = np.hstack((self.metas, M))

--- a/Orange/data/tests/test_domain.py
+++ b/Orange/data/tests/test_domain.py
@@ -1,0 +1,19 @@
+import unittest
+
+from Orange.data import Domain, ContinuousVariable
+from Orange.util import OrangeDeprecationWarning
+
+
+class DomainTest(unittest.TestCase):
+    def test_bool_raises_warning(self):
+        self.assertWarns(OrangeDeprecationWarning, bool, Domain([]))
+        self.assertWarns(OrangeDeprecationWarning, bool,
+                         Domain([ContinuousVariable()]))
+
+    def test_empty(self):
+        var = ContinuousVariable()
+        self.assertTrue(Domain([]).empty())
+
+        self.assertFalse(Domain([var]).empty())
+        self.assertFalse(Domain([], [var]).empty())
+        self.assertFalse(Domain([], [], [var]).empty())

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -166,9 +166,9 @@ class Results:
                     probabilities is not None and probabilities.shape[1]],
             "mismatching number of rows")
         nclasses = set_or_raise(
-            nclasses, [domain and (len(domain.class_var.values)
-                                   if domain.has_discrete_class
-                                   else None),
+            nclasses, [len(domain.class_var.values)
+                       if domain is not None and domain.has_discrete_class
+                       else None,
                        probabilities is not None and probabilities.shape[2]],
             "mismatching number of class values")
         if nclasses is not None and probabilities is not None:

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -176,7 +176,7 @@ class FeatureEditor(QFrame):
         self.setModified(False)
         self.featureChanged.emit()
         self.attrs_model[:] = ["Select Feature"]
-        if domain is not None and (domain or domain.metas):
+        if domain is not None and not domain.empty():
             self.attrs_model[:] += chain(domain.attributes,
                                          domain.class_vars,
                                          domain.metas)

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -254,7 +254,7 @@ class TestDomainContextHandler(TestCase):
                           [x.category for x in w])
 
     def create_context(self, domain, values):
-        if not domain:
+        if domain is None:
             domain = Domain([])
 
         context = self.handler.new_context(domain,

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -267,13 +267,7 @@ class OWMDS(OWWidget):
         self.update_graph(reset_view=False)
 
     def init_attr_values(self):
-        domain = self.data.domain if self.data and len(self.data) else None
-        for model in self.models:
-            model.set_domain(domain)
-        self.graph.attr_color = self.data.domain.class_var if domain else None
-        self.graph.attr_shape = None
-        self.graph.attr_size = None
-        self.graph.attr_label = None
+        self.graph.set_domain(self.data)
 
     def prepare_data(self):
         pass

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -618,13 +618,16 @@ class OWFreeViz(widget.OWWidget):
         self._new_plotdata()
 
     def init_attr_values(self):
-        domain = self.data and len(self.data) and self.data.domain or None
+        domain = self.data.domain if self.data and len(self.data) else None
         for model in self.models:
             model.set_domain(domain)
         self.graph.attr_label = None
         self.graph.attr_size = None
         self.graph.attr_shape = None
-        self.graph.attr_color = self.data.domain.class_var if domain else None
+        if domain is not None:
+            self.graph.attr_color = self.data.domain.class_var
+        else:
+            self.graph.attr_color = None
 
     @Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -618,16 +618,7 @@ class OWFreeViz(widget.OWWidget):
         self._new_plotdata()
 
     def init_attr_values(self):
-        domain = self.data.domain if self.data and len(self.data) else None
-        for model in self.models:
-            model.set_domain(domain)
-        self.graph.attr_label = None
-        self.graph.attr_size = None
-        self.graph.attr_shape = None
-        if domain is not None:
-            self.graph.attr_color = self.data.domain.class_var
-        else:
-            self.graph.attr_color = None
+        self.graph.set_domain(self.data)
 
     @Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -464,16 +464,7 @@ class OWLinearProjection(widget.OWWidget):
             QApplication.postEvent(self, QEvent(self.ReplotRequest), Qt.LowEventPriority - 10)
 
     def init_attr_values(self):
-        domain = self.data.domain if self.data and len(self.data) else None
-        for model in self.models:
-            model.set_domain(domain)
-        if domain is not None:
-            self.graph.attr_color = self.data.domain.class_var
-        else:
-            self.graph.attr_color = None
-        self.graph.attr_shape = None
-        self.graph.attr_size = None
-        self.graph.attr_label = None
+        self.graph.set_domain(self.data)
 
     def _vizrank_color_change(self):
         is_enabled = False

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -464,10 +464,13 @@ class OWLinearProjection(widget.OWWidget):
             QApplication.postEvent(self, QEvent(self.ReplotRequest), Qt.LowEventPriority - 10)
 
     def init_attr_values(self):
-        domain = self.data and len(self.data) and self.data.domain or None
+        domain = self.data.domain if self.data and len(self.data) else None
         for model in self.models:
             model.set_domain(domain)
-        self.graph.attr_color = self.data.domain.class_var if domain else None
+        if domain is not None:
+            self.graph.attr_color = self.data.domain.class_var
+        else:
+            self.graph.attr_color = None
         self.graph.attr_shape = None
         self.graph.attr_size = None
         self.graph.attr_label = None

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -735,7 +735,7 @@ class OWNomogram(OWWidget):
         self.class_combo.clear()
         self.norm_check.setHidden(True)
         self.cont_feature_dim_combo.setEnabled(True)
-        if self.domain:
+        if self.domain is not None:
             self.class_combo.addItems(self.domain.class_vars[0].values)
             if len(self.domain.attributes) > self.MAX_N_ATTRS:
                 self.display_index = 1
@@ -775,7 +775,8 @@ class OWNomogram(OWWidget):
         self.calculate_log_reg_coefficients()
         self.update_controls()
         self.target_class_index = 0
-        self.openContext(self.domain and self.domain.class_var)
+        self.openContext(self.domain.class_var if self.domain is not None
+                         else None)
         self.points = self.log_odds_ratios or self.log_reg_coeffs
         self.feature_marker_values = []
         self.old_target_class_index = self.target_class_index
@@ -954,7 +955,7 @@ class OWNomogram(OWWidget):
 
     def get_ordered_attributes(self):
         """Return (in_domain_index, attr) pairs, ordered by method in SortBy combo"""
-        if not self.domain or not self.domain.attributes:
+        if self.domain is None or not self.domain.attributes:
             return []
 
         attrs = self.domain.attributes

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -533,10 +533,13 @@ class OWRadviz(widget.OWWidget):
             QApplication.postEvent(self, QEvent(self.ReplotRequest), Qt.LowEventPriority - 10)
 
     def init_attr_values(self):
-        domain = self.data and len(self.data) and self.data.domain or None
+        domain = self.data.domain if self.data and len(self.data) else None
         for model in self.models:
             model.set_domain(domain)
-        self.graph.attr_color = self.data.domain.class_var if domain else None
+        if domain is not None:
+            self.graph.attr_color = self.data.domain.class_var
+        else:
+            self.graph.attr_color = None
         self.graph.attr_shape = None
         self.graph.attr_size = None
         self.graph.attr_label = None

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -533,16 +533,7 @@ class OWRadviz(widget.OWWidget):
             QApplication.postEvent(self, QEvent(self.ReplotRequest), Qt.LowEventPriority - 10)
 
     def init_attr_values(self):
-        domain = self.data.domain if self.data and len(self.data) else None
-        for model in self.models:
-            model.set_domain(domain)
-        if domain is not None:
-            self.graph.attr_color = self.data.domain.class_var
-        else:
-            self.graph.attr_color = None
-        self.graph.attr_shape = None
-        self.graph.attr_size = None
-        self.graph.attr_label = None
+        self.graph.set_domain(self.data)
 
     def _vizrank_color_change(self):
         attr_color = self.graph.attr_color

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -359,19 +359,13 @@ class OWScatterPlot(OWWidget):
             self.attribute_selection_list = None
 
     def init_attr_values(self):
-        domain = self.data.domain if self.data else None
-        for model in self.models:
-            model.set_domain(domain)
+        data = self.data
+        domain = data.domain if data and len(data) else None
+        self.xy_model.set_domain(domain)
         self.attr_x = self.xy_model[0] if self.xy_model else None
         self.attr_y = self.xy_model[1] if len(self.xy_model) >= 2 \
             else self.attr_x
-        if domain is not None:
-            self.graph.attr_color = self.data.domain.class_var
-        else:
-            self.graph.attr_color = None
-        self.graph.attr_shape = None
-        self.graph.attr_size = None
-        self.graph.attr_label = None
+        self.graph.set_domain(data)
 
     def set_attr(self, attr_x, attr_y):
         self.attr_x, self.attr_y = attr_x, attr_y

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -328,7 +328,7 @@ class OWScatterPlot(OWWidget):
     # called when all signals are received, so the graph is updated only once
     def handleNewSignals(self):
         self.graph.new_data(self.data, self.subset_data)
-        if self.attribute_selection_list and self.graph.domain and \
+        if self.attribute_selection_list and self.graph.domain is not None and \
                 all(attr in self.graph.domain
                         for attr in self.attribute_selection_list):
             self.attr_x = self.attribute_selection_list[0]
@@ -359,13 +359,16 @@ class OWScatterPlot(OWWidget):
             self.attribute_selection_list = None
 
     def init_attr_values(self):
-        domain = self.data and self.data.domain
+        domain = self.data.domain if self.data else None
         for model in self.models:
             model.set_domain(domain)
         self.attr_x = self.xy_model[0] if self.xy_model else None
         self.attr_y = self.xy_model[1] if len(self.xy_model) >= 2 \
             else self.attr_x
-        self.graph.attr_color = self.data.domain.class_var if domain else None
+        if domain is not None:
+            self.graph.attr_color = self.data.domain.class_var
+        else:
+            self.graph.attr_color = None
         self.graph.attr_shape = None
         self.graph.attr_size = None
         self.graph.attr_label = None

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -616,6 +616,14 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
         data = self.sparse_to_dense()
         self.set_data(data, **args)
 
+    def set_domain(self, data):
+        domain = data.domain if data and len(data) else None
+        for attr in ("attr_color", "attr_shape", "attr_size", "attr_label"):
+            getattr(self.controls, attr).model().set_domain(domain)
+            setattr(self, attr, None)
+        if domain is not None:
+            self.attr_color = domain.class_var
+
     def sparse_to_dense(self):
         data = self._data
         if data is None or not data.is_sparse():

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import unittest
+
 import numpy as np
 
 from AnyQt.QtCore import QPoint
@@ -209,3 +211,6 @@ class TestOWNomogram(WidgetTest):
         # had problems on PyQt4
         m = MovableToolTip()
         m.show(QPoint(0, 0), "Some text.")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Based on #2866 (1 commit). You may want to merge that request first.**

##### Issue

#2866 fixes an issue with labels in MDS that occured since `self.data.domain` was `False` for a `Domain` with only meta attributes. This occurs since `Domain.__len__` (correctly) returns the number of elements that `Domain.__iter__` iterates across, however, `Domain.__iter__` (incorrectly) ignores metas.

The issue will remain even after we fix `Domain.__iter__`: when checking whether a domain is true, we usually mean whether it's not `None`.

##### Description of changes

`Domain` has a new method, `empty`.

`__bool__` warns that it's ambiguous and suggests using either `empty` or `is None`. The behaviour of `__bool__` is unchanged - it returns `True` if the lenght of the domain is non-zero.


##### Includes
- [X] Code changes
- [X] Tests
