### PR TITLE
Modify Mosaic widget to use domain models

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -1222,7 +1222,7 @@ def rename_setting(settings, old_name, new_name):
         settings[new_name] = settings.pop(old_name)
 
 
-def migrate_str_to_variable(settings, names=None):
+def migrate_str_to_variable(settings, names=None, none_placeholder=None):
     """
     Change variables stored as `(str, int)` to `(Variable, int)`.
 
@@ -1235,6 +1235,8 @@ def migrate_str_to_variable(settings, names=None):
         var, vartype = settings.values[name]
         if 0 <= vartype <= 100:
             settings.values[name] = (var, 100 + vartype)
+        elif var == none_placeholder and vartype == -2:
+            settings.values[name] = None
 
     if names is None:
         for name, setting in settings.values.items():

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -654,8 +654,7 @@ class OWMosaicDisplay(OWWidget):
                           y0 + currpos + height * 0.5 * perc,
                           y0 - self.ATTR_VAL_OFFSET,
                           y0 + currpos + height * 0.5 * perc]
-                    if side == 0:
-                        CanvasText(self.canvas, val, xs[side], ys[side], align)
+                    CanvasText(self.canvas, val, xs[side], ys[side], align)
                     space = height if side % 2 else width
                     currpos += perc * space + spacing * (total_attrs - side)
 

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -268,7 +268,7 @@ class OWMosaicDisplay(OWWidget):
 
     settingsHandler = DomainContextHandler()
     vizrank = SettingProvider(MosaicVizRank)
-    settings_version = 1
+    settings_version = 2
     use_boxes = Setting(True)
     variable1 = ContextSetting(None)
     variable2 = ContextSetting(None)
@@ -920,8 +920,8 @@ class OWMosaicDisplay(OWWidget):
 
     @classmethod
     def migrate_context(cls, context, version):
-        if not version:
-            settings.migrate_str_to_variable(context)
+        if version < 2:
+            settings.migrate_str_to_variable(context, none_placeholder="(None)")
 
 
 def get_conditional_distribution(data, attrs):
@@ -974,6 +974,7 @@ def main():
     ow.set_subset_data(data[::10])
     ow.handleNewSignals()
     a.exec_()
+    ow.saveSettings()
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -86,15 +86,15 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         def assertCount(cb_color, cb_attr, areas):
             self.assertEqual(len(self.widget.areas), areas)
             self.assertEqual(self.widget.cb_attr_color.count(), cb_color)
-            for i, combo in enumerate(self.widget.attr_combos):
-                self.assertEqual(combo.count(), cb_attr[i])
+            for combo, cb_count in zip(self.widget.attr_combos, cb_attr):
+                self.assertEqual(combo.count(), cb_count)
 
         data = Table("iris")
-        assertCount(1, [0, 0, 0, 0], 0)
+        assertCount(1, [0, 1, 1, 1], 0)
         self.send_signal(self.widget.Inputs.data, data)
         assertCount(6, [5, 6, 6, 6], 16)
         self.send_signal(self.widget.Inputs.data, None)
-        assertCount(1, [0, 0, 0, 0], 0)
+        assertCount(1, [0, 1, 1, 1], 0)
 
 # Derive from WidgetTest to simplify creation of the Mosaic widget, although
 # we are actually testing the MosaicVizRank dialog and not the widget

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -134,7 +134,6 @@ class MosaicVizRankTests(WidgetTest):
             self.send_signal(self.widget.Inputs.data, data)
 
             simulate.combobox_activate_index(self.widget.controls.variable_color, 0, 0)
-            self.assertTrue(widget.interior_coloring == widget.PEARSON)
             vizrank.max_attrs = 2
             self.assertEqual(vizrank.state_count(), 10)  # 5x4 / 2
             vizrank.max_attrs = 3
@@ -143,7 +142,6 @@ class MosaicVizRankTests(WidgetTest):
             self.assertEqual(vizrank.state_count(), 25)  # above + 5x4x3x2 / 2x3x4
 
             simulate.combobox_activate_index(self.widget.controls.variable_color, 2, 0)
-            self.assertTrue(widget.interior_coloring == widget.CLASS_DISTRIBUTION)
             vizrank.max_attrs = 2
             self.assertEqual(vizrank.state_count(), 10)  # 4 + 4x3 / 2
             vizrank.max_attrs = 3
@@ -167,7 +165,6 @@ class MosaicVizRankTests(WidgetTest):
         self.send_signal(self.widget.Inputs.data, self.iris)
         vizrank.compute_attr_order()
 
-        widget.interior_coloring = widget.CLASS_DISTRIBUTION
         vizrank.max_attrs = 4
         self.assertEqual([state.copy()
                           for state in vizrank.iterate_states(None)],
@@ -190,7 +187,7 @@ class MosaicVizRankTests(WidgetTest):
                           for state in vizrank.iterate_states([0, 3])],
                          [[0, 3], [1, 3], [2, 3]])
 
-        widget.interior_coloring = widget.PEARSON
+        widget.variable_color = None
         vizrank.max_attrs = 4
         self.assertEqual([state.copy()
                           for state in vizrank.iterate_states(None)],
@@ -303,10 +300,8 @@ class MosaicVizRankTests(WidgetTest):
             discrete_data = self.widget.discrete_data
 
             if color == "(Pearson residuals)":
-                self.widget.interior_coloring = self.widget.PEARSON
                 self.assertIsNone(discrete_data.domain.class_var)
             else:
-                self.widget.interior_coloring = self.widget.CLASS_DISTRIBUTION
                 self.assertEqual(color, str(discrete_data.domain.class_var))
 
             output = self.get_output("Data")


### PR DESCRIPTION
Fixes #3283 

Best if reviewed one commit at a time.

Change to DomainModels was not trivial because widget uses discretized data. Models are filled with original domain so that variables have the right icons, but the widget then has to convert variables from original to discretized and back.

PR also includes some refactoring. `interior_coloring` was declared as setting, yet it served just as an attribute and was not even needed since it was synonymous with `variable_color is None`.

I also reduced the number of lines to 1000. :)

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
