### PR TITLE
[FIX] tests: Fix time tracking in process_events

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -183,7 +183,7 @@ class WidgetTest(GuiTest):
         if until is None:
             until = lambda: True
 
-        started = time.clock()
+        started = time.perf_counter()
         while True:
             app.processEvents()
             try:
@@ -192,7 +192,7 @@ class WidgetTest(GuiTest):
                     return result
             except Exception:  # until can fail with anything; pylint: disable=broad-except
                 pass
-            if (time.clock() - started) * 1000 > timeout:
+            if (time.perf_counter() - started) * 1000 > timeout:
                 raise TimeoutError()
             time.sleep(.05)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Sometimes tests seemingly [deadlock](https://travis-ci.org/biolab/orange3/jobs/383185760#L4309) but in reality it they spin (really sleep) in `WidgetTest.process_events` way past the real timeout (due to improper time keeping).

##### Description of changes

Use [`time.perf_counter`](https://docs.python.org/3/library/time.html#time.perf_counter) not `time.clock`. `clock` is deprecated and platform dependent, but mostly does not measure time
spent in sleep.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
