### PR TITLE
[ENH] Scatterplot: indicate overlap of points.

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -56,6 +56,12 @@ class OWMDSGraph(OWScatterPlotGraph):
         self.plot_widget.setAspectLocked(True, 1)
 
     def compute_sizes(self):
+        """Handle 'Stress' size option.
+        Everything else is passed to Scatterplot's compute_sizes"""
+
+        if self.attr_size != "Stress":
+            return super().compute_sizes()
+
         def scale(a):
             dmin, dmax = np.nanmin(a), np.nanmax(a)
             if dmax - dmin > 0:
@@ -64,17 +70,8 @@ class OWMDSGraph(OWScatterPlotGraph):
                 return np.zeros_like(a)
 
         self.master.Information.missing_size.clear()
-        if self.attr_size is None:
-            size_data = np.full((self.n_points,), self.point_width,
-                                dtype=float)
-        elif self.attr_size == "Stress":
-            size_data = scale(stress(self.master.embedding, self.master.effective_matrix))
-            size_data = self.MinShapeSize + size_data * self.point_width
-        else:
-            size_data = \
-                self.MinShapeSize + \
-                self.scaled_data.get_column_view(self.attr_size)[0][self.valid_data] * \
-                self.point_width
+        size_data = scale(stress(self.master.embedding, self.master.effective_matrix))
+        size_data = self.MinShapeSize + size_data * self.point_width
         nans = np.isnan(size_data)
         if np.any(nans):
             size_data[nans] = self.MinShapeSize - 2

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -465,10 +465,13 @@ class OWPlotGUI:
         self.shape_model = DomainModel(placeholder="(Same shape)",
                                        valid_types=DiscreteVariable)
         self.size_model = DomainModel(placeholder="(Same size)",
+                                      order=(self.SizeByOverlap,) + DomainModel.SEPARATED,
                                       valid_types=ContinuousVariable)
         self.label_model = DomainModel(placeholder="(No labels)")
         self.points_models = [self.color_model, self.shape_model,
                               self.size_model, self.label_model]
+
+    SizeByOverlap = "Overlap"
 
     Spacing = 0
 

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -812,7 +812,7 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
 
     def compute_sizes(self):
         self.master.Information.missing_size.clear()
-        if self.attr_size is None:
+        if self.attr_size in [None, OWPlotGUI.SizeByOverlap]:
             size_data = np.full((self.n_points,), self.point_width,
                                 dtype=float)
         else:
@@ -826,7 +826,8 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
             self.master.Information.missing_size(self.attr_size)
 
         # scale sizes because of overlaps
-        size_data = np.multiply(size_data, self.overlap_factor)
+        if self.attr_size == OWPlotGUI.SizeByOverlap:
+            size_data = np.multiply(size_data, self.overlap_factor)
 
         return size_data
 
@@ -971,12 +972,13 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
                     for col in colors])
                 self.brush_colors = brush_colors_palette[c_data]
 
-                # color overlapping points by most frequent color
-                for i, xy in enumerate(zip(self.x_data, self.y_data)):
-                    if self.overlaps[i] > 1:
-                        c = Counter(c_data[j] for j in self.coord_to_id[xy]).most_common(1)[0][0]
-                        self.brush_colors[i] = brush_colors_palette[c]
-                        self.pen_colors[i] = pen_colors_palette[c]
+                if self.attr_size == OWPlotGUI.SizeByOverlap:
+                    # color overlapping points by most frequent color
+                    for i, xy in enumerate(zip(self.x_data, self.y_data)):
+                        if self.overlaps[i] > 1:
+                            c = Counter(c_data[j] for j in self.coord_to_id[xy]).most_common(1)[0][0]
+                            self.brush_colors[i] = brush_colors_palette[c]
+                            self.pen_colors[i] = pen_colors_palette[c]
 
             if subset is not None:
                 brush = np.where(

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -976,7 +976,8 @@ class OWScatterPlotGraph(gui.OWComponent, ScaleScatterPlotData):
                     # color overlapping points by most frequent color
                     for i, xy in enumerate(zip(self.x_data, self.y_data)):
                         if self.overlaps[i] > 1:
-                            c = Counter(c_data[j] for j in self.coord_to_id[xy]).most_common(1)[0][0]
+                            cnt = Counter(c_data[j] for j in self.coord_to_id[xy])
+                            c = cnt.most_common(1)[0][0]
                             self.brush_colors[i] = brush_colors_palette[c]
                             self.pen_colors[i] = pen_colors_palette[c]
 

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -25,14 +25,6 @@ class TestOWFreeViz(WidgetTest, WidgetOutputsTestMixin):
     def setUp(self):
         self.widget = self.create_widget(OWFreeViz)
 
-    def test_points_combo_boxes(self):
-        self.send_signal(self.widget.Inputs.data, self.heart_disease)
-        graph = self.widget.controls.graph
-        self.assertEqual(len(graph.attr_color.model()), 17)
-        self.assertEqual(len(graph.attr_shape.model()), 11)
-        self.assertEqual(len(graph.attr_size.model()), 8)
-        self.assertEqual(len(graph.attr_label.model()), 17)
-
     def test_ugly_datasets(self):
         self.send_signal(self.widget.Inputs.data, Table(datasets.path("testing_dataset_cls")))
         self.send_signal(self.widget.Inputs.data, Table(datasets.path("testing_dataset_reg")))

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -65,14 +65,6 @@ class TestOWLinearProjection(WidgetTest, WidgetOutputsTestMixin):
         with excepthook_catch():
             simulate.combobox_activate_item(cb.attr_size, "X1")
 
-    def test_points_combo_boxes(self):
-        self.send_signal("Data", self.data)
-        graph = self.widget.controls.graph
-        self.assertEqual(len(graph.attr_color.model()), 8)
-        self.assertEqual(len(graph.attr_shape.model()), 3)
-        self.assertEqual(len(graph.attr_size.model()), 6)
-        self.assertEqual(len(graph.attr_label.model()), 8)
-
     def test_buttons(self):
         for btn in self.widget.radio_placement.buttons[:3]:
             self.send_signal(self.widget.Inputs.data, self.data)

--- a/Orange/widgets/visualize/tests/test_owradviz.py
+++ b/Orange/widgets/visualize/tests/test_owradviz.py
@@ -22,14 +22,6 @@ class TestOWFreeViz(WidgetTest, WidgetOutputsTestMixin):
     def setUp(self):
         self.widget = self.create_widget(OWRadviz)
 
-    def test_points_combo_boxes(self):
-        self.send_signal(self.widget.Inputs.data, self.heart_disease)
-        graph = self.widget.controls.graph
-        self.assertEqual(len(graph.attr_color.model()), 17)
-        self.assertEqual(len(graph.attr_shape.model()), 11)
-        self.assertEqual(len(graph.attr_size.model()), 8)
-        self.assertEqual(len(graph.attr_label.model()), 17)
-
     def test_ugly_datasets(self):
         self.send_signal(self.widget.Inputs.data, Table(datasets.path("testing_dataset_cls")))
         self.send_signal(self.widget.Inputs.data, Table(datasets.path("testing_dataset_reg")))

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -154,13 +154,24 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
     def test_points_combo_boxes(self):
         """Check Point box combo models and values"""
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.assertEqual(len(self.widget.controls.graph.attr_color.model()), 8)
-        self.assertEqual(len(self.widget.controls.graph.attr_shape.model()), 3)
-        self.assertEqual(len(self.widget.controls.graph.attr_size.model()), 6)
-        self.assertEqual(len(self.widget.controls.graph.attr_label.model()), 8)
+        graph = self.widget.controls.graph
+
+        # color and label should contain all variables
+        # size should contain only continuous variables
+        # shape should contain only discrete variables
+        for var in self.data.domain.variables + self.data.domain.metas:
+            self.assertIn(var, graph.attr_color.model())
+            self.assertIn(var, graph.attr_label.model())
+            if var.is_continuous:
+                self.assertIn(var, graph.attr_size.model())
+                self.assertNotIn(var, graph.attr_shape.model())
+            if var.is_discrete:
+                self.assertNotIn(var, graph.attr_size.model())
+                self.assertIn(var, graph.attr_shape.model())
+
         other_widget = self.create_widget(OWScatterPlot)
         self.send_signal(self.widget.Inputs.data, self.data, widget=other_widget)
-        self.assertEqual(self.widget.graph.controls.attr_color.currentText(),
+        self.assertEqual(graph.attr_color.currentText(),
                          self.data.domain.class_var.name)
 
     def test_group_selections(self):

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -8,6 +8,7 @@ from AnyQt.QtCore import QRectF, Qt
 from AnyQt.QtWidgets import QToolTip
 
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
+from Orange.widgets.utils.plot import OWPlotGUI
 from Orange.widgets.visualize.owscatterplotgraph import MAX
 from Orange.widgets.widget import AttributeList
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin, datasets
@@ -173,6 +174,13 @@ class TestOWScatterPlot(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, self.data, widget=other_widget)
         self.assertEqual(graph.attr_color.currentText(),
                          self.data.domain.class_var.name)
+
+    def test_overlap(self):
+        self.send_signal(self.widget.Inputs.data, Table("iris"))
+        self.assertEqual(len(set(self.widget.graph.compute_sizes())), 1)
+        simulate.combobox_activate_item(self.widget.controls.graph.attr_size,
+                                        OWPlotGUI.SizeByOverlap)
+        self.assertGreater(len(set(self.widget.graph.compute_sizes())), 1)
 
     def test_group_selections(self):
         self.send_signal(self.widget.Inputs.data, self.data)

--- a/doc/visual-programming/source/widgets/visualize/scatterplot.rst
+++ b/doc/visual-programming/source/widgets/visualize/scatterplot.rst
@@ -41,7 +41,8 @@ the left side of the widget. A snapshot below shows the scatterplot of the
 2. Set the color of the displayed points (you will get colors for discrete
    values and grey-scale points for continuous). Set label, shape and
    size to differentiate between points. Set symbol size and opacity for
-   all data points. Set the desired colors scale.
+   all data points. Set the desired colors scale. To visualize the number
+   of overlapping points use *Overlap* for size.
 3. Adjust *plot properties*:
 
    -  *Show legend* displays a legend on the right. Click and drag the legend to move it.


### PR DESCRIPTION
##### Issue
Implements #3028 

##### Description of changes
Scatterplot computes the set of indices at each coordinate for later use in compute_sizes and compute_colors. The sizes are multiplied by log_2 of the number of points. The color represents the most frequent color (or one of them if there are several).

![scatterplot-overlap](https://user-images.githubusercontent.com/919223/43512260-ea567932-957a-11e8-9ce6-ee8d38aefd3d.png)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
