### PR TITLE
[FIX] heatmap: Do not crash on all zero column

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -822,6 +822,8 @@ class OWHeatMap(widget.OWWidget):
         if need_dist:
             data = Orange.distance._preprocess(data)
             matrix = Orange.distance.PearsonR(data, axis=0)
+            # nan values break clustering below
+            matrix = np.nan_to_num(matrix)
 
         if cluster is None:
             cluster = hierarchical.dist_matrix_clustering(matrix)

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -19,7 +19,7 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         cls.signal_data = cls.data
 
     def setUp(self):
-        self.widget = self.create_widget(OWHeatMap)
+        self.widget = self.create_widget(OWHeatMap)  # type: OWHeatMap
 
     def test_input_data(self):
         """Check widget's data with data on the input"""
@@ -117,3 +117,12 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         table = datasets.data_one_column_nans()
         self.widget.controls.merge_kmeans.setChecked(True)
         self.send_signal(self.widget.Inputs.data, table)
+
+    def test_cluster_column_on_all_zero_column(self):
+        # Pearson distance used for clustering of columns does not
+        # handle all zero columns well
+        iris = Table("iris")
+        iris[:, 0] = 0
+
+        self.widget.col_clustering = True
+        self.widget.set_dataset(iris)


### PR DESCRIPTION
##### Issue
Heatmap with column clustering crashes when data contains a column an all-zero column.
Column clustering is done using Pearson distance which is nan for a column of all zeros.

##### Description of changes
Convert non-finite values to finite using np.nan_to_num. This results in zero feature being clustered with a random other feature, but the rest of the clustering should make sense.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
