### PR TITLE
[FIX] Projection widgets: transform data properly

### DIFF
--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -793,9 +793,9 @@ class OWFreeViz(widget.OWWidget):
         mask = self.plotdata.validmask
         array = np.zeros((len(self.data), 2), dtype=np.float)
         array[mask] = self.plotdata.embedding_coords
-        data = Table.from_numpy(domain, X=np.hstack((self.data.X, array)),
-                                Y=self.data.Y,
-                                metas=self.data.metas)
+        data = self.data.transform(domain)
+        data[:, self.variable_x] = array[:, 0].reshape(-1, 1)
+        data[:, self.variable_y] = array[:, 1].reshape(-1, 1)
         subset_data = data[self._subset_mask & mask]\
             if self._subset_mask is not None and len(self._subset_mask) else None
         self.plotdata.data = data

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -732,8 +732,9 @@ class OWLinearProjection(widget.OWWidget):
         valid_mask = self.plotdata.valid_mask
         array = np.zeros((len(self.data), 2), dtype=np.float)
         array[valid_mask] = self.plotdata.embedding_coords
-        self.plotdata.data = data = Table.from_numpy(
-            domain, X=self.data.X, Y=self.data.Y, metas=np.hstack((self.data.metas, array)))
+        self.plotdata.data = data = self.data.transform(domain)
+        data[:, self.variable_x] = array[:, 0].reshape(-1, 1)
+        data[:, self.variable_y] = array[:, 1].reshape(-1, 1)
         subset_data = data[self._subset_mask & valid_mask]\
             if self._subset_mask is not None and len(self._subset_mask) else None
         self.plotdata.data = data

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -719,8 +719,9 @@ class OWRadviz(widget.OWWidget):
         mask = self.plotdata.valid_mask
         array = np.zeros((len(self.data), 2), dtype=np.float)
         array[mask] = self.plotdata.embedding_coords
-        data = Table.from_numpy(
-            domain, X=self.data.X, Y=self.data.Y, metas=np.hstack((self.data.metas, array)))
+        data = self.data.transform(domain)
+        data[:, self.variable_x] = array[:, 0].reshape(-1, 1)
+        data[:, self.variable_y] = array[:, 1].reshape(-1, 1)
         subset_data = data[self._subset_mask & mask]\
             if self._subset_mask is not None and len(self._subset_mask) else None
         self.plotdata.data = data


### PR DESCRIPTION
##### Issue
Thanks to @markotoplak and his new widget (https://github.com/biolab/orange3-prototypes/pull/117) a new issue has been found.

Data in widgets **Radviz**, **FreeViz**, and **Linear Projection** is not transformed properly. Data indices are not preserved.

##### Description of changes
Use `Table.transform`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
