### PR TITLE
[FIX] report: Fix the number of hidden rows.

### DIFF
--- a/Orange/widgets/report/report.py
+++ b/Orange/widgets/report/report.py
@@ -323,7 +323,7 @@ class Report:
         elif isinstance(table, Iterable):
             body = report_list(table, header_rows, header_columns)
             table = list(table)
-            n_hidden_rows = len(table)
+            n_hidden_rows = len(table) - row_limit
             if len(table) and isinstance(table[0], Iterable):
                 n_cols = len(table[0])
         else:


### PR DESCRIPTION
##### Issue
report_table sometimes incorrectly displays the number of hidden rows (e.g. in the word enrichment widget).

##### Description of changes
Minor bug fix.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
