### PR TITLE
owkmeans: always use the same random seed

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -19,6 +19,9 @@ from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.widget import Input, Output
 
 
+RANDOM_STATE = 0
+
+
 class ClusterTableModel(QAbstractTableModel):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -252,14 +255,14 @@ class OWKMeans(widget.OWWidget):
         return len(self.data) >= k
 
     @staticmethod
-    def _compute_clustering(data, k, init, n_init, max_iter, silhouette):
+    def _compute_clustering(data, k, init, n_init, max_iter, silhouette, random_state):
         # type: (Table, int, str, int, int, bool) -> KMeansModel
         if k > len(data):
             raise NotEnoughData()
 
         return KMeans(
             n_clusters=k, init=init, n_init=n_init, max_iter=max_iter,
-            compute_silhouette_score=silhouette,
+            compute_silhouette_score=silhouette, random_state=random_state,
         )(data)
 
     @Slot(int, int)
@@ -321,6 +324,7 @@ class OWKMeans(widget.OWWidget):
             n_init=self.n_init,
             max_iter=self.max_iterations,
             silhouette=True,
+            random_state=RANDOM_STATE,
         ) for k in ks]
         watcher = FutureSetWatcher(futures)
         watcher.resultReadyAt.connect(self.__clustering_complete)

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -426,6 +426,25 @@ class TestOWKMeans(WidgetTest):
             self.commit_and_wait()
             self.assertEqual(compute.call_args[1]['init'], "random")
 
+    def test_always_same_cluster(self):
+        """The same random state should always return the same clusters"""
+        self.send_signal(self.widget.Inputs.data, self.iris[::10], wait=5000)
+
+        def cluster():
+            self.widget.invalidate()  # reset caches
+            self.commit_and_wait()
+            return self.get_output(self.widget.Outputs.annotated_data).metas[:, 0]
+
+        def assert_all_same(l):
+            for a1, a2 in zip(l, l[1:]):
+                np.testing.assert_equal(a1, a2)
+
+        self.widget.smart_init = 0
+        assert_all_same([cluster() for _ in range(5)])
+
+        self.widget.smart_init = 1
+        assert_all_same([cluster() for _ in range(5)])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
#3103

Fixes #3075

##### Description of changes
K-means now always uses the same random seed and outputs the same data

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
