### PR TITLE
[MNT] Improve macOS application signing

### DIFF
--- a/scripts/macos/python-framework.sh
+++ b/scripts/macos/python-framework.sh
@@ -208,7 +208,7 @@ patch-ssl() {
     # lib/python relative to prefix
     local pylibdir=$(
         cd "${prefix}";
-        shopt -s nullglob;
+        shopt -s failglob;
         local path=( lib/python?.? )
         echo "${path:?}"
     )
@@ -258,3 +258,10 @@ python-framework-extract-pkg \
     ~/.cache/pkgs/python-${VERSION}-macosx10.6.pkg
 
 python-framework-relocate "${1:?}"/Python.framework
+
+# Update the Versions/Current symlink
+(
+    cd "${1:?}"/Python.framework/Versions
+    shopt -s failglob
+    ln -sf ?.? ./Current  # assuming single version framework
+)

--- a/scripts/macos/sign-app.sh
+++ b/scripts/macos/sign-app.sh
@@ -2,23 +2,57 @@
 
 set -e
 
-SCRIPTS="$( cd "$(dirname "$0")" ; pwd -P )"
-DIST="$( cd "$(dirname "$0")/../../dist" ; pwd -P )"
-APP=${DIST}/Orange3.app
+usage() {
+    echo 'usage: sign-app.sh -s IDENTITY PATH
 
-# Build app
-rm -rf ${APP}
-${SCRIPTS}/build-macos-app.sh ${APP}
-# Missing symlink Current messes with code signing
-ln -s 3.6 ${APP}/Contents/Frameworks/Python.framework/Versions/Current
-# sign bundle
-codesign -s "Developer ID" ${APP}/Contents/Frameworks/Python.framework/Versions/3.6
-codesign -s "Developer ID" ${APP}/Contents/MacOS/pip
-codesign -s "Developer ID" ${APP}
+Sign an Orange.app application at PATH and create a signed .dmg installer.
 
+OPTIONS
+    --sign -s IDENTITY
+        Signing identity to use. The \`identity\` must name a signing
+        certificate in a macOS keychain (see \`man codesign\` SIGNING
+        IDENTITIES section for details).
 
-VERSION=$($APP/Contents/MacOS/python -c 'import pkg_resources; print(pkg_resources.get_distribution("Orange3").version)')
+    --help -h
+        Print this help.
+
+'
+}
+
+SCRIPTS=$( cd "$(dirname "$0")" ; pwd -P )
+DIST=$( cd "$(dirname "$0")/../../dist" ; pwd -P )
+
+IDENTITY="Developer ID"
+
+while true; do
+    case "${1}" in
+        -s|--sign) IDENTITY="${2:?"no identity provided"}"; shift 2;;
+        -h|--help) usage; exit 0;;
+        -*) echo "unrecognized parameter: ${1}" >&2; usage >&2; exit 1;;
+        *)  break;;
+    esac
+done
+
+APPPATH=${1}
+if [ ! "${APPPATH}" ]; then
+    APPPATH=${DIST}/Orange3.app
+    echo "No path supplied; using default ${APPPATH}"
+fi
+
+# sign .app bundle
+codesign -s "${IDENTITY}" --deep --verbose "${APPPATH}"
+
+VERSION=$(
+    "${APPPATH}"/Contents/MacOS/python -c '
+import pkg_resources
+print(pkg_resources.get_distribution("Orange3").version)
+'
+)
+
 # Create disk image
-${SCRIPTS}/create-dmg-installer.sh --app ${APP} ${DIST}/Orange3-${VERSION}.dmg
+"${SCRIPTS}"/create-dmg-installer.sh --app "${APPPATH}" \
+    "${DIST}/Orange3-${VERSION}.dmg"
+
 # Sign disk image
-codesign -s "Developer ID" ${DIST}/Orange3-${VERSION}.dmg
+codesign -s "${IDENTITY}" "${DIST}/Orange3-${VERSION}.dmg"
+

--- a/scripts/macos/sign-app.sh
+++ b/scripts/macos/sign-app.sh
@@ -15,7 +15,6 @@ OPTIONS
 
     --help -h
         Print this help.
-
 '
 }
 
@@ -39,9 +38,6 @@ if [ ! "${APPPATH}" ]; then
     echo "No path supplied; using default ${APPPATH}"
 fi
 
-# sign .app bundle
-codesign -s "${IDENTITY}" --deep --verbose "${APPPATH}"
-
 VERSION=$(
     "${APPPATH}"/Contents/MacOS/python -c '
 import pkg_resources
@@ -51,8 +47,6 @@ print(pkg_resources.get_distribution("Orange3").version)
 
 # Create disk image
 "${SCRIPTS}"/create-dmg-installer.sh --app "${APPPATH}" \
+    --sign "${IDENTITY}" \
     "${DIST}/Orange3-${VERSION}.dmg"
-
-# Sign disk image
-codesign -s "${IDENTITY}" "${DIST}/Orange3-${VERSION}.dmg"
 

--- a/scripts/macos/sign-dmg.sh
+++ b/scripts/macos/sign-dmg.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -e
+shopt -s failglob
+
+usage() {
+    echo "sign-dmg.sh [-s IDENTITY] [-o OUTPUT] PATH
+
+Sign a .dmg application installer at 'path'.
+
+\`path\` must name a .dmg image.
+
+OPTIONS
+    --sign -s IDENTITY
+        Signing identity to use. The \`identity\` must name a signing
+        certificate in a macOS keychain (see \`man codesign\` SIGNING
+        IDENTITIES section for details)
+
+    --output -o PATH
+        Specify the output path for the resulting .dmg installer. If not
+        supplied, then the signed dmg image is placed next to the input path
+        with the same name and .signed appended at the end.
+
+    --help -h
+        Show this help.
+
+EXAMPLES
+    $ ./sign-dmg.sh -s \"Developer ID\" SupperApp.dmg
+"
+}
+
+IDENTITY="Developer ID"
+OUTPUT=
+
+while true; do
+    case "${1}" in
+        -s|--sign) IDENTITY=${2:?"no identity provided"}; shift 2;;
+        -o|--output) OUTPUT=${2:?"${1} requires a path parameter"}; shift 2;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "Unrecognized parameter: ${1}" >&2; echo; usage >&2; exit 1;;
+        *) break;;
+    esac
+done
+
+DMG="${1:?"Missing positional argument: PATH"}"
+
+if [ ! -f "${DMG}" ]; then
+    echo "${DMG} does not exist or is not a file." >&2;
+    exit 1
+fi
+
+# Temporary work directory
+WORKDIR=
+# Temporary mount point for the dmg
+MOUNT=
+
+cleanup() {
+    if [ -d "${MOUNT}" ]; then hdiutil detach "${MOUNT}" -force || true; fi
+    if [ -d "${WORKDIR}" ]; then rm -rf "${WORKDIR}"; fi
+    return
+}
+trap cleanup EXIT
+
+BASENAME=$(basename "${DMG}")
+WORKDIR=$(mktemp -d -t "${BASENAME}")
+MOUNT=${WORKDIR}/mnt
+
+IMGRW=${WORKDIR}/image
+IMG=${WORKDIR}/${BASENAME}
+
+# convert the input dmg to a read write growable uncompressed image
+# NOTE: hdiutil convert always appends the extension on the output even if
+# already present (the ext for UDSB is .sparsebundle so the actual filename
+# is ${IMGRW}.sparsebundle)
+hdiutil convert -format UDSB -o "${IMGRW}" "${DMG}"
+# 'resize' the sparse image allowing growth for signing data
+# (1GB should be enough for everybody)
+hdiutil resize -size 1g "${IMGRW}".sparsebundle
+# mount it R/W for modification
+mkdir "${MOUNT}"
+hdiutil attach "${IMGRW}".sparsebundle -readwrite -noverify -noautoopen \
+        -mountpoint "${MOUNT}"
+
+codesign --sign "${IDENTITY}" --deep --verbose "${MOUNT}"/*.app
+
+# detach/unmount to sync
+hdiutil detach "${MOUNT}" -force
+# resize the image to minimum required size
+hdiutil resize -sectors min "${IMGRW}".sparsebundle
+# convert back to compressed read only image
+hdiutil convert -format UDZO -imagekey zlib-level=9 \
+        -o "${IMG}" "${IMGRW}.sparsebundle"
+codesign -s "${IDENTITY}" "${IMG}"
+
+if [ ! "${OUTPUT}" ]; then
+    OUTPUT=${DMG}.signed
+fi
+
+mv "${IMG}" "${OUTPUT}"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Separate the application build and signing step so that an existing .app build can be signed. This is to better support CI test and build

##### Description of changes

* Change sign-app.sh to accept a .app directory on the input.
* Change python-framework.sh to fix the 'Current' version symlink (used to be done by sign-app.sh)
* Add --sign option to create-dmg-installer.sh script.
* Add a new sign-dmg.sh script that signs an existing unsigned application installer.  

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
