### PR TITLE
[FIX] Replace use of obsolete QStyle.standardPixmap

### DIFF
--- a/Orange/canvas/gui/dock.py
+++ b/Orange/canvas/gui/dock.py
@@ -10,7 +10,7 @@ A dock widget that can be a collapsed/expanded.
 import logging
 
 from AnyQt.QtWidgets import QDockWidget, QAbstractButton, QSizePolicy, QStyle
-from AnyQt.QtGui import  QIcon, QTransform
+from AnyQt.QtGui import QIcon, QTransform
 from AnyQt.QtCore import Qt, QEvent
 from AnyQt.QtCore import pyqtProperty as Property, pyqtSignal as Signal
 
@@ -54,18 +54,19 @@ class CollapsibleDockWidget(QDockWidget):
 
         # Use the toolbar horizontal extension button icon as the default
         # for the expand/collapse button
-        pm = self.style().standardPixmap(
-            QStyle.SP_ToolBarHorizontalExtensionButton
-        )
+        icon = self.style().standardIcon(
+            QStyle.SP_ToolBarHorizontalExtensionButton)
 
-        # Rotate the icon
+        # Mirror the icon
         transform = QTransform()
-        transform.rotate(180)
+        transform = transform.scale(-1.0, 1.0)
+        icon_rev = QIcon()
+        for s in (8, 12, 14, 16, 18, 24, 32, 48, 64):
+            pm = icon.pixmap(s, s)
+            icon_rev.addPixmap(pm.transformed(transform))
 
-        pm_rev = pm.transformed(transform)
-
-        self.__iconRight = QIcon(pm)
-        self.__iconLeft = QIcon(pm_rev)
+        self.__iconRight = QIcon(icon)
+        self.__iconLeft = QIcon(icon_rev)
 
         close = self.findChild(QAbstractButton,
                                name="qt_dockwidget_closebutton")

--- a/Orange/canvas/gui/tests/test_lineedit.py
+++ b/Orange/canvas/gui/tests/test_lineedit.py
@@ -18,9 +18,7 @@ class TestSearchWidget(QAppTestCase):
         line = LineEdit()
         line.show()
 
-        action1 = QAction(QIcon(line.style().standardPixmap(
-                                    QStyle.SP_ArrowBack)
-                                ),
+        action1 = QAction(line.style().standardIcon(QStyle.SP_ArrowBack),
                           "Search", line)
         menu = QMenu()
         menu.addAction("Regex")
@@ -40,8 +38,7 @@ class TestSearchWidget(QAppTestCase):
 
         line.setAction(action1, LineEdit.LeftPosition)
 
-        action2 = QAction(QIcon(line.style().standardPixmap(
-                                        QStyle.SP_TitleBarCloseButton)),
+        action2 = QAction(line.style().standardIcon(QStyle.SP_TitleBarCloseButton),
                           "Delete", line)
         line.setAction(action2, LineEdit.RightPosition)
 

--- a/Orange/canvas/gui/tests/test_toolbox.py
+++ b/Orange/canvas/gui/tests/test_toolbox.py
@@ -14,7 +14,7 @@ class TestToolBox(test.QAppTestCase):
     def test_tool_box(self):
         w = toolbox.ToolBox()
         style = self.app.style()
-        icon = QIcon(style.standardPixmap(style.SP_FileIcon))
+        icon = QIcon(style.standardIcon(style.SP_FileIcon))
         p1 = QLabel("A Label")
         p2 = QListView()
         p3 = QLabel("Another\nlabel")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The `QStyle.standardPixmap` method is obsolete and will/should disappear in the future (http://pyqt.sourceforge.net/Docs/PyQt5/pyqt4_differences.html#deprecated-features)

##### Description of changes

* Use `standardIcon` method
* Also fix the *inverse* icon rendering in widget tool dock's header.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
