### PR TITLE
[FIX] OWFreeViz: fix class density size

### DIFF
--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -224,7 +224,7 @@ class OWFreeVizGraph(OWScatterPlotGraph):
         for axis_loc in ["left", "bottom"]:
             self.plot_widget.hideAxis(axis_loc)
 
-    def update_data(self, attr_x, attr_y, reset_view=True):
+    def update_data(self, attr_x, attr_y, reset_view=False):
         super().update_data(attr_x, attr_y, reset_view=reset_view)
         for axis in ["left", "bottom"]:
             self.plot_widget.hideAxis(axis)
@@ -736,7 +736,7 @@ class OWFreeViz(widget.OWWidget):
         if reset_view:
             self.viewbox.setRange(RANGE)
             self.viewbox.setAspectLocked(True, 1)
-        self.plot(reset_view=reset_view)
+        self.plot()
 
     def randomize_indices(self):
         X = self._X
@@ -798,7 +798,7 @@ class OWFreeViz(widget.OWWidget):
     def reset_graph_data(self, *_):
         if self.data is not None:
             self.graph.rescale_data()
-            self._update_graph()
+            self._update_graph(reset_view=False)
 
     def _update_graph(self, reset_view=True, **_):
         self.graph.zoomStack = []


### PR DESCRIPTION
##### Issue
Fixes #2910 
##### Description of changes
Before on data change, freeviz displayed class density only for a small rectangle around the data points and not for the full window. Additionally, I noticed the same behavior when changing color, opacity and jittering options. This fixes all of those problems.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
