### PR TITLE
[FIX] Variable: Prevent hashing of Values of DiscreteVariable.

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -207,6 +207,11 @@ class Value(float):
         raise TypeError("invalid operation on Value()")
 
     def __hash__(self):
+        if self.variable.is_discrete:
+            # It is not possible to hash the id and the domain value to the same number as required by __eq__.
+            # hash(1) == hash(Value(DiscreteVariable("var", ["red", "green", "blue"]), 1)) == hash("green")
+            # User should hash directly ids or domain values instead.
+            raise TypeError("unhashable type - cannot hash values of discrete variables!")
         if self._value is None:
             return super().__hash__()
         else:

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -210,7 +210,7 @@ class Value(float):
         if self._value is None:
             return super().__hash__()
         else:
-            return hash((super().__hash__(), self._value))
+            return hash(self._value)
 
     @property
     def value(self):

--- a/Orange/tests/test_value.py
+++ b/Orange/tests/test_value.py
@@ -5,7 +5,8 @@ import pickle
 import unittest
 import numpy as np
 
-from Orange.data import Table, Domain, DiscreteVariable
+from Orange.data import Table, Domain, Value,\
+    DiscreteVariable, ContinuousVariable, StringVariable, TimeVariable
 
 
 class TestValue(unittest.TestCase):
@@ -50,3 +51,16 @@ class TestValue(unittest.TestCase):
         zoo2 = zoo[1]['name']  # antelope
         self.assertTrue(zoo1 < zoo2)
         self.assertTrue(zoo1 >= "aardvark")
+
+    def test_hash(self):
+        v = 1234.5
+        val = Value(ContinuousVariable("var"), v)
+        self.assertTrue(val == v and hash(val) == hash(v))
+        v = "test"
+        val = Value(StringVariable("var"), v)
+        self.assertTrue(val == v and hash(val) == hash(v))
+        v = 1234.5
+        val = Value(TimeVariable("var"), v)
+        self.assertTrue(val == v and hash(val) == hash(v))
+        val = Value(DiscreteVariable("var", ["red", "green", "blue"]), 1)
+        self.assertRaises(TypeError, hash, val)


### PR DESCRIPTION
##### Issue
Values of StringVariable are hashed incorrectly (fixes #2912).

Values of DiscreteVariable are impossible to hash as dictated by the `__eq__` function. For example:
```
from Orange.data.variable import *
val = Value(DiscreteVariable("var", ["red","green","blue"]), 1)
print(val == 1, hash(val) == hash(1))  # True True
print(val == "green", hash(val) == hash("green"))  # True False
```

##### Description of changes
As we can not make `hash(1) == hash("green")`, we prevent hashing of Values of DiscreteVariables with an exception. Users should hash directly ids or domain values instead.

This might break things that use dictionaries or sets of Values. However, the tests didn't discover any such cases.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
