### PR TITLE
[MNT] tests: Fix compatibility with numpy.testing in numpy 1.15

### DIFF
--- a/Orange/tests/__init__.py
+++ b/Orange/tests/__init__.py
@@ -3,6 +3,12 @@ import unittest
 import tempfile
 from contextlib import contextmanager
 
+try:
+    from numpy.testing import assert_array_compare
+except ImportError:
+    # numpy < 1.14
+    from numpy.testing.utils import assert_array_compare
+
 import numpy as np
 import Orange
 
@@ -42,7 +48,7 @@ def assert_array_nanequal(a, b, *args, **kwargs):
     a : array-like
     b : array-like
     """
-    return np.testing.utils.assert_array_compare(naneq, a, b, *args, **kwargs)
+    return assert_array_compare(naneq, a, b, *args, **kwargs)
 
 
 def test_dirname():

--- a/Orange/tests/test_contingency.py
+++ b/Orange/tests/test_contingency.py
@@ -12,6 +12,14 @@ from Orange import data
 from Orange.tests import test_filename
 
 
+def assert_dist_equal(dist, expected):
+    np.testing.assert_array_equal(np.asarray(dist), expected)
+
+
+def assert_dist_almost_equal(dist, expected):
+    np.testing.assert_array_almost_equal(np.asarray(dist), expected)
+
+
 class TestDiscrete(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -19,22 +27,19 @@ class TestDiscrete(unittest.TestCase):
 
     def test_discrete(self):
         cont = contingency.Discrete(self.zoo, 0)
-        np.testing.assert_almost_equal(cont["amphibian"], [4, 0])
-        np.testing.assert_almost_equal(cont,
-                                       [[4, 0], [20, 0], [13, 0],
-                                        [4, 4], [10, 0], [2, 39], [5, 0]])
+        assert_dist_equal(cont["amphibian"], [4, 0])
+        assert_dist_equal(cont, [[4, 0], [20, 0], [13, 0],
+                                 [4, 4], [10, 0], [2, 39], [5, 0]])
 
         cont = contingency.Discrete(self.zoo, "predator")
-        np.testing.assert_almost_equal(cont["fish"], [4, 9])
-        np.testing.assert_almost_equal(cont,
-                                       [[1, 3], [11, 9], [4, 9],
-                                        [7, 1], [2, 8], [19, 22], [1, 4]])
+        assert_dist_equal(cont["fish"], [4, 9])
+        assert_dist_equal(cont, [[1, 3], [11, 9], [4, 9], [7, 1],
+                                 [2, 8], [19, 22], [1, 4]])
 
         cont = contingency.Discrete(self.zoo, self.zoo.domain["predator"])
-        np.testing.assert_almost_equal(cont["fish"], [4, 9])
-        np.testing.assert_almost_equal(cont,
-                                       [[1, 3], [11, 9], [4, 9],
-                                        [7, 1], [2, 8], [19, 22], [1, 4]])
+        assert_dist_equal(cont["fish"], [4, 9])
+        assert_dist_equal(cont, [[1, 3], [11, 9], [4, 9], [7, 1],
+                                 [2, 8], [19, 22], [1, 4]])
         self.assertEqual(cont.unknown_rows, 0)
 
     def test_discrete_missing(self):
@@ -42,9 +47,9 @@ class TestDiscrete(unittest.TestCase):
         d.Y[25] = float("nan")
         d[0][0] = float("nan")
         cont = contingency.Discrete(d, 0)
-        np.testing.assert_almost_equal(cont["amphibian"], [3, 0])
-        np.testing.assert_almost_equal(cont,
-                                       [[3, 0], [20, 0], [13, 0], [4, 4], [10, 0], [2, 38], [5, 0]])
+        assert_dist_equal(cont["amphibian"], [3, 0])
+        assert_dist_equal(cont, [[3, 0], [20, 0], [13, 0], [4, 4],
+                                 [10, 0], [2, 38], [5, 0]])
         np.testing.assert_almost_equal(cont.unknowns,
                                        [0, 0, 0, 0, 0, 1, 0])
         self.assertEqual(cont.unknown_rows, 1)
@@ -53,9 +58,9 @@ class TestDiscrete(unittest.TestCase):
         d.Y[2] = float("nan")
         d[2]["predator"] = float("nan")
         cont = contingency.Discrete(d, "predator")
-        np.testing.assert_almost_equal(cont["fish"], [4, 8])
-        np.testing.assert_almost_equal(cont,
-                                       [[1, 3], [11, 9], [4, 8], [7, 1], [2, 8], [19, 22], [1, 4]])
+        assert_dist_equal(cont["fish"], [4, 8])
+        assert_dist_equal(cont, [[1, 3], [11, 9], [4, 8], [7, 1],
+                                 [2, 8], [19, 22], [1, 4]])
         self.assertEqual(cont.unknown_rows, 1)
         np.testing.assert_almost_equal(cont.unknowns, [0, 0, 0, 0, 0, 0, 0])
 
@@ -67,9 +72,9 @@ class TestDiscrete(unittest.TestCase):
         d._compute_contingency = Mock(side_effect=NotImplementedError)
         fallback = contingency.Discrete(d, 0)
 
-        np.testing.assert_almost_equal(fallback, default)
-        np.testing.assert_almost_equal(fallback.unknowns, default.unknowns)
-        np.testing.assert_almost_equal(fallback.unknown_rows, default.unknown_rows)
+        np.testing.assert_array_equal(np.asarray(fallback), np.asarray(default))
+        np.testing.assert_array_equal(fallback.unknowns, default.unknowns)
+        np.testing.assert_array_equal(fallback.unknown_rows, default.unknown_rows)
 
     def test_continuous(self):
         d = data.Table("iris")
@@ -120,15 +125,13 @@ class TestDiscrete(unittest.TestCase):
                                  zoo.domain.metas + zoo.domain.attributes[:2])
         t = Orange.data.Table(dom, zoo)
         cont = contingency.get_contingency(zoo, 2, t.domain.metas[1])
-        np.testing.assert_almost_equal(cont["1"], [38, 5])
-        np.testing.assert_almost_equal(cont, [[4, 54],
-                                              [38, 5]])
+        assert_dist_equal(cont["1"], [38, 5])
+        assert_dist_equal(cont, [[4, 54], [38, 5]])
         zoo[25][t.domain.metas[1]] = float("nan")
         zoo[0][2] = float("nan")
         cont = contingency.get_contingency(zoo, 2, t.domain.metas[1])
-        np.testing.assert_almost_equal(cont["1"], [37, 5])
-        np.testing.assert_almost_equal(cont, [[4, 53],
-                                              [37, 5]])
+        assert_dist_equal(cont["1"], [37, 5])
+        assert_dist_equal(cont, [[4, 53], [37, 5]])
         np.testing.assert_almost_equal(cont.unknowns, [0, 1])
         self.assertEqual(cont.unknown_rows, 1)
 
@@ -165,52 +168,52 @@ class TestDiscrete(unittest.TestCase):
     def test_sparse(self):
         d = self._construct_sparse()
         cont = contingency.Discrete(d, 5)
-        np.testing.assert_almost_equal(cont[0], [2, 0, 0])
-        np.testing.assert_almost_equal(cont["b"], [0, 1, 1])
-        np.testing.assert_almost_equal(cont[2], [1, 0, 0])
+        assert_dist_equal(cont[0], [2, 0, 0])
+        assert_dist_equal(cont["b"], [0, 1, 1])
+        assert_dist_equal(cont[2], [1, 0, 0])
 
         cont = contingency.Continuous(d, 14)
-        np.testing.assert_almost_equal(cont[0], [[], []])
-        np.testing.assert_almost_equal(cont["b"], [[1], [1]])
-        np.testing.assert_almost_equal(cont[2], [[2], [1]])
+        assert_dist_equal(cont[0], [[], []])
+        assert_dist_equal(cont["b"], [[1], [1]])
+        assert_dist_equal(cont[2], [[2], [1]])
 
         cont = contingency.Continuous(d, "c3")
-        np.testing.assert_almost_equal(cont[0], [[1.1], [1]])
-        np.testing.assert_almost_equal(cont["b"], [[1], [1]])
-        np.testing.assert_almost_equal(cont[2], [[], []])
+        assert_dist_equal(cont[0], [[1.1], [1]])
+        assert_dist_equal(cont["b"], [[1], [1]])
+        assert_dist_equal(cont[2], [[], []])
 
         d[4].set_class(1)
         cont = contingency.Continuous(d, 13)
-        np.testing.assert_almost_equal(cont[0], [[], []])
-        np.testing.assert_almost_equal(cont["b"], [[1, 1.1], [1, 1]])
-        np.testing.assert_almost_equal(cont[2], [[], []])
+        assert_dist_equal(cont[0], [[], []])
+        assert_dist_equal(cont["b"], [[1, 1.1], [1, 1]])
+        assert_dist_equal(cont[2], [[], []])
 
         cont = contingency.Continuous(d, 12)
-        np.testing.assert_almost_equal(cont[0], [[], []])
-        np.testing.assert_almost_equal(cont["b"], [[], []])
-        np.testing.assert_almost_equal(cont[2], [[], []])
+        assert_dist_equal(cont[0], [[], []])
+        assert_dist_equal(cont["b"], [[], []])
+        assert_dist_equal(cont[2], [[], []])
 
 
     def test_get_contingency(self):
         d = self._construct_sparse()
         cont = contingency.get_contingency(d, 5)
         self.assertIsInstance(cont, contingency.Discrete)
-        np.testing.assert_almost_equal(cont[0], [2, 0, 0])
-        np.testing.assert_almost_equal(cont["b"], [0, 1, 1])
-        np.testing.assert_almost_equal(cont[2], [1, 0, 0])
+        assert_dist_equal(cont[0], [2, 0, 0])
+        assert_dist_equal(cont["b"], [0, 1, 1])
+        assert_dist_equal(cont[2], [1, 0, 0])
 
         cont = contingency.get_contingency(d, "c4")
         self.assertIsInstance(cont, contingency.Continuous)
-        np.testing.assert_almost_equal(cont[0], [[], []])
-        np.testing.assert_almost_equal(cont["b"], [[1], [1]])
-        np.testing.assert_almost_equal(cont[2], [[2], [1]])
+        assert_dist_equal(cont[0], [[], []])
+        assert_dist_equal(cont["b"], [[1], [1]])
+        assert_dist_equal(cont[2], [[2], [1]])
 
         cont = contingency.get_contingency(d, d.domain[13])
         self.assertIsInstance(cont, contingency.Continuous)
-        np.testing.assert_almost_equal(cont[0], [[1.1], [1]])
-        np.testing.assert_almost_equal(cont["b"], [[1], [1]])
-        np.testing.assert_almost_equal(cont[2], [[], []])
-        np.testing.assert_almost_equal(cont[2], [[], []])
+        assert_dist_equal(cont[0], [[1.1], [1]])
+        assert_dist_equal(cont["b"], [[1], [1]])
+        assert_dist_equal(cont[2], [[], []])
+        assert_dist_equal(cont[2], [[], []])
 
     def test_get_contingencies(self):
         d = self._construct_sparse()
@@ -220,38 +223,38 @@ class TestDiscrete(unittest.TestCase):
 
         cont = conts[5]
         self.assertIsInstance(cont, contingency.Discrete)
-        np.testing.assert_almost_equal(cont[0], [2, 0, 0])
-        np.testing.assert_almost_equal(cont["b"], [0, 1, 1])
-        np.testing.assert_almost_equal(cont[2], [1, 0, 0])
+        assert_dist_equal(cont[0], [2, 0, 0])
+        assert_dist_equal(cont["b"], [0, 1, 1])
+        assert_dist_equal(cont[2], [1, 0, 0])
 
         cont = conts[14]
         self.assertIsInstance(cont, contingency.Continuous)
-        np.testing.assert_almost_equal(cont[0], [[], []])
-        np.testing.assert_almost_equal(cont["b"], [[1], [1]])
-        np.testing.assert_almost_equal(cont[2], [[2], [1]])
+        assert_dist_equal(cont[0], [[], []])
+        assert_dist_equal(cont["b"], [[1], [1]])
+        assert_dist_equal(cont[2], [[2], [1]])
 
         conts = contingency.get_contingencies(d, skip_discrete=True)
         self.assertEqual(len(conts), 10)
         cont = conts[4]
         self.assertIsInstance(cont, contingency.Continuous)
-        np.testing.assert_almost_equal(cont[0], [[], []])
-        np.testing.assert_almost_equal(cont["b"], [[1], [1]])
-        np.testing.assert_almost_equal(cont[2], [[2], [1]])
+        assert_dist_equal(cont[0], [[], []])
+        assert_dist_equal(cont["b"], [[1], [1]])
+        assert_dist_equal(cont[2], [[2], [1]])
 
         conts = contingency.get_contingencies(d, skip_continuous=True)
         self.assertEqual(len(conts), 10)
         cont = conts[5]
         self.assertIsInstance(cont, contingency.Discrete)
-        np.testing.assert_almost_equal(cont[0], [2, 0, 0])
-        np.testing.assert_almost_equal(cont["b"], [0, 1, 1])
-        np.testing.assert_almost_equal(cont[2], [1, 0, 0])
+        assert_dist_equal(cont[0], [2, 0, 0])
+        assert_dist_equal(cont["b"], [0, 1, 1])
+        assert_dist_equal(cont[2], [1, 0, 0])
 
     def test_compute_contingency_metas(self):
         d = data.Table(test_filename("test9.tab"))
         var1, var2 = d.domain[-2], d.domain[-4]
         cont, _ = d._compute_contingency([var1], var2)[0][0]
-        np.testing.assert_almost_equal(cont, [[3, 0, 0], [0, 2, 0],
-                                              [0, 0, 2], [0, 1, 0]])
+        assert_dist_equal(cont, [[3, 0, 0], [0, 2, 0],
+                                 [0, 0, 2], [0, 1, 0]])
 
     def test_compute_contingency_invalid(self):
         rstate = np.random.RandomState(0xFFFF)

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -13,6 +13,14 @@ from Orange import data
 from Orange.tests import test_filename
 
 
+def assert_dist_equal(dist, expected):
+    np.testing.assert_array_equal(np.asarray(dist), expected)
+
+
+def assert_dist_almost_equal(dist, expected):
+    np.testing.assert_almost_equal(np.asarray(dist), expected)
+
+
 class TestDiscreteDistribution(unittest.TestCase):
     def setUp(self):
         self.freqs = [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0]
@@ -39,7 +47,7 @@ class TestDiscreteDistribution(unittest.TestCase):
         self.assertIsInstance(disc, np.ndarray)
         self.assertIs(disc.variable, d.domain["type"])
         self.assertEqual(disc.unknowns, 0)
-        np.testing.assert_array_equal(disc, self.freqs)
+        assert_dist_equal(disc, self.freqs)
 
         disc2 = distribution.Discrete(d, d.domain.class_var)
         self.assertIsInstance(disc2, np.ndarray)
@@ -75,8 +83,7 @@ class TestDiscreteDistribution(unittest.TestCase):
         self.assertIsInstance(disc1, np.ndarray)
         self.assertIs(disc1.variable, d.domain.class_var)
         self.assertEqual(disc.unknowns, 0)
-        np.testing.assert_array_equal(disc1,
-                                      [0]*len(d.domain.class_var.values))
+        assert_dist_equal(disc1, [0]*len(d.domain.class_var.values))
 
     def test_fallback(self):
         d = data.Table("zoo")
@@ -85,7 +92,8 @@ class TestDiscreteDistribution(unittest.TestCase):
         d._compute_distributions = Mock(side_effect=NotImplementedError)
         fallback = distribution.Discrete(d, "type")
 
-        np.testing.assert_almost_equal(fallback, default)
+        np.testing.assert_almost_equal(
+            np.asarray(fallback), np.asarray(default))
         np.testing.assert_almost_equal(fallback.unknowns, default.unknowns)
 
     def test_fallback_with_weights_and_nan(self):
@@ -97,7 +105,8 @@ class TestDiscreteDistribution(unittest.TestCase):
         d._compute_distributions = Mock(side_effect=NotImplementedError)
         fallback = distribution.Discrete(d, "type")
 
-        np.testing.assert_almost_equal(fallback, default)
+        np.testing.assert_almost_equal(
+            np.asarray(fallback), np.asarray(default))
         np.testing.assert_almost_equal(fallback.unknowns, default.unknowns)
 
     def test_equality(self):
@@ -172,7 +181,7 @@ class TestDiscreteDistribution(unittest.TestCase):
         disc1 = distribution.Discrete(None, d.domain.class_var)
         disc1.normalize()
         v = len(d.domain.class_var.values)
-        np.testing.assert_almost_equal(disc1, [1/v]*v)
+        assert_dist_almost_equal(disc1, [1/v]*v)
 
     def test_modus(self):
         d = data.Table("zoo")
@@ -231,7 +240,7 @@ class TestContinuousDistribution(unittest.TestCase):
             self.assertIsInstance(disc, np.ndarray)
             self.assertIs(disc.variable, petal_length)
             self.assertEqual(disc.unknowns, 0)
-            np.testing.assert_almost_equal(disc, self.freqs)
+            assert_dist_almost_equal(disc, self.freqs)
 
     def test_construction(self):
         d = self.iris
@@ -255,14 +264,14 @@ class TestContinuousDistribution(unittest.TestCase):
         self.assertIsInstance(disc1, np.ndarray)
         self.assertIs(disc7.variable, petal_length)
         self.assertEqual(disc7.unknowns, 0)
-        np.testing.assert_array_equal(disc1, np.zeros((2, 10)))
+        assert_dist_equal(disc1, np.zeros((2, 10)))
 
         dd = [list(range(5)), [1, 1, 2, 5, 1]]
         disc2 = distribution.Continuous(dd)
         self.assertIsInstance(disc2, np.ndarray)
         self.assertIsNone(disc2.variable)
         self.assertEqual(disc2.unknowns, 0)
-        np.testing.assert_array_equal(disc2, dd)
+        assert_dist_equal(disc2, dd)
 
     def test_hash(self):
         d = self.iris
@@ -287,16 +296,16 @@ class TestContinuousDistribution(unittest.TestCase):
 
         disc = distribution.Continuous(d, "petal length")
 
-        np.testing.assert_almost_equal(disc, self.freqs)
+        assert_dist_equal(disc, self.freqs)
         disc.normalize()
         self.freqs[1, :] /= 150
-        np.testing.assert_almost_equal(disc, self.freqs)
+        assert_dist_equal(disc, self.freqs)
 
         disc1 = distribution.Continuous(10, petal_length)
         disc1.normalize()
         f = np.zeros((2, 10))
         f[1, :] = 0.1
-        np.testing.assert_almost_equal(disc1, f)
+        assert_dist_equal(disc1, f)
 
     def test_modus(self):
         disc = distribution.Continuous([list(range(5)), [1, 1, 2, 5, 1]])
@@ -327,8 +336,7 @@ class TestClassDistribution(unittest.TestCase):
         self.assertIsInstance(disc, np.ndarray)
         self.assertIs(disc.variable, d.domain["type"])
         self.assertEqual(disc.unknowns, 0)
-        np.testing.assert_array_equal(disc,
-                                      [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0])
+        assert_dist_equal(disc, [4.0, 20.0, 13.0, 8.0, 10.0, 41.0, 5.0])
 
     def test_multiple_target_variables(self):
         d = data.Table.from_numpy(
@@ -360,7 +368,7 @@ class TestGetDistribution(unittest.TestCase):
         self.assertIsInstance(disc, np.ndarray)
         self.assertIs(disc.variable, cls)
         self.assertEqual(disc.unknowns, 0)
-        np.testing.assert_array_equal(disc, [50, 50, 50])
+        assert_dist_equal(disc, [50, 50, 50])
 
         petal_length = d.columns.petal_length
         freqs = np.array([(1.0, 1), (1.1, 1), (1.2, 2), (1.3, 7), (1.4, 12),
@@ -373,7 +381,7 @@ class TestGetDistribution(unittest.TestCase):
                           (5.9, 2), (6.0, 2), (6.1, 3), (6.3, 1), (6.4, 1),
                           (6.6, 1), (6.7, 2), (6.9, 1)]).T
         disc = distribution.get_distribution(d, petal_length)
-        np.testing.assert_almost_equal(disc, freqs)
+        assert_dist_equal(disc, freqs)
 
 
 class TestDomainDistribution(unittest.TestCase):
@@ -395,8 +403,8 @@ class TestDomainDistribution(unittest.TestCase):
                           (5.4, 2), (5.5, 3), (5.6, 6), (5.7, 3), (5.8, 3),
                           (5.9, 2), (6.0, 2), (6.1, 3), (6.3, 1), (6.4, 1),
                           (6.6, 1), (6.7, 2), (6.9, 1)]).T
-        np.testing.assert_almost_equal(ddist[2], freqs)
-        np.testing.assert_almost_equal(ddist[-1], [50, 50, 50])
+        assert_dist_equal(ddist[2], freqs)
+        assert_dist_equal(ddist[-1], [50, 50, 50])
 
     def test_sparse_get_distributions(self):
         def assert_dist_and_unknowns(computed, goal_dist):
@@ -405,7 +413,7 @@ class TestDomainDistribution(unittest.TestCase):
             sum_dist = np.sum(goal_dist[1, :] if goal_dist.ndim == 2 else goal_dist)
             n_all = np.sum(d.W) if d.has_weights() else len(d)
 
-            np.testing.assert_almost_equal(computed, goal_dist)
+            assert_dist_almost_equal(computed, goal_dist)
             self.assertEqual(computed.unknowns, n_all - sum_dist)
 
         domain = data.Domain(
@@ -483,13 +491,13 @@ class TestDomainDistribution(unittest.TestCase):
         d = data.Table(test_filename("test9.tab"))
         variable = d.domain[-2]
         dist, _ = d._compute_distributions([variable])[0]
-        np.testing.assert_almost_equal(dist, [3, 3, 2])
+        assert_dist_equal(dist, [3, 3, 2])
         # repeat with nan values
         assert d.metas.dtype.kind == "O"
         assert d.metas[0, 1] == 0
         d.metas[0, 1] = np.nan
         dist, nanc = d._compute_distributions([variable])[0]
-        np.testing.assert_almost_equal(dist, [2, 3, 2])
+        assert_dist_equal(dist, [2, 3, 2])
         self.assertEqual(nanc, 1)
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Tests fail to run with numpy 1.15

E.g.
```
======================================================================
ERROR: test_discrete (Orange.tests.test_contingency.TestDiscrete)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/tests/test_contingency.py", line 22, in test_discrete
    np.testing.assert_almost_equal(cont["amphibian"], [4, 0])
  File "/Users/aleserjavec/workspace/numpy/numpy/testing/_private/utils.py", line 568, in assert_almost_equal
    return assert_array_almost_equal(actual, desired, decimal, err_msg)
  File "/Users/aleserjavec/workspace/numpy/numpy/testing/_private/utils.py", line 964, in assert_array_almost_equal
    precision=decimal)
  File "/Users/aleserjavec/workspace/numpy/numpy/testing/_private/utils.py", line 736, in assert_array_compare
    flagged = func_assert_same_pos(x, y, func=isnan, hasval='nan')
  File "/Users/aleserjavec/workspace/numpy/numpy/testing/_private/utils.py", line 707, in func_assert_same_pos
    if (x_id == y_id).all() != True:
AttributeError: 'bool' object has no attribute 'all'
...
======================================================================
ERROR: test_init_inst (Orange.tests.test_instance.TestInstance)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/tests/test_instance.py", line 166, in test_init_inst
    assert_array_nanequal(inst2._x, np.array([Unknown, 0, 43]))
  File "/Users/aleserjavec/workspace/orange3/Orange/tests/__init__.py", line 45, in assert_array_nanequal
    return np.testing.utils.assert_array_compare(naneq, a, b, *args, **kwargs)
AttributeError: module 'numpy.testing' has no attribute 'utils'
...
```


##### Description of changes

* numpy.testing.utils was private before and is removed in 1.15
* assert_array_equal/assert_array_almost_equal preserve subclasses
  and dispatch equality testing to them. This breaks array subclasses
  in Orange.statistics that do not adhere to the array interface.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
