### PR TITLE
[FIX] EditDomain: Editing TimeVariable broke formatting

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -417,6 +417,12 @@ time,continuous
         var = TimeVariable('time')
         self.assertEqual(var.repr_val(Value(var, 416.3)), '416.3')
 
+    def test_have_date_have_time_in_construct(self):
+        """Test if have_time and have_date is correctly set"""
+        var = TimeVariable('time', have_date=1)
+        self.assertTrue(var.have_date)
+        self.assertFalse(var.have_time)
+
 
 PickleContinuousVariable = create_pickling_tests(
     "PickleContinuousVariable",

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -929,10 +929,10 @@ class TimeVariable(ContinuousVariable):
     utc_offset = None
     timezone = timezone.utc
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, have_date=0, have_time=0, **kwargs):
         super().__init__(*args, **kwargs)
-        self.have_date = 0
-        self.have_time = 0
+        self.have_date = have_date
+        self.have_time = have_time
 
     def copy(self, compute_value=None):
         copy = super().copy(compute_value=compute_value)

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -55,20 +55,19 @@ def variable_description(var, skip_attributes=False):
                 var.name,
                 (("values", tuple(var.values)),),
                 attributes)
+    elif var.is_time:
+        return (var_type.__module__,
+                var_type.__name__,
+                var.name,
+                (("have_date", var.have_date),
+                 ("have_time", var.have_time)),
+                attributes)
     else:
-        if var.is_time:
-            return (var_type.__module__,
-                    var_type.__name__,
-                    var.name,
-                    (("have_date", var.have_date),
-                     ("have_time", var.have_time)),
-                    attributes)
-        else:
-            return (var_type.__module__,
-                    var_type.__name__,
-                    var.name,
-                    (),
-                    attributes)
+        return (var_type.__module__,
+                var_type.__name__,
+                var.name,
+                (),
+                attributes)
 
 
 def variable_from_description(description, compute_value=None):
@@ -83,12 +82,8 @@ def variable_from_description(description, compute_value=None):
         raise ValueError("Invalid descriptor type '{}.{}"
                          "".format(module, type_name))
 
-    kwargs = dict(list(args))
-    var = constructor(name, compute_value=compute_value, **kwargs)
+    var = constructor(name, compute_value=compute_value, **dict(list(args)))
     var.attributes.update(attrs)
-    if var.is_time:
-        var.have_date = kwargs['have_date']
-        var.have_time = kwargs['have_time']
     return var
 
 
@@ -449,8 +444,8 @@ class OWEditDomain(widget.OWWidget):
         self.editor_stack = QStackedWidget()
 
         self.editor_stack.addWidget(DiscreteVariableEditor())
-        self.editor_stack.addWidget(TimeVariableEditor())
         self.editor_stack.addWidget(ContinuousVariableEditor())
+        self.editor_stack.addWidget(TimeVariableEditor())
         self.editor_stack.addWidget(VariableEditor())
 
         box.layout().addWidget(self.editor_stack)
@@ -549,10 +544,11 @@ class OWEditDomain(widget.OWWidget):
         editor_index = 3
         if var.is_discrete:
             editor_index = 0
+        # TimeVariable is also continuous, first check if time
         elif var.is_time:
-            editor_index = 1
-        elif var.is_continuous:
             editor_index = 2
+        elif var.is_continuous:
+            editor_index = 1
         editor = self.editor_stack.widget(editor_index)
         self.editor_stack.setCurrentWidget(editor)
 

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -177,19 +177,6 @@ class TestOWEditDomain(WidgetTest):
         output = self.get_output(self.widget.Outputs.data)
         self.assertEqual(str(table[0, 4]), str(output[0, 4]))
 
-        # if continuous variable edit is used have_time and have_date is not
-        # copied and the time string format is changed
-        idx = self.widget.domain_view.model().index(4)
-        self.widget.domain_view.setCurrentIndex(idx)
-        editor = self.widget.editor_stack.findChild(ContinuousVariableEditor)
-
-        editor.name_edit.setText("Date_Posted")
-        editor.commit()
-        self.widget.commit()
-        output = self.get_output(self.widget.Outputs.data)
-        self.assertNotEqual(str(table[0, 4]), str(output[0, 4]))
-
-        self.widget.reset_selected()
         editor = self.widget.editor_stack.findChild(TimeVariableEditor)
         editor.name_edit.setText("Date")
         editor.commit()
@@ -254,13 +241,17 @@ class TestEditors(GuiTest):
         w = TimeVariableEditor()
         self.assertIs(w.get_data(), None)
 
-        v = TimeVariable("T")
+        v = TimeVariable("T", have_date=1)
         v.attributes.update({"A": 1, "B": "b"})
         w.set_data(v)
 
         self.assertEqual(w.name_edit.text(), v.name)
         self.assertEqual(w.labels_model.get_dict(), v.attributes)
         self.assertTrue(w.is_same())
+
+        var = w.get_data()
+        self.assertTrue(var.have_date)
+        self.assertFalse(var.have_time)
 
         w.set_data(None)
         self.assertEqual(w.name_edit.text(), "")


### PR DESCRIPTION
##### Issue
Fixes #2776 

##### Description of changes
Add TimeVariableEditor and update variable_description and variable_from_description to correctly handle TimeVariables.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
