### PR TITLE
travis: pin pandas to 0.20.3 for Python3.4 tests

### DIFF
--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -3,6 +3,8 @@ foldable pip install -U setuptools pip codecov
 # Don't install PyQt5 if PyQt4 is requested
 [ "$PYQT4" ] && sed -i '/pyqt5/Id' requirements-doc.txt
 
+if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install pandas==0.20.3; fi
+
 # Install dependencies sequentially
 cat requirements-core.txt \
     requirements-gui.txt \


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Travis unitests fails since Pandas in the latest versions do not support Python3.4

##### Description of changes

Downgraded Pandas to version 0.20.3 which is the last version that supports Python3.4 for tests that run in Python3.4

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
