### PR TITLE
Put red dot of Canvas LinkItem on top

### DIFF
--- a/Orange/canvas/canvas/items/linkitem.py
+++ b/Orange/canvas/canvas/items/linkitem.py
@@ -286,7 +286,7 @@ class LinkItem(QGraphicsWidget):
     """
 
     #: Z value of the item
-    Z_VALUE = 0
+    Z_VALUE = 200  # the red dot should appear on top of the node
 
     #: Runtime link state value
     #: These are pulled from SchemeLink.State for ease of binding to it's


### PR DESCRIPTION
##### Issue
The NodeItem was cutting the processing indicator dot in two, which was visible only when the colors didn't match, i.e. during processing, while the dot is red.

##### Description of changes
Looks better if the red processing indicator dot is on top.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
