### PR TITLE
[RFC][FIX] BoxPlot: Hide groups with no instances

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -773,6 +773,8 @@ class OWBoxPlot(widget.OWWidget):
         Draw the horizontal axis and sets self.scale_x for discrete attributes
         """
         if self.stretched:
+            if not self.attr_labels:
+                return
             step = steps = 10
         else:
             if self.group_var:

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -407,8 +407,11 @@ class OWBoxPlot(widget.OWWidget):
                 dataset, attr, self.group_var)
             if self.is_continuous:
                 self.stats = [BoxData(cont, attr, i, self.group_var)
-                              for i, cont in enumerate(self.conts)]
-            self.label_txts_all = self.group_var.values
+                              for i, cont in enumerate(self.conts)
+                              if np.sum(cont) > 0]
+            self.label_txts_all = \
+                [v for v, c in zip(self.group_var.values, self.conts)
+                 if np.sum(c) > 0]
         else:
             self.dist = distribution.get_distribution(dataset, attr)
             self.conts = []
@@ -528,14 +531,17 @@ class OWBoxPlot(widget.OWWidget):
             if self.group_var:
                 self.labels = [
                     QGraphicsTextItem("{}".format(int(sum(cont))))
-                    for cont in self.conts]
+                    for cont in self.conts if np.sum(cont) > 0]
             else:
                 self.labels = [
                     QGraphicsTextItem(str(int(sum(self.dist))))]
 
         self.draw_axis_disc()
         if self.group_var:
-            self.boxes = [self.strudel(cont, i) for i, cont in enumerate(self.conts)]
+            self.boxes = \
+                [self.strudel(cont, i) for i, cont in enumerate(self.conts)
+                 if np.sum(cont) > 0]
+            self.conts = self.conts[np.sum(np.array(self.conts), axis=1) > 0]
         else:
             self.boxes = [self.strudel(self.dist)]
 

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -162,6 +162,20 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         QTest.qWait(3000)
         self.widget.hide()
 
+    def test_empty_groups(self):
+        """Test if groups with zero elements are not shown"""
+        table = Table("cyber-security-breaches")
+        self.send_signal(self.widget.Inputs.data, table)
+        self.__select_variable("US State")
+        self.__select_group("US State")
+        self.assertEqual(52, len(self.widget.boxes))
+
+        # select rows with US State equal to TX or MO
+        use_indexes = np.array([0, 1, 25, 26, 27])
+        table.X = table.X[use_indexes]
+        self.send_signal(self.widget.Inputs.data, table)
+        self.assertEqual(2, len(self.widget.boxes))
+
     def _select_data(self):
         items = [item for item in self.widget.box_scene.items()
                  if isinstance(item, FilterGraphicsRectItem)]


### PR DESCRIPTION
##### Issue
Fixes #3094 
##### Description of changes
Groups that have zero elements are no longer shown.
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
