### PR TITLE
[ENH] ROC analysis: show thresholds

### DIFF
--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -606,12 +606,12 @@ class OWROCAnalysis(widget.OWWidget):
 
     def _on_mouse_moved(self, pos):
         curves = [crv for crv in self.plot.curves if isinstance(crv, pg.PlotCurveItem)]
-        for i in self.selected_classifiers:
+        for i in range(len(self.selected_classifiers)):
             sp = curves[i].childItems()[0]
             act_pos = sp.mapFromScene(pos)
             pts = sp.pointsAt(act_pos)
 
-            curve_data = self.curve_data(self.target_index, i)
+            curve_data = self.curve_data(self.target_index, self.selected_classifiers[i])
 
             if self.roc_averaging == OWROCAnalysis.Merge:
                 curve_data = curve_data.merged
@@ -625,7 +625,6 @@ class OWROCAnalysis(widget.OWWidget):
 
             if len(pts) > 0:
                 mouse_pt = pts[0].pos()
-
                 if self._tooltip_cache:
                     if numpy.linalg.norm(mouse_pt - self._tooltip_cache) < 10e-6:
                         if not QToolTip.isVisible():

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -642,15 +642,14 @@ class OWROCAnalysis(widget.OWWidget):
 
                 curve_pts = curve.curve.points
 
-                # Find closest point on curve and display it
-                idx_closest = numpy.argmin(
-                    [numpy.linalg.norm(mouse_pt - [curve_pts.fpr[idx], curve_pts.tpr[idx]])
-                     for idx in range(len(curve_pts.thresholds))])
+                roc_points = numpy.column_stack((curve_pts.fpr, curve_pts.tpr))
+                diff = numpy.subtract(roc_points, mouse_pt)
+                # Find closest point on curve and display the tooltip there
+                idx_closest = numpy.argmin(numpy.linalg.norm(diff, axis=1))
 
                 thresh = curve_pts.thresholds[idx_closest]
                 if not numpy.isnan(thresh):
-                    tt_loc = QCursor.pos()
-                    QToolTip.showText(tt_loc, "Threshold: {:.3f}".format(thresh))
+                    QToolTip.showText(QCursor.pos(), "Threshold: {:.3f}".format(thresh))
                     self._tooltip_cache = ([curve_pts.fpr[idx_closest], curve_pts.tpr[idx_closest]],
                                            thresh, clf_idx, self.roc_averaging)
                 return

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -2,8 +2,10 @@ import sys
 import warnings
 import contextlib
 
-from AnyQt.QtCore import Qt, QObject, QEventLoop, QTimer, QLocale
+from AnyQt.QtCore import Qt, QObject, QEventLoop, QTimer, QLocale, QPoint
 from AnyQt.QtTest import QTest
+from AnyQt.QtGui import QMouseEvent
+from AnyQt.QtWidgets import QApplication
 
 
 class EventSpy(QObject):
@@ -303,3 +305,15 @@ def override_locale(language):
             return result
         return wrap
     return wrapper
+
+
+def mouseMove(widget, pos=QPoint(), delay=-1):  # pragma: no-cover
+    # Like QTest.mouseMove, but functional without QCursor.setPos
+    if pos.isNull():
+        pos = widget.rect().center()
+    me = QMouseEvent(QMouseEvent.MouseMove, pos, widget.mapToGlobal(pos),
+                     Qt.NoButton, Qt.MouseButtons(0), Qt.NoModifier)
+    if delay > 0:
+        QTest.qWait(delay)
+
+    QApplication.sendEvent(widget, me)

--- a/Orange/widgets/utils/tests/test_combobox.py
+++ b/Orange/widgets/utils/tests/test_combobox.py
@@ -2,11 +2,11 @@
 
 import unittest
 
-from AnyQt.QtCore import Qt, QPoint, QRect
-from AnyQt.QtGui import QMouseEvent
+from AnyQt.QtCore import Qt, QRect
 from AnyQt.QtWidgets import QListView, QApplication
 from AnyQt.QtTest import QTest, QSignalSpy
 from Orange.widgets.tests.base import GuiTest
+from Orange.widgets.tests.utils import mouseMove
 
 from Orange.widgets.utils import combobox
 
@@ -133,15 +133,3 @@ class TestComboBoxSearch(GuiTest):
             geom, QRect(0, 500, 100, 20), screen
         )
         self.assertEqual(g4, QRect(0, 500 - 400, 100, 400))
-
-
-def mouseMove(widget, pos=QPoint(), delay=-1):  # pragma: no-cover
-    # Like QTest.mouseMove, but functional without QCursor.setPos
-    if pos.isNull():
-        pos = widget.rect().center()
-    me = QMouseEvent(QMouseEvent.MouseMove, pos, widget.mapToGlobal(pos),
-                     Qt.NoButton, Qt.MouseButtons(0), Qt.NoModifier)
-    if delay > 0:
-        QTest.qWait(delay)
-
-    QApplication.sendEvent(widget, me)


### PR DESCRIPTION
##### Issue
Implements #3057.


##### Description of changes
When mouse is put over a point on ROC curve, the threshold that was used for calculation now appears. If threshold value is _nan_, the value does not get shown. Also, the displaying of thresholds is currently not implemented when showing individual curves.

My questions:
- currently thresholds are displayed when mouse goes 'perfectly' over a point - should this be changed so that they get displayed if mouse is in some very small radius of the point?
- what kind of a test do I write for this functionality (i. e. mouse events) - if any?

General comments are also welcome.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
