### PR TITLE
OWFile: Fix paths, file on relative path can be found on other computer

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1325,6 +1325,7 @@ class CanvasMainWindow(QMainWindow):
         # existing scheme file if `scheme.save_to` raises an error.
         buffer = BytesIO()
         try:
+            scheme.set_runtime_env("basedir", dirname)
             scheme.save_to(buffer, pretty=True, pickle_fallback=True)
         except Exception:
             log.error("Error saving %r to %r", scheme, filename, exc_info=True)
@@ -1340,7 +1341,6 @@ class CanvasMainWindow(QMainWindow):
         try:
             with open(filename, "wb") as f:
                 f.write(buffer.getvalue())
-            scheme.set_runtime_env("basedir", dirname)
             return True
         except (IOError, OSError) as ex:
             log.error("%s saving '%s'", type(ex).__name__, filename,

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -483,6 +483,15 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             self.source = self.LOCAL_FILE
             self.load_data()
 
+    def workflowEnvChanged(self, key, value, oldvalue):
+        """
+        Function called when environment changes (e.g. while saving the scheme)
+        It make sure that all environment connected values are modified
+        (e.g. relative file paths are changed)
+        """
+        self.update_file_list(key, value, oldvalue)
+
+
 if __name__ == "__main__":
     import sys
     from AnyQt.QtWidgets import QApplication

--- a/Orange/widgets/utils/filedialogs.py
+++ b/Orange/widgets/utils/filedialogs.py
@@ -350,16 +350,6 @@ class RecentPathsWidgetMixin:
         # in some model (untested!)
         self.recent_paths[:] = rec
 
-    def workflowEnvChanged(self, key, value, oldvalue):
-        """
-        Handle changes of the working directory
-
-        The function is triggered by a signal from the canvas when the user
-        saves the schema.
-        """
-        if key == "basedir":
-            self._relocate_recent_files()
-
     def add_path(self, filename):
         """Add (or move) a file name to the top of recent paths"""
         self._check_init()
@@ -420,7 +410,7 @@ class RecentPathsWComboMixin(RecentPathsWidgetMixin):
                     self.file_combo.setItemData(i, QBrush(Qt.red),
                                                 Qt.TextColorRole)
 
-    def workflowEnvChanged(self, key, value, oldvalue):
-        super().workflowEnvChanged(key, value, oldvalue)
+    def update_file_list(self, key, value, oldvalue):
         if key == "basedir":
+            self._relocate_recent_files()
             self.set_file_list()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
File widget does not find file when opening the scheme generated on other computer. 
The file is moved together with the ows in the zip, the file should be on the same relative path than on computer where scheme generated.

##### Description of changes
In this PR, I enabled relative path generation before the scheme is saved. 

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
