### PR TITLE
[FIX][RFC] OWHeatMap: remove empty clusters from visualization

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -444,6 +444,9 @@ class OWHeatMap(widget.OWWidget):
             "Not enough instances for k-means merging")
         not_enough_memory = Msg("Not enough memory to show this data")
 
+    class Warning(widget.OWWidget.Warning):
+        empty_clusters = Msg("Empty clusters were removed")
+
     def __init__(self):
         super().__init__()
 
@@ -863,11 +866,17 @@ class OWHeatMap(widget.OWWidget):
                 nclust = min(self.merge_kmeans_k, len(effective_data) - 1)
                 self.kmeans_model = kmeans_compress(effective_data, k=nclust)
                 effective_data.domain = self.kmeans_model.pre_domain
-                self.merge_indices = [np.flatnonzero(self.kmeans_model.labels_ == ind)
-                                      for ind in range(nclust)]
+                merge_indices = [np.flatnonzero(self.kmeans_model.labels_ == ind)
+                                 for ind in range(nclust)]
+                not_empty_indices = [i for i, x in enumerate(merge_indices)
+                                     if len(x) > 0]
+                self.merge_indices = \
+                    [merge_indices[i] for i in not_empty_indices]
+                if len(merge_indices) != len(self.merge_indices):
+                    self.Warning.empty_clusters()
                 effective_data = Orange.data.Table(
                     Orange.data.Domain(effective_data.domain.attributes),
-                    self.kmeans_model.centroids
+                    self.kmeans_model.centroids[not_empty_indices]
                 )
             else:
                 effective_data = self.effective_data

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import numpy as np
+
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.preprocess import Continuize
 from Orange.widgets.visualize.owheatmap import OWHeatMap
@@ -126,3 +128,15 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
 
         self.widget.col_clustering = True
         self.widget.set_dataset(iris)
+
+    def test_empty_clusters(self):
+        """Test if empty clusters are not displayed and warning is shown"""
+        data = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3])
+
+        table = Table.from_numpy(Domain([ContinuousVariable()]),
+                                 data.reshape((9, 1)))
+        self.widget.controls.merge_kmeans.setChecked(True)
+        self.send_signal(self.widget.Inputs.data, table)
+
+        self.assertTrue(self.widget.Warning.empty_clusters.is_shown())
+        self.assertEqual(len(self.widget.merge_indices), 3)


### PR DESCRIPTION
##### Issue
Fixes #2907 
##### Description of changes
Kmeans in the OWHeatMap can produce clusters with no elements. Before those clusters were shown in the visualization and could be selected. Because there was no data in those clusters if they were selected no output was given and it seemed like the widget's selection had a bug. This fix removes those empty clusters from the visualization and they can no longer be selected. Additionally, a warning is shown.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
