### PR TITLE
[FIX] WidgetManager: Schedule delayed deletion for managed OWWidgets

### DIFF
--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -581,6 +581,7 @@ class WidgetManager(QObject):
                 widget.close()
                 widget.saveSettings()
                 widget.onDeleteWidget()
+                widget.deleteLater()
 
             event.accept()
             return True


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When the canvas editor creates a new workflow (via *New* or *Open* actions) the old OWWidgets are not deleted (promptly or even ever), like they are when explicitly deleted from the workflow.

##### Description of changes

Call deleteLater for managed widgets when the whole workflow is discarded.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
