### PR TITLE
[ENH] Make filters available in Orange.data namespace.

### DIFF
--- a/Orange/data/__init__.py
+++ b/Orange/data/__init__.py
@@ -7,3 +7,4 @@ from .domain import *
 from .storage import *
 from .table import *
 from .io import *
+from .filter import *

--- a/Orange/data/filter.py
+++ b/Orange/data/filter.py
@@ -12,6 +12,11 @@ from Orange.data import Instance, Storage, Variable
 from Orange.util import Enum
 
 
+__all__ = ["IsDefined", "HasClass", "Random", "SameValue", "Values",
+           "FilterDiscrete", "FilterContinuous", "FilterString",
+           "FilterStringList", "FilterRegex"]
+
+
 class Filter(Reprable):
     """
     The base class for filters.


### PR DESCRIPTION
##### Issue
It would be convenient to access filters in the same way as other classes from the data module.
```
import Orange
tab = Orange.data.Table("iris")
filter = Orange.data.SameValue("petal length", 5.1)
print(len(filter(tab)))
```

##### Description of changes
Import everything from filters in `data/__init__.py`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
