### PR TITLE
[FIX] Feature Constructor: Make FeatureFunc picklable

### DIFF
--- a/Orange/__init__.py
+++ b/Orange/__init__.py
@@ -1,13 +1,3 @@
-import pickle
-from unittest.mock import patch
-# Needed because the pure-Python Unpickler that dill uses can also fail
-# with struct.error Exception. This seems to work, side effects unknown.
-with patch('pickle._Unpickler', pickle.Unpickler):
-    import dill
-dill.settings['protocol'] = pickle.HIGHEST_PROTOCOL
-dill.settings['recurse'] = True
-dill.settings['byref'] = True
-
 from .misc.lazy_module import _LazyModule
 from .misc.datasets import _DatasetInfo
 from .version import \

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -2,6 +2,8 @@ import unittest
 import ast
 import sys
 import math
+import pickle
+import copy
 
 import numpy as np
 
@@ -14,9 +16,11 @@ from Orange.widgets.data.owfeatureconstructor import (
     construct_variables, OWFeatureConstructor,
     FeatureEditor, DiscreteFeatureEditor)
 
-from Orange.widgets.data.owfeatureconstructor import freevars, validate_exp
+from Orange.widgets.data.owfeatureconstructor import (
+    freevars, validate_exp, FeatureFunc
+)
 
-import dill as pickle  # Import dill after Orange because patched
+import dill  # Import dill after Orange because patched
 
 
 class FeatureConstructorTest(unittest.TestCase):
@@ -105,9 +109,9 @@ class PicklingTest(unittest.TestCase):
             return x * local_const * NONLOCAL_CONST * self.CLASS_CONST * GLOBAL_CONST
 
         self.assertEqual(lambda_func(11),
-                         pickle.loads(pickle.dumps(lambda_func))(11))
+                         dill.loads(dill.dumps(lambda_func))(11))
         self.assertEqual(nested_func(11),
-                         pickle.loads(pickle.dumps(nested_func))(11))
+                         dill.loads(dill.dumps(nested_func))(11))
 
 
 class TestTools(unittest.TestCase):
@@ -216,6 +220,30 @@ class TestTools(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             validate_("{a:1 for a in s}")
+
+
+class FeatureFuncTest(unittest.TestCase):
+    def test_reconstruct(self):
+        f = FeatureFunc("a * x + c", [("x", "x")], {"a": 2, "c": 10})
+        self.assertEqual(f({"x": 2}), 14)
+        f1 = pickle.loads(pickle.dumps(f))
+        self.assertEqual(f1({"x": 2}), 14)
+        fc = copy.copy(f)
+        self.assertEqual(fc({"x": 3}), 16)
+
+    def test_repr(self):
+        self.assertEqual(repr(FeatureFunc("a + 1", [("a", 2)])),
+                         "FeatureFunc('a + 1', [('a', 2)], {})")
+
+    def test_call(self):
+        f = FeatureFunc("a + 1", [("a", "a")])
+        self.assertEqual(f({"a": 2}), 3)
+
+        iris = Table("iris")
+        f = FeatureFunc("sepal_width + 10",
+                        [("sepal_width", iris.domain["sepal width"])])
+        r = f(iris)
+        np.testing.assert_array_equal(r, iris.X[:, 1] + 10)
 
 
 class OWFeatureConstructorTests(WidgetTest):

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -20,8 +20,6 @@ from Orange.widgets.data.owfeatureconstructor import (
     freevars, validate_exp, FeatureFunc
 )
 
-import dill  # Import dill after Orange because patched
-
 
 class FeatureConstructorTest(unittest.TestCase):
     def test_construct_variables_discrete(self):
@@ -91,27 +89,6 @@ class FeatureConstructorTest(unittest.TestCase):
         np.testing.assert_array_equal(ndata.X[:, 0],
                                       data.X[:, :2].sum(axis=1))
         ContinuousVariable._clear_all_caches()
-
-
-GLOBAL_CONST = 2
-
-
-class PicklingTest(unittest.TestCase):
-    CLASS_CONST = 3
-
-    def test_lambdas_pickle(self):
-        NONLOCAL_CONST = 5
-
-        lambda_func = lambda x, local_const=7: \
-            x * local_const * NONLOCAL_CONST * self.CLASS_CONST * GLOBAL_CONST
-
-        def nested_func(x, local_const=7):
-            return x * local_const * NONLOCAL_CONST * self.CLASS_CONST * GLOBAL_CONST
-
-        self.assertEqual(lambda_func(11),
-                         dill.loads(dill.dumps(lambda_func))(11))
-        self.assertEqual(nested_func(11),
-                         dill.loads(dill.dumps(nested_func))(11))
 
 
 class TestTools(unittest.TestCase):

--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -1,6 +1,6 @@
 import os
+import pickle
 
-import dill as pickle
 from AnyQt.QtCore import QTimer
 from AnyQt.QtWidgets import (
     QSizePolicy, QHBoxLayout, QComboBox, QStyle, QFileDialog

--- a/Orange/widgets/model/owsavemodel.py
+++ b/Orange/widgets/model/owsavemodel.py
@@ -1,6 +1,7 @@
 import os
 
-import dill as pickle
+import pickle
+
 from AnyQt.QtWidgets import (
     QComboBox, QStyle, QSizePolicy, QFileDialog, QApplication
 )

--- a/Orange/widgets/model/tests/test_owloadmodel.py
+++ b/Orange/widgets/model/tests/test_owloadmodel.py
@@ -4,8 +4,6 @@ import os
 import pickle
 from tempfile import mkstemp
 
-import dill    # Import dill after Orange because patched
-
 from Orange.classification.majority import ConstantModel
 from Orange.widgets.model.owloadmodel import OWLoadModel
 from Orange.widgets.tests.base import WidgetTest
@@ -23,11 +21,10 @@ class TestOWLoadModel(WidgetTest):
         fd, fname = mkstemp(suffix='.pkcls')
         os.close(fd)
         try:
-            for pickle_impl in (pickle, dill):
-                with open(fname, 'wb') as f:
-                    pickle_impl.dump(clsf, f)
-                self.widget.load(fname)
-                self.assertFalse(self.widget.Error.load_error.is_shown())
+            with open(fname, 'wb') as f:
+                pickle.dump(clsf, f)
+            self.widget.load(fname)
+            self.assertFalse(self.widget.Error.load_error.is_shown())
 
             with open(fname, "w") as f:
                 f.write("X")

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -48,7 +48,6 @@ requirements:
     - anyqt         >=0.0.6
     - joblib
     - python.app    # [osx]
-    - dill          # pickle anything
     - commonmark
     - serverfiles
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -11,6 +11,5 @@ chardet>=3.0.2
 joblib>=0.9.4
 keyring
 keyrings.alt    # for alternative keyring implementations
-dill
 setuptools>=36.3
 serverfiles		# for Data Sets synchronization

--- a/scripts/macos/requirements.txt
+++ b/scripts/macos/requirements.txt
@@ -7,7 +7,6 @@
 AnyQt==0.0.8
 Bottleneck==1.2.0
 chardet==3.0.4
-dill==0.2.6
 docutils==0.13.1
 joblib==0.11
 keyring==10.3.1

--- a/scripts/windows/specs/PY34-win32.txt
+++ b/scripts/windows/specs/PY34-win32.txt
@@ -18,7 +18,6 @@ AnyQt==0.0.8
 PyQt5==5.5.1
 docutils==0.13.1
 pip==9.0.1
-dill==0.2.6
 pyqtgraph==0.10.0
 six==1.10.0
 xlrd==1.0.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-2686

##### Description of changes

* Make owfetureconsctructior.FeatureFunc picklable
* Change how discrete variable's symbolic values are captured in the resulting lambda (via closure and not argument list).
* Remove dill as a dependency

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
