### PR TITLE
domain editor: make continuous/string variables

### DIFF
--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -16,8 +16,9 @@ from os.path import dirname
 
 import Orange
 from Orange.data import FileFormat, dataset_dirs, StringVariable, Table, \
-    Domain, DiscreteVariable
+    Domain, DiscreteVariable, ContinuousVariable
 from Orange.util import OrangeDeprecationWarning
+
 from Orange.data.io import TabReader
 from Orange.tests import named_file
 from Orange.widgets.data.owfile import OWFile
@@ -392,6 +393,25 @@ a
             data = self.get_output(self.widget.Outputs.data)
             self.assertSequenceEqual(data.metas.ravel().tolist(), ['1', '', '3'])
 
+    def test_domaineditor_makes_variables(self):
+        # Variables created with domain editor should be interchangeable
+        # with variables read from file.
+
+        dat = """V0\tV1\nc\td\n\n1.0\t2"""
+        v0 = StringVariable.make("V0")
+        v1 = ContinuousVariable.make("V1")
+
+        with named_file(dat, suffix=".tab") as filename:
+            self.open_dataset(filename)
+
+            model = self.widget.domain_editor.model()
+            model.setData(model.createIndex(0, 1), "text", Qt.EditRole)
+            model.setData(model.createIndex(1, 1), "numeric", Qt.EditRole)
+            self.widget.apply_button.click()
+
+            data = self.get_output(self.widget.Outputs.data)
+            self.assertEqual(data.domain["V0"], v0)
+            self.assertEqual(data.domain["V1"], v1)
 
     def test_url_no_scheme(self):
         mock_urlreader = Mock(side_effect=ValueError())

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -297,7 +297,7 @@ class DomainEditor(QTableView):
                 var = tpe(name, values)
                 col_data = self._to_column(col_data, is_sparse)
             elif tpe == StringVariable:
-                var = tpe(name)
+                var = tpe.make(name)
                 if type(orig_var) == DiscreteVariable:
                     col_data = [orig_var.repr_val(x) if not np.isnan(x) else ""
                                 for x in self._iter_vals(col_data)]
@@ -311,7 +311,7 @@ class DomainEditor(QTableView):
                 # in metas which are transformed to dense below
                 col_data = self._to_column(col_data, False, dtype=object)
             elif tpe == ContinuousVariable and type(orig_var) == DiscreteVariable:
-                var = tpe(name)
+                var = tpe.make(name)
                 if may_be_numeric:
                     col_data = [np.nan if self._is_missing(x) else float(orig_var.values[int(x)])
                                 for x in self._iter_vals(col_data)]


### PR DESCRIPTION
##### Issue
When two files that contain numeric/text feature with the same name are concatenated, the resulting table contains one variable with all values.

When variable type in file widget was changed to numeric/text via domain editor, variables are considered different and result in two columns after concatenation.

##### Description of changes
Use make to construct new variables in domain editor

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
