### PR TITLE
Vizrank: Disable editing of vizrank table

### DIFF
--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -121,7 +121,8 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin):
         self.rank_table = view = QTableView(
             selectionBehavior=QTableView.SelectRows,
             selectionMode=QTableView.SingleSelection,
-            showGrid=False)
+            showGrid=False,
+            editTriggers=gui.TableView.NoEditTriggers)
         if self._has_bars:
             view.setItemDelegate(TableBarItem())
         else:


### PR DESCRIPTION
**Issue**: user can edit the table in VizRank. 
**Description of changes**: Prevent it.
**Includes**: A new argument in initialization of the view

Fixes the first half of #3255.