### PR TITLE
[ENH] Replace scikit-learn tSNE with faster implementation

### DIFF
--- a/Orange/projection/manifold.py
+++ b/Orange/projection/manifold.py
@@ -1,11 +1,12 @@
 import warnings
 
-import fastTSNE
 import numpy as np
-import scipy.sparse as sp
 import sklearn.manifold as skl_manifold
+import scipy.sparse as sp
 from scipy.linalg import eigh as lapack_eigh
 from scipy.sparse.linalg import eigsh as arpack_eigh
+
+import fastTSNE
 
 import Orange
 from Orange.data import Table, Domain, ContinuousVariable

--- a/Orange/projection/manifold.py
+++ b/Orange/projection/manifold.py
@@ -1,7 +1,8 @@
 import warnings
 
-import numpy as np
 import fastTSNE
+import numpy as np
+import scipy.sparse as sp
 import sklearn.manifold as skl_manifold
 from scipy.linalg import eigh as lapack_eigh
 from scipy.sparse.linalg import eigsh as arpack_eigh
@@ -197,6 +198,11 @@ class TSNEModel(Projection):
         self.embedding = table
 
     def transform(self, X: np.ndarray, **kwargs) -> fastTSNE.PartialTSNEEmbedding:
+        if sp.issparse(X):
+            raise TypeError(
+                'A sparse matrix was passed, but dense data is required. Use '
+                'X.toarray() to convert to a dense numpy array.'
+            )
         return self.embedding_.transform(X, **kwargs)
 
     def __call__(self, data: Table, **kwargs) -> Table:
@@ -329,6 +335,11 @@ class TSNE(Projector):
         )
 
     def fit(self, X: np.ndarray, Y: np.ndarray = None) -> fastTSNE.TSNEEmbedding:
+        if sp.issparse(X):
+            raise TypeError(
+                'A sparse matrix was passed, but dense data is required. Use '
+                'X.toarray() to convert to a dense numpy array.'
+            )
         return self.tsne.fit(X)
 
     def __call__(self, data: Table) -> TSNEModel:

--- a/Orange/projection/manifold.py
+++ b/Orange/projection/manifold.py
@@ -1,3 +1,4 @@
+import Orange
 import warnings
 
 import numpy as np
@@ -6,9 +7,11 @@ from scipy.sparse.linalg import eigsh as arpack_eigh
 from scipy.linalg import eigh as lapack_eigh
 
 import sklearn.manifold as skl_manifold
+import fastTSNE
 
+from Orange.data import Table, Domain, ContinuousVariable
 from Orange.distance import Distance, DistanceModel, Euclidean
-from Orange.projection import SklProjector
+from Orange.projection import SklProjector, Projector, Projection
 
 __all__ = ["MDS", "Isomap", "LocallyLinearEmbedding", "SpectralEmbedding",
            "TSNE"]
@@ -178,31 +181,176 @@ class SpectralEmbedding(SklProjector):
         self.params = vars()
 
 
-class TSNE(SklProjector):
-    __wraps__ = skl_manifold.TSNE
-    name = 't-SNE'
+class TSNEModel(Projection):
+    """A tSNE embedding object. Supports further optimization as well as
+    adding new data into the existing embedding.
 
-    def __init__(self, n_components=2, perplexity=30.0, early_exaggeration=4.0,
-                 learning_rate=1000.0, n_iter=1000, n_iter_without_progress=30,
-                 min_grad_norm=1e-07, metric='euclidean', init='random',
-                 random_state=None, method='barnes_hut', angle=0.5, n_jobs=1,
+    Attributes
+    ----------
+    embedding_ : fastTSNE.TSNEEmbedding
+        The embedding object which takes care of subsequent optimizations of
+        transforms.
+    embedding : Table
+        The embedding in an Orange table, easily accessible.
+
+    """
+    def __init__(self, embedding: fastTSNE.TSNEEmbedding, table: Table):
+        self.embedding_ = embedding
+        self.embedding = table
+
+    def transform(self, X: np.ndarray, **kwargs) -> fastTSNE.PartialTSNEEmbedding:
+        return self.embedding_.transform(X, **kwargs)
+
+    def __call__(self, data: Table, **kwargs) -> Table:
+        # If we want to transform new data, ensure that we use correct domain
+        if data.domain != self.original_domain:
+            data = data.transform(self.original_domain)
+
+        embedding = self.transform(data.X, **kwargs)
+        return Table(self.embedding.domain, embedding.view(), data.Y, data.metas)
+
+    def optimize(self, n_iter, inplace=False, propagate_exception=False, **kwargs):
+        """Resume optimization for the current embedding."""
+        kwargs = {'n_iter': n_iter, 'inplace': inplace,
+                  'propagate_exception': propagate_exception, **kwargs}
+        if inplace:
+            self.embedding_.optimize(**kwargs)
+            return self
+
+        # If not inplace, we return a new TSNEModel object
+        new_embedding = self.embedding_.optimize(**kwargs)
+        table = Table(self.embedding.domain, new_embedding.view(np.ndarray),
+                      self.embedding.Y, self.embedding.metas)
+        return TSNEModel(new_embedding, table)
+
+
+class TSNE(Projector):
+    """t-distributed stochastic neighbor embedding (tSNE).
+
+    Parameters
+    ----------
+    n_components : int
+        The number of embedding that the embedding should contain. Note that
+        only up to two dimensions are supported as otherwise the process can
+        become prohibitively expensive.
+    perplexity : float
+        The desired perplexity of the probability distribution.
+    learning_rate : float
+        The learning rate for t-SNE. Typical values range from 1 to 1000.
+        Setting the learning rate too high will result in the crowding problem
+        where all the points form a ball in the center of the space.
+    early_exaggeration_iter : int
+        The number of iterations that the early exaggeration phase will be run
+        for. Early exaggeration helps better separate clusters by increasing
+        attractive forces between similar points.
+    early_exaggeration : float
+        The exaggeration term is used to increase the attractive forces during
+        the first steps of the optimization. This enables points to move more
+        easily through others, helping find their true neighbors quicker.
+    n_iter : int
+        The number of iterations to run the optimization after the early
+        exaggeration phase.
+    theta : float
+        This is the trade-off parameter between speed and accuracy of the
+        Barnes-Hut approximation of the negative forces. Setting a lower value
+        will produce more accurate results, while setting a higher value will
+        search through less of the space providing a rougher approximation.
+        Scikit-learn recommends values between 0.2-0.8. This value is ignored
+        unless the Barnes-Hut algorithm is used to compute negative gradients.
+    min_num_intervals : int
+        The minimum number of intervals into which we split our embedding. A
+        larger value will produce better embeddings at the cost of performance.
+        This value is ignored unless the interpolation based algorithm is used
+        to compute negative gradients.
+    ints_in_interval : float
+        Since the coordinate range of the embedding will certainly change
+        during optimization, this value tells us how many integer values should
+        appear in a single interval. This number of intervals affect the
+        embedding quality at the cost of performance. Less ints per interval
+        will incur a larger number of intervals. This value is ignored unless
+        the interpolation based algorithm is used to compute negative gradients.
+    initialization : Optional[Union[np.ndarray, str]]
+        An initial embedding strategy can be provided. A precomputed array with
+        coordinates can be passed in, or optionally "random" or "pca"
+        initializations are available. Note that while PCA can sometimes lead
+        to faster convergence times, it can sometimes also lead to poor
+        embeddings. Random initialization is typically a safe bet.
+    metric : str
+        The metric which will be used to evaluate the similarities between the
+        input data points in the high dimensional space.
+    n_jobs : int
+        Parts of the algorithm can be in parallel and thus - faster.
+    neighbors : str
+        The method used to compute the nearest neighbors in the original, high
+        dimensional data set. Possible values are "exact" or "approx" or any
+        instance inheriting from `fastTSNE.nearest_neighbors.KNNIndex`. When
+        dealing with larger data sets, approximate NN search is faster, when
+        dealing with smaller data sets, exact NN search is typically faster.
+    negative_gradient_method : str
+        The method used to evaluate negative gradients (repulsive forces) in
+        the embedding. Possible values are "bh" for Barnes-Hut or "fft" for
+        Fast Fourier Accelerated Interpolation based tSNE or FItSNE for short.
+        BH tends to be faster for smaller data sets but scales as O(n log n)
+        while FItSNE is faster for larger data sets and scales linearly in the
+        number of points.
+    callbacks : Callable[[int, float, np.ndarray] -> bool]
+        The callback should accept three parameters, the first is the current
+        iteration, the second is the current KL divergence error and the last
+        is the current embedding. The callback should return a boolean value
+        indicating whether or not to stop optimization i.e. True to stop.
+        This is convenient because returning `None` is falsey and helps avoid
+        potential bugs if forgetting to return. Optionally, a list of callbacks
+        is also supported.
+    callbacks_every_iters : int
+        How often should the callback be called.
+    preprocessors
+
+    """
+    name = 't-SNE'
+    preprocessors = [
+        Orange.preprocess.Continuize(),
+        Orange.preprocess.SklImpute(),
+    ]
+
+    def __init__(self, n_components=2, perplexity=30, learning_rate=200,
+                 early_exaggeration_iter=250, early_exaggeration=12,
+                 n_iter=750, theta=0.5, min_num_intervals=10, ints_in_interval=1,
+                 initialization='random', metric='euclidean', n_jobs=1, neighbors='exact',
+                 negative_gradient_method='bh', callbacks=None, callbacks_every_iters=50,
                  preprocessors=None):
         super().__init__(preprocessors=preprocessors)
-        self.params = vars()
+        self.tsne = fastTSNE.TSNE(
+            n_components=n_components, perplexity=perplexity,
+            learning_rate=learning_rate, early_exaggeration=early_exaggeration,
+            early_exaggeration_iter=early_exaggeration_iter, n_iter=n_iter,
+            theta=theta, min_num_intervals=min_num_intervals,
+            ints_in_interval=ints_in_interval, initialization=initialization,
+            metric=metric, n_jobs=n_jobs, neighbors=neighbors,
+            negative_gradient_method=negative_gradient_method,
+            callbacks=callbacks, callbacks_every_iters=callbacks_every_iters,
+        )
 
-    def __call__(self, data):
-        params = self.params.copy()
-        metric = params["metric"]
-        if metric == 'precomputed':
-            X, Y, domain = data, None, None
-        else:
-            data = self.preprocess(data)
-            X, Y, domain = data.X, data.Y, data.domain
-            if isinstance(metric, Distance):
-                X = metric(X)
-                params['metric'] = 'precomputed'
+    def fit(self, X: np.ndarray, Y: np.ndarray = None) -> fastTSNE.TSNEEmbedding:
+        return self.tsne.fit(X)
 
-        tsne = self.__wraps__(**params)
-        tsne.fit(X, y=Y)
-        tsne.domain = domain
-        return tsne
+    def __call__(self, data: Table) -> TSNEModel:
+        # Preprocess the data - convert discrete to continuous
+        data = self.preprocess(data)
+
+        # Run tSNE optimization
+        embedding = self.fit(data.X, data.Y)
+
+        # The results should be accessible in an Orange table, which doesn't
+        # need the full embedding attributes and is cast into a regular array
+        tsne_cols = [ContinuousVariable('t-SNE-%d' % (i + 1))
+                     for i in range(self.tsne.n_components)]
+        embedding_domain = Domain(tsne_cols, data.domain.class_vars, data.domain.metas)
+        embedding_table = Table(embedding_domain, embedding.view(np.ndarray), data.Y, data.metas)
+
+        # Create a model object which will be capable of transforming new data
+        # into the existing embedding
+        model = TSNEModel(embedding, embedding_table)
+        model.original_domain = data.domain
+        model.name = self.name
+
+        return model

--- a/Orange/projection/manifold.py
+++ b/Orange/projection/manifold.py
@@ -318,16 +318,16 @@ class TSNE(Projector):
 
     def __init__(self, n_components=2, perplexity=30, learning_rate=200,
                  early_exaggeration_iter=250, early_exaggeration=12,
-                 n_iter=750, theta=0.5, min_num_intervals=10, ints_in_interval=1,
-                 initialization='random', metric='euclidean', n_jobs=1, neighbors='exact',
-                 negative_gradient_method='bh', callbacks=None, callbacks_every_iters=50,
-                 preprocessors=None):
+                 n_iter=750, exaggeration=None, theta=0.5, min_num_intervals=10,
+                 ints_in_interval=1, initialization='random', metric='euclidean',
+                 n_jobs=1, neighbors='exact', negative_gradient_method='bh', callbacks=None,
+                 callbacks_every_iters=50, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.tsne = fastTSNE.TSNE(
             n_components=n_components, perplexity=perplexity,
             learning_rate=learning_rate, early_exaggeration=early_exaggeration,
             early_exaggeration_iter=early_exaggeration_iter, n_iter=n_iter,
-            theta=theta, min_num_intervals=min_num_intervals,
+            exaggeration=exaggeration, theta=theta, min_num_intervals=min_num_intervals,
             ints_in_interval=ints_in_interval, initialization=initialization,
             metric=metric, n_jobs=n_jobs, neighbors=neighbors,
             negative_gradient_method=negative_gradient_method,

--- a/Orange/projection/manifold.py
+++ b/Orange/projection/manifold.py
@@ -1,14 +1,12 @@
-import Orange
 import warnings
 
 import numpy as np
-
-from scipy.sparse.linalg import eigsh as arpack_eigh
-from scipy.linalg import eigh as lapack_eigh
-
-import sklearn.manifold as skl_manifold
 import fastTSNE
+import sklearn.manifold as skl_manifold
+from scipy.linalg import eigh as lapack_eigh
+from scipy.sparse.linalg import eigsh as arpack_eigh
 
+import Orange
 from Orange.data import Table, Domain, ContinuousVariable
 from Orange.distance import Distance, DistanceModel, Euclidean
 from Orange.projection import SklProjector, Projector, Projection
@@ -113,9 +111,9 @@ class MDS(SklProjector):
     def __call__(self, data):
         params = self.params.copy()
         dissimilarity = params['dissimilarity']
-        if isinstance(self._metric, DistanceModel) \
-                or (isinstance(self._metric, type)
-                    and issubclass(self._metric, Distance)):
+        if isinstance(self._metric, DistanceModel) or (
+                isinstance(self._metric, type) and issubclass(self._metric, Distance)
+        ):
             data = self.preprocess(data)
             _X, Y, domain = data.X, data.Y, data.domain
             X = dist_matrix = self._metric(_X)

--- a/Orange/tests/test_manifold.py
+++ b/Orange/tests/test_manifold.py
@@ -2,13 +2,14 @@
 # pylint: disable=missing-docstring
 
 import unittest
+
 import numpy as np
 
+from Orange.data import Table
+from Orange.distance import Euclidean
 from Orange.projection import (MDS, Isomap, LocallyLinearEmbedding,
                                SpectralEmbedding, TSNE)
 from Orange.projection.manifold import torgerson
-from Orange.distance import Euclidean
-from Orange.data import Table
 
 
 class TestManifold(unittest.TestCase):
@@ -116,25 +117,6 @@ class TestManifold(unittest.TestCase):
         se = SpectralEmbedding(n_components=n_com, n_neighbors=5)
         se = se(data)
         self.assertEqual((data.X.shape[0], n_com), se.embedding_.shape)
-
-    def test_tsne(self):
-        data = self.ionosphere[:50]
-        for i in range(1, 4):
-            self.__tsne_test_helper(data, n_com=i)
-
-    def __tsne_test_helper(self, data, n_com):
-        tsne_def = TSNE(n_components=n_com, metric='euclidean')
-        tsne_def = tsne_def(data)
-
-        tsne_euc = TSNE(n_components=n_com, metric=Euclidean)
-        tsne_euc = tsne_euc(data)
-
-        tsne_pre = TSNE(n_components=n_com, metric='precomputed')
-        tsne_pre = tsne_pre(Euclidean(data))
-
-        self.assertEqual((data.X.shape[0], n_com), tsne_def.embedding_.shape)
-        self.assertEqual((data.X.shape[0], n_com), tsne_euc.embedding_.shape)
-        self.assertEqual((data.X.shape[0], n_com), tsne_pre.embedding_.shape)
 
     def test_torgerson(self):
         data = self.ionosphere[::5]

--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -206,9 +206,7 @@ class OWManifoldLearning(OWWidget):
         n_neighbors_too_small = Msg("For chosen method and components, "
                                     "neighbors must be greater than {}")
         manifold_error = Msg("{}")
-        sparse_methods = Msg('Only t-SNE method supported on sparse data')
-        sparse_tsne_distance = Msg('Chebyshev, Jaccard, and Mahalanobis '
-                                   'distances not supported with sparse data.')
+        sparse_not_supported = Msg("Sparse data is not supported.")
         out_of_memory = Msg("Out of memory")
 
     @classmethod
@@ -283,10 +281,11 @@ class OWManifoldLearning(OWWidget):
         data = self.data
         method = self.MANIFOLD_METHODS[self.manifold_method_index]
         have_data = data is not None and len(data)
-        sparse_incompat = have_data and data.is_sparse() and method != TSNE
         self.Error.clear()
-        self.Error.sparse_methods(shown=sparse_incompat)
-        if have_data and not sparse_incompat:
+
+        if have_data and data.is_sparse():
+            self.Error.sparse_not_supported()
+        elif have_data:
             domain = Domain([ContinuousVariable("C{}".format(i))
                              for i in range(self.n_components)],
                             data.domain.class_vars,
@@ -299,17 +298,10 @@ class OWManifoldLearning(OWWidget):
                 else:
                     X = model.embedding_
                     out = Table(domain, X, data.Y, data.metas)
-            except TypeError as e:
-                if 'sparse' in e.args[0] and 'distance' in e.args[0]:
-                    self.Error.sparse_tsne_distance()
-                else:
-                    raise
             except ValueError as e:
-                if 'sparse' in e.args[0] and 'metric' in e.args[0]:
-                    self.Error.sparse_tsne_distance()
-                elif e.args[0] == "for method='hessian', n_neighbors " \
-                                  "must be greater than [n_components" \
-                                  " * (n_components + 3) / 2]":
+                if e.args[0] == "for method='hessian', n_neighbors " \
+                                "must be greater than [n_components" \
+                                " * (n_components + 3) / 2]":
                     n = self.n_components * (self.n_components + 3) / 2
                     self.Error.n_neighbors_too_small("{}".format(n))
                 else:
@@ -324,8 +316,6 @@ class OWManifoldLearning(OWWidget):
     def get_method_parameters(self, data, method):
         parameters = dict(n_components=self.n_components)
         parameters.update(self.params_widget.parameters)
-        if data is not None and data.is_sparse() and method == TSNE:
-            parameters.update(initialization='random')
         return parameters
 
     def send_report(self):

--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -88,11 +88,9 @@ class ManifoldParametersEditor(QWidget, gui.OWComponent):
 
 
 class TSNEParametersEditor(ManifoldParametersEditor):
-    _metrics = ("manhattan", "chebyshev")
+    _metrics = ("euclidean", "manhattan", "chebyshev", "jaccard")
     metric_index = Setting(0)
     metric_values = [(x, x.capitalize()) for x in _metrics]
-    # rename l2 to Euclidean
-    metric_values = [("l2", "Euclidean")] + metric_values
 
     perplexity = Setting(30)
     early_exaggeration = Setting(12)

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -85,6 +85,25 @@ class TestOWManifoldLearning(WidgetTest):
             self.widget.manifold_methods_combo, callback=__callback,
         )
 
+    def test_metrics(self):
+        # Select t-SNE method, which is the only method that supports metrics
+        simulate.combobox_activate_item(self.widget.manifold_methods_combo, "t-SNE")
+
+        def __callback():
+            # Send data to input
+            self.send_signal(self.widget.Inputs.data, self.iris)
+            self.widget.apply_button.button.click()
+            self.assertFalse(self.widget.Error.manifold_error.is_shown())
+
+            # Clear input
+            self.send_signal(self.widget.Inputs.data, None)
+            self.widget.apply_button.button.click()
+            self.assertFalse(self.widget.Error.manifold_error.is_shown())
+
+        simulate.combobox_run_through_all(
+            self.widget.tsne_editor.metric_combo, callback=__callback,
+        )
+
     @skip
     def test_singular_matrices(self):
         """

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from unittest import skip
 from unittest.mock import patch, Mock
 
 import numpy as np
@@ -89,10 +90,16 @@ class TestOWManifoldLearning(WidgetTest):
         self.widget.apply_button.button.click()
         self.assertTrue(self.widget.Error.sparse_tsne_distance.is_shown())
 
+    @skip
     def test_singular_matrices(self):
         """
         Handle singular matrices.
         GH-2228
+
+        TODO: This test makes sense with the ``Mahalanobis`` distance metric
+        which is currently not supported by tSNE. In case it is ever
+        re-introduced, this test is very much required.
+
         """
         table = Table(
             Domain(

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, Mock
 import numpy as np
 from scipy import sparse
 
-from Orange.data import Table
+from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owmanifoldlearning import OWManifoldLearning
 

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -6,9 +6,9 @@ from unittest.mock import patch, Mock
 import numpy as np
 from scipy import sparse
 
-from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
-from Orange.widgets.unsupervised.owmanifoldlearning import OWManifoldLearning
+from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.unsupervised.owmanifoldlearning import OWManifoldLearning
 
 
 class TestOWManifoldLearning(WidgetTest):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,6 @@ environment:
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
     TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
 
-    # Numba's ``parallel`` directive does not work on 32 bit machines
-    NUMBA_COMPATIBILITY_MODE: 1
-
   matrix:
     - PYTHON: C:\Python35
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,9 @@ environment:
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
     TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
 
+    # Numba's ``parallel`` directive does not work on 32 bit machines
+    NUMBA_COMPATIBILITY_MODE: 1
+
   matrix:
     - PYTHON: C:\Python35
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
-    - fasttsne      >=0.2.9
+    - fasttsne      >=0.2.10
 
 test:
   # Python imports

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
-    - fasttsne      >=0.2.11
+    - fasttsne      >=0.2.12
 
 test:
   # Python imports

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
+    - fasttsne      >=0.2.9
 
 test:
   # Python imports

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
-    - fasttsne      >=0.2.10
+    - fasttsne      >=0.2.11
 
 test:
   # Python imports

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,4 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE
+fastTSNE>=0.2.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,4 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE>=0.2.3
+fastTSNE>=0.2.9

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,4 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE>=0.2.9
+fastTSNE>=0.2.10

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,4 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE>=0.2.11
+fastTSNE>=0.2.12

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,4 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE>=0.2.0
+fastTSNE>=0.2.3

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,4 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE>=0.2.10
+fastTSNE>=0.2.11

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,3 +16,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
+fastTSNE


### PR DESCRIPTION
##### Issue
Scikit learn's implementation of tSNE is slow. It only supports the Barnes-Hut approximation. Adding new data to an existing embedding is not supported by and existing tSNE implementation.

##### Description of changes
Implement wrappers around my implementation of tSNE which includes both Barnes-Hut for small data sets and the interpolation based tSNE recently introduced which runs in linear time for larger data sets.

We can also now add new data points to an existing embedding by running optimization on those points only, w.r.t. the existing embedding.

Also, I've never packaged anything to pypi yet, and I've had a fair number of issues with this, but *hopefully* it's all ok now.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
