### PR TITLE
[FIX] OWWidget: Store quicktip displayed state in non versioned settings dir

### DIFF
--- a/Orange/misc/environ.py
+++ b/Orange/misc/environ.py
@@ -45,23 +45,27 @@ def data_dir_base():
     return base
 
 
-def data_dir():
+def data_dir(versioned=True):
     """
     Return the platform dependent Orange data directory.
 
-    This is ``data_dir_base()``/Orange/__VERSION__/ directory.
+    This is ``data_dir_base()``/Orange/__VERSION__/ directory if versioned is
+    `True` and ``data_dir_base()``/Orange/ otherwise.
     """
     base = data_dir_base()
-    return os.path.join(base, "Orange", Orange.__version__)
+    if versioned:
+        return os.path.join(base, "Orange", Orange.__version__)
+    else:
+        return os.path.join(base, "Orange")
 
 
-def widget_settings_dir():
+def widget_settings_dir(versioned=True):
     """
     Return the platform dependent directory where widgets save their settings.
 
-    This a subdirectory of ``data_dir()`` named "widgets"
+    This a subdirectory of ``data_dir(versioned)`` named "widgets"
     """
-    return os.path.join(data_dir(), "widgets")
+    return os.path.join(data_dir(versioned=versioned), "widgets")
 
 
 def cache_dir(*args):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -821,7 +821,13 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.__showMessage(message)
 
     def __quicktipOnce(self):
-        filename = os.path.join(settings.widget_settings_dir(),
+        dirpath = settings.widget_settings_dir(versioned=False)
+        try:
+            os.makedirs(dirpath, exist_ok=True)
+        except OSError:  # EPERM, EEXISTS, ...
+            pass
+
+        filename = os.path.join(settings.widget_settings_dir(versioned=False),
                                 "user-session-state.ini")
         namespace = ("user-message-history/{0.__module__}.{0.__qualname__}"
                      .format(type(self)))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The annoying quicktip overlays are displayed again on every minor version upgrade.

##### Description of changes

Store the displayed state in non versioned directory.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
