### PR TITLE
Revert "[REF] Rename Data Sets to Datasets"

### DIFF
--- a/Orange/canvas/application/workflows/110-file-and-data-table-widget.ows
+++ b/Orange/canvas/application/workflows/110-file-and-data-table-widget.ows
@@ -8,10 +8,10 @@
 		<link enabled="true" id="0" sink_channel="Data" sink_node_id="1" source_channel="Data" source_node_id="0" />
 	</links>
 	<annotations>
-		<text font-family="Helvetica" font-size="14" id="0" rect="(17.0, 21.0, 160.0, 55.0)">A File widget. Double click to open it and select the dataset file.</text>
+		<text font-family="Helvetica" font-size="14" id="0" rect="(17.0, 21.0, 160.0, 55.0)">A File widget. Double click to open it and select the data set file.</text>
 		<text font-family="Helvetica" font-size="14" id="1" rect="(50.0, 229.0, 118.0, 40.0)">The output of the File widget.</text>
 		<text font-family="Helvetica" font-size="14" id="2" rect="(241.0, 227.0, 131.0, 41.0)">The input of the Data Table widget.</text>
-		<text font-family="Helvetica" font-size="14" id="3" rect="(138.0, 297.0, 150.0, 82.0)">The communication channel. It passes the dataset from the File widget to the Data Table.</text>
+		<text font-family="Helvetica" font-size="14" id="3" rect="(138.0, 297.0, 150.0, 82.0)">The communication channel. It passes the data set from the File widget to the Data Table.</text>
 		<text font-family="Helvetica" font-size="14" id="4" rect="(262.0, 21.0, 150.0, 68.0)">A Data Table widget. Double click the icon to see the data in a spreadsheet.</text>
 		<text font-family="Helvetica" font-size="14" id="5" rect="(415.0, 68.0, 150.0, 83.0)">The output of the Data Table to send out any data (rows) that are selected to the widget.</text>
 		<text font-family="Helvetica" font-size="14" id="6" rect="(489.0, 177.0, 216.0, 181.0)">This output is not used, hence dashed line. You can add another Data Table by clicking on its icon from the toolbox on the left, connect the ouput of Data Table to the input of new Data Table (1) and check if the selected data from Data Table is indeed sent to the downstream widget. This demo works best if both widgets are open, that is, their windows displayed.</text>

--- a/Orange/canvas/application/workflows/120-scatterplot-data-table.ows
+++ b/Orange/canvas/application/workflows/120-scatterplot-data-table.ows
@@ -10,7 +10,7 @@
 		<link enabled="true" id="1" sink_channel="Data" sink_node_id="2" source_channel="Selected Data" source_node_id="1" />
 	</links>
 	<annotations>
-		<text font-family="Helvetica" font-size="12" id="0" rect="(26.0, 7.0, 150.0, 112.59375)">This File widget is set to read the Iris dataset. Double click on the icon to change the input data file and observe how this workflow works for some other datasets such as housing or auto-mpg.</text>
+		<text font-family="Helvetica" font-size="12" id="0" rect="(26.0, 7.0, 150.0, 112.59375)">This File widget is set to read the Iris data set. Double click on the icon to change the input data file and observe how this workflow works for some other data sets such as housing or auto-mpg.</text>
 		<text font-family="Helvetica" font-size="12" id="1" rect="(224.0, 24.0, 150.0, 83.0)">Double click on the Scatter Plot icon to visualize the data. Then select the data subset by selecting the points from the scatter plot.</text>
 		<text font-family="Helvetica" font-size="12" id="2" rect="(412.0, 55.0, 150.0, 48.0)">Data Table widget shows the data subset selected in the Scatter Plot.</text>
 		<arrow end="(99.00000000000003, 175.0)" fill="#C1272D" id="3" start="(98.00000000000003, 118.0)" />

--- a/Orange/canvas/application/workflows/250-tree-scatterplot.ows
+++ b/Orange/canvas/application/workflows/250-tree-scatterplot.ows
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<scheme description="This workflow combines the inference and visualization of classification trees with a scatterplot. When both the tree browser and the scatterplot are open, selection of any node of the tree sends the related data instances to scatterplot. In the workflow, the selected data is treated as a subset of the entire dataset and is highlighted in the scatterplot. With simple combination of widgets we have constructed an interactive classification tree browser." title="Classification Tree" version="2.0">
+<scheme description="This workflow combines the inference and visualization of classification trees with a scatterplot. When both the tree browser and the scatterplot are open, selection of any node of the tree sends the related data instances to scatterplot. In the workflow, the selected data is treated as a subset of the entire data set and is highlighted in the scatterplot. With simple combination of widgets we have constructed an interactive classification tree browser." title="Classification Tree" version="2.0">
 	<nodes>
 		<node id="0" name="File" position="(98.0, 140.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owfile.OWFile" title="File" version="" />
 		<node id="1" name="Tree Viewer" position="(329.0, 275.0)" project_name="Orange3" qualified_name="Orange.widgets.visualize.owtreeviewer.OWTreeGraph" title="Classification Tree Viewer" version="" />
@@ -16,7 +16,7 @@
 	</links>
 	<annotations>
 		<arrow end="(113.0, 111.0)" fill="#C1272D" id="0" start="(152.0, 76.0)" />
-		<text font-family="Helvetica" font-size="14" id="1" rect="(158.0, 49.0, 174.0, 55.0)">Load data on Iris ("iris.tab") from preloaded documentation datasets.</text>
+		<text font-family="Helvetica" font-size="14" id="1" rect="(158.0, 49.0, 174.0, 55.0)">Load data on Iris ("iris.tab") from preloaded documentation data sets.</text>
 		<arrow end="(350.0, 230.0)" fill="#39B54A" id="2" start="(414.0, 138.0)" />
 		<arrow end="(452.0, 173.0)" fill="#39B54A" id="3" start="(421.0, 133.0)" />
 		<text font-family="Helvetica" font-size="14" id="4" rect="(396.0, 50.0, 150.0, 82.0)">Any change in selection of the tree node changes the rendering in the scatter plot.</text>

--- a/Orange/canvas/application/workflows/305-pca.ows
+++ b/Orange/canvas/application/workflows/305-pca.ows
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<scheme description="PCA transforms the data into a dataset with uncorrelated variables, also called principal components. PCA widget displays a graph (scree diagram) showing a degree of explained variance by best principal components and allows to interactively set the number of components to be included in the output dataset. In this workflow, we can observe the transformation in the Data Table and visualize the data using the constructed principal components in the Scatter Plot." title="Principal Component Analysis" version="2.0">
+<scheme description="PCA transforms the data into a data set with uncorrelated variables, also called principal components. PCA widget displays a graph (scree diagram) showing a degree of explained variance by best principal components and allows to interactively set the number of components to be included in the output data set. In this workflow, we can observe the transformation in the Data Table and visualize the data using the constructed principal components in the Scatter Plot." title="Principal Component Analysis" version="2.0">
 	<nodes>
 		<node id="0" name="File" position="(59.0, 211.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owfile.OWFile" title="File" version="" />
 		<node id="1" name="PCA" position="(225.0, 210.0)" project_name="Orange3" qualified_name="Orange.widgets.unsupervised.owpca.OWPCA" title="PCA" version="" />
@@ -13,8 +13,8 @@
 	</links>
 	<annotations>
 		<text font-family="Helvetica" font-size="12" id="0" rect="(152.0, 63.0, 150.0, 60.0)">Open to see the scree diagram and interactively select the number of components.</text>
-		<text font-family="Helvetica" font-size="12" id="1" rect="(346.0, 9.0, 150.0, 72.0)">Choose two best principal components and check if the classes from the input dataset are well separated.</text>
-		<text font-family="Helvetica" font-size="12" id="2" rect="(37.0, 302.0, 209.0, 58.0)">The File widget loads brown-selected, a dataset from molecular biology with 79 features, 186 instances and 3 classes.</text>
+		<text font-family="Helvetica" font-size="12" id="1" rect="(346.0, 9.0, 150.0, 72.0)">Choose two best principal components and check if the classes from the input data set are well separated.</text>
+		<text font-family="Helvetica" font-size="12" id="2" rect="(37.0, 302.0, 209.0, 58.0)">The File widget loads brown-selected, a data set from molecular biology with 79 features, 186 instances and 3 classes.</text>
 		<arrow end="(221.0, 177.0)" fill="#C1272D" id="3" start="(216.0, 126.0)" />
 		<arrow end="(412.0, 121.0)" fill="#C1272D" id="4" start="(426.0, 74.0)" />
 		<arrow end="(95.0, 242.0)" fill="#C1272D" id="5" start="(132.0, 298.0)" />

--- a/Orange/canvas/application/workflows/310-clustering.ows
+++ b/Orange/canvas/application/workflows/310-clustering.ows
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<scheme description="The workflow clusters the data items in Iris dataset by first estimating the distances between data instances. Distance matrix is passed to hierarchical clustering, which renders the dendrogram. Select different parts of the dendrogram to further analyze the corresponding data.&#10;&#10;Notice that hierarchical clustering can only handle small datasets, that is, those that contain only a small number of data instances. For larger datasets the distance matrix may get too big and may not fit in the memory. An alternative method that can consider such datasets is k-means clustering." title="Hierarchical Clustering" version="2.0">
+<scheme description="The workflow clusters the data items in Iris data set by first estimating the distances between data instances. Distance matrix is passed to hierarchical clustering, which renders the dendrogram. Select different parts of the dendrogram to further analyze the corresponding data.&#10;&#10;Notice that hierarchical clustering can only handle small data sets, that is, those that contain only a small number of data instances. For larger data sets the distance matrix may get too big and may not fit in the memory. An alternative method that can consider such data sets is k-means clustering." title="Hierarchical Clustering" version="2.0">
 	<nodes>
 		<node id="0" name="File" position="(135.0, 135.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owfile.OWFile" title="File" version="" />
 		<node id="1" name="Distances" position="(242.0, 203.0)" project_name="Orange3" qualified_name="Orange.widgets.unsupervised.owdistances.OWDistances" title="Distances" version="" />
@@ -18,7 +18,7 @@
 		<link enabled="true" id="5" sink_channel="Data" sink_node_id="6" source_channel="Selected Data" source_node_id="4" />
 	</links>
 	<annotations>
-		<text font-family="Helvetica" font-size="14" id="0" rect="(18.0, 15.0, 150.0, 82.0)">Read the data. Try this schema with the "brown-selected" data (from datasets that come with Orange).</text>
+		<text font-family="Helvetica" font-size="14" id="0" rect="(18.0, 15.0, 150.0, 82.0)">Read the data. Try this schema with the "brown-selected" data (from data sets that come with Orange).</text>
 		<text font-family="Helvetica" font-size="14" id="1" rect="(402.0, 63.0, 150.0, 54.0)">Visualize the data distances in a heat map.</text>
 		<text font-family="Helvetica" font-size="14" id="2" rect="(597.0, 56.0, 214.0, 153.0)">Choose any part of the clustering dendrogram in Hierarchical Clustering. Then, observe the selected data in a data table, or in any other analysis widget. Open both Hierarchical Clustering and Data Table (1) widget to turn this schema into interactive data analysis.
 </text>

--- a/Orange/canvas/application/workflows/410-feature-ranking.ows
+++ b/Orange/canvas/application/workflows/410-feature-ranking.ows
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<scheme description="For supervised problems, where data instances are annotated with class labels, we would like to know which are the most informative features. Rank widget provides a table of features and their informativity scores, and supports manual feature selection. In the workflow, we used it to find the best two features (of initial 79 from brown-selected dataset) and display its scatter plot." title="Feature Ranking" version="2.0">
+<scheme description="For supervised problems, where data instances are annotated with class labels, we would like to know which are the most informative features. Rank widget provides a table of features and their informativity scores, and supports manual feature selection. In the workflow, we used it to find the best two features (of initial 79 from brown-selected data set) and display its scatter plot." title="Feature Ranking" version="2.0">
 	<nodes>
 		<node id="0" name="File" position="(39.0, 195.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owfile.OWFile" title="File" version="" />
 		<node id="1" name="Rank" position="(296.0, 195.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owrank.OWRank" title="Rank" version="" />

--- a/Orange/canvas/application/workflows/450-cross-validation.ows
+++ b/Orange/canvas/application/workflows/450-cross-validation.ows
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<scheme description="How good are supervised data mining methods on your classification dataset? Here's a workflow that scores various classification techniques on a dataset from medicine. The central widget here is the one for testing and scoring, which is given the data and a set of learners, does cross-validation and scores predictive accuracy, and outputs the scores for further examination." title="Cross-Validation" version="2.0">
+<scheme description="How good are supervised data mining methods on your classification data set? Here's a workflow that scores various classification techniques on a data set from medicine. The central widget here is the one for testing and scoring, which is given the data and a set of learners, does cross-validation and scores predictive accuracy, and outputs the scores for further examination." title="Cross-Validation" version="2.0">
 	<nodes>
 		<node id="0" name="File" position="(91.0, 170.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owfile.OWFile" title="File" version="" />
 		<node id="1" name="Test &amp; Score" position="(364.0, 218.0)" project_name="Orange3" qualified_name="Orange.widgets.evaluate.owtestlearners.OWTestLearners" title="Test &amp; Score" version="" />
@@ -20,7 +20,7 @@
 		<link enabled="true" id="6" sink_channel="Data" sink_node_id="6" source_channel="Selected Data" source_node_id="7" />
 	</links>
 	<annotations>
-		<text font-family="Helvetica" font-size="14" id="0" rect="(16.0, 56.0, 180.0, 82.0)">Choose class-labeled dataset. Say, "iris.tab" from documentation datasets.</text>
+		<text font-family="Helvetica" font-size="14" id="0" rect="(16.0, 56.0, 180.0, 82.0)">Choose class-labeled data set. Say, "iris.tab" from documentation data sets.</text>
 		<text font-family="Helvetica" font-size="14" id="1" rect="(381.0, 76.0, 171.0, 54.0)">It's always a good idea to check out the data first.</text>
 		<text font-family="Helvetica" font-size="14" id="2" rect="(586.0, 90.0, 197.0, 96.0)">Select a cell in confusion matrix to obtain related data instances. Here we examine them in the spreadheet.</text>
 		<text font-family="Helvetica" font-size="14" id="3" rect="(533.0, 308.0, 150.0, 54.0)">Use for additional analysis of cross-validation results.</text>

--- a/Orange/canvas/application/workflows/470-misclassification-scatterplot.ows
+++ b/Orange/canvas/application/workflows/470-misclassification-scatterplot.ows
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<scheme description="Cross-validation of, say, logistic regression can expose the data instances which were misclassified. There are six such instances for Iris Dataset and ridge-regularized logistic regression. We can select different types of misclassification in Confusion Matrix and highlight them in the Scatter Plot. No surprise: the misclassified instances are close to the class-bordering regions in the scatter plot projection." title="Where are Misclassifications?" version="2.0">
+<scheme description="Cross-validation of, say, logistic regression can expose the data instances which were misclassified. There are six such instances for Iris Data set and ridge-regularized logistic regression. We can select different types of misclassification in Confusion Matrix and highlight them in the Scatter Plot. No surprise: the misclassified instances are close to the class-bordering regions in the scatter plot projection." title="Where are Misclassifications?" version="2.0">
 	<nodes>
 		<node id="0" name="File" position="(77.0, 71.0)" project_name="Orange3" qualified_name="Orange.widgets.data.owfile.OWFile" title="File" version="" />
 		<node id="1" name="Test &amp; Score" position="(196.0, 149.0)" project_name="Orange3" qualified_name="Orange.widgets.evaluate.owtestlearners.OWTestLearners" title="Test &amp; Score" version="" />
@@ -15,8 +15,8 @@
 		<link enabled="true" id="4" sink_channel="Data Subset" sink_node_id="4" source_channel="Selected Data" source_node_id="3" />
 	</links>
 	<annotations>
-		<text font-family="Helvetica" font-size="12" id="0" rect="(266.0, 236.0, 150.0, 72.0)">Shows different types of misclassifications. For Iris dataset, Iris virginica are confused with versicolor and vice versa.</text>
-		<text font-family="Helvetica" font-size="12" id="1" rect="(469.0, 146.0, 150.0, 60.0)">Misclassifications for Iris datasets are best seen in petal length-petal width projection.</text>
+		<text font-family="Helvetica" font-size="12" id="0" rect="(266.0, 236.0, 150.0, 72.0)">Shows different types of misclassifications. For Iris data set, Iris virginica are confused with versicolor and vice versa.</text>
+		<text font-family="Helvetica" font-size="12" id="1" rect="(469.0, 146.0, 150.0, 60.0)">Misclassifications for Iris data sets are best seen in petal length-petal width projection.</text>
 		<text font-family="Helvetica" font-size="12" id="2" rect="(36.0, 319.0, 150.0, 48.0)">Replace logistic regression with any other classification method.</text>
 		<arrow end="(494.0, 98.0)" fill="#C1272D" id="3" start="(522.0, 142.0)" />
 		<arrow end="(337.0, 199.0)" fill="#C1272D" id="4" start="(335.0, 233.0)" />

--- a/Orange/classification/majority.py
+++ b/Orange/classification/majority.py
@@ -17,7 +17,7 @@ class MajorityLearner(Learner):
 
     In the special case of uniform class distribution within the training data,
     class value is selected randomly. In order to produce consistent results on
-    the same dataset, this value is selected based on hash of the class vector.
+    the same data set, this value is selected based on hash of the class vector.
     """
     def fit_storage(self, dat):
         if not dat.domain.has_discrete_class:

--- a/Orange/classification/rules.py
+++ b/Orange/classification/rules.py
@@ -1302,7 +1302,7 @@ class CN2UnorderedLearner(_RuleLearner):
     by the relative frequency of the class corrected by the Laplace correction.
     After adding a rule, only the covered examples of that class are removed.
 
-    The code below loads the *iris* dataset (four continuous attributes
+    The code below loads the *iris* data set (four continuous attributes
     and a discrete class) and fits the learner.
 
     .. literalinclude:: code/classification-cn2ruleinduction1.py

--- a/Orange/classification/simple_tree.py
+++ b/Orange/classification/simple_tree.py
@@ -70,7 +70,7 @@ class SimpleTreeLearner(Learner):
         - if "log2", then `skip_prob = 1 - log2(n_features) / n_features`
 
     bootstrap : data table, optional (default = False)
-        A bootstrap dataset.
+        A bootstrap data set.
 
     seed : int, optional (default = 42)
         Random seed.

--- a/Orange/clustering/hierarchical.py
+++ b/Orange/clustering/hierarchical.py
@@ -69,9 +69,9 @@ def squareform(X, mode="upper"):
 def data_clustering(data, distance=Euclidean,
                     linkage=AVERAGE):
     """
-    Return the hierarchical clustering of the dataset's rows.
+    Return the hierarchical clustering of the data set's rows.
 
-    :param Orange.data.Table data: Dataset to cluster.
+    :param Orange.data.Table data: Data set to cluster.
     :param Orange.distance.Distance distance: A distance measure.
     :param str linkage:
     """
@@ -82,9 +82,9 @@ def data_clustering(data, distance=Euclidean,
 def feature_clustering(data, distance=PearsonR,
                        linkage=AVERAGE):
     """
-    Return the hierarchical clustering of the dataset's columns.
+    Return the hierarchical clustering of the data set's columns.
 
-    :param Orange.data.Table data: Dataset to cluster.
+    :param Orange.data.Table data: Data set to cluster.
     :param Orange.distance.Distance distance: A distance measure.
     :param str linkage:
     """

--- a/Orange/datasets/iris.tab.metadata
+++ b/Orange/datasets/iris.tab.metadata
@@ -1,5 +1,5 @@
-Name: Iris flower dataset
-Description: Classical dataset with 150 instances of Iris setosa, Iris virginica and Iris versicolor.
+Name: Iris flower data set
+Description: Classical data set with 150 instances of Iris setosa, Iris virginica and Iris versicolor.
 Author: Edgar Anderson, Ronald Fisher
 Year: 1936
 Reference: R. A. Fisher (1936). "The use of multiple measurements in taxonomic problems". Annals of Eugenics. 7 (2): 179–188. doi:10.1111/j.1469-1809.1936.tb02137.x

--- a/Orange/distance/base.py
+++ b/Orange/distance/base.py
@@ -429,7 +429,7 @@ class FittedDistance(Distance):
 
         Args:
             column (np.ndarray): column data
-            n_bins (int): maximal number of bins in the dataset
+            n_bins (int): maximal number of bins in the data set
 
         Returns:
             dist_missing_disc (np.ndarray): `dist_missing_disc[value]` is

--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -322,7 +322,7 @@ def compute_CD(avranks, n, alpha="0.05", test="nemenyi"):
     """
     Returns critical difference for Nemenyi or Bonferroni-Dunn test
     according to given alpha (either alpha="0.05" or alpha="0.1") for average
-    ranks and number of tested datasets N. Test can be either "nemenyi" for
+    ranks and number of tested data sets N. Test can be either "nemenyi" for
     for Nemenyi two tailed test or "bonferroni-dunn" for Bonferroni-Dunn test.
     """
     k = len(avranks)

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -538,7 +538,7 @@ class ShuffleSplit(Results):
 
 class TestOnTestData(Results):
     """
-    Test on a separate test dataset.
+    Test on a separate test data set.
     """
     def __init__(self, train_data, test_data, learners, store_data=False,
                  store_models=False, preprocessor=None, callback=None, n_jobs=1):
@@ -577,7 +577,7 @@ def sample(table, n=0.7, stratified=False, replace=False,
            random_state=None):
     """
     Samples data instances from a data table. Returns the sample and
-    a dataset from input data table that are not in the sample. Also
+    a data set from input data table that are not in the sample. Also
     uses several sampling functions from
     `scikit-learn <http://scikit-learn.org>`_.
 

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -15,7 +15,7 @@ __all__ = ["SelectBestFeatures", "RemoveNaNColumns", "SelectRandomFeatures"]
 
 class SelectBestFeatures(Reprable):
     """
-    A feature selector that builds a new dataset consisting of either the top
+    A feature selector that builds a new data set consisting of either the top
     `k` features or all those that exceed a given `threshold`. Features are
     scored using the provided feature scoring `method`. By default it is
     assumed that feature importance diminishes with decreasing scores.
@@ -24,7 +24,7 @@ class SelectBestFeatures(Reprable):
     conditions will be selected.
 
     If `method` is not set, it is automatically selected when presented with
-    the dataset. Datasets with both continuous and discrete features are
+    the data set. Data sets with both continuous and discrete features are
     scored using a method suitable for the majority of features.
 
     Parameters
@@ -98,7 +98,7 @@ class SelectBestFeatures(Reprable):
 class SelectRandomFeatures(Reprable):
     """
     A feature selector that selects random `k` features from an input
-    dataset and returns a dataset with selected features. Parameter
+    data set and returns a data set with selected features. Parameter
     `k` is either an integer (number of feature) or float (from 0.0 to
     1.0, proportion of retained features).
 

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -130,7 +130,7 @@ class Impute(Preprocess):
 
     def __call__(self, data):
         """
-        Apply an imputation method to the given dataset. Returns a new
+        Apply an imputation method to the given data set. Returns a new
         data table with missing values replaced by their imputations.
 
         Parameters
@@ -177,17 +177,17 @@ class SklImpute(Preprocess):
 class RemoveConstant(Preprocess):
     """
     Construct a preprocessor that removes features with constant values
-    from the dataset.
+    from the data set.
     """
 
     def __call__(self, data):
         """
-        Remove columns with constant values from the dataset and return
+        Remove columns with constant values from the data set and return
         the resulting data table.
 
         Parameters
         ----------
-        data : an input dataset
+        data : an input data set
         """
 
         oks = bn.nanmin(data.X, axis=0) != \
@@ -202,21 +202,21 @@ class RemoveConstant(Preprocess):
 class RemoveNaNClasses(Preprocess):
     """
     Construct preprocessor that removes examples with missing class
-    from the dataset.
+    from the data set.
     """
 
     def __call__(self, data):
         """
-        Remove rows that contain NaN in any class variable from the dataset
+        Remove rows that contain NaN in any class variable from the data set
         and return the resulting data table.
 
         Parameters
         ----------
-        data : an input dataset
+        data : an input data set
 
         Returns
         -------
-        data : dataset without rows with missing classes
+        data : data set without rows with missing classes
         """
         return HasClass()(data)
 
@@ -286,7 +286,7 @@ class Normalize(Preprocess):
 
         if all(a.attributes.get('skip-normalization', False)
                for a in data.domain.attributes if a.is_continuous):
-            # Skip normalization for datasets where all features are marked as already normalized.
+            # Skip normalization for data sets where all features are marked as already normalized.
             # Required for SVMs (with normalizer as their default preprocessor) on sparse data to
             # retain sparse structure. Normalizing sparse data would otherwise result in a dense
             # matrix, which requires too much memory. For example, this is used for Bag of Words
@@ -490,7 +490,7 @@ class Scale(Preprocess):
 
 class PreprocessorList(Preprocess):
     """
-    Store a list of preprocessors and on call apply them to the dataset.
+    Store a list of preprocessors and on call apply them to the data set.
 
     Parameters
     ----------
@@ -503,7 +503,7 @@ class PreprocessorList(Preprocess):
 
     def __call__(self, data):
         """
-        Applies a list of preprocessors to the dataset.
+        Applies a list of preprocessors to the data set.
 
         Parameters
         ----------

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -181,14 +181,14 @@ class LearnerScorer(Scorer):
 
 class ClassificationScorer(Scorer):
     """
-    Base class for feature scores in a class-labeled dataset.
+    Base class for feature scores in a class-labeled data set.
 
     Parameters
     ----------
     feature : int, string, Orange.data.Variable
         Feature id
     data : Orange.data.Table
-        Dataset
+        Data set
 
     Attributes
     ----------

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -143,7 +143,7 @@ class Lookup(Transformation):
         self.unknown = unknown
 
     def transform(self, column):
-        # Densify DiscreteVariable values coming from sparse datasets.
+        # Densify DiscreteVariable values coming from sparse data sets.
         if sp.issparse(column):
             column = column.toarray().ravel()
         mask = np.isnan(column)

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -2,7 +2,7 @@
 Concatenate
 ===========
 
-Concatenate (append) two or more datasets.
+Concatenate (append) two or more data sets.
 
 """
 
@@ -24,7 +24,7 @@ from Orange.widgets.widget import Input, Output
 
 class OWConcatenate(widget.OWWidget):
     name = "Concatenate"
-    description = "Concatenate (append) two or more datasets."
+    description = "Concatenate (append) two or more data sets."
     priority = 1111
     icon = "icons/Concatenate.svg"
 

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -18,7 +18,7 @@ except ImportError:
 class OWDataInfo(widget.OWWidget):
     name = "Data Info"
     id = "orange.widgets.data.info"
-    description = """Display basic information about the dataset, such
+    description = """Display basic information about the data set, such
     as the number and type of variables in the columns and the number of rows."""
     icon = "icons/DataInfo.svg"
     priority = 80

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -18,7 +18,7 @@ from Orange.util import Reprable
 class OWDataSampler(OWWidget):
     name = "Data Sampler"
     description = "Randomly draw a subset of data points " \
-                  "from the input dataset."
+                  "from the input data set."
     icon = "icons/DataSampler.svg"
     priority = 100
     category = "Data"
@@ -57,7 +57,7 @@ class OWDataSampler(OWWidget):
         too_many_folds = Msg("Number of folds exceeds data size")
         sample_larger_than_data = Msg("Sample must be smaller than data")
         not_enough_to_stratify = Msg("Data is too small to stratify")
-        no_data = Msg("Dataset is empty")
+        no_data = Msg("Data set is empty")
 
     def __init__(self):
         super().__init__()
@@ -175,7 +175,7 @@ class OWDataSampler(OWWidget):
             self.cb_stratify.setVisible(not sql)
             self.cb_sql_dl.setVisible(sql)
             self.dataInfoLabel.setText(
-                '{}{} instances in input dataset.'.format(*(
+                '{}{} instances in input data set.'.format(*(
                     ('~', dataset.approx_len()) if sql else
                     ('', len(dataset)))))
             if not sql:

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -45,7 +45,7 @@ def ensure_local(index_url, file_path, local_cache_path,
 
 def format_info(n_all, n_cached):
     plural = lambda x: '' if x == 1 else 's'
-    return "{} dataset{}\n{} dataset{} cached".format(
+    return "{} data set{}\n{} data set{} cached".format(
         n_all, plural(n_all), n_cached if n_cached else 'No', plural(n_cached))
 
 
@@ -90,8 +90,8 @@ class NumericalDelegate(QStyledItemDelegate):
 
 
 class OWDataSets(widget.OWWidget):
-    name = "Datasets"
-    description = "Load a dataset from an online repository"
+    name = "Data Sets"
+    description = "Load a data set from an online repository"
     icon = "icons/DataSets.svg"
     priority = 20
     replaces = ["orangecontrib.prototypes.widgets.owdatasets.OWDataSets"]
@@ -103,16 +103,16 @@ class OWDataSets(widget.OWWidget):
     DATASET_DIR = "datasets"
 
     class Error(widget.OWWidget.Error):
-        no_remote_datasets = Msg("Could not fetch dataset list")
+        no_remote_datasets = Msg("Could not fetch data set list")
 
     class Warning(widget.OWWidget.Warning):
-        only_local_datasets = Msg("Could not fetch datasets list, only local "
-                                  "cached datasets are shown")
+        only_local_datasets = Msg("Could not fetch data sets list, only local "
+                                  "cached data sets are shown")
 
     class Outputs:
         data = Output("Data", Orange.data.Table)
 
-    #: Selected dataset id
+    #: Selected data set id
     selected_id = settings.Setting(None)   # type: Optional[str]
 
     auto_commit = settings.Setting(False)  # type: bool
@@ -331,7 +331,7 @@ class OWDataSets(widget.OWWidget):
 
     def selected_dataset(self):
         """
-        Return the current selected dataset info or None if not selected
+        Return the current selected data set info or None if not selected
 
         Returns
         -------
@@ -354,7 +354,7 @@ class OWDataSets(widget.OWWidget):
             proxyModel.setFilterFixedString(filter_string)
 
     def __on_selection(self):
-        # Main datasets view selection has changed
+        # Main data sets view selection has changed
         rows = self.view.selectionModel().selectedRows(0)
         assert 0 <= len(rows) <= 1
         current = rows[0] if rows else None  # type: Optional[QModelIndex]

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -423,7 +423,7 @@ class OWEditDomain(widget.OWWidget):
     @Inputs.data
     @check_sql_input
     def set_data(self, data):
-        """Set input dataset."""
+        """Set input data set."""
         self.closeContext()
         self.clear()
         self.data = data

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -324,7 +324,7 @@ class FeatureConstructorHandler(DomainContextHandler):
 class OWFeatureConstructor(OWWidget):
     name = "Feature Constructor"
     description = "Construct new features (data columns) from a set of " \
-                  "existing features in the input dataset."
+                  "existing features in the input data set."
     icon = "icons/FeatureConstructor.svg"
 
     class Inputs:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -80,7 +80,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     keywords = ["data", "file", "load", "read"]
 
     class Outputs:
-        data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")
+        data = Output("Data", Table, doc="Attribute-valued data set read from the input file.")
 
     want_main_area = False
 
@@ -201,7 +201,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         box = gui.hBox(self.controlArea)
         gui.button(
-            box, self, "Browse documentation datasets",
+            box, self, "Browse documentation data sets",
             callback=lambda: self.browse_file(True), autoDefault=False)
         gui.rubber(box)
 
@@ -261,7 +261,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             if not os.path.exists(start_file):
                 QMessageBox.information(
                     None, "File",
-                    "Cannot find the directory with documentation datasets")
+                    "Cannot find the directory with documentation data sets")
                 return
         else:
             start_file = self.last_path() or os.path.expanduser("~/")

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -24,7 +24,7 @@ INDEX = "Position (index)"
 
 class OWMergeData(widget.OWWidget):
     name = "Merge Data"
-    description = "Merge datasets based on the values of selected features."
+    description = "Merge data sets based on the values of selected features."
     icon = "icons/MergeData.svg"
     priority = 1110
 

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1141,7 +1141,7 @@ class OWPreprocess(widget.OWWidget):
     @Inputs.data
     @check_sql_input
     def set_data(self, data=None):
-        """Set the input dataset."""
+        """Set the input data set."""
         self.data = data
 
     def handleNewSignals(self):

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -9,7 +9,7 @@ from Orange.widgets.widget import Input, Output
 
 class OWPurgeDomain(widget.OWWidget):
     name = "Purge Domain"
-    description = "Remove redundant values and features from the dataset. " \
+    description = "Remove redundant values and features from the data set. " \
                   "Sort values."
     icon = "icons/PurgeDomain.svg"
     category = "Data"

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -40,14 +40,14 @@ class BackendModel(PyListModel):
 class OWSql(OWWidget):
     name = "SQL Table"
     id = "orange.widgets.data.sql"
-    description = "Load dataset from SQL."
+    description = "Load data set from SQL."
     icon = "icons/SQLTable.svg"
     priority = 30
     category = "Data"
     keywords = ["data", "file", "load", "read", "SQL"]
 
     class Outputs:
-        data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")
+        data = Output("Data", Table, doc="Attribute-valued data set read from the input file.")
 
     settings_version = 2
 

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -362,7 +362,7 @@ TableSlot = namedtuple("TableSlot", ["input_id", "table", "summary", "view"])
 
 class OWDataTable(widget.OWWidget):
     name = "Data Table"
-    description = "View the dataset in a spreadsheet."
+    description = "View the data set in a spreadsheet."
     icon = "icons/Table.svg"
     priority = 50
 

--- a/Orange/widgets/data/tests/test_owconcatenate.py
+++ b/Orange/widgets/data/tests/test_owconcatenate.py
@@ -50,7 +50,7 @@ class TestOWConcatenate(WidgetTest):
         outvars = output.domain.variables
         self.assertLess(set(self.iris.domain.variables), set(outvars))
         self.assertLess(set(self.titanic.domain.variables), set(outvars))
-        # the first part of the dataset is iris, the second part is titanic
+        # the first part of the data set is iris, the second part is titanic
         np.testing.assert_equal(self.iris.X, output.X[:len(self.iris), :-3])
         self.assertTrue(np.isnan(output.X[:len(self.iris), -3:]).all())
         np.testing.assert_equal(self.titanic.X, output.X[len(self.iris):, -3:])

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -52,7 +52,7 @@ class TestOWDataSets(WidgetTest):
            Mock(return_value="iris.tab"))
     def test_download_iris(self):
         w = self.create_widget(OWDataSets)  # type: OWDataSets
-        # select the only dataset
+        # select the only data set
         sel_type = QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows
         w.view.selectionModel().select(w.view.model().index(0, 0), sel_type)
         w.unconditional_commit()

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -45,7 +45,7 @@ class OWPredictions(OWWidget):
     name = "Predictions"
     icon = "icons/Predictions.svg"
     priority = 200
-    description = "Display the predictions of models for an input dataset."
+    description = "Display the predictions of models for an input data set."
 
     class Inputs:
         data = Input("Data", Orange.data.Table)
@@ -58,7 +58,7 @@ class OWPredictions(OWWidget):
                                     dynamic=False)
 
     class Warning(OWWidget.Warning):
-        empty_data = Msg("Empty dataset")
+        empty_data = Msg("Empty data set")
 
     class Error(OWWidget.Error):
         predictor_failed = \
@@ -123,7 +123,7 @@ class OWPredictions(OWWidget):
                      callback=self._update_prediction_delegate)
 
         box = gui.vBox(self.controlArea, "Data View")
-        gui.checkBox(box, self, "show_attrs", "Show full dataset",
+        gui.checkBox(box, self, "show_attrs", "Show full data set",
                      callback=self._update_column_visibility)
 
         box = gui.vBox(self.controlArea, "Output", spacing=-1)
@@ -184,7 +184,7 @@ class OWPredictions(OWWidget):
     @Inputs.data
     @check_sql_input
     def set_data(self, data):
-        """Set the input dataset"""
+        """Set the input data set"""
         if data is not None and not len(data):
             data = None
             self.Warning.empty_data()

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -197,13 +197,13 @@ class OWTestLearners(OWWidget):
         settings.Setting(set(chain(*BUILTIN_ORDER.values())))
 
     class Error(OWWidget.Error):
-        train_data_empty = Msg("Train dataset is empty.")
-        test_data_empty = Msg("Test dataset is empty.")
+        train_data_empty = Msg("Train data set is empty.")
+        test_data_empty = Msg("Test data set is empty.")
         class_required = Msg("Train data input requires a target variable.")
         too_many_classes = Msg("Too many target variables.")
         class_required_test = Msg("Test data input requires a target variable.")
         too_many_folds = Msg("Number of folds exceeds the data size")
-        class_inconsistent = Msg("Test and train datasets "
+        class_inconsistent = Msg("Test and train data sets "
                                  "have different target variables.")
         memory_error = Msg("Not enough memory.")
         no_class_values = Msg("Target variable has no values.")

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -752,7 +752,7 @@ class datasets:
     @classmethod
     def missing_data_1(cls):
         """
-        Dataset with 3 continuous features (X{1,2,3}) where all the columns
+        Data set with 3 continuous features (X{1,2,3}) where all the columns
         and rows contain at least one NaN value.
 
         One discrete class D with NaN values
@@ -767,7 +767,7 @@ class datasets:
     @classmethod
     def missing_data_2(cls):
         """
-        Dataset with 3 continuous features (X{1,2,3}) where all the columns
+        Data set with 3 continuous features (X{1,2,3}) where all the columns
         and rows contain at least one NaN value and X1, X2 are constant.
 
         One discrete constant class D with NaN values.
@@ -782,7 +782,7 @@ class datasets:
     @classmethod
     def missing_data_3(cls):
         """
-        Dataset with 3 discrete features D{1,2,3} where all the columns and
+        Data set with 3 discrete features D{1,2,3} where all the columns and
         rows contain at least one NaN value
 
         One discrete class D with NaN values
@@ -797,7 +797,7 @@ class datasets:
     @classmethod
     def data_one_column_vals(cls, value=np.nan):
         """
-        Dataset with two continuous features and one discrete. One continuous
+        Data set with two continuous features and one discrete. One continuous
         columns has custom set values (default nan).
 
         Returns
@@ -821,7 +821,7 @@ class datasets:
     @classmethod
     def data_one_column_nans(cls):
         """
-        Dataset with two continuous features and one discrete. One continuous
+        Data set with two continuous features and one discrete. One continuous
         columns has missing values (NaN).
 
         Returns

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -60,7 +60,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     graph_name = "plot.plotItem"
 
     class Error(widget.OWWidget.Error):
-        empty_data = widget.Msg("Empty dataset")
+        empty_data = widget.Msg("Empty data set")
         no_disc_vars = widget.Msg("No categorical data")
 
     def __init__(self):

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -56,7 +56,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
 
         box = gui.hBox(self.controlArea)
         gui.button(
-            box, self, "Browse documentation datasets",
+            box, self, "Browse documentation data sets",
             callback=lambda: self.browse_file(True), autoDefault=False)
         box.layout().addSpacing(200)
 
@@ -80,7 +80,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
             if not os.path.exists(start_file):
                 QMessageBox.information(
                     None, "File",
-                    "Cannot find the directory with documentation datasets")
+                    "Cannot find the directory with documentation data sets")
                 return
         else:
             start_file = self.last_path() or os.path.expanduser("~/")

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -290,7 +290,7 @@ class OWMDS(OWWidget):
     @Inputs.data
     @check_sql_input
     def set_data(self, data):
-        """Set the input dataset.
+        """Set the input data set.
 
         Parameters
         ----------

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -301,7 +301,7 @@ class RecentPathsWidgetMixin:
     `RecentPathsWidgetMixin.__init__(self)`.
     """
 
-    #: list with search paths; overload to add, say, documentation datasets dir
+    #: list with search paths; overload to add, say, documentation data sets dir
     SEARCH_PATHS = []
 
     #: List[RecentPath]

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -131,7 +131,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
     @Inputs.data
     @check_sql_input
     def set_data(self, data):
-        """Set the input train dataset."""
+        """Set the input train data set."""
         self.Error.data_error.clear()
         self.data = data
         if data is not None and data.domain.class_var is None:
@@ -181,7 +181,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
             if not self.learner.check_learner_adequacy(self.data.domain):
                 self.Error.data_error(self.learner.learner_adequacy_err_msg)
             elif not len(self.data):
-                self.Error.data_error("Dataset is empty.")
+                self.Error.data_error("Data set is empty.")
             elif len(np.unique(self.data.Y)) < 2:
                 self.Error.data_error("Data contains a single target value.")
             elif self.data.X.size == 0:

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -556,7 +556,7 @@ class OWPlotGUI:
         AntialiasPlot : ('Antialias plot', 'antialias_plot', 'update_antialiasing'),
         AntialiasPoints : ('Antialias points', 'antialias_points', 'update_antialiasing'),
         AntialiasLines : ('Antialias lines', 'antialias_lines', 'update_antialiasing'),
-        AutoAdjustPerformance : ('Disable effects for large datasets', 'auto_adjust_performance',
+        AutoAdjustPerformance : ('Disable effects for large data sets', 'auto_adjust_performance',
                                  'update_performance')
     }
 

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -142,7 +142,7 @@ class OWDistributions(widget.OWWidget):
     priority = 120
 
     class Inputs:
-        data = Input("Data", Orange.data.Table, doc="Set the input dataset")
+        data = Input("Data", Orange.data.Table, doc="Set the input data set")
 
     settingsHandler = settings.DomainContextHandler(
         match_values=settings.DomainContextHandler.MATCH_VALUES_ALL)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -165,7 +165,7 @@ class OWSilhouettePlot(widget.OWWidget):
     @check_sql_input
     def set_data(self, data):
         """
-        Set the input dataset.
+        Set the input data set.
         """
         self.closeContext()
         self.clear()

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -41,7 +41,7 @@ _ItemSet = namedtuple("_ItemSet", ["key", "name", "title", "items"])
 class OWVennDiagram(widget.OWWidget):
     name = "Venn Diagram"
     description = "A graphical visualization of the overlap of data instances " \
-                  "from a collection of input datasets."
+                  "from a collection of input data sets."
     icon = "icons/VennDiagram.svg"
     priority = 280
 
@@ -102,7 +102,7 @@ class OWVennDiagram(widget.OWWidget):
         self.inputsBox.setEnabled(bool(self.useidentifiers))
 
         for i in range(5):
-            box = gui.vBox(self.inputsBox, "Dataset #%i" % (i + 1),
+            box = gui.vBox(self.inputsBox, "Data set #%i" % (i + 1),
                            addSpace=False)
             box.setFlat(True)
             model = itemmodels.VariableListModel(parent=self)
@@ -163,7 +163,7 @@ class OWVennDiagram(widget.OWWidget):
             # TODO: Allow setting more them 5 inputs and let the user
             # select the 5 to display.
             if len(self.data) == 5:
-                self.error("Venn diagram accepts at most five datasets.")
+                self.error("Venn diagram accepts at most five data sets.")
                 return
             # Add a new input
             self._add(key, data)
@@ -207,7 +207,7 @@ class OWVennDiagram(widget.OWWidget):
         self._createDiagram()
         if self.data:
             self.info.setText(
-                "{} datasets on input.\n".format(len(self.data)))
+                "{} data sets on input.\n".format(len(self.data)))
         else:
             self.info.setText("No data on input\n")
 
@@ -264,7 +264,7 @@ class OWVennDiagram(widget.OWWidget):
 
         item = self.inputsBox.layout().itemAt(index)
         box = item.widget()
-        box.setTitle("Dataset: {}".format(name))
+        box.setTitle("Data set: {}".format(name))
 
     def _remove(self, key):
         index = list(self.data.keys()).index(key)
@@ -284,9 +284,9 @@ class OWVennDiagram(widget.OWWidget):
         for i in range(5):
             box, _ = self._controlAtIndex(i)
             if i < len(inputs):
-                title = "Dataset: {}".format(inputs[i].name)
+                title = "Data set: {}".format(inputs[i].name)
             else:
-                title = "Dataset #{}".format(i + 1)
+                title = "Data set #{}".format(i + 1)
             box.setTitle(title)
 
         self._invalidate([key], incremental=False)
@@ -303,7 +303,7 @@ class OWVennDiagram(widget.OWWidget):
 
         item = self.inputsBox.layout().itemAt(index)
         box = item.widget()
-        box.setTitle("Dataset: {}".format(name))
+        box.setTitle("Data set: {}".format(name))
 
     def _itemsForInput(self, key):
         useidentifiers = self.useidentifiers or not self.samedomain
@@ -454,17 +454,17 @@ class OWVennDiagram(widget.OWWidget):
             self.info.setText("No data on input\n")
         else:
             self.info.setText(
-                "{0} datasets on input\n".format(len(self.data)))
+                "{0} data sets on input\n".format(len(self.data)))
 
         if self.useidentifiers:
             no_idx = ["#{}".format(i + 1)
                       for i, key in enumerate(self.data)
                       if not source_attributes(self.data[key].table.domain)]
             if len(no_idx) == 1:
-                self.warning("Dataset {} has no suitable identifiers."
+                self.warning("Data set {} has no suitable identifiers."
                              .format(no_idx[0]))
             elif len(no_idx) > 1:
-                self.warning("Datasets {} and {} have no suitable identifiers."
+                self.warning("Data sets {} and {} have no suitable identifiers."
                              .format(", ".join(no_idx[:-1]), no_idx[-1]))
 
     def _on_selectionChanged(self):

--- a/doc/data-mining-library/source/reference/classification.rst
+++ b/doc/data-mining-library/source/reference/classification.rst
@@ -62,8 +62,8 @@ Naive Bayes
 .. autoclass:: NaiveBayesLearner
    :members:
 
-The following code loads lenses dataset (four discrete attributes and discrete
-class), constructs naive Bayesian learner, uses it on the entire dataset
+The following code loads lenses data set (four discrete attributes and discrete
+class), constructs naive Bayesian learner, uses it on the entire data set
 to construct a classifier, and then applies classifier to the first three
 data instances:
 
@@ -76,7 +76,7 @@ data instances:
            [ 0.17428279,  0.20342097,  0.62229625],
            [ 0.18633359,  0.79518516,  0.01848125]])
 
-For datasets that include continuous attributes,
+For data sets that include continuous attributes,
 
 .. _`Naive Bayes`: http://en.wikipedia.org/wiki/Naive_Bayes_classifier
 .. _`scikit-learn`: http://scikit-learn.org

--- a/doc/data-mining-library/source/reference/code/discretization-table-method.py
+++ b/doc/data-mining-library/source/reference/code/discretization-table-method.py
@@ -5,10 +5,10 @@ disc.method = Orange.preprocess.discretize.EqualFreq(n=2)
 d_disc_iris = disc(iris)
 disc_iris = Orange.data.Table(d_disc_iris, iris)
 
-print("Original dataset:")
+print("Original data set:")
 for e in iris[:3]:
     print(e)
 
-print("Discretized dataset:")
+print("Discretized data set:")
 for e in disc_iris[:3]:
     print(e)

--- a/doc/data-mining-library/source/reference/code/discretization-table.py
+++ b/doc/data-mining-library/source/reference/code/discretization-table.py
@@ -4,10 +4,10 @@ disc = Orange.preprocess.Discretize()
 disc.method = Orange.preprocess.discretize.EqualFreq(n=3)
 d_iris = disc(iris)
 
-print("Original dataset:")
+print("Original data set:")
 for e in iris[:3]:
     print(e)
 
-print("Discretized dataset:")
+print("Discretized data set:")
 for e in d_iris[:3]:
     print(e)

--- a/doc/data-mining-library/source/reference/data.domain.rst
+++ b/doc/data-mining-library/source/reference/data.domain.rst
@@ -85,7 +85,7 @@ wrapping the numpy arrays into Orange's :obj:`~Orange.data.Table`. ::
             >>> domain
             [gender, age | salary]
 
-        This constructs a new domain with some features from the Iris dataset
+        This constructs a new domain with some features from the Iris data set
         and a new feature *color*. ::
 
             >>> new_domain = Domain(["sepal length",

--- a/doc/data-mining-library/source/reference/data.instance.rst
+++ b/doc/data-mining-library/source/reference/data.instance.rst
@@ -14,7 +14,7 @@ data storages, therefore changing them actually changes the data.
 Like data tables, every data instance is associated with a domain and its
 data is split into attributes, classes, meta attributes and the weight. Its
 constructor thus requires a domain and, optionally, data. For the following
-example, we borrow the domain from the Iris dataset. ::
+example, we borrow the domain from the Iris data set. ::
 
     >>> from Orange.data import Table, Instance
     >>> iris = Table("iris")

--- a/doc/data-mining-library/source/reference/data.variable.rst
+++ b/doc/data-mining-library/source/reference/data.variable.rst
@@ -11,10 +11,10 @@ and other properties. Descriptors serve three main purposes:
   the internal representation and back (e.g. when writing files or printing
   out);
 
-- identification of variables: two variables from different datasets are
+- identification of variables: two variables from different data sets are
   considered to be the same if they have the same descriptor;
 
-- conversion of values between domains or datasets, for instance from
+- conversion of values between domains or data sets, for instance from
   continuous to discrete data, using a pre-computed transformation.
 
 Descriptors are most often constructed when loading the data from files. ::
@@ -50,9 +50,9 @@ Constructors
 ------------
 
 Orange maintains lists of existing descriptors for variables. This facilitates
-the reuse of descriptors: if two datasets refer to the same variables, they
+the reuse of descriptors: if two data sets refer to the same variables, they
 should be assigned the same descriptors so that, for instance, a model
-trained on one dataset can make predictions for the other.
+trained on one data set can make predictions for the other.
 
 Variable descriptors are seldom constructed in user scripts. When needed,
 this can be done by calling the constructor directly or by calling the class

--- a/doc/data-mining-library/source/reference/preprocess.rst
+++ b/doc/data-mining-library/source/reference/preprocess.rst
@@ -40,11 +40,11 @@ features:
 The variable in the new data table indicate the bins to which the original
 values belong. ::
 
-    Original dataset:
+    Original data set:
     [5.1, 3.5, 1.4, 0.2 | Iris-setosa]
     [4.9, 3.0, 1.4, 0.2 | Iris-setosa]
     [4.7, 3.2, 1.3, 0.2 | Iris-setosa]
-    Discretized dataset:
+    Discretized data set:
     [<5.5, >=3.2, <2.5, <0.8 | Iris-setosa]
     [<5.5, [2.8, 3.2), <2.5, <0.8 | Iris-setosa]
     [<5.5, >=3.2, <2.5, <0.8 | Iris-setosa]
@@ -159,7 +159,7 @@ Continuization
            Note that these variables are not independent, so they cannot be
            used (directly) in, for instance, linear or logistic regression.
 
-           For example, dataset "titanic" has feature "status" with
+           For example, data set "titanic" has feature "status" with
            values "crew", "first", "second" and "third", in that order. Its
            value for the 15th row is "first". Continuization replaces the
            variable with variables "status=crew", "status=first",
@@ -280,7 +280,7 @@ Continuization
     :obj:`Orange.preprocess.Continuize` calls `DomainContinuizer` to construct
     the domain.
 
-    Domain continuizers can be given either a dataset or a domain, and return
+    Domain continuizers can be given either a data set or a domain, and return
     a new domain. When given only the domain, use the most frequent value as
     the base value.
 
@@ -316,7 +316,7 @@ prediction of the dependant (class) variable. Orange provides classes
 that compute the common feature scores for classification and regression.
 
 The code below computes the information gain of feature "tear_rate"
-in the Lenses dataset:
+in the Lenses data set:
 
     >>> data = Orange.data.Table("lenses")
     >>> Orange.preprocess.score.InfoGain(data, "tear_rate")
@@ -388,12 +388,12 @@ to obtain the feature scores as calculated by these learners. For example:
 -------------------
 
 We can use feature selection to limit the analysis to only the most relevant
-or informative features in the dataset.
+or informative features in the data set.
 
 Feature selection with a scoring method that works on continuous features will
 retain all discrete features and vice versa.
 
-The code below constructs a new dataset consisting of two best features
+The code below constructs a new data set consisting of two best features
 according to the ANOVA method:
 
     >>> data = Orange.data.Table("wine")

--- a/doc/data-mining-library/source/tutorial/classification.rst
+++ b/doc/data-mining-library/source/tutorial/classification.rst
@@ -5,7 +5,7 @@ Classification
 .. index::
    single: data mining; supervised
 
-Much of Orange is devoted to machine learning methods for classification, or supervised data mining. These methods rely on the data with class-labeled instances, like that of senate voting. Here is a code that loads this dataset, displays the first data instance and shows its predicted class (``republican``)::
+Much of Orange is devoted to machine learning methods for classification, or supervised data mining. These methods rely on the data with class-labeled instances, like that of senate voting. Here is a code that loads this data set, displays the first data instance and shows its predicted class (``republican``)::
 
    >>> import Orange
    >>> data = Orange.data.Table("voting")
@@ -42,7 +42,7 @@ Classification uses two types of objects: learners and classifiers. Learners con
     >>> classifier(data[:3])
     array([ 0.,  0.,  1.])
 
-Above, we read the data, constructed a logistic regression learner, gave it the dataset to construct a classifier, and used it to predict the class of the first three data instances. We also use these concepts in the following code that predicts the classes of the selected three instances in the dataset:
+Above, we read the data, constructed a logistic regression learner, gave it the data set to construct a classifier, and used it to predict the class of the first three data instances. We also use these concepts in the following code that predicts the classes of the selected three instances in the data set:
 
 ..  literalinclude:: code/classification-classifier1.py
     :lines: 4-
@@ -53,7 +53,7 @@ The script outputs::
     republican, originally democrat
     republican, originally republican
 
-Logistic regression has made a mistake in the second case, but otherwise predicted correctly. No wonder, since this was also the data it trained from. The following code counts the number of such mistakes in the entire dataset:
+Logistic regression has made a mistake in the second case, but otherwise predicted correctly. No wonder, since this was also the data it trained from. The following code counts the number of such mistakes in the entire data set:
 
 ..  literalinclude:: code/classification-accuracy-train.py
     :lines: 4-
@@ -78,7 +78,7 @@ Cross-Validation
 
 .. index:: cross-validation
 
-Validating the accuracy of classifiers on the training data, as we did above, serves demonstration purposes only. Any performance measure that assess accuracy should be estimated on the independent test set. Such is also a procedure called `cross-validation <http://en.wikipedia.org/wiki/Cross-validation_(statistics)>`_, which averages the evaluation scores across several runs, each time considering a different training and test subsets as sampled from the original dataset:
+Validating the accuracy of classifiers on the training data, as we did above, serves demonstration purposes only. Any performance measure that assess accuracy should be estimated on the independent test set. Such is also a procedure called `cross-validation <http://en.wikipedia.org/wiki/Cross-validation_(statistics)>`_, which averages the evaluation scores across several runs, each time considering a different training and test subsets as sampled from the original data set:
 
 .. literalinclude:: code/classification-cv.py
    :lines: 3-
@@ -107,7 +107,7 @@ Orange includes a variety of classification algorithms, most of them wrapped fro
 - classification trees (``Orange.classification.tree.SklTreeLearner``)
 - radnom forest (``Orange.classification.RandomForestLearner``)
 
-Some of these are included in the code that estimates the probability of a target class on a testing data. This time, training and test datasets are disjoint:
+Some of these are included in the code that estimates the probability of a target class on a testing data. This time, training and test data sets are disjoint:
 
 .. index::
    single: classification; logistic regression
@@ -128,7 +128,7 @@ For these five data items, there are no major differences between predictions of
     republican      0.991 1.000 0.979
     republican      0.991 0.667 0.963
 
-The following code cross-validates these learners on the titanic dataset.
+The following code cross-validates these learners on the titanic data set.
 
 .. literalinclude:: code/classification-cv2.py
 

--- a/doc/data-mining-library/source/tutorial/code/data-subsetting.py
+++ b/doc/data-mining-library/source/tutorial/code/data-subsetting.py
@@ -1,7 +1,7 @@
 import Orange
 
 data = Orange.data.Table("iris.tab")
-print("Dataset instances:", len(data))
+print("Data set instances:", len(data))
 subset = Orange.data.Table(data.domain,
                            [d for d in data if d["petal length"] > 3.0])
 print("Subset size:", len(subset))

--- a/doc/data-mining-library/source/tutorial/data.rst
+++ b/doc/data-mining-library/source/tutorial/data.rst
@@ -13,7 +13,7 @@ Data Input
 
 Orange can read files in native tab-delimited format, or can load data from any of the major standard spreadsheet file type, like CSV and Excel. Native format starts with a header row with feature (column) names. Second header row gives the attribute type, which can be continuous, discrete, time, or string. The third header line contains meta information to identify dependent features (class), irrelevant features (ignore) or meta features (meta).
 More detailed specification is available in :doc:`../reference/data.io`.
-Here are the first few lines from a dataset :download:`lenses.tab <code/lenses.tab>`::
+Here are the first few lines from a data set :download:`lenses.tab <code/lenses.tab>`::
 
     age       prescription  astigmatic    tear_rate     lenses
     discrete  discrete      discrete      discrete      discrete 
@@ -25,19 +25,19 @@ Here are the first few lines from a dataset :download:`lenses.tab <code/lenses.t
     young     hypermetrope  no            reduced       none
 
 
-Values are tab-limited. This dataset has four attributes (age of the patient, spectacle prescription, notion on astigmatism, and information on tear production rate) and an associated three-valued dependent variable encoding lens prescription for the patient (hard contact lenses, soft contact lenses, no lenses). Feature descriptions could use one letter only, so the header of this dataset could also read::
+Values are tab-limited. This data set has four attributes (age of the patient, spectacle prescription, notion on astigmatism, and information on tear production rate) and an associated three-valued dependent variable encoding lens prescription for the patient (hard contact lenses, soft contact lenses, no lenses). Feature descriptions could use one letter only, so the header of this data set could also read::
 
     age       prescription  astigmatic    tear_rate     lenses
     d         d             d             d             d 
                                                         c
 
-The rest of the table gives the data. Note that there are 5 instances in our table above. For the full dataset, check out or download :download:`lenses.tab <code/lenses.tab>`) to a target directory. You can also skip this step as Orange comes preloaded with several demo datasets, lenses being one of them. Now, open a python shell, import Orange and load the data:
+The rest of the table gives the data. Note that there are 5 instances in our table above. For the full data set, check out or download :download:`lenses.tab <code/lenses.tab>`) to a target directory. You can also skip this step as Orange comes preloaded with several demo data sets, lenses being one of them. Now, open a python shell, import Orange and load the data:
 
     >>> import Orange
     >>> data = Orange.data.Table("lenses")
     >>>
 
-Note that for the file name no suffix is needed; as Orange checks if any files in the current directory are of the readable type. The call to ``Orange.data.Table`` creates an object called ``data`` that holds your dataset and information about the lenses domain:
+Note that for the file name no suffix is needed; as Orange checks if any files in the current directory are of the readable type. The call to ``Orange.data.Table`` creates an object called ``data`` that holds your data set and information about the lenses domain:
 
     >>> data.domain.attributes
     (DiscreteVariable('age', values=['pre-presbyopic', 'presbyopic', 'young']),
@@ -127,7 +127,7 @@ The script above displays the following output::
     Value of 'sepal width' for the first instance: 3.500
     The 3rd value of the 25th data instance: 1.900
 
-Iris dataset we have used above has four continous attributes. Here's a script that computes their mean:
+Iris data set we have used above has four continous attributes. Here's a script that computes their mean:
 
 ..  literalinclude:: code/data-instances2.py
     :lines: 3-
@@ -154,13 +154,13 @@ Of the four features, petal width and length look quite discriminative for the t
     petal length               1.46            4.26            5.55
     petal width                0.24            1.33            2.03
 
-Finally, here is a quick code that computes the class distribution for another dataset:
+Finally, here is a quick code that computes the class distribution for another data set:
 
 ..  literalinclude:: code/data-instances4.py
 
-Orange Datasets and NumPy
--------------------------
-Orange datasets are actually wrapped `NumPy <http://www.numpy.org>`_ arrays. Wrapping is performed to retain the information about the feature names and values, and NumPy arrays are used for speed and compatibility with different machine learning toolboxes, like `scikit-learn <http://scikit-learn.org>`_, on which Orange relies. Let us display the values of these arrays for the first three data instances of the iris dataset::
+Orange Data Sets and NumPy
+--------------------------
+Orange data sets are actually wrapped `NumPy <http://www.numpy.org>`_ arrays. Wrapping is performed to retain the information about the feature names and values, and NumPy arrays are used for speed and compatibility with different machine learning toolboxes, like `scikit-learn <http://scikit-learn.org>`_, on which Orange relies. Let us display the values of these arrays for the first three data instances of the iris data set::
 
     >>> data = Orange.data.Table("iris")
     >>> data.X[:3]
@@ -176,7 +176,7 @@ Notice that we access the arrays for attributes and class separately, using ``da
     >>> np.mean(data.X, axis=0)
     array([ 5.84333333,  3.054     ,  3.75866667,  1.19866667])
 
-We can also construct a (classless) dataset from a numpy array::
+We can also construct a (classless) data set from a numpy array::
 
     >>> X = np.array([[1,2], [4,5]])
     >>> data = Orange.data.Table(X)
@@ -191,7 +191,7 @@ If we want to provide meaninful names to attributes, we need to construct an app
     >>> data.domain
     [lenght, width]
 
-Here is another example, this time with construction of dataset that includes a numerical class and different type of attributes:
+Here is another example, this time with construction of data set that includes a numerical class and different type of attributes:
 
 ..  literalinclude:: code/data-domain-numpy.py
     :lines: 4-
@@ -249,7 +249,7 @@ Missing Values
 ..  index::
     single: data; missing values
 
-Consider the following exploration of the dataset on votes of the US senate::
+Consider the following exploration of the data set on votes of the US senate::
 
     >>> import numpy as np
     >>> data = Orange.data.Table("voting.tab")
@@ -260,7 +260,7 @@ Consider the following exploration of the dataset on votes of the US senate::
     >>> np.isnan(data[2][1])
     False
 
-The particular data instance included missing data (represented with '?') for the first and the fourth attribute. In the original dataset file, the missing values are, by default, represented with a blank space. We can now examine each attribute and report on proportion of data instances for which this feature was undefined:
+The particular data instance included missing data (represented with '?') for the first and the fourth attribute. In the original data set file, the missing values are, by default, represented with a blank space. We can now examine each attribute and report on proportion of data instances for which this feature was undefined:
 
 ..  literalinclude:: code/data-missing.py
     :lines: 4-
@@ -284,17 +284,17 @@ Data Selection and Sampling
 ..  index::
     single: data; sampling
 
-Besides the name of the data file, ``Orange.data.Table`` can accept the data domain and a list of data items and returns a new dataset. This is useful for any data subsetting:
+Besides the name of the data file, ``Orange.data.Table`` can accept the data domain and a list of data items and returns a new data set. This is useful for any data subsetting:
 
 ..  literalinclude:: code/data-subsetting.py
     :lines: 3-
 
 The code outputs::
 
-    Dataset instances: 150
+    Data set instances: 150
     Subset size: 99
 
-and inherits the data description (domain) from the original dataset. Changing the domain requires setting up a new domain descriptor. This feature is useful for any kind of feature selection:
+and inherits the data description (domain) from the original data set. Changing the domain requires setting up a new domain descriptor. This feature is useful for any kind of feature selection:
 
 ..  literalinclude:: code/data-feature-selection.py
     :lines: 3-
@@ -302,7 +302,7 @@ and inherits the data description (domain) from the original dataset. Changing t
 ..  index::
     single: feature; selection
 
-We could also construct a random sample of the dataset::
+We could also construct a random sample of the data set::
 
     >>> sample = Orange.data.Table(data.domain, random.sample(data, 3))
     >>> sample

--- a/doc/data-mining-library/source/tutorial/regression.rst
+++ b/doc/data-mining-library/source/tutorial/regression.rst
@@ -32,7 +32,7 @@ The script outputs the tree::
    |    |    TAX<=534.500: 45.9
    |    |    TAX>534.500: 21.9
 
-Following is initialization of few other regressors and their prediction of the first five data instances in housing price dataset:
+Following is initialization of few other regressors and their prediction of the first five data instances in housing price data set:
 
 .. index::
    single: regression; linear

--- a/doc/development/source/orange-demo/orangedemo/OWDataSamplerA.py
+++ b/doc/development/source/orange-demo/orangedemo/OWDataSamplerA.py
@@ -8,7 +8,7 @@ from Orange.widgets import gui
 
 class OWDataSamplerA(OWWidget):
     name = "Data Sampler"
-    description = "Randomly selects a subset of instances from the dataset"
+    description = "Randomly selects a subset of instances from the data set"
     icon = "icons/DataSamplerA.svg"
     priority = 10
 
@@ -33,7 +33,7 @@ class OWDataSamplerA(OWWidget):
     @Inputs.data
     def set_data(self, dataset):
         if dataset is not None:
-            self.infoa.setText('%d instances in input dataset' % len(dataset))
+            self.infoa.setText('%d instances in input data set' % len(dataset))
             indices = numpy.random.permutation(len(dataset))
             indices = indices[:int(numpy.ceil(len(dataset) * 0.1))]
             sample = dataset[indices]

--- a/doc/development/source/orange-demo/orangedemo/OWDataSamplerB.py
+++ b/doc/development/source/orange-demo/orangedemo/OWDataSamplerB.py
@@ -9,7 +9,7 @@ from Orange.widgets import gui
 # [start-snippet-1]
 class OWDataSamplerB(OWWidget):
     name = "Data Sampler (B)"
-    description = "Randomly selects a subset of instances from the dataset."
+    description = "Randomly selects a subset of instances from the data set."
     icon = "icons/DataSamplerB.svg"
     priority = 20
 
@@ -53,7 +53,7 @@ class OWDataSamplerB(OWWidget):
     def set_data(self, dataset):
         if dataset is not None:
             self.dataset = dataset
-            self.infoa.setText('%d instances in input dataset' % len(dataset))
+            self.infoa.setText('%d instances in input data set' % len(dataset))
             self.optionsBox.setDisabled(False)
             self.selection()
         else:

--- a/doc/development/source/orange-demo/orangedemo/OWDataSamplerC.py
+++ b/doc/development/source/orange-demo/orangedemo/OWDataSamplerC.py
@@ -8,7 +8,7 @@ from Orange.widgets import gui
 
 class OWDataSamplerC(OWWidget):
     name = "Data Sampler (C)"
-    description = "Randomly selects a subset of instances from the dataset."
+    description = "Randomly selects a subset of instances from the data set."
     icon = "icons/DataSamplerC.svg"
     priority = 30
 
@@ -53,7 +53,7 @@ class OWDataSamplerC(OWWidget):
     def set_data(self, dataset):
         if dataset is not None:
             self.dataset = dataset
-            self.infoa.setText('%d instances in input dataset' % len(dataset))
+            self.infoa.setText('%d instances in input data set' % len(dataset))
             self.optionsBox.setDisabled(False)
             self.selection()
         else:

--- a/doc/development/source/orange-demo/orangedemo/OWLearningCurveA.py
+++ b/doc/development/source/orange-demo/orangedemo/OWLearningCurveA.py
@@ -15,7 +15,7 @@ from Orange.evaluation.testing import Results
 
 class OWLearningCurveA(OWWidget):
     name = "Learning Curve (A)"
-    description = ("Takes a dataset and a set of learners and shows a "
+    description = ("Takes a data set and a set of learners and shows a "
                    "learning curve in a table")
     icon = "icons/LearningCurve.svg"
     priority = 1000
@@ -112,7 +112,7 @@ class OWLearningCurveA(OWWidget):
         self.data = data
 
         if data is not None:
-            self.infoa.setText('%d instances in input dataset' % len(data))
+            self.infoa.setText('%d instances in input data set' % len(data))
         else:
             self.infoa.setText('No data on input.')
 

--- a/doc/development/source/orange-demo/orangedemo/OWLearningCurveB.py
+++ b/doc/development/source/orange-demo/orangedemo/OWLearningCurveB.py
@@ -17,7 +17,7 @@ from Orange.evaluation.testing import Results
 
 class OWLearningCurveB(OWWidget):
     name = "Learning Curve (B)"
-    description = ("Takes a dataset and a set of learners and shows a "
+    description = ("Takes a data set and a set of learners and shows a "
                    "learning curve in a table")
     icon = "icons/LearningCurve.svg"
     priority = 1010
@@ -115,7 +115,7 @@ class OWLearningCurveB(OWWidget):
         self.data = data
 
         if data is not None:
-            self.infoa.setText('%d instances in input dataset' % len(data))
+            self.infoa.setText('%d instances in input data set' % len(data))
         else:
             self.infoa.setText('No data on input.')
 

--- a/doc/development/source/orange-demo/orangedemo/OWLearningCurveC.py
+++ b/doc/development/source/orange-demo/orangedemo/OWLearningCurveC.py
@@ -61,7 +61,7 @@ class Task:
 
 class OWLearningCurveC(widget.OWWidget):
     name = "Learning Curve (C)"
-    description = ("Takes a dataset and a set of learners and shows a "
+    description = ("Takes a data set and a set of learners and shows a "
                    "learning curve in a table")
     icon = "icons/LearningCurve.svg"
     priority = 1010
@@ -162,7 +162,7 @@ class OWLearningCurveC(widget.OWWidget):
         self.data = data
 
         if data is not None:
-            self.infoa.setText('%d instances in input dataset' % len(data))
+            self.infoa.setText('%d instances in input data set' % len(data))
         else:
             self.infoa.setText('No data on input.')
 

--- a/doc/development/source/tutorial-channels.rst
+++ b/doc/development/source/tutorial-channels.rst
@@ -23,7 +23,7 @@ be used to connect them with several output channels. That is, if a
 widget supports such a channel, several widgets can feed their input
 to that widget simultaneously.
 
-Say we want to build a widget that takes a dataset and test
+Say we want to build a widget that takes a data set and test
 various predictive modeling techniques on it. A widget has to have an
 input data channel, and this we know how to deal with from our
 :doc:`previous <tutorial-settings>` lesson. But, somehow differently, we
@@ -39,7 +39,7 @@ just in brief: learning curve is something that you can use to test
 some machine learning algorithm in trying to see how its performance
 depends on the size of the training set size. For this, one can draw a
 smaller subset of data, learn the classifier, and test it on remaining
-dataset. To do this in a just way (by Salzberg, 1997), we perform
+data set. To do this in a just way (by Salzberg, 1997), we perform
 k-fold cross validation but use only a proportion of the data for
 training. The output widget should then look something like:
 
@@ -86,7 +86,7 @@ and curve point for that channel id, marking for update in
 when we receive a learner for a new channel id.
 
 Note that in this widget the evaluation (k-fold cross
-validation) is carried out just once given the learner, dataset and
+validation) is carried out just once given the learner, data set and
 evaluation parameters, and scores are then derived from class
 probability estimates as obtained from the evaluation procedure. Which
 essentially means that switching from one to another scoring function
@@ -144,13 +144,13 @@ Default Channels (When Using Input Channels of the Same Type)
 
 Now, let's say we want to extend our learning curve widget such
 that it does the learning the same way as it used to, but can -
-provided that such dataset is defined - test the
-learners (always) on the same, external dataset. That is, besides the
-training dataset, we need another channel of the same type but used
-for training dataset. Notice, however, that most often we will only
-provide the training dataset, so we would not like to be bothered (in
+provided that such data set is defined - test the
+learners (always) on the same, external data set. That is, besides the
+training data set, we need another channel of the same type but used
+for training data set. Notice, however, that most often we will only
+provide the training data set, so we would not like to be bothered (in
 Orange Canvas) with the dialog which channel to connect to, as the
-training dataset channel will be the default one.
+training data set channel will be the default one.
 
 When enlisting the input channel of the same type, the default
 channels have a special flag in the channel specification list. So for

--- a/doc/development/source/tutorial-cont.rst
+++ b/doc/development/source/tutorial-cont.rst
@@ -6,8 +6,8 @@ After learning what an Orange Widget is and how to define them on
 a toy example, we will build an semi-useful widgets that can
 work together with the existing Orange Widgets.
 
-We will start with a very simple one, that will receive a dataset
-on the input and will output a dataset with 10% of the data instances.
+We will start with a very simple one, that will receive a data set
+on the input and will output a data set with 10% of the data instances.
 We will call this widget `OWDataSamplerA` (OW for Orange Widget,
 DataSampler since this is what widget will be doing, and A since we
 prototype a number of this widgets in our tutorial).
@@ -112,7 +112,7 @@ info was processed correctly:
 .. image:: images/samplewidgetontoolbox.png
 
 Now for the real test. We put the File widget on the schema (from
-Data pane) and load the iris.tab dataset. We also put our Data
+Data pane) and load the iris.tab data set. We also put our Data
 Sampler widget on the scheme and open it (double click on the icon,
 or right-click and choose Open):
 

--- a/doc/development/source/tutorial-settings.rst
+++ b/doc/development/source/tutorial-settings.rst
@@ -15,7 +15,7 @@ What we added is an Options box, with a spin entry box to set the
 sample size, and a check box and button to commit (send out) any
 change we made in setting. If the check box with "Commit data on
 selection change" is checked, than any change in the sample size will
-make the widget send out the sampled dataset. If datasets are large
+make the widget send out the sampled data set. If data sets are large
 (say of several thousands or more) instances, we may want to send out
 the sample data only after we are done setting the sample size, hence
 we left the commit check box unchecked and press "Commit" when we are
@@ -167,15 +167,15 @@ selection with which one can select the examples based on values of
 certain attributes. Before applying the saved settings, these widgets
 needs to check their compliance with the domain of the actual data
 set. To be truly useful, context dependent settings needs to save a
-setting configuration for each particular dataset used. That is, when
-given a particular dataset, it has to select the saved settings that
-is applicable and matches best currently used dataset.
+setting configuration for each particular data set used. That is, when
+given a particular data set, it has to select the saved settings that
+is applicable and matches best currently used data set.
 
 Saving, loading and matching contexts is taken care of by context
 handlers. Currently, there are only two classes of context handlers
 implemented. The first one is the abstract :class:`ContextHandler`
 and the second one is :class:`DomainContextHandler` in which the
-context is defined by the dataset domain and where the settings
+context is defined by the data set domain and where the settings
 contain attribute names. The latter should cover most of your needs,
 while for more complicated widgets you will need to derive a new
 classes from it. There may even be some cases in which the context is

--- a/doc/visual-programming/source/loading-your-data/index.rst
+++ b/doc/visual-programming/source/loading-your-data/index.rst
@@ -27,7 +27,7 @@ In a Nutshell
 Example: Data from Excel
 ------------------------
 
-Here is an example dataset (download it from :download:`sample.xlsx <sample.xlsx>`) as entered in Excel:
+Here is an example data set (download it from :download:`sample.xlsx <sample.xlsx>`) as entered in Excel:
 
 .. image:: spreadsheet1.png
     :width: 600 px
@@ -96,10 +96,10 @@ by clicking the **Apply** button. The data from this widget is fed into
     :width: 548 px
     :align: center
 
-We could also define the domain for this dataset in a different way.
-Say, we could make the dataset ready for regression, and use `heat 0`
+We could also define the domain for this data set in a different way.
+Say, we could make the data set ready for regression, and use `heat 0`
 as a continuous class variable, keep gene function and name as meta
-variables, and remove `heat 10` and `heat 20` from the dataset:
+variables, and remove `heat 10` and `heat 20` from the data set:
 
 .. image:: select-columns-regression.png
     :width: 413 px
@@ -115,7 +115,7 @@ Data Table widget gives the following output:
 Header with Attribute Type Information
 --------------------------------------
 
-Consider again the :download:`sample.xlsx <sample.xlsx>` dataset. This time 
+Consider again the :download:`sample.xlsx <sample.xlsx>` data set. This time 
 we will augment the names of the attributes with prefixes
 that define attribute type (continuous, discrete, time, string) and role (class or meta attribute)
 Prefixes are separated from the attribute name with a hash sign ("\#"). Prefixes for attribute roles are:
@@ -139,14 +139,14 @@ Excel (:download:`sample-head.xlsx <sample-head.xlsx>`):
     :width: 414 px
     :align: center
 
-We can again use a **File** widget to load this dataset and then render it in the **Data Table**:
+We can again use a **File** widget to load this data set and then render it in the **Data Table**:
 
 .. image:: select-cols-simplified-header.png
     :width: 509 px
     :align: center
 
 Notice that the attributes we have ignored (label "i" in the
-attribute name) are not present in the dataset.
+attribute name) are not present in the data set.
 
 Three-Row Header Format
 -----------------------

--- a/doc/visual-programming/source/widgets/data/color.rst
+++ b/doc/visual-programming/source/widgets/data/color.rst
@@ -12,13 +12,13 @@ Signals
 
 -  **Data**
 
-   An input dataset. 
+   An input data set. 
 
 **Outputs**:
 
 - **Data**
 
-   A dataset with a new color legend. 
+   A data set with a new color legend. 
 
 Description
 -----------
@@ -65,7 +65,7 @@ Numeric variables
 Example
 -------
 
-We chose to work with the *Iris* dataset. We opened the color palette and selected three new colors for the three types of Irises. Then we opened the :doc:`Scatter Plot<../visualize/scatterplot>` widget and viewed the changes made to the scatter plot. 
+We chose to work with the *Iris* data set. We opened the color palette and selected three new colors for the three types of Irises. Then we opened the :doc:`Scatter Plot<../visualize/scatterplot>` widget and viewed the changes made to the scatter plot. 
 
 .. figure:: images/Color-Example-1.png
 

--- a/doc/visual-programming/source/widgets/data/concatenate.rst
+++ b/doc/visual-programming/source/widgets/data/concatenate.rst
@@ -12,11 +12,11 @@ Signals
 
 -  **Primary Data**
 
-   A dataset that defines the attribute set.
+   A data set that defines the attribute set.
 
 -  **Additional Data**
 
-   An additional dataset.
+   An additional data set.
 
 **Outputs**:
 
@@ -25,14 +25,14 @@ Signals
 Description
 -----------
 
-The widget concatenates multiple sets of instances (datasets). The
+The widget concatenates multiple sets of instances (data sets). The
 merge is “vertical”, in a sense that two sets of 10 and 5 instances
 yield a new set of 15 instances.
 
 .. figure:: images/Concatenate-stamped.png
 
 1. Set the attribute merging method.
-2. Add the identification of source datasets to the output dataset.
+2. Add the identification of source data sets to the output data set.
 3. Produce a report. 
 4. If *Apply automatically* is ticked, changes are communicated automatically. Otherwise, click *Apply*. 
 
@@ -46,13 +46,13 @@ tables.
 Example
 -------
 
-As shown below, the widget can be used for merging data from two separate files. Let's say we have two datasets with the
+As shown below, the widget can be used for merging data from two separate files. Let's say we have two data sets with the
 same attributes, one containing instances from the first experiment and the other
 instances from the second experiment and we wish to join the two data
-tables together. We use the **Concatenate** widget to merge the datasets by
+tables together. We use the **Concatenate** widget to merge the data sets by
 attributes (appending new rows under existing attributes).
 
-Below, we used a modified *Zoo* dataset. In the
+Below, we used a modified *Zoo* data set. In the
 :download:`first <../data/zoo-first.tab>` :doc:`File<../data/file>` widget, we loaded only the animals
 beginning with the letters A and B and in the :download:`second <../data/zoo-second.tab>` 
 one only the animals beginning with the letter C. Upon concatenation, we

--- a/doc/visual-programming/source/widgets/data/continuize.rst
+++ b/doc/visual-programming/source/widgets/data/continuize.rst
@@ -12,19 +12,19 @@ Signals
 
 -  **Data**
 
-   Input dataset
+   Input data set
 
 **Outputs**:
 
 -  **Data**
 
-   Output dataset
+   Output data set
 
 Description
 -----------
 
-The **Continuize** widget receives a dataset in the input and outputs the
-same dataset in which the discrete attributes (including binary attributes)
+The **Continuize** widget receives a data set in the input and outputs the
+same data set in which the discrete attributes (including binary attributes)
 are replaced with continuous ones.
 
 .. figure:: images/Continuize-stamped.png
@@ -60,7 +60,7 @@ Examples
 --------
 
 First, let's see what is the output of the **Continuize** widget. We feed the
-original data (the *Heart disease* dataset) into the :doc:`Data Table <../data/datatable>` and see how they look like. Then
+original data (the *Heart disease* data set) into the :doc:`Data Table <../data/datatable>` and see how they look like. Then
 we continuize the discrete values and observe them in another :doc:`Data
 Table <../data/datatable>`.
 

--- a/doc/visual-programming/source/widgets/data/createclass.rst
+++ b/doc/visual-programming/source/widgets/data/createclass.rst
@@ -12,13 +12,13 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 **Outputs**:
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 Description
 -----------
@@ -41,7 +41,7 @@ Description
 Example
 -------
 
-Here is a simple example with the *auto-mpg* dataset. Pass the data to **Create Class**. Select *car_name* as a column to create the new class from. Here, we wish to create new values that match the car brand. First, we type *ford* as the new value for the matching strings. Then we define the substring that will match the data instances. This means that all instances containing *ford* in their *car_name*, will now have a value *ford* in the new class column. Next, we define the same for *honda* and *fiat*. The widget will tell us how many instance are yet unmatched (remaining instances). We will name them *other*, but you can continue creating new values by adding a condition with '+'.
+Here is a simple example with the *auto-mpg* data set. Pass the data to **Create Class**. Select *car_name* as a column to create the new class from. Here, we wish to create new values that match the car brand. First, we type *ford* as the new value for the matching strings. Then we define the substring that will match the data instances. This means that all instances containing *ford* in their *car_name*, will now have a value *ford* in the new class column. Next, we define the same for *honda* and *fiat*. The widget will tell us how many instance are yet unmatched (remaining instances). We will name them *other*, but you can continue creating new values by adding a condition with '+'.
 
 We named our new class column *car_brand* and we matched at the beginning of the string.
 

--- a/doc/visual-programming/source/widgets/data/datainfo.rst
+++ b/doc/visual-programming/source/widgets/data/datainfo.rst
@@ -3,7 +3,7 @@ Data Info
 
 .. figure:: icons/data-info.png
 
-Displays information on a selected dataset.
+Displays information on a selected data set.
 
 Signals
 -------
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 -  **Selected Data**
 
@@ -25,12 +25,12 @@ Signals
 Description
 -----------
 
-A simple widget that presents information on dataset size, features,
+A simple widget that presents information on data set size, features,
 targets, meta attributes, and location. 
 
 .. figure:: images/data-info-stamped.png
 
-1. Information on dataset size
+1. Information on data set size
 2. Information on discrete and continuous features
 3. Information on targets
 4. Information on meta attributes
@@ -41,8 +41,8 @@ Example
 -------
 
 Below, we compare the basic statistics of two **Data Info** widgets - one
-with information on the entire dataset and the other with
+with information on the entire data set and the other with
 information on the (manually) selected subset from the :doc:`Scatterplot <../visualize/scatterplot>`
-widget. We used the *Iris* dataset. 
+widget. We used the *Iris* data set. 
 
 .. figure:: images/DataInfo-Example.png

--- a/doc/visual-programming/source/widgets/data/datasampler.rst
+++ b/doc/visual-programming/source/widgets/data/datasampler.rst
@@ -3,7 +3,7 @@ Data Sampler
 
 .. figure:: icons/data-sampler.png
 
-Selects a subset of data instances from an input dataset.
+Selects a subset of data instances from an input data set.
 
 Signals
 -------
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   Input dataset to be sampled.
+   Input data set to be sampled.
 
 **Outputs**:
 
@@ -22,7 +22,7 @@ Signals
 
 -  **Remaining Data**
 
-   All other data instances from the input dataset, which are not included in
+   All other data instances from the input data set, which are not included in
    the sample.
 
 Description
@@ -30,20 +30,20 @@ Description
 
 The **Data Sampler** widget implements several means of sampling data from
 an input channel. It outputs a sampled and a complementary
-dataset (with instances from the input set that are not included in the
-sampled dataset). The output is processed after the input dataset is
+data set (with instances from the input set that are not included in the
+sampled data set). The output is processed after the input data set is
 provided and *Sample Data* is pressed.
 
 .. figure:: images/DataSampler-stamped.png
 
-1. Information on the input and output dataset
+1. Information on the input and output data set
 2. The desired sampling method:
 
    -  **Fixed proportion of data** returns a selected percentage of the
       entire data (e.g. 70% of all the data)
    -  **Fixed sample size** returns a selected number of data instances
       with a chance to set *Sample with replacement*, which always samples
-      from the entire dataset (does not subtract instances already in
+      from the entire data set (does not subtract instances already in
       the subset)
    -  `Cross Validation <https://en.wikipedia.org/wiki/Cross-validation_(statistics)>`_
       partitions data instances into complementary subsets, where you can
@@ -52,7 +52,7 @@ provided and *Sample Data* is pressed.
 
 3. *Replicable sampling* maintains sampling patterns that can be carried
    across users, while *stratification* mimics the composition of the
-   input dataset.
+   input data set.
 4. Produce a report.
 5. Press *Sample data* to output the data sample.
  
@@ -61,7 +61,7 @@ Examples
 --------
 
 First, let's see how the **Data Sampler** works. Let's look at the
-information on the original dataset in the :doc:`Data Info <../data/datainfo>` widget. We see
+information on the original data set in the :doc:`Data Info <../data/datainfo>` widget. We see
 there are 24 instances in the data (we used *lenses.tab*). We sampled
 the data with the **Data Sampler** widget and we chose to go with a fixed
 sample size of 5 instances for simplicity. We can observe the sampled
@@ -71,9 +71,9 @@ remaining 19 instances that weren't in the sample.
 .. figure:: images/DataSampler-Example1.png 
 
 In the workflow below, we have sampled 10 data instances from the *Iris*
-dataset and sent the original data and the sample to :doc:`Scatter Plot <../visualize/scatterplot>`
+data set and sent the original data and the sample to :doc:`Scatter Plot <../visualize/scatterplot>`
 widget for exploratory data analysis. The sampled data instances are plotted
-with filled circles, while the original dataset is represented with
+with filled circles, while the original data set is represented with
 empty circles.
 
 .. figure:: images/DataSampler-Example.png

--- a/doc/visual-programming/source/widgets/data/datasets.rst
+++ b/doc/visual-programming/source/widgets/data/datasets.rst
@@ -1,10 +1,10 @@
 
-Datasets
-========
+Data Sets
+=========
 
 .. figure:: icons/datasets.png
 
-Load a dataset from an online repository.
+Load a data set from an online repository.
 
 Signals
 -------
@@ -17,23 +17,23 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 Description
 -----------
 
-**Datasets** widget retrives selected dataset from the server and sends it to the output. File is downloaded to the local memory and thus instantly available even without the internet connection. Each dataset is provided with a description and information on the data size, number of instances, number of variables, target and tags.
+**Datasets** widget retrives selected data set from the server and sends it to the output. File is downloaded to the local memory and thus instantly available even without the internet connection. Each data set is provided with a description and information on the data size, number of instances, number of variables, target and tags.
 
 .. figure:: images/Datasets-stamped.png
 
-1. Information on the number of datasets available and the number of them downloaded to the local memory.
-2. Content of available datasets. Each dataset is described with the size, number of instances and variables, type of the target variable and tags.
-3. Formal description of the selected dataset.
-4. If *Send Data Automatically* is ticked, selected dataset is communicated automatically. Alternatively, press *Send Data*.
+1. Information on the number of data sets available and the number of them downloaded to the local memory. 
+2. Content of available data sets. Each data set is described with the size, number of instances and variables, type of the target variable and tags.
+3. Formal description of the selected data set.
+4. If *Send Data Automatically* is ticked, selected data set is communicated automatically. Alternatively, press *Send Data*.
 
 Example
 -------
 
-Orange workflows can start with **Datasets** widget instead of **File** widget. In the example below, the widget retrieves a dataset from an online repository (Kickstarter data), which is subsequently sent to both the :doc:`Data Table <../data/datatable>` and the :doc:`Distributions <../visualize/distributions>`.
+Orange workflows can start with **Data Sets** widget instead of **File** widget. In the example below, the widget retrieves a data set from an online repository (Kickstarter data), which is subsequently sent to both the :doc:`Data Table <../data/datatable>` and the :doc:`Distributions <../visualize/distributions>`.
 
 .. figure:: images/Datasets-Workflow.png

--- a/doc/visual-programming/source/widgets/data/datatable.rst
+++ b/doc/visual-programming/source/widgets/data/datatable.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 **Outputs**:
 
@@ -23,17 +23,17 @@ Signals
 Description
 -----------
 
-The **Data Table** widget receives one or more datasets in its input and
+The **Data Table** widget receives one or more data sets in its input and
 presents them as a spreadsheet. Data instances may be sorted by
 attribute values. The widget also supports manual selection of data
 instances.
 
 .. figure:: images/DataTable-stamped.png
 
-1. The name of the dataset (usually the input data file). Data
+1. The name of the data set (usually the input data file). Data
    instances are in rows and their attribute values in columns. In this
-   example, the dataset is sorted by the attribute "sepal length".
-2. Info on current dataset size and number and types of attributes
+   example, the data set is sorted by the attribute "sepal length".
+2. Info on current data set size and number and types of attributes
 3. Values of continuous attributes can be visualized with bars; colors
    can be attributed to different classes.
 4. Data instances (rows) can be selected and sent to the widget's output
@@ -47,15 +47,15 @@ instances.
 Example
 -------
 
-We used two :doc:`File <../data/file>` widgets to read the *Iris* and *Glass* dataset
+We used two :doc:`File <../data/file>` widgets to read the *Iris* and *Glass* data set
 (provided in Orange distribution), and send them to the **Data Table**
 widget.
 
 .. figure:: images/DataTable-Schema.png
 
 Selected data instances in the first **Data Table** are passed to the
-second **Data Table**. Notice that we can select which dataset to view
-(iris or glass). Changing from one dataset to another alters the
+second **Data Table**. Notice that we can select which data set to view
+(iris or glass). Changing from one data set to another alters the
 communicated selection of data instances if *Commit on any change*
 is selected.
 

--- a/doc/visual-programming/source/widgets/data/discretize.rst
+++ b/doc/visual-programming/source/widgets/data/discretize.rst
@@ -3,7 +3,7 @@ Discretize
 
 .. figure:: icons/discretize.png
 
-Discretizes continuous attributes from an input dataset. 
+Discretizes continuous attributes from an input data set. 
 
 Signals
 -------
@@ -12,13 +12,13 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 **Outputs**:
 
 -  **Data**
 
-   A dataset with discretized values.
+   A data set with discretized values.
 
 Description
 -----------
@@ -72,7 +72,7 @@ continuous attributes with a selected method.
 Example
 -------
 
-In the schema below, we show the *Iris* dataset with continuous attributes
+In the schema below, we show the *Iris* data set with continuous attributes
 (as in the original data file) and with discretized attributes.
 
 .. figure:: images/Discretize-Example.png

--- a/doc/visual-programming/source/widgets/data/editdomain.rst
+++ b/doc/visual-programming/source/widgets/data/editdomain.rst
@@ -10,22 +10,22 @@ Signals
 
 -  **Data**
 
-   An input dataset
+   An input data set
 
 **Outputs**:
 
 -  **Data**
 
-   An edited output dataset
+   An edited output data set
 
 Description
 -----------
 
-This widget can be used to edit/change a dataset's domain. 
+This widget can be used to edit/change a data set's domain. 
 
 .. figure:: images/EditDomain-stamped.png
 
-1. All features (including meta attributes) from the input dataset are
+1. All features (including meta attributes) from the input data set are
    listed in the *Domain Features* list in the box on the left.
    Selecting one feature displays an editor on the right.
 2. The name of the feature can be changed in the *Name* line edit. For
@@ -38,14 +38,14 @@ This widget can be used to edit/change a dataset's domain.
    button in the *Reset* box while the feature is selected in the
    *Domain Features* list. Pressing *Reset All* will reset all features
    in the domain at the same time.
-4. Pressing the *Apply* button will send the changed domain dataset to the
+4. Pressing the *Apply* button will send the changed domain data set to the
    output channel.
 
 Example
 -------
 
 Below, we demonstrate how to simply edit an existing domain. We selected the
-*lenses.tab* dataset and edited the *perscription* attribute. Where in
+*lenses.tab* data set and edited the *perscription* attribute. Where in
 the original we had the values *myope* and *hypermetrope*, we changed it
 into *nearsightedness* and *farsightedness* instead. For an easier
 comparison, we fed both the original and edited data into the :doc:`Data

--- a/doc/visual-programming/source/widgets/data/featureconstructor.rst
+++ b/doc/visual-programming/source/widgets/data/featureconstructor.rst
@@ -3,7 +3,7 @@ Feature Constructor
 
 .. figure:: icons/feature-constructor.png
 
-Add new features to your dataset.
+Add new features to your data set.
 
 Signals
 -------
@@ -12,19 +12,19 @@ Signals
 
 -  **Data**
 
-A dataset
+A data set
 
 **Outputs**:
 
 -  **Data**
 
-A modified dataset
+A modified data set
 
 Description
 -----------
 
 The **Feature Constructor** allows you to manually add features (columns)
-into your dataset. The new feature can be a computation of an existing
+into your data set. The new feature can be a computation of an existing
 one or a combination of several (addition, subtraction, etc.). You can
 choose what type of feature it will be (discrete, continuous or string)
 and what its parameters are (name, value, expression). For continuous
@@ -71,10 +71,10 @@ Example
 
 With the **Feature Constructor** you can easily adjust or combine existing
 features into new ones. Below, we added one new discrete feature to the
-*Titanic* dataset. We created a new attribute called *Financial status*
+*Titanic* data set. We created a new attribute called *Financial status*
 and set the values to be *rich* if the person belongs to the first class
 (status = first) and *not rich* for everybody else. We can see the new
-dataset with :doc:`Data Table<../data/datatable>` widget.
+data set with :doc:`Data Table<../data/datatable>` widget.
 
 .. figure:: images/FeatureConstructor-Example.png
 

--- a/doc/visual-programming/source/widgets/data/file.rst
+++ b/doc/visual-programming/source/widgets/data/file.rst
@@ -24,9 +24,9 @@ Description
 
 The **File** widget :doc:`reads the input data
 file <../../loading-your-data/index>` (data table
-with data instances) and sends the dataset to its output channel.
+with data instances) and sends the data set to its output channel.
 The history of most recently opened files is maintained in the widget.
-The widget also includes a directory with sample datasets that come
+The widget also includes a directory with sample data sets that come
 pre-installed with Orange.
 
 The widget reads data from Excel (**.xlsx**), simple tab-delimited
@@ -38,9 +38,9 @@ The widget reads data from Excel (**.xlsx**), simple tab-delimited
 2. Browse for a data file.
 3. Reloads currently selected data file.
 4. Insert data from URL adresses, including data from Google Sheets. 
-5. Information on the loaded dataset: dataset size, number and types of data features.
-6. Additional information on the features in the dataset. Features can be edited by double-clicking on them. The user can change the attribute names, select the type of variable per each attribute (*Continuous*, *Nominal*, *String*, *Datetime*), and choose how to further define the attributes (as *Features*, *Targets* or *Meta*). The user can also decide to ignore an attribute. 
-7. Browse documentation datasets.
+5. Information on the loaded data set: data set size, number and types of data features.
+6. Additional information on the features in the data set. Features can be edited by double-clicking on them. The user can change the attribute names, select the type of variable per each attribute (*Continuous*, *Nominal*, *String*, *Datetime*), and choose how to further define the attributes (as *Features*, *Targets* or *Meta*). The user can also decide to ignore an attribute. 
+7. Browse documentation data sets.
 8. Produce a report. 
 
 Example

--- a/doc/visual-programming/source/widgets/data/impute.rst
+++ b/doc/visual-programming/source/widgets/data/impute.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 -  **Learner for Imputation**
 
@@ -24,7 +24,7 @@ Signals
 
 -  **Data**
 
-   The same dataset as in the input, but with the missing values imputed.
+   The same data set as in the input, but with the missing values imputed.
 
 Description
 -----------
@@ -83,7 +83,7 @@ set by the user.
 Example
 -------
 
-To demonstrate how the **Impute** widget works, we played around with the *Iris* dataset
+To demonstrate how the **Impute** widget works, we played around with the *Iris* data set
 and deleted some of the data. We used the **Impute** widget and selected the 
 *Model-based imputer* to impute the missing values. In another :doc:`Data Table <../data/datatable>`, 
 we see how the question marks turned into distinct values ("Iris-setosa, "Iris-versicolor"). 

--- a/doc/visual-programming/source/widgets/data/mergedata.rst
+++ b/doc/visual-programming/source/widgets/data/mergedata.rst
@@ -3,7 +3,7 @@ Merge Data
 
 .. figure:: icons/merge-data.png
 
-Merges two datasets, based on values of selected attributes.
+Merges two data sets, based on values of selected attributes.
 
 Signals
 -------
@@ -12,11 +12,11 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 -  **Extra Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 **Outputs**:
 
@@ -28,8 +28,8 @@ Signals
 Description
 -----------
 
-The **Merge Data** widget is used to horizontally merge two datasets, based
-on values of selected attributes. In the input, two datasets are
+The **Merge Data** widget is used to horizontally merge two data sets, based
+on values of selected attributes. In the input, two data sets are
 required, data and extra data. The widget allows selection of an attribute from each
 domain, which will be used to perform the merging. The widget produces
 one output. It corresponds to instances from the input data
@@ -59,7 +59,7 @@ Data was to be found, the attribute is removed from available merging attributes
 Example
 -------
 
-Merging two datasets results in appending new attributes to the
+Merging two data sets results in appending new attributes to the
 original file, based on a selected common attribute. In the example
 below, we wanted to merge the **zoo.tab** file containing only factual
 data with :download:`zoo-with-images.tab <../data/zoo-with-images.tab>`

--- a/doc/visual-programming/source/widgets/data/outliers.rst
+++ b/doc/visual-programming/source/widgets/data/outliers.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Distances**
 
@@ -22,17 +22,17 @@ Signals
 
 -  **Outliers**
 
-   A dataset containing instances scored as outliers
+   A data set containing instances scored as outliers
 
 -  **Inliers**
 
-   A dataset containing instances not scored as outliers
+   A data set containing instances not scored as outliers
 
 Description
 -----------
 
 The **Outliers** widget applies one of the two methods for outlier
-detection. Both methods apply classification to the dataset, one with
+detection. Both methods apply classification to the data set, one with
 SVM (multiple kernels) and the other with elliptical envelope.
 *One-class SVM with non-linear kernels (RBF)* performs well with
 non-Gaussian distributions, while *Covariance estimator* works only for
@@ -56,7 +56,7 @@ data with Gaussian distribution.
    -  **Covariance estimator**: fits ellipsis to central points with
       Mahalanobis distance metric
 
-      -  **Contamination** is the proportion of outliers in the dataset
+      -  **Contamination** is the proportion of outliers in the data set
       -  **Support fraction** specifies the proportion of points included
          in the estimate
 
@@ -67,7 +67,7 @@ Example
 -------
 
 Below, is a simple example of how to use this widget. We used the *Iris*
-dataset to detect the outliers. We chose the *one class SVM with
+data set to detect the outliers. We chose the *one class SVM with
 non-linear kernel (RBF)* method, with Nu set at 20% (less training
 errors, more support vectors). Then we observed the outliers in the
 :doc:`Data Table <../data/datatable>` widget, while we sent the inliers to the :doc:`Scatter

--- a/doc/visual-programming/source/widgets/data/paintdata.rst
+++ b/doc/visual-programming/source/widgets/data/paintdata.rst
@@ -4,7 +4,7 @@ Paint Data
 .. figure:: icons/paint-data.png
 
 Paints data on a 2D plane. You can place individual data points or
-use a brush to paint larger datasets.
+use a brush to paint larger data sets.
 
 Signals
 -------
@@ -17,12 +17,12 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset created in the widget
+   Attribute-valued data set created in the widget
 
 Description
 -----------
 
-The widget supports the creation of a new dataset by visually placing
+The widget supports the creation of a new data set by visually placing
 data points on a two-dimension plane. Data points can be placed on the
 plane individually (*Put*) or in a larger number by brushing (*Brush*).
 Data points can belong to classes if the data is intended to be used in
@@ -32,7 +32,7 @@ supervised learning.
 
 1. Name the axes and select a class to paint data instances. You can
    add or remove classes. Use only one class to create classless,
-   unsupervised datasets.
+   unsupervised data sets.
 2. Drawing tools. Paint data points with *Brush* (multiple data
    instances) or *Put* (individual data instance). Select data points
    with *Select* and remove them with the Delete/Backspace key. Reposition
@@ -50,7 +50,7 @@ supervised learning.
 Example
 -------
 
-In the example below, we have painted a dataset with 4 classes. Such dataset
+In the example below, we have painted a data set with 4 classes. Such data set
 is great for demonstrating k-means and hierarchical clustering methods.
 In the screenshot, we see that :doc:`k-means <../unsupervised/kmeansclustering>`, overall, recognizes 
 clusters better than :doc:`hierarchical clustering <../unsupervised/hierarchicalclustering>`. 

--- a/doc/visual-programming/source/widgets/data/preprocess.rst
+++ b/doc/visual-programming/source/widgets/data/preprocess.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
@@ -52,7 +52,7 @@ combines four separate widgets for simpler processing.
 Example
 -------
 
-In the example below, we have used the *adult* dataset and preprocessed the
+In the example below, we have used the *adult* data set and preprocessed the
 data. We continuized discrete values (age, education and marital
 status...) as *one attribute per value*, we imputed missing values
 (replacing ? with average values), selected 10 most relevant attributes

--- a/doc/visual-programming/source/widgets/data/purgedomain.rst
+++ b/doc/visual-programming/source/widgets/data/purgedomain.rst
@@ -13,13 +13,13 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
 -  **Data**
 
-   A filtered dataset
+   A filtered data set
 
 Description
 -----------
@@ -78,7 +78,7 @@ Example
 The **Purge Domain** widget would typically appear after data filtering, for
 instance when selecting a subset of visualized examples.
 
-In the above schema, we play with the *adult.tab* dataset: we visualize
+In the above schema, we play with the *adult.tab* data set: we visualize
 it and select a portion of the data, which contains only four out of the
 five original classes. To get rid of the empty class, we put the data
 through **Purge Domain** before going on to the :doc:`Box Plot <../visualize/boxplot>` widget. The

--- a/doc/visual-programming/source/widgets/data/pythonscript.rst
+++ b/doc/visual-programming/source/widgets/data/pythonscript.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **in\_data (Orange.data.Table)**
 
-   Input dataset bound to ``in_data`` variable in the script’s local
+   Input data set bound to ``in_data`` variable in the script’s local
    namespace.
 
 -  **in\_distance (Orange.core.SymMatrix)**
@@ -39,7 +39,7 @@ Signals
 
 -  **out\_data (Orange.data.Table)**
 
-   Dataset retrieved from ``out_data`` variable in the script’s local
+   Data set retrieved from ``out_data`` variable in the script’s local
    namespace after execution.
 
 -  **out\_distance (Orange.core.SymMatrix)**

--- a/doc/visual-programming/source/widgets/data/randomize.rst
+++ b/doc/visual-programming/source/widgets/data/randomize.rst
@@ -3,7 +3,7 @@ Randomize
 
 .. figure:: icons/randomize.png
 
-Shuffles classes, attributes and/or metas of an input dataset.
+Shuffles classes, attributes and/or metas of an input data set.
 
 Signals
 -------
@@ -12,25 +12,25 @@ Signals
 
 -  **Data**
 
-   Dataset.
+   Data set.
 
 **Outputs**:
 
 -  **Data**
 
-   Randomized dataset.
+   Randomized data set.
 
 Description
 -----------
 
-The **Randomize** widget receives a dataset in the input and outputs the same
-dataset in which the classes, attributes or/and metas are shuffled.
+The **Randomize** widget receives a data set in the input and outputs the same
+data set in which the classes, attributes or/and metas are shuffled.
 
 .. figure:: images/Randomize-Default.png
 
-1. Select group of columns of the dataset you want to shuffle.
+1. Select group of columns of the data set you want to shuffle.
 
-2. Select proportion of the dataset you want to shuffle.
+2. Select proportion of the data set you want to shuffle.
 
 3. Produce replicable output.
 
@@ -43,11 +43,11 @@ Example
 
 The **Randomize** widget is usually placed right after
 (e.g. :doc:`File <../data/file>` widget. The basic usage is shown in the following
-workflow, where values of class variable of Iris dataset are randomly shuffled.
+workflow, where values of class variable of Iris data set are randomly shuffled.
 
 .. figure:: images/Randomize-Example1.png
 
 In the next example we show how shuffling class values influences model
-performance on the same dataset as above.
+performance on the same data set as above.
 
 .. figure:: images/Randomize-Example2.png

--- a/doc/visual-programming/source/widgets/data/rank.rst
+++ b/doc/visual-programming/source/widgets/data/rank.rst
@@ -3,7 +3,7 @@ Rank
 
 .. figure:: icons/rank.png
 
-Ranking of attributes in classification or regression datasets.
+Ranking of attributes in classification or regression data sets.
 
 Signals
 -------
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 - **Scorer**  (multiple)
 
@@ -23,12 +23,12 @@ Signals
 
 -  **Reduced Data**
 
-   A dataset whith selected attributes.
+   A data set whith selected attributes.
 
 Description
 -----------
 
-The **Rank** widget considers class-labeled datasets (classification or
+The **Rank** widget considers class-labeled data sets (classification or
 regression) and scores the attributes according to their correlation
 with the class.
 
@@ -67,7 +67,7 @@ informative ones:
 
 .. figure:: images/Rank-Select-Schema.png
 
-Notice how the widget outputs a dataset that includes only the
+Notice how the widget outputs a data set that includes only the
 best-scored attributes:
 
 .. figure:: images/Rank-Select-Widgets.png
@@ -79,12 +79,12 @@ What follows is a bit more complicated example. In the workflow below, we
 first split the data into a training set and a test set. In the upper branch, the
 training data passes through the **Rank** widget to select the most
 informative attributes, while in the lower branch there is no feature
-selection. Both feature selected and original datasets are passed to
+selection. Both feature selected and original data sets are passed to
 their own :doc:`Test & Score <../evaluation/testandscore>` widgets, which develop a *Naive Bayes*
 classifier and score it on a test set.
 
 .. figure:: images/Rank-and-Test.png
 
-For datasets with many features, a naive Bayesian classifier feature
+For data sets with many features, a naive Bayesian classifier feature
 selection, as shown above, would often yield a better predictive
 accuracy.

--- a/doc/visual-programming/source/widgets/data/save.rst
+++ b/doc/visual-programming/source/widgets/data/save.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
@@ -21,7 +21,7 @@ Signals
 Description
 -----------
 
-The **Save Data** widget considers a dataset provided in the input channel
+The **Save Data** widget considers a data set provided in the input channel
 and saves it to a data file with a specified name. It can save the
 data as a tab-delimited or a comma-separated file.
 
@@ -38,7 +38,7 @@ name is set or the user pushes the *Save* button.
 Example
 -------
 
-In the workflow below, we used the *Zoo* dataset. We loaded the data into the :doc:`Scatter Plot <../visualize/scatterplot>` widget, with which
+In the workflow below, we used the *Zoo* data set. We loaded the data into the :doc:`Scatter Plot <../visualize/scatterplot>` widget, with which
 we selected a subset of data instances and pushed them to the
 **Save Data** widget to store them in a file.
 

--- a/doc/visual-programming/source/widgets/data/selectcolumns.rst
+++ b/doc/visual-programming/source/widgets/data/selectcolumns.rst
@@ -12,13 +12,13 @@ Signals
 
 -  **Data**
 
-   Attribute-valued dataset.
+   Attribute-valued data set.
 
 **Outputs**:
 
 -  **Data**
 
-   Attribute-valued dataset composed using the domain specification from
+   Attribute-valued data set composed using the domain specification from
    the widget.
 
 Description
@@ -40,9 +40,9 @@ before the name of the attribute (D, C, S, respectively).
 
 1. Left-out data attributes that will not be in the output data file
 2. Data attributes in the new data file
-3. Target variable. If none, the new dataset will be without a target variable. 
+3. Target variable. If none, the new data set will be without a target variable. 
 4. Meta attributes of the new data file. These attributes are included
-   in the dataset but are, for most methods, not considered in the
+   in the data set but are, for most methods, not considered in the
    analysis.
 5. Produce a report.
 6. Reset the domain composition to that of the input data file.
@@ -57,13 +57,13 @@ Examples
 In the workflow below, the *Iris* data from the :doc:`File <../data/file>` widget is fed into
 the **Select Columns** widget, where we select to output only two
 attributes (namely petal width and petal length). We view both the
-original dataset and the dataset with selected columns in the :doc:`Data
+original data set and the data set with selected columns in the :doc:`Data
 Table <../data/datatable>` widget.
 
 .. figure:: images/SelectColumns-Example1.png 
 
 For a more complex use of the widget, we composed a workflow to redefine
-the classification problem in the *heart-disease* dataset. Originally, the
+the classification problem in the *heart-disease* data set. Originally, the
 task was to predict if the patient has a coronary artery diameter
 narrowing. We changed the problem to that of gender classification, based
 on age, chest pain and cholesterol level, and informatively kept the

--- a/doc/visual-programming/source/widgets/data/selectrows.rst
+++ b/doc/visual-programming/source/widgets/data/selectrows.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   Dataset.
+   Data set.
 
 **Outputs**:
 
@@ -27,7 +27,7 @@ Signals
 Description
 -----------
 
-This widget selects a subset from an input dataset, based on user-defined
+This widget selects a subset from an input data set, based on user-defined
 conditions. Instances that match the selection rule are placed in the
 output *Matching Data* channel.
 
@@ -45,7 +45,7 @@ discrete, continuous and string attributes.
 2. Add a new condition to the list of conditions.
 3. Add all the possible variables at once.
 4. Remove all the listed variables at once.
-5. Information on the input dataset and information on instances that match the condition(s)
+5. Information on the input data set and information on instances that match the condition(s)
 6. Purge the output data.
 7. When the *Send automatically* box is ticked, all changes will be
    automatically communicated to other widgets.
@@ -63,14 +63,14 @@ Example
 In the workflow below, we used the *Zoo* data from the :doc:`File <../data/file>` widget and
 fed it into the **Select Rows** widget. In the widget, we chose to output only
 two animal types, namely fish and reptiles. We can inspect both the
-original dataset and the dataset with selected rows in the :doc:`Data
+original data set and the data set with selected rows in the :doc:`Data
 Table <../data/datatable>` widget.
 
 .. figure:: images/SelectRows-Example.png 
 
-In the next example, we used the data from the *Titanic* dataset and
+In the next example, we used the data from the *Titanic* data set and
 similarly fed it into the :doc:`Box Plot <../visualize/boxplot>` widget. We first observed the
-entire dataset based on survival. Then we selected only first class passengers in the **Select Rows** widget and fed it again into the :doc:`Box Plot <../visualize/boxplot>`.
+entire data set based on survival. Then we selected only first class passengers in the **Select Rows** widget and fed it again into the :doc:`Box Plot <../visualize/boxplot>`.
 There we could see all the first class passengers listed by their survival rate and grouped by gender. 
 
 .. figure:: images/SelectRows-Workflow.png

--- a/doc/visual-programming/source/widgets/data/transpose.rst
+++ b/doc/visual-programming/source/widgets/data/transpose.rst
@@ -12,13 +12,13 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
 -  **Data**
 
-   Transposed dataset
+   Transposed data set
 
 Description
 -----------

--- a/doc/visual-programming/source/widgets/evaluation/calibrationplot.rst
+++ b/doc/visual-programming/source/widgets/evaluation/calibrationplot.rst
@@ -41,6 +41,6 @@ needed by the **Calibration Plot** is :doc:`Test&Score <../evaluation/testandsco
 Plot will hence always follow Test&Score and, since it has no
 outputs, no other widgets follow it.
 
-Here is a typical example, where we compare three classifiers (namely :doc:`Naive Bayes<../model/naivebayes>`, :doc:`Tree <../model/tree>` and :doc:`Constant <../model/constant>`) and input them into :doc:`Test&Score <../evaluation/testandscore>`. We used the *Titanic* dataset. Test&Score then displays evaluation results for each classifier. Then we draw **Calibration Plot** and :doc:`ROC Analysis <../evaluation/rocanalysis>` widgets from Test&Score to further analyze the performance of classifiers. **Calibration Plot** enables you to see prediction accuracy of class probabilities in a plot.
+Here is a typical example, where we compare three classifiers (namely :doc:`Naive Bayes<../model/naivebayes>`, :doc:`Tree <../model/tree>` and :doc:`Constant <../model/constant>`) and input them into :doc:`Test&Score <../evaluation/testandscore>`. We used the *Titanic* data set. Test&Score then displays evaluation results for each classifier. Then we draw **Calibration Plot** and :doc:`ROC Analysis <../evaluation/rocanalysis>` widgets from Test&Score to further analyze the performance of classifiers. **Calibration Plot** enables you to see prediction accuracy of class probabilities in a plot.
 
 .. figure:: images/CalibrationPlot-example.png

--- a/doc/visual-programming/source/widgets/evaluation/liftcurve.rst
+++ b/doc/visual-programming/source/widgets/evaluation/liftcurve.rst
@@ -60,7 +60,7 @@ At the moment, the only widget which gives the right type of the signal
 needed by the **Lift Curve** is :doc:`Test&Score <../evaluation/testandscore>`.
 
 In the example below, we try to see the prediction quality for the class
-'survived' on the *Titanic* dataset. We compared three different
+'survived' on the *Titanic* data set. We compared three different
 classifiers in the Test Learners widget and sent them to Lift Curve to see
 their performance against a random model. We see the :doc:`Tree <../model/tree>` classifier is the best out of the three, since it best aligns
 with *lift convex hull*. We also see that its performance is the best

--- a/doc/visual-programming/source/widgets/evaluation/predictions.rst
+++ b/doc/visual-programming/source/widgets/evaluation/predictions.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 -  **Predictors**
 
@@ -27,7 +27,7 @@ Signals
 Description
 -----------
 
-The widget receives a dataset and one or more predictors (classifiers,
+The widget receives a data set and one or more predictors (classifiers,
 not learning algorithms - see the example below). It outputs the data
 and the predictions.
 
@@ -35,7 +35,7 @@ and the predictions.
 
 1. Information on the input
 2. The user can select the options for classification. If *Show predicted class* is ticked, the appended data table provides information on predicted class. If *Show predicted probabilities* is ticked, the appended data table provides information on probabilities predicted by the classifiers. The user can also select the predicted class he or she wants displayed in the appended data table. The option *Draw distribution bars* provides a nice visualization of the predictions. 
-3. By ticking the *Show full dataset*, the user can append the entire data table to the *Predictions* widget. 
+3. By ticking the *Show full data set*, the user can append the entire data table to the *Predictions* widget. 
 4. Select the desired output.
 5. The appended data table
 6. Produce a report.
@@ -46,9 +46,9 @@ a simple demonstration at the bottom of the page. :doc:`Confusion Matrix <../eva
 is a related widget and although many things can be done with any of
 them, there are tasks for which one of them might be much more
 convenient than the other.
-The output of the widget is another dataset, where predictions are
+The output of the widget is another data set, where predictions are
 appended as new meta attributes. You can select which features you wish
-to output (original data, predictions, probabilities). The resulting dataset can be appended to the widget, but you can still choose to display it in a separate data table. 
+to output (original data, predictions, probabilities). The resulting data set can be appended to the widget, but you can still choose to display it in a separate data table. 
 
 Example
 -------

--- a/doc/visual-programming/source/widgets/evaluation/testandscore.rst
+++ b/doc/visual-programming/source/widgets/evaluation/testandscore.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   Data for training and, if there is no separate test dataset, also
+   Data for training and, if there is no separate test data set, also
    testing.
 
 -  **Test Data**
@@ -59,10 +59,10 @@ than one widget to test multiple learners with the same procedures.
    -  **Random sampling** randomly splits the data into the training and
       testing set in the given proportion (e.g. 70:30); the whole procedure
       is repeated for a specified number of times.
-   -  **Test on train data** uses the whole dataset for training and then
+   -  **Test on train data** uses the whole data set for training and then
       for testing. This method practically always gives wrong results.
    -  **Test on test data**: the above methods use the data from *Data*
-      signal only. To input another dataset with testing examples (for
+      signal only. To input another data set with testing examples (for
       instance from another file or some data selected in another widget),
       we select *Separate Test Data* signal in the communication channel
       and select Test on test data.
@@ -101,11 +101,11 @@ Regression
 Example
 -------
 
-In a typical use of the widget, we give it a dataset and a few learning
+In a typical use of the widget, we give it a data set and a few learning
 algorithms and we observe their performance in the table inside the
 **Test & Score** widget and in the :doc:`ROC <../evaluation/rocanalysis>`. The data is often
 preprocessed before testing; in this case we did some manual feature
-selection (:doc:`Select Columns <../data/selectcolumns>` widget) on *Titanic* dataset, where we
+selection (:doc:`Select Columns <../data/selectcolumns>` widget) on *Titanic* data set, where we
 want to know only the sex and status of the survived and omit the age.
 
 .. figure:: images/TestLearners-example-classification.png

--- a/doc/visual-programming/source/widgets/model/adaboost.rst
+++ b/doc/visual-programming/source/widgets/model/adaboost.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset. 
+   A data set. 
 
 -  **Preprocessor**
 
@@ -60,10 +60,10 @@ The `AdaBoost <https://en.wikipedia.org/wiki/AdaBoost>`_ (short for "Adaptive bo
 Examples
 --------
 
-For classification, we loaded the *iris* dataset. We used *AdaBoost*, :doc:`Tree <../model/tree>` and :doc:`Logistic Regression <../model/logisticregression>` and evaluated the models' performance in :doc:`Test & Score <../evaluation/testandscore>`.
+For classification, we loaded the *iris* data set. We used *AdaBoost*, :doc:`Tree <../model/tree>` and :doc:`Logistic Regression <../model/logisticregression>` and evaluated the models' performance in :doc:`Test & Score <../evaluation/testandscore>`.
 
 .. figure:: images/AdaBoost-classification.png
 
-For regression, we loaded the *housing* dataset, sent the data instances to two different models (**AdaBoost** and :doc:`Tree <../model/tree>`) and output them to the :doc:`Predictions <../evaluation/predictions>` widget. 
+For regression, we loaded the *housing* data set, sent the data instances to two different models (**AdaBoost** and :doc:`Tree <../model/tree>`) and output them to the :doc:`Predictions <../evaluation/predictions>` widget. 
 
 .. figure:: images/AdaBoost-regression.png

--- a/doc/visual-programming/source/widgets/model/cn2ruleinduction.rst
+++ b/doc/visual-programming/source/widgets/model/cn2ruleinduction.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   Dataset.
+   Data set.
 
 -  **Preprocessor**
 
@@ -97,7 +97,7 @@ then predict *class*", even in domains where noise may be present.
 Examples
 --------
 
-For the example below, we have used *zoo* dataset and passed it to **CN2 Rule Induction**. We can review and interpret the built model with :doc:`CN2 Rule Viewer <../visualize/cn2ruleviewer>` widget.
+For the example below, we have used *zoo* data set and passed it to **CN2 Rule Induction**. We can review and interpret the built model with :doc:`CN2 Rule Viewer <../visualize/cn2ruleviewer>` widget.
 
 .. figure:: images/CN2-visualize.png
 

--- a/doc/visual-programming/source/widgets/model/constant.rst
+++ b/doc/visual-programming/source/widgets/model/constant.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 
@@ -53,10 +53,10 @@ If you change the widget's name, you need to click *Apply*. Alternatively, tick 
 Examples
 --------
 
-In a typical classification example, we would use this widget to compare the scores of other learning algorithms (such as kNN) with the default scores. Use *iris* dataset and connect it to :doc:`Test & Score <../evaluation/testandscore>`. Then connect **Constant** and :doc:`kNN <../model/knn>` to :doc:`Test & Score <../evaluation/testandscore>` and observe how well :doc:`kNN <../model/knn>` performs against a constant baseline.
+In a typical classification example, we would use this widget to compare the scores of other learning algorithms (such as kNN) with the default scores. Use *iris* data set and connect it to :doc:`Test & Score <../evaluation/testandscore>`. Then connect **Constant** and :doc:`kNN <../model/knn>` to :doc:`Test & Score <../evaluation/testandscore>` and observe how well :doc:`kNN <../model/knn>` performs against a constant baseline.
 
 .. figure:: images/Constant-classification.png
 
-For regression, we use **Constant** to construct a predictor in :doc:`Predictions <../evaluation/predictions>`. We used the *housing* dataset. In **Predictions**, you can see that *Mean Learner* returns one (mean) value for all instances.
+For regression, we use **Constant** to construct a predictor in :doc:`Predictions <../evaluation/predictions>`. We used the *housing* data set. In **Predictions**, you can see that *Mean Learner* returns one (mean) value for all instances.
 
 .. figure:: images/Constant-regression.png

--- a/doc/visual-programming/source/widgets/model/knn.rst
+++ b/doc/visual-programming/source/widgets/model/knn.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 
@@ -61,10 +61,10 @@ The **kNN** widget uses the `kNN algorithm <https://en.wikipedia.org/wiki/K-near
 Examples
 --------
 
-The first example is a classification task on *iris* dataset. We compare the results of `k-Nearest neighbors <https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm>`_ with the default model :doc:`Constant <../model/constant>`, which always predicts the majority class.
+The first example is a classification task on *iris* data set. We compare the results of `k-Nearest neighbors <https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm>`_ with the default model :doc:`Constant <../model/constant>`, which always predicts the majority class.
 
 .. figure:: images/Constant-classification.png
 
-The second example is a regression task. This workflow shows how to use the *Learner* output. For the purpose of this example, we used the *housing* dataset. We input the **kNN** prediction model into :doc:`Predictions <../evaluation/predictions>` and observe the predicted values.
+The second example is a regression task. This workflow shows how to use the *Learner* output. For the purpose of this example, we used the *housing* data set. We input the **kNN** prediction model into :doc:`Predictions <../evaluation/predictions>` and observe the predicted values.
 
 .. figure:: images/kNN-regression.png

--- a/doc/visual-programming/source/widgets/model/linearregression.rst
+++ b/doc/visual-programming/source/widgets/model/linearregression.rst
@@ -14,11 +14,11 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 
-   A preprocessed dataset.
+   A preprocessed data set.
 
 **Outputs**:
 
@@ -58,6 +58,6 @@ Linear regreesion works only on regression tasks.
 Example
 -------
 
-Below, is a simple workflow with *housing* dataset. We trained **Linear Regression** and :doc:`Random Forest <../model/randomforest>` and evaluated their performance in :doc:`Test&Score <../evaluation/testandscore>`.
+Below, is a simple workflow with *housing* data set. We trained **Linear Regression** and :doc:`Random Forest <../model/randomforest>` and evaluated their performance in :doc:`Test&Score <../evaluation/testandscore>`.
 
 .. figure:: images/LinearRegression-regression.png

--- a/doc/visual-programming/source/widgets/model/loadmodel.rst
+++ b/doc/visual-programming/source/widgets/model/loadmodel.rst
@@ -31,6 +31,6 @@ Description
 Example
 -------
 
-When you want to use a custom-set model that you've saved before, open the **Load Model** widget and select the desired file with the *Browse* icon. This widget loads the exisiting model into :doc:`Predictions <../evaluation/predictions>` widget. Datasets used with **Load Model** have to contain compatible attributes!
+When you want to use a custom-set model that you've saved before, open the **Load Model** widget and select the desired file with the *Browse* icon. This widget loads the exisiting model into :doc:`Predictions <../evaluation/predictions>` widget. Data sets used with **Load Model** have to contain compatible attributes!
 
 .. figure:: images/LoadModel-example.png

--- a/doc/visual-programming/source/widgets/model/logisticregression.rst
+++ b/doc/visual-programming/source/widgets/model/logisticregression.rst
@@ -14,7 +14,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 - **Preprocessor**
 
@@ -53,8 +53,8 @@ It only works for classification tasks.
 Example
 -------
 
-The widget is used just as any other widget for inducing a classifier. This is an example demonstrating prediction results with logistic regression on the *hayes-roth* dataset. We first load *hayes-roth_learn* in the :doc:`File <../data/file>` widget and pass the data to **Logistic Regression**. Then we pass the trained model to :doc:`Predictions <../evaluation/predictions>`.
+The widget is used just as any other widget for inducing a classifier. This is an example demonstrating prediction results with logistic regression on the *hayes-roth* data set. We first load *hayes-roth_learn* in the :doc:`File <../data/file>` widget and pass the data to **Logistic Regression**. Then we pass the trained model to :doc:`Predictions <../evaluation/predictions>`.
 
-Now we want to predict class value on a new dataset. We load *hayes-roth_test* in the second **File** widget and connect it to **Predictions**. We can now observe class values predicted with **Logistic Regression** directly in **Predictions**.
+Now we want to predict class value on a new data set. We load *hayes-roth_test* in the second **File** widget and connect it to **Predictions**. We can now observe class values predicted with **Logistic Regression** directly in **Predictions**.
 
 .. figure:: images/LogisticRegression-classification.png

--- a/doc/visual-programming/source/widgets/model/naivebayes.rst
+++ b/doc/visual-programming/source/widgets/model/naivebayes.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 

--- a/doc/visual-programming/source/widgets/model/neuralnetwork.rst
+++ b/doc/visual-programming/source/widgets/model/neuralnetwork.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 
@@ -63,7 +63,7 @@ The **Neural Network** widget uses sklearn's `Multi\-layer Perceptron algorithm 
 Examples
 --------
 
-The first example is a classification task on *iris* dataset. We compare the results of **Neural Network** with the :doc:`Logistic Regression <../model/logisticregression>`.
+The first example is a classification task on *iris* data set. We compare the results of **Neural Network** with the :doc:`Logistic Regression <../model/logisticregression>`.
 
 .. figure:: images/NN-Example-Test.png
 

--- a/doc/visual-programming/source/widgets/model/randomforest.rst
+++ b/doc/visual-programming/source/widgets/model/randomforest.rst
@@ -14,7 +14,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 
@@ -52,7 +52,7 @@ Description
 Examples
 --------
 
-For classification tasks, we use *iris* dataset. Connect it to :doc:`Predictions <../evaluation/predictions>`. Then, connect :doc:`File <../data/file>` to **Random Forest** and :doc:`Tree <../model/tree>` and connect them further to :doc:`Predictions <../evaluation/predictions>`. Finally, observe the predictions for the two models.
+For classification tasks, we use *iris* data set. Connect it to :doc:`Predictions <../evaluation/predictions>`. Then, connect :doc:`File <../data/file>` to **Random Forest** and :doc:`Tree <../model/tree>` and connect them further to :doc:`Predictions <../evaluation/predictions>`. Finally, observe the predictions for the two models.
 
 .. figure:: images/RandomForest-classification.png
 

--- a/doc/visual-programming/source/widgets/model/savemodel.rst
+++ b/doc/visual-programming/source/widgets/model/savemodel.rst
@@ -36,6 +36,6 @@ Description
 Example
 -------
 
-When you want to save a custom-set model, feed the data to the model (e.g. :doc:`Logistic Regression <../model/logisticregression>`) and connect it to **Save Model**. Name the model; load it later into workflows with :doc:`Load Model <../model/loadmodel>`. Datasets used with **Load Model** have to contain compatible attributes.
+When you want to save a custom-set model, feed the data to the model (e.g. :doc:`Logistic Regression <../model/logisticregression>`) and connect it to **Save Model**. Name the model; load it later into workflows with :doc:`Load Model <../model/loadmodel>`. Data sets used with **Load Model** have to contain compatible attributes.
 
 .. figure:: images/SaveModel-example.png

--- a/doc/visual-programming/source/widgets/model/stochasticgradient.rst
+++ b/doc/visual-programming/source/widgets/model/stochasticgradient.rst
@@ -14,7 +14,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 -  **Preprocessor**
 
@@ -33,7 +33,7 @@ Signals
 Description
 -----------
 
-The **Stochastic Gradient Descent** widget uses `stochastic gradient descent <https://en.wikipedia.org/wiki/Stochastic_gradient_descent>`_ that minimizes a chosen loss function with a linear function. The algorithm approximates a true gradient by considering one sample at a time, and simultaneously updates the model based on the gradient of the loss function. For regression, it returns predictors as minimizers of the sum, i.e. M-estimators, and is especially useful for large-scale and sparse datasets.
+The **Stochastic Gradient Descent** widget uses `stochastic gradient descent <https://en.wikipedia.org/wiki/Stochastic_gradient_descent>`_ that minimizes a chosen loss function with a linear function. The algorithm approximates a true gradient by considering one sample at a time, and simultaneously updates the model based on the gradient of the loss function. For regression, it returns predictors as minimizers of the sum, i.e. M-estimators, and is especially useful for large-scale and sparse data sets.
 
 .. figure:: images/StochasticGradientDescent-stamped.png
    :scale: 50 %
@@ -96,10 +96,10 @@ The **Stochastic Gradient Descent** widget uses `stochastic gradient descent <ht
 Examples
 --------
 
-For the classification task, we will use *iris* dataset and test two models on it. We connected :doc:`Stochastic Gradient Descent <../model/stochasticgradient>` and :doc:`Tree <../model/tree>` to :doc:`Test & Score <../evaluation/testandscore>`. We also connected :doc:`File <../data/file>` to **Test & Score** and observed model performance in the widget.
+For the classification task, we will use *iris* data set and test two models on it. We connected :doc:`Stochastic Gradient Descent <../model/stochasticgradient>` and :doc:`Tree <../model/tree>` to :doc:`Test & Score <../evaluation/testandscore>`. We also connected :doc:`File <../data/file>` to **Test & Score** and observed model performance in the widget.
 
 .. figure:: images/StochasticGradientDescent-classification.png
 
-For the regression task, we will compare three different models to see which predict what kind of results. For the purpose of this example, the *housing* dataset is used. We connect the :doc:`File <../data/file>` widget to **Stochastic Gradient Descent**, :doc:`Linear Regression <../model/linearregression>` and :doc:`kNN <../model/knn>` widget and all four to the :doc:`Predictions <../evaluation/predictions>` widget.
+For the regression task, we will compare three different models to see which predict what kind of results. For the purpose of this example, the *housing* data set is used. We connect the :doc:`File <../data/file>` widget to **Stochastic Gradient Descent**, :doc:`Linear Regression <../model/linearregression>` and :doc:`kNN <../model/knn>` widget and all four to the :doc:`Predictions <../evaluation/predictions>` widget.
 
 .. figure:: images/StochasticGradientDescent-regression.png

--- a/doc/visual-programming/source/widgets/model/svm.rst
+++ b/doc/visual-programming/source/widgets/model/svm.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 -  **Preprocessor**
 
@@ -80,7 +80,7 @@ The widget works for both classification and regression tasks.
 Examples
 --------
 
-In the first (regression) example, we have used *housing* dataset and split the data into two data subsets (*Data Sample* and *Remaining Data*) with :doc:`Data Sampler <../data/datasampler>`. The sample was sent to SVM which produced a *Model*, which was then used in :doc:`Predictions <../evaluation/predictions>` to predict the values in *Remaining Data*. A similar schema can be used if the data is already in two separate files; in this case, two :doc:`File <../data/file>` widgets would be used instead of the :doc:`File <../data/file>` - :doc:`Data Sampler <../data/datasampler>` combination.
+In the first (regression) example, we have used *housing* data set and split the data into two data subsets (*Data Sample* and *Remaining Data*) with :doc:`Data Sampler <../data/datasampler>`. The sample was sent to SVM which produced a *Model*, which was then used in :doc:`Predictions <../evaluation/predictions>` to predict the values in *Remaining Data*. A similar schema can be used if the data is already in two separate files; in this case, two :doc:`File <../data/file>` widgets would be used instead of the :doc:`File <../data/file>` - :doc:`Data Sampler <../data/datasampler>` combination.
 
 .. figure:: images/SVM-predictions.png
 

--- a/doc/visual-programming/source/widgets/model/tree.rst
+++ b/doc/visual-programming/source/widgets/model/tree.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 -  **Preprocessor**
 
@@ -31,7 +31,7 @@ Signals
 Description
 -----------
 
-**Tree** is a simple algorithm that splits the data into nodes by class purity. It is a precursor to :doc:`Random Forest <randomforest>`. Tree in Orange is designed in-house and can handle both discrete and continuous datasets.
+**Tree** is a simple algorithm that splits the data into nodes by class purity. It is a precursor to :doc:`Random Forest <randomforest>`. Tree in Orange is designed in-house and can handle both discrete and continuous data sets.
 
 It can also be used for both classification and regression tasks.
 
@@ -62,6 +62,6 @@ The second schema trains a model and evaluates its performance against :doc:`Log
 
 .. figure:: images/Tree-classification-model.png
 
-We used the *iris* dataset in both examples. However, **Tree** works for regression tasks as well. Use *housing* dataset and pass it to **Tree**. The selected tree node from :doc:`Tree Viewer <../visualize/treeviewer>` is presented in the :doc:`Scatter Plot <../visualize/scatterplot>` and we can see that the selected examples exhibit the same features. 
+We used the *iris* data set in both examples. However, **Tree** works for regression tasks as well. Use *housing* data set and pass it to **Tree**. The selected tree node from :doc:`Tree Viewer <../visualize/treeviewer>` is presented in the :doc:`Scatter Plot <../visualize/scatterplot>` and we can see that the selected examples exhibit the same features. 
 
 .. figure:: images/Tree-regression-subset.png

--- a/doc/visual-programming/source/widgets/unsupervised/PCA.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/PCA.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
@@ -29,7 +29,7 @@ Description
 
 `Principal Component Analysis <https://en.wikipedia.org/wiki/Principal_component_analysis>`_
 (PCA) computes the PCA linear transformation of the input data. It
-outputs either a transformed dataset with weights of individual
+outputs either a transformed data set with weights of individual
 instances or weights of principal components.
 
 .. figure:: images/PCA-stamped.png
@@ -53,9 +53,9 @@ line in the graph.
 Examples
 --------
 
-**PCA** can be used to simplify visualizations of large datasets. Below,
-we used the *Iris* dataset to show how we can improve the visualization of
-the dataset with PCA. The transformed data in the :doc:`Scatter Plot <../visualize/scatterplot>` show a
+**PCA** can be used to simplify visualizations of large data sets. Below,
+we used the *Iris* data set to show how we can improve the visualization of
+the data set with PCA. The transformed data in the :doc:`Scatter Plot <../visualize/scatterplot>` show a
 much clearer distinction between classes than the default settings.
 
 .. figure:: images/PCAExample.png

--- a/doc/visual-programming/source/widgets/unsupervised/correspondenceanalysis.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/correspondenceanalysis.rst
@@ -10,7 +10,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
@@ -37,7 +37,7 @@ Example
 -------
 
 Below, is a simple comparison between the **Correspondence Analysis** and
-:doc:`Scatter plot <../visualize/scatterplot>` widgets on the *Titanic* dataset. While the :doc:`Scatter plot <../visualize/scatterplot>` shows
+:doc:`Scatter plot <../visualize/scatterplot>` widgets on the *Titanic* data set. While the :doc:`Scatter plot <../visualize/scatterplot>` shows
 fairly well which class and sex had a good survival rate and which one
 didn't, **Correspondence Analysis** can plot several variables in a 2-D
 graph, thus making it easy to see the relations between variable values.

--- a/doc/visual-programming/source/widgets/unsupervised/distancefile.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/distancefile.rst
@@ -27,12 +27,12 @@ Description
 2. Browse for saved distance files.
 3. Reload the selected distance file. 
 4. Information about the distance file (number of points, labelled/unlabelled)
-5. Browse documentation datasets.
+5. Browse documentation data sets.
 6. Produce a report. 
 
 Example
 -------
 
-When you want to use a custom-set distance file that you've saved before, open the **Distance File** widget and select the desired file with the *Browse* icon. This widget loads the existing distance file. In the snapshot below, we loaded the transformed *Iris* distance matrix from the :doc:`Save Distance Matrix <../unsupervised/savedistancematrix>` example. We displayed the transformed data matrix in the :doc:`Distance Map <../unsupervised/distancemap>` widget. We also decided to display a distance map of the original *Iris* dataset for comparison. 
+When you want to use a custom-set distance file that you've saved before, open the **Distance File** widget and select the desired file with the *Browse* icon. This widget loads the existing distance file. In the snapshot below, we loaded the transformed *Iris* distance matrix from the :doc:`Save Distance Matrix <../unsupervised/savedistancematrix>` example. We displayed the transformed data matrix in the :doc:`Distance Map <../unsupervised/distancemap>` widget. We also decided to display a distance map of the original *Iris* data set for comparison. 
 
 .. figure:: images/DistanceFile-Example.png

--- a/doc/visual-programming/source/widgets/unsupervised/distancemap.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/distancemap.rst
@@ -50,7 +50,7 @@ while the diagonal may also be non-zero.
 
 1. *Element sorting* arranges elements in the map by
 
-   -  None (lists instances as found in the dataset)
+   -  None (lists instances as found in the data set)
    -  **Clustering** (clusters data by similarity)
    -  **Clustering with ordered leaves** (maximizes the sum of
       similarities of adjacent elements)
@@ -75,7 +75,7 @@ distances outside this interval and visualize the interesting part of
 the distribution.
 
 Below, we visualized the most correlated attributes (distances by
-columns) in the *heart disease* dataset by setting the color threshold
+columns) in the *heart disease* data set by setting the color threshold
 for high distances to the minimum. We get a predominantly black square,
 where attributes with the lowest distance scores are represented by
 a lighter shade of the selected color schema (in our case: orange). Beside the diagonal line, we see that in our example *ST by

--- a/doc/visual-programming/source/widgets/unsupervised/distancematrix.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/distancematrix.rst
@@ -27,11 +27,11 @@ Signals
 Description
 -----------
 
-The **Distance Matrix** widget creates a distance matrix, which is a two-dimensional array containing the distances, taken pairwise, between the elements of a set. The number of elements in the dataset defines the size of the matrix. Data matrices are essential for hierarchical clustering and they are extremely useful in bioinformatics as well, where they are used to represent protein structures in a coordinate-independent manner. 
+The **Distance Matrix** widget creates a distance matrix, which is a two-dimensional array containing the distances, taken pairwise, between the elements of a set. The number of elements in the data set defines the size of the matrix. Data matrices are essential for hierarchical clustering and they are extremely useful in bioinformatics as well, where they are used to represent protein structures in a coordinate-independent manner. 
 
 .. figure:: images/DistanceMatrix-stamped.png
 
-1. Elements in the dataset and the distances between them
+1. Elements in the data set and the distances between them
 2. Label the table. The options are: *none*, *enumeration*, *according to variables*.
 3. Produce a report.
 4. Click *Send* to communicate changes to other widgets. Alternatively, tick the box in front of the *Send* button and changes will be communicated automatically (*Send Automatically*). 
@@ -43,6 +43,6 @@ Example
 --------
 
 The example below displays a very standard use of the **Distance Matrix**
-widget. We compute the distances between rows in the sample from the *Iris* dataset and output them in the **Distance Matrix**. It comes as no surprise that Iris Virginica and Iris Setosa are the furthest apart. 
+widget. We compute the distances between rows in the sample from the *Iris* data set and output them in the **Distance Matrix**. It comes as no surprise that Iris Virginica and Iris Setosa are the furthest apart. 
 
 .. figure:: images/DistanceMatrix-Example.png

--- a/doc/visual-programming/source/widgets/unsupervised/distances.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/distances.rst
@@ -3,7 +3,7 @@ Distances
 
 .. figure:: icons/distances.png
 
-Computes distances between rows/columns in a dataset.
+Computes distances between rows/columns in a data set.
 
 Signals
 -------
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 **Outputs**:
 
@@ -24,7 +24,7 @@ Description
 -----------
 
 The **Distances** widget computes distances between rows or
-columns in a dataset.
+columns in a data set.
 
 .. figure:: images/Distances-stamped.png
 

--- a/doc/visual-programming/source/widgets/unsupervised/distancetransformation.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/distancetransformation.rst
@@ -3,7 +3,7 @@ Distance Transformation
 
 .. figure:: icons/distance-transformation.png
 
-Transforms distances in a dataset. 
+Transforms distances in a data set. 
 
 Signals
 -------
@@ -48,6 +48,6 @@ The **Distances Transformation** widget is used for the normalization and invers
 Example
 -------
 
-In the snapshot below, you can see how transformation affects the distance matrix. We loaded the *Iris* dataset and calculated the distances between rows with the help of the :doc:`Distances <../unsupervised/distances>` widget. In order to demonstrate how **Distance Transformation** affects the :doc:`Distance Matrix <../unsupervised/distancematrix>`, we created the worflow below and compared the transformed distance matrix with the "original" one. 
+In the snapshot below, you can see how transformation affects the distance matrix. We loaded the *Iris* data set and calculated the distances between rows with the help of the :doc:`Distances <../unsupervised/distances>` widget. In order to demonstrate how **Distance Transformation** affects the :doc:`Distance Matrix <../unsupervised/distancematrix>`, we created the worflow below and compared the transformed distance matrix with the "original" one. 
 
 .. figure:: images/DistanceTransformation-Example.png

--- a/doc/visual-programming/source/widgets/unsupervised/hierarchicalclustering.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/hierarchicalclustering.rst
@@ -78,14 +78,14 @@ corresponding `dendrogram <https://en.wikipedia.org/wiki/Dendrogram>`_.
 Examples
 --------
 
-The workflow below shows the output of **Hierarchical Clustering** for the *Iris* dataset in :doc:`Data Table <../data/datatable>` widget. We see that if we choose
+The workflow below shows the output of **Hierarchical Clustering** for the *Iris* data set in :doc:`Data Table <../data/datatable>` widget. We see that if we choose
 *Append cluster IDs* in hierarchical clustering, we can see an
 additional column in the :doc:`Data Table <../data/datatable>` named *Cluster*. This is a way
 to check how hierarchical clustering clustered individual instances.
 
 .. figure:: images/HierarchicalClustering-Example.png
 
-In the second example, we loaded the *Iris* dataset again, but this time
+In the second example, we loaded the *Iris* data set again, but this time
 we added the :doc:`Scatter Plot <../visualize/scatterplot>`, showing all the instances from the
 :doc:`File<../data/file>` widget, while at the same time receiving the selected instances
 signal from **Hierarchical Clustering**. This way we can observe the

--- a/doc/visual-programming/source/widgets/unsupervised/kmeansclustering.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/kmeansclustering.rst
@@ -12,19 +12,19 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**:
 
 -  **Data**
 
-   A dataset with cluster index as a class attribute.
+   A data set with cluster index as a class attribute.
 
 Description
 -----------
 
 The widget applies the `k-Means clustering <https://en.wikipedia.org/wiki/K-means_clustering>`_
-algorithm to the data and outputs a new dataset in which the cluster
+algorithm to the data and outputs a new data set in which the cluster
 index is used as a class attribute. The original class attribute, if it
 exists, is moved to meta attributes. Scores of clustering results for
 various k are also shown in the widget.
@@ -59,7 +59,7 @@ various k are also shown in the widget.
    **Re-runs** (how many times the algorithm is run) and **maximal
    iterations** (the maximum number of iteration within each algorithm
    run) can be set manually.
-3. The widget outputs a new dataset with appended cluster information.
+3. The widget outputs a new data set with appended cluster information.
    Select how to append cluster information (as class, feature or meta
    attribute) and name the column.
 4. If *Apply Automatically* is ticked, the widget will commit changes
@@ -74,7 +74,7 @@ We are going to explore the widget with the following schema.
 
 .. figure:: images/K-MeansClustering-Schema.png
 
-First, we load the *Iris* dataset, divide it into three clusters and
+First, we load the *Iris* data set, divide it into three clusters and
 show it in the :doc:`Data Table <../data/datatable>`, where we can observe which instance went into
 which cluster. The interesting parts are the :doc:`Scatter Plot <../visualize/scatterplot>` and
 :doc:`Select Rows <../data/selectrows>`.

--- a/doc/visual-programming/source/widgets/unsupervised/manifoldlearning.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/manifoldlearning.rst
@@ -12,13 +12,13 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 **Outputs**:
 
 -  **Transformed Data**
 
-   A dataset with new, reduced coordinates.
+   A data set with new, reduced coordinates.
 
 Description
 -----------
@@ -80,6 +80,6 @@ From left to right, top to bottom: t-SNE, MDS, Isomap, Locally Linear Embedding 
 Example
 -------
 
-*Manifold Learning* widget transforms high-dimensional data into a lower dimensional approximation. This makes it great for visualizing datasets with many features. We used *voting.tab* to map 16-dimensional data onto a 2D graph. Then we used :doc:`Scatter Plot <../visualize/scatterplot>` to plot the embeddings.
+*Manifold Learning* widget transforms high-dimensional data into a lower dimensional approximation. This makes it great for visualizing data sets with many features. We used *voting.tab* to map 16-dimensional data onto a 2D graph. Then we used :doc:`Scatter Plot <../visualize/scatterplot>` to plot the embeddings.
 
 .. figure:: images/manifold-learning-example.png

--- a/doc/visual-programming/source/widgets/unsupervised/mds.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/mds.rst
@@ -17,13 +17,13 @@ Signals
 
 -  **Data**
 
-   A dataset
+   A data set
 
 **Outputs**:
 
 -  **Data**
 
-   A dataset with MDS coordinates.
+   A data set with MDS coordinates.
 
 -  **Data subset**
 
@@ -39,7 +39,7 @@ well as possible. The perfect fit is typically impossible to obtain
 since the data is high-dimensional or the distances are not
 `Euclidean <https://en.wikipedia.org/wiki/Euclidean_distance>`_.
 
-In the input, the widget needs either a dataset or a matrix of
+In the input, the widget needs either a data set or a matrix of
 distances. When visualizing distances between rows, you can also adjust
 the color of the points, change their shape, mark them, and output them
 upon selection.
@@ -83,11 +83,11 @@ corresponds to the sum of forces acting on it.
 3. Adjust the graph with *Zoom/Select*. The arrow enables you to select data instances. The magnifying glass enables zooming, which can be also done by scrolling in and out. The hand allows you to move the graph around. The rectangle readjusts the graph proportionally.
 4. Select the desired output:
 
-   -  **Original features only** (input dataset)
+   -  **Original features only** (input data set)
    -  **Coordinates only** (MDS coordinates)
-   -  **Coordinates as features** (input dataset + MDS coordinates as
+   -  **Coordinates as features** (input data set + MDS coordinates as
       regular attributes)
-   -  **Coordinates as meta attributes** (input dataset + MDS
+   -  **Coordinates as meta attributes** (input data set + MDS
       coordinates as meta attributes) 
 
 5. Sending the instances can be automatic if *Send selected automatically* is ticked. Alternatively, click *Send selected*.
@@ -102,7 +102,7 @@ recommend reading that widget's description as well.
 Example
 -------
 
-The above graphs were drawn using the following simple schema. We used the *iris.tab* dataset. Using the
+The above graphs were drawn using the following simple schema. We used the *iris.tab* data set. Using the
 :doc:`Distances <../unsupervised/distances>` widget we input the distance matrix into the **MDS**
 widget, where we see the *Iris* data displayed in a 2-dimensional plane.
 We can see the appended coordinates in the :doc:`Data Table <../data/datatable>` widget.

--- a/doc/visual-programming/source/widgets/unsupervised/savedistancematrix.rst
+++ b/doc/visual-programming/source/widgets/unsupervised/savedistancematrix.rst
@@ -30,7 +30,7 @@ Description
 Example
 -------
 
-In the snapshot below, we used the :doc:`Distance Transformation <../unsupervised/distancetransformation>` widget to transform the distances in the *Iris* dataset. We then chose to save the transformed version to our computer, so we could use it later on. We decided to output all data instances. You can choose to output just a minor subset of the data matrix. Pairs are marked automatically. 
+In the snapshot below, we used the :doc:`Distance Transformation <../unsupervised/distancetransformation>` widget to transform the distances in the *Iris* data set. We then chose to save the transformed version to our computer, so we could use it later on. We decided to output all data instances. You can choose to output just a minor subset of the data matrix. Pairs are marked automatically. 
 If you wish to know what happened to our changed file, go :doc:`here <../unsupervised/distancefile>`
 
 .. figure:: images/SaveDistanceMatrix-Example.png

--- a/doc/visual-programming/source/widgets/visualize/boxplot.rst
+++ b/doc/visual-programming/source/widgets/visualize/boxplot.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset
+   An input data set
 
 **Outputs**:
 
@@ -48,14 +48,14 @@ For continuous attributes the widget displays:
 6. The median (yellow vertical line). The thin blue line represents the
    area between the first (25%) and the third (75%) quantile, while the
    thin dotted line represents the entire range of values (from the
-   lowest to the highest value in the dataset for the selected
+   lowest to the highest value in the data set for the selected
    parameter).
 7. Save image.
 8. Produce a report. 
 
 For discrete attributes, the bars represent the number of instances with
 each particular attribute value. The plot shows the number of different
-animal types in the *Zoo* dataset: there are 41 mammals, 13 fish, 20
+animal types in the *Zoo* data set: there are 41 mammals, 13 fish, 20
 birds and so on.
 
 .. figure:: images/BoxPlot-Discrete.png
@@ -64,8 +64,8 @@ Example
 -------
 
 The **Box Plot** widget is most commonly used immediately after the :doc:`File <../data/file>` widget
-to observe the statistical properties of a dataset. It is also useful for
-finding the properties of a specific dataset, for instance a set of
+to observe the statistical properties of a data set. It is also useful for
+finding the properties of a specific data set, for instance a set of
 instances manually defined in another widget (e.g. :doc:`Scatterplot <../visualize/scatterplot>`) or
 instances belonging to some cluster or a classification tree node, as
 shown in the schema below.

--- a/doc/visual-programming/source/widgets/visualize/cn2ruleviewer.rst
+++ b/doc/visual-programming/source/widgets/visualize/cn2ruleviewer.rst
@@ -12,7 +12,7 @@ Signals
 
 - **Data**
 
-   Dataset to filter.
+   Data set to filter.
 
 - **CN2 Rule Classifier**
 
@@ -52,7 +52,7 @@ Examples
 
 In the schema below, the most common use of the widget is presented.
 First, the data is read and a CN2 rule classifier is trained. We are using
-*titanic* dataset for the rule constrution. The rules
+*titanic* data set for the rule constrution. The rules
 are then viewed using the :doc:`Rule Viewer <../visualize/cn2ruleviewer>`. To explore different CN2
 algorithms and understand how adjusting parameters influences the
 learning process, **Rule Viewer** should be kept open and in sight, while

--- a/doc/visual-programming/source/widgets/visualize/distributions.rst
+++ b/doc/visual-programming/source/widgets/visualize/distributions.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 **Outputs**:
 
@@ -29,7 +29,7 @@ For discrete attributes, the graph displayed by the widget shows how
 many times (e.g., in how many instances) each attribute value appears in
 the data. If the data contains a class variable, class distributions for
 each of the attribute values will be displayed as well (like in the
-snapshot below). In order to create this graph, we used the *Zoo* dataset. 
+snapshot below). In order to create this graph, we used the *Zoo* data set. 
 
 .. figure:: images/Distributions-Disc-stamped.png
 
@@ -40,7 +40,7 @@ snapshot below). In order to create this graph, we used the *Zoo* dataset.
    smoothness for the distribution curves of continuous variables.
 3. The widget may be requested to display value distributions only for
    instances of certain class (*Group by*). *Show relative frequencies*
-   will scale the data by percentage of the dataset.
+   will scale the data by percentage of the data set.
 4. Show probabilities. 
 5. *Save image* saves the graph to your computer in a .svg or .png
    format.
@@ -50,13 +50,13 @@ For continuous attributes, the attribute values are displayed as a
 function graph. Class probabilities for continuous attributes are
 obtained with gaussian kernel density estimation, while the appearance
 of the curve is set with the *Precision* bar (smooth or precise). For the purpose
-of this example, we used the *Iris* dataset. 
+of this example, we used the *Iris* data set. 
 
 .. figure:: images/Distributions-Cont.png
 
 In class-less domains, the bars are displayed in gray. Here we set *Bin
 continuous variables into 10 bins*, which distributes variables into 10
 intervals and displays averages of these intervals as histograms (see 2.
-above). We used the *Housing* dataset. 
+above). We used the *Housing* data set. 
 
 .. figure:: images/Distributions-NoClass.png

--- a/doc/visual-programming/source/widgets/visualize/freeviz.rst
+++ b/doc/visual-programming/source/widgets/visualize/freeviz.rst
@@ -13,11 +13,11 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 -  **Data Subset**
 
-   A subset of instances from the input dataset.
+   A subset of instances from the input data set.
 
 **Outputs**:
 

--- a/doc/visual-programming/source/widgets/visualize/heatmap.rst
+++ b/doc/visual-programming/source/widgets/visualize/heatmap.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 **Outputs**:
 
@@ -25,7 +25,7 @@ Description
 
 `Heat map <https://en.wikipedia.org/wiki/Heat_map>`_ is a graphical
 method for visualizing attribute values by class in a two-way matrix.
-It only works on datasets containing continuous variables. 
+It only works on data sets containing continuous variables. 
 The values are represented by color: the higher a certain value is, the
 darker the represented color. By combining class and attributes on x and
 y axes, we see where the attribute values are the strongest and where the
@@ -39,7 +39,7 @@ range (continuous) for each class.
    attributes with high values).
 2. Merge data. 
 3. Sort columns and rows:
-   - **No Sorting** (lists attributes as found in the dataset)
+   - **No Sorting** (lists attributes as found in the data set)
    - **Clustering** (clusters data by similarity)
    - **Clustering with ordered leaves** (maximizes the sum of similarities of adjacent elements)
 4. Set what is displayed in the plot in **Annotation & Legend**.
@@ -55,14 +55,14 @@ range (continuous) for each class.
 Example
 -------
 
-The **Heat Map** below displays attribute values for the *Housing* dataset. 
-The aforementioned dataset concerns the housing values in the suburbs of Boston. 
+The **Heat Map** below displays attribute values for the *Housing* data set. 
+The aforementioned data set concerns the housing values in the suburbs of Boston. 
 The first thing we see in the map are the 'B' and 'Tax' attributes, which are
 the only two colored in dark orange. The 'B' attribute provides information 
 on the proportion of blacks by town and the 'Tax' attribute informs us about 
 the full-value property-tax rate per $10,000. In order to get a clearer heat map,
 we then use the :doc:`Select Columns <../data/selectcolumns>` widget and remove
-the two attributes from the dataset. Then we again feed the data to the **Heat map**.
+the two attributes from the data set. Then we again feed the data to the **Heat map**.
 The new projection offers additional information. 
 By removing 'B' and 'Tax', we can see other deciding factors, 
 namely 'Age' and 'ZN'. The ‘Age’ attribute provides information 
@@ -77,4 +77,4 @@ By removing some of the more pronounced features, we came across new information
 References
 ----------
 
-`Housing Dataset <https://archive.ics.uci.edu/ml/datasets/Housing>`_
+`Housing Data Set <https://archive.ics.uci.edu/ml/datasets/Housing>`_

--- a/doc/visual-programming/source/widgets/visualize/linearprojection.rst
+++ b/doc/visual-programming/source/widgets/visualize/linearprojection.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset
+   An input data set
 
 -  **Data Subset**
 
@@ -49,7 +49,7 @@ of class-labeled data. It supports various types of projections such as circular
 custom projection.
 
 Consider, for a start, a projection of the *Iris*
-dataset shown below. Notice that it is the sepal width and sepal length
+data set shown below. Notice that it is the sepal width and sepal length
 that already separate *Iris setosa* from the other two, while the petal
 length is the attribute best separating *Iris versicolor* from *Iris
 virginica*.

--- a/doc/visual-programming/source/widgets/visualize/mosaicdisplay.rst
+++ b/doc/visual-programming/source/widgets/visualize/mosaicdisplay.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 -  **Data subset**
 
@@ -39,7 +39,7 @@ The **Mosaic plot** is a graphical representation of a two-way frequency table o
 Example
 -------
 
-We loaded the *titanic* dataset and connected it to the **Mosaic Display** widget. We decided to focus on two variables, namely status, sex and survival. We colored the interiors according to Pearson residuals in order to demonstrate the difference between observed and fitted values. 
+We loaded the *titanic* data set and connected it to the **Mosaic Display** widget. We decided to focus on two variables, namely status, sex and survival. We colored the interiors according to Pearson residuals in order to demonstrate the difference between observed and fitted values. 
 
 .. figure:: images/Mosaic-Display-Example.png
 

--- a/doc/visual-programming/source/widgets/visualize/nomogram.rst
+++ b/doc/visual-programming/source/widgets/visualize/nomogram.rst
@@ -26,7 +26,7 @@ and Logistic Regression classifier) visual representation. It offers an insight
 into the structure of the training data and effects of the attributes on the
 class probabilities. Besides visualization of the classifier, the widget offers
 interactive support to prediction of class probabilities.
-A snapshot below shows the nomogram of the Titanic dataset, that models the
+A snapshot below shows the nomogram of the Titanic data set, that models the
 probability for a passenger not to survive the disaster of the Titanic.
 
 .. figure:: images/Nomogram-NaiveBayes.png
@@ -38,13 +38,13 @@ probability for a passenger not to survive the disaster of the Titanic.
    re-scaling the log odds so that the maximal absolute log odds ratio in the
    nomogram represents 100 points.
 
-3. When there are to many attributes in the plotted dataset, you can choose to
+3. When there are to many attributes in the plotted data set, you can choose to
    display only best ranked ones. It is possible to choose from 'No sorting',
    'Name', 'Absolute importance', 'Positive influence' and 'Negative influence'
    for Naive Bayes representation and from 'No sorting', 'Name' and
    'Absolute importance' for Logistic Regression representation.
 
-To represent nomogram for Logistic Regressing classifier Iris dataset is used:
+To represent nomogram for Logistic Regressing classifier Iris data set is used:
 
 .. figure:: images/Nomogram-LogisticRegression.png
 
@@ -67,7 +67,7 @@ instance using any widget that enables selection
 
 .. figure:: images/Nomogram-Example.png
 
-Referring to the Titanic dataset once again, 1490 (68%) of passengers on Titanic,
+Referring to the Titanic data set once again, 1490 (68%) of passengers on Titanic,
 of 2201 in total, died. To make a prediction, the contribution of each attribute
 is measured as a point score and the individual point scores are summed to determine
 the probability. When the value of the attribute is unknown, its contribution is

--- a/doc/visual-programming/source/widgets/visualize/pythagoreanforest.rst
+++ b/doc/visual-programming/source/widgets/visualize/pythagoreanforest.rst
@@ -25,7 +25,7 @@ Description
 
 **Pythagorean Forest** shows all learned decision tree models from :doc:`Random Forest <../model/randomforest>` widget. It displays then as Pythagorean trees, each visualization pertaining to one randomly constructed tree. In the visualization, you can select a tree and display it in :doc:`Pythagorean Tree <../visualize/pythagoreantree>` wigdet. The best tree is the one with the shortest and most strongly colored branches. This means few attributes split the branches well.
 
-Widget displays both classification and regression results. Classification requires discrete target variable in the dataset, while regression requires a continuous target variable. Still, they both should be fed a :doc:`Tree <../model/tree>` on the input.
+Widget displays both classification and regression results. Classification requires discrete target variable in the data set, while regression requires a continuous target variable. Still, they both should be fed a :doc:`Tree <../model/tree>` on the input.
 
 .. figure:: images/Pythagorean-Forest-stamped.png
 
@@ -44,7 +44,7 @@ Widget displays both classification and regression results. Classification requi
 Example
 -------
 
-**Pythagorean Forest** is great for visualizing several built trees at once. In the example below, we've used *housing* dataset and plotted all 10 trees we've grown with :doc:`Random Forest <../model/randomforest>`. When changing the parameters in Random Forest, visualization in Pythagorean Forest will change as well.
+**Pythagorean Forest** is great for visualizing several built trees at once. In the example below, we've used *housing* data set and plotted all 10 trees we've grown with :doc:`Random Forest <../model/randomforest>`. When changing the parameters in Random Forest, visualization in Pythagorean Forest will change as well.
 
 Then we've selected a tree in the visualization and inspected it further with :doc:`Pythagorean Tree <../visualize/pythagoreantree>` widget.
 

--- a/doc/visual-programming/source/widgets/visualize/pythagoreantree.rst
+++ b/doc/visual-programming/source/widgets/visualize/pythagoreantree.rst
@@ -53,7 +53,7 @@ Pythagorean Tree can visualize both classification and regression trees. Below i
 Example
 -------
 
-The workflow from the screenshot below demonstrates the difference between :doc:`Tree Viewer <../visualize/treeviewer>` and Pythagorean Tree. They can both visualize :doc:`Tree <../model/tree>`, but Pythagorean visualization takes less space and is more compact, even for a small `Iris flower <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ dataset. For both visualization widgets, we have hidden the control area on the left by clicking on the splitter between control and visualization area.
+The workflow from the screenshot below demonstrates the difference between :doc:`Tree Viewer <../visualize/treeviewer>` and Pythagorean Tree. They can both visualize :doc:`Tree <../model/tree>`, but Pythagorean visualization takes less space and is more compact, even for a small `Iris flower <https://en.wikipedia.org/wiki/Iris_flower_data_set>`_ data set. For both visualization widgets, we have hidden the control area on the left by clicking on the splitter between control and visualization area.
 
 .. figure:: images/Pythagorean-Tree-comparison.png
 
@@ -63,7 +63,7 @@ Pythagorean Tree is interactive: click on any of the nodes (squares) to select t
     :scale: 80
     :align: center 
 
-The selected data instances are shown as a subset in the :doc:`Scatter Plot <../visualize/scatterplot>`, sent to the :doc:`Data Table <../data/datatable>` and examined in the :doc:`Box Plot <../visualize/boxplot>`. We have used brown-selected dataset in this example. The tree and scatter plot are shown below; the selected node in the tree has a black outline.
+The selected data instances are shown as a subset in the :doc:`Scatter Plot <../visualize/scatterplot>`, sent to the :doc:`Data Table <../data/datatable>` and examined in the :doc:`Box Plot <../visualize/boxplot>`. We have used brown-selected data set in this example. The tree and scatter plot are shown below; the selected node in the tree has a black outline.
 
 .. figure:: images/Pythagorean-Tree-scatterplot.png
 

--- a/doc/visual-programming/source/widgets/visualize/radviz.rst
+++ b/doc/visual-programming/source/widgets/visualize/radviz.rst
@@ -13,11 +13,11 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 -  **Data Subset**
 
-   A subset of instances from the input dataset.
+   A subset of instances from the input data set.
 
 **Outputs**:
 
@@ -54,7 +54,7 @@ instances that are close to a set of variable anchors have higher values for
 these variables than for the others.
 
 The snapshot shown below shows a Radviz widget with a visualization of the
-dataset from functional genomics ([2]_). In this particular
+data set from functional genomics ([2]_). In this particular
 visualization the data instances are colored according to the corresponding
 class, and the visualization space is colored according to the computed class
 probability. Notice that the particular visualization very nicely separates

--- a/doc/visual-programming/source/widgets/visualize/scattermap.rst
+++ b/doc/visual-programming/source/widgets/visualize/scattermap.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset
+   An input data set
 
 **Outputs**:
 
@@ -52,7 +52,7 @@ Example
 Below, you can see an example workflow for the **Scatter Map** widget. Notice
 that the widget only works with continuous data, so you need to first
 continuize the data attributes you want to visualize. The Scatter map below
-displays two attributes from the *Iris* dataset, namely the petal width
+displays two attributes from the *Iris* data set, namely the petal width
 and petal length. Here, we can see the distribution of width and length
 values per Iris type. You can see that the variety *Iris setosa* is
 distinctly separated from the other two varieties by petal width and

--- a/doc/visual-programming/source/widgets/visualize/scatterplot.rst
+++ b/doc/visual-programming/source/widgets/visualize/scatterplot.rst
@@ -13,11 +13,11 @@ Signals
 
 -  **Data**
 
-   An input dataset.
+   An input data set.
 
 -  **Data Subset**
 
-   A subset of instances from the input dataset.
+   A subset of instances from the input data set.
 
 -  **Features**
 
@@ -45,7 +45,7 @@ value of the y-axis attribute determining the position on the vertical axis.
 Various properties of the graph, like color, size and shape of the
 points, axis titles, maximum point size and jittering can be adjusted on
 the left side of the widget. A snapshot below shows the scatterplot of the
-*Iris* dataset with the coloring matching of the class attribute.
+*Iris* data set with the coloring matching of the class attribute.
 
 .. figure:: images/Scatterplot-Iris-stamped.png
 
@@ -82,7 +82,7 @@ the left side of the widget. A snapshot below shows the scatterplot of the
 For discrete attributes, jittering circumvents the overlap of points
 which have the same value for both axes, and therefore the density of
 points in the region corresponds better to the data. As an example, the
-scatterplot for the Titanic dataset, reporting on the gender of the
+scatterplot for the Titanic data set, reporting on the gender of the
 passengers and the traveling class is shown below; without jittering,
 the scatterplot would display only eight distinct points.
 
@@ -96,7 +96,7 @@ density* and *Show regression line* boxes are ticked.
 Intelligent Data Visualization
 ------------------------------
 
-If a dataset has many attributes, it is impossible to manually scan
+If a data set has many attributes, it is impossible to manually scan
 through all the pairs to find interesting or useful scatterplots. Orange
 implements intelligent data visualization with the **Find Informative Projections**
 option in the widget. The goal of optimization is to find scatterplot
@@ -108,7 +108,7 @@ list of attribute pairs by average classification accuracy score.
 
 Below, there is an example demonstrating the utility of ranking. The
 first scatterplot projection was set as the default sepal width to sepal
-length plot (we used the Iris dataset for simplicity). Upon running *Find Informative Projections* optimization, the scatterplot converted to a much better
+length plot (we used the Iris data set for simplicity). Upon running *Find Informative Projections* optimization, the scatterplot converted to a much better
 projection of petal width to petal length plot.
 
 .. figure:: images/ScatterPlotExample-Ranking.png

--- a/doc/visual-programming/source/widgets/visualize/sievediagram.rst
+++ b/doc/visual-programming/source/widgets/visualize/sievediagram.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   An input dataset
+   An input data set
 
 **Outputs**:
 
@@ -39,9 +39,9 @@ color to indicate whether the deviation from independence is positive
    format.
 4. Produce a report. 
 
-The snapshot below shows a sieve diagram for the *Titanic* dataset and has the
+The snapshot below shows a sieve diagram for the *Titanic* data set and has the
 attributes *sex* and *survived* (the latter is a class attribute in this
-dataset). The plot shows that the two variables are highly associated,
+data set). The plot shows that the two variables are highly associated,
 as there are substantial differences between observed and expected
 frequencies in all of the four quadrants. For example, and as highlighted
 in the balloon, the chance for surviving the accident was much higher for
@@ -58,7 +58,7 @@ diagram of the least interesting pair (age vs. survival) is shown below.
 Example
 -------
 
-Below, we see a simple schema using the *Titanic* dataset, where we use the
+Below, we see a simple schema using the *Titanic* data set, where we use the
 :doc:`Rank <../data/rank>` widget to select the best attributes (the ones with the highest
 information gain, gain ratio or gini index) and feed them into the **Sieve
 Diagram**. This displays the sieve plot for the two best attributes,

--- a/doc/visual-programming/source/widgets/visualize/silhouetteplot.rst
+++ b/doc/visual-programming/source/widgets/visualize/silhouetteplot.rst
@@ -12,7 +12,7 @@ Signals
 
 -  **Data**
 
-   A dataset.
+   A data set.
 
 **Outputs**
 
@@ -54,7 +54,7 @@ The **Silhouette Plot** widget offers a graphical representation of consistency 
 Example
 -------
 
-In the snapshot below, we have decided to use the **Silhoutte Plot** on the *iris* dataset. We selected data intances with low silhouette scores and passed them on as a subset to the :doc:`Scatter Plot <../visualize/scatterplot>` widget. This visualization only confirms the accuracy of the **Silhouette Plot** widget, as you can clearly see that the subset lies in the border between two clusters. 
+In the snapshot below, we have decided to use the **Silhoutte Plot** on the *iris* data set. We selected data intances with low silhouette scores and passed them on as a subset to the :doc:`Scatter Plot <../visualize/scatterplot>` widget. This visualization only confirms the accuracy of the **Silhouette Plot** widget, as you can clearly see that the subset lies in the border between two clusters. 
 
 .. figure:: images/SilhouettePlot-Example.png
 

--- a/doc/visual-programming/source/widgets/visualize/treeviewer.rst
+++ b/doc/visual-programming/source/widgets/visualize/treeviewer.rst
@@ -22,7 +22,7 @@ Signals
 
 -  **Data**
 
-   Dataset with an additional attribute for selection labels.
+   Data set with an additional attribute for selection labels.
 
 Description
 -----------
@@ -68,7 +68,7 @@ Clicking on any node will output the related data instances. This is explored in
 
 .. figure:: images/TreeViewer-selection.png
 
-Finally, **Tree Viewer** can be used also for visualizing regression trees. Connect :doc:`Random Forest <../model/randomforest>` to :doc:`File <../data/file>` widget using *housing.tab* dataset. Then connect :doc:`Pythagorean Forest <../visualize/pythagoreanforest>` to **Random Forest**. In **Pythagorean Forest** select a regression tree you wish to further analyze and pass it to the **Tree Viewer**. The widget will display the constructed tree. For visualizing larger trees, especially for regression, :doc:`Pythagorean Tree <../visualize/pythagoreantree>` could be a better option.
+Finally, **Tree Viewer** can be used also for visualizing regression trees. Connect :doc:`Random Forest <../model/randomforest>` to :doc:`File <../data/file>` widget using *housing.tab* data set. Then connect :doc:`Pythagorean Forest <../visualize/pythagoreanforest>` to **Random Forest**. In **Pythagorean Forest** select a regression tree you wish to further analyze and pass it to the **Tree Viewer**. The widget will display the constructed tree. For visualizing larger trees, especially for regression, :doc:`Pythagorean Tree <../visualize/pythagoreantree>` could be a better option.
 
 .. figure:: images/TreeViewer-regression.png
 

--- a/doc/visual-programming/source/widgets/visualize/venndiagram.rst
+++ b/doc/visual-programming/source/widgets/visualize/venndiagram.rst
@@ -13,7 +13,7 @@ Signals
 
 -  **Data**
 
-   An input dataset
+   An input data set
 
 **Outputs**:
 
@@ -25,10 +25,10 @@ Signals
 Description
 -----------
 
-The **Venn Diagram** widget displays logical relations between datasets. This
-projection shows two or more datasets represented by circles of
+The **Venn Diagram** widget displays logical relations between data sets. This
+projection shows two or more data sets represented by circles of
 different colors. The intersections are subsets that belong to more than one
-dataset. To further analyze or visualize the subset, click on the
+data set. To further analyze or visualize the subset, click on the
 intersection.
 
 .. figure:: images/venn-workflow.png
@@ -49,7 +49,7 @@ Examples
 
 The easiest way to use the **Venn Diagram** is to select data subsets and
 find matching instances in the visualization. We use the *breast-cancer*
-dataset to select two subsets with :doc:`Select Rows <../data/selectrows>` widget - the first
+data set to select two subsets with :doc:`Select Rows <../data/selectrows>` widget - the first
 subset is that of breast cancer patients aged between 40 and 49 and the
 second is that of patients with a tumor size between 20 and 29. The **Venn
 Diagram** helps us find instances that correspond to both criteria,


### PR DESCRIPTION
Reverts biolab/orange3#2842.

There seems no consensus in the community, with native speakers leaning towards "data sets". We thus don't gain anything by changing this, except for outdating screenshot, manuals, tutorials...

We currently consistently write it separately in all materials we publish, so let's keep it this way.