### PR TITLE
[FIX] Sorting add-ons in the alphabetical order

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -311,6 +311,7 @@ class AddonManagerWidget(QWidget):
                 self.__view.model().index(0, 0),
                 QItemSelectionModel.Select | QItemSelectionModel.Rows
             )
+        self.__proxy.sort(1)  # sorting list of add-ons in alphabetical order
 
     def item_state(self):
         steps = []


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Add-ons are in unpredictable order https://github.com/biolab/orange3/issues/3007

##### Description of changes
Sorting add-ons in the alphabetical order

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
