### PR TITLE
RemoveConstant: remove constant NaN features.

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -190,8 +190,8 @@ class RemoveConstant(Preprocess):
         data : an input dataset
         """
 
-        oks = bn.nanmin(data.X, axis=0) != \
-              bn.nanmax(data.X, axis=0)
+        oks = np.logical_and(~bn.allnan(data.X, axis=0),
+                             bn.nanmin(data.X, axis=0) != bn.nanmax(data.X, axis=0))
         atts = [data.domain.attributes[i] for i, ok in enumerate(oks) if ok]
         domain = Orange.data.Domain(atts, data.domain.class_vars,
                                     data.domain.metas)

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -61,10 +61,11 @@ class TestPreprocess(unittest.TestCase):
 
 class TestRemoveConstant(unittest.TestCase):
     def test_remove_columns(self):
-        X = np.random.rand(6, 4)
+        X = np.random.rand(6, 5)
         X[:, (1,3)] = 5
         X[3, 1] = np.nan
         X[1, 1] = np.nan
+        X[:, 4] = np.nan
         data = Table(X)
         d = RemoveConstant()(data)
         self.assertEqual(len(d.domain.attributes), 2)


### PR DESCRIPTION
##### Issue
RemoveConstant doesn't remove columns containing only NaN values.

##### Description of changes
Comparison of min and max value in a column doesn't work for features containing only nan-s (because np.nan != np.nan). Check for this separately.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
