### PR TITLE
[RFC] [FIX] Warning renamed in Test and Score widget

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -213,7 +213,8 @@ class OWTestLearners(OWWidget):
         missing_data = \
             Msg("Instances with unknown target values were removed from{}data.")
         test_data_missing = Msg("Missing separate test data input.")
-        scores_not_computed = Msg("Some scores could not be computed.")
+        # as I know only AUC is exception in conditions for computation
+        scores_not_computed = Msg("AUC could not be computed.")
         test_data_unused = Msg("Test data is present but unused. "
                                "Select 'Test on test data' to use it.")
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The warning tells just that one score is missing. 
As I know this warning will be triggered just by AUC.

##### Description of changes
The warning message was changed to tell that the AUC score is missing. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
