### PR TITLE
[FIX] OWMosaic: Don't offer String meta attributes

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -383,7 +383,7 @@ class OWMosaicDisplay(OWWidget):
 
         icons = gui.attributeIconDict
         for attr in chain(data.domain.variables, data.domain.metas):
-            if attr.is_primitive:
+            if attr.is_primitive():
                 for combo in self.attr_combos:
                     combo.addItem(icons[attr], attr.name)
 


### PR DESCRIPTION
##### Issue
Mosaic crashes if the user selects a string meta attribute as one of the variables.

##### Description of changes
A check is_primitive was used as a property but is in fact a method.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
