### PR TITLE
[FIX] distribution.py: Fix computation on multiclass data

### DIFF
--- a/Orange/data/_valuecount.pyx
+++ b/Orange/data/_valuecount.pyx
@@ -12,8 +12,7 @@ from numpy cimport NPY_FLOAT64 as NPY_float64
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def valuecount(np.ndarray[np.float64_t, ndim=2] a not None):
-    """
-    Count the occurrences of each value.
+    """Count the occurrences of each value.
 
     It does so in-place, on a 2-d array of shape (2, N); the first row
     contains values and the second contains weights (1's, if unweighted).
@@ -22,10 +21,13 @@ def valuecount(np.ndarray[np.float64_t, ndim=2] a not None):
     consecutive columns with the same value in the first row, and adding
     the corresponding weights in the second row.
 
+    Examples
+    --------
     >>> a = np.array([[1, 1, 2, 3, 3], [0.1, 0.2, 0.3, 0.4, 0.5]])
     >>> _orange.valuecount(a)
     [[ 1.   2.   3. ]
      [ 0.3  0.3  0.9]]
+
     """
     cdef np.npy_intp *dim
     dim = np.PyArray_DIMS(a)

--- a/Orange/statistics/contingency.py
+++ b/Orange/statistics/contingency.py
@@ -1,45 +1,39 @@
-import math
 import numpy as np
+
 from Orange import data
 
 
-def _get_variable(variable, dat, attr_name,
-                  expected_type=None, expected_name=""):
+def _get_variable(variable, dat, attr_name, expected_type=None, expected_name=""):
     failed = False
     if isinstance(variable, data.Variable):
         datvar = getattr(dat, "variable", None)
         if datvar is not None and datvar is not variable:
-            raise ValueError("variable does not match the variable"
-                             "in the data")
+            raise ValueError("variable does not match the variable in the data")
     elif hasattr(dat, "domain"):
         variable = dat.domain[variable]
     elif hasattr(dat, attr_name):
         variable = dat.variable
     else:
         failed = True
-    if failed or (expected_type is not None and
-                  not isinstance(variable, expected_type)):
+    if failed or (expected_type is not None and not isinstance(variable, expected_type)):
         if not expected_type or isinstance(variable, data.Variable):
-            raise ValueError(
-                "expected %s variable not %s" % (expected_name, variable))
+            raise ValueError("expected %s variable not %s" % (expected_name, variable))
         else:
-            raise ValueError("expected %s, not '%s'" %
-                             (expected_type.__name__, type(variable).__name__))
+            raise ValueError("expected %s, not '%s'" % (
+                expected_type.__name__, type(variable).__name__))
     return variable
 
 
-def create_discrete(cls, *args):
+def _create_discrete(cls, *args):
     return cls(*args)
 
 
 class Discrete(np.ndarray):
-    def __new__(cls, dat=None,
-                col_variable=None, row_variable=None,
+    def __new__(cls, dat=None, col_variable=None, row_variable=None,
                 unknowns=None, unknown_rows=None):
         if isinstance(dat, data.Storage):
             if unknowns is not None:
-                raise TypeError(
-                    "incompatible arguments (data storage and 'unknowns'")
+                raise TypeError("incompatible arguments (data storage and 'unknowns'")
             return cls.from_data(dat, col_variable, row_variable)
 
         if row_variable is not None:
@@ -62,24 +56,20 @@ class Discrete(np.ndarray):
             self.unknown_rows = unknown_rows or 0
         else:
             self[...] = dat
-            self.unknowns = (unknowns if unknowns is not None
-                             else getattr(dat, "unknowns", 0))
+            self.unknowns = unknowns if unknowns is not None else getattr(dat, "unknowns", 0)
             self.unknown_rows = unknown_rows if unknown_rows is not None else 0
         return self
-
 
     @classmethod
     def from_data(cls, data, col_variable, row_variable=None):
         if row_variable is None:
             row_variable = data.domain.class_var
             if row_variable is None:
-                raise ValueError("row_variable needs to be specified (data "
-                                 "has no class)")
+                raise ValueError("row_variable needs to be specified (data has no class)")
         row_variable = _get_variable(row_variable, data, "row_variable")
         col_variable = _get_variable(col_variable, data, "col_variable")
         try:
-            conts, unknown_rows = data._compute_contingency(
-                            [col_variable], row_variable)
+            conts, unknown_rows = data._compute_contingency([col_variable], row_variable)
             dist, unknowns = conts[0]
 
             self = super().__new__(cls, dist.shape)
@@ -97,10 +87,10 @@ class Discrete(np.ndarray):
             for row in data:
                 rval, cval = row[rind], row[cind]
                 w = row.weight
-                if math.isnan(rval):
+                if np.isnan(rval):
                     self.unknown_rows += w
                     continue
-                if math.isnan(cval):
+                if np.isnan(cval):
                     self.unknowns[cval] += w
                 else:
                     self[int(rval), int(cval)] += w
@@ -108,12 +98,11 @@ class Discrete(np.ndarray):
         self.col_variable = col_variable
         return self
 
-
     def __eq__(self, other):
-        return np.array_equal(self, other) and (
-            not hasattr(other, "unknowns") or
-            np.array_equal(self.unknowns, other.unknowns))
-
+        return (
+            np.array_equal(self, other) and
+            (not hasattr(other, "unknowns") or np.array_equal(self.unknowns, other.unknowns))
+        )
 
     def __getitem__(self, index):
         if isinstance(index, str):
@@ -150,7 +139,6 @@ class Discrete(np.ndarray):
                 index = (index[0], self.col_variable.to_val(index[1]))
         super().__setitem__(index, value)
 
-
     def normalize(self, axis=None):
         t = np.sum(self, axis=axis)
         if t > 1e-6:
@@ -159,9 +147,10 @@ class Discrete(np.ndarray):
                 self.unknowns /= t
 
     def __reduce__(self):
-        return create_discrete, (Discrete, np.copy(self),
-                                 self.col_variable, self.row_variable,
-                                 self.unknowns)
+        return (
+            _create_discrete,
+            (Discrete, np.copy(self), self.col_variable, self.row_variable, self.unknowns)
+        )
 
 
 class Continuous:
@@ -169,8 +158,7 @@ class Continuous:
                  unknowns=None, unknown_rows=None):
         if isinstance(dat, data.Storage):
             if unknowns is not None:
-                raise TypeError(
-                    "incompatible arguments (data storage and 'unknowns'")
+                raise TypeError("incompatible arguments (data storage and 'unknowns'")
             return self.from_data(dat, col_variable, row_variable)
 
         if row_variable is not None:
@@ -195,30 +183,27 @@ class Continuous:
         else:
             self.unknown_rows = None
 
-
     def from_data(self, data, col_variable, row_variable=None):
         if row_variable is None:
             row_variable = data.domain.class_var
             if row_variable is None:
-                raise ValueError("row_variable needs to be specified (data"
-                                 "has no class)")
+                raise ValueError("row_variable needs to be specified (data has no class)")
         self.row_variable = _get_variable(row_variable, data, "row_variable")
         self.col_variable = _get_variable(col_variable, data, "col_variable")
         try:
-            conts, self.unknown_rows = data._compute_contingency(
-                [col_variable], row_variable)
+            conts, self.unknown_rows = data._compute_contingency([col_variable], row_variable)
             (self.values, self.counts), self.unknowns = conts[0]
         except NotImplementedError:
-            raise NotImplementedError("Fallback method for computation of "
-                                      "contingencies is not implemented yet")
-
+            raise NotImplementedError(
+                "Fallback method for computation of contingencies is not implemented yet"
+            )
 
     def __eq__(self, other):
-        return (np.array_equal(self.values, other.values) and
-                np.array_equal(self.counts, other.counts) and
-                (not hasattr(other, "unknowns") or
-                 np.array_equal(self.unknowns, other.unknowns)))
-
+        return (
+            np.array_equal(self.values, other.values) and
+            np.array_equal(self.counts, other.counts) and
+            (not hasattr(other, "unknowns") or np.array_equal(self.unknowns, other.unknowns))
+        )
 
     def __getitem__(self, index):
         """ Return contingencies for a given class value. """
@@ -228,15 +213,14 @@ class Continuous:
         ind = C > 0
         return np.vstack((self.values[ind], C[ind]))
 
-
     def __len__(self):
         return self.counts.shape[0]
 
-
     def __setitem__(self, index, value):
-        raise NotImplementedError("Setting individual class contingencies is "
-                                  "not implemented yet. Set .values and .counts.")
-
+        raise NotImplementedError(
+            "Setting individual class contingencies is not implemented yet. "
+            "Set .values and .counts."
+        )
 
     def normalize(self, axis=None):
         if axis is None:
@@ -245,8 +229,9 @@ class Continuous:
                 for x in self:
                     x[:, 1] /= t
         elif axis != 1:
-            raise ValueError("contingencies can be normalized only with axis=1"
-                             " or without axis")
+            raise ValueError(
+                "contingencies can be normalized only with axis=1 or without axis"
+            )
         else:
             for i, x in enumerate(self):
                 t = np.sum(x[:, 1])
@@ -265,20 +250,19 @@ def get_contingency(dat, col_variable, row_variable=None, unknowns=None, unknown
     elif variable.is_continuous:
         return Continuous(dat, col_variable, row_variable, unknowns, unknown_rows)
     else:
-        raise TypeError("cannot compute distribution of '%s'" %
-                        type(variable).__name__)
+        raise TypeError("cannot compute distribution of '%s'" % type(variable).__name__)
 
 
-def get_contingencies(dat, skipDiscrete=False, skipContinuous=False):
+def get_contingencies(dat, skip_discrete=False, skip_continuous=False):
     vars = dat.domain.attributes
     row_var = dat.domain.class_var
     if row_var is None:
         raise ValueError("data has no target variable")
-    if skipDiscrete:
-        if skipContinuous:
+    if skip_discrete:
+        if skip_continuous:
             return []
         columns = [i for i, var in enumerate(vars) if var.is_continuous]
-    elif skipContinuous:
+    elif skip_continuous:
         columns = [i for i, var in enumerate(vars) if var.is_discrete]
     else:
         columns = None

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -270,7 +270,6 @@ class Continuous(Distribution):
         val = np.argmax(self[1, :])
         return self[0, val]
 
-    # TODO implement __getitem__ that will return a normal array, not Continuous
     def min(self):
         return self[0, 0]
 

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -61,6 +61,21 @@ class Distribution(np.ndarray):
         """Normalize the distribution to a probability distribution."""
         raise NotImplementedError
 
+    def min(self):
+        """Get the smallest value for the distribution.
+
+        If the variable is not ordinal, return None.
+
+        """
+        raise NotImplementedError
+
+    def max(self):
+        """Get the largest value for the distribution.
+
+        If the variable is not ordinal, return None.
+
+        """
+        raise NotImplementedError
 
 
 class Discrete(Distribution):
@@ -187,6 +202,14 @@ class Discrete(Distribution):
             to_value = np.vectorize(lambda idx: data.Value(self.variable, idx))
             return to_value(value_indices)
         return data.Value(self.variable, value_indices)
+
+    def min(self):
+        if self.variable.ordered:
+            return self.variable.values[0]
+
+    def max(self):
+        if self.variable.ordered:
+            return self.variable.values[-1]
 
 
 class Continuous(Distribution):

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -57,6 +57,10 @@ class Distribution(np.ndarray):
         """
         raise NotImplementedError
 
+    def normalize(self):
+        """Normalize the distribution to a probability distribution."""
+        raise NotImplementedError
+
 
 
 class Discrete(Distribution):
@@ -261,7 +265,7 @@ class Continuous(Distribution):
         return sum(((x - mean) ** 2) * w for x, w in zip(self[0], self[1])) / sum(self[1])
 
     def standard_deviation(self):
-        return math.sqrt(self.variance())
+        return np.sqrt(self.variance())
 
 
 def class_distribution(data):

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -295,7 +295,7 @@ def class_distribution(data):
     if data.domain.class_var:
         return get_distribution(data, data.domain.class_var)
     elif data.domain.class_vars:
-        return [get_distribution(cls, data) for cls in data.domain.class_vars]
+        return [get_distribution(data, cls) for cls in data.domain.class_vars]
     else:
         raise ValueError("domain has no class attribute")
 

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -1,8 +1,9 @@
-import random
-import zlib
-import math
+from collections import Iterable
 from numbers import Real
+
 import numpy as np
+import zlib
+
 from Orange import data
 
 
@@ -40,6 +41,21 @@ class Distribution(np.ndarray):
 
     def __hash__(self):
         return zlib.adler32(self) ^ hash(self.unknowns)
+
+    def sample(self, size=None, replace=True):
+        """Get a random sample from the distribution.
+
+        Parameters
+        ----------
+        size : Optional[Union[int, Tuple[int, ...]]]
+        replace : bool
+
+        Returns
+        -------
+        Union[float, data.Value, np.ndarray]
+
+        """
+        raise NotImplementedError
 
 
 
@@ -161,14 +177,12 @@ class Discrete(Distribution):
         val = np.argmax(self)
         return data.Value(self.variable, val) if self.variable is not None else val
 
-    def random(self):
-        v = random.random() * np.sum(self)
-        s = i = 0
-        for i, e in enumerate(self):
-            s += e
-            if s > v:
-                break
-        return data.Value(self.variable, i) if self.variable is not None else i
+    def sample(self, size=None, replace=True):
+        value_indices = np.random.choice(range(len(self)), size, replace, self.normalize())
+        if isinstance(value_indices, Iterable):
+            to_value = np.vectorize(lambda idx: data.Value(self.variable, idx))
+            return to_value(value_indices)
+        return data.Value(self.variable, value_indices)
 
 
 class Continuous(Distribution):
@@ -236,13 +250,8 @@ class Continuous(Distribution):
     def max(self):
         return self[0, -1]
 
-    def random(self):
-        v = random.random() * np.sum(self[1, :])
-        s = 0
-        for x, prob in self.T:
-            s += prob
-            if s > v:
-                return x
+    def sample(self, size=None, replace=True):
+        return np.random.choice(self[0, :], size, replace, self.normalize()[1, :])
 
     def mean(self):
         return np.average(np.asarray(self[0]), weights=np.asarray(self[1]))

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -277,7 +277,9 @@ class Continuous(Distribution):
         return self[0, -1]
 
     def sample(self, size=None, replace=True):
-        return np.random.choice(self[0, :], size, replace, self.normalize()[1, :])
+        normalized = Continuous(self, self.variable, self.unknowns)
+        normalized.normalize()
+        return np.random.choice(self[0, :], size, replace, normalized[1, :])
 
     def mean(self):
         return np.average(np.asarray(self[0]), weights=np.asarray(self[1]))

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -7,35 +7,47 @@ from Orange import data
 
 
 def _get_variable(dat, variable, expected_type=None, expected_name=""):
+    """Get the variable instance from data."""
     failed = False
     if isinstance(variable, data.Variable):
         datvar = getattr(dat, "variable", None)
         if datvar is not None and datvar is not variable:
-            raise ValueError("variable does not match the variable"
-                             "in the data")
+            raise ValueError("variable does not match the variable in the data")
     elif hasattr(dat, "domain"):
         variable = dat.domain[variable]
     elif hasattr(dat, "variable"):
         variable = dat.variable
     else:
         failed = True
-    if failed or (expected_type is not None
-                  and not isinstance(variable, expected_type)):
+    if failed or (expected_type is not None and not isinstance(variable, expected_type)):
         if isinstance(variable, data.Variable):
-            raise ValueError(
-                "expected %s variable not %s" % (expected_name, variable))
+            raise ValueError("expected %s variable not %s" % (expected_name, variable))
         else:
-            raise ValueError("expected %s, not '%s'" %
-                             (expected_type.__name__, type(variable).__name__))
+            raise ValueError("expected %s, not '%s'" % (
+                expected_type.__name__, type(variable).__name__))
     return variable
 
 
-class Discrete(np.ndarray):
+class Distribution(np.ndarray):
+    def __eq__(self, other):
+        return (
+            np.array_equal(self, other) and
+            (not hasattr(other, "unknowns") or self.unknowns == other.unknowns)
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __hash__(self):
+        return zlib.adler32(self) ^ hash(self.unknowns)
+
+
+
+class Discrete(Distribution):
     def __new__(cls, dat, variable=None, unknowns=None):
         if isinstance(dat, data.Storage):
             if unknowns is not None:
-                raise TypeError(
-                    "incompatible arguments (data storage and 'unknowns'")
+                raise TypeError("incompatible arguments (data storage and 'unknowns'")
             return cls.from_data(dat, variable)
 
         if variable is not None:
@@ -51,10 +63,8 @@ class Discrete(np.ndarray):
             self.unknowns = unknowns or 0
         else:
             self[:] = dat
-            self.unknowns = (unknowns if unknowns is not None
-                             else getattr(dat, "unknowns", 0))
+            self.unknowns = unknowns if unknowns is not None else getattr(dat, "unknowns", 0)
         return self
-
 
     @classmethod
     def from_data(cls, data, variable):
@@ -85,53 +95,35 @@ class Discrete(np.ndarray):
         self.variable = variable
         return self
 
-
-    def __eq__(self, other):
-        return np.array_equal(self, other) and (
-            not hasattr(other, "unknowns") or self.unknowns == other.unknowns)
-
-    def __ne__(self, other):
-        return not self == other
-
     def __getitem__(self, index):
         if isinstance(index, str):
             index = self.variable.to_val(index)
         return super().__getitem__(index)
-
 
     def __setitem__(self, index, value):
         if isinstance(index, str):
             index = self.variable.to_val(index)
         super().__setitem__(index, value)
 
-
-    def __hash__(self):
-        return zlib.adler32(self) ^ hash(self.unknowns)
-
-
     def __add__(self, other):
         s = super().__add__(other)
         s.unknowns = self.unknowns + getattr(other, "unknowns", 0)
         return s
-
 
     def __iadd__(self, other):
         super().__iadd__(other)
         self.unknowns += getattr(other, "unknowns", 0)
         return self
 
-
     def __sub__(self, other):
         s = super().__sub__(other)
         s.unknowns = self.unknowns - getattr(other, "unknowns", 0)
         return s
 
-
     def __isub__(self, other):
         super().__isub__(other)
         self.unknowns -= getattr(other, "unknowns", 0)
         return self
-
 
     def __mul__(self, other):
         s = super().__mul__(other)
@@ -139,13 +131,11 @@ class Discrete(np.ndarray):
             s.unknowns = self.unknowns / other
         return s
 
-
     def __imul__(self, other):
         super().__imul__(other)
         if isinstance(other, Real):
             self.unknowns *= other
         return self
-
 
     def __div__(self, other):
         s = super().__mul__(other)
@@ -153,13 +143,11 @@ class Discrete(np.ndarray):
             s.unknowns = self.unknowns / other
         return s
 
-
     def __idiv__(self, other):
         super().__imul__(other)
         if isinstance(other, Real):
             self.unknowns /= other
         return self
-
 
     def normalize(self):
         t = np.sum(self)
@@ -169,12 +157,9 @@ class Discrete(np.ndarray):
         elif self.shape[0]:
             self[:] = 1 / self.shape[0]
 
-
     def modus(self):
         val = np.argmax(self)
-        return data.Value(self.variable,
-                          val) if self.variable is not None else val
-
+        return data.Value(self.variable, val) if self.variable is not None else val
 
     def random(self):
         v = random.random() * np.sum(self)
@@ -186,12 +171,11 @@ class Discrete(np.ndarray):
         return data.Value(self.variable, i) if self.variable is not None else i
 
 
-class Continuous(np.ndarray):
+class Continuous(Distribution):
     def __new__(cls, dat, variable=None, unknowns=None):
         if isinstance(dat, data.Storage):
             if unknowns is not None:
-                raise TypeError(
-                    "incompatible arguments (data storage and 'unknowns'")
+                raise TypeError("incompatible arguments (data storage and 'unknowns'")
             return cls.from_data(variable, dat)
         if isinstance(dat, int):
             self = super().__new__(cls, (2, dat))
@@ -202,8 +186,7 @@ class Continuous(np.ndarray):
                 dat = np.asarray(dat)
             self = super().__new__(cls, dat.shape)
             self[:] = dat
-            self.unknowns = (unknowns if unknowns is not None
-                             else getattr(dat, "unknowns", 0))
+            self.unknowns = (unknowns if unknowns is not None else getattr(dat, "unknowns", 0))
         self.variable = variable
         return self
 
@@ -233,13 +216,6 @@ class Continuous(np.ndarray):
         self.unknowns = unknowns
         self.variable = variable
         return self
-
-    def __eq__(self, other):
-        return np.array_equal(self, other) and (
-            not hasattr(other, "unknowns") or self.unknowns == other.unknowns)
-
-    def __hash__(self):
-        return zlib.adler32(self) ^ hash(self.unknowns)
 
     def normalize(self):
         t = np.sum(self[1, :])
@@ -279,8 +255,8 @@ class Continuous(np.ndarray):
         return math.sqrt(self.variance())
 
 
-
 def class_distribution(data):
+    """Get the distribution of the class variable(s)."""
     if data.domain.class_var:
         return get_distribution(data, data.domain.class_var)
     elif data.domain.class_vars:
@@ -290,17 +266,18 @@ def class_distribution(data):
 
 
 def get_distribution(dat, variable, unknowns=None):
+    """Get the distribution of the given variable."""
     variable = _get_variable(dat, variable)
     if variable.is_discrete:
         return Discrete(dat, variable, unknowns)
     elif variable.is_continuous:
         return Continuous(dat, variable, unknowns)
     else:
-        raise TypeError("cannot compute distribution of '%s'" %
-                        type(variable).__name__)
+        raise TypeError("cannot compute distribution of '%s'" % type(variable).__name__)
 
 
 def get_distributions(dat, skipDiscrete=False, skipContinuous=False):
+    """Get the distributions of all variables in the data."""
     vars = dat.domain.variables
     if skipDiscrete:
         if skipContinuous:
@@ -325,19 +302,18 @@ def get_distributions(dat, skipDiscrete=False, skipContinuous=False):
 
 
 def get_distributions_for_columns(data, columns):
-    """
-    Compute the distributions for columns.
+    """Compute the distributions for columns.
 
-    :param Orange.data.Table data:
-    :param list columns:
+    Parameters
+    ----------
+    data : data.Table
         List of column indices into the `data.domain` (indices can be
         :class:`int` or instances of `Orange.data.Variable`)
 
     """
     domain = data.domain
     # Normailze the columns to int indices
-    columns = [col if isinstance(col, int) else domain.index(col)
-               for col in columns]
+    columns = [col if isinstance(col, int) else domain.index(col) for col in columns]
     try:
         # Try the optimized code path (query the table|storage directly).
         dist_unks = data._compute_distributions(columns)

--- a/Orange/tests/test_contingency.py
+++ b/Orange/tests/test_contingency.py
@@ -230,7 +230,7 @@ class TestDiscrete(unittest.TestCase):
         np.testing.assert_almost_equal(cont["b"], [[1], [1]])
         np.testing.assert_almost_equal(cont[2], [[2], [1]])
 
-        conts = contingency.get_contingencies(d, skipDiscrete=True)
+        conts = contingency.get_contingencies(d, skip_discrete=True)
         self.assertEqual(len(conts), 10)
         cont = conts[4]
         self.assertIsInstance(cont, contingency.Continuous)
@@ -238,7 +238,7 @@ class TestDiscrete(unittest.TestCase):
         np.testing.assert_almost_equal(cont["b"], [[1], [1]])
         np.testing.assert_almost_equal(cont[2], [[2], [1]])
 
-        conts = contingency.get_contingencies(d, skipContinuous=True)
+        conts = contingency.get_contingencies(d, skip_continuous=True)
         self.assertEqual(len(conts), 10)
         cont = conts[5]
         self.assertIsInstance(cont, contingency.Discrete)

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -19,6 +19,20 @@ class Distribution_DiscreteTestCase(unittest.TestCase):
         s = sum(self.freqs)
         self.rfreqs = [x/s for x in self.freqs]
 
+        self.data = data.Table.from_numpy(
+            data.Domain(
+                attributes=[
+                    data.DiscreteVariable('rgb', values=['r', 'g', 'b', 'a']),
+                    data.DiscreteVariable('num', values=['1', '2', '3'], ordered=True),
+                ]
+            ),
+            X=np.array([
+                [0, 2, 0, 1, 1, 0, np.nan, 1],
+                [0, 2, 0, np.nan, 1, 2, np.nan, 1],
+            ]).T
+        )
+        self.rgb, self.num = distribution.get_distributions(self.data)
+
     def test_from_table(self):
         d = data.Table("zoo")
         disc = distribution.Discrete(d, "type")
@@ -172,6 +186,13 @@ class Distribution_DiscreteTestCase(unittest.TestCase):
         # Check that samping a single value works too
         self.assertIn(self.num.sample(), [0, 1, 2])
 
+    def test_min_max(self):
+        # Min and max don't make sense in the context of nominal variables
+        self.assertEqual(self.rgb.min(), None)
+        self.assertEqual(self.rgb.max(), None)
+        # Min and max should work for ordinal variables
+        self.assertEqual(self.num.min(), '1')
+        self.assertEqual(self.num.max(), '3')
 
 
 class Distribution_ContinuousTestCase(unittest.TestCase):

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -200,6 +200,17 @@ class Distribution_ContinuousTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.iris = data.Table("iris")
 
+        cls.data = data.Table.from_numpy(
+            data.Domain(
+                attributes=[
+                    data.ContinuousVariable('n1'),
+                    data.ContinuousVariable('n2'),
+                ]
+            ),
+            X=np.array([range(10), [1, 1, 1, 5, 5, 8, 9, np.nan, 9, 9]]).T
+        )
+        cls.n1, cls.n2 = distribution.get_distributions(cls.data)
+
     def setUp(self):
         self.freqs = np.array([(1.0, 1), (1.1, 1), (1.2, 2), (1.3, 7), (1.4, 12),
                                (1.5, 14), (1.6, 7), (1.7, 4), (1.9, 2), (3.0, 1),
@@ -301,6 +312,12 @@ class Distribution_ContinuousTestCase(unittest.TestCase):
             self.assertIn(v, self.freqs)
             ans.add(v)
         self.assertGreater(len(ans), 10)
+
+    def test_min_max(self):
+        self.assertEqual(self.n1.min(), 0)
+        self.assertFalse(isinstance(self.n1.min(), distribution.Continuous))
+        self.assertEqual(self.n1.max(), 9)
+        self.assertFalse(isinstance(self.n1.max(), distribution.Continuous))
 
 
 class TestClassDistribution(unittest.TestCase):

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -330,6 +330,27 @@ class TestClassDistribution(unittest.TestCase):
         np.testing.assert_array_equal(disc,
                                       [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0])
 
+    def test_multiple_target_variables(self):
+        d = data.Table.from_numpy(
+            data.Domain(
+                attributes=[data.ContinuousVariable('n1')],
+                class_vars=[
+                    data.DiscreteVariable('c1', values=['r', 'g', 'b', 'a']),
+                    data.DiscreteVariable('c2', values=['r', 'g', 'b', 'a']),
+                    data.DiscreteVariable('c3', values=['r', 'g', 'b', 'a']),
+                ]
+            ),
+            X=np.array([range(5)]).T,
+            Y=np.array([
+                [0, 1, 2, 3, 4],
+                [0, 1, 2, 3, 4],
+                [0, 1, 2, 3, 4],
+            ]).T
+        )
+        dists = distribution.class_distribution(d)
+        self.assertEqual(len(dists), 3)
+        self.assertTrue(all(isinstance(dist, distribution.Discrete) for dist in dists))
+
 
 class TestGetDistribution(unittest.TestCase):
     def test_get_distribution(self):

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -13,7 +13,7 @@ from Orange import data
 from Orange.tests import test_filename
 
 
-class Distribution_DiscreteTestCase(unittest.TestCase):
+class TestDiscreteDistribution(unittest.TestCase):
     def setUp(self):
         self.freqs = [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0]
         s = sum(self.freqs)
@@ -195,7 +195,7 @@ class Distribution_DiscreteTestCase(unittest.TestCase):
         self.assertEqual(self.num.max(), '3')
 
 
-class Distribution_ContinuousTestCase(unittest.TestCase):
+class TestContinuousDistribution(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.iris = data.Table("iris")

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -165,13 +165,13 @@ class Distribution_DiscreteTestCase(unittest.TestCase):
         disc = distribution.Discrete(d, "type")
         self.assertEqual(str(disc.modus()), "mammal")
 
-    def test_random(self):
-        d = data.Table("zoo")
-        disc = distribution.Discrete(d, "type")
-        ans = set()
-        for i in range(1000):
-            ans.add(int(disc.random()))
-        self.assertEqual(ans, set(range(len(d.domain.class_var.values))))
+    def test_sample(self):
+        ans = self.num.sample((500, 2), replace=True)
+        np.testing.assert_equal(np.unique(ans), [0, 1, 2])
+
+        # Check that samping a single value works too
+        self.assertIn(self.num.sample(), [0, 1, 2])
+
 
 
 class Distribution_ContinuousTestCase(unittest.TestCase):
@@ -276,7 +276,7 @@ class Distribution_ContinuousTestCase(unittest.TestCase):
         disc = distribution.Continuous(d, "petal length")
         ans = set()
         for i in range(1000):
-            v = disc.random()
+            v = disc.sample()
             self.assertIn(v, self.freqs)
             ans.add(v)
         self.assertGreater(len(ans), 10)


### PR DESCRIPTION
#2680, but without 7d675ba. Apparently force-pushing on a closed PR makes it impossible to re-open it, hence the new PR... @kernc could you take a look?

##### Issue
The function `class_distribution` was apparently never used throughout the entire codebase and was never tested, and the parameter ordering was incorrect.

##### Description of changes
af5a1c7 fixes the mentioned issue. The other commits add various tests, docstrings and code formatting fixes. I've also added a better `sample` method, similar to the python `random.sample`. I've also added `min` and `max` for ordered categorical variables.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
