### PR TITLE
[ENH] Add-ons: Option to list only trusted add-ons

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -48,11 +48,16 @@ log = logging.getLogger(__name__)
 
 OFFICIAL_ADDONS = [
     "Orange-Bioinformatics",
-    "Orange3-DataFusion",
     "Orange3-Prototypes",
     "Orange3-Text",
     "Orange3-Network",
     "Orange3-Associate",
+    "Orange-Spectroscopy",
+    "Orange3-Textable",
+    "Orange3-Educational",
+    "Orange3-Geo",
+    "Orange3-ImageAnalytics",
+    "Orange3-Timeseries",
 ]
 
 Installable = namedtuple(

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -407,16 +407,6 @@ class AddonManagerWidget(QWidget):
             item = self.__model.item(index, 1)
             item = item.data(Qt.UserRole)
             assert isinstance(item, (Installed, Available))
-#             if isinstance(item, Available):
-#                 self.__installed_label.setText("")
-#                 self.__available_label.setText(str(item.available.version))
-#             elif item.installable is not None:
-#                 self.__installed_label.setText(str(item.local.version))
-#                 self.__available_label.setText(str(item.available.version))
-#             else:
-#                 self.__installed_label.setText(str(item.local.version))
-#                 self.__available_label.setText("")
-
             text = self._detailed_text(item)
             self.__details.setText(text)
 


### PR DESCRIPTION
##### Description of changes
Add-on with has a new checkbox which by default hides unofficial add-ons.

Installed add-ons are always shown.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
