### PR TITLE
Enable Conda for installing add-ons by default

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -869,8 +869,8 @@ class PipInstaller:
 
 class CondaInstaller:
     def __init__(self):
-        enabled = QSettings().value('add-ons/allow-conda-experimental',
-                                    False, type=bool)
+        enabled = QSettings().value('add-ons/allow-conda',
+                                    True, type=bool)
         if enabled:
             self.conda = self._find_conda()
         else:

--- a/Orange/canvas/application/settings.py
+++ b/Orange/canvas/application/settings.py
@@ -386,8 +386,8 @@ class UserSettingsDialog(QMainWindow):
         conda.layout().setContentsMargins(0, 0, 0, 0)
 
         cb_conda_install = QCheckBox(self.tr("Install add-ons with conda"), self,
-                                     objectName="allow-conda-experimental")
-        self.bind(cb_conda_install, "checked", "add-ons/allow-conda-experimental")
+                                     objectName="allow-conda")
+        self.bind(cb_conda_install, "checked", "add-ons/allow-conda")
         conda.layout().addWidget(cb_conda_install)
 
         form.addRow(self.tr("Conda"), conda)

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -122,7 +122,7 @@ spec = \
      ("error-reporting/machine-id", str, '',
      "Report custom name instead of machine ID"),
 
-     ("add-ons/allow-conda-experimental", bool, False,
+     ("add-ons/allow-conda", bool, True,
       "Install add-ons with conda"),
      ]
 


### PR DESCRIPTION
##### Issue

install add-ons with Conda `false` by default

##### Description of changes
Changing install add-ons with Conda to be `true` by default. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
