### PR TITLE
[FIX] Feature constructor did not restore features when loading from saved workflow

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -317,9 +317,14 @@ class FeatureConstructorHandler(DomainContextHandler):
         except Exception:
             return False
 
-        for name in freevars(exp_ast, []):
-            if not (name in attrs or name in metas):
-                return False
+        available = dict(globals()["__GLOBALS"])
+        for var in attrs:
+            available[sanitized_name(var)] = None
+        for var in metas:
+            available[sanitized_name(var)] = None
+
+        if freevars(exp_ast, available):
+            return False
         return True
 
 

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -277,8 +277,28 @@ class FeatureConstructorHandlerTests(unittest.TestCase):
         self.assertTrue(
             FeatureConstructorHandler().is_valid_item(
                 OWFeatureConstructor.descriptors,
-                StringDescriptor("X", "str(A)"),
+                StringDescriptor("X", "str(A) + str(B)"),
                 {"A": vartype(DiscreteVariable)},
+                {"B": vartype(DiscreteVariable)}
+            )
+        )
+
+        # no variables is also ok
+        self.assertTrue(
+            FeatureConstructorHandler().is_valid_item(
+                OWFeatureConstructor.descriptors,
+                StringDescriptor("X", "str('foo')"),
+                {},
+                {}
+            )
+        )
+
+        # should fail on unknown variables
+        self.assertFalse(
+            FeatureConstructorHandler().is_valid_item(
+                OWFeatureConstructor.descriptors,
+                StringDescriptor("X", "str(X)"),
+                {},
                 {}
             )
         )

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -10,11 +10,12 @@ import numpy as np
 from Orange.data import (Table, Domain, StringVariable,
                          ContinuousVariable, DiscreteVariable)
 from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.utils import vartype
 from Orange.widgets.utils.itemmodels import PyListModel
 from Orange.widgets.data.owfeatureconstructor import (
     DiscreteDescriptor, ContinuousDescriptor, StringDescriptor,
     construct_variables, OWFeatureConstructor,
-    FeatureEditor, DiscreteFeatureEditor)
+    FeatureEditor, DiscreteFeatureEditor, FeatureConstructorHandler)
 
 from Orange.widgets.data.owfeatureconstructor import (
     freevars, validate_exp, FeatureFunc
@@ -269,3 +270,25 @@ class TestFeatureEditor(unittest.TestCase):
     def test_has_functions(self):
         self.assertIs(FeatureEditor.FUNCTIONS["abs"], abs)
         self.assertIs(FeatureEditor.FUNCTIONS["sqrt"], math.sqrt)
+
+
+class FeatureConstructorHandlerTests(unittest.TestCase):
+    def test_handles_builtins_in_expression(self):
+        self.assertTrue(
+            FeatureConstructorHandler().is_valid_item(
+                OWFeatureConstructor.descriptors,
+                StringDescriptor("X", "str(A)"),
+                {"A": vartype(DiscreteVariable)},
+                {}
+            )
+        )
+
+    def test_handles_special_characters_in_var_names(self):
+        self.assertTrue(
+            FeatureConstructorHandler().is_valid_item(
+                OWFeatureConstructor.descriptors,
+                StringDescriptor("X", "A_2_f"),
+                {"A.2 f": vartype(DiscreteVariable)},
+                {}
+            )
+        )


### PR DESCRIPTION
##### Issue
When feature expression in feature constructor widget contained anything else than simple variable names, they were not restored when opening a saved workflow.

##### Description of changes
Update matching logic to support variable names containing special characters and usage of builtin functions.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
