### PR TITLE
[FIX] OWBoxPlot: Fix empty continuous contingency check

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -407,12 +407,17 @@ class OWBoxPlot(widget.OWWidget):
             self.conts = contingency.get_contingency(
                 dataset, attr, self.group_var)
             if self.is_continuous:
-                self.stats = [BoxData(cont, attr, i, self.group_var)
-                              for i, cont in enumerate(self.conts)
-                              if np.sum(cont) > 0]
-            self.label_txts_all = \
-                [v for v, c in zip(self.group_var.values, self.conts)
-                 if np.sum(c) > 0]
+                stats, label_texts = [], []
+                for i, cont in enumerate(self.conts):
+                    if np.sum(cont[1]):
+                        stats.append(BoxData(cont, attr, i, self.group_var))
+                        label_texts.append(self.group_var.values[i])
+                self.stats = stats
+                self.label_txts_all = label_texts
+            else:
+                self.label_txts_all = \
+                    [v for v, c in zip(self.group_var.values, self.conts)
+                     if np.sum(c) > 0]
         else:
             self.dist = distribution.get_distribution(dataset, attr)
             self.conts = []
@@ -524,6 +529,7 @@ class OWBoxPlot(widget.OWWidget):
         self.select_box_items()
 
     def display_changed_disc(self):
+        assert not self.is_continuous
         self.clear_scene()
         self.attr_labels = [QGraphicsSimpleTextItem(lab)
                             for lab in self.label_txts_all]
@@ -588,6 +594,7 @@ class OWBoxPlot(widget.OWWidget):
         row: int
             row index
         """
+        assert not self.is_continuous
         label = self.labels[row]
         b = label.boundingRect()
         if self.group_var:
@@ -773,6 +780,7 @@ class OWBoxPlot(widget.OWWidget):
         """
         Draw the horizontal axis and sets self.scale_x for discrete attributes
         """
+        assert not self.is_continuous
         if self.stretched:
             if not self.attr_labels:
                 return

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 from AnyQt.QtCore import QItemSelectionModel
-from AnyQt.QtTest import QTest
 
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain
 from Orange.widgets.visualize.owboxplot import OWBoxPlot, FilterGraphicsRectItem
@@ -158,9 +157,9 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         self.widget.stretched = False
         self.__select_variable("chest pain")
         self.__select_group("gender")
-        self.widget.show()
-        QTest.qWait(3000)
-        self.widget.hide()
+        self.widget.adjustSize()
+        self.widget.layout().activate()
+        self.widget.grab()  # ensure that the painting code is run
 
     def test_empty_groups(self):
         """Test if groups with zero elements are not shown"""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

A wrong check for empty continuous contingencies omits groups that it should not.

For instance on:  [vowel.tab.txt](https://github.com/biolab/orange3/files/2235833/vowel.tab.txt)
on variable: f0, group by: Class
<img width="1005" alt="screen shot 2018-07-27 at 15 16 58" src="https://user-images.githubusercontent.com/4716745/43322837-266d539c-91b0-11e8-9dc5-fd5eddad00be.png">


##### Description of changes

Fix check for empty continuous contingency, add asserts where contingencies are summed over.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
