### PR TITLE
Fixed workflow basedir when saving

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1331,7 +1331,7 @@ class CanvasMainWindow(QMainWindow):
         try:
             with open(filename, "wb") as f:
                 f.write(buffer.getvalue())
-            scheme.set_runtime_env("basedir", os.path.dirname(dirname))
+            scheme.set_runtime_env("basedir", dirname)
             return True
         except (IOError, OSError) as ex:
             log.error("%s saving '%s'", type(ex).__name__, filename,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`basedir` points to the parent directory of the basedir.

##### Description of changes
`basedir` changed to actually point to the base directory. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
