### PR TITLE
[FIX] io: Handle mismatched number of header/data values

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -618,9 +618,13 @@ class FileFormat(metaclass=FileFormatMeta):
         # Determine maximum row length
         rowlen = max(map(len, (names, types, flags)))
 
+        strip = False
+
         def _equal_length(lst):
+            nonlocal strip
             if len(lst) > rowlen > 0:
                 lst = lst[:rowlen]
+                strip = True
             elif len(lst) < rowlen:
                 lst.extend(['']*(rowlen - len(lst)))
             return lst
@@ -629,6 +633,9 @@ class FileFormat(metaclass=FileFormatMeta):
         data = [_equal_length([s.strip() for s in row])
                 for row in data if any(row)]
         data = np.array(data, dtype=object, order='F')
+
+        if strip:
+            warnings.warn("Columns with no headers were removed.")
 
         # Data may actually be longer than headers were
         try:

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -619,7 +619,10 @@ class FileFormat(metaclass=FileFormatMeta):
         rowlen = max(map(len, (names, types, flags)))
 
         def _equal_length(lst):
-            lst.extend(['']*(rowlen - len(lst)))
+            if len(lst) > rowlen > 0:
+                lst = lst[:rowlen]
+            elif len(lst) < rowlen:
+                lst.extend(['']*(rowlen - len(lst)))
             return lst
 
         # Ensure all data is of equal width in a column-contiguous array

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -5,6 +5,7 @@ import unittest
 import os
 import tempfile
 import shutil
+import io
 
 from Orange.data import ContinuousVariable
 from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader, \
@@ -103,6 +104,17 @@ class TestReader(unittest.TestCase):
         reader = PickleReader("")
         with unittest.mock.patch("pickle.load", return_value=None):
             self.assertRaises(TypeError, reader.read, "foo")
+
+    def test_empty_columns(self):
+        """Can't read files with more columns then headers. GH-1417"""
+        samplefile = """\
+        a, b
+        1, 0,
+        1, 2,
+        """
+        c = io.StringIO(samplefile)
+        table = CSVReader(c).read()
+        self.assertEqual(len(table.domain.attributes), 2)
 
 
 class TestIo(unittest.TestCase):

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -113,8 +113,11 @@ class TestReader(unittest.TestCase):
         1, 2,
         """
         c = io.StringIO(samplefile)
-        table = CSVReader(c).read()
+        with self.assertWarns(UserWarning) as cm:
+            table = CSVReader(c).read()
         self.assertEqual(len(table.domain.attributes), 2)
+        self.assertEqual(cm.warning.args[0],
+                         "Columns with no headers were removed.")
 
 
 class TestIo(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Fixes #1471 
Orange can't load fils where there are more data then header columns
##### Description of changes
Strip data columns
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
