### PR TITLE
contingency: allow weights

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -233,7 +233,8 @@ def contingency(X, y, max_X=None, max_y=None, weights=None, mask=None):
         The maximal value in the array
     max_y : int
         The maximal value in `y`
-    weights : ...
+    weights : array_like
+        Row weights. When not None, contingencies contain weighted counts
     mask : sequence
         Discrete columns of X.
 
@@ -247,9 +248,6 @@ def contingency(X, y, max_X=None, max_y=None, weights=None, mask=None):
     nans : array_like
         Number of nans in each column of X for each unique value of y.
     """
-    if weights is not None and np.any(weights) and np.unique(weights)[0] != 1:
-        raise ValueError('weights not yet supported')
-
     was_1d = False
     if X.ndim == 1:
         X = X[..., np.newaxis]
@@ -268,7 +266,8 @@ def contingency(X, y, max_X=None, max_y=None, weights=None, mask=None):
             col = np.ravel(col.todense())
         contingencies.append(
             bincount(y + ny * col,
-                     minlength=ny * nx)[0].reshape(nx, ny).T)
+                     minlength=ny * nx,
+                     weights=weights)[0].reshape(nx, ny).T)
         nans.append(
             bincount(y[np.isnan(col)], minlength=ny)[0])
     if was_1d:

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -56,6 +56,16 @@ class TestUtil(unittest.TestCase):
                                              [0, 0, 0]])
         np.testing.assert_equal(nans, [1, 0, 0])
 
+    def test_weighted_contingency(self):
+        x = np.array([0, 1, 0, 2, np.nan])
+        y = np.array([0, 0, 1, np.nan, 0])
+        w = np.array([1, 2, 2, 3, 4])
+        cont_table, nans = contingency(x, y, 2, 2, weights=w)
+        np.testing.assert_equal(cont_table, [[1, 2, 0],
+                                             [2, 0, 0],
+                                             [0, 0, 0]])
+        np.testing.assert_equal(nans, [1, 0, 0])
+
     def test_stats(self):
         X = np.arange(4).reshape(2, 2).astype(float)
         X[1, 1] = np.nan


### PR DESCRIPTION
##### Issue
Contingency did not allow weights since our old bottlechest implementation of bincount (probably) did not support them. As our current bincount handles weights just fine, there is no need for the error anymore


##### Description of changes
Remove weights check in contingency, pass weights to bincount.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
