### PR TITLE
[FIX] ci/appveyor: Update test dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,18 +21,18 @@ environment:
     BUILD_GLOBAL_OPTIONS: build -j1
     BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.9.3
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy==1.12.1 scipy==1.0.0b1 scikit-learn pandas==0.21.1
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
 
   matrix:
     - PYTHON: C:\Python34
       BUILD_GLOBAL_OPTIONS: build
       # override test env for Py34; test with PyQt4 and legacy scipy
       # from the 'super' installer.
-      TEST_ENV: numpy==1.12.1 scipy==0.16.1 scikit-learn PyQt4==4.11.4
+      TEST_ENV: numpy==1.12.1 scipy==0.16.1 scikit-learn==0.19.1 PyQt4==4.11.4
 
     - PYTHON: C:\Python34-x64
       BUILD_GLOBAL_OPTIONS: build
-      TEST_ENV: numpy==1.12.1 scipy==1.0.0b1 scikit-learn PyQt5==5.5.1
+      TEST_ENV: numpy==1.12.1 scipy==1.0.0b1 scikit-learn==0.19.1 PyQt5==5.5.1
 
     - PYTHON: C:\Python35
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Test on appveyor are failing

##### Description of changes

* Pin scikit-learn to 0.19.1 for Python 3.4 tests
* Bump numpy to 1.14 for the rest

Fixes failing tests due to incompatibility of scikit-learn 0.19.2
wheels with older numpy abi.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
