### PR TITLE
FloatSlider: fix rounding of values

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -3233,8 +3233,8 @@ class FloatSlider(QSlider):
         self.setSingleStep(1)
         if self.min_value != self.max_value:
             self.setEnabled(True)
-            self.setMinimum(int(self.min_value / self.step))
-            self.setMaximum(int(self.max_value / self.step))
+            self.setMinimum(int(round(self.min_value / self.step)))
+            self.setMaximum(int(round(self.max_value / self.step)))
         else:
             self.setEnabled(False)
 
@@ -3250,7 +3250,7 @@ class FloatSlider(QSlider):
         Args:
             value: new value
         """
-        super().setValue(value // self.step)
+        super().setValue(int(round(value / self.step)))
 
     def setScale(self, minValue, maxValue, step=0):
         """

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -1,3 +1,5 @@
+from AnyQt.QtCore import Qt
+
 from Orange.data import ContinuousVariable
 from Orange.widgets import gui
 from Orange.widgets.tests.base import GuiTest
@@ -70,6 +72,17 @@ class TestListModel(GuiTest):
         selection = view.selectedIndexes()
         self.assertEqual(len(selection), 2)
         self.assertEqual({selection[0].row(), selection[1].row()}, {1, 2})
+
+
+class TestFloatSlider(GuiTest):
+
+    def test_set_value(self):
+        w = gui.FloatSlider(Qt.Horizontal, 0., 1., 0.5)
+        w.setValue(1)
+        self.assertEqual(w.value(), 2)
+        w = gui.FloatSlider(Qt.Horizontal, 0., 1., 0.05)
+        w.setValue(1)
+        self.assertEqual(w.value(), 20)
 
 
 class ComboBoxTest(GuiTest):

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -79,9 +79,12 @@ class TestFloatSlider(GuiTest):
     def test_set_value(self):
         w = gui.FloatSlider(Qt.Horizontal, 0., 1., 0.5)
         w.setValue(1)
+        # Float slider returns value divided by step
+        # 1/0.5 = 2
         self.assertEqual(w.value(), 2)
         w = gui.FloatSlider(Qt.Horizontal, 0., 1., 0.05)
         w.setValue(1)
+        # 1/0.05 = 20
         self.assertEqual(w.value(), 20)
 
 


### PR DESCRIPTION
##### Issue
FloatSliders can show a different values than stored (sometimes they are moved 1 step too much towards left). @stuart-cls, for the report.

##### Description of changes
Method set_value now avoid the // operator which can return wrong
results:
1.0//0.5 = 2 (as expected, what we would want)
1.0//0.05 = 19 (we would like to see 20 there)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
