### PR TITLE
OWKMeans: Speed-up silhouette test.

### DIFF
--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -9,6 +9,7 @@ from Orange.distance import Euclidean
 
 __all__ = ["KMeans"]
 
+SILHOUETTE_MAX_SAMPLES = 5000
 
 class KMeans(SklProjector):
     __wraps__ = skl_cluster.KMeans
@@ -26,14 +27,14 @@ class KMeans(SklProjector):
         proj.silhouette = np.nan
         try:
             if self._compute_silhouette and 2 <= proj.n_clusters < X.shape[0]:
-                if len(X) <= 5000:
+                if len(X) <= SILHOUETTE_MAX_SAMPLES:
                     proj.silhouette_samples = \
                         silhouette_samples(X, proj.labels_)
                     proj.silhouette = np.mean(proj.silhouette_samples)
                 else:
                     proj.silhouette_samples = None
                     proj.silhouette = \
-                        silhouette_score(X, proj.labels_, sample_size=5000)
+                        silhouette_score(X, proj.labels_, sample_size=SILHOUETTE_MAX_SAMPLES)
         except MemoryError:  # Pairwise dist in silhouette fails for large data
             pass
         proj.inertia = proj.inertia_ / X.shape[0]

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -8,7 +8,7 @@ from AnyQt.QtGui import QIntValidator
 from AnyQt.QtWidgets import QGridLayout, QTableView
 
 from Orange.clustering import KMeans
-from Orange.clustering.kmeans import KMeansModel  # pylint: disable=unused-import
+from Orange.clustering.kmeans import KMeansModel, SILHOUETTE_MAX_SAMPLES  # pylint: disable=unused-import
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
@@ -109,7 +109,8 @@ class OWKMeans(widget.OWWidget):
 
     class Warning(widget.OWWidget.Warning):
         no_silhouettes = widget.Msg(
-            "Silhouette scores are not computed for >5000 samples"
+            "Silhouette scores are not computed for >{} samples".format(
+                SILHOUETTE_MAX_SAMPLES)
         )
         not_enough_data = widget.Msg(
             "Too few ({}) unique data instances for {} clusters"

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -347,10 +347,11 @@ class TestOWKMeans(WidgetTest):
         widget.optimize_k = False
 
         random = np.random.RandomState(0)  # Avoid randomness in the test
-        table = Table(random.rand(5010, 2))
-        self.send_signal(self.widget.Inputs.data, table)
-        outtable = self.get_output(widget.Outputs.annotated_data)
-        outtable = outtable.get_column_view("Silhouette")[0]
+        table = Table(random.rand(110, 2))
+        with patch("Orange.clustering.kmeans.SILHOUETTE_MAX_SAMPLES", 100):
+            self.send_signal(self.widget.Inputs.data, table)
+            outtable = self.get_output(widget.Outputs.annotated_data)
+            outtable = outtable.get_column_view("Silhouette")[0]
         self.assertTrue(np.all(np.isnan(outtable)))
         self.assertTrue(widget.Warning.no_silhouettes.is_shown())
 


### PR DESCRIPTION
##### Issue
test_silhouette_column in test_owkmeans.py is a common cause of timeout on AppVeyor.

##### Description of changes
Decrease the number of samples used for silhouette computation in unit tests.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
