### PR TITLE
addons: remove support for old bioinformatics

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -47,7 +47,7 @@ from ..help.manager import get_dist_meta, trim, parse_meta
 log = logging.getLogger(__name__)
 
 OFFICIAL_ADDONS = [
-    "Orange-Bioinformatics",
+    "Orange3-Bioinformatics",
     "Orange3-Prototypes",
     "Orange3-Text",
     "Orange3-Network",


### PR DESCRIPTION
##### Issue
Orange3-Bioinformatics does not list as trusted. Bioinformatics add-on prior to version 3.0.0 is not supported anymore.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
