### PR TITLE
[FIX] SPG Legend: Fix vertical spacing

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -83,7 +83,6 @@ class LegendItem(LegendItem):
         super().__init__(size, offset)
 
         self.layout.setContentsMargins(5, 5, 5, 5)
-        self.layout.setVerticalSpacing(0)
         self.layout.setHorizontalSpacing(15)
         self.layout.setColumnAlignment(1, Qt.AlignLeft | Qt.AlignVCenter)
 


### PR DESCRIPTION
##### Issue
Fixes #2683


##### Description of changes
Default vertical spacing is 6. Anything below 5 seems to mess up the spacing. 6 looks ok, so use that.

Screenshot of changes on same data from issue.
![](https://i.gyazo.com/cd0eb4b038506ff1688115df8cca98da.png)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
