### PR TITLE
[ENH] Data Table: Enable deselection

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -619,7 +619,11 @@ class OWDataTable(widget.OWWidget):
                             return True     # eat event
                         return False
                 table.efc = efc()
+                # disconnect default handler for clicks and connect a new one, which supports
+                # both selection and deselection of all data
+                btn.clicked.disconnect()
                 btn.installEventFilter(table.efc)
+                btn.clicked.connect(self._on_select_all)
                 table.btn = btn
 
                 if sys.platform == "darwin":
@@ -642,6 +646,14 @@ class OWDataTable(widget.OWWidget):
                     table.verticalHeader().setMinimumWidth(s.width())
             except Exception:
                 pass
+
+    def _on_select_all(self, _):
+        data_info = self.tabs.currentWidget()._input_slot.summary
+        if len(self.selected_rows) == data_info.len \
+                and len(self.selected_cols) == len(data_info.domain):
+            self.tabs.currentWidget().clearSelection()
+        else:
+            self.tabs.currentWidget().selectAll()
 
     def _on_current_tab_changed(self, index):
         """Update the info box on current tab change"""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements #3161 - adds a "deselect all" functionality to the top left corner button in Data Table.

##### Description of changes
As far as I can tell, the current "select all" functionality is actually built in by default, i.e. `clicked` is connected to a `selectAll()` call (please correct me if I'm wrong).  
This commit disconnects the default handler and connects a new one, which decides whether to **select all** (`selectAll()`) or **deselect all** (`clearSelection()`) data based on information about selected rows and columns.
![peek 2018-08-10 01-34](https://user-images.githubusercontent.com/17293960/43931227-cd31aa4c-9c3d-11e8-9b26-366d154e7d90.gif)


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
