### PR TITLE
Data without specified column names can now be concatenated

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -183,12 +183,7 @@ def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
     if issubclass(coltype, DiscreteVariable) and valuemap is not None:
         coltype_kwargs.update(values=valuemap)
 
-    if existing_var:
-        # Use existing variable if available
-        var = coltype.make(existing_var.strip(), **coltype_kwargs)
-    else:
-        # Never use existing for un-named variables
-        var = coltype(new_var_name, **coltype_kwargs)
+    var = coltype.make(existing_var.strip() if existing_var else new_var_name, **coltype_kwargs)
 
     if isinstance(var, DiscreteVariable):
         # Map discrete data to 'ints' (or at least what passes as int around

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -170,8 +170,19 @@ def guess_data_type(orig_values, namask=None):
 
 
 def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
-                      domain_vars, existing_var, new_var_name, data=None):
+                      domain_vars=None, existing_var=None, new_var_name=None, data=None, name=None):
     assert issubclass(coltype, Variable)
+
+    if name is None or existing_var is not None or new_var_name is not None:
+        name = existing_var.strip() if existing_var else new_var_name
+        raise DeprecationWarning("Arguments 'existing_var' and 'new_var_name' are "\
+                                 "deprecated since 3.14; use 'name' instead")
+
+    if domain_vars is not None:
+        raise DeprecationWarning("Argument 'domain_vars' is deprecated since 3.14")
+
+    if data is not None:
+        raise DeprecationWarning("Argument 'data' is deprecated since 3.14")
 
     def get_number_of_decimals(values):
         len_ = len
@@ -183,7 +194,7 @@ def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
     if issubclass(coltype, DiscreteVariable) and valuemap is not None:
         coltype_kwargs.update(values=valuemap)
 
-    var = coltype.make(existing_var.strip() if existing_var else new_var_name, **coltype_kwargs)
+    var = coltype.make(name, **coltype_kwargs)
 
     if isinstance(var, DiscreteVariable):
         # Map discrete data to 'ints' (or at least what passes as int around
@@ -709,16 +720,14 @@ class FileFormat(metaclass=FileFormatMeta):
 
             cols, domain_vars = append_to
 
-            existing_var, new_var_name = None, None
             if domain_vars is not None:
-                existing_var = names and names[col]
-                if not existing_var:
-                    new_var_name = next(NAMEGEN)
+                var_name = names and names[col]
+                if not var_name:
+                    var_name = next(NAMEGEN)
 
-            if domain_vars is not None:
                 values, var = sanitize_variable(
                     valuemap, values, orig_values, coltype, coltype_kwargs,
-                    domain_vars, existing_var, new_var_name, data)
+                    name=var_name)
             else:
                 var = None
             if domain_vars is not None:

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -176,13 +176,13 @@ def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
     if name is None or existing_var is not None or new_var_name is not None:
         name = existing_var.strip() if existing_var else new_var_name
         raise DeprecationWarning("Arguments 'existing_var' and 'new_var_name' are "\
-                                 "deprecated since 3.14; use 'name' instead")
+                                 "deprecated since 3.16; use 'name' instead")
 
     if domain_vars is not None:
-        raise DeprecationWarning("Argument 'domain_vars' is deprecated since 3.14")
+        raise DeprecationWarning("Argument 'domain_vars' is deprecated since 3.16")
 
     if data is not None:
-        raise DeprecationWarning("Argument 'data' is deprecated since 3.14")
+        raise DeprecationWarning("Argument 'data' is deprecated since 3.16")
 
     def get_number_of_decimals(values):
         len_ = len

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1629,8 +1629,7 @@ class Table(MutableSequence, Storage):
             orig_vals = M[:, i]
             val_map, vals, var_type = Orange.data.io.guess_data_type(orig_vals)
             values, variable = Orange.data.io.sanitize_variable(
-                val_map, vals, orig_vals, var_type,
-                {}, _metas, None, var_name)
+                val_map, vals, orig_vals, var_type, {}, name=var_name)
             M[:, i] = values
             return variable
 

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -6,8 +6,11 @@ import os
 import tempfile
 import shutil
 
-from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader
+from Orange.data import ContinuousVariable
+from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader, \
+    sanitize_variable
 from Orange.data.table import get_sample_datasets_dir
+from Orange.version import version
 
 
 class WildcardReader(FileFormat):
@@ -100,3 +103,12 @@ class TestReader(unittest.TestCase):
         reader = PickleReader("")
         with unittest.mock.patch("pickle.load", return_value=None):
             self.assertRaises(TypeError, reader.read, "foo")
+
+
+class TestIo(unittest.TestCase):
+    def test_sanitize_variable_deprecated_params(self):
+        """In version 3.18 deprecation warnings in function 'sanitize_variable'
+        should be removed along with unused parameters."""
+        if version > "3.18":
+            _, _ = sanitize_variable(None, None, None, ContinuousVariable,
+                                     {}, name="name", data="data")

--- a/Orange/tests/test_tab_reader.py
+++ b/Orange/tests/test_tab_reader.py
@@ -143,6 +143,17 @@ class TestTabReader(unittest.TestCase):
         self.assertTrue(table.domain[0].is_continuous)
         self.assertEqual(table.domain[0].name, 'Feature 1')
 
+    def test_read_data_no_header_feature_reuse(self):
+        samplefile = """\
+        0.1\t0.2\t0.3
+        1.1\t1.2\t1.5
+        """
+        file = io.StringIO(samplefile)
+        t1 = read_tab_file(file)
+        file = io.StringIO(samplefile)
+        t2 = read_tab_file(file)
+        self.assertEqual(t1.domain[0], t2.domain[0])
+
     def test_reuse_variables(self):
         file1 = io.StringIO("\n".join("xd dbac"))
         t1 = read_tab_file(file1)


### PR DESCRIPTION
##### Issue
Fixes #3087

##### Description of changes
Changed `io.sanitize_variable` to always use `Variable.make`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
