### PR TITLE
[FIX] VizRank: Fix race condition in `toggle`

### DIFF
--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -352,6 +352,9 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin):
         else:
             self.button.setText("Continue")
             self._thread.quit()
+            # Need to sync state (the worker must read the keep_running
+            # state and stop) for reliable restart.
+            self._thread.wait()
 
     def before_running(self):
         """Code that is run before running vizrank in its own thread"""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

There was a race condition in the `toggle` method where VizRank could
be left without a running worker thread. This could happen between
setting `keep_running` from False to True and subsequent call to
`QThread.start`. The worker could read `keep_running` as False right
before that and not yet exit before the call to start. Then start would
be a noop and the thread would stop right after.

This manifests in a sometimes failing `Orange.widgets.visualize.tests.test_owmosaic.MosaicVizRankTests.test_pause_continue`

##### Description of changes

Fix by explicitly joining the thread on 'pause' as a synchronization point.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
