### PR TITLE
[FIX] WebView fixes

### DIFF
--- a/Orange/widgets/report/report.py
+++ b/Orange/widgets/report/report.py
@@ -184,7 +184,7 @@ class Report:
         elif isinstance(plot, WebviewWidget):
             try:
                 svg = plot.svg()
-            except IndexError:
+            except (IndexError, ValueError):
                 svg = plot.html()
             self.report_html += svg
 

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -475,23 +475,23 @@ elif HAVE_WEBENGINE:
         def __init__(self):
             self.id = 0
             self.lock = threading.Lock()
-            self.ids = set()
+            self.ids = dict()
 
         def create(self):
             with self.lock:
                 self.id += 1
                 return self.id
 
-        def store(self, id):
+        def store(self, id, value):
             with self.lock:
-                self.ids.add(id)
+                self.ids[id] = value
 
         def __contains__(self, id):
             return id in self.ids
 
-        def remove(self, id):
+        def pop(self, id):
             with self.lock:
-                self.ids.remove(id)
+                return self.ids.pop(id, None)
 
 
     class _JSObjectChannel(QObject):
@@ -556,9 +556,9 @@ elif HAVE_WEBENGINE:
             if sip.isdeleted(self):
                 return
             result = self._results.create()
-            self.runJavaScript(code, lambda x: self._results.store(result))
+            self.runJavaScript(code, lambda x: self._results.store(result, x))
             wait(until=lambda: result in self._results)
-            self._results.remove(result)
+            return self._results.pop(result)
 
         def onloadJS(self, code):
             self._onloadJS(code, injection_point=QWebEngineScript.Deferred)

--- a/Orange/widgets/utils/webview.py
+++ b/Orange/widgets/utils/webview.py
@@ -554,7 +554,7 @@ elif HAVE_WEBENGINE:
         def _evalJS(self, code):
             wait(until=self._jsobject_channel.is_all_exposed)
             if sip.isdeleted(self):
-                return
+                return None
             result = self._results.create()
             self.runJavaScript(code, lambda x: self._results.store(result, x))
             wait(until=lambda: result in self._results)


### PR DESCRIPTION
##### Issue
1. _evalJS of WebEngine ignores the returned value since 3b11a9090b3111d0052faa8617e015de3ccdc1f7.
2. Report_plot doesn't work for webview (although it should).

##### Description of changes
1. Store ids together with results in IdStore for scheduled JS executions.
2. Unsuccessful search for `<svg>` tag results in ValueError (and not IndexError).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
