### PR TITLE
discovery: log errors during import as errors

### DIFF
--- a/Orange/canvas/registry/discovery.py
+++ b/Orange/canvas/registry/discovery.py
@@ -259,12 +259,10 @@ class WidgetDiscovery(object):
                 if desc is None:
                     try:
                         module = asmodule(name)
-                    except ImportError:
-                        log.info("Could not import %r.", name, exc_info=True)
-                        continue
                     except Exception:
-                        log.warning("Error while importing %r.", name,
-                                    exc_info=True)
+                        log.error("Error while importing %r. "
+                                  "The widget will not be shown.", name,
+                                  exc_info=True)
                         continue
 
                     try:


### PR DESCRIPTION
##### Issue
When a widget module cannot be imported because a dependency is missing, Orange silently ignores the error (unless log level is manually increased).

##### Description of changes
Change log level of the message to error so they are always shown.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
