### PR TITLE
[ENH] Save data with compression

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -297,13 +297,13 @@ class FileFormatMeta(Registry):
             for compression in Compression.all:
                 for ext in newcls.EXTENSIONS:
                     new_extensions.append(ext + compression)
-                    # OSX file dialog doesn't support filtering on double
-                    # extensions (e.g. .csv.gz)
-                    # https://bugreports.qt.io/browse/QTBUG-38303
-                    # This is just here for OWFile that gets QFileDialog
-                    # filters from FileFormat.readers.keys()
-                    if sys.platform == 'darwin':
-                        new_extensions.append(compression)
+                # OSX file dialog doesn't support filtering on double
+                # extensions (e.g. .csv.gz)
+                # https://bugreports.qt.io/browse/QTBUG-38303
+                # This is just here for OWFile that gets QFileDialog
+                # filters from FileFormat.readers.keys()
+                if sys.platform == 'darwin':
+                    new_extensions.append(compression)
             newcls.EXTENSIONS = tuple(new_extensions)
 
         return newcls

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -913,19 +913,20 @@ class PickleReader(FileFormat):
     """Reader for pickled Table objects"""
     EXTENSIONS = ('.pickle', '.pkl')
     DESCRIPTION = 'Pickled Python object file'
+    SUPPORT_COMPRESSED = True
     SUPPORT_SPARSE_DATA = True
 
     def read(self):
-        with open(self.filename, 'rb') as f:
+        with self.open(self.filename, 'rb') as f:
             table = pickle.load(f)
             if not isinstance(table, Table):
                 raise TypeError("file does not contain a data table")
             else:
                 return table
 
-    @staticmethod
-    def write_file(filename, data):
-        with open(filename, 'wb') as f:
+    @classmethod
+    def write_file(cls, filename, data):
+        with cls.open(filename, 'wb') as f:
             pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
 
 

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -297,12 +297,14 @@ class FileFormatMeta(Registry):
             for compression in Compression.all:
                 for ext in newcls.EXTENSIONS:
                     new_extensions.append(ext + compression)
-                # OSX file dialog doesn't support filtering on double
-                # extensions (e.g. .csv.gz)
-                # https://bugreports.qt.io/browse/QTBUG-38303
-                # This is just here for OWFile that gets QFileDialog
-                # filters from FileFormat.readers.keys()
-                if sys.platform == 'darwin':
+                if sys.platform in ('darwin', 'win32'):
+                    # OSX file dialog doesn't support filtering on double
+                    # extensions (e.g. .csv.gz)
+                    # https://bugreports.qt.io/browse/QTBUG-38303
+                    # This is just here for OWFile that gets QFileDialog
+                    # filters from FileFormat.readers.keys()
+                    # EDIT: Windows exhibit similar problems:
+                    # while .tab.gz works, .tab.xz and .tab.bz2 do not!
                     new_extensions.append(compression)
             newcls.EXTENSIONS = tuple(new_extensions)
 

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -911,7 +911,7 @@ class TabReader(CSVReader):
 
 class PickleReader(FileFormat):
     """Reader for pickled Table objects"""
-    EXTENSIONS = ('.pickle', '.pkl')
+    EXTENSIONS = ('.pkl', '.pickle')
     DESCRIPTION = 'Pickled Python object file'
     SUPPORT_COMPRESSED = True
     SUPPORT_SPARSE_DATA = True

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -5,7 +5,7 @@ from AnyQt.QtGui import QBrush
 from AnyQt.QtWidgets import \
     QMessageBox, QFileDialog, QFileIconProvider, QComboBox
 
-from Orange.data.io import FileFormat
+from Orange.data.io import FileFormat, Compression
 from Orange.widgets.settings import Setting
 from Orange.util import deprecated
 
@@ -82,6 +82,9 @@ def open_filename_dialog_save(start_dir, start_filter, file_formats):
             return None, None, None
 
         base, ext = os.path.splitext(filename)
+        if ext in Compression.all:
+            base, base_ext = os.path.splitext(base)
+            ext = base_ext + ext
         if not ext:
             filename += format.EXTENSIONS[0]
         elif ext not in format.EXTENSIONS:


### PR DESCRIPTION
1. Saving with compression was prevented due to a file format extension check that used only the last extension (in e.g. file.tab.gz)
2. Compression was not supported when saving and loading in pickle format
3. Changed default extension for PickleReader from .pickle to the shorter .pkl (both were supported before and still are).

