### PR TITLE
[ENH] Widget Insertion

### DIFF
--- a/Orange/canvas/canvas/items/linkitem.py
+++ b/Orange/canvas/canvas/items/linkitem.py
@@ -28,6 +28,8 @@ class LinkCurveItem(QGraphicsPathItem):
     """
     def __init__(self, parent):
         super().__init__(parent)
+        self.__parent = parent
+
         self.setAcceptedMouseButtons(Qt.NoButton)
         self.setAcceptHoverEvents(True)
 
@@ -90,6 +92,9 @@ class LinkCurveItem(QGraphicsPathItem):
     def setPath(self, path):
         self.__shape = None
         super().setPath(path)
+
+    def parent(self):
+        return self.__parent
 
     def __update(self):
         shadow_enabled = self.__hover

--- a/Orange/canvas/canvas/items/linkitem.py
+++ b/Orange/canvas/canvas/items/linkitem.py
@@ -28,8 +28,6 @@ class LinkCurveItem(QGraphicsPathItem):
     """
     def __init__(self, parent):
         super().__init__(parent)
-        self.__parent = parent
-
         self.setAcceptedMouseButtons(Qt.NoButton)
         self.setAcceptHoverEvents(True)
 
@@ -92,9 +90,6 @@ class LinkCurveItem(QGraphicsPathItem):
     def setPath(self, path):
         self.__shape = None
         super().setPath(path)
-
-    def parent(self):
-        return self.__parent
 
     def __update(self):
         shadow_enabled = self.__hover

--- a/Orange/canvas/document/commands.py
+++ b/Orange/canvas/document/commands.py
@@ -6,8 +6,6 @@ from typing import Callable
 
 from AnyQt.QtWidgets import QUndoCommand
 
-from Orange.canvas.scheme import SchemeLink
-
 
 class AddNodeCommand(QUndoCommand):
     def __init__(self, scheme, node, parent=None):
@@ -72,23 +70,12 @@ class RemoveLinkCommand(QUndoCommand):
 
 
 class InsertNodeCommand(QUndoCommand):
-    def __init__(self, scheme, link, new_node, parent=None):
-        QUndoCommand.__init__(self, "Remove link", parent)
+    def __init__(self, scheme, new_node, old_link, new_links, parent=None):
+        QUndoCommand.__init__(self, "Insert widget into link", parent)
         self.scheme = scheme
-        self.original_link = link
         self.inserted_widget = new_node
-
-        possible_links = (self.scheme.propose_links(link.source_node, new_node),
-                          self.scheme.propose_links(new_node, link.sink_node))
-
-        if not possible_links[0] or not possible_links[1]:
-            raise ValueError("Cannot insert widget: links not possible")
-
-        self.new_links = (
-            SchemeLink(link.source_node, link.source_channel,
-                       new_node, possible_links[0][0][1]),  # first link, first entry, output (1)
-            SchemeLink(new_node, possible_links[1][0][0],  # second link, first entry, input (0)
-                       link.sink_node, link.sink_channel))
+        self.original_link = old_link
+        self.new_links = new_links
 
     def redo(self):
         self.scheme.add_node(self.inserted_widget)


### PR DESCRIPTION
##### Feature
Insert a widget in-between two already connected widgets by either:
- dragging it from the widget selection menu onto the link,
- right-clicking the link and selecting 'Insert Widget'

##### Description of changes
- Added an 'Insert Node' command for purposes of undo/redo
- Added entry to 'right-click on link' context menu
- Widget drag from menu -> insert

##### Includes
- [X] Code changes
- [ ] Tests
- [X] Documentation
