### PR TITLE
[ENH] Rank: SklScorer should use the faster SklImputer.

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -8,7 +8,7 @@ from sklearn import feature_selection as skl_fss
 from Orange.data import Domain, Variable, DiscreteVariable, ContinuousVariable
 from Orange.data.filter import HasClass
 from Orange.misc.wrapper_meta import WrapperMeta
-from Orange.preprocess.preprocess import Discretize, Impute
+from Orange.preprocess.preprocess import Discretize, SklImpute
 from Orange.preprocess.util import _RefuseDataInConstructor
 from Orange.statistics import contingency, distribution
 from Orange.util import Reprable
@@ -86,7 +86,7 @@ class SklScorer(Scorer, metaclass=WrapperMeta):
     supports_sparse_data = True
 
     preprocessors = Scorer.preprocessors + [
-        Impute()
+        SklImpute()
     ]
 
     def score_data(self, data, feature):


### PR DESCRIPTION
##### Issue
Fixes #3129.

##### Description of changes
Replace Imputer preprocessor with SklImputer.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
