### PR TITLE
[FIX] Vizrank: Properly shutdown/wait when parent deleted

### DIFF
--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -182,6 +182,10 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin):
 
         def deleteEvent():
             vizrank.keep_running = False
+            if vizrank._thread is not None and vizrank._thread.isRunning():
+                vizrank._thread.quit()
+                vizrank._thread.wait()
+
             master_delete_event()
 
         master.closeEvent = closeEvent

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -86,7 +86,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin):
 
     def __init__(self, master):
         """Initialize the attributes and set up the interface"""
-        QDialog.__init__(self, windowTitle=self.captionTitle)
+        QDialog.__init__(self, master, windowTitle=self.captionTitle)
         WidgetMessagesMixin.__init__(self)
         self.setLayout(QVBoxLayout())
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

*File -> Scatter Plot*

Run the vizrank dialog (on fairly large data), while the vizrank still runs delete the scatter plot from the canvas. The following error occurs:

```
--------------------------- RuntimeError Exception ----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/utils/__init__.py", line 169, in <lambda>
    vizrank.selectionChanged.connect(lambda args: set_attr_callback(*args))
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owscatterplot.py", line 371, in set_attr
    self.attr_x, self.attr_y = attr_x, attr_y
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 182, in __setattr__
    callback(value)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 2361, in __call__
    self.action(*args)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 2429, in action
    self.control.setCurrentIndex(self.model.indexOf(value))
RuntimeError: wrapped C/C++ object of type OrangeComboBox has been deleted
````
 
##### Description of changes

Wait for for completion when the widget is deleted.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
