### PR TITLE
[FIX] owkmeans: fix initialization choice

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -115,7 +115,8 @@ class OWKMeans(widget.OWWidget):
             "Too few ({}) unique data instances for {} clusters"
         )
 
-    INIT_METHODS = "Initialize with KMeans++", "Random initialization"
+    INIT_METHODS = (("Initialize with KMeans++", "k-means++"),
+                    ("Random initialization", "random"))
 
     resizing_enabled = False
     buttons_area_orientation = Qt.Vertical
@@ -181,7 +182,7 @@ class OWKMeans(widget.OWWidget):
 
         box = gui.vBox(self.controlArea, "Initialization")
         gui.comboBox(
-            box, self, "smart_init", items=self.INIT_METHODS,
+            box, self, "smart_init", items=[m[0] for m in self.INIT_METHODS],
             callback=self.invalidate)
 
         layout = QGridLayout()
@@ -316,7 +317,7 @@ class OWKMeans(widget.OWWidget):
             self._compute_clustering,
             data=self.data,
             k=k,
-            init=['random', 'k-means++'][self.smart_init],
+            init=self.INIT_METHODS[self.smart_init][1],
             n_init=self.n_init,
             max_iter=self.max_iterations,
             silhouette=True,
@@ -485,7 +486,7 @@ class OWKMeans(widget.OWWidget):
             k_clusters = self.k_from + self.selected_row()
         else:
             k_clusters = self.k
-        init_method = self.INIT_METHODS[self.smart_init]
+        init_method = self.INIT_METHODS[self.smart_init][0]
         init_method = init_method[0].lower() + init_method[1:]
         self.report_items((
             ("Number of clusters", k_clusters),

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -411,6 +411,21 @@ class TestOWKMeans(WidgetTest):
             self.commit_and_wait()
             self.assertEqual(call_count + 1, commit.call_count)
 
+    def test_correct_smart_init(self):
+        # due to a bug where wrong init was passed to _compute_clustering
+        self.send_signal(self.widget.Inputs.data, self.iris[::10], wait=5000)
+        self.widget.smart_init = 0
+        with patch.object(self.widget, "_compute_clustering",
+                          wraps=self.widget._compute_clustering) as compute:
+            self.commit_and_wait()
+            self.assertEqual(compute.call_args[1]['init'], "k-means++")
+        self.widget.invalidate()  # reset caches
+        self.widget.smart_init = 1
+        with patch.object(self.widget, "_compute_clustering",
+                          wraps=self.widget._compute_clustering) as compute:
+            self.commit_and_wait()
+            self.assertEqual(compute.call_args[1]['init'], "random")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
Initialization (random or k-means++) was wrongly passed from widget to the library.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
