### PR TITLE
settings: include SettingProvider in __all__

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -46,7 +46,7 @@ from Orange.widgets.utils import vartype
 
 log = logging.getLogger(__name__)
 
-__all__ = ["Setting", "SettingsHandler",
+__all__ = ["Setting", "SettingsHandler", "SettingProvider",
            "ContextSetting", "ContextHandler",
            "DomainContextHandler", "PerfectDomainContextHandler",
            "ClassValuesContextHandler", "widget_settings_dir"]


### PR DESCRIPTION
module members not included in `__all__` are considered private.
SettingProvider is used in widgets to declare subcomponents and should
therefore be included in `__all__`.