### PR TITLE
[ENH] Data Info widget displays data attributes

### DIFF
--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -37,7 +37,7 @@ class OWDataInfo(widget.OWWidget):
         self.data_set_size = self.features = self.meta_attributes = ""
         self.location = ""
         for box in ("Data Set Size", "Features", "Targets", "Meta Attributes",
-                    "Location"):
+                    "Location", "Data Attributes"):
             name = box.lower().replace(" ", "_")
             bo = gui.vBox(self.controlArea, box,
                           addSpace=False and box != "Meta Attributes")
@@ -54,6 +54,7 @@ class OWDataInfo(widget.OWWidget):
         self.layout().setSizeConstraint(QtWidgets.QLayout.SetFixedSize)
 
         self.targets = ""
+        self.data_attributes = ""
         self.data_desc = None
 
     @Inputs.data
@@ -179,9 +180,13 @@ class OWDataInfo(widget.OWWidget):
             ("{} textual", str_metas)
         ))
 
+        if data.attributes:
+            self.data_attributes = pack_table(data.attributes.items())
+
     def send_report(self):
         if self.data_desc:
             self.report_items(self.data_desc)
+
 
 if __name__ == "__main__":
     a = QtWidgets.QApplication([])

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 import threading
 
 from AnyQt import QtWidgets
-from AnyQt import QtCore
 
 from Orange.widgets import widget, gui
 from Orange.widgets.widget import Input
@@ -65,13 +64,10 @@ class OWDataInfo(widget.OWWidget):
         def count(s, tpe):
             return sum(isinstance(x, tpe) for x in s)
 
-        def count_n(s, tpe):
-            return n_or_none(count(s, tpe))
-
-        def pack_table(data):
+        def pack_table(info):
             return "<table>\n" + "\n".join(
                 '<tr><td align="right" width="90">%s:</td>\n'
-                '<td width="40">%s</td></tr>\n' % dv for dv in data
+                '<td width="40">%s</td></tr>\n' % dv for dv in info
             ) + "</table>\n"
 
         if data is None:
@@ -79,24 +75,25 @@ class OWDataInfo(widget.OWWidget):
             self.features = self.targets = self.meta_attributes = "None"
             self.location = ""
             self.data_desc = None
+            self.data_attributes = ""
             return
 
-        sparses = [s for s, m in (("features", data.X_density),
-                                  ("meta attributes", data.metas_density),
-                                  ("targets", data.Y_density)) if m() > 1]
-        if sparses:
-            sparses = "<p>Sparse representation: %s</p>" % ", ".join(sparses)
+        sparseness = [s for s, m in (("features", data.X_density),
+                                     ("meta attributes", data.metas_density),
+                                     ("targets", data.Y_density)) if m() > 1]
+        if sparseness:
+            sparseness = "<p>Sparse representation: %s</p>" % ", ".join(sparseness)
         else:
-            sparses = ""
+            sparseness = ""
         domain = data.domain
         self.data_set_size = pack_table((
             ("Rows", '~{}'.format(data.approx_len())),
-            ("Variables", len(domain)))) + sparses
+            ("Columns", len(domain)+len(domain.metas)))) + sparseness
 
         def update_size():
             self.data_set_size = pack_table((
                 ("Rows", len(data)),
-                ("Variables", len(domain)))) + sparses
+                ("Columns", len(domain)+len(domain.metas)))) + sparseness
 
         threading.Thread(target=update_size).start()
 
@@ -132,13 +129,13 @@ class OWDataInfo(widget.OWWidget):
             disc_class = count(domain.class_vars, DiscreteVariable)
             cont_class = count(domain.class_vars, ContinuousVariable)
             if not cont_class:
-                self.targets = "Multitarget data,\n%i categorical targets" % \
+                self.targets = "Multi-target data,\n%i categorical targets" % \
                                n_or_none(disc_class)
             elif not disc_class:
-                self.targets = "Multitarget data,\n%i numeric targets" % \
+                self.targets = "Multi-target data,\n%i numeric targets" % \
                                n_or_none(cont_class)
             else:
-                self.targets = "<p>Multi target data</p>\n" + pack_table(
+                self.targets = "<p>Multi-target data</p>\n" + pack_table(
                     (("Categorical", disc_class), ("Numeric", cont_class)))
 
         self.data_desc = dd = OrderedDict()

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 import threading
+import textwrap
 
 from AnyQt import QtWidgets
 
@@ -65,9 +66,10 @@ class OWDataInfo(widget.OWWidget):
             return sum(isinstance(x, tpe) for x in s)
 
         def pack_table(info):
-            return "<table>\n" + "\n".join(
+            return '<table>\n' + "\n".join(
                 '<tr><td align="right" width="90">%s:</td>\n'
-                '<td width="40">%s</td></tr>\n' % dv for dv in info
+                '<td width="40">%s</td></tr>\n' % (d, textwrap.shorten(str(v), width=30, placeholder="..."))
+                for d, v in info
             ) + "</table>\n"
 
         if data is None:
@@ -179,6 +181,8 @@ class OWDataInfo(widget.OWWidget):
 
         if data.attributes:
             self.data_attributes = pack_table(data.attributes.items())
+        else:
+            self.data_attributes = ""
 
     def send_report(self):
         if self.data_desc:

--- a/Orange/widgets/data/tests/test_owdatainfo.py
+++ b/Orange/widgets/data/tests/test_owdatainfo.py
@@ -10,7 +10,7 @@ class TestOWDataInfo(WidgetTest):
         self.widget = self.create_widget(OWDataInfo)
 
     def test_data(self):
-        """No crash on empty data"""
+        """No crash on iris"""
         data = Table("iris")
         self.send_signal(self.widget.Inputs.data, data)
 

--- a/Orange/widgets/data/tests/test_owdatainfo.py
+++ b/Orange/widgets/data/tests/test_owdatainfo.py
@@ -1,0 +1,26 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+from Orange.data import Table
+from Orange.widgets.data.owdatainfo import OWDataInfo
+from Orange.widgets.tests.base import WidgetTest
+
+
+class TestOWDataInfo(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWDataInfo)
+
+    def test_data(self):
+        """No crash on empty data"""
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, data)
+
+    def test_empty_data(self):
+        """No crash on empty data"""
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, Table(data.domain))
+
+    def test_data_attributes(self):
+        """No crash on data attributes of different types"""
+        data = Table("iris")
+        data.attributes = {"att 1": 1, "att 2": True, "att 3": 3}
+        self.send_signal(self.widget.Inputs.data, data)


### PR DESCRIPTION
##### Issue
Some data in orange contain meta information about the data table. For instance, bioinformatics add-on passes the data on the organism or location of gene names by adding this information in .attributes field of the Orange data table. While this information is used in practically all bioinformatics widgets, there is no widget that would explicitly display this information.

##### Description of changes
The box Data Attributes was added to the widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
