### PR TITLE
[ENH] OWBoxPlot: add option to sort discrete distributions by size

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -141,6 +141,7 @@ class OWBoxPlot(widget.OWWidget):
     sig_threshold = Setting(0.05)
     stretched = Setting(True)
     show_labels = Setting(True)
+    sort_freqs = Setting(False)
     auto_commit = Setting(True)
 
     _sorting_criteria_attrs = {
@@ -234,6 +235,9 @@ class OWBoxPlot(widget.OWWidget):
             callback=self.display_changed)
         gui.checkBox(
             box, self, 'show_labels', "Show box labels",
+            callback=self.display_changed)
+        self.sort_cb = gui.checkBox(
+            box, self, 'sort_freqs', "Sort by subgroup frequencies",
             callback=self.display_changed)
         gui.rubber(box)
 
@@ -432,6 +436,7 @@ class OWBoxPlot(widget.OWWidget):
         else:
             self.stretching_box.show()
             self.display_box.hide()
+            self.sort_cb.setEnabled(self.group_var is not None)
 
     def clear_scene(self):
         self.closeContext()
@@ -537,22 +542,28 @@ class OWBoxPlot(widget.OWWidget):
                 self.labels = [
                     QGraphicsTextItem(str(int(sum(self.dist))))]
 
+        self.order = list(range(len(self.attr_labels)))
+
         self.draw_axis_disc()
         if self.group_var:
             self.boxes = \
                 [self.strudel(cont, i) for i, cont in enumerate(self.conts)
                  if np.sum(cont) > 0]
             self.conts = self.conts[np.sum(np.array(self.conts), axis=1) > 0]
+
+            if self.sort_freqs:
+                self.order = sorted(self.order, key=(-np.sum(self.conts, axis=1)).__getitem__)
         else:
             self.boxes = [self.strudel(self.dist)]
 
-        for row, box in enumerate(self.boxes):
+        for row, box_index in enumerate(self.order):
             y = (-len(self.boxes) + row) * 40 + 10
+            box = self.boxes[box_index]
             bars, labels = box[::2], box[1::2]
 
-            self.__draw_group_labels(y, row)
+            self.__draw_group_labels(y, box_index)
             if not self.stretched:
-                self.__draw_row_counts(y, row)
+                self.__draw_row_counts(y, box_index)
             if self.show_labels and self.attribute is not self.group_var:
                 self.__draw_bar_labels(y, bars, labels)
             self.__draw_bars(y, bars)

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -442,6 +442,7 @@ class OWBoxPlot(widget.OWWidget):
         self.closeContext()
         self.box_scene.clearSelection()
         self.box_scene.clear()
+        self.box_view.viewport().update()
         self.attr_labels = []
         self.labels = []
         self.boxes = []

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -178,17 +178,17 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
 
     def test_sorting_disc_group_var(self):
         """Test if subgroups are sorted by their size"""
-        table = Table("adult")
+        table = Table("adult_sample")
         self.send_signal(self.widget.Inputs.data, table)
         self.__select_variable("education")
         self.__select_group("workclass")
 
         # checkbox not checked - preserve original order of selected grouping attribute
-        self.assertListEqual(self.widget.order, [0, 1, 2, 3, 4, 5, 6, 7])
+        self.assertListEqual(self.widget.order, [0, 1, 2, 3, 4, 5, 6])
 
         # checkbox checked - sort by frequencies
         self.widget.controls.sort_freqs.setChecked(True)
-        self.assertListEqual(self.widget.order, [0, 1, 4, 5, 2, 3, 6, 7])
+        self.assertListEqual(self.widget.order, [0, 1, 4, 5, 3, 2, 6])
 
     def _select_data(self):
         items = [item for item in self.widget.box_scene.items()

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -176,6 +176,20 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, table)
         self.assertEqual(2, len(self.widget.boxes))
 
+    def test_sorting_disc_group_var(self):
+        """Test if subgroups are sorted by their size"""
+        table = Table("adult")
+        self.send_signal(self.widget.Inputs.data, table)
+        self.__select_variable("education")
+        self.__select_group("workclass")
+
+        # checkbox not checked - preserve original order of selected grouping attribute
+        self.assertListEqual(self.widget.order, [0, 1, 2, 3, 4, 5, 6, 7])
+
+        # checkbox checked - sort by frequencies
+        self.widget.controls.sort_freqs.setChecked(True)
+        self.assertListEqual(self.widget.order, [0, 1, 4, 5, 2, 3, 6, 7])
+
     def _select_data(self):
         items = [item for item in self.widget.box_scene.items()
                  if isinstance(item, FilterGraphicsRectItem)]


### PR DESCRIPTION
##### Issue
Implements #3093.

##### Description of changes
Added option (checkbox) to allow sorting discrete distributions by their size. If checkbox is unchecked, original order is preserved.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
