### PR TITLE
[FIX] listfilter: Fix filter line edit completion

### DIFF
--- a/Orange/widgets/utils/listfilter.py
+++ b/Orange/widgets/utils/listfilter.py
@@ -211,7 +211,7 @@ def variables_filter(model, parent=None):
     filter_edit.setPlaceholderText("Filter")
 
     completer_model = QStringListModel()
-    completer = QCompleter(completer_model)
+    completer = QCompleter(completer_model, filter_edit)
     completer.setCompletionMode(QCompleter.InlineCompletion)
     completer.setModelSorting(QCompleter.CaseSensitivelySortedModel)
 

--- a/Orange/widgets/utils/listfilter.py
+++ b/Orange/widgets/utils/listfilter.py
@@ -179,8 +179,7 @@ def variables_filter(model, parent=None):
 
         """
         nonlocal original_completer_items
-        items = [var.name for var in model]
-        items += ["%s=%s" % item for v in model for item in v.attributes.items()]
+        items = ["%s=%s" % item for v in model for item in v.attributes.items()]
 
         new = sorted(set(items))
         if new != original_completer_items:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Inline filter completion in the Select Columns widget does not work.

##### Description of changes

Make QCompleter a child of the filter line edit.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
