### PR TITLE
[FIX] oweditdomain: Fix an IndexError when all rows are deselected

### DIFF
--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -422,9 +422,15 @@ class DiscreteVariableEditor(VariableEditor):
 
     @Slot()
     def on_value_selection_changed(self):
-        i = self.values_edit.selectionModel().selectedRows()[0].row()
-        self.move_value_up.setEnabled(i)
-        self.move_value_down.setEnabled(i != len(self.var.values)-1)
+        rows = self.values_edit.selectionModel().selectedRows()
+        if rows:
+            i = rows[0].row()
+            self.move_value_up.setEnabled(i)
+            self.move_value_down.setEnabled(i != len(self.var.values)-1)
+        else:
+            self.move_value_up.setEnabled(False)
+            self.move_value_down.setEnabled(False)
+
 
 class ContinuousVariableEditor(VariableEditor):
     # TODO: enable editing of number_of_decimals, scientific format ...

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 import numpy as np
 
-from AnyQt.QtCore import QModelIndex, Qt
+from AnyQt.QtCore import QModelIndex, QItemSelectionModel, Qt
 
 from Orange.data import ContinuousVariable, DiscreteVariable, \
     StringVariable, TimeVariable, Table, Domain
@@ -236,6 +236,16 @@ class TestEditors(GuiTest):
         self.assertEqual(w.name_edit.text(), "")
         self.assertEqual(w.labels_model.get_dict(), {})
         self.assertIs(w.get_data(), None)
+
+        # test selection/deselection in the view
+        w.set_data(v)
+        view = w.values_edit
+        model = view.model()
+        assert model.rowCount()
+        sel_model = view.selectionModel()
+        model = sel_model.model()
+        sel_model.select(model.index(0, 0), QItemSelectionModel.Select)
+        sel_model.select(model.index(0, 0), QItemSelectionModel.Deselect)
 
     def test_time_editor(self):
         w = TimeVariableEditor()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

'Edit Domain' widget raises a:
```
---------------------------- IndexError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/oweditdomain.py", line 425, in on_value_selection_changed
    i = self.values_edit.selectionModel().selectedRows()[0].row()
IndexError: list index out of range
-------------------------------------------------------------------------------
```
... when editing a discrete variable and the current item in the 'Values' list view is deselected (via a <kbd>Ctrl</kbd> + mouse click or when selecting a different variable to edit in the left 'Domain Features' view.

##### Description of changes

Check for an empty selection.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
