### PR TITLE
Table.from_table: do not copy ids or weights

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -397,12 +397,12 @@ class Table(MutableSequence, Storage):
                 if self.metas.ndim == 1:
                     self.metas = self.metas.reshape(-1, len(self.domain.metas))
                 if source.has_weights():
-                    self.W = np.array(source.W[row_indices])
+                    self.W = source.W[row_indices]
                 else:
                     self.W = np.empty((n_rows, 0))
                 self.name = getattr(source, 'name', '')
                 if hasattr(source, 'ids'):
-                    self.ids = np.array(source.ids[row_indices])
+                    self.ids = source.ids[row_indices]
                 else:
                     cls._init_ids(self)
                 self.attributes = getattr(source, 'attributes', {})


### PR DESCRIPTION
##### Issue
C library can allocates memory in a way where is not returned to the system and therefore the python process seems to leak memory (which is not true - the space can be reused by the same python process). At least on linux, this depends on size of allocated memory:
http://www.gnu.org/software/libc/manual/html_node/Malloc-Tunable-Parameters.htm

My file had 16384 instances and 1608 features. Therefore for SklImpute, from_table internally copied size 16384 array 1608 times, which is afterwards not be released to the system.

With parameter `MALLOC_MMAP_THRESHOLD_` (from the link above) I can get different kinds of behavior for my program:

1. export MALLOC_MMAP_THRESHOLD_=130000 - force mmap for my ids arrays - final memory usage: **131 MB**
2. export MALLOC_MMAP_THRESHOLD_=200000 - force the system not to use mmap for my ids arrays - final memory usage: **334 MB**
3. unset MALLOC_MMAP_THRESHOLD_ - my system uses some heuristics - final memory usage: **334 MB** 

With this PR  I always end with around **130 MB**.

##### Description of changes
`ids` and `weights` and not explicitly  copied anymore in `from_table`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
