### PR TITLE
Selection of attributes in the widget is reflected in VizRank

### DIFF
--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -60,6 +60,10 @@ class RadvizVizRank(VizRankDialog, OWComponent):
         self.data = None
         self.valid_data = None
 
+        self.rank_table.clicked.connect(self.on_row_clicked)
+        self.rank_table.verticalHeader().sectionClicked.connect(
+            self.on_header_clicked)
+
     def initialize(self):
         super().initialize()
         self.attr_color = self.master.attr_color
@@ -131,9 +135,11 @@ class RadvizVizRank(VizRankDialog, OWComponent):
         self.n_attrs_spin.setMaximum(20)  # all primitive vars except color one
         return True
 
-    def on_selection_changed(self, selected, deselected):
-        attrs = selected.indexes()[0].data(self._AttrRole)
-        self.selectionChanged.emit([attrs])
+    def on_row_clicked(self, index):
+        self.selectionChanged.emit(index.data(self._AttrRole))
+
+    def on_header_clicked(self, section):
+        self.on_row_clicked(self.rank_model.index(section, 0))
 
     def iterate_states(self, state):
         if state is None:  # on the first call, compute order
@@ -285,7 +291,7 @@ class OWRadviz(OWAnchorProjectionWidget):
         self.model_other = VariableListModel(enable_dnd=True)
 
         self.vizrank, self.btn_vizrank = RadvizVizRank.add_vizrank(
-            None, self, "Suggest features", self.__vizrank_set_attrs
+            None, self, "Suggest features", self.vizrank_set_attrs
         )
         super().__init__()
 
@@ -314,7 +320,7 @@ class OWRadviz(OWAnchorProjectionWidget):
     def effective_variables(self):
         return self.model_selected[:]
 
-    def __vizrank_set_attrs(self, attrs):
+    def vizrank_set_attrs(self, *attrs):
         if not attrs:
             return
         self.model_selected[:] = attrs[:]

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -6,7 +6,7 @@ from scipy.stats import linregress
 from sklearn.neighbors import NearestNeighbors
 from sklearn.metrics import r2_score
 
-from AnyQt.QtCore import Qt, QTimer, QPointF
+from AnyQt.QtCore import Qt, QTimer, QPointF, Signal
 from AnyQt.QtGui import QColor
 
 import pyqtgraph as pg
@@ -173,6 +173,8 @@ class OWScatterPlot(OWDataProjectionWidget):
     graph = SettingProvider(OWScatterPlotGraph)
     embedding_variables_names = None
 
+    xy_changed_manually = Signal(Variable, Variable)
+
     class Warning(OWDataProjectionWidget.Warning):
         missing_coords = Msg(
             "Plot cannot be displayed because '{}' or '{}' "
@@ -216,10 +218,12 @@ class OWScatterPlot(OWDataProjectionWidget):
         dmod = DomainModel
         self.xy_model = DomainModel(dmod.MIXED, valid_types=ContinuousVariable)
         self.cb_attr_x = gui.comboBox(
-            box, self, "attr_x", label="Axis x:", callback=self.attr_changed,
+            box, self, "attr_x", label="Axis x:",
+            callback=self.set_attr_from_combo,
             model=self.xy_model, **common_options)
         self.cb_attr_y = gui.comboBox(
-            box, self, "attr_y", label="Axis y:", callback=self.attr_changed,
+            box, self, "attr_y", label="Axis y:",
+            callback=self.set_attr_from_combo,
             model=self.xy_model, **common_options)
         vizrank_box = gui.hBox(box)
         self.vizrank, self.vizrank_button = ScatterPlotVizRank.add_vizrank(
@@ -394,6 +398,10 @@ class OWScatterPlot(OWDataProjectionWidget):
         if attr_x != self.attr_x or attr_y != self.attr_y:
             self.attr_x, self.attr_y = attr_x, attr_y
             self.attr_changed()
+
+    def set_attr_from_combo(self):
+        self.attr_changed()
+        self.xy_changed_manually.emit(self.attr_x, self.attr_y)
 
     def attr_changed(self):
         self.setup_plot()

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -4,7 +4,7 @@ from itertools import chain
 import numpy as np
 from scipy.stats.distributions import chi2
 
-from AnyQt.QtCore import Qt, QSize
+from AnyQt.QtCore import Qt, QSize, Signal
 from AnyQt.QtGui import QColor, QPen, QBrush
 from AnyQt.QtWidgets import QGraphicsScene, QGraphicsLineItem, QSizePolicy
 
@@ -94,6 +94,8 @@ class OWSieveDiagram(OWWidget):
     attr_y = ContextSetting(None)
     selection = ContextSetting(set())
 
+    xy_changed_manually = Signal(Variable, Variable)
+
     def __init__(self):
         # pylint: disable=missing-docstring
         super().__init__()
@@ -108,7 +110,7 @@ class OWSieveDiagram(OWWidget):
         self.domain_model = DomainModel(valid_types=DomainModel.PRIMITIVE)
         combo_args = dict(
             widget=self.attr_box, master=self, contentsLength=12,
-            callback=self.update_attr, sendSelectedValue=True, valueType=str,
+            callback=self.attr_changed, sendSelectedValue=True, valueType=str,
             model=self.domain_model)
         fixed_size = (QSizePolicy.Fixed, QSizePolicy.Fixed)
         gui.comboBox(value="attr_x", **combo_args)
@@ -195,6 +197,10 @@ class OWSieveDiagram(OWWidget):
     def set_attr(self, attr_x, attr_y):
         self.attr_x, self.attr_y = attr_x, attr_y
         self.update_attr()
+
+    def attr_changed(self):
+        self.update_attr()
+        self.xy_changed_manually.emit(self.attr_x, self.attr_y)
 
     def update_attr(self):
         """Update the graph and selection."""

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -128,6 +128,21 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         output = self.get_output(self.widget.Outputs.annotated_data)
         np.testing.assert_array_equal(output.X, self.data[:1].X)
 
+    @patch('Orange.widgets.visualize.owmosaic.MosaicVizRank.on_manual_change')
+    def test_vizrank_receives_manual_change(self, on_manual_change):
+        # Recreate the widget so the patch kicks in
+        self.widget = self.create_widget(OWMosaicDisplay)
+        data = Table("iris.tab")
+        self.send_signal(self.widget.Inputs.data, data)
+        self.widget.variable1 = data.domain[0]
+        self.widget.variable2 = data.domain[1]
+        simulate.combobox_activate_index(self.widget.controls.variable2, 3)
+        self.assertEqual(self.widget.variable2, data.domain[2])
+        call_args = on_manual_change.call_args[0][0]
+        self.assertEqual(len(call_args), 2)
+        self.assertEqual(call_args[0].name, data.domain[0].name)
+        self.assertEqual(call_args[1].name, data.domain[2].name)
+
 
 # Derive from WidgetTest to simplify creation of the Mosaic widget, although
 # we are actually testing the MosaicVizRank dialog and not the widget
@@ -393,6 +408,23 @@ class MosaicVizRankTests(WidgetTest):
         self.assertTrue(self.widget.Warning.incompatible_subset.is_shown())
         self.send_signal(self.widget.Inputs.data_subset, self.iris)
         self.assertFalse(self.widget.Warning.incompatible_subset.is_shown())
+
+    def test_on_manual_change(self):
+        data = Table("iris.tab")
+        self.send_signal(self.widget.Inputs.data, data)
+        self.vizrank.toggle()
+        self.process_events(until=lambda: not self.vizrank.keep_running)
+
+        model = self.vizrank.rank_model
+        attrs = model.data(model.index(3, 0), self.vizrank._AttrRole)
+        self.vizrank.on_manual_change(attrs)
+        selection = self.vizrank.rank_table.selectedIndexes()
+        self.assertEqual(len(selection), 1)
+        self.assertEqual(selection[0].row(), 3)
+
+        self.vizrank.on_manual_change(attrs[::-1])
+        selection = self.vizrank.rank_table.selectedIndexes()
+        self.assertEqual(len(selection), 0)
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -434,8 +434,9 @@ class VizRankDialogAttr(VizRankDialog):
         return can_rank
 
     def on_selection_changed(self, selected, deselected):
-        attr = selected.indexes()[0].data(self._AttrRole)
-        self.attrSelected.emit(attr)
+        if not selected.isEmpty():
+            attr = selected.indexes()[0].data(self._AttrRole)
+            self.attrSelected.emit(attr)
 
     def state_count(self):
         return len(self.attrs)
@@ -470,6 +471,9 @@ class VizRankDialogAttrPair(VizRankDialog):
         VizRankDialog.__init__(self, master)
         self.resize(320, 512)
         self.attrs = []
+        manual_change_signal = getattr(master, "xy_changed_manually", None)
+        if manual_change_signal:
+            manual_change_signal.connect(self.on_manual_change)
 
     def sizeHint(self):
         """Assuming two columns in the table, return `QSize(320, 512)` as
@@ -490,6 +494,15 @@ class VizRankDialogAttrPair(VizRankDialog):
             return
         attrs = selected.indexes()[0].data(self._AttrRole)
         self.selectionChanged.emit(attrs)
+
+    def on_manual_change(self, attr1, attr2):
+        model = self.rank_model
+        self.rank_table.selectionModel().clear()
+        for row in range(model.rowCount()):
+            a1, a2 = model.data(model.index(row, 0), self._AttrRole)
+            if a1 is attr1 and a2 is attr2:
+                self.rank_table.selectRow(row)
+                return
 
     def state_count(self):
         n_attrs = len(self.attrs)


### PR DESCRIPTION
##### Issue

#3255, second part. The problem can be re-viewed from a different perspective: the problem is that after the user selects something in VizRank, he can change the selection in the widget, while VizRank still incorrectly highlights the previously selected combination of attributes.

With this in mind, the correct solution is as follows.

##### Description of changes

As the user changes the selection in the widget, the widget emits signal that the attributes have been changed. Its vizrank highlights the newly selected combination if it exists, otherwise it clears the selection.

Caveat: if the user changes the selection while vizrank is running, nothing bad will happen. However, if the combination (s)he selected has not been evaluated by VizRank *yet*, it will not be highlighted neither at that moment (obviously) nor later. I don't think this is worth losing sleep over, though.

Radviz is a special case since the user can move anchors there, so reselecting the same combination makes sense - it resets the anchors. (Plus, signals in this widget are more complicated so I was unable to do it in the same way as in others. :))

##### Includes
- [X] Code changes
- [X] Tests