### PR TITLE
OWKMeans: add error for data with no features

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -109,6 +109,7 @@ class OWKMeans(widget.OWWidget):
         not_enough_data = widget.Msg(
             "Too few ({}) unique data instances for {} clusters"
         )
+        no_attributes = widget.Msg("Data is missing features.")
 
     class Warning(widget.OWWidget.Warning):
         no_silhouettes = widget.Msg(
@@ -255,6 +256,10 @@ class OWKMeans(widget.OWWidget):
         """k cannot be larger than the number of data instances."""
         return len(self.data) >= k
 
+    @property
+    def has_attributes(self):
+        return len(self.data.domain.attributes)
+
     @staticmethod
     def _compute_clustering(data, k, init, n_init, max_iter, silhouette, random_state):
         # type: (Table, int, str, int, int, bool) -> KMeansModel
@@ -391,9 +396,15 @@ class OWKMeans(widget.OWWidget):
         # cause flickering when the clusters are computed quickly, so this is
         # the better alternative
         self.table_model.clear_scores()
-        self.mainArea.setVisible(self.optimize_k and self.data is not None)
+        self.mainArea.setVisible(self.optimize_k and self.data is not None and
+                                 self.has_attributes)
 
         if self.data is None:
+            self.send_data()
+            return
+
+        if not self.has_attributes:
+            self.Error.no_attributes()
             self.send_data()
             return
 

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -446,6 +446,13 @@ class TestOWKMeans(WidgetTest):
         self.widget.smart_init = 1
         assert_all_same([cluster() for _ in range(5)])
 
+    def test_error_no_attributes(self):
+        domain = Domain([])
+        table = Table.from_domain(domain, n_rows=10)
+        self.widget.auto_commit = True
+        self.send_signal(self.widget.Inputs.data, table)
+        self.assertTrue(self.widget.Error.no_attributes.is_shown())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
OWKMeans showed an uncaught error when given data with no attributes.
##### Description of changes
Check if input data has attributes, if not show error.
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
