### PR TITLE
[ENH] RecentFiles: Check for missing file in workflow dir

### DIFF
--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -240,14 +240,17 @@ class RecentPath:
     def resolve(self, searchpaths):
         if self.prefix is None and os.path.exists(self.abspath):
             return self
-        elif self.prefix is not None:
+        else:
             for prefix, base in searchpaths:
-                if self.prefix == prefix:
+                path = None
+                if self.prefix and self.prefix == prefix:
                     path = os.path.join(base, self.relpath)
-                    if os.path.exists(path):
-                        return RecentPath(
-                            os.path.normpath(path), self.prefix, self.relpath,
-                            file_format=self.file_format)
+                elif not self.prefix and prefix == "basedir":
+                    path = os.path.join(base, self.basename)
+                if path and os.path.exists(path):
+                    return RecentPath(
+                        os.path.normpath(path), self.prefix, self.relpath,
+                        file_format=self.file_format)
         return None
 
     @property

--- a/Orange/widgets/utils/tests/test_filedialogs.py
+++ b/Orange/widgets/utils/tests/test_filedialogs.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+from tempfile import NamedTemporaryFile
+
+from Orange.widgets.utils.filedialogs import RecentPath
+
+
+class TestRecentPath(unittest.TestCase):
+    def test_resolve(self):
+        temp_file = NamedTemporaryFile(dir=os.getcwd(), delete=False)
+        file_name = temp_file.name
+        temp_file.close()
+        base_name = os.path.basename(file_name)
+        try:
+            recent_path = RecentPath(
+                os.path.join("temp/datasets", base_name), "",
+                os.path.join("datasets", base_name)
+            )
+            search_paths = [("basedir", os.getcwd())]
+            self.assertIsNotNone(recent_path.resolve(search_paths))
+        finally:
+            os.remove(file_name)


### PR DESCRIPTION
##### Description of changes
When opening saved workflow and file widget detects missing file, check if the file is placed in the same directory as workflow is saved.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
