### PR TITLE
[FIX] OWScatterOWScatterPlotGraph: Match group colors with marker colors

### DIFF
--- a/Orange/widgets/utils/annotated_data.py
+++ b/Orange/widgets/utils/annotated_data.py
@@ -117,9 +117,16 @@ def create_groups_table(data, selection,
                         var_name=ANNOTATED_DATA_FEATURE_NAME):
     if data is None:
         return None
-    values = ["G{}".format(i + 1) for i in range(np.max(selection))]
+    max_sel = np.max(selection)
+    values = ["G{}".format(i + 1) for i in range(max_sel)]
     if include_unselected:
-        values.insert(0, "Unselected")
+        # Place Unselected instances in the "last group", so that the group
+        # colors and scatter diagram marker colors will match
+        values.append("Unselected")
+        mask = (selection != 0)
+        selection = selection.copy()
+        selection[mask] = selection[mask] - 1
+        selection[~mask] = selection[~mask] = max_sel
     else:
         mask = np.flatnonzero(selection)
         data = data[mask]

--- a/Orange/widgets/utils/tests/test_annotated_data.py
+++ b/Orange/widgets/utils/tests/test_annotated_data.py
@@ -4,9 +4,11 @@ import unittest
 import numpy as np
 
 from Orange.data import Table, Variable
+from Orange.data.filter import SameValue
 from Orange.widgets.utils.annotated_data import (
     create_annotated_table, get_next_name, get_unique_names,
-    ANNOTATED_DATA_FEATURE_NAME)
+    create_groups_table, ANNOTATED_DATA_FEATURE_NAME
+)
 
 
 class TestGetNextName(unittest.TestCase):
@@ -115,3 +117,14 @@ class TestAnnotatedData(unittest.TestCase):
                  "bravo (3)"]
         self.assertEqual(get_unique_names(names, ["bravo", "charlie"]),
                          ["bravo (5)", "charlie (5)"])
+
+    def test_create_groups_table_include_unselected(self):
+        group_indices = random.sample(range(0, len(self.zoo)), 20)
+        selection = np.zeros(len(self.zoo), dtype=np.uint8)
+        selection[group_indices[:10]] = 1
+        selection[group_indices[10:]] = 2
+        table = create_groups_table(self.zoo, selection)
+        self.assertEqual(
+            len(SameValue(table.domain["Selected"], "Unselected")(table)),
+            len(self.zoo) - len(group_indices)
+        )

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -851,12 +851,9 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
                         _make_pen(QColor(255, 190, 0, 255),
                                   SELECTION_WIDTH + 1.)]
             else:
-                # Start with the first color so that the colors of the
-                # additional attribute in annotation (which start with 0,
-                # unselected) will match these colors
                 palette = ColorPaletteGenerator(number_of_colors=sels + 1)
                 pens = [nopen] + \
-                       [_make_pen(palette[i + 1], SELECTION_WIDTH + 1.)
+                       [_make_pen(palette[i], SELECTION_WIDTH + 1.)
                         for i in range(sels)]
             pen = [pens[a] for a in self.selection[self.valid_data]]
         else:

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -196,7 +196,9 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
             graph.select(points[5:10])
         np.testing.assert_equal(selectedx(), x[:10])
         np.testing.assert_equal(selected_groups(), np.array([0] * 5 + [1] * 5))
-        sel_column[5:10] = 2
+        sel_column[:5] = 0
+        sel_column[5:10] = 1
+        sel_column[10:] = 2
         np.testing.assert_equal(annotated(), sel_column)
         self.assertEqual(len(annotations()), 3)
 
@@ -232,7 +234,9 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         # ... then Ctrl-Shift-select (add-to-last) 10:17; we have 17:25, 30:40
         with self.modifiers(Qt.ShiftModifier | Qt.ControlModifier):
             graph.select(points[35:40])
-        sel_column[30:40] = 2
+        sel_column[:] = 2
+        sel_column[17:25] = 0
+        sel_column[30:40] = 1
         np.testing.assert_equal(selected_groups(), np.array([0] * 8 + [1] * 10))
         np.testing.assert_equal(annotated(), sel_column)
         self.assertEqual(len(annotations()), 3)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3051

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
