### PR TITLE
conda installer: drop support for conda 4.1

### DIFF
--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -6,25 +6,12 @@ rem Target install prefix
 set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
-rem Path to activate.bat
-set ACTIVATE=%CONDA%\..\activate.bat
 
 if not exist "%PREFIX%\python.exe" (
     echo Creating a conda env in "%PREFIX%"
     rem # Create an empty initial skeleton to layout the conda, activate.bat
-    rem # and other things needed to manage the environment. conda 4.1.*
-    rem # requires at least one package name to succeed
-    for %%f in ( vs*_runtime*.tar.bz2 ) do (
-        "%CONDA%" create --yes  --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
-            || exit /b !ERRORLEVEL!
-    )
-
-    rem # Also install python (msvc runtime and python might be required
-    rem # for any post-link scripts).
-    for %%f in ( python-*.tar.bz2 ) do (
-        "%CONDA%" install --yes --copy --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
-            || exit /b !ERRORLEVEL!
-    )
+    rem # and other things needed to manage the environment.
+    "%CONDA%" create --yes  --quiet --prefix "%PREFIX%"
 )
 
 rem # Create .condarc file that includes conda-forge channel
@@ -39,8 +26,3 @@ for %%f in ( *.tar.bz2 ) do (
     "%CONDA%" install --yes  --copy --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
         || exit /b !ERRORLEVEL!
 )
-
-rem # Activate the environment makes conda create
-rem # activate.bat, conda.bat and other shortcuts.
-echo Activating the environment for the first time"
-"%ACTIVATE%" "%PREFIX%"

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -7,11 +7,18 @@ set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
 
-if not exist "%PREFIX%\Scripts\activate.bat" (
+if not exist "%PREFIX%\python.exe" (
     echo Creating a conda env in "%PREFIX%"
     rem # Create an empty initial skeleton to layout the conda, activate.bat
     rem # and other things needed to manage the environment.
     "%CONDA%" create --yes  --quiet --prefix "%PREFIX%"
+
+    rem # Also install python (msvc runtime and python might be required
+    rem # for any post-link scripts).
+    for %%f in ( python-*.tar.bz2 ) do (
+        "%CONDA%" install --yes --copy --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
+            || exit /b !ERRORLEVEL!
+    )
 )
 
 rem # Create .condarc file that includes conda-forge channel

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -6,6 +6,8 @@ rem Target install prefix
 set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
+rem Path to activate.bat
+set ACTIVATE=%CONDA%\..\activate.bat
 
 if not exist "%PREFIX%\python.exe" (
     echo Creating a conda env in "%PREFIX%"
@@ -25,18 +27,6 @@ if not exist "%PREFIX%\python.exe" (
     )
 )
 
-rem # `conda create` does not add a conda.bat script when used
-rem # with a local package, we need to create it manually.
-echo @echo off           > "%PREFIX%\Scripts\conda.bat"
-echo call "%CONDA%" %%* >> "%PREFIX%\Scripts\conda.bat"
-
-rem # same for activate.bat
-rem #
-for %%f in ( "%CONDA%" ) do ( set "CONDA_DIR=%%~dpf" )
-echo @echo off                           > "%PREFIX%\Scripts\activate.bat"
-echo call "%CONDA_DIR%\activate.bat" %%* >> "%PREFIX%\Scripts\activate.bat"
-set CONDA_DIR=
-
 rem # Create .condarc file that includes conda-forge channel
 rem # We need it so add-ons can be installed from conda-forge
 echo Appending conda-forge channel
@@ -49,3 +39,8 @@ for %%f in ( *.tar.bz2 ) do (
     "%CONDA%" install --yes  --copy --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
         || exit /b !ERRORLEVEL!
 )
+
+rem # Activate the environment makes conda create
+rem # activate.bat, conda.bat and other shortcuts.
+echo Activating the environment for the first time"
+"%ACTIVATE%" "%PREFIX%"

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -7,7 +7,7 @@ set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
 
-if not exist "%PREFIX%\python.exe" (
+if not exist "%PREFIX%\Scripts\activate.bat" (
     echo Creating a conda env in "%PREFIX%"
     rem # Create an empty initial skeleton to layout the conda, activate.bat
     rem # and other things needed to manage the environment.


### PR DESCRIPTION
Almost half the lines in condainstall.bat were workarounds to make it work with conda 4.1. Since conda 4.1 is not available for python3.6 (included in installer), this PR drops support for it. conda 4.2 has been available for the past year and a half, which should be enough time.

When a new environment is created with no packages (supported in conda 4.2+), activate, deactivate and conda scripts are automatically created.

I also removed the separate installation of python into the created environment and I get no errors. If I missed something, let me know. 

Fixes #2921
