### PR TITLE
[ENH] Neural network widget that works in a separate thread

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -383,8 +383,11 @@ class SklLearner(Learner, metaclass=WrapperMeta):
         m.params = self.params
         return m
 
+    def _initialize_wrapped(self):
+        return self.__wraps__(**self.params)
+
     def fit(self, X, Y, W=None):
-        clf = self.__wraps__(**self.params)
+        clf = self._initialize_wrapped()
         Y = Y.reshape(-1)
         if W is None or not self.supports_weights:
             return self.__returns__(clf.fit(X, Y))

--- a/Orange/classification/neural_network.py
+++ b/Orange/classification/neural_network.py
@@ -5,5 +5,28 @@ from Orange.classification import SklLearner
 __all__ = ["NNClassificationLearner"]
 
 
+class NIterCallbackMixin:
+    orange_callback = None
+
+    @property
+    def n_iter_(self):
+        return self.__orange_n_iter
+
+    @n_iter_.setter
+    def n_iter_(self, v):
+        self.__orange_n_iter = v
+        if self.orange_callback:
+            self.orange_callback(v)
+
+
+class MLPClassifierWCallback(skl_nn.MLPClassifier, NIterCallbackMixin):
+    pass
+
+
 class NNClassificationLearner(NNBase, SklLearner):
-    __wraps__ = skl_nn.MLPClassifier
+    __wraps__ = MLPClassifierWCallback
+
+    def _initialize_wrapped(self):
+        clf = SklLearner._initialize_wrapped(self)
+        clf.orange_callback = getattr(self, "callback", None)
+        return clf

--- a/Orange/modelling/neural_network.py
+++ b/Orange/modelling/neural_network.py
@@ -8,3 +8,10 @@ __all__ = ['NNLearner']
 class NNLearner(SklFitter):
     __fits__ = {'classification': NNClassificationLearner,
                 'regression': NNRegressionLearner}
+
+    callback = None
+
+    def get_learner(self, problem_type):
+        learner = super().get_learner(problem_type)
+        learner.callback = self.callback
+        return learner

--- a/Orange/regression/neural_network.py
+++ b/Orange/regression/neural_network.py
@@ -1,9 +1,19 @@
 import sklearn.neural_network as skl_nn
 from Orange.base import NNBase
 from Orange.regression import SklLearner
+from Orange.classification.neural_network import NIterCallbackMixin
 
 __all__ = ["NNRegressionLearner"]
 
 
+class MLPRegressorWCallback(skl_nn.MLPRegressor, NIterCallbackMixin):
+    pass
+
+
 class NNRegressionLearner(NNBase, SklLearner):
-    __wraps__ = skl_nn.MLPRegressor
+    __wraps__ = MLPRegressorWCallback
+
+    def _initialize_wrapped(self):
+        clf = SklLearner._initialize_wrapped(self)
+        clf.orange_callback = getattr(self, "callback", None)
+        return clf

--- a/Orange/widgets/model/owneuralnetwork.py
+++ b/Orange/widgets/model/owneuralnetwork.py
@@ -87,7 +87,7 @@ class OWNNLearner(OWBaseLearner):
             label="Alpha:", decimals=5, alignment=Qt.AlignRight,
             callback=self.settings_changed, controlWidth=80)
         self.max_iter_spin = gui.spin(
-            box, self, "max_iterations", 10, 300, step=10,
+            box, self, "max_iterations", 10, 10000, step=10,
             label="Max iterations:", orientation=Qt.Horizontal,
             alignment=Qt.AlignRight, callback=self.settings_changed,
             controlWidth=80)

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -514,13 +514,16 @@ class WidgetLearnerTestMixin:
         self.assertEqual(self.widget.data, None)
         self.send_signal("Data", self.data)
         self.assertEqual(self.widget.data, self.data)
+        self.wait_until_stop_blocking()
 
     def test_input_data_disconnect(self):
         """Check widget's data and model after disconnecting data from input"""
         self.send_signal("Data", self.data)
         self.assertEqual(self.widget.data, self.data)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.send_signal("Data", None)
+        self.wait_until_stop_blocking()
         self.assertEqual(self.widget.data, None)
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
 
@@ -529,9 +532,11 @@ class WidgetLearnerTestMixin:
         for inadequate in self.inadequate_dataset:
             self.send_signal("Data", inadequate)
             self.widget.apply_button.button.click()
+            self.wait_until_stop_blocking()
             self.assertTrue(self.widget.Error.data_error.is_shown())
         for valid in self.valid_datasets:
             self.send_signal("Data", valid)
+            self.wait_until_stop_blocking()
             self.assertFalse(self.widget.Error.data_error.is_shown())
 
     def test_input_preprocessor(self):
@@ -542,6 +547,7 @@ class WidgetLearnerTestMixin:
             randomize, self.widget.preprocessors,
             'Preprocessor not added to widget preprocessors')
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.assertEqual(
             (randomize,), self.widget.learner.preprocessors,
             'Preprocessors were not passed to the learner')
@@ -551,6 +557,7 @@ class WidgetLearnerTestMixin:
         pp_list = PreprocessorList([Randomize(), RemoveNaNColumns()])
         self.send_signal("Preprocessor", pp_list)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.assertEqual(
             (pp_list,), self.widget.learner.preprocessors,
             '`PreprocessorList` was not added to preprocessors')
@@ -560,10 +567,12 @@ class WidgetLearnerTestMixin:
         randomize = Randomize()
         self.send_signal("Preprocessor", randomize)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.assertEqual(randomize, self.widget.preprocessors)
 
         self.send_signal("Preprocessor", None)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.assertIsNone(self.widget.preprocessors,
                           'Preprocessors not removed on disconnect.')
 
@@ -585,6 +594,7 @@ class WidgetLearnerTestMixin:
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.send_signal('Data', self.data)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
         self.assertIsNotNone(model)
         self.assertIsInstance(model, self.widget.LEARNER.__returns__)
@@ -598,6 +608,7 @@ class WidgetLearnerTestMixin:
                          self.widget.name_line_edit.text())
         self.widget.name_line_edit.setText(new_name)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.assertEqual(self.get_output("Learner").name, new_name)
 
     def test_output_model_name(self):
@@ -606,6 +617,7 @@ class WidgetLearnerTestMixin:
         self.widget.name_line_edit.setText(new_name)
         self.send_signal("Data", self.data)
         self.widget.apply_button.button.click()
+        self.wait_until_stop_blocking()
         self.assertEqual(self.get_output(self.widget.Outputs.model).name, new_name)
 
     def _get_param_value(self, learner, param):
@@ -626,6 +638,7 @@ class WidgetLearnerTestMixin:
         for dataset in self.valid_datasets:
             self.send_signal("Data", dataset)
             self.widget.apply_button.button.click()
+            self.wait_until_stop_blocking()
             for parameter in self.parameters:
                 # Skip if the param isn't used for the given data type
                 if self._should_check_parameter(parameter, dataset):
@@ -639,6 +652,7 @@ class WidgetLearnerTestMixin:
         # to only certain problem types
         for dataset in self.valid_datasets:
             self.send_signal("Data", dataset)
+            self.wait_until_stop_blocking()
 
             for parameter in self.parameters:
                 # Skip if the param isn't used for the given data type
@@ -650,6 +664,7 @@ class WidgetLearnerTestMixin:
                 for value in parameter.values:
                     parameter.set_value(value)
                     self.widget.apply_button.button.click()
+                    self.wait_until_stop_blocking()
                     param = self._get_param_value(self.widget.learner, parameter)
                     self.assertEqual(
                         param, parameter.get_value(),
@@ -674,6 +689,7 @@ class WidgetLearnerTestMixin:
         """Check that the learner gets updated whenever a param is changed."""
         for dataset in self.valid_datasets:
             self.send_signal("Data", dataset)
+            self.wait_until_stop_blocking()
 
             for parameter in self.parameters:
                 # Skip if the param isn't used for the given data type


### PR DESCRIPTION
##### Issue
In general, long computation shouldn't leave the GUI unresponsive. But the real issue is that I am not sure I can write threaded widgets, so I tried.

##### Description of changes
Implemented with the help of @ales-erjavec's example from the documentation with minor changes. Callbacks with scikit-learn are very hackish though. Does anybody have a better idea?

Just to test stopping, I also added a cancel button to the widget. Perhaps all interruptible widget should get a stop icon in the status bar and perhaps also some actionable "icon" on the canvas.  

##### Includes
- [X] Code changes
- [X] Fixed tests
- [ ] Documentation
