### PR TITLE
Fixed usage of `== True` in if statements

### DIFF
--- a/Orange/canvas/application/widgettoolbox.py
+++ b/Orange/canvas/application/widgettoolbox.py
@@ -419,7 +419,7 @@ class WidgetToolBox(ToolBox):
         Items have been inserted in the model.
         """
         # Only the top level items (categories) are handled here.
-        if not parent is not None:
+        if parent is None:
             root = self.__model.invisibleRootItem()
             for i in range(start, end + 1):
                 item = root.child(i)
@@ -430,6 +430,6 @@ class WidgetToolBox(ToolBox):
         Rows have been removed from the model.
         """
         # Only the top level items (categories) are handled here.
-        if not parent is not None:
+        if parent is None:
             for i in range(end, start - 1, -1):
                 self.removeItem(i)

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -1180,7 +1180,7 @@ class SchemeEditWidget(QWidget):
             # just yet (instead wait for the mouse move event).
             handler = interactions.RectangleSelectionAction(self)
             rval = handler.mousePressEvent(event)
-            if rval == True:
+            if rval is True:
                 self.__possibleSelectionHandler = handler
             return rval
 

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -432,11 +432,11 @@ class DendrogramWidget(QGraphicsWidget):
 
         """
         if state is False and item not in self._selection or \
-                state == True and item in self._selection:
+                state is True and item in self._selection:
             return  # State unchanged
 
         if item in self._selection:
-            if state == False:
+            if state is False:
                 self._remove_selection(item)
                 self._re_enumerate_selections()
                 self.selectionChanged.emit()


### PR DESCRIPTION
##### Issue

This does not address a particular open issue.

##### Description of changes

Please consider this small PR to clean up some `if` statements in the project. I addressed two small problems:

1. The condition `if not parent is not None:` was difficult to read, so I recommend replacing with `if parent is None` (removing the double-negative)
2. There are a few places in the project where the convention `if <something> == True` is used. This can lead to subtle and silent issues (`1 == True` returns `True` while `1 is True` returns `False`)

Thank you for considering this PR!

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
