### PR TITLE
[FIX][RFC] KMeans upgrade sparse support

### DIFF
--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -27,7 +27,7 @@ class KMeans(SklProjector):
         proj.silhouette = np.nan
         try:
             if self._compute_silhouette and 2 <= proj.n_clusters < X.shape[0]:
-                if len(X) <= SILHOUETTE_MAX_SAMPLES:
+                if X.shape[0] <= SILHOUETTE_MAX_SAMPLES:
                     proj.silhouette_samples = \
                         silhouette_samples(X, proj.labels_)
                     proj.silhouette = np.mean(proj.silhouette_samples)

--- a/Orange/clustering/kmeans.py
+++ b/Orange/clustering/kmeans.py
@@ -69,4 +69,4 @@ class KMeansModel(Projection):
                 domain,
                 np.atleast_2d(self.proj.predict(data._x.reshape(1, -1))).astype(int))
         else:
-            return self.proj.predict(data).reshape((len(data), 1))
+            return self.proj.predict(data).reshape((data.shape[0], 1))

--- a/Orange/tests/test_clustering_kmeans.py
+++ b/Orange/tests/test_clustering_kmeans.py
@@ -2,11 +2,11 @@
 # pylint: disable=missing-docstring
 
 import unittest
+import numpy as np
 
 import Orange
 from Orange.clustering.kmeans import KMeans
 from scipy.sparse import csc_matrix
-import numpy as np
 
 
 class TestKMeans(unittest.TestCase):

--- a/Orange/tests/test_clustering_kmeans.py
+++ b/Orange/tests/test_clustering_kmeans.py
@@ -49,6 +49,12 @@ class TestKMeans(unittest.TestCase):
         X = self.iris.X[::20]
         p = c(X)
 
+    def test_predict_sparse(self):
+        kmeans = KMeans()
+        c = kmeans(self.iris)
+        X = csc_matrix(self.iris.X[::20])
+        p = c(X)
+
     def test_silhouette_sparse(self):
         """Test if silhouette gets calculated for sparse data"""
         kmeans = KMeans(compute_silhouette_score=True)

--- a/Orange/tests/test_clustering_kmeans.py
+++ b/Orange/tests/test_clustering_kmeans.py
@@ -5,6 +5,8 @@ import unittest
 
 import Orange
 from Orange.clustering.kmeans import KMeans
+from scipy.sparse import csc_matrix
+import numpy as np
 
 
 class TestKMeans(unittest.TestCase):
@@ -47,3 +49,10 @@ class TestKMeans(unittest.TestCase):
         X = self.iris.X[::20]
         p = c(X)
 
+    def test_silhouette_sparse(self):
+        """Test if silhouette gets calculated for sparse data"""
+        kmeans = KMeans(compute_silhouette_score=True)
+        sparse_iris = self.iris.copy()
+        sparse_iris.X = csc_matrix(sparse_iris.X)
+        c = kmeans(sparse_iris)
+        self.assertFalse(np.isnan(c.silhouette))


### PR DESCRIPTION
##### Issue
Fixes #2913 
Additionally, I noticed that you can not predict sparse data.
##### Description of changes
Replaced `len(X)` with `X.shape[0]`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
