### PR TITLE
ubuntu 16.04 lts

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,4 +3,4 @@ docutils
 numpydoc
 recommonmark>=0.1.1
 Sphinx>=1.3
-PyQt5
+PyQt5==5.10.1


### PR DESCRIPTION
remediation for error:
    from PyQt5.QtCore import *
ImportError: /home/forensic/Documents/Workspace/orange-ml/lib/python3.5/site-packages/PyQt5/QtCore.so: undefined symbol: PySlice_AdjustIndices

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
