### PR TITLE
[ENH] Add cosine distance

### DIFF
--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -75,7 +75,8 @@ class OWSilhouettePlot(widget.OWWidget):
     auto_commit = settings.Setting(True)
 
     Distances = [("Euclidean", Orange.distance.Euclidean),
-                 ("Manhattan", Orange.distance.Manhattan)]
+                 ("Manhattan", Orange.distance.Manhattan),
+                 ("Cosine", Orange.distance.Cosine)]
 
     graph_name = "scene"
     buttons_area_orientation = Qt.Vertical


### PR DESCRIPTION
##### Issue
Silhouette widget supported only Euclidean and Manhattan distance.

##### Description of changes
Added a cosine distance. Could add other distances, but that would require more elaborate fix, as some of them crash with this widget. Cosine distance is needed in some of the demonstrations with current Orange, so this is a minimal fix at this stage.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
