### PR TITLE
owkmeans: Add `replaces` for the recently changed output name

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -95,7 +95,10 @@ class OWKMeans(widget.OWWidget):
         data = Input("Data", Table)
 
     class Outputs:
-        annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Table, default=True)
+        annotated_data = Output(
+            ANNOTATED_DATA_SIGNAL_NAME, Table, default=True,
+            replaces=["Annotated Data"]
+        )
         centroids = Output("Centroids", Table)
 
     class Error(widget.OWWidget.Error):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

*K-Means* output connections saved in a workflow with Orange <= 3.10 cannot be restored.

##### Description of changes

Record the old name in the `replaces` parameter.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
