### PR TITLE
widget: Do not restore __splitter if there is None

### DIFF
--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -3,6 +3,7 @@
 
 from unittest.mock import patch, MagicMock
 
+from AnyQt.QtGui import QShowEvent
 from AnyQt.QtWidgets import QAction
 
 from Orange.widgets.gui import OWComponent
@@ -76,6 +77,15 @@ class WidgetTestCase(WidgetTest):
         help_action = widget.findChild(QAction, "action-help")
         help_action.setEnabled(True)
         help_action.setVisible(True)
+
+    def test_widget_without_basic_layout(self):
+        class TestWidget2(OWWidget):
+            name = "Test"
+
+            want_basic_layout = False
+
+        w = TestWidget2()
+        w.showEvent(QShowEvent())
 
 
 class WidgetMsgTestCase(WidgetTest):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -572,7 +572,8 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         QDialog.showEvent(self, event)
         if self.save_position and not self.__was_restored:
             # Restore saved geometry on (first) show
-            self.__splitter.setControlAreaVisible(self.controlAreaVisible)
+            if self.__splitter is not None:
+                self.__splitter.setControlAreaVisible(self.controlAreaVisible)
             self.__restoreWidgetGeometry()
             self.__was_restored = True
         self.__quicktipOnce()


### PR DESCRIPTION
##### Issue
When widget declares want_basic_layout = False, __splitter is not set causing an error in showEvent.

##### Description of changes
Check whether __splitter exists before modifying it.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
