### PR TITLE
[ENH] Matplotlib output for Scatter plot

### DIFF
--- a/Orange/tests/test_evaluation_scoring.py
+++ b/Orange/tests/test_evaluation_scoring.py
@@ -1,10 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
-import sys
-import contextlib
 import unittest
-from unittest.mock import Mock
 import numpy as np
 
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain
@@ -337,23 +334,9 @@ class TestComputeCD(unittest.TestCase):
         cd = scoring.compute_CD(avranks, 30, test="bonferroni-dunn")
         np.testing.assert_almost_equal(cd, 0.798)
 
-        @contextlib.contextmanager
-        def mock_module(name):
-            if not name in sys.modules:
-                try:
-                    sys.modules[name] = Mock()
-                    yield
-                finally:
-                    del sys.modules[name]
-            else:
-                yield
-
         # Do what you will, just don't crash
-        with mock_module("matplotlib"), \
-                mock_module("matplotlib.pyplot"), \
-                mock_module("matplotlib.backends.backend_agg"):
-            scoring.graph_ranks(avranks, "abcd", cd)
-            scoring.graph_ranks(avranks, "abcd", cd, cdmethod=0)
+        scoring.graph_ranks(avranks, "abcd", cd)
+        scoring.graph_ranks(avranks, "abcd", cd, cdmethod=0)
 
 
 class TestLogLoss(unittest.TestCase):

--- a/Orange/widgets/io.py
+++ b/Orange/widgets/io.py
@@ -182,7 +182,8 @@ class SvgFormat(ImgFormat):
         super().write_image(filename, scene)
 
 
-class MatplotlibFormat(FileFormat):
+class MatplotlibFormat:
+    # not registered as a FileFormat as it only works with scatter plot
     EXTENSIONS = ('.py',)
     DESCRIPTION = 'Python Code (with Matplotlib)'
     PRIORITY = 300
@@ -201,7 +202,7 @@ class MatplotlibFormat(FileFormat):
 
 
 class MatplotlibPDFFormat(MatplotlibFormat):
-    EXTENSIONS = ('.matplotlib.pdf',)  # file formats with same extension are not supported
+    EXTENSIONS = ('.pdf',)
     DESCRIPTION = 'Portable Document Format (from Matplotlib)'
     PRIORITY = 200
 

--- a/Orange/widgets/tests/test_io.py
+++ b/Orange/widgets/tests/test_io.py
@@ -1,11 +1,18 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from AnyQt.QtWidgets import QGraphicsScene, QGraphicsRectItem
-from Orange.widgets.tests.base import GuiTest
+
+import Orange
+from Orange.tests import named_file
+from Orange.widgets.tests.base import GuiTest, WidgetTest
 
 from Orange.widgets import io as imgio
+from Orange.widgets.io import MatplotlibFormat, MatplotlibPDFFormat
+from Orange.widgets.visualize.owscatterplot import OWScatterPlot
+
 
 @unittest.skipUnless(hasattr(imgio, "PdfFormat"), "QPdfWriter not available")
 class TestIO(GuiTest):
@@ -18,3 +25,33 @@ class TestIO(GuiTest):
             imgio.PdfFormat.write_image(fname, sc)
         finally:
             os.unlink(fname)
+
+
+class TestMatplotlib(WidgetTest):
+
+    def test_python(self):
+        iris = Orange.data.Table("iris")
+        self.widget = self.create_widget(OWScatterPlot)
+        self.send_signal(OWScatterPlot.Inputs.data, iris[::10])
+        with named_file("", suffix=".py") as fname:
+            with patch("Orange.widgets.utils.filedialogs.open_filename_dialog_save",
+                       lambda *x: (fname, MatplotlibFormat, None)):
+                self.widget.save_graph()
+                with open(fname, "rt") as f:
+                    code = f.read()
+                self.assertIn("plt.show()", code)
+                self.assertIn("plt.scatter", code)
+                # test if the runs
+                exec(code.replace("plt.show()", ""), {})
+
+    def test_pdf(self):
+        iris = Orange.data.Table("iris")
+        self.widget = self.create_widget(OWScatterPlot)
+        self.send_signal(OWScatterPlot.Inputs.data, iris[::10])
+        with named_file("", suffix=".pdf") as fname:
+            with patch("Orange.widgets.utils.filedialogs.open_filename_dialog_save",
+                       lambda *x: (fname, MatplotlibPDFFormat, None)):
+                self.widget.save_graph()
+                with open(fname, "rb") as f:
+                    code = f.read()
+                self.assertTrue(code.startswith(b"%PDF"))

--- a/Orange/widgets/tests/test_matplotlib_export.py
+++ b/Orange/widgets/tests/test_matplotlib_export.py
@@ -9,6 +9,13 @@ from Orange.widgets.utils.matplotlib_export import scatterplot_code
 from Orange.widgets.visualize.owscatterplot import OWScatterPlot
 
 
+def add_intro(a):
+    r = "import matplotlib.pyplot as plt\n" + \
+        "from numpy import array\n" + \
+        "plt.clf()"
+    return r + a
+
+
 class TestScatterPlot(WidgetTest):
 
     def test_owscatterplot_ignore_empty(self):
@@ -24,3 +31,13 @@ class TestScatterPlot(WidgetTest):
         self.widget.graph.select_by_rectangle(QRectF(4, 3, 3, 1))
         code = scatterplot_code(self.widget.graph.scatterplot_item_sel)
         self.assertIn("plt.scatter", code)
+        exec(add_intro(code), {})
+
+    def test_scatterplot_simple(self):
+        plotWidget = pg.PlotWidget(background="w")
+        scatterplot = pg.ScatterPlotItem()
+        scatterplot.setData(x=[1, 2, 3], y=[3, 2, 1])
+        plotWidget.addItem(scatterplot)
+        code = scatterplot_code(scatterplot)
+        self.assertIn("plt.scatter", code)
+        exec(add_intro(code), {})

--- a/Orange/widgets/tests/test_matplotlib_export.py
+++ b/Orange/widgets/tests/test_matplotlib_export.py
@@ -1,0 +1,26 @@
+import pyqtgraph as pg
+
+from AnyQt.QtCore import QRectF
+
+import Orange
+
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.utils.matplotlib_export import scatterplot_code
+from Orange.widgets.visualize.owscatterplot import OWScatterPlot
+
+
+class TestScatterPlot(WidgetTest):
+
+    def test_owscatterplot_ignore_empty(self):
+        iris = Orange.data.Table("iris")
+        self.widget = self.create_widget(OWScatterPlot)
+        self.send_signal(OWScatterPlot.Inputs.data, iris[::10])
+        code = scatterplot_code(self.widget.graph.scatterplot_item)
+        self.assertIn("plt.scatter", code)
+        # tbe selected graph has to generate nothing
+        code = scatterplot_code(self.widget.graph.scatterplot_item_sel)
+        self.assertEqual(code, "")
+        # for a selection the selected graph has to be non-empty
+        self.widget.graph.select_by_rectangle(QRectF(4, 3, 3, 1))
+        code = scatterplot_code(self.widget.graph.scatterplot_item_sel)
+        self.assertIn("plt.scatter", code)

--- a/Orange/widgets/utils/matplotlib_export.py
+++ b/Orange/widgets/utils/matplotlib_export.py
@@ -11,11 +11,21 @@ from AnyQt.QtGui import QPen, QBrush
 def numpy_repr(a):
     """ A numpy repr without summarization """
     opts = np.get_printoptions()
+    # avoid numpy repr as it changes between versions
+    # TODO handle numpy repr differences
+    if isinstance(a, np.ndarray):
+        return "array(" + repr(list(a)) + ")"
     try:
         np.set_printoptions(threshold=10**10)
         return repr(a)
     finally:
         np.set_printoptions(**opts)
+
+
+def numpy_repr_int(a):
+    # avoid numpy repr as it changes between versions
+    # TODO handle numpy repr differences
+    return "array(" + repr(list(a)) + ", dtype='int')"
 
 
 def compress_if_all_same(l):
@@ -113,7 +123,7 @@ def scatterplot_code(scatterplot_item):
 
         code.append("{} = {}".format(name, repr(colors)))
         if index is not None:
-            code.append("{}_index = {}".format(name, repr(index)))
+            code.append("{}_index = {}".format(name, numpy_repr_int(index)))
 
         decompresssed_code = name
         if index is not None:
@@ -153,7 +163,7 @@ def scatterplot_code(scatterplot_item):
         if np.all(indices == np.arange(x.shape[0])):
             indices = None
         if indices is not None:
-            code.append("indices = {}".format(numpy_repr(indices)))
+            code.append("indices = {}".format(numpy_repr_int(indices)))
 
         def indexed(data, data_name, indices=indices):
             return code_with_indices(data, data_name, indices, "indices")

--- a/Orange/widgets/utils/matplotlib_export.py
+++ b/Orange/widgets/utils/matplotlib_export.py
@@ -39,7 +39,15 @@ def scatterplot_code(scatterplot_item):
 
     pen_style = [a.style() for a in scatterplot_item.data["pen"]]
     no_pen = [s == Qt.NoPen for s in pen_style]
-    linewidths[np.nonzero(no_pen)[0]] = 0
+    edgecolors[:, 3][np.nonzero(no_pen)[0]] = 0  # set alpha channel to zero
+
+    brush_style = [a.style() for a in scatterplot_item.data["brush"]]
+    no_brush = [s == Qt.NoBrush for s in brush_style]
+    facecolors[:, 3][np.nonzero(no_brush)[0]] = 0  # set alpha channel to zero
+
+    # return early if the scatterplot is all transparent
+    if not any(edgecolors[:, 3] > 0) and not any(facecolors[:, 3] > 0):
+        return ""
 
     code.append("edgecolors = {}".format(numpy_repr(edgecolors)))
     code.append("facecolors = {}".format(numpy_repr(facecolors)))

--- a/Orange/widgets/utils/matplotlib_export.py
+++ b/Orange/widgets/utils/matplotlib_export.py
@@ -1,0 +1,108 @@
+from itertools import chain
+
+import numpy as np
+
+from pyqtgraph.graphicsItems.ScatterPlotItem import ScatterPlotItem
+
+
+def numpy_repr(a):
+    """ A numpy repr without summarization """
+    opts = np.get_printoptions()
+    try:
+        np.set_printoptions(threshold=10**10)
+        return repr(a)
+    finally:
+        np.set_printoptions(**opts)
+
+
+def scatterplot_code(scatterplot_item):
+    x = scatterplot_item.data['x']
+    y = scatterplot_item.data['y']
+    sizes = scatterplot_item.data["size"]
+
+    code = []
+
+    code.append("# data")
+    code.append("x = {}".format(numpy_repr(x)))
+    code.append("y = {}".format(numpy_repr(y)))
+
+    code.append("# style")
+    code.append("sizes = {}".format(numpy_repr(sizes)))
+
+    def colortuple(color):
+        return color.redF(), color.greenF(), color.blueF(), color.alphaF()
+
+    edgecolors = np.array([colortuple(a.color()) for a in scatterplot_item.data["pen"]])
+    facecolors = np.array([colortuple(a.color()) for a in scatterplot_item.data["brush"]])
+
+    code.append("edgecolors = {}".format(numpy_repr(edgecolors)))
+    code.append("facecolors = {}".format(numpy_repr(facecolors)))
+
+    # possible_markers for scatterplot are in .graph.CurveSymbols
+    def matplotlib_marker(m):
+        if m == "t":
+            return "^"
+        elif m == "t2":
+            return ">"
+        elif m == "t3":
+            return "<"
+        elif m == "star":
+            return "*"
+        elif m == "+":
+            return "P"
+        elif m == "x":
+            return "X"
+        return m
+
+    # TODO labels are missing
+
+    # each marker requires one call to matplotlib's scatter!
+    markers = np.array([matplotlib_marker(m) for m in scatterplot_item.data["symbol"]])
+    for m in set(markers):
+        indices = np.where(markers == m)[0]
+        if np.all(indices == np.arange(x.shape[0])):
+            # indices are unused
+            code.append("plt.scatter(x=x, y=y, s=sizes**2/4, marker={},".format(repr(m)))
+            code.append("            facecolors=facecolors, edgecolors=edgecolors)")
+        else:
+            code.append("indices = {}".format(numpy_repr(indices)))
+            code.append("plt.scatter(x=x[indices], y=y[indices], s=sizes[indices]**2/4, "
+                        "marker={},".format(repr(m)))
+            code.append("            facecolors=facecolors[indices], "
+                        "edgecolors=edgecolors[indices])")
+
+    return "\n".join(code)
+
+
+def scene_code(scene):
+
+    code = []
+
+    code.append("import matplotlib.pyplot as plt")
+    code.append("from numpy import array")
+
+    code.append("")
+    code.append("plt.clf()")
+
+    code.append("")
+
+    for item in scene.items:
+        if isinstance(item, ScatterPlotItem):
+            code.append(scatterplot_code(item))
+
+    # TODO currently does not work for graphs without axes and for multiple axes!
+    for position, set_ticks, set_label in [("bottom", "plt.xticks", "plt.xlabel"),
+                                           ("left", "plt.yticks", "plt.ylabel")]:
+        axis = scene.getAxis(position)
+        code.append("{}({})".format(set_label, repr(str(axis.labelText))))
+
+        # textual tick labels
+        if axis._tickLevels is not None:
+            major_minor = list(chain(*axis._tickLevels))
+            locs = [a[0] for a in major_minor]
+            labels = [a[1] for a in major_minor]
+            code.append("{}({}, {})".format(set_ticks, locs, repr(labels)))
+
+    return "\n".join(code)
+
+

--- a/Orange/widgets/utils/matplotlib_export.py
+++ b/Orange/widgets/utils/matplotlib_export.py
@@ -3,6 +3,7 @@ from itertools import chain
 import numpy as np
 
 from pyqtgraph.graphicsItems.ScatterPlotItem import ScatterPlotItem
+from AnyQt.QtCore import Qt
 
 
 def numpy_repr(a):
@@ -34,9 +35,15 @@ def scatterplot_code(scatterplot_item):
 
     edgecolors = np.array([colortuple(a.color()) for a in scatterplot_item.data["pen"]])
     facecolors = np.array([colortuple(a.color()) for a in scatterplot_item.data["brush"]])
+    linewidths = np.array([a.widthF() for a in scatterplot_item.data["pen"]])
+
+    pen_style = [a.style() for a in scatterplot_item.data["pen"]]
+    no_pen = [s == Qt.NoPen for s in pen_style]
+    linewidths[np.nonzero(no_pen)[0]] = 0
 
     code.append("edgecolors = {}".format(numpy_repr(edgecolors)))
     code.append("facecolors = {}".format(numpy_repr(facecolors)))
+    code.append("linewidths = {}".format(numpy_repr(linewidths)))
 
     # possible_markers for scatterplot are in .graph.CurveSymbols
     def matplotlib_marker(m):
@@ -63,13 +70,15 @@ def scatterplot_code(scatterplot_item):
         if np.all(indices == np.arange(x.shape[0])):
             # indices are unused
             code.append("plt.scatter(x=x, y=y, s=sizes**2/4, marker={},".format(repr(m)))
-            code.append("            facecolors=facecolors, edgecolors=edgecolors)")
+            code.append("            facecolors=facecolors, edgecolors=edgecolors,")
+            code.append("            linewidths=linewidths)")
         else:
             code.append("indices = {}".format(numpy_repr(indices)))
             code.append("plt.scatter(x=x[indices], y=y[indices], s=sizes[indices]**2/4, "
                         "marker={},".format(repr(m)))
             code.append("            facecolors=facecolors[indices], "
-                        "edgecolors=edgecolors[indices])")
+                        "edgecolors=edgecolors[indices],")
+            code.append("            linewidths=linewidths[indices])")
 
     return "\n".join(code)
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -15,6 +15,7 @@ from Orange.data.sql.table import SqlTable, AUTO_DL_LIMIT
 from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.widgets import gui
 from Orange.widgets import report
+from Orange.widgets.io import MatplotlibFormat, MatplotlibPDFFormat
 from Orange.widgets.settings import \
     DomainContextHandler, Setting, ContextSetting, SettingProvider
 from Orange.widgets.utils.itemmodels import DomainModel
@@ -210,6 +211,12 @@ class OWScatterPlot(OWWidget):
                         "Send Selection", "Send Automatically")
 
         self.graph.zoom_actions(self)
+
+        # manually register Matplotlib file writers
+        self.graph_writers = self.graph_writers.copy()
+        for w in [MatplotlibFormat, MatplotlibPDFFormat]:
+            for ext in w.EXTENSIONS:
+                self.graph_writers[ext] = w
 
     def keyPressEvent(self, event):
         super().keyPressEvent(event)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - python.app    # [osx]
     - commonmark
     - serverfiles
+    - matplotlib    >=2.0.0
 
 test:
   # Python imports

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -2,6 +2,7 @@
 AnyQt>=0.0.8
 
 pyqtgraph>=0.10.0
+matplotlib>=2.0.0
 
 # For add-ons' descriptions
 docutils

--- a/scripts/macos/requirements.txt
+++ b/scripts/macos/requirements.txt
@@ -20,3 +20,4 @@ sip==4.19.3
 six==1.10.0
 xlrd==1.0.0
 CommonMark==0.7.3
+matplotlib==2.2.3

--- a/scripts/windows/specs/PY34-win32.txt
+++ b/scripts/windows/specs/PY34-win32.txt
@@ -21,3 +21,4 @@ pip==9.0.1
 pyqtgraph==0.10.0
 six==1.10.0
 xlrd==1.0.0
+matplotlib==2.2.3


### PR DESCRIPTION
##### Issue
Our outputs are ugly and non-configurable. Outputting python code could solve output flexibility problem for people with basic programming knowledge. 

##### Description of changes
The changes here just enable the user to save graphs as Python code. Currently a pyplot plot is drawn directly.

The code gets the data for drawing from the pyqtgraph's graph.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
