### PR TITLE
[ENH] Match Keywords in Widget Search

### DIFF
--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -325,18 +325,16 @@ class SortFilterProxyModel(QSortFilterProxyModel):
     def filterAcceptsRow(self, row, parent=QModelIndex()):
         flat_model = self.sourceModel()
         index = flat_model.index(row, self.filterKeyColumn(), parent)
-        keywords = flat_model.data(index, role=QtWidgetRegistry.WIDGET_DESC_ROLE).keywords
+        description = flat_model.data(index, role=QtWidgetRegistry.WIDGET_DESC_ROLE)
+        name = description.name
+        keywords = description.keywords
 
-        # match keywords
+        # match name and keywords
         accepted = False
-        for keyword in keywords:
+        for keyword in [name] + keywords:
             if self.filterRegExp().indexIn(keyword) > -1:
                 accepted = True
                 break
-
-        # if does not match keywords, match title
-        if not accepted:
-            accepted = QSortFilterProxyModel.filterAcceptsRow(self, row, parent)
 
         # if matches query, apply filter function (compatibility with paired widget)
         if accepted and self.__filterFunc is not None:

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -27,6 +27,7 @@ class OWConcatenate(widget.OWWidget):
     description = "Concatenate (append) two or more datasets."
     priority = 1111
     icon = "icons/Concatenate.svg"
+    keywords = ["append", "join", "extend"]
 
     class Inputs:
         primary_data = Input("Primary Data", Orange.data.Table)

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -24,7 +24,7 @@ class OWContinuize(widget.OWWidget):
                    "optionally, normalize numeric values.")
     icon = "icons/Continuize.svg"
     category = "Data"
-    keywords = ["data", "continuize"]
+    keywords = ["continuize"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -24,7 +24,7 @@ class OWContinuize(widget.OWWidget):
                    "optionally, normalize numeric values.")
     icon = "icons/Continuize.svg"
     category = "Data"
-    keywords = ["continuize"]
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -127,7 +127,7 @@ class OWCreateClass(widget.OWWidget):
     description = "Create class attribute from a string attribute"
     icon = "icons/CreateClass.svg"
     category = "Data"
-    keywords = ["data"]
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -23,7 +23,7 @@ class OWDataInfo(widget.OWWidget):
     icon = "icons/DataInfo.svg"
     priority = 80
     category = "Data"
-    keywords = ["data", "info"]
+    keywords = ["information", "inspect"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -22,7 +22,7 @@ class OWDataSampler(OWWidget):
     icon = "icons/DataSampler.svg"
     priority = 100
     category = "Data"
-    keywords = ["data", "sample"]
+    keywords = ["random"]
 
     _MAX_SAMPLE_SIZE = 2 ** 31 - 1
 

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -130,6 +130,7 @@ class OWDataSets(widget.OWWidget):
     icon = "icons/DataSets.svg"
     priority = 20
     replaces = ["orangecontrib.prototypes.widgets.owdatasets.OWDataSets"]
+    keywords = ["online"]
 
     # The following constants can be overridden in a subclass
     # to reuse this widget for a different repository

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -127,6 +127,7 @@ class OWDiscretize(widget.OWWidget):
     name = "Discretize"
     description = "Discretize the numeric data features."
     icon = "icons/Discretize.svg"
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table, doc="Input data table")

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -401,6 +401,7 @@ class OWEditDomain(widget.OWWidget):
     description = "Rename features and their values."
     icon = "icons/EditDomain.svg"
     priority = 3125
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -333,6 +333,7 @@ class OWFeatureConstructor(OWWidget):
     description = "Construct new features (data columns) from a set of " \
                   "existing features in the input dataset."
     icon = "icons/FeatureConstructor.svg"
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -77,7 +77,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     icon = "icons/File.svg"
     priority = 10
     category = "Data"
-    keywords = ["data", "file", "load", "read"]
+    keywords = ["file", "load", "read"]
 
     class Outputs:
         data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -77,7 +77,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     icon = "icons/File.svg"
     priority = 10
     category = "Data"
-    keywords = ["file", "load", "read"]
+    keywords = ["file", "load", "read", "open"]
 
     class Outputs:
         data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -129,6 +129,7 @@ class OWImpute(OWWidget):
     description = "Impute missing values in the data table."
     icon = "icons/Impute.svg"
     priority = 2130
+    keywords = ["substitute", "missing"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -27,6 +27,7 @@ class OWMergeData(widget.OWWidget):
     description = "Merge datasets based on the values of selected features."
     icon = "icons/MergeData.svg"
     priority = 1110
+    keywords = ["join"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table, default=True, replaces=["Data A"])

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -18,7 +18,7 @@ class OWOutliers(widget.OWWidget):
     icon = "icons/Outliers.svg"
     priority = 3000
     category = "Data"
-    keywords = ["outlier", "inlier"]
+    keywords = ["inlier"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -18,7 +18,7 @@ class OWOutliers(widget.OWWidget):
     icon = "icons/Outliers.svg"
     priority = 3000
     category = "Data"
-    keywords = ["data", "outlier", "inlier"]
+    keywords = ["outlier", "inlier"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -743,7 +743,7 @@ class OWPaintData(OWWidget):
     description = "Create data by painting data points on a plane."
     icon = "icons/PaintData.svg"
     priority = 60
-    keywords = ["data", "paint", "create"]
+    keywords = ["create", "draw"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -952,6 +952,7 @@ class OWPreprocess(widget.OWWidget):
     description = "Construct a data preprocessing pipeline."
     icon = "icons/Preprocess.svg"
     priority = 2105
+    keywords = ["process"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -13,7 +13,7 @@ class OWPurgeDomain(widget.OWWidget):
                   "Sort values."
     icon = "icons/PurgeDomain.svg"
     category = "Data"
-    keywords = ["purge", "domain"]
+    keywords = ["remove", "delete", "unused"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -13,7 +13,7 @@ class OWPurgeDomain(widget.OWWidget):
                   "Sort values."
     icon = "icons/PurgeDomain.svg"
     category = "Data"
-    keywords = ["data", "purge", "domain"]
+    keywords = ["purge", "domain"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -368,6 +368,7 @@ class OWPythonScript(widget.OWWidget):
     description = "Write a Python script and run it on input data or models."
     icon = "icons/PythonScript.svg"
     priority = 3150
+    keywords = ["file", "program"]
 
     class Inputs:
         data = Input("Data", Table, replaces=["in_data"],

--- a/Orange/widgets/data/owrandomize.py
+++ b/Orange/widgets/data/owrandomize.py
@@ -15,6 +15,7 @@ class OWRandomize(OWWidget):
     description = "Randomize features, class and/or metas in data table."
     icon = "icons/Random.svg"
     priority = 2100
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -169,6 +169,7 @@ class OWRank(OWWidget):
     description = "Rank and filter data features by their relevance."
     icon = "icons/Rank.svg"
     priority = 1102
+    keywords = []
 
     buttons_area_orientation = Qt.Vertical
 

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -13,7 +13,7 @@ class OWSave(widget.OWWidget):
     description = "Save data to an output file."
     icon = "icons/Save.svg"
     category = "Data"
-    keywords = ["data", "save"]
+    keywords = ["save"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -13,7 +13,7 @@ class OWSave(widget.OWWidget):
     description = "Save data to an output file."
     icon = "icons/Save.svg"
     category = "Data"
-    keywords = ["save"]
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -103,6 +103,7 @@ class OWSelectAttributes(widget.OWWidget):
                   "data features, classes or meta variables."
     icon = "icons/SelectColumns.svg"
     priority = 100
+    keywords = ["filter"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -76,6 +76,7 @@ class OWSelectRows(widget.OWWidget):
     icon = "icons/SelectRows.svg"
     priority = 100
     category = "Data"
+    keywords = ["filter"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -44,7 +44,7 @@ class OWSql(OWWidget):
     icon = "icons/SQLTable.svg"
     priority = 30
     category = "Data"
-    keywords = ["data", "file", "load", "read", "SQL"]
+    keywords = ["file", "load", "read", "SQL"]
 
     class Outputs:
         data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -44,7 +44,7 @@ class OWSql(OWWidget):
     icon = "icons/SQLTable.svg"
     priority = 30
     category = "Data"
-    keywords = ["file", "load", "read", "SQL"]
+    keywords = ["load"]
 
     class Outputs:
         data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -370,6 +370,7 @@ class OWDataTable(widget.OWWidget):
     description = "View the dataset in a spreadsheet."
     icon = "icons/Table.svg"
     priority = 50
+    keywords = []
 
     buttons_area_orientation = Qt.Vertical
 

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -12,6 +12,7 @@ class OWTranspose(OWWidget):
     description = "Transpose data table."
     icon = "icons/Transpose.svg"
     priority = 2000
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -37,6 +37,7 @@ class OWCalibrationPlot(widget.OWWidget):
     description = "Calibration plot based on evaluation of classifiers."
     icon = "icons/CalibrationPlot.svg"
     priority = 1030
+    keywords = []
 
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -83,6 +83,7 @@ class OWConfusionMatrix(widget.OWWidget):
                   "the results of classifier evaluations."
     icon = "icons/ConfusionMatrix.svg"
     priority = 1001
+    keywords = []
 
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -58,6 +58,7 @@ class OWLiftCurve(widget.OWWidget):
                   "from the evaluation of classifiers."
     icon = "icons/LiftCurve.svg"
     priority = 1020
+    keywords = []
 
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -46,6 +46,7 @@ class OWPredictions(OWWidget):
     icon = "icons/Predictions.svg"
     priority = 200
     description = "Display the predictions of models for an input dataset."
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -297,6 +297,7 @@ class OWROCAnalysis(widget.OWWidget):
                   "based on the evaluation of classifiers."
     icon = "icons/ROCAnalysis.svg"
     priority = 1010
+    keywords = []
 
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -141,6 +141,7 @@ class OWTestLearners(OWWidget):
     description = "Cross-validation accuracy estimation."
     icon = "icons/TestLearners1.svg"
     priority = 100
+    keywords = []
 
     class Inputs:
         train_data = Input("Data", Table, default=True)

--- a/Orange/widgets/model/owadaboost.py
+++ b/Orange/widgets/model/owadaboost.py
@@ -19,6 +19,7 @@ class OWAdaBoost(OWBaseLearner):
         "Orange.widgets.regression.owadaboostregression.OWAdaBoostRegression",
     ]
     priority = 80
+    keywords = ["boost"]
 
     LEARNER = SklAdaBoostLearner
 

--- a/Orange/widgets/model/owconstant.py
+++ b/Orange/widgets/model/owconstant.py
@@ -13,6 +13,7 @@ class OWConstant(OWBaseLearner):
         "Orange.widgets.regression.owmean.OWMean",
     ]
     priority = 10
+    keywords = ["majority", "mean"]
 
     LEARNER = ConstantLearner
 

--- a/Orange/widgets/model/owknn.py
+++ b/Orange/widgets/model/owknn.py
@@ -16,6 +16,7 @@ class OWKNNLearner(OWBaseLearner):
         "Orange.widgets.regression.owknnregression.OWKNNRegression",
     ]
     priority = 20
+    keywords = ["k nearest", "knearest", "neighbor", "neighbour"]
 
     LEARNER = KNNLearner
 

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -22,6 +22,7 @@ class OWLinearRegression(OWBaseLearner):
         "Orange.widgets.regression.owlinearregression.OWLinearRegression",
     ]
     priority = 60
+    keywords = ["ridge", "lasso", "elastic net"]
 
     LEARNER = LinearRegressionLearner
 

--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -20,6 +20,7 @@ class OWLoadModel(widget.OWWidget):
     priority = 3050
     replaces = ["Orange.widgets.classify.owloadclassifier.OWLoadClassifier"]
     icon = "icons/LoadModel.svg"
+    keywords = ["file", "open"]
 
     class Outputs:
         model = Output("Model", Model)

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -19,6 +19,7 @@ class OWLogisticRegression(OWBaseLearner):
         "Orange.widgets.classify.owlogisticregression.OWLogisticRegression",
     ]
     priority = 60
+    keywords = []
 
     LEARNER = LogisticRegressionLearner
 

--- a/Orange/widgets/model/ownaivebayes.py
+++ b/Orange/widgets/model/ownaivebayes.py
@@ -15,6 +15,7 @@ class OWNaiveBayes(OWBaseLearner):
         "Orange.widgets.classify.ownaivebayes.OWNaiveBayes",
     ]
     priority = 70
+    keywords = []
 
     LEARNER = NaiveBayesLearner
 

--- a/Orange/widgets/model/owneuralnetwork.py
+++ b/Orange/widgets/model/owneuralnetwork.py
@@ -64,6 +64,7 @@ class OWNNLearner(OWBaseLearner):
                   "backpropagation."
     icon = "icons/NN.svg"
     priority = 90
+    keywords = ["mlp"]
 
     LEARNER = NNLearner
 

--- a/Orange/widgets/model/owrandomforest.py
+++ b/Orange/widgets/model/owrandomforest.py
@@ -16,6 +16,7 @@ class OWRandomForest(OWBaseLearner):
         "Orange.widgets.regression.owrandomforestregression.OWRandomForestRegression",
     ]
     priority = 40
+    keywords = []
 
     LEARNER = RandomForestLearner
 

--- a/Orange/widgets/model/owrules.py
+++ b/Orange/widgets/model/owrules.py
@@ -212,6 +212,7 @@ class OWRuleLearner(OWBaseLearner):
         "Orange.widgets.classify.owrules.OWRuleLearner",
     ]
     priority = 19
+    keywords = []
 
     want_main_area = False
     resizing_enabled = False

--- a/Orange/widgets/model/owsavemodel.py
+++ b/Orange/widgets/model/owsavemodel.py
@@ -19,6 +19,7 @@ class OWSaveModel(widget.OWWidget):
     icon = "icons/SaveModel.svg"
     replaces = ["Orange.widgets.classify.owsaveclassifier.OWSaveClassifier"]
     priority = 3000
+    keywords = []
 
     class Inputs:
         model = Input("Model", Model)

--- a/Orange/widgets/model/owsgd.py
+++ b/Orange/widgets/model/owsgd.py
@@ -23,6 +23,7 @@ class OWSGD(OWBaseLearner):
         "Orange.widgets.regression.owsgdregression.OWSGDRegression",
     ]
     priority = 90
+    keywords = ["sgd"]
 
     settings_version = 2
 

--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -21,6 +21,7 @@ class OWSVM(OWBaseLearner):
         "Orange.widgets.regression.owsvmregression.OWSVMRegression",
     ]
     priority = 50
+    keywords = ["support vector machines"]
 
     LEARNER = SVMLearner
 

--- a/Orange/widgets/model/owtree.py
+++ b/Orange/widgets/model/owtree.py
@@ -23,6 +23,7 @@ class OWTreeLearner(OWBaseLearner):
         "Orange.widgets.regression.owregressiontree.OWTreeLearner",
     ]
     priority = 30
+    keywords = []
 
     LEARNER = TreeLearner
 

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -47,6 +47,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     name = "Correspondence Analysis"
     description = "Correspondence analysis for categorical multivariate data."
     icon = "icons/CorrespondenceAnalysis.svg"
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -17,7 +17,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
     icon = "icons/DistanceFile.svg"
     priority = 10
     category = "Data"
-    keywords = ["data", "distances", "load", "read"]
+    keywords = ["distances", "load", "read"]
 
     class Outputs:
         distances = Output("Distances", DistMatrix, dynamic=False)

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -17,7 +17,7 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
     icon = "icons/DistanceFile.svg"
     priority = 10
     category = "Data"
-    keywords = ["distances", "load", "read"]
+    keywords = ["load", "read", "open"]
 
     class Outputs:
         distances = Output("Distances", DistMatrix, dynamic=False)

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -245,6 +245,7 @@ class OWDistanceMap(widget.OWWidget):
     description = "Visualize a distance matrix."
     icon = "icons/DistanceMap.svg"
     priority = 1200
+    keywords = []
 
     class Inputs:
         distances = Input("Distances", Orange.misc.DistMatrix)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -202,6 +202,7 @@ class OWDistanceMatrix(widget.OWWidget):
     description = "View distance matrix."
     icon = "icons/DistanceMatrix.svg"
     priority = 200
+    keywords = []
 
     class Inputs:
         distances = Input("Distances", DistMatrix)

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -27,6 +27,7 @@ class OWDistances(OWWidget):
     name = "Distances"
     description = "Compute a matrix of pairwise distances."
     icon = "icons/Distance.svg"
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -11,6 +11,7 @@ class OWDistanceTransformation(widget.OWWidget):
     name = "Distance Transformation"
     description = "Transform distances according to selected criteria."
     icon = "icons/DistancesTransformation.svg"
+    keywords = []
 
     class Inputs:
         distances = Input("Distances", DistMatrix)

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -759,6 +759,7 @@ class OWHierarchicalClustering(widget.OWWidget):
                   "constructed from the input distance matrix."
     icon = "icons/HierarchicalClustering.svg"
     priority = 2100
+    keywords = []
 
     class Inputs:
         distances = Input("Distances", Orange.misc.DistMatrix)

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -90,7 +90,7 @@ class OWKMeans(widget.OWWidget):
                   "quality estimation."
     icon = "icons/KMeans.svg"
     priority = 2100
-    keywords = ["means", "kmeans"]
+    keywords = ["kmeans", "clustering"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -90,6 +90,7 @@ class OWKMeans(widget.OWWidget):
                   "quality estimation."
     icon = "icons/KMeans.svg"
     priority = 2100
+    keywords = ["means", "kmeans"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -176,6 +176,7 @@ class OWManifoldLearning(OWWidget):
     description = "Nonlinear dimensionality reduction."
     icon = "icons/Manifold.svg"
     priority = 2200
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -90,6 +90,7 @@ class OWMDS(OWWidget):
     description = "Two-dimensional data projection by multidimensional " \
                   "scaling constructed from a distance matrix."
     icon = "icons/MDS.svg"
+    keywords = ["multidimensional scaling", "multi dimensional scaling"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table, default=True)

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -35,6 +35,7 @@ class OWPCA(widget.OWWidget):
     description = "Principal component analysis with a scree-diagram."
     icon = "icons/PCA.svg"
     priority = 3050
+    keywords = ["principal component analysis", "linear transformation"]
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -117,6 +117,7 @@ class OWBoxPlot(widget.OWWidget):
     description = "Visualize the distribution of feature values in a box plot."
     icon = "icons/BoxPlot.svg"
     priority = 100
+    keywords = ["whisker"]
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -140,6 +140,7 @@ class OWDistributions(widget.OWWidget):
     description = "Display value distributions of a data feature in a graph."
     icon = "icons/Distribution.svg"
     priority = 120
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table, doc="Set the input dataset")

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -316,6 +316,7 @@ class OWFreeViz(widget.OWWidget):
     description = "Displays FreeViz projection"
     icon = "icons/Freeviz.svg"
     priority = 240
+    keywords = ["viz"]
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -387,6 +387,7 @@ class OWHeatMap(widget.OWWidget):
     description = "Plot a heat map for a pair of attributes."
     icon = "icons/Heatmap.svg"
     priority = 260
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -217,6 +217,7 @@ class OWLinearProjection(widget.OWWidget):
                   "a two-dimensional plane."
     icon = "icons/LinearProjection.svg"
     priority = 240
+    keywords = []
 
     selection_indices = settings.Setting(None, schema_only=True)
 

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -256,6 +256,7 @@ class OWMosaicDisplay(OWWidget):
     description = "Display data in a mosaic plot."
     icon = "icons/MosaicDisplay.svg"
     priority = 220
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -565,6 +565,7 @@ class OWNomogram(OWWidget):
                   " and Logistic Regression Classifiers."
     icon = "icons/Nomogram.svg"
     priority = 2000
+    keywords = []
 
     class Inputs:
         classifier = Input("Classifier", Model)

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -41,6 +41,7 @@ class OWPythagorasTree(OWWidget):
     name = 'Pythagorean Tree'
     description = 'Pythagorean Tree visualization for tree like-structures.'
     icon = 'icons/PythagoreanTree.svg'
+    keywords = ["fractal"]
 
     priority = 1000
 

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -160,6 +160,7 @@ class OWPythagoreanForest(OWWidget):
     description = 'Pythagorean forest for visualising random forests.'
     icon = 'icons/PythagoreanForest.svg'
     settings_version = 2
+    keywords = ["fractal"]
 
     priority = 1001
 

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -373,9 +373,9 @@ MAX_POINTS = 100
 class OWRadviz(widget.OWWidget):
     name = "Radviz"
     description = "Radviz"
-
     icon = "icons/Radviz.svg"
     priority = 240
+    keywords = ["viz"]
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/Orange/widgets/visualize/owruleviewer.py
+++ b/Orange/widgets/visualize/owruleviewer.py
@@ -21,6 +21,7 @@ class OWRuleViewer(widget.OWWidget):
     description = "Review rules induced from data."
     icon = "icons/CN2RuleViewer.svg"
     priority = 1140
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table)

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -98,6 +98,7 @@ class OWScatterPlot(OWWidget):
                   "intelligent data visualization enhancements."
     icon = "icons/ScatterPlot.svg"
     priority = 140
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -72,6 +72,7 @@ class OWSieveDiagram(OWWidget):
                   "for a combination of values."
     icon = "icons/SieveDiagram.svg"
     priority = 200
+    keywords = []
 
     class Inputs:
         data = Input("Data", Table, default=True)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -44,6 +44,7 @@ class OWSilhouettePlot(widget.OWWidget):
 
     icon = "icons/SilhouettePlot.svg"
     priority = 300
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table)

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -159,6 +159,7 @@ class OWTreeGraph(OWTreeViewer2D):
     name = "Tree Viewer"
     icon = "icons/TreeViewer.svg"
     priority = 35
+    keywords = []
 
     class Inputs:
         # Had different input names before merging from

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -44,6 +44,7 @@ class OWVennDiagram(widget.OWWidget):
                   "from a collection of input datasets."
     icon = "icons/VennDiagram.svg"
     priority = 280
+    keywords = []
 
     class Inputs:
         data = Input("Data", Orange.data.Table, multiple=True)


### PR DESCRIPTION
##### Issue
At the moment, searching for widgets only queries widget titles. This leads to one having to type the widget's exact name to find it (e.g. "k-means"). With searching by keyword, widgets can be assigned other tags (e.g. "means", "kmeans").


##### Description of changes
Overriding filterAcceptsRow() in quick menu, matching both keywords and widget title.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
