### PR TITLE
[FIX] Add-ons working again (PyPI JSON interface + local official index)

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -778,7 +778,7 @@ class PipInstaller:
     def install(self, pkg):
         cmd = ["python", "-m", "pip", "install"]
         cmd.extend(self.arguments)
-        if pkg.package_url.startswith("http://"):
+        if pkg.package_url.startswith("http://") or pkg.package_url.startswith("https://"):
             cmd.append(pkg.name)
         else:
             # Package url is path to the (local) wheel

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -650,13 +650,17 @@ def list_available_versions():
 
     packages = []
     for addon in addons:
-        info = addon["info"]
-        packages.append(
-            Installable(info["name"], info["version"],
-                        info["summary"], info["description"],
-                        info["package_url"],
-                        info["package_url"])
-        )
+        try:
+            info = addon["info"]
+            packages.append(
+                Installable(info["name"], info["version"],
+                            info["summary"], info["description"],
+                            info["package_url"],
+                            info["package_url"])
+            )
+        except (TypeError, KeyError):
+            continue  # skip invalid packages
+
     return packages
 
 


### PR DESCRIPTION
##### Issue
The add-ons dialog can not find add-ons after the pypi.org server upgrade (#3001).

pypi announcement: https://mail.python.org/mm3/archives/list/pypi-announce@python.org/thread/JCNO7SWQTKY54MKOZQ22PV3TUJGRM3GR/

##### Description of changes
Official add-on list is now hosted on orange.biolab.si

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
