### PR TITLE
[FIX] test_owmosaic: Cleanup/join threads on test tear down

### DIFF
--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -114,6 +114,10 @@ class MosaicVizRankTests(WidgetTest):
         self.widget = self.create_widget(OWMosaicDisplay)
         self.vizrank = self.widget.vizrank
 
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
+
     def test_count(self):
         """MosaicVizrank correctly computes the number of combinations"""
         widget = self.widget


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

VizRank tests for OWMosaic leave threads running after test completion influencing other tests via reduced performance and resulting TimeoutErrors.

For instance, run in bash:
```bash
$ python -m unittest  Orange.widgets.visualize.tests.test_owmosaic.MosaicVizRankTests{,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,}
```

##### Description of changes

Cleanup/join threads on test tear down

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
