### PR TITLE
[FIX] OWBoxPlot: Fix quartiles computation

### DIFF
--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -1,12 +1,15 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import unittest
 
 import numpy as np
 from AnyQt.QtCore import QItemSelectionModel
 from AnyQt.QtTest import QTest
 
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain
-from Orange.widgets.visualize.owboxplot import OWBoxPlot, FilterGraphicsRectItem
+from Orange.widgets.visualize.owboxplot import (
+    OWBoxPlot, FilterGraphicsRectItem, _quantiles
+)
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 
 
@@ -208,3 +211,40 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
             if m.data(idx) == value:
                 list.selectionModel().setCurrentIndex(
                     idx, QItemSelectionModel.ClearAndSelect)
+
+
+class TestUtils(unittest.TestCase):
+    def test(self):
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 8 + 1), [1.] * 8, [0.0, 0.25, 0.5, 0.75, 1.0]),
+            [1., 2.5, 4.5, 6.5, 8.]
+        )
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 8 + 1), [1.] * 8, [0.0, 0.25, 0.5, 0.75, 1.0]),
+            [1., 2.5, 4.5, 6.5, 8.]
+        )
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 4 + 1), [1., 2., 1., 2],
+                       [0.0, 0.25, 0.5, 0.75, 1.0]),
+            [1.0, 2.0, 2.5, 4.0, 4.0]
+        )
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 4 + 1), [2., 1., 1., 2.],
+                       [0.0, 0.25, 0.5, 0.75, 1.0]),
+            [1.0, 1.0, 2.5, 4.0, 4.0]
+        )
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 4 + 1), [1., 1., 1., 1.],
+                       [0.0, 0.25, 0.5, 0.75, 1.0]),
+            [1.0, 1.5, 2.5, 3.5, 4.0]
+        )
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 4 + 1), [1., 1., 1., 1.],
+                       [0.0, 0.25, 0.5, 0.75, 1.0], interpolation="higher"),
+            [1, 2, 3, 4, 4]
+        )
+        np.testing.assert_array_equal(
+            _quantiles(range(1, 4 + 1), [1., 1., 1., 1.],
+                       [0.0, 0.25, 0.5, 0.75, 1.0], interpolation="lower"),
+            [1, 1, 2, 3, 4]
+        )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref gh-1737

Fix quartiles computation

The code assumed that all quartiles would (or need to) be distinct.

##### Description of changes

Replace the linear scan in BoxPlot constructor with a numpy based implementation.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
