### PR TITLE
[RFC][WIP] Add Mssql testing to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 sudo: false
 dist: trusty
 
+services:
+  - docker
+
 matrix:
     include:
         - env: RUN_PYLINT=true

--- a/.travis/install_mssql.sh
+++ b/.travis/install_mssql.sh
@@ -1,0 +1,7 @@
+sudo docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=YourStrong!Passw0rd' \
+   -p 1433:1433 -d microsoft/mssql-server-linux:2017-latest
+
+export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1
+pip install pymssql
+
+export ORANGE_TEST_DB_URI="${ORANGE_TEST_DB_URI}|mssql://SA:YourStrong!Passw0rd@0.0.0.0:1433"

--- a/.travis/stage_install.sh
+++ b/.travis/stage_install.sh
@@ -4,6 +4,7 @@
 for script in \
     install_orange.sh    \
     install_postgres.sh  \
+    install_mssql.sh    \
     install_pyqt.sh
 do
     foldable source $TRAVIS_BUILD_DIR/.travis/$script

--- a/Orange/tests/sql/test_filter.py
+++ b/Orange/tests/sql/test_filter.py
@@ -5,10 +5,10 @@ import unittest
 from Orange.data.sql.table import SqlTable, SqlRowInstance
 from Orange.data import filter, domain
 
-from Orange.tests.sql.base import PostgresTest, sql_version, sql_test
+from Orange.tests.sql.base import PostgresTest, postgresql_test
 
 
-@sql_test
+@postgresql_test
 class TestIsDefinedSql(PostgresTest):
     def setUp(self):
         self.data = [
@@ -61,7 +61,7 @@ class TestIsDefinedSql(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
+@postgresql_test
 class TestHasClass(PostgresTest):
     def setUp(self):
         self.data = [
@@ -95,7 +95,7 @@ class TestHasClass(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
+@postgresql_test
 class TestSameValueSql(PostgresTest):
     def setUp(self):
         self.data = [
@@ -183,7 +183,7 @@ class TestSameValueSql(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
+@postgresql_test
 class TestValuesSql(PostgresTest):
     def setUp(self):
         self.data = [
@@ -317,7 +317,7 @@ class TestValuesSql(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
+@postgresql_test
 class TestFilterStringSql(PostgresTest):
     def setUp(self):
         self.data = [

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -7,14 +7,14 @@ from Orange import preprocess
 from Orange.data.sql.table import SqlTable
 from Orange.data import Domain
 from Orange.data.variable import DiscreteVariable
-from Orange.tests.sql.base import sql_test, connection_params
+from Orange.tests.sql.base import postgresql_test, connection_params
 
 
 @unittest.skip("Fails on travis.")
-@sql_test
+@postgresql_test
 class NaiveBayesTest(unittest.TestCase):
     def test_NaiveBayes(self):
-        table = SqlTable(connection_params(), 'iris',
+        table = SqlTable(connection_params()['postgres'], 'iris',
                          type_hints=Domain([], DiscreteVariable("iris",
                                 values=['Iris-setosa', 'Iris-virginica',
                                         'Iris-versicolor'])))

--- a/Orange/tests/sql/test_pca.py
+++ b/Orange/tests/sql/test_pca.py
@@ -4,14 +4,14 @@ from unittest.mock import patch, MagicMock
 from Orange.data import DiscreteVariable, Domain
 from Orange.data.sql.table import SqlTable
 from Orange.projection.pca import RemotePCA
-from Orange.tests.sql.base import sql_test, connection_params
+from Orange.tests.sql.base import postgresql_test, connection_params
 
 
-@sql_test
+@postgresql_test
 class PCATest(unittest.TestCase):
     @patch("Orange.projection.pca.save_state", MagicMock())
     def test_PCA(self):
-        table = SqlTable(connection_params(), 'iris',
+        table = SqlTable(connection_params()['postgres'], 'iris',
                          type_hints=Domain([], DiscreteVariable("iris",
                                 values=['Iris-setosa', 'Iris-virginica',
                                         'Iris-versicolor'])))

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -17,10 +17,11 @@ from Orange.preprocess.discretize import EqualWidth
 from Orange.statistics.basic_stats import BasicStats, DomainBasicStats
 from Orange.statistics.contingency import Continuous, Discrete, get_contingencies
 from Orange.statistics.distribution import get_distributions
-from Orange.tests.sql.base import PostgresTest, sql_version, sql_test
+from Orange.tests.sql.base import PostgresTest, postgressql_version, \
+    postgresql_test
 
 
-@sql_test
+@postgresql_test
 class TestSqlTable(PostgresTest):
     def test_constructs_correct_attributes(self):
         data = list(zip(self.float_variable(21),
@@ -485,7 +486,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
-    @unittest.skipIf(sql_version < 90200,
+    @unittest.skipIf(postgressql_version < 90200,
                      "Type not supported on this server version.")
     def test_smallserial(self):
         table = np.arange(25).reshape((-1, 1))
@@ -497,7 +498,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
-    @unittest.skipIf(sql_version < 90200,
+    @unittest.skipIf(postgressql_version < 90200,
                      "Type not supported on this server version.")
     def test_bigserial(self):
         table = np.arange(25).reshape((-1, 1))


### PR DESCRIPTION
##### Issue
Fixes #2839 
##### Description of changes
Add a docker instance of Microsoft SQL server to Travis for testing pymssql dependent components.
Changed the utility functions for testing sql to accommodate the new database.
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
