### PR TITLE
[ENH] Smart widget suggestions

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -66,6 +66,7 @@ from .outputview import OutputView, TextStream
 from .settings import UserSettingsDialog
 
 from ..document.schemeedit import SchemeEditWidget
+from ..document.suggestions import Suggestions
 
 from ..scheme import widgetsscheme
 from ..scheme.readwrite import scheme_load
@@ -176,6 +177,8 @@ class CanvasMainWindow(QMainWindow):
         self.setup_actions()
         self.setup_ui()
         self.setup_menu()
+
+        self.suggestions = Suggestions(self.scheme_widget)
 
         self.restore()
 

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -66,7 +66,6 @@ from .outputview import OutputView, TextStream
 from .settings import UserSettingsDialog
 
 from ..document.schemeedit import SchemeEditWidget
-from ..document.suggestions import Suggestions
 
 from ..scheme import widgetsscheme
 from ..scheme.readwrite import scheme_load
@@ -177,8 +176,6 @@ class CanvasMainWindow(QMainWindow):
         self.setup_actions()
         self.setup_ui()
         self.setup_menu()
-
-        self.suggestions = Suggestions(self.scheme_widget)
 
         self.restore()
 

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -787,6 +787,15 @@ class NewNodeAction(UserInteraction):
         menu = self.document.quickMenu()
         menu.setFilterFunc(None)
 
+        # compares probability of the user needing the widget as a source
+        def defaultSort(left, right):
+            default_suggestions = self.suggestions.get_default_suggestions()
+            left_frequency = sum(default_suggestions[left].values())
+            right_frequency = sum(default_suggestions[right].values())
+            return left_frequency > right_frequency
+
+        menu.setSortingFunc(defaultSort)
+
         action = menu.exec_(pos, search_text)
         if action:
             item = action.property("item")

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -22,6 +22,7 @@ from AnyQt.QtCore import (
 )
 from AnyQt.QtCore import pyqtSignal as Signal
 
+from .suggestions import Suggestions
 from ..registry.description import WidgetDescription
 from ..registry.qt import QtWidgetRegistry
 from .. import scheme
@@ -458,6 +459,14 @@ class NewLinkAction(UserInteraction):
         if self.direction == self.FROM_SINK:
             # Reverse the argument order.
             is_compatible = reversed_arguments(is_compatible)
+            suggestions = Suggestions.instance.get_source_suggestions(from_desc.id)
+        else:
+            suggestions = Suggestions.instance.get_sink_suggestions(from_desc.id)
+
+        def sort(index):
+            return None  # TODO, using suggestinos
+
+        menu.setSortingFunc(sort)
 
         def filter(index):
             desc = index.data(QtWidgetRegistry.WIDGET_DESC_ROLE)

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -22,7 +22,6 @@ from AnyQt.QtCore import (
 )
 from AnyQt.QtCore import pyqtSignal as Signal
 
-from .suggestions import Suggestions
 from ..registry.description import WidgetDescription
 from ..registry.qt import QtWidgetRegistry
 from .. import scheme
@@ -456,6 +455,8 @@ class NewLinkAction(UserInteraction):
             return any(scheme.compatible_channels(output, input) \
                        for output in source.outputs \
                        for input in sink.inputs)
+
+        self.suggestions.set_last_direction(self.direction)
 
         if self.direction == self.FROM_SINK:
             # Reverse the argument order.

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -429,6 +429,7 @@ class NewLinkAction(UserInteraction):
                 else:
                     source_node = node
                     sink_node = self.scene.node_for_item(self.sink_item)
+                self.suggestions.set_direction(self.direction)
                 self.connect_nodes(source_node, sink_node)
 
                 if not self.isCanceled() or not self.isFinished() and \
@@ -455,8 +456,6 @@ class NewLinkAction(UserInteraction):
             return any(scheme.compatible_channels(output, input) \
                        for output in source.outputs \
                        for input in sink.inputs)
-
-        self.suggestions.set_last_direction(self.direction)
 
         if self.direction == self.FROM_SINK:
             # Reverse the argument order.

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -81,6 +81,7 @@ class UserInteraction(QObject):
         self.document = document
         self.scene = document.scene()
         self.scheme = document.scheme()
+        self.suggestions = document.suggestions()
         self.deleteOnEnd = deleteOnEnd
 
         self.cancelOnEsc = False
@@ -459,12 +460,12 @@ class NewLinkAction(UserInteraction):
         if self.direction == self.FROM_SINK:
             # Reverse the argument order.
             is_compatible = reversed_arguments(is_compatible)
-            suggestions = Suggestions.instance.get_source_suggestions(from_desc.id)
+            suggestion_sort = self.suggestions.get_source_suggestions(node.title)
         else:
-            suggestions = Suggestions.instance.get_sink_suggestions(from_desc.id)
+            suggestion_sort = self.suggestions.get_sink_suggestions(node.title)
 
-        def sort(index):
-            return None  # TODO, using suggestinos
+        def sort(left, right):
+            return suggestion_sort[left] > suggestion_sort[right]  # list stores frequencies, so sign is flipped
 
         menu.setSortingFunc(sort)
 

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -465,7 +465,8 @@ class NewLinkAction(UserInteraction):
             suggestion_sort = self.suggestions.get_sink_suggestions(from_desc.name)
 
         def sort(left, right):
-            return suggestion_sort[left] > suggestion_sort[right]  # list stores frequencies, so sign is flipped
+            # list stores frequencies, so sign is flipped
+            return suggestion_sort[left] > suggestion_sort[right]
 
         menu.setSortingFunc(sort)
 

--- a/Orange/canvas/document/interactions.py
+++ b/Orange/canvas/document/interactions.py
@@ -460,9 +460,9 @@ class NewLinkAction(UserInteraction):
         if self.direction == self.FROM_SINK:
             # Reverse the argument order.
             is_compatible = reversed_arguments(is_compatible)
-            suggestion_sort = self.suggestions.get_source_suggestions(node.title)
+            suggestion_sort = self.suggestions.get_source_suggestions(from_desc.name)
         else:
-            suggestion_sort = self.suggestions.get_sink_suggestions(node.title)
+            suggestion_sort = self.suggestions.get_sink_suggestions(from_desc.name)
 
         def sort(left, right):
             return suggestion_sort[left] > suggestion_sort[right]  # list stores frequencies, so sign is flipped

--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -297,21 +297,24 @@ class SuggestMenuPage(MenuPage):
         filter_proxy.setFilterFunc(func)
 
     def setSortingFunc(self, func):
+        """
+        Set a sorting function.
+        """
         filter_proxy = self.view().model()
         filter_proxy.setSortingFunc(func)
 
 
 class SortFilterProxyModel(QSortFilterProxyModel):
     """
-    An filter proxy model used to filter items based on a filtering
-    function.
+    An filter proxy model used to sort and filter items based on
+    a sort and filtering function.
 
     """
     def __init__(self, parent=None):
         QSortFilterProxyModel.__init__(self, parent)
 
         self.__filterFunc = None
-        self.__order = None
+        self.__sortingFunc = None
 
     def setFilterFunc(self, func):
         """
@@ -337,12 +340,18 @@ class SortFilterProxyModel(QSortFilterProxyModel):
             return accepted
 
     def setSortingFunc(self, func):
+        self.invalidate()
         self.__sortingFunc = func
+        self.sort(0)
+
+    def sortingFunc(self):
+        return self.__sortingFunc
 
     def lessThan(self, left, right):
         model = self.sourceModel()
-        # TODO
-        return self.__sortingFunc(left, right)
+        left_data = model.data(left)
+        right_data = model.data(right)
+        return self.__sortingFunc(left_data, right_data)
 
 
 class SearchWidget(LineEdit):
@@ -864,7 +873,7 @@ class QuickMenu(FramelessWindow):
         self.setWindowFlags(Qt.Popup)
 
         self.__filterFunc = None
-        self.__ordering = None
+        self.__sortingFunc = None
 
         self.__setupUi()
 
@@ -1028,10 +1037,15 @@ class QuickMenu(FramelessWindow):
         self.__model = model
         self.__suggestPage.setModel(model)
 
-    def setOrdering(self, suggestions):
-        if self.__ordering != suggestions:
-            self.__ordering = suggestions
-            #TODO
+    def setSortingFunc(self, func):
+        """
+        Set a sorting function in the suggest (search) menu.
+        """
+        if self.__sortingFunc != func:
+            self.__sortingFunc = func
+            for i in range(0, self.__pages.count()):
+                if isinstance(self.__pages.page(i), SuggestMenuPage):
+                    self.__pages.page(i).setSortingFunc(func)
 
     def setFilterFunc(self, func):
         """

--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -348,6 +348,8 @@ class SortFilterProxyModel(QSortFilterProxyModel):
         return self.__sortingFunc
 
     def lessThan(self, left, right):
+        if self.__sortingFunc is None:
+            return QSortFilterProxyModel.lessThan(self, left, right)
         model = self.sourceModel()
         left_data = model.data(left)
         right_data = model.data(right)

--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -296,6 +296,10 @@ class SuggestMenuPage(MenuPage):
         filter_proxy = self.view().model()
         filter_proxy.setFilterFunc(func)
 
+    def setSortingFunc(self, func):
+        filter_proxy = self.view().model()
+        filter_proxy.setSortingFunc(func)
+
 
 class SortFilterProxyModel(QSortFilterProxyModel):
     """
@@ -307,6 +311,7 @@ class SortFilterProxyModel(QSortFilterProxyModel):
         QSortFilterProxyModel.__init__(self, parent)
 
         self.__filterFunc = None
+        self.__order = None
 
     def setFilterFunc(self, func):
         """
@@ -330,6 +335,14 @@ class SortFilterProxyModel(QSortFilterProxyModel):
             return self.__filterFunc(index)
         else:
             return accepted
+
+    def setSortingFunc(self, func):
+        self.__sortingFunc = func
+
+    def lessThan(self, left, right):
+        model = self.sourceModel()
+        # TODO
+        return self.__sortingFunc(left, right)
 
 
 class SearchWidget(LineEdit):
@@ -851,6 +864,7 @@ class QuickMenu(FramelessWindow):
         self.setWindowFlags(Qt.Popup)
 
         self.__filterFunc = None
+        self.__ordering = None
 
         self.__setupUi()
 
@@ -1013,6 +1027,11 @@ class QuickMenu(FramelessWindow):
 
         self.__model = model
         self.__suggestPage.setModel(model)
+
+    def setOrdering(self, suggestions):
+        if self.__ordering != suggestions:
+            self.__ordering = suggestions
+            #TODO
 
     def setFilterFunc(self, func):
         """

--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -340,8 +340,8 @@ class SortFilterProxyModel(QSortFilterProxyModel):
             return accepted
 
     def setSortingFunc(self, func):
-        self.invalidate()
         self.__sortingFunc = func
+        self.invalidate()
         self.sort(0)
 
     def sortingFunc(self):

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -857,6 +857,12 @@ class SchemeEditWidget(QWidget):
         command = commands.RemoveLinkCommand(self.__scheme, link)
         self.__undoStack.push(command)
 
+    def onNewLink(self, func):
+        """
+        Runs function when new link is added to current scheme.
+        """
+        self.__scheme.link_added.connect(func)
+
     def addAnnotation(self, annotation):
         """
         Add `annotation` (:class:`.BaseSchemeAnnotation`) to the scheme

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -34,6 +34,7 @@ from AnyQt.QtCore import (
 
 from AnyQt.QtCore import pyqtProperty as Property, pyqtSignal as Signal
 
+from .suggestions import Suggestions
 from ..registry.qt import whats_this_helper
 from ..gui.quickhelp import QuickHelpTipEvent
 from ..gui.utils import message_information, disabled
@@ -172,6 +173,8 @@ class SchemeEditWidget(QWidget):
         self.__linkMenu.addSeparator()
         self.__linkMenu.addAction(self.__linkRemoveAction)
         self.__linkMenu.addAction(self.__linkResetAction)
+
+        self.__suggestions = Suggestions()
 
     def __setupActions(self):
         self.__cleanUpAction = \
@@ -640,6 +643,7 @@ class SchemeEditWidget(QWidget):
                         self.__signalManagerStateChanged)
 
             self.__scheme = scheme
+            self.__suggestions.set_scheme(self)
 
             self.setPath("")
 
@@ -727,6 +731,12 @@ class SchemeEditWidget(QWidget):
 
         """
         return self.__view
+
+    def suggestions(self):
+        """
+        Return the widget suggestion prediction class.
+        """
+        return self.__suggestions
 
     def setRegistry(self, registry):
         # Is this method necessary?

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -1,9 +1,12 @@
+from collections import defaultdict
+
+
 class Suggestions:
     def __init__(self, scheme):
         self.__scheme = scheme
-        self.links_added = []
+        self.link_frequencies = defaultdict(int)
         self.__scheme.onNewLink(self.new_link)
 
     def new_link(self, link):
-        self.links_added.append(link)
-        print(self.links_added)
+        link_key = (link.source_node.description.id, link.sink_node.description.id)
+        self.link_frequencies[link_key] += 1

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -12,6 +12,7 @@ class Suggestions:
     """
     def __init__(self):
         self.__frequencies_path = config.data_dir() + "/widget-use-frequency.p"
+        self.__import_factor = 0.8  # every time you reopen orange, imported frequencies are reduced
 
         self.__scheme = None
         self.__direction = None
@@ -26,8 +27,11 @@ class Suggestions:
         if not os.path.isfile(self.__frequencies_path):
             return False
         file = open(self.__frequencies_path, "rb")
-        self.link_frequencies = pickle.load(file)
+        imported_freq = pickle.load(file)
+        for k, v in imported_freq.items():
+            imported_freq[k] = self.__import_factor * v
 
+        self.link_frequencies = imported_freq
         self.overwrite_probabilities_with_frequencies()
         return True
 

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -1,0 +1,9 @@
+class Suggestions:
+    def __init__(self, scheme):
+        self.__scheme = scheme
+        self.links_added = []
+        self.__scheme.onNewLink(self.new_link)
+
+    def new_link(self, link):
+        self.links_added.append(link)
+        print(self.links_added)

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -7,6 +7,9 @@ from .interactions import NewLinkAction
 
 
 class Suggestions:
+    """
+    Handles sorting of quick menu items when dragging a link from a widget onto empty canvas.
+    """
     def __init__(self):
         self.__frequencies_path = config.data_dir() + "/widget-use-frequency.p"
 
@@ -37,6 +40,7 @@ class Suggestions:
             self.increment_probability(link[0], link[1], link[2], count)
 
     def new_link(self, link):
+        # direction is none when a widget was not added+linked via quick menu
         if self.__direction is None:
             return
 
@@ -67,6 +71,9 @@ class Suggestions:
 
     def get_source_suggestions(self, sink_id):
         return self.sink_probability[sink_id]
+
+    def get_default_suggestions(self):
+        return self.source_probability
 
     def set_scheme(self, scheme):
         self.__scheme = scheme

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -10,82 +10,92 @@ class Suggestions:
     """
     Handles sorting of quick menu items when dragging a link from a widget onto empty canvas.
     """
+    class __Suggestions:
+        def __init__(self):
+            self.__frequencies_path = config.data_dir() + "/widget-use-frequency.p"
+            self.__import_factor = 0.8  # upon starting Orange, imported frequencies are reduced
+
+            self.__scheme = None
+            self.__direction = None
+            self.link_frequencies = defaultdict(int)
+            self.source_probability = defaultdict(lambda: defaultdict(float))
+            self.sink_probability = defaultdict(lambda: defaultdict(float))
+
+            if not self.load_link_frequency():
+                self.default_link_frequency()
+
+        def load_link_frequency(self):
+            if not os.path.isfile(self.__frequencies_path):
+                return False
+            file = open(self.__frequencies_path, "rb")
+            imported_freq = pickle.load(file)
+            for k, v in imported_freq.items():
+                imported_freq[k] = self.__import_factor * v
+
+            self.link_frequencies = imported_freq
+            self.overwrite_probabilities_with_frequencies()
+            return True
+
+        def default_link_frequency(self):
+            self.link_frequencies[("File", "Data Table", NewLinkAction.FROM_SOURCE)] = 3
+            self.overwrite_probabilities_with_frequencies()
+
+        def overwrite_probabilities_with_frequencies(self):
+            for link, count in self.link_frequencies.items():
+                self.increment_probability(link[0], link[1], link[2], count)
+
+        def new_link(self, link):
+            # direction is none when a widget was not added+linked via quick menu
+            if self.__direction is None:
+                return
+
+            source_id = link.source_node.description.name
+            sink_id = link.sink_node.description.name
+
+            link_key = (source_id, sink_id, self.__direction)
+            self.link_frequencies[link_key] += 1
+
+            self.increment_probability(source_id, sink_id, self.__direction, 1)
+            self.write_link_frequency()
+
+            self.__direction = None
+
+        def increment_probability(self, source_id, sink_id, direction, factor):
+            if direction == NewLinkAction.FROM_SOURCE:
+                self.source_probability[source_id][sink_id] += factor
+                self.sink_probability[sink_id][source_id] += factor * 0.5
+            else:  # FROM_SINK
+                self.source_probability[source_id][sink_id] += factor * 0.5
+                self.sink_probability[sink_id][source_id] += factor
+
+        def write_link_frequency(self):
+            pickle.dump(self.link_frequencies, open(self.__frequencies_path, "wb"))
+
+        def set_direction(self, direction):
+            """
+            When opening quick menu, before the widget is created, set the direction
+            of creation (FROM_SINK, FROM_SOURCE).
+            """
+            self.__direction = direction
+
+        def set_scheme(self, scheme):
+            self.__scheme = scheme
+            scheme.onNewLink(self.new_link)
+
+        def get_sink_suggestions(self, source_id):
+            return self.source_probability[source_id]
+
+        def get_source_suggestions(self, sink_id):
+            return self.sink_probability[sink_id]
+
+        def get_default_suggestions(self):
+            return self.source_probability
+
+    instance = None
+
     def __init__(self):
-        self.__frequencies_path = config.data_dir() + "/widget-use-frequency.p"
-        self.__import_factor = 0.8  # every time you reopen orange, imported frequencies are reduced
+        if not Suggestions.instance:
+            Suggestions.instance = Suggestions.__Suggestions()
 
-        self.__scheme = None
-        self.__direction = None
-        self.link_frequencies = defaultdict(int)
-        self.source_probability = defaultdict(lambda: defaultdict(float))
-        self.sink_probability = defaultdict(lambda: defaultdict(float))
-
-        if not self.load_link_frequency():
-            self.default_link_frequency()
-
-    def load_link_frequency(self):
-        if not os.path.isfile(self.__frequencies_path):
-            return False
-        file = open(self.__frequencies_path, "rb")
-        imported_freq = pickle.load(file)
-        for k, v in imported_freq.items():
-            imported_freq[k] = self.__import_factor * v
-
-        self.link_frequencies = imported_freq
-        self.overwrite_probabilities_with_frequencies()
-        return True
-
-    def default_link_frequency(self):
-        self.link_frequencies[("File", "Data Table", NewLinkAction.FROM_SOURCE)] = 3
-        self.overwrite_probabilities_with_frequencies()
-
-    def overwrite_probabilities_with_frequencies(self):
-        for link, count in self.link_frequencies.items():
-            self.increment_probability(link[0], link[1], link[2], count)
-
-    def new_link(self, link):
-        # direction is none when a widget was not added+linked via quick menu
-        if self.__direction is None:
-            return
-
-        source_id = link.source_node.description.name
-        sink_id = link.sink_node.description.name
-
-        link_key = (source_id, sink_id, self.__direction)
-        self.link_frequencies[link_key] += 1
-
-        self.increment_probability(source_id, sink_id, self.__direction, 1)
-        self.write_link_frequency()
-
-        self.__direction = None
-
-    def increment_probability(self, source_id, sink_id, direction, factor):
-        if direction == NewLinkAction.FROM_SOURCE:
-            self.source_probability[source_id][sink_id] += factor
-            self.sink_probability[sink_id][source_id] += factor * 0.5
-        else:  # FROM_SINK
-            self.source_probability[source_id][sink_id] += factor * 0.5
-            self.sink_probability[sink_id][source_id] += factor
-
-    def write_link_frequency(self):
-        pickle.dump(self.link_frequencies, open(self.__frequencies_path, "wb"))
-
-    def get_sink_suggestions(self, source_id):
-        return self.source_probability[source_id]
-
-    def get_source_suggestions(self, sink_id):
-        return self.sink_probability[sink_id]
-
-    def get_default_suggestions(self):
-        return self.source_probability
-
-    def set_scheme(self, scheme):
-        self.__scheme = scheme
-        scheme.onNewLink(self.new_link)
-
-    def set_direction(self, direction):
-        """
-        When opening quick menu, before the widget is created, set the direction
-        of creation (FROM_SINK, FROM_SOURCE).
-        """
-        self.__direction = direction
+    def __getattr__(self, name):
+        return getattr(self.instance, name)

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -3,30 +3,35 @@ from collections import defaultdict
 
 
 class Suggestions:
+    class __Suggestions:
+        def __init__(self, scheme):
+            self.__scheme = scheme
+
+            self.link_frequencies = defaultdict(int)
+            self.source_frequencies = defaultdict(lambda: defaultdict(int))
+            self.sink_frequencies = defaultdict(lambda: defaultdict(int))
+
+            self.__scheme.onNewLink(self.new_link)
+
+        def new_link(self, link):
+            source_id = link.source_node.description.id
+            sink_id = link.sink_node.description.id
+
+            link_key = (source_id, sink_id)
+            self.link_frequencies[link_key] += 1
+
+            # optimize by making a 2d matrix of id (string) indices
+            self.source_frequencies[source_id][sink_id] += 1
+            self.sink_frequencies[sink_id][source_id] += 1
+
+        def get_sink_suggestions(self, source_id):
+            return sorted(self.source_frequencies[source_id].items(), key=operator.itemgetter(1)).reverse()
+
+        def get_source_suggestions(self, sink_id):
+            return sorted(self.sink_frequencies[sink_id].items(), key=operator.itemgetter(1)).reverse()
+
+    instance = None
+
     def __init__(self, scheme):
-        self.__scheme = scheme
-
-        self.link_frequencies = defaultdict(int)
-        self.source_frequencies = defaultdict(lambda: defaultdict(int))
-        self.sink_frequencies = defaultdict(lambda: defaultdict(int))
-
-        self.__scheme.onNewLink(self.new_link)
-
-    def new_link(self, link):
-        source_id = link.source_node.description.id
-        sink_id = link.sink_node.description.id
-
-        link_key = (source_id, sink_id)
-        self.link_frequencies[link_key] += 1
-
-        # optimize by making a 2d matrix of id (string) indices
-        self.source_frequencies[source_id][sink_id] += 1
-        self.sink_frequencies[sink_id][source_id] += 1
-
-        print(self.get_sink_suggestions(source_id))
-
-    def get_sink_suggestions(self, source_id):
-        return sorted(self.source_frequencies[source_id].items(), key=operator.itemgetter(1)).reverse()
-
-    def get_source_suggestions(self, sink_id):
-        return sorted(self.sink_frequencies[sink_id].items(), key=operator.itemgetter(1)).reverse()
+        if not Suggestions.instance:
+            Suggestions.instance = Suggestions.__Suggestions(scheme)

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -11,13 +11,12 @@ class Suggestions:
         self.sink_frequencies = defaultdict(lambda: defaultdict(int))
 
     def new_link(self, link):
-        source_id = link.source_node.title
-        sink_id = link.sink_node.title
+        source_id = link.source_node.description.name
+        sink_id = link.sink_node.description.name
 
         link_key = (source_id, sink_id)
         self.link_frequencies[link_key] += 1
 
-        # optimize by making a 2d matrix of id (string) indices
         self.source_frequencies[source_id][sink_id] += 1
         self.sink_frequencies[sink_id][source_id] += 1
 

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -1,12 +1,32 @@
+import operator
 from collections import defaultdict
 
 
 class Suggestions:
     def __init__(self, scheme):
         self.__scheme = scheme
+
         self.link_frequencies = defaultdict(int)
+        self.source_frequencies = defaultdict(lambda: defaultdict(int))
+        self.sink_frequencies = defaultdict(lambda: defaultdict(int))
+
         self.__scheme.onNewLink(self.new_link)
 
     def new_link(self, link):
-        link_key = (link.source_node.description.id, link.sink_node.description.id)
+        source_id = link.source_node.description.id
+        sink_id = link.sink_node.description.id
+
+        link_key = (source_id, sink_id)
         self.link_frequencies[link_key] += 1
+
+        # optimize by making a 2d matrix of id (string) indices
+        self.source_frequencies[source_id][sink_id] += 1
+        self.sink_frequencies[sink_id][source_id] += 1
+
+        print(self.get_sink_suggestions(source_id))
+
+    def get_sink_suggestions(self, source_id):
+        return sorted(self.source_frequencies[source_id].items(), key=operator.itemgetter(1)).reverse()
+
+    def get_source_suggestions(self, sink_id):
+        return sorted(self.sink_frequencies[sink_id].items(), key=operator.itemgetter(1)).reverse()

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -3,35 +3,30 @@ from collections import defaultdict
 
 
 class Suggestions:
-    class __Suggestions:
-        def __init__(self, scheme):
-            self.__scheme = scheme
+    def __init__(self):
+        self.__scheme = None
 
-            self.link_frequencies = defaultdict(int)
-            self.source_frequencies = defaultdict(lambda: defaultdict(int))
-            self.sink_frequencies = defaultdict(lambda: defaultdict(int))
+        self.link_frequencies = defaultdict(int)
+        self.source_frequencies = defaultdict(lambda: defaultdict(int))
+        self.sink_frequencies = defaultdict(lambda: defaultdict(int))
 
-            self.__scheme.onNewLink(self.new_link)
+    def new_link(self, link):
+        source_id = link.source_node.title
+        sink_id = link.sink_node.title
 
-        def new_link(self, link):
-            source_id = link.source_node.description.id
-            sink_id = link.sink_node.description.id
+        link_key = (source_id, sink_id)
+        self.link_frequencies[link_key] += 1
 
-            link_key = (source_id, sink_id)
-            self.link_frequencies[link_key] += 1
+        # optimize by making a 2d matrix of id (string) indices
+        self.source_frequencies[source_id][sink_id] += 1
+        self.sink_frequencies[sink_id][source_id] += 1
 
-            # optimize by making a 2d matrix of id (string) indices
-            self.source_frequencies[source_id][sink_id] += 1
-            self.sink_frequencies[sink_id][source_id] += 1
+    def get_sink_suggestions(self, source_id):
+        return self.source_frequencies[source_id]
 
-        def get_sink_suggestions(self, source_id):
-            return sorted(self.source_frequencies[source_id].items(), key=operator.itemgetter(1)).reverse()
+    def get_source_suggestions(self, sink_id):
+        return self.sink_frequencies[sink_id]
 
-        def get_source_suggestions(self, sink_id):
-            return sorted(self.sink_frequencies[sink_id].items(), key=operator.itemgetter(1)).reverse()
-
-    instance = None
-
-    def __init__(self, scheme):
-        if not Suggestions.instance:
-            Suggestions.instance = Suggestions.__Suggestions(scheme)
+    def set_scheme(self, scheme):
+        self.__scheme = scheme
+        scheme.onNewLink(self.new_link)

--- a/Orange/canvas/document/suggestions.py
+++ b/Orange/canvas/document/suggestions.py
@@ -1,14 +1,42 @@
-import operator
+import os
+import pickle
 from collections import defaultdict
+
+from Orange.canvas import config
 
 
 class Suggestions:
     def __init__(self):
-        self.__scheme = None
+        self.__frequencies_path = config.data_dir() + "widget-use-frequency.p"
 
+        self.__scheme = None
         self.link_frequencies = defaultdict(int)
-        self.source_frequencies = defaultdict(lambda: defaultdict(int))
-        self.sink_frequencies = defaultdict(lambda: defaultdict(int))
+        self.source_probability = defaultdict(lambda: defaultdict(float))
+        self.sink_probability = defaultdict(lambda: defaultdict(float))
+
+        if not self.load_link_frequency():
+            self.default_link_frequency()
+
+    def load_link_frequency(self):
+        if not os.path.isfile(self.__frequencies_path):
+            return False
+        file = open(self.__frequencies_path, "rb")
+        self.link_frequencies = pickle.load(file)
+
+        self.overwrite_probabilities_with_frequencies()
+        return True
+
+    def default_link_frequency(self):
+        self.link_frequencies[("File", "Data Table")] = 3
+        self.overwrite_probabilities_with_frequencies()
+
+    def overwrite_probabilities_with_frequencies(self):
+        for link, count in self.link_frequencies.items():
+            self.source_probability[link[0]][link[1]] = count
+            self.sink_probability[link[1]][link[0]] = count
+
+    def write_link_frequency(self):
+        pickle.dump(self.link_frequencies, open(self.__frequencies_path, "wb"))
 
     def new_link(self, link):
         source_id = link.source_node.description.name
@@ -17,14 +45,16 @@ class Suggestions:
         link_key = (source_id, sink_id)
         self.link_frequencies[link_key] += 1
 
-        self.source_frequencies[source_id][sink_id] += 1
-        self.sink_frequencies[sink_id][source_id] += 1
+        self.source_probability[source_id][sink_id] += 1
+        self.sink_probability[sink_id][source_id] += 1
+
+        self.write_link_frequency()
 
     def get_sink_suggestions(self, source_id):
-        return self.source_frequencies[source_id]
+        return self.source_probability[source_id]
 
     def get_source_suggestions(self, sink_id):
-        return self.sink_frequencies[sink_id]
+        return self.sink_probability[sink_id]
 
     def set_scheme(self, scheme):
         self.__scheme = scheme


### PR DESCRIPTION
##### Issue
When adding an input or output to a widget, the suggested widgets in the search window follow a default ordering, regardless of which widget is being extended (aside incompatible widgets being filtered out).


##### Description of changes
Addition of Suggestions singleton class, which tracks which widgets the user most often connects, ordering the widgets presented in the 'quick menu' search tab accordingly.


##### Includes
- [X] Code changes
- [ ] Tests
- [x] Documentation
