### PR TITLE
[FIX] Test & Score: Make the scores view table non-editable

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -293,6 +293,7 @@ class OWTestLearners(OWWidget):
 
         self.view = gui.TableView(
             wordWrap=True,
+            editTriggers=gui.TableView.NoEditTriggers
         )
         header = self.view.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeToContents)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The scores table in *Test & Score* is editable (via a double click on a cell) since gh-1421.

##### Description of changes

Make it non-editable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
