### PR TITLE
[ENH] Data Table: Optimize performance

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -11,7 +11,7 @@ from xml.sax.saxutils import escape
 
 from AnyQt.QtCore import (
     Qt, QObject, QAbstractListModel, QAbstractTableModel, QModelIndex,
-    QItemSelectionModel
+    QItemSelectionModel, QT_VERSION
 )
 from AnyQt.QtCore import pyqtSignal as Signal
 from AnyQt.QtGui import QColor
@@ -197,7 +197,12 @@ class AbstractSortTableModel(QAbstractTableModel):
         data table is left unmodified. Use mapToSourceRows()/mapFromSourceRows()
         when accessing data by row indexes.
         """
-        self.layoutAboutToBeChanged.emit()
+        if QT_VERSION >= 0x50000:
+            self.layoutAboutToBeChanged.emit(
+                [], QAbstractTableModel.VerticalSortHint
+            )
+        else:
+            self.layoutAboutToBeChanged.emit()
 
         # Store persistent indices as well as their (actual) rows in the
         # source data table.
@@ -230,7 +235,10 @@ class AbstractSortTableModel(QAbstractTableModel):
             persistent,
             [self.index(row, pind.column())
              for row, pind in zip(persistent_rows, persistent)])
-        self.layoutChanged.emit()
+        if QT_VERSION >= 0x50000:
+            self.layoutChanged.emit([], QAbstractTableModel.VerticalSortHint)
+        else:
+            self.layoutChanged.emit()
 
 
 class PyTableModel(AbstractSortTableModel):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Data Table is slow when it displays large a large table with large selection.

##### Description of changes

* Avoid enumerating all QModenIndex's in the selection; use QItemSelectionRange's
* Remove one proxying layer in favor of subclassing to minimize QModelIndex mappings.
* Use Qt5 layout change hinting in TableModel.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
