### PR TITLE
owselectbydataindex: also output unmatched data

### DIFF
--- a/Orange/widgets/data/tests/test_owselectbydataindex.py
+++ b/Orange/widgets/data/tests/test_owselectbydataindex.py
@@ -1,6 +1,7 @@
 from Orange.data import Table, Domain
 from Orange.widgets.data.owselectbydataindex import OWSelectByDataIndex
 from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_FEATURE_NAME
 
 
 class TestOWSelectSubset(WidgetTest):
@@ -8,19 +9,37 @@ class TestOWSelectSubset(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWSelectByDataIndex)
 
-    def test_subset(self):
-        data = Table("iris")
+    def apply_subset_20_40(self, data):
         data_subset = data[20:40].transform(Domain([]))  # destroy domain
         self.send_signal(self.widget.Inputs.data, data)
         self.send_signal(self.widget.Inputs.data_subset, data_subset)
-        out = self.get_output(self.widget.Outputs.data)
+
+    def test_subset(self):
+        data = Table("iris")
+        self.apply_subset_20_40(data)
+        out = self.get_output(self.widget.Outputs.matching_data)
         self.assertEqual(list(data[20:40]), list(out))
+
+    def test_non_matching(self):
+        data = Table("iris")
+        self.apply_subset_20_40(data)
+        out = self.get_output(self.widget.Outputs.non_matching_data)
+        self.assertEqual(list(data[:20]) + list(data[40:]), list(out))
+
+    def test_annotated(self):
+        data = Table("iris")
+        self.apply_subset_20_40(data)
+        out = self.get_output(self.widget.Outputs.annotated_data)
+        vals = [a[ANNOTATED_DATA_FEATURE_NAME].value for a in out]
+        self.assertEqual(['No']*20 + ['Yes']*20 + ['No']*(len(data) - 40), vals)
 
     def test_subset_nosubset(self):
         data = Table("iris")
         data_subset = Table("titanic")
         self.send_signal(self.widget.Inputs.data, data)
         self.send_signal(self.widget.Inputs.data_subset, data_subset)
-        out = self.get_output(self.widget.Outputs.data)
+        matching = self.get_output(self.widget.Outputs.matching_data)
+        non_matching = self.get_output(self.widget.Outputs.non_matching_data)
         self.assertTrue(self.widget.Warning.instances_not_matching.is_shown())
-        self.assertEqual([], list(out))
+        self.assertEqual([], list(matching))
+        self.assertEqual(list(data), list(non_matching))

--- a/doc/visual-programming/source/widgets/data/select-by-data-index.rst
+++ b/doc/visual-programming/source/widgets/data/select-by-data-index.rst
@@ -10,8 +10,12 @@ Inputs
         subset to match
 
 Outputs
-    Data
+    Matching data
         subset from reference data set that matches indices from subset data
+    Unmatched data
+        subset from reference data set that does not match indices from subset data
+    Annotated data
+        reference data set with an additional column defining matches
 
 
 **Select by Data Index** enables matching the data by indices. Each row in a data set has an index and given a subset, this widget can match these indices to indices from the reference data. Most often it is used to retrieve the original data from the transformed data (say, from PCA space).


### PR DESCRIPTION
##### Issue
After transformation of the data such as PCA and then selecting some of the transformed data, users wish to remove the selected instances from the original data.

##### Description of changes
Added two outputs to Select by Data Index widget. Don't be shy If you remember better names for these outputs.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
