### PR TITLE
Allow oversampling in Data Sampler widget

### DIFF
--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -7,7 +7,7 @@ from AnyQt.QtCore import Qt
 import numpy as np
 import sklearn.model_selection as skl
 
-from Orange.widgets import widget, gui
+from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.data import Table
 from Orange.data.sql.table import SqlTable
@@ -77,10 +77,10 @@ class OWDataSampler(OWWidget):
                                     callback=self.sampling_type_changed)
 
         def set_sampling_type(i):
-            def f():
+            def set_sampling_type_i():
                 self.sampling_type = i
                 self.sampling_type_changed()
-            return f
+            return set_sampling_type_i
 
         gui.appendRadioButton(sampling, "Fixed proportion of data:")
         self.sampleSizePercentageSlider = gui.hSlider(
@@ -134,7 +134,6 @@ class OWDataSampler(OWWidget):
                         callback=set_sampling_type(self.SqlProportion))
         spin.setSuffix(" %")
         self.sql_box.setVisible(False)
-
 
         self.options_box = gui.vBox(self.controlArea, "Options")
         self.cb_seed = gui.checkBox(
@@ -279,7 +278,7 @@ class OWDataSampler(OWWidget):
             self.Warning.bigger_sample()
 
         stratified = (self.stratify and
-                      type(self.data) == Table and
+                      isinstance(self.data, Table) and
                       self.data.domain.has_discrete_class)
         try:
             self.indices = self.sample(data_length, size, stratified)
@@ -295,7 +294,8 @@ class OWDataSampler(OWWidget):
                 random_state=rnd)
         elif self.sampling_type == self.FixedProportion:
             self.indice_gen = SampleRandomP(
-                self.sampleSizePercentage / 100, stratified=stratified, random_state=rnd)
+                self.sampleSizePercentage / 100, stratified=stratified,
+                random_state=rnd)
         elif self.sampling_type == self.Bootstrap:
             self.indice_gen = SampleBootstrap(data_length, random_state=rnd)
         else:
@@ -341,7 +341,8 @@ class SampleFoldIndices(Reprable):
         Args:
             folds (int): Number of folds
             stratified (bool): Return stratified indices (if applicable).
-            random_state (Random): An initial state for replicable random behavior
+            random_state (Random): An initial state for replicable random
+            behavior
 
         Returns:
             tuple-of-arrays: A tuple of array indices one for each fold.
@@ -367,7 +368,7 @@ class SampleFoldIndices(Reprable):
 
 class SampleRandomN(Reprable):
     def __init__(self, n=0, stratified=False, replace=False,
-                    random_state=None):
+                 random_state=None):
         self.n = n
         self.stratified = stratified
         self.replace = replace

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -95,7 +95,8 @@ class OWDataSampler(OWWidget):
         self.sampleSizeSpin = gui.spin(
             ibox, self, "sampleSizeNumber", label="Instances: ",
             minv=1, maxv=self._MAX_SAMPLE_SIZE,
-            callback=set_sampling_type(self.FixedSize))
+            callback=set_sampling_type(self.FixedSize),
+            controlWidth=90)
         gui.checkBox(
             ibox, self, "replacement", "Sample with replacement",
             callback=set_sampling_type(self.FixedSize),

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -81,6 +81,38 @@ class TestOWDataSampler(WidgetTest):
                     self.assertEqual(len(self.zoo), len(sample) + len(other))
                     self.assertNoIntersection(sample, other)
 
+    def test_bigger_size_with_replacement(self):
+        """Allow bigger output without replacement."""
+        _, out_size, actual_size = self._set_bigger_sample_size(True)
+        self.assertEqual(out_size, actual_size,
+                         'Sample size should not be lowered with replacement')
+
+    def test_bigger_size_without_replacement(self):
+        """Lower output samples to match input's without replacement."""
+        in_size, _, actual_size = self._set_bigger_sample_size(False)
+        self.assertEqual(in_size, actual_size)
+
+    def _set_bigger_sample_size(self, with_replacement):
+        """Load data, set sample size and click to generate samples.
+
+        The sample size is set to out_size which is bigger than the input size
+        in_size.
+
+        Returns integers in_size, out_size and the actual gui sample size.
+        """
+        in_size = 2
+        out_size = in_size + 1
+        data = self.iris[:in_size]
+        self.widget.set_data(data)
+
+        self.select_sampling_type(self.widget.FixedSize)
+        self.widget.controls.replacement.setChecked(with_replacement)
+        self.widget.sampleSizeSpin.setValue(out_size)
+        self.widget.commit()
+
+        actual_size = self.widget.sampleSizeSpin.value()
+        return in_size, out_size, actual_size
+
     def assertNoIntersection(self, sample, other):
         for inst in sample:
             self.assertNotIn(inst, other)

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -83,39 +83,35 @@ class TestOWDataSampler(WidgetTest):
 
     def test_bigger_size_with_replacement(self):
         """Allow bigger output without replacement."""
-        _, out_size, actual_size = self._set_bigger_sample_size(True)
-        self.assertEqual(out_size, actual_size,
-                         'Sample size should not be lowered with replacement')
+        self.send_signal('Data', self.iris[:2])
+        sample_size = self.set_fixed_sample_size(3, with_replacement=True)
+        self.assertEqual(3, sample_size, 'Should be able to set a bigger size '
+                         'with replacement')
 
     def test_bigger_size_without_replacement(self):
         """Lower output samples to match input's without replacement."""
-        in_size, _, actual_size = self._set_bigger_sample_size(False)
-        self.assertEqual(in_size, actual_size)
+        self.send_signal('Data', self.iris[:2])
+        sample_size = self.set_fixed_sample_size(3)
+        self.assertEqual(2, sample_size)
 
     def test_bigger_output_warning(self):
-        self._set_bigger_sample_size(with_replacement=True)
+        """Should warn when sample size is bigger than input."""
+        self.send_signal('Data', self.iris[:2])
+        self.set_fixed_sample_size(3, with_replacement=True)
         self.assertTrue(self.widget.Warning.bigger_sample.is_shown())
 
-    def _set_bigger_sample_size(self, with_replacement):
-        """Load data, set sample size and click to generate samples.
+    def set_fixed_sample_size(self, sample_size, with_replacement=False):
+        """Set fixed sample size and return the number of gui spin.
 
-        The sample size is set to out_size which is bigger than the input size
-        in_size.
-
-        Returns integers in_size, out_size and the actual gui sample size.
+        Return the actual number in gui so we can check whether it is different
+        from sample_size. The number can be changed depending on the spin
+        maximum value.
         """
-        in_size = 2
-        out_size = in_size + 1
-        data = self.iris[:in_size]
-        self.widget.set_data(data)
-
         self.select_sampling_type(self.widget.FixedSize)
         self.widget.controls.replacement.setChecked(with_replacement)
-        self.widget.sampleSizeSpin.setValue(out_size)
+        self.widget.sampleSizeSpin.setValue(sample_size)
         self.widget.commit()
-
-        actual_size = self.widget.sampleSizeSpin.value()
-        return in_size, out_size, actual_size
+        return self.widget.sampleSizeSpin.value()
 
     def assertNoIntersection(self, sample, other):
         for inst in sample:

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -92,6 +92,10 @@ class TestOWDataSampler(WidgetTest):
         in_size, _, actual_size = self._set_bigger_sample_size(False)
         self.assertEqual(in_size, actual_size)
 
+    def test_bigger_output_warning(self):
+        self._set_bigger_sample_size(with_replacement=True)
+        self.assertTrue(self.widget.Warning.bigger_sample.is_shown())
+
     def _set_bigger_sample_size(self, with_replacement):
         """Load data, set sample size and click to generate samples.
 

--- a/doc/visual-programming/source/widgets/data/datasampler.rst
+++ b/doc/visual-programming/source/widgets/data/datasampler.rst
@@ -30,7 +30,8 @@ provided and *Sample Data* is pressed.
    -  **Fixed sample size** returns a selected number of data instances
       with a chance to set *Sample with replacement*, which always samples
       from the entire dataset (does not subtract instances already in
-      the subset)
+      the subset). With replacement, you can generate more instances than
+      available in the input dataset.
    -  `Cross Validation <https://en.wikipedia.org/wiki/Cross-validation_(statistics)>`_
       partitions data instances into complementary subsets, where you can
       select the number of folds (subsets) and which fold you want to


### PR DESCRIPTION
##### Issue
Fixes #2850


##### Description of changes
Changes:
1. Set instances' limit when there is data and replacement is chosen;
2. Remove instances' limit otherwise;
3. Warn if sample with replacement is bigger than input.

Refactoring:
1. Extract 2 ** 31 - 1 constant;
2. Clear warnings when errors are cleared.

##### Includes
- [X] Code changes
- [X] Tests
- [x] Documentation
