### PR TITLE
[ENH] Select Rows: Add annotated data output

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -28,6 +28,7 @@ from Orange.canvas import report
 from Orange.widgets.widget import Msg
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
+import numpy as np
 
 
 class SelectRowsContextHandler(DomainContextHandler):
@@ -516,8 +517,9 @@ class OWSelectRows(widget.OWWidget):
                 matching_output = self.filters(self.data)
                 self.filters.negate = True
                 non_matching_output = self.filters(self.data)
-                rowsel = [self.filters(d) for d in self.data]
-                annotated_output = create_annotated_table(self.data, rowsel)
+
+                row_sel = np.in1d(self.data.ids, matching_output.ids)
+                annotated_output = create_annotated_table(self.data, row_sel)
 
             # if hasattr(self.data, "name"):
             #     matching_output.name = self.data.name

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -1,7 +1,8 @@
 import enum
-
 from collections import OrderedDict
 from itertools import chain
+
+import numpy as np
 
 from AnyQt.QtWidgets import (
     QWidget, QTableWidget, QHeaderView, QComboBox, QLineEdit, QToolButton,
@@ -28,7 +29,6 @@ from Orange.canvas import report
 from Orange.widgets.widget import Msg
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
-import numpy as np
 
 
 class SelectRowsContextHandler(DomainContextHandler):

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -538,8 +538,6 @@ class OWSelectRows(widget.OWWidget):
 
                 matching_output = remover(matching_output)
                 non_matching_output = remover(non_matching_output)
-
-                remover = Remove(attr_flags)  # do not remove class for annotated data
                 annotated_output = remover(annotated_output)
 
         if matching_output is not None and not len(matching_output):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -115,43 +115,6 @@ class TestOWSelectRows(WidgetTest):
         self.enterFilter(iris.domain[2], "is below", "5.2")
         self.assertEqual(self.widget.conditions[0][2], ("52",))
 
-    def enterFilter(self, variable, filter, value=None, value2=None):
-        row = self.widget.cond_list.model().rowCount()
-        self.widget.add_button.click()
-
-        var_combo = self.widget.cond_list.cellWidget(row, 0)
-        simulate.combobox_activate_item(var_combo, variable.name, delay=0)
-
-        oper_combo = self.widget.cond_list.cellWidget(row, 1)
-        simulate.combobox_activate_item(oper_combo, filter, delay=0)
-
-        value_inputs = self.__get_value_widgets(row)
-        for i, value in enumerate([value, value2]):
-            if value is None:
-                continue
-            self.__set_value(value_inputs[i], value)
-
-    def __get_value_widgets(self, row):
-        value_inputs = self.widget.cond_list.cellWidget(row, 2)
-        if value_inputs:
-            if isinstance(value_inputs, QComboBox):
-                value_inputs = [value_inputs]
-            else:
-                value_inputs = [
-                    w for w in value_inputs.children()
-                    if isinstance(w, QLineEdit)]
-        return value_inputs
-
-    def __set_value(self, widget, value):
-        if isinstance(widget, QLineEdit):
-            QTest.mouseClick(widget, Qt.LeftButton)
-            QTest.keyClicks(widget, value, delay=0)
-            QTest.keyClick(widget, Qt.Key_Enter)
-        elif isinstance(widget, QComboBox):
-            simulate.combobox_activate_item(widget, value)
-        else:
-            raise ValueError("Unsupported widget {}".format(widget))
-
     @override_locale(QLocale.Slovenian)
     def test_stores_settings_in_invariant_locale(self):
         iris = Table("iris")[:5]
@@ -244,14 +207,6 @@ class TestOWSelectRows(WidgetTest):
         # Test saving of settings
         self.widget.settingsHandler.pack_data(self.widget)
 
-    def widget_with_context(self, domain, conditions):
-        ch = SelectRowsContextHandler()
-        context = ch.new_context(domain, *ch.encode_domain(domain))
-        context.values = dict(conditions=conditions)
-        settings = dict(context_settings=[context])
-
-        return self.create_widget(OWSelectRows, settings)
-
     def test_output_filter(self):
         """
         None on output when there is no data.
@@ -270,3 +225,48 @@ class TestOWSelectRows(WidgetTest):
         self.assertIsNone(self.get_output("Unmatched Data"))
         self.assertEqual(len(self.get_output("Matching Data")), len_data)
         self.assertEqual(len(self.get_output("Data")), len_data)
+
+    def widget_with_context(self, domain, conditions):
+        ch = SelectRowsContextHandler()
+        context = ch.new_context(domain, *ch.encode_domain(domain))
+        context.values = dict(conditions=conditions)
+        settings = dict(context_settings=[context])
+
+        return self.create_widget(OWSelectRows, settings)
+
+    def enterFilter(self, variable, filter, value=None, value2=None):
+        row = self.widget.cond_list.model().rowCount()
+        self.widget.add_button.click()
+
+        var_combo = self.widget.cond_list.cellWidget(row, 0)
+        simulate.combobox_activate_item(var_combo, variable.name, delay=0)
+
+        oper_combo = self.widget.cond_list.cellWidget(row, 1)
+        simulate.combobox_activate_item(oper_combo, filter, delay=0)
+
+        value_inputs = self.__get_value_widgets(row)
+        for i, value in enumerate([value, value2]):
+            if value is None:
+                continue
+            self.__set_value(value_inputs[i], value)
+
+    def __get_value_widgets(self, row):
+        value_inputs = self.widget.cond_list.cellWidget(row, 2)
+        if value_inputs:
+            if isinstance(value_inputs, QComboBox):
+                value_inputs = [value_inputs]
+            else:
+                value_inputs = [
+                    w for w in value_inputs.children()
+                    if isinstance(w, QLineEdit)]
+        return value_inputs
+
+    def __set_value(self, widget, value):
+        if isinstance(widget, QLineEdit):
+            QTest.mouseClick(widget, Qt.LeftButton)
+            QTest.keyClicks(widget, value, delay=0)
+            QTest.keyClick(widget, Qt.Key_Enter)
+        elif isinstance(widget, QComboBox):
+            simulate.combobox_activate_item(widget, value)
+        else:
+            raise ValueError("Unsupported widget {}".format(widget))

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -4,6 +4,8 @@ from AnyQt.QtCore import QLocale, Qt
 from AnyQt.QtTest import QTest
 from AnyQt.QtWidgets import QLineEdit, QComboBox
 
+import numpy as np
+
 from Orange.data import (
     Table, ContinuousVariable, StringVariable, DiscreteVariable)
 from Orange.widgets.data.owselectrows import (
@@ -12,6 +14,7 @@ from Orange.widgets.tests.base import WidgetTest, datasets
 
 from Orange.data.filter import FilterContinuous, FilterString
 from Orange.widgets.tests.utils import simulate, override_locale
+from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_FEATURE_NAME
 
 CFValues = {
     FilterContinuous.Equal: ["5.4"],
@@ -225,6 +228,18 @@ class TestOWSelectRows(WidgetTest):
         self.assertIsNone(self.get_output("Unmatched Data"))
         self.assertEqual(len(self.get_output("Matching Data")), len_data)
         self.assertEqual(len(self.get_output("Data")), len_data)
+
+    def test_annotated_data(self):
+        iris = Table("iris")
+        self.send_signal(self.widget.Inputs.data, iris)
+
+        self.enterFilter(iris.domain["iris"], "is", "Iris-setosa")
+
+        annotated = self.get_output(self.widget.Outputs.annotated_data)
+        self.assertEqual(len(annotated), 150)
+        annotations = annotated.get_column_view(ANNOTATED_DATA_FEATURE_NAME)[0]
+        np.testing.assert_equal(annotations[:50], True)
+        np.testing.assert_equal(annotations[50:], False)
 
     def widget_with_context(self, domain, conditions):
         ch = SelectRowsContextHandler()

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -249,7 +249,7 @@ class TestOWSelectRows(WidgetTest):
 
         return self.create_widget(OWSelectRows, settings)
 
-    def enterFilter(self, variable, filter, value=None, value2=None):
+    def enterFilter(self, variable, filter, value1=None, value2=None):
         row = self.widget.cond_list.model().rowCount()
         self.widget.add_button.click()
 
@@ -260,7 +260,7 @@ class TestOWSelectRows(WidgetTest):
         simulate.combobox_activate_item(oper_combo, filter, delay=0)
 
         value_inputs = self.__get_value_widgets(row)
-        for i, value in enumerate([value, value2]):
+        for i, value in enumerate([value1, value2]):
             if value is None:
                 continue
             self.__set_value(value_inputs[i], value)

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -231,6 +231,7 @@ class TestOWSelectRows(WidgetTest):
         self.assertFalse(self.widget.Error.parsing_error.is_shown())
         self.assertEqual(len(self.get_output("Matching Data")), 3)
         self.assertEqual(len(self.get_output("Unmatched Data")), 1)
+        self.assertEqual(len(self.get_output("Data")), len(data))
 
         # Test saving of settings
         self.widget.settingsHandler.pack_data(self.widget)
@@ -255,7 +256,9 @@ class TestOWSelectRows(WidgetTest):
         self.enterFilter(data.domain[0], "is below", "-1")
         self.assertIsNone(self.get_output("Matching Data"))
         self.assertEqual(len(self.get_output("Unmatched Data")), len_data)
+        self.assertEqual(len(self.get_output("Data")), len_data)
         self.widget.remove_all_button.click()
         self.enterFilter(data.domain[0], "is below", "10")
         self.assertIsNone(self.get_output("Unmatched Data"))
         self.assertEqual(len(self.get_output("Matching Data")), len_data)
+        self.assertEqual(len(self.get_output("Data")), len_data)

--- a/doc/visual-programming/source/widgets/data/selectrows.rst
+++ b/doc/visual-programming/source/widgets/data/selectrows.rst
@@ -12,6 +12,8 @@ Outputs
         instances that match the conditions
     Non-Matching Data
         instances that do not match the conditions
+    Data
+        data with an additional column showing whether a instance is selected
 
 
 This widget selects a subset from an input dataset, based on user-defined


### PR DESCRIPTION
##### Issue
Widget outputted only selected or unselected data, whereas in a number of cases one would benefit to have data with the Selected column, especially if selection would be performed on a combination or continuous meta attribute(s) and then used to test if we can predict the grouping.

##### Description of changes
Added an output channel (Data).

##### Includes
- [X] Code changes
- [X] Tests
- [x] Documentation
