### PR TITLE
OWKMeans: Perform clustering in worker threads

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -258,8 +258,9 @@ class WidgetTest(GuiTest):
         if widget is None:
             widget = self.widget
 
-        spy = QSignalSpy(widget.blockingStateChanged)
-        self.assertTrue(spy.wait(timeout=wait))
+        if widget.isBlocking():
+            spy = QSignalSpy(widget.blockingStateChanged)
+            self.assertTrue(spy.wait(timeout=wait))
 
     def commit_and_wait(self, widget=None, wait=1000):
         """Unconditinal commit and wait to stop blocking if needed.
@@ -275,18 +276,8 @@ class WidgetTest(GuiTest):
         if widget is None:
             widget = self.widget
 
-        blocking = False
-
-        def __set_blocking():
-            nonlocal blocking
-            blocking = True
-
-        widget.blockingStateChanged.connect(__set_blocking)
         widget.unconditional_commit()
-        widget.blockingStateChanged.disconnect(__set_blocking)
-
-        if blocking:
-            self.wait_until_stop_blocking(widget=widget, wait=wait)
+        self.wait_until_stop_blocking(widget=widget, wait=wait)
 
     def get_output(self, output, widget=None, wait=5000):
         """Return the last output that has been sent from the widget.

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -244,6 +244,50 @@ class WidgetTest(GuiTest):
             spy = QSignalSpy(widget.blockingStateChanged)
             self.assertTrue(spy.wait(timeout=wait))
 
+    def wait_until_stop_blocking(self, widget=None, wait=1000):
+        """Wait until the widget stops blocking i.e. finishes computation.
+
+        Parameters
+        ----------
+        widget : Optional[OWWidget]
+            widget to send signal to. If not set, self.widget is used
+        wait : int
+            The amount of time to wait for the widget to complete.
+
+        """
+        if widget is None:
+            widget = self.widget
+
+        spy = QSignalSpy(widget.blockingStateChanged)
+        self.assertTrue(spy.wait(timeout=wait))
+
+    def commit_and_wait(self, widget=None, wait=1000):
+        """Unconditinal commit and wait to stop blocking if needed.
+
+        Parameters
+        ----------
+        widget : Optional[OWWidget]
+            widget to send signal to. If not set, self.widget is used
+        wait : int
+            The amount of time to wait for the widget to complete.
+
+        """
+        if widget is None:
+            widget = self.widget
+
+        blocking = False
+
+        def __set_blocking():
+            nonlocal blocking
+            blocking = True
+
+        widget.blockingStateChanged.connect(__set_blocking)
+        widget.unconditional_commit()
+        widget.blockingStateChanged.disconnect(__set_blocking)
+
+        if blocking:
+            self.wait_until_stop_blocking(widget=widget, wait=wait)
+
     def get_output(self, output, widget=None, wait=5000):
         """Return the last output that has been sent from the widget.
 
@@ -273,7 +317,6 @@ class WidgetTest(GuiTest):
         assert output in (out.name for out in outputs), \
             "widget {} has no output {}".format(widget.name, output)
         return self.signal_manager.outputs.get((widget, output), None)
-
 
     @contextmanager
     def modifiers(self, modifiers):

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -299,7 +299,8 @@ class OWKMeans(widget.OWWidget):
 
         if self.optimize_k and all(isinstance(self.clusterings[i], str)
                                    for i in range(self.k_from, self.k_to + 1)):
-            self.Error.failed('All failed')
+            # Show the error of the last clustering
+            self.Error.failed(self.clusterings[self.k_to])
 
         self.send_data()
 

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -331,8 +331,6 @@ class OWKMeans(widget.OWWidget):
             task.watcher.exceptionReadyAt.disconnect(self.__on_exception)
             task.watcher.doneAll.disconnect(self.__commit_finished)
 
-            concurrent.futures.wait(task.futures)
-            task.watcher.flush()
             self.progressBarFinished()
             self.setBlocking(False)
 

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -1,6 +1,5 @@
-import concurrent
-from concurrent.futures import Future
-from typing import Optional, Union, List, Dict
+from concurrent.futures import Future  # pylint: disable=unused-import
+from typing import Optional, List, Dict  # pylint: disable=unused-import
 
 import numpy as np
 from AnyQt.QtCore import Qt, QTimer, QAbstractTableModel, QModelIndex, QThread, \
@@ -9,7 +8,7 @@ from AnyQt.QtGui import QIntValidator
 from AnyQt.QtWidgets import QGridLayout, QTableView
 
 from Orange.clustering import KMeans
-from Orange.clustering.kmeans import KMeansModel
+from Orange.clustering.kmeans import KMeansModel  # pylint: disable=unused-import
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -360,6 +360,7 @@ class OWKMeans(widget.OWWidget):
     def cluster(self):
         # Check if the k already has a computed clustering
         if self.k in self.clusterings:
+            self.send_data()
             return
 
         # Check if there is enough data

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -393,6 +393,7 @@ class OWKMeans(widget.OWWidget):
         QTimer.singleShot(100, self.adjustSize)
 
     def invalidate(self, force=False):
+        self.cancel()
         self.Error.clear()
         self.Warning.clear()
         self.clusterings = {}

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -1,17 +1,21 @@
-import re
-from itertools import chain
+import concurrent
+from concurrent.futures import Future
+from typing import Optional, Union, List, Dict
 
 import numpy as np
-
-from AnyQt.QtWidgets import QGridLayout, QTableView
+from AnyQt.QtCore import Qt, QTimer, QAbstractTableModel, QModelIndex, QThread, \
+    pyqtSlot as Slot
 from AnyQt.QtGui import QIntValidator
-from AnyQt.QtCore import Qt, QTimer, QAbstractTableModel, QModelIndex
+from AnyQt.QtWidgets import QGridLayout, QTableView
 
 from Orange.clustering import KMeans
+from Orange.clustering.kmeans import KMeansModel
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
-from Orange.widgets.utils.annotated_data import get_next_name
+from Orange.widgets.utils.annotated_data import get_next_name, \
+    ANNOTATED_DATA_SIGNAL_NAME, add_columns
+from Orange.widgets.utils.concurrent import ThreadExecutor, FutureSetWatcher
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.widget import Input, Output
 
@@ -39,6 +43,12 @@ class ClusterTableModel(QAbstractTableModel):
         self.start_k = start_k
         self.modelReset.emit()
 
+    def clear_scores(self):
+        self.modelAboutToBeReset.emit()
+        self.scores = []
+        self.start_k = 0
+        self.modelReset.emit()
+
     def data(self, index, role=Qt.DisplayRole):
         score = self.scores[index.row()]
         valid = not isinstance(score, str)
@@ -56,6 +66,25 @@ class ClusterTableModel(QAbstractTableModel):
             return str(row + self.start_k)
 
 
+class Task:
+    futures = []    # type: List[Future]
+    watcher = ...   # type: FutureSetWatcher
+    cancelled = False
+
+    def __init__(self, futures, watcher):
+        self.futures = futures
+        self.watcher = watcher
+
+    def cancel(self):
+        self.cancelled = True
+        for f in self.futures:
+            f.cancel()
+
+
+class NotEnoughData(ValueError):
+    pass
+
+
 class OWKMeans(widget.OWWidget):
     name = "k-Means"
     description = "k-Means clustering algorithm with silhouette-based " \
@@ -67,15 +96,22 @@ class OWKMeans(widget.OWWidget):
         data = Input("Data", Table)
 
     class Outputs:
-        annotated_data = Output("Annotated Data", Table, default=True)
+        annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Table, default=True)
         centroids = Output("Centroids", Table)
 
     class Error(widget.OWWidget.Error):
         failed = widget.Msg("Clustering failed\nError: {}")
+        not_enough_data = widget.Msg(
+            "Too few ({}) unique data instances for {} clusters"
+        )
 
     class Warning(widget.OWWidget.Warning):
         no_silhouettes = widget.Msg(
-            "Silhouette scores are not computed for >5000 samples")
+            "Silhouette scores are not computed for >5000 samples"
+        )
+        not_enough_data = widget.Msg(
+            "Too few ({}) unique data instances for {} clusters"
+        )
 
     INIT_METHODS = "Initialize with KMeans++", "Random initialization"
 
@@ -89,18 +125,37 @@ class OWKMeans(widget.OWWidget):
     max_iterations = Setting(300)
     n_init = Setting(10)
     smart_init = Setting(0)  # KMeans++
-    auto_run = Setting(True)
+    auto_commit = Setting(True)
+
+    settings_version = 2
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        # type: (Dict, int) -> None
+        if version < 2:
+            if 'auto_apply' in settings:
+                settings['auto_commit'] = settings['auto_apply']
+                del settings['auto_apply']
 
     def __init__(self):
         super().__init__()
 
-        self.data = None
+        self.data = None  # type: Optional[Table]
         self.clusterings = {}
+
+        self.__executor = ThreadExecutor(parent=self)
+        self.__task = None  # type: Optional[Task]
 
         layout = QGridLayout()
         bg = gui.radioButtonsInBox(
             self.controlArea, self, "optimize_k", orientation=layout,
-            box="Number of Clusters", callback=self.invalidate)
+            box="Number of Clusters",
+            # Because commit is only wrapped when creating the auto_commit
+            # buttons, we can't pass it as the callback here, so we can add
+            # this hacky lambda to call the wrapped commit when necessary
+            callback=lambda: self.commit(),
+        )
+
         layout.addWidget(
             gui.appendRadioButton(bg, "Fixed:", addToLayout=False), 1, 1)
         sb = gui.hBox(None, margin=0)
@@ -148,13 +203,15 @@ class OWKMeans(widget.OWWidget):
             validator=QIntValidator(), callback=self.invalidate)
 
         self.apply_button = gui.auto_commit(
-            self.buttonsArea, self, "auto_run", "Apply", box=None,
-            commit=self.apply)
+            self.buttonsArea, self, "auto_commit", "Apply", box=None,
+            commit=self.commit)
         gui.rubber(self.controlArea)
 
         box = gui.vBox(self.mainArea, box="Silhouette Scores")
+        self.mainArea.setVisible(self.optimize_k)
+        self.table_model = ClusterTableModel(self)
         table = self.table_view = QTableView(self.mainArea)
-        table.setModel(ClusterTableModel(self))
+        table.setModel(self.table_model)
         table.setSelectionMode(QTableView.SingleSelection)
         table.setSelectionBehavior(QTableView.SelectRows)
         table.setItemDelegate(gui.ColoredBarItemDelegate(self, color=Qt.cyan))
@@ -172,114 +229,187 @@ class OWKMeans(widget.OWWidget):
 
     def update_k(self):
         self.optimize_k = False
-        self.apply()
+        self.commit()
 
     def update_from(self):
         self.k_to = max(self.k_from + 1, self.k_to)
         self.optimize_k = True
-        self.apply()
+        self.commit()
 
     def update_to(self):
         self.k_from = min(self.k_from, self.k_to - 1)
         self.optimize_k = True
-        self.apply()
+        self.commit()
 
-    def check_data_size(self, n, msg_group):
-        msg_group.add_message(
-            "not_enough_data",
-            "Too few ({}) unique data instances for {} clusters")
-        data_ok = n <= len(self.data)
-        msg_group.not_enough_data(len(self.data), n, shown=not data_ok)
-        return data_ok
+    def enough_data_instances(self, k):
+        """k cannot be larger than the number of data instances."""
+        return len(self.data) >= k
 
     def _compute_clustering(self, k):
+        # type: (int) -> KMeansModel
         # False positives (Setting is not recognized as int)
         # pylint: disable=invalid-sequence-index
-        # pylint: disable=broad-except
-        try:
-            if k > len(self.data):
-                self.clusterings[k] = "not enough data"
-            else:
-                self.clusterings[k] = KMeans(
-                    n_clusters=k,
-                    init=['random', 'k-means++'][self.smart_init],
-                    n_init=self.n_init,
-                    max_iter=self.max_iterations,
-                    compute_silhouette_score=True)(self.data)
-        except Exception as exc:
-            self.clusterings[k] = str(exc)
-            return False
-        else:
-            return True
+        if k > len(self.data):
+            raise NotEnoughData()
 
-    def run_optimization(self):
-        # Disabling is needed since this function is not reentrant
-        # Fast clicking on, say, "To: " causes multiple calls
-        try:
-            self.controlArea.setDisabled(True)
-            if not self.check_data_size(self.k_from, self.Error):
-                return False
-            self.check_data_size(self.k_to, self.Warning)
-            needed_ks = [k for k in range(self.k_from, self.k_to + 1)
-                         if k not in self.clusterings]
-            if not needed_ks:
-                return True  # Skip showing progress bar
-            with self.progressBar(len(needed_ks)) as progress:
-                for k in needed_ks:
-                    progress.advance()
-                    self._compute_clustering(k)
-            if all(isinstance(score, str)
-                   for score in self.clusterings.values()):
-                # Tooltip shows just the last error
-                # pylint: disable=undefined-loop-variable
-                self.Error.failed(self.clusterings[k])
-                self.mainArea.hide()
-        finally:
-            self.controlArea.setDisabled(False)
-        return True
+        return KMeans(
+            n_clusters=k,
+            init=['random', 'k-means++'][self.smart_init],
+            n_init=self.n_init,
+            max_iter=self.max_iterations,
+            compute_silhouette_score=True,
+        )(self.data)
 
-    def cluster(self):
-        if self.k in self.clusterings or \
-                not self.check_data_size(self.k, self.Error):
-            return
-        try:
-            self.controlArea.setDisabled(True)
-            if not self._compute_clustering(self.k):
-                self.Error.failed(self.clusterings[self.k])
-        finally:
-            self.controlArea.setDisabled(False)
+    @Slot(int, int)
+    def __progress_changed(self, n, d):
+        assert QThread.currentThread() is self.thread()
+        assert self.__task is not None
+        self.progressBarSet(100 * n / d)
 
-    def apply(self):
-        self.clear_messages()
-        if self.data is not None:
-            if self.optimize_k and self.run_optimization():
-                self.mainArea.show()
-                self.update_results()
-            else:
-                self.cluster()
-                self.mainArea.hide()
-        else:
-            self.mainArea.hide()
-        QTimer.singleShot(100, self.adjustSize)
+    @Slot(int, Exception)
+    def __on_exception(self, idx, ex):
+        assert QThread.currentThread() is self.thread()
+        assert self.__task is not None
+
+        if isinstance(ex, NotEnoughData):
+            self.Error.not_enough_data(len(self.data), self.k_from + idx)
+
+        # Only show failed message if there is only 1 k to compute
+        elif not self.optimize_k:
+            self.Error.failed(str(ex))
+
+        self.clusterings[self.k_from + idx] = str(ex)
+
+    @Slot(int, object)
+    def __clustering_complete(self, _, result):
+        # type: (int, KMeansModel) -> None
+        assert QThread.currentThread() is self.thread()
+        assert self.__task is not None
+
+        self.clusterings[result.k] = result
+
+    @Slot()
+    def __commit_finished(self):
+        assert QThread.currentThread() is self.thread()
+        assert self.__task is not None
+        assert self.data is not None
+
+        self.__task = None
+        self.setBlocking(False)
+        self.progressBarFinished()
+
+        if self.optimize_k:
+            self.update_results()
+
+        if self.optimize_k and all(isinstance(self.clusterings[i], str)
+                                   for i in range(self.k_from, self.k_to + 1)):
+            self.Error.failed('All failed')
+
         self.send_data()
 
-    def invalidate(self, force_apply=False):
+    def __launch_tasks(self, ks):
+        # type: (List[int]) -> None
+        """Execute clustering in separate threads for all given ks."""
+        futures = [self.__executor.submit(self._compute_clustering, k) for k in ks]
+        watcher = FutureSetWatcher(futures)
+        watcher.resultReadyAt.connect(self.__clustering_complete)
+        watcher.progressChanged.connect(self.__progress_changed)
+        watcher.exceptionReadyAt.connect(self.__on_exception)
+        watcher.doneAll.connect(self.__commit_finished)
+
+        self.__task = Task(futures, watcher)
+        self.progressBarInit(processEvents=False)
+        self.setBlocking(True)
+
+    def cancel(self):
+        if self.__task is not None:
+            task, self.__task = self.__task, None
+            task.cancel()
+
+            task.watcher.resultReadyAt.disconnect(self.__clustering_complete)
+            task.watcher.progressChanged.disconnect(self.__progress_changed)
+            task.watcher.exceptionReadyAt.disconnect(self.__on_exception)
+            task.watcher.doneAll.disconnect(self.__commit_finished)
+
+            concurrent.futures.wait(task.futures)
+            task.watcher.flush()
+            self.progressBarFinished()
+            self.setBlocking(False)
+
+    def run_optimization(self):
+        if not self.enough_data_instances(self.k_from):
+            self.Error.not_enough_data(len(self.data), self.k_from)
+            return
+
+        if not self.enough_data_instances(self.k_to):
+            self.Warning.not_enough_data(len(self.data), self.k_to)
+            return
+
+        needed_ks = [k for k in range(self.k_from, self.k_to + 1)
+                     if k not in self.clusterings]
+
+        if needed_ks:
+            self.__launch_tasks(needed_ks)
+        else:
+            # If we don't need to recompute anything, just set the results to
+            # what they were before
+            self.update_results()
+
+    def cluster(self):
+        # Check if the k already has a computed clustering
+        if self.k in self.clusterings:
+            return
+
+        # Check if there is enough data
+        if not self.enough_data_instances(self.k):
+            self.Error.not_enough_data(len(self.data), self.k)
+            return
+
+        self.__launch_tasks([self.k])
+
+    def commit(self):
+        self.cancel()
+        self.clear_messages()
+
+        # Some time may pass before the new scores are computed, so clear the
+        # old scores to avoid potential confusion. Hiding the mainArea could
+        # cause flickering when the clusters are computed quickly, so this is
+        # the better alternative
+        self.table_model.clear_scores()
+        self.mainArea.setVisible(self.optimize_k and self.data is not None)
+
+        if self.data is None:
+            self.send_data()
+            return
+
+        if self.optimize_k:
+            self.run_optimization()
+        else:
+            self.cluster()
+
+        QTimer.singleShot(100, self.adjustSize)
+
+    def invalidate(self, force=False):
         self.Error.clear()
         self.Warning.clear()
         self.clusterings = {}
-        if force_apply:
-            self.unconditional_apply()
+        self.table_model.clear_scores()
+
+        if force:
+            self.unconditional_commit()
         else:
-            self.apply()
+            self.commit()
 
     def update_results(self):
         scores = [
             mk if isinstance(mk, str) else mk.silhouette for mk in (
-                self.clusterings[k] for k in range(self.k_from, self.k_to + 1))]
+                self.clusterings[k] for k in range(self.k_from, self.k_to + 1))
+        ]
         best_row = max(
             range(len(scores)), default=0,
-            key=lambda x: 0 if isinstance(scores[x], str) else scores[x])
-        self.table_view.model().set_scores(scores, self.k_from)
+            key=lambda x: 0 if isinstance(scores[x], str) else scores[x]
+        )
+        self.table_model.set_scores(scores, self.k_from)
         self.table_view.selectRow(best_row)
         self.table_view.setFocus(Qt.OtherFocusReason)
         self.table_view.resizeRowsToContents()
@@ -298,6 +428,7 @@ class OWKMeans(widget.OWWidget):
             k = self.k_from + row if row is not None else None
         else:
             k = self.k
+
         km = self.clusterings.get(k)
         if not self.data or km is None or isinstance(km, str):
             self.Outputs.annotated_data.send(None)
@@ -305,25 +436,22 @@ class OWKMeans(widget.OWWidget):
             return
 
         domain = self.data.domain
-        existing_vars = [var.name for var in chain(domain.variables, domain.metas)]
-        clust_var = DiscreteVariable(
-            get_next_name(existing_vars, "Cluster"),
-            values=["C%d" % (x + 1) for x in range(km.k)])
+        cluster_var = DiscreteVariable(
+            get_next_name(domain, "Cluster"),
+            values=["C%d" % (x + 1) for x in range(km.k)]
+        )
         clust_ids = km(self.data)
-        silhouette_var = ContinuousVariable(
-            get_next_name(existing_vars, "Silhouette"))
+        silhouette_var = ContinuousVariable(get_next_name(domain, "Silhouette"))
         if km.silhouette_samples is not None:
             self.Warning.no_silhouettes.clear()
             scores = np.arctan(km.silhouette_samples) / np.pi + 0.5
         else:
             self.Warning.no_silhouettes()
             scores = np.nan
-        new_domain = Domain(
-            domain.attributes,
-            [clust_var, silhouette_var],
-            domain.metas + domain.class_vars)
+
+        new_domain = add_columns(domain, metas=[cluster_var, silhouette_var])
         new_table = self.data.transform(new_domain)
-        new_table.get_column_view(clust_var)[0][:] = clust_ids.X.ravel()
+        new_table.get_column_view(cluster_var)[0][:] = clust_ids.X.ravel()
         new_table.get_column_view(silhouette_var)[0][:] = scores
 
         centroids = Table(Domain(km.pre_domain.attributes), km.centroids)
@@ -335,7 +463,7 @@ class OWKMeans(widget.OWWidget):
     @check_sql_input
     def set_data(self, data):
         self.data = data
-        self.invalidate(True)
+        self.invalidate()
 
     def send_report(self):
         # False positives (Setting is not recognized as int)
@@ -357,6 +485,10 @@ class OWKMeans(widget.OWWidget):
                     "Silhouette scores for different numbers of clusters",
                     self.table_view)
 
+    def onDeleteWidget(self):
+        self.cancel()
+        super().onDeleteWidget()
+
 
 def main():  # pragma: no cover
     import sys
@@ -364,11 +496,12 @@ def main():  # pragma: no cover
 
     a = QApplication(sys.argv)
     ow = OWKMeans()
-    d = Table("iris.tab")
+    d = Table(sys.argv[1] if len(sys.argv) > 1 else "iris.tab")
     ow.set_data(d)
     ow.show()
     a.exec()
     ow.saveSettings()
+
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -363,6 +363,20 @@ class TestOWKMeans(WidgetTest):
         np.testing.assert_array_less(-0.01, outtable)
         self.assertFalse(widget.Warning.no_silhouettes.is_shown())
 
+    def test_invalidate_clusterings_cancels_jobs(self):
+        widget = self.widget
+        widget.auto_commit = False
+
+        # Send the data without waiting
+        self.send_signal(widget.Inputs.data, self.iris)
+        widget.unconditional_commit()
+        # Now, invalidate by changing max_iter
+        widget.max_iterations = widget.max_iterations + 1
+        widget.invalidate()
+        self.wait_until_stop_blocking()
+
+        self.assertEqual(widget.clusterings, {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -45,28 +45,44 @@ class TestClusterTableModel(unittest.TestCase):
 class TestOWKMeans(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(
-            OWKMeans, stored_settings={"auto_apply": False})  # type: OWKMeans
+            OWKMeans, stored_settings={"auto_commit": False, "version": 2}
+        )  # type: OWKMeans
         self.iris = Table("iris")
+
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
+
+    def test_migrate_version_1_settings(self):
+        widget = self.create_widget(
+            OWKMeans,
+            stored_settings={'auto_apply': False}
+        )
+        self.assertFalse(widget.auto_commit)
 
     def test_optimization_report_display(self):
         """Check visibility of the table after selecting number of clusters"""
-        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.widget.auto_commit = True
+        self.send_signal(self.widget.Inputs.data, self.iris, wait=1000)
         self.widget.optimize_k = True
         radio_buttons = self.widget.controls.optimize_k.findChildren(QRadioButton)
+
         radio_buttons[0].click()
         self.assertFalse(self.widget.optimize_k)
         self.assertTrue(self.widget.mainArea.isHidden())
+
         radio_buttons[1].click()
         self.assertTrue(self.widget.optimize_k)
         self.assertFalse(self.widget.mainArea.isHidden())
         self.widget.apply_button.button.click()
+
+        self.wait_until_stop_blocking()
         self.assertEqual(self.widget.table_view.model().rowCount() > 0, True)
 
     def test_changing_k_changes_radio(self):
-        self.send_signal(self.widget.Inputs.data, self.iris)
-
         widget = self.widget
-        widget.auto_run = True
+        widget.auto_commit = True
+        self.send_signal(self.widget.Inputs.data, self.iris, wait=1000)
 
         widget.optimize_k = True
 
@@ -98,79 +114,86 @@ class TestOWKMeans(WidgetTest):
 
     def test_no_data_hides_main_area(self):
         widget = self.widget
+        widget.auto_commit = True
         widget.optimize_k = True
         widget.k_from, widget.k_to = 3, 4
 
-        self.send_signal(self.widget.Inputs.data, None)
+        self.send_signal(self.widget.Inputs.data, None, wait=1000)
         self.assertTrue(self.widget.mainArea.isHidden())
-        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.send_signal(self.widget.Inputs.data, self.iris, wait=1000)
         self.assertFalse(self.widget.mainArea.isHidden())
-        self.send_signal(self.widget.Inputs.data, None)
+        self.send_signal(self.widget.Inputs.data, None, wait=1000)
         self.assertTrue(self.widget.mainArea.isHidden())
 
     def test_data_limits(self):
+        """Data error should be shown when `k` > n or when `k_from` > n. Data
+        warning should be shown when `k_to` > n"""
         widget = self.widget
+        widget.auto_commit = False
 
         self.send_signal(self.widget.Inputs.data, self.iris[:5])
 
         widget.k = 10
-        widget.unconditional_apply()
+        self.commit_and_wait()
         self.assertTrue(widget.Error.not_enough_data.is_shown())
 
         widget.k = 3
-        widget.unconditional_apply()
+        self.commit_and_wait()
         self.assertFalse(widget.Error.not_enough_data.is_shown())
 
         widget.k_from = 10
         widget.optimize_k = True
-        widget.unconditional_apply()
+        self.commit_and_wait()
         self.assertTrue(widget.Error.not_enough_data.is_shown())
 
         widget.k_from = 3
         widget.k_to = 4
-        widget.unconditional_apply()
+        self.commit_and_wait()
         self.assertFalse(widget.Error.not_enough_data.is_shown())
 
         widget.k_from = 3
         widget.k_to = 6
-        widget.unconditional_apply()
+        self.commit_and_wait()
         self.assertFalse(widget.Error.not_enough_data.is_shown())
         self.assertTrue(widget.Warning.not_enough_data.is_shown())
 
     def test_use_cache(self):
+        """Cache various clusterings for the dataset until data changes."""
         widget = self.widget
-        widget.k = 3
-        widget.optimize_k = False
-
+        widget.auto_commit = False
         self.send_signal(self.widget.Inputs.data, self.iris[:50])
-        widget.unconditional_apply()
 
-        widget.k_from = 2
-        widget.k_to = 3
-        widget.optimize_k = True
         with patch.object(widget, "_compute_clustering",
-                          wraps=widget._compute_clustering) as compute, \
-            patch.object(widget, "progressBar",
-                         wraps=widget.progressBar) as progressBar:
-            widget.unconditional_apply()
+                          wraps=widget._compute_clustering) as compute:
+
+            widget.k = 3
+            widget.optimize_k = False
+
+            self.commit_and_wait()
             self.assertEqual(compute.call_count, 1)
-            compute.assert_called_with(2)
-            self.assertEqual(progressBar.call_count, 1)
-            progressBar.assert_called_with(1)
+            compute.assert_called_with(3)
+
+            widget.k_from = 2
+            widget.k_to = 3
+            widget.optimize_k = True
 
             compute.reset_mock()
-            progressBar.reset_mock()
+            self.commit_and_wait()
+            # Since 3 was already computed before when we weren't optimizing,
+            # we only need to compute for 3
+            self.assertEqual(compute.call_count, 1)
+            compute.assert_called_with(2)
 
-            widget.unconditional_apply()
+            # Commiting again should not recompute the clusterings
+            compute.reset_mock()
+            self.commit_and_wait()
             # compute.assert_not_called unfortunately didn't exist before 3.5
             self.assertFalse(compute.called)
-            self.assertFalse(progressBar.called)
-
 
     def test_data_on_output(self):
         """Check if data is on output after create widget and run"""
-        # Connect iris to widget
-        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.widget.auto_commit = True
+        self.send_signal(self.widget.Inputs.data, self.iris[::25], wait=1000)
         self.widget.apply_button.button.click()
         self.assertNotEqual(self.widget.data, None)
         # Disconnect the data
@@ -191,22 +214,23 @@ class TestOWKMeans(WidgetTest):
     @patch("Orange.widgets.unsupervised.owkmeans.KMeans", new=KMeansFail)
     def test_optimization_fails(self):
         widget = self.widget
-        widget.k_from = 3
-        widget.k_to = 8
-        widget.scoring = 0
+        widget.auto_commit = True
+        widget.k_from, widget.k_to = 3, 8
         widget.optimize_k = True
 
         self.KMeansFail.fail_on = {3, 5, 7}
         model = widget.table_view.model()
-        with patch.object(model, "set_scores",
-                          wraps=model.set_scores) as set_scores:
-            self.send_signal(self.widget.Inputs.data, self.iris)
+
+        with patch.object(model, "set_scores", wraps=model.set_scores) as set_scores:
+            self.send_signal(self.widget.Inputs.data, self.iris, wait=1000)
             scores, start_k = set_scores.call_args[0]
-            self.assertEqual(scores,
-                             [km if isinstance(km, str) else km.silhouette
-                              for km in (widget.clusterings[k]
-                                         for k in range(3, 9))])
+            self.assertEqual(
+                scores,
+                [km if isinstance(km, str) else km.silhouette
+                 for km in (widget.clusterings[k] for k in range(3, 9))]
+            )
             self.assertEqual(start_k, 3)
+
         self.assertIsInstance(widget.clusterings[3], str)
         self.assertIsInstance(widget.clusterings[5], str)
         self.assertIsInstance(widget.clusterings[7], str)
@@ -219,11 +243,13 @@ class TestOWKMeans(WidgetTest):
 
         self.KMeansFail.fail_on = set(range(3, 9))
         widget.invalidate()
+        self.wait_until_stop_blocking()
         self.assertTrue(widget.Error.failed.is_shown())
         self.assertIsNone(self.get_output(self.widget.Outputs.annotated_data))
 
         self.KMeansFail.fail_on = set()
         widget.invalidate()
+        self.wait_until_stop_blocking()
         self.assertFalse(widget.Error.failed.is_shown())
         self.assertEqual(widget.selected_row(), 0)
         self.assertIsNotNone(self.get_output(self.widget.Outputs.annotated_data))
@@ -231,14 +257,16 @@ class TestOWKMeans(WidgetTest):
     @patch("Orange.widgets.unsupervised.owkmeans.KMeans", new=KMeansFail)
     def test_run_fails(self):
         self.widget.k = 3
+        self.widget.auto_commit = True
         self.widget.optimize_k = False
         self.KMeansFail.fail_on = {3}
-        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.send_signal(self.widget.Inputs.data, self.iris, wait=1000)
         self.assertTrue(self.widget.Error.failed.is_shown())
         self.assertIsNone(self.get_output(self.widget.Outputs.annotated_data))
 
         self.KMeansFail.fail_on = set()
         self.widget.invalidate()
+        self.wait_until_stop_blocking()
         self.assertFalse(self.widget.Error.failed.is_shown())
         self.assertIsNotNone(self.get_output(self.widget.Outputs.annotated_data))
 
@@ -293,30 +321,32 @@ class TestOWKMeans(WidgetTest):
         Widget should not crash when there is less rows than k_from.
         GH-2172
         """
-        table = Table("iris")
+        table = self.iris[0:1, :]
         self.widget.controls.k_from.setValue(2)
         self.widget.controls.k_to.setValue(9)
-        self.send_signal(self.widget.Inputs.data, table[0:1, :])
+        self.send_signal(self.widget.Inputs.data, table)
 
     def test_from_to_table(self):
         """
         From and To spins and number of rows in a scores table changes.
         GH-2172
         """
-        table = Table("iris")
         k_from, k_to = 2, 9
         self.widget.controls.k_from.setValue(k_from)
-        self.send_signal(self.widget.Inputs.data, table)
+        self.send_signal(self.widget.Inputs.data, self.iris[:50], wait=1000)
         check = lambda x: 2 if x - k_from + 1 < 2 else x - k_from + 1
         for i in range(k_from, k_to):
             self.widget.controls.k_to.setValue(i)
+            self.commit_and_wait()
             self.assertEqual(len(self.widget.table_view.model().scores), check(i))
         for i in range(k_to, k_from, -1):
             self.widget.controls.k_to.setValue(i)
+            self.commit_and_wait()
             self.assertEqual(len(self.widget.table_view.model().scores), check(i))
 
     def test_silhouette_column(self):
         widget = self.widget
+        widget.auto_commit = True
         widget.k = 4
         widget.optimize_k = False
 

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -61,7 +61,7 @@ class TestOWKMeans(WidgetTest):
     def test_optimization_report_display(self):
         """Check visibility of the table after selecting number of clusters"""
         self.widget.auto_commit = True
-        self.send_signal(self.widget.Inputs.data, self.iris, wait=1000)
+        self.send_signal(self.widget.Inputs.data, self.iris[:25], wait=2000)
         self.widget.optimize_k = True
         radio_buttons = self.widget.controls.optimize_k.findChildren(QRadioButton)
 

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -4,16 +4,14 @@ import unittest
 from unittest.mock import patch, Mock
 
 import numpy as np
-
-from AnyQt.QtWidgets import QRadioButton
 from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QRadioButton
 
+import Orange.clustering
+from Orange.data import Table
 from Orange.widgets import gui
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owkmeans import OWKMeans, ClusterTableModel
-import Orange.clustering
-
-from Orange.data import Table
 
 
 class TestClusterTableModel(unittest.TestCase):
@@ -171,7 +169,7 @@ class TestOWKMeans(WidgetTest):
 
             self.commit_and_wait()
             self.assertEqual(compute.call_count, 1)
-            compute.assert_called_with(3)
+            self.assertEqual(compute.call_args[1]['k'], 3)
 
             widget.k_from = 2
             widget.k_to = 3
@@ -182,7 +180,7 @@ class TestOWKMeans(WidgetTest):
             # Since 3 was already computed before when we weren't optimizing,
             # we only need to compute for 3
             self.assertEqual(compute.call_count, 1)
-            compute.assert_called_with(2)
+            self.assertEqual(compute.call_args[1]['k'], 2)
 
             # Commiting again should not recompute the clusterings
             compute.reset_mock()


### PR DESCRIPTION
##### Issue
K-means executed everything in the main GUI thread, leading to freezing when processing large datasets. Moreover, the computation started as soon as any data was connected, so connecting large datasets was, again, problematic.


##### Description of changes
Offload all the computation into separate threads, and start clustering only when Apply is clicked (or checkbox is checked).

Also some general refactoring, to improve consistency with other, newer widgets.

As far as I can tell, and the tests were written, the behavior remained the same as before (other than the time of execution).

@ales-erjavec Could you take a look at this please, since you're the thread master? I wasn't sure how to go about testing threaded code, is this method ok?


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
