### PR TITLE
[FIX] Speed-up prediction by circumventing Instance-specific prediction.

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -242,12 +242,9 @@ class Model(Reprable):
             prediction = self.predict(np.atleast_2d(data))
         elif isinstance(data, scipy.sparse.csr.csr_matrix):
             prediction = self.predict(data)
-        elif isinstance(data, Instance):
-            if data.domain != self.domain:
-                data = Instance(self.domain, data)
-            data = Table(data.domain, [data])
-            prediction = self.predict_storage(data)
-        elif isinstance(data, Table):
+        elif isinstance(data, (Table, Instance)):
+            if isinstance(data, Instance):
+                data = Table(data.domain, [data])
             if data.domain != self.domain:
                 data = data.transform(self.domain)
             prediction = self.predict_storage(data)


### PR DESCRIPTION
##### Issue
Improves #2957 

##### Description of changes
Convert an Instance to a Table with a single row right from the start. Handling a Table with a single instance seems to be more efficient than handling an individual Instance, which results in several conversions to a Table anyway.

Speed-up in the case mentioned in #2957 is by more than a factor of 7.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
