### PR TITLE
[FIX] DiscreteVariable reconstruction

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -491,9 +491,9 @@ class VariableTestMakeProxy(unittest.TestCase):
         self.assertEqual(abc1p, abc)
 
         abcp, abc1p, abc2p = pickle.loads(pickle.dumps((abc, abc1, abc2)))
-        self.assertIs(abcp.master, abcp)
-        self.assertIs(abc1p.master, abcp)
-        self.assertIs(abc2p.master, abcp)
+        self.assertIs(abcp.master, abcp.master)
+        self.assertIs(abc1p.master, abcp.master)
+        self.assertIs(abc2p.master, abcp.master)
         self.assertEqual(abcp, abc1p)
         self.assertEqual(abcp, abc2p)
         self.assertEqual(abc1p, abc2p)

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -266,6 +266,23 @@ class TestDiscreteVariable(VariableTest):
         a = DiscreteVariable("foo", values=["a", "b", "c"])
         self.assertRaises(TypeError, a.add_value, 42)
 
+    def test_unpickle(self):
+        d1 = DiscreteVariable("A", values=["two", "one"])
+        s = pickle.dumps(d1)
+        d2 = DiscreteVariable.make("A", values=["one", "two", "three"])
+        d2_values = tuple(d2.values)
+        d1c = pickle.loads(s)
+        # See: gh-3238
+        # The unpickle reconstruction picks an existing variable (d2), on which
+        # __setstate__ or __dict__.update is called
+        self.assertSequenceEqual(d2.values, d2_values)
+        self.assertSequenceEqual(d1c.values, d1.values)
+        s = pickle.dumps(d2)
+        DiscreteVariable._clear_all_caches()  # [comment redacted]
+        d1 = DiscreteVariable("A", values=["one", "two"])
+        d2 = pickle.loads(s)
+        self.assertSequenceEqual(d2.values, ["two", "one", "three"])
+
 
 @variabletest(ContinuousVariable)
 class TestContinuousVariable(VariableTest):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -707,9 +707,11 @@ class DiscreteVariable(Variable):
     def __reduce__(self):
         if not self.name:
             raise PickleError("Variables without names cannot be pickled")
+        __dict__ = dict(self.__dict__)
+        __dict__.pop("master")
         return make_variable, (self.__class__, self._compute_value, self.name,
                                self.values, self.ordered, self.base_value), \
-            self.__dict__
+            __dict__
 
     @classmethod
     def make(cls, name, values=(), ordered=False, base_value=-1):
@@ -742,7 +744,7 @@ class DiscreteVariable(Variable):
         var = cls._find_compatible(
             name, values, ordered, base_value)
         if var:
-            return var
+            return var.make_proxy()
         if not ordered:
             base_value_rep = base_value != -1 and values[base_value]
             values = cls.ordered_values(values)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-3238

##### Description of changes

* Return proxies from DiscreteVariable.make (as already done in gh-2667 for other variables)

* Ensure `var.values` are preserved exactly on deserialization, even at the expanse of variable 'equality'.  This is done to ensure any indices into the `values` list, that are serialized alongside the variable, retain their meaning.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
