### PR TITLE
LineEditWFocusOut: Pressing enters selects text

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -798,7 +798,10 @@ class LineEditWFocusOut(QtWidgets.QLineEdit):
         self.__changed = True
 
     def returnPressedHandler(self):
-        self.clearFocus()
+        self.selectAll()
+        self.__callback_if_changed()
+
+    def __callback_if_changed(self):
         if self.__changed:
             self.__changed = False
             if hasattr(self, "cback") and self.cback:
@@ -812,7 +815,7 @@ class LineEditWFocusOut(QtWidgets.QLineEdit):
 
     def focusOutEvent(self, *e):
         super().focusOutEvent(*e)
-        self.returnPressedHandler()
+        self.__callback_if_changed()
 
     def focusInEvent(self, *e):
         self.__changed = False


### PR DESCRIPTION
Pressing Enter in line edit should show the user that the data has
been "entered". Selecting the field seems better than clearing the focus
because (1) it allows the field to be easily re-edited (maybe the user
just wanted to see the efects of her change) and because (2) we do not
lose the focus position (moving or field forward or backward is easy).

This is also what QSpinBox does on Enter.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
