### PR TITLE
Silhouette Plot: Add cosine distance

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -348,7 +348,8 @@ class Cosine(FittedDistance):
             dist = safe_sparse_dot(data1, data2.T)
             np.clip(dist, 0, 1, out=dist)
             if x2 is None:
-                dist.flat[::dist.shape[0] + 1] = 1.0
+                diag = np.diag_indices_from(dist)
+                dist[diag] = np.where(np.isnan(dist[diag]), np.nan, 1.0)
             return 1 - dist
 
 

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -75,7 +75,8 @@ class OWSilhouettePlot(widget.OWWidget):
     auto_commit = settings.Setting(True)
 
     Distances = [("Euclidean", Orange.distance.Euclidean),
-                 ("Manhattan", Orange.distance.Manhattan)]
+                 ("Manhattan", Orange.distance.Manhattan),
+                 ("Cosine", Orange.distance.Cosine)]
 
     graph_name = "scene"
     buttons_area_orientation = Qt.Vertical

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -81,6 +81,24 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         # the scores must match
         np.testing.assert_almost_equal(scores_1, scores[valid], decimal=12)
 
+    def test_nan_distances(self):
+        self.widget.controls.add_scores.setChecked(1)
+        self.widget.distance_idx = 2
+        self.assertEqual(self.widget.Distances[self.widget.distance_idx][0],
+                         'Cosine')
+        scorename = "Silhouette (iris)"
+        data = self.data[[0, 1, 2, 50, 51, 52, 100, 101, 102]]
+        data.X[::3] = 0
+        valid = np.any(data.X != 0, axis=1)
+        self.assertFalse(self.widget.Warning.nan_distances.is_shown())
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertTrue(np.isnan(self.widget._matrix).any())
+        self.assertTrue(self.widget.Warning.nan_distances.is_shown())
+        output = self.get_output(ANNOTATED_DATA_SIGNAL_NAME)
+        scores = output[:, scorename].metas.flatten()
+        self.assertTrue(np.all(np.isnan(scores[::3])))
+        self.assertTrue(np.all(np.isfinite(scores[valid])))
+
     def test_meta_object_dtype(self):
         # gh-1875: Test on mixed string/discrete metas
         data = self.data[::5]

--- a/doc/visual-programming/source/widgets/visualize/silhouetteplot.rst
+++ b/doc/visual-programming/source/widgets/visualize/silhouetteplot.rst
@@ -20,8 +20,9 @@ The **Silhouette Plot** widget offers a graphical representation of consistency 
 
 1. Choose the distance metric. You can choose between:
 
-   -  `Euclidean <https://en.wikipedia.org/wiki/Euclidean_distance>`_ ("straight line", distance between two points)
+   -  `Euclidean <https://en.wikipedia.org/wiki/Euclidean_distance>`_ ("straight line" distance between two points)
    -  `Manhattan <https://en.wiktionary.org/wiki/Manhattan_distance>`_ (the sum of absolute differences for all attributes)
+   -  `Cosine <https://en.wiktionary.org/wiki/Cosine_similarity>`_ (1 - cosine of the angle between two vectors)
 
 2. Select the cluster label. You can decide whether to group the instances by cluster or not.
 3. Display options:


### PR DESCRIPTION
Added cosine distance to Silhouette Plot.
Handle nan values in the computed dist matrix (e.g. in case of all-zero vectors for cosine) by omitting instances and showing a warning.


##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
