### PR TITLE
OWBoxplot: remove minimum width to further shrink widget

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -252,7 +252,6 @@ class OWBoxPlot(widget.OWWidget):
 
         e = gui.hBox(self.mainArea, addSpace=False)
         self.infot1 = gui.widgetLabel(e, "<center>No test results.</center>")
-        self.mainArea.setMinimumWidth(600)
 
         self.stats = self.dist = self.conts = []
         self.is_continuous = False


### PR DESCRIPTION
##### Issue
Fixes #3132 
##### Description of changes
Remove minimum width constrained.
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
