### PR TITLE
[FIX] OWSql: enforce data download for non PostgreSQL databases

### DIFF
--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -250,6 +250,10 @@ class OWSql(OWWidget):
                 self.download = True
                 self.downloadcb.setEnabled(False)
 
+            if not is_postgres(self.backend):
+                self.download = True
+                self.downloadcb.setEnabled(False)
+
             self._save_credentials()
             self.database_desc = OrderedDict((
                 ("Host", self.host), ("Port", self.port),


### PR DESCRIPTION
##### Issue
Fixes #3043 
##### Description of changes
SqlTable has poor support for non-PostgreSQL databases. This enforces the download of the selected table so that it works as a normal Table.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
