### PR TITLE
[ENH] Display Widgets on Top option

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -616,6 +616,13 @@ class CanvasMainWindow(QMainWindow):
             QAction(self.tr("Reset Widget Settings..."), self,
                     triggered=self.reset_widget_settings)
 
+        self.float_widgets_on_top_action = \
+            QAction(self.tr("Float Widgets on Top"), self,
+                    checkable=True,
+                    toolTip=self.tr("Widgets are always displayed above other windows."))
+        self.float_widgets_on_top_action.toggled.connect(
+            self.set_float_widgets_on_top_enabled)
+
     def setup_menu(self):
         if sys.platform == "darwin" and QT_VERSION >= 0x50000:
             self.__menu_glob = QMenuBar(None)
@@ -694,6 +701,7 @@ class CanvasMainWindow(QMainWindow):
         self.view_menu.addSeparator()
 
         self.view_menu.addAction(self.toogle_margins_action)
+        self.view_menu.addAction(self.float_widgets_on_top_action)
         menu_bar.addMenu(self.view_menu)
 
         # Options menu
@@ -758,6 +766,10 @@ class CanvasMainWindow(QMainWindow):
 
         self.canvas_tool_dock.setQuickHelpVisible(
             settings.value("quick-help/visible", True, type=bool)
+        )
+
+        self.float_widgets_on_top_action.setChecked(
+            settings.value("widgets-float-on-top", False, type=bool)
         )
 
         self.__update_from_settings()
@@ -1654,6 +1666,14 @@ class CanvasMainWindow(QMainWindow):
                 message_information(
                     "Settings will still be reset at next application start",
                     parent=self)
+
+    def set_float_widgets_on_top_enabled(self, enabled):
+        wm = self.current_document().scheme().widget_manager
+
+        settings = QSettings()
+        settings.setValue("mainwindow/widgets-float-on-top", bool(enabled))
+        wm.show_widgets_on_top_changed()
+
 
     def show_report_view(self):
         from Orange.canvas.report.owreport import OWReport

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -617,7 +617,7 @@ class CanvasMainWindow(QMainWindow):
                     triggered=self.reset_widget_settings)
 
         self.float_widgets_on_top_action = \
-            QAction(self.tr("Float Widgets on Top"), self,
+            QAction(self.tr("Display Widgets on Top"), self,
                     checkable=True,
                     toolTip=self.tr("Widgets are always displayed above other windows."))
         self.float_widgets_on_top_action.toggled.connect(

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1669,11 +1669,7 @@ class CanvasMainWindow(QMainWindow):
 
     def set_float_widgets_on_top_enabled(self, enabled):
         wm = self.current_document().scheme().widget_manager
-
-        settings = QSettings()
-        settings.setValue("mainwindow/widgets-float-on-top", bool(enabled))
-        wm.show_widgets_on_top_changed()
-
+        wm.set_float_widgets_on_top(enabled)
 
     def show_report_view(self):
         from Orange.canvas.report.owreport import OWReport
@@ -1842,6 +1838,8 @@ class CanvasMainWindow(QMainWindow):
 
         settings.setValue("quick-help/visible",
                           self.canvas_tool_dock.quickHelpVisible())
+        settings.setValue("widgets-float-on-top",
+                          self.float_widgets_on_top_action.isChecked())
 
         settings.endGroup()
         self.help_dock.close()
@@ -1993,6 +1991,11 @@ class CanvasMainWindow(QMainWindow):
         self.num_recent_schemes = settings.value("num-recent-schemes",
                                                  defaultValue=15,
                                                  type=int)
+
+        float_widgets_on_top = settings.value("widgets-float-on-top",
+                                              defaultValue=False,
+                                              type=bool)
+        self.set_float_widgets_on_top_enabled(float_widgets_on_top)
 
         settings.endGroup()
         settings.beginGroup("quickmenu")

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -937,6 +937,7 @@ class CanvasMainWindow(QMainWindow):
         window.restoreState(self.saveState(self.SETTINGS_VERSION),
                             self.SETTINGS_VERSION)
         window.set_tool_dock_expanded(self.dock_widget.expanded())
+        window.set_float_widgets_on_top_enabled(self.float_widgets_on_top_action.isChecked())
 
         logview = window.log_view()  # type: OutputView
         te = logview.findChild(QPlainTextEdit)
@@ -1668,6 +1669,9 @@ class CanvasMainWindow(QMainWindow):
                     parent=self)
 
     def set_float_widgets_on_top_enabled(self, enabled):
+        if self.float_widgets_on_top_action.isChecked() != enabled:
+            self.float_widgets_on_top_action.setChecked(enabled)
+
         wm = self.current_document().scheme().widget_manager
         wm.set_float_widgets_on_top(enabled)
 

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -85,6 +85,9 @@ spec = \
       "Use a popover menu to select a widget when clicking on a category "
       "button"),
 
+     ("mainwindow/widgets-float-on-top", bool, False,
+      "Float widgets on top of other windows"),
+
      ("mainwindow/number-of-recent-schemes", int, 15,
       "Number of recent workflows to keep in history"),
 

--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -258,8 +258,10 @@ class WidgetManager(QObject):
         # Tracks the widget in the update loop by the SignalManager
         self.__updating_widget = None
 
-        # disables/enables widget floating when app (de)activates
-        qApp.applicationStateChanged.connect(self.show_widgets_on_top_changed)
+        if hasattr(qApp, "applicationStateChanged"):
+            # disables/enables widget floating when app (de)activates
+            # available in Qt >= 5.2
+            qApp.applicationStateChanged.connect(self.show_widgets_on_top_changed)
 
     def set_scheme(self, scheme):
         """
@@ -809,7 +811,10 @@ class WidgetManager(QObject):
         """Set or unset widget's float on top flag"""
         settings = QSettings()
         should_float_on_top = settings.value("mainwindow/widgets-float-on-top", False, type=bool)
-        should_float_on_top &= qApp.applicationState() == Qt.ApplicationActive
+        if hasattr(qApp, "applicationState"):
+            # only float on top when the application is active
+            # available in Qt >= 5.2
+            should_float_on_top &= qApp.applicationState() == Qt.ApplicationActive
         float_on_top = widget.windowFlags() & Qt.WindowStaysOnTopHint
 
         if float_on_top == should_float_on_top:

--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -25,7 +25,7 @@ from urllib.parse import urlencode
 
 import sip
 
-from AnyQt.QtWidgets import QWidget, QShortcut, QLabel, QSizePolicy, QAction
+from AnyQt.QtWidgets import QWidget, QShortcut, QLabel, QSizePolicy, QAction, qApp
 from AnyQt.QtGui import QKeySequence, QWhatsThisClickedEvent
 
 from AnyQt.QtCore import Qt, QObject, QCoreApplication, QTimer, QEvent, QSettings
@@ -257,6 +257,9 @@ class WidgetManager(QObject):
 
         # Tracks the widget in the update loop by the SignalManager
         self.__updating_widget = None
+
+        # disables/enables widget floating when app (de)activates
+        qApp.applicationStateChanged.connect(self.show_widgets_on_top_changed)
 
     def set_scheme(self, scheme):
         """
@@ -806,6 +809,7 @@ class WidgetManager(QObject):
         """Set or unset widget's float on top flag"""
         settings = QSettings()
         should_float_on_top = settings.value("mainwindow/widgets-float-on-top", False, type=bool)
+        should_float_on_top &= qApp.applicationState() == Qt.ApplicationActive
         float_on_top = widget.windowFlags() & Qt.WindowStaysOnTopHint
 
         if float_on_top == should_float_on_top:


### PR DESCRIPTION
##### Issue
When Canvas gets focus, all widgets get hidden behind it

##### Description of changes
View -> Float Widgets on Top flag to show widgets on top of all other windows.
