### PR TITLE
Sparse utils: Add std

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -560,3 +560,8 @@ def var(x, axis=None):
     result = x.multiply(x).mean(axis) - np.square(x.mean(axis))
     result = np.squeeze(np.asarray(result))
     return result
+
+
+def std(x, axis=None):
+    """ Equivalent of np.std that supports sparse and dense matrices. """
+    return np.sqrt(var(x, axis=axis))

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -5,8 +5,9 @@ from functools import partial, wraps
 import numpy as np
 from scipy.sparse import csr_matrix, issparse, lil_matrix, csc_matrix
 
-from Orange.statistics.util import bincount, countnans, contingency, stats, \
-    nanmin, nanmax, unique, nanunique, mean, nanmean, digitize, var, nansum, nanmedian
+from Orange.statistics.util import bincount, countnans, contingency, digitize, \
+    mean, nanmax, nanmean, nanmedian, nanmin, nansum, nanunique, stats, std, \
+    unique, var
 
 
 def dense_sparse(test_case):
@@ -189,6 +190,15 @@ class TestUtil(unittest.TestCase):
                 np.testing.assert_array_almost_equal(
                     var(csr_matrix(data), axis=axis),
                     np.var(data, axis=axis)
+                )
+
+    def test_std(self):
+        for data in self.data:
+            for axis in chain((None,), range(len(data.shape))):
+                # Can't use array_equal here due to differences on 1e-16 level
+                np.testing.assert_array_almost_equal(
+                    std(csr_matrix(data), axis=axis),
+                    np.std(data, axis=axis)
                 )
 
 


### PR DESCRIPTION
##### Issue
`Orange.statistics.util` missing implementation of standard deviation.

##### Description of changes
Add the equivalent of `np.std` that also supports sparse matrices. Also, I ordered the imports in the test file.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
