### PR TITLE
[FIX] owlouvainclustering: Make the task completion handler a single slot

### DIFF
--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -265,8 +265,7 @@ class OWLouvainClustering(widget.OWWidget):
 
         # Prepare callbacks
         queue.on_progress.connect(lambda val: self.progressBarSet(100 * val))
-        queue.on_complete.connect(self._processing_complete)
-        queue.on_complete.connect(self._send_data)
+        queue.on_complete.connect(self._on_complete)
         queue.on_exception.connect(self._handle_exceptions)
         self.__queue = queue
 
@@ -274,6 +273,10 @@ class OWLouvainClustering(widget.OWWidget):
         self.progressBarInit()
         self.setBlocking(True)
         self.__future = self.__executor.submit(queue.start)
+
+    def _on_complete(self):
+        self._processing_complete()
+        self._send_data()
 
     def _send_data(self):
         if self.partition is None or self.data is None:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The
`Orange.widgets.unsupervised.tests.test_owlouvain.TestOWLouvain.test_clusters_ordered_by_size` test errors randomly with:
```
======================================================================
ERROR: test_clusters_ordered_by_size (Orange.widgets.unsupervised.tests.test_owlouvain.TestOWLouvain)
Cluster names should be sorted based on the number of instances.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/unsupervised/tests/test_owlouvain.py", line 47, in test_clusters_ordered_by_size
    clustering = output.get_column_view('Cluster')[0].astype(int)
AttributeError: 'NoneType' object has no attribute 'get_column_view'

----------------------------------------------------------------------
```

##### Description of changes

Make the task completion handler a single slot.

The handlers are invoked with the Qt.QueuedConnection semantics and the first (_processing_complete) advertised to the world that the processing has completed, but the actual send  would be done later at an unspecified time. This tripped the `TestOWLouvain.test_clusters_ordered_by_size` test.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
