### PR TITLE
addons: catch OSError in have_install_permission

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -756,7 +756,7 @@ def have_install_permissions():
             pass
         os.remove(fn)
         return True
-    except PermissionError:
+    except OSError:
         return False
 
 


### PR DESCRIPTION
PermissionError is just one of the possible errors that can be raised from a failed open attempt. When one of the other errors occurs, an error was
shown (as can be seen on sentry)
