### PR TITLE
[FIX] OWBoxPlot: Plot axis labels and quartiles label layout

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -859,7 +859,7 @@ class OWBoxPlot(widget.OWWidget):
         if stat.median is not None:
             msc = stat.median * self.scale_x
             med_t = centered_text(stat.median, msc)
-            med_box_width2 = med_t.boundingRect().width()
+            med_box_width2 = med_t.boundingRect().width() / 2
             line(msc)
 
         if stat.q25 is not None:

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -751,13 +751,13 @@ class OWBoxPlot(widget.OWWidget):
         self.scene_width = (gtop - gbottom) * scale_x
 
         val = first_val
+        decimals = max(3, 4 - int(math.log10(step)))
         while True:
             l = self.box_scene.addLine(val * scale_x, -1, val * scale_x, 1,
                                        self._pen_axis_tick)
             l.setZValue(100)
-
             t = self.box_scene.addSimpleText(
-                self.attribute.repr_val(val) if not misssing_stats else "?",
+                repr(round(val, decimals)) if not misssing_stats else "?",
                 self._axis_font)
             t.setFlags(
                 t.flags() | QGraphicsItem.ItemIgnoresTransformations)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref gh-1737

##### Description of changes

* Fix axis label formating.
* Tighter quartiles label layout

The first and third quartile labels can still fall out of view. To fix that would pretty much involve a complete rewrite.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
