### PR TITLE
[FIX] boxplot labels overlap

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -610,9 +610,6 @@ class OWBoxPlot(widget.OWWidget):
                          y - label.boundingRect().height() - 8)
             label.setMaxWidth(bar_part.boundingRect().width())
             self.box_scene.addItem(label)
-        if label is not None and bar_part.boundingRect().width() >= label.MIN_LABEL_WIDTH:
-            # last label in row can extend beyond its bar
-            label.setMaxWidth(None)
 
     def __draw_bars(self, y, bars):
         """Draw bars

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -541,43 +541,93 @@ class OWBoxPlot(widget.OWWidget):
 
         for row, box in enumerate(self.boxes):
             y = (-len(self.boxes) + row) * 40 + 10
+            bars, labels = box[::2], box[1::2]
 
-            label = self.attr_labels[row]
-            b = label.boundingRect()
-            label.setPos(-b.width() - 10, y - b.height() / 2)
-            self.box_scene.addItem(label)
+            self.__draw_group_labels(y, row)
             if not self.stretched:
-                label = self.labels[row]
-                b = label.boundingRect()
-                if self.group_var:
-                    right = self.scale_x * sum(self.conts[row])
-                else:
-                    right = self.scale_x * sum(self.dist)
-                label.setPos(right + 10, y - b.height() / 2)
-                self.box_scene.addItem(label)
-
+                self.__draw_row_counts(y, row)
             if self.show_labels and self.attribute is not self.group_var:
-                label = None
-                for text_item, bar_part in zip(box[1::2], box[::2]):
-                    label = self.Label(
-                        text_item.toPlainText())
-                    label.setPos(bar_part.boundingRect().x(),
-                                 y - label.boundingRect().height() - 8)
-                    label.setMaxWidth(bar_part.boundingRect().width())
-                    self.box_scene.addItem(label)
-                if label is not None and bar_part.boundingRect().width() >= label.MIN_LABEL_WIDTH:
-                    # last label in row can extend beyond its bar
-                    label.setMaxWidth(None)
-            for item in box:
-                if isinstance(item, QGraphicsTextItem):
-                    continue
-                self.box_scene.addItem(item)
-                item.setPos(0, y)
+                self.__draw_bar_labels(y, bars, labels)
+            self.__draw_bars(y, bars)
+
         self.box_scene.setSceneRect(-self.label_width - 5,
                                     -30 - len(self.boxes) * 40,
                                     self.scene_width, len(self.boxes * 40) + 90)
         self.infot1.setText("")
         self.select_box_items()
+
+    def __draw_group_labels(self, y, row):
+        """Draw group labels
+
+        Parameters
+        ----------
+        y: int
+            vertical offset of bars
+        row: int
+            row index
+        """
+        label = self.attr_labels[row]
+        b = label.boundingRect()
+        label.setPos(-b.width() - 10, y - b.height() / 2)
+        self.box_scene.addItem(label)
+
+    def __draw_row_counts(self, y, row):
+        """Draw row counts
+
+        Parameters
+        ----------
+        y: int
+            vertical offset of bars
+        row: int
+            row index
+        """
+        label = self.labels[row]
+        b = label.boundingRect()
+        if self.group_var:
+            right = self.scale_x * sum(self.conts[row])
+        else:
+            right = self.scale_x * sum(self.dist)
+        label.setPos(right + 10, y - b.height() / 2)
+        self.box_scene.addItem(label)
+
+    def __draw_bar_labels(self, y, bars, labels):
+        """Draw bar labels
+
+        Parameters
+        ----------
+        y: int
+            vertical offset of bars
+        bars: List[FilterGraphicsRectItem]
+            list of bars being drawn
+        labels: List[QGraphicsTextItem]
+            list of labels for corresponding bars
+        """
+        label = bar_part = None
+        for text_item, bar_part in zip(labels, bars):
+            label = self.Label(
+                text_item.toPlainText())
+            label.setPos(bar_part.boundingRect().x(),
+                         y - label.boundingRect().height() - 8)
+            label.setMaxWidth(bar_part.boundingRect().width())
+            self.box_scene.addItem(label)
+        if label is not None and bar_part.boundingRect().width() >= label.MIN_LABEL_WIDTH:
+            # last label in row can extend beyond its bar
+            label.setMaxWidth(None)
+
+    def __draw_bars(self, y, bars):
+        """Draw bars
+
+        Parameters
+        ----------
+        y: int
+            vertical offset of bars
+
+        bars: List[FilterGraphicsRectItem]
+            list of bars to draw
+        """
+        for item in bars:
+            item.setPos(0, y)
+            self.box_scene.addItem(item)
 
     # noinspection PyPep8Naming
     def compute_tests(self):

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from AnyQt.QtCore import QItemSelectionModel
+from AnyQt.QtTest import QTest
 
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain
 from Orange.widgets.visualize.owboxplot import OWBoxPlot, FilterGraphicsRectItem
@@ -158,6 +159,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         self.__select_variable("chest pain")
         self.__select_group("gender")
         self.widget.show()
+        QTest.qWait(3000)
         self.widget.hide()
 
     def _select_data(self):

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 
 import numpy as np
+from AnyQt.QtCore import QItemSelectionModel
 
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain
 from Orange.widgets.visualize.owboxplot import OWBoxPlot, FilterGraphicsRectItem
@@ -88,11 +89,6 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
             m.setCurrentIndex(group_list.model().index(i), m.ClearAndSelect)
             self._select_list_items(self.widget.controls.attribute)
 
-    def _select_list_items(self, _list):
-        model = _list.selectionModel()
-        for i in range(len(_list.model())):
-            model.setCurrentIndex(_list.model().index(i), model.ClearAndSelect)
-
     def test_apply_sorting(self):
         controls = self.widget.controls
         group_list = controls.group_var
@@ -148,6 +144,22 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         np.testing.assert_array_equal(self.get_output(self.widget.Outputs.selected_data).X,
                                       self.data.X[selected_indices])
 
+    def test_continuous_metas(self):
+        domain = self.iris.domain
+        metas = domain.attributes[:-1] + (StringVariable("str"),)
+        domain = Domain([], domain.class_var, metas)
+        data = Table.from_table(domain, self.iris)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.widget.controls.order_by_importance.setChecked(True)
+
+    def test_label_overlap(self):
+        self.send_signal(self.widget.Inputs.data, self.heart)
+        self.widget.stretched = False
+        self.__select_variable("chest pain")
+        self.__select_group("gender")
+        self.widget.show()
+        self.widget.hide()
+
     def _select_data(self):
         items = [item for item in self.widget.box_scene.items()
                  if isinstance(item, FilterGraphicsRectItem)]
@@ -156,10 +168,27 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
                 120, 123, 124, 126, 128, 132, 133, 136, 137,
                 139, 140, 141, 143, 144, 145, 146, 147, 148]
 
-    def test_continuous_metas(self):
-        domain = self.iris.domain
-        metas = domain.attributes[:-1] + (StringVariable("str"),)
-        domain = Domain([], domain.class_var, metas)
-        data = Table.from_table(domain, self.iris)
-        self.send_signal(self.widget.Inputs.data, data)
-        self.widget.controls.order_by_importance.setChecked(True)
+    def _select_list_items(self, _list):
+        model = _list.selectionModel()
+        for i in range(len(_list.model())):
+            model.setCurrentIndex(_list.model().index(i), model.ClearAndSelect)
+
+    def __select_variable(self, name, widget=None):
+        if widget is None:
+            widget = self.widget
+
+        self.__select_value(widget.controls.attribute, name)
+
+    def __select_group(self, name, widget=None):
+        if widget is None:
+            widget = self.widget
+
+        self.__select_value(widget.controls.group_var, name)
+
+    def __select_value(self, list, value):
+        m = list.model()
+        for i in range(m.rowCount()):
+            idx = m.index(i)
+            if m.data(idx) == value:
+                list.selectionModel().setCurrentIndex(
+                    idx, QItemSelectionModel.ClearAndSelect)


### PR DESCRIPTION
##### Issue
When labels are wider than their respective bars in a boxplot, labels overlap:

<img width="550" alt="screen shot 2018-04-19 at 15 39 12" src="https://user-images.githubusercontent.com/588601/38995009-283ef68c-43e8-11e8-94a7-16955061c8d6.png">

##### Description of changes
Limit  (all but the last) label width to the width of the bar they are labelling. Hide labels for very short bars (unless the whole label can be displayed in available space).

<img width="553" alt="screen shot 2018-04-19 at 20 49 11" src="https://user-images.githubusercontent.com/588601/39011930-2c613830-4413-11e8-8f85-227eab69f5a9.png">

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
