### PR TITLE
[FIX] Test and Score: Fix averaging over classes for binary scores

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -567,7 +567,7 @@ class OWTestLearners(OWWidget):
 
                     # Cell variable is used immediatelly, it's not stored
                     # pylint: disable=cell-var-from-loop
-                    stats = [Try(scorer_caller(scorer, ovr_results))
+                    stats = [Try(scorer_caller(scorer, ovr_results, target=1))
                              for scorer in self.scorers]
                 else:
                     stats = None
@@ -950,9 +950,9 @@ class OWTestLearners(OWWidget):
         super().onDeleteWidget()
 
 
-def scorer_caller(scorer, ovr_results):
+def scorer_caller(scorer, ovr_results, target=None):
     if scorer.is_binary:
-        return lambda: scorer(ovr_results, target=1, average='weighted')
+        return lambda: scorer(ovr_results, target=target, average='weighted')
     else:
         return lambda: scorer(ovr_results)
 

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -7,7 +7,7 @@ import numpy as np
 from AnyQt.QtWidgets import QMenu
 from AnyQt.QtCore import QPoint
 
-from Orange.classification import MajorityLearner
+from Orange.classification import MajorityLearner, LogisticRegressionLearner
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.evaluation import Results, TestOnTestData
 from Orange.evaluation.scoring import ClassificationScore, RegressionScore, \
@@ -246,6 +246,35 @@ class TestOWTestLearners(WidgetTest):
             del Score.registry["NewScore"]
             del Score.registry["NewClassificationScore"]
             del Score.registry["NewRegressionScore"]
+
+    def test_target_changing(self):
+        data = Table("iris")
+        w = self.widget  #: OWTestLearners
+
+        w.n_folds = 2
+        self.send_signal(self.widget.Inputs.train_data, data)
+        self.send_signal(self.widget.Inputs.learner,
+                         LogisticRegressionLearner(), 0, wait=5000)
+
+        average_auc = float(w.view.model().item(0, 1).text())
+
+        w.class_selection = "Iris-setosa"
+        w._on_target_class_changed()
+        setosa_auc = float(w.view.model().item(0, 1).text())
+
+        w.class_selection = "Iris-versicolor"
+        w._on_target_class_changed()
+        versicolor_auc = float(w.view.model().item(0, 1).text())
+
+        w.class_selection = "Iris-virginica"
+        w._on_target_class_changed()
+        virginica_auc = float(w.view.model().item(0, 1).text())
+
+        self.assertGreater(average_auc, versicolor_auc)
+        self.assertGreater(average_auc, virginica_auc)
+        self.assertLess(average_auc, setosa_auc)
+        self.assertGreater(setosa_auc, versicolor_auc)
+        self.assertGreater(setosa_auc, virginica_auc)
 
 
 class TestHelpers(unittest.TestCase):


### PR DESCRIPTION

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Binary scores were evaluated with target class when no target class was selected

##### Description of changes
This PR is fixing binary scores to use weighted scoring when no target class is selected

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
