### PR TITLE
Add-ons: show warning on insufficient permissions

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -811,8 +811,13 @@ class Installer(QObject):
 
 class PipInstaller:
 
+    def __init__(self):
+        arguments = QSettings().value('add-ons/pip-install-arguments', '', type=str)
+        self.arguments = shlex.split(arguments)
+
     def install(self, pkg):
         cmd = ["python", "-m", "pip", "install"]
+        cmd.extend(self.arguments)
         if pkg.package_url.startswith("http://"):
             cmd.append(pkg.name)
         else:
@@ -829,6 +834,7 @@ class PipInstaller:
 
     def upgrade_no_deps(self, package):
         cmd = ["python", "-m", "pip", "install", "--upgrade", "--no-deps"]
+        cmd.extend(self.arguments)
         cmd.append(package.name)
 
         run_command(cmd)

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -1,4 +1,5 @@
 import sys
+import sysconfig
 import os
 import logging
 import re
@@ -719,6 +720,19 @@ def unique(iterable):
         return observed
 
     return (el for el in iterable if not observed(el))
+
+
+def have_install_permissions():
+    """Check if we can create a file in the site-packages folder.
+    This works on a Win7 miniconda install, where os.access did not. """
+    try:
+        fn = os.path.join(sysconfig.get_path("purelib"), "test_write_" + str(os.getpid()))
+        with open(fn, "w"):
+            pass
+        os.remove(fn)
+        return True
+    except PermissionError:
+        return False
 
 
 Install, Upgrade, Uninstall = 1, 2, 3

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1595,7 +1595,13 @@ class CanvasMainWindow(QMainWindow):
             self.__update_from_settings()
 
     def open_addons(self):
-        from .addons import AddonManagerDialog
+        from .addons import AddonManagerDialog, have_install_permissions
+        if not have_install_permissions():
+            QMessageBox(QMessageBox.Warning,
+                        "Add-ons: insufficient permissions",
+                        "Insufficient permissions to install add-ons. Try starting Orange "
+                        "as a system administrator or install Orange in user folders.",
+                        parent=self).exec_()
         dlg = AddonManagerDialog(self, windowTitle=self.tr("Add-ons"))
         dlg.setAttribute(Qt.WA_DeleteOnClose)
         return dlg.exec_()

--- a/Orange/canvas/application/settings.py
+++ b/Orange/canvas/application/settings.py
@@ -16,7 +16,7 @@ from ..utils.propertybindings import (
 from AnyQt.QtWidgets import (
     QWidget, QMainWindow, QComboBox, QCheckBox, QListView, QTabWidget,
     QToolBar, QAction, QStackedWidget, QVBoxLayout, QHBoxLayout,
-    QFormLayout, QSizePolicy, QLineEdit,
+    QFormLayout, QSizePolicy, QLineEdit, QLabel
 )
 
 from AnyQt.QtCore import (
@@ -391,6 +391,12 @@ class UserSettingsDialog(QMainWindow):
         conda.layout().addWidget(cb_conda_install)
 
         form.addRow(self.tr("Conda"), conda)
+
+        form.addRow(self.tr("Pip"), QLabel("Pip install arguments:"))
+        line_edit_pip = QLineEdit()
+        self.bind(line_edit_pip, "text", "add-ons/pip-install-arguments")
+        form.addRow("", line_edit_pip)
+
         tab.setLayout(form)
 
         if self.__macUnified:

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -124,6 +124,9 @@ spec = \
 
      ("add-ons/allow-conda-experimental", bool, False,
       "Install add-ons with conda"),
+
+     ("add-ons/pip-install-arguments", str, '',
+      'Arguments to pass to "pip install" when installing add-ons.'),
      ]
 
 spec = [config_slot(*t) for t in spec]


### PR DESCRIPTION
##### Issue
Installing add-ons as a normal user raises PermissionErrors on Windows 

##### Description of changes
Removed user_install option (pip's --user) because:
- it does not work with conda installers
- possible clashes between different installers
- the user_install check did not work in some cases (system-wide Win7
  conda install)

Now Orange checks if it can write in site-packages folder. If it can not, it shows a warning instead of the add-on dialog.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
