### PR TITLE
[FIX] domaineditor: Give the VarTableModel a parent

### DIFF
--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -40,8 +40,8 @@ class VarTableModel(QAbstractTableModel):
     name2type = dict(zip(typenames, vartypes))
     type2name = dict(zip(vartypes, typenames))
 
-    def __init__(self, variables):
-        super().__init__()
+    def __init__(self, variables, *args):
+        super().__init__(*args)
         self.variables = variables
 
     def set_variables(self, variables):
@@ -186,7 +186,8 @@ class DomainEditor(QTableView):
         widget.contextOpened.connect(lambda: self.model().set_variables(self.variables))
         widget.contextClosed.connect(lambda: self.model().set_variables([]))
 
-        self.setModel(VarTableModel(self.variables))
+        self.setModel(VarTableModel(self.variables, self))
+
         self.setSelectionMode(QTableView.NoSelection)
         self.horizontalHeader().setStretchLastSection(True)
         self.setShowGrid(False)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

OWFile creates a uncollectable ref cycle by connecting the [VarTableModel.dataChanged](https://github.com/biolab/orange3/blob/468e3faae26ff7115bcae190241cdd888edca2f7/Orange/widgets/data/owfile.py#L212) to a lambda capturing self (and the VarTableModel instance) in the closure.

##### Description of changes

Make the VarTableModel a child of the DomainEditor so it is destroyed with it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
