### PR TITLE
[ENH] OWSelectAttributes: Use input features

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -33,7 +33,7 @@ from Orange.widgets.settings import (DomainContextHandler, Setting,
                                      ContextSetting)
 from Orange.widgets.utils.itemmodels import PyTableModel
 from Orange.widgets.utils.sql import check_sql_input
-from Orange.widgets.widget import OWWidget, Msg, Input, Output
+from Orange.widgets.widget import OWWidget, Msg, Input, Output, AttributeList
 
 
 log = logging.getLogger(__name__)
@@ -180,6 +180,7 @@ class OWRank(OWWidget):
     class Outputs:
         reduced_data = Output("Reduced Data", Table, default=True)
         scores = Output("Scores", Table)
+        features = Output("Features", AttributeList, dynamic=False)
 
     SelectNone, SelectAll, SelectManual, SelectNBest = range(4)
 
@@ -526,12 +527,14 @@ class OWRank(OWWidget):
                               for i in self.selected_rows]
         if not selected_attrs:
             self.Outputs.reduced_data.send(None)
+            self.Outputs.features.send(None)
             self.out_domain_desc = None
         else:
             reduced_domain = Domain(
                 selected_attrs, self.data.domain.class_var, self.data.domain.metas)
             data = self.data.transform(reduced_domain)
             self.Outputs.reduced_data.send(data)
+            self.Outputs.features.send(AttributeList(selected_attrs))
             self.out_domain_desc = report.describe_domain(data.domain)
 
     def create_scores_table(self, labels):

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -14,7 +14,7 @@ from Orange.widgets.data.contexthandlers import \
     SelectAttributesDomainContextHandler
 from Orange.widgets.settings import ContextSetting, Setting
 from Orange.widgets.utils.listfilter import VariablesListItemView, slices, variables_filter
-from Orange.widgets.widget import Input, Output
+from Orange.widgets.widget import Input, Output, AttributeList, Msg
 from Orange.data.table import Table
 from Orange.widgets.utils import vartype
 from Orange.widgets.utils.itemmodels import VariableListModel
@@ -106,21 +106,29 @@ class OWSelectAttributes(widget.OWWidget):
     keywords = ["filter"]
 
     class Inputs:
-        data = Input("Data", Table)
+        data = Input("Data", Table, default=True)
+        features = Input("Features", AttributeList)
 
     class Outputs:
         data = Output("Data", Table)
-        features = Output("Features", widget.AttributeList, dynamic=False)
+        features = Output("Features", AttributeList, dynamic=False)
 
     want_main_area = False
     want_control_area = True
 
     settingsHandler = SelectAttributesDomainContextHandler()
     domain_role_hints = ContextSetting({})
+    use_input_features = Setting(False)
     auto_commit = Setting(True)
+
+    class Warning(widget.OWWidget.Warning):
+        mismatching_domain = Msg("Features and data domain do not match")
 
     def __init__(self):
         super().__init__()
+        self.data = None
+        self.features = None
+
         # Schedule interface updates (enabled buttons) using a coalescing
         # single shot timer (complex interactions on selection and filtering
         # updates in the 'available_attrs_view')
@@ -161,6 +169,8 @@ class OWSelectAttributes(widget.OWWidget):
 
         box = gui.vBox(self.controlArea, "Features", addToLayout=False)
         self.used_attrs = VariablesListItemModel()
+        self.used_attrs.rowsInserted.connect(self.__used_attrs_changed)
+        self.used_attrs.rowsRemoved.connect(self.__used_attrs_changed)
         self.used_attrs_view = VariablesListItemView(
             acceptedType=(Orange.data.DiscreteVariable,
                           Orange.data.ContinuousVariable))
@@ -169,6 +179,14 @@ class OWSelectAttributes(widget.OWWidget):
         self.used_attrs_view.selectionModel().selectionChanged.connect(
             partial(update_on_change, self.used_attrs_view))
         self.used_attrs_view.dragDropActionDidComplete.connect(dropcompleted)
+        self.use_features_box = gui.auto_commit(
+            self.controlArea, self, "use_input_features",
+            "Use input features", "Always use input features",
+            box=False, commit=self.__use_features_clicked,
+            callback=self.__use_features_changed, addToLayout=False
+        )
+        self.enable_use_features_box()
+        box.layout().addWidget(self.use_features_box)
         box.layout().addWidget(self.used_attrs_view)
         layout.addWidget(box, 0, 2, 1, 1)
 
@@ -244,11 +262,39 @@ class OWSelectAttributes(widget.OWWidget):
         layout.setHorizontalSpacing(0)
         self.controlArea.setLayout(layout)
 
-        self.data = None
         self.output_data = None
         self.original_completer_items = []
 
-        self.resize(500, 600)
+        self.resize(600, 600)
+
+    @property
+    def features_from_data_attributes(self):
+        if self.data is None or self.features is None:
+            return []
+        domain = self.data.domain
+        return [domain[feature.name] for feature in self.features
+                if feature.name in domain and domain[feature.name]
+                in domain.attributes]
+
+    def can_use_features(self):
+        return bool(self.features_from_data_attributes) and \
+               self.features_from_data_attributes != self.used_attrs[:]
+
+    def __use_features_changed(self):  # Use input features check box
+        # Needs a check since callback is invoked before object is created
+        if not hasattr(self, "use_features_box"):
+            return
+        self.enable_used_attrs(not self.use_input_features)
+        if self.use_input_features and self.can_use_features():
+            self.use_features()
+        if not self.use_input_features:
+            self.enable_use_features_box()
+
+    def __use_features_clicked(self):  # Use input features button
+        self.use_features()
+
+    def __used_attrs_changed(self):
+        self.enable_use_features_box()
 
     @Inputs.data
     def set_data(self, data=None):
@@ -302,8 +348,6 @@ class OWSelectAttributes(widget.OWWidget):
             self.meta_attrs[:] = []
             self.available_attrs[:] = []
 
-        self.unconditional_commit()
-
     def update_domain_role_hints(self):
         """ Update the domain hints to be stored in the widgets settings.
         """
@@ -315,6 +359,46 @@ class OWSelectAttributes(widget.OWWidget):
         hints.update(hints_from_model("class", self.class_attrs))
         hints.update(hints_from_model("meta", self.meta_attrs))
         self.domain_role_hints = hints
+
+    @Inputs.features
+    def set_features(self, features):
+        self.features = features
+
+    def handleNewSignals(self):
+        self.check_data()
+        self.enable_used_attrs()
+        self.enable_use_features_box()
+        if self.use_input_features and len(self.features_from_data_attributes):
+            self.enable_used_attrs(False)
+            self.use_features()
+        self.unconditional_commit()
+
+    def check_data(self):
+        self.Warning.mismatching_domain.clear()
+        if self.data is not None and self.features is not None and \
+                not len(self.features_from_data_attributes):
+            self.Warning.mismatching_domain()
+
+    def enable_used_attrs(self, enable=True):
+        self.up_attr_button.setEnabled(enable)
+        self.move_attr_button.setEnabled(enable)
+        self.down_attr_button.setEnabled(enable)
+        self.used_attrs_view.setEnabled(enable)
+        self.used_attrs_view.repaint()
+
+    def enable_use_features_box(self):
+        self.use_features_box.button.setEnabled(self.can_use_features())
+        enable_checkbox = bool(self.features_from_data_attributes)
+        self.use_features_box.setHidden(not enable_checkbox)
+        self.use_features_box.repaint()
+
+    def use_features(self):
+        attributes = self.features_from_data_attributes
+        available, used = self.available_attrs[:], self.used_attrs[:]
+        self.available_attrs[:] = [attr for attr in used + available
+                                   if attr not in attributes]
+        self.used_attrs[:] = attributes
+        self.commit()
 
     def selected_rows(self, view):
         """ Return the selected rows in the view.
@@ -397,8 +481,9 @@ class OWSelectAttributes(widget.OWWidget):
         all_primitive = all(var.is_primitive()
                             for var in available_types)
 
-        move_attr_enabled = (available_selected and all_primitive) or \
-                             attrs_selected
+        move_attr_enabled = \
+            ((available_selected and all_primitive) or attrs_selected) and \
+            self.used_attrs_view.isEnabled()
 
         self.move_attr_button.setEnabled(bool(move_attr_enabled))
         if move_attr_enabled:
@@ -429,13 +514,15 @@ class OWSelectAttributes(widget.OWWidget):
             newdata = self.data.transform(domain)
             self.output_data = newdata
             self.Outputs.data.send(newdata)
-            self.Outputs.features.send(widget.AttributeList(attributes))
+            self.Outputs.features.send(AttributeList(attributes))
         else:
             self.output_data = None
             self.Outputs.data.send(None)
             self.Outputs.features.send(None)
 
     def reset(self):
+        self.enable_used_attrs()
+        self.use_features_box.checkbox.setChecked(False)
         if self.data is not None:
             self.available_attrs[:] = []
             self.used_attrs[:] = self.data.domain.attributes
@@ -476,6 +563,8 @@ def main(argv=None):  # pragma: no cover
     w = OWSelectAttributes()
     data = Orange.data.Table(filename)
     w.set_data(data)
+    w.set_features(AttributeList(data.domain.attributes[:2]))
+    w.handleNewSignals()
     w.show()
     w.raise_()
     rval = app.exec_()

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -8,6 +8,7 @@ from Orange.regression import LinearRegressionLearner
 from Orange.projection import PCA
 from Orange.widgets.data.owrank import OWRank, ProblemType, CLS_SCORES, REG_SCORES
 from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.widget import AttributeList
 
 from AnyQt.QtCore import Qt, QItemSelection
 from AnyQt.QtWidgets import QCheckBox
@@ -106,6 +107,13 @@ class TestOWRank(WidgetTest):
         output = self.get_output(self.widget.Outputs.scores)
         self.assertIsInstance(output, Table)
         self.assertEqual(output.X.shape, (len(self.iris.domain.attributes), 5))
+
+    def test_output_features(self):
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        output = self.get_output(self.widget.Outputs.features)
+        self.assertIsInstance(output, AttributeList)
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertIsNone(self.get_output(self.widget.Outputs.features))
 
     def test_scoring_method_problem_type(self):
         """Check scoring methods check boxes"""

--- a/Orange/widgets/data/tests/test_owselectcolumns.py
+++ b/Orange/widgets/data/tests/test_owselectcolumns.py
@@ -11,6 +11,8 @@ from Orange.widgets.utils import vartype
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.data.owselectcolumns \
     import OWSelectAttributes, VariablesListItemModel
+from Orange.widgets.data.owrank import OWRank
+from Orange.widgets.widget import AttributeList
 
 Continuous = vartype(ContinuousVariable())
 Discrete = vartype(DiscreteVariable())
@@ -138,10 +140,25 @@ class TestOWSelectAttributes(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWSelectAttributes)
 
-    def assertVariableCountsEqual(self, available, used, classattrs):
+    def assertVariableCountsEqual(self, available, used, classattrs, metas=0):
         self.assertEqual(len(self.widget.available_attrs), available)
         self.assertEqual(len(self.widget.used_attrs), used)
         self.assertEqual(len(self.widget.class_attrs), classattrs)
+        self.assertEqual(len(self.widget.meta_attrs), metas)
+
+    def assertControlsEnabled(self, _list, button, box, widget=None):
+        if widget is None:
+            widget = self.widget
+        control = widget.use_features_box
+        self.assertEqual(control.button.isEnabled(), button)
+        self.assertEqual(control.isVisibleTo(widget), box)
+        self.assertEqual(widget.used_attrs_view.isEnabled(), _list)
+        self.assertEqual(widget.up_attr_button.isEnabled(), _list)
+        self.assertEqual(widget.move_attr_button.isEnabled(), _list)
+        self.assertEqual(widget.down_attr_button.isEnabled(), _list)
+        if button:
+            control.button.click()
+            self.assertEqual(control.button.isEnabled(), False)
 
     def test_multiple_target_variable(self):
         """
@@ -163,4 +180,169 @@ class TestOWSelectAttributes(WidgetTest):
 
         self.widget.available_attrs_view.selectAll()
         self.widget.move_selected(self.widget.class_attrs_view)
-        self.assertVariableCountsEqual(available=0, used=0, classattrs=5)
+        self.assertVariableCountsEqual(0, 0, 5)
+
+    def test_input_features(self):
+        data = Table("zoo")
+        in_features = AttributeList(data.domain.attributes)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, False, True)
+        self.assertVariableCountsEqual(0, 16, 1, 1)
+        self.assertListEqual(self.get_output(self.widget.Outputs.features),
+                             list(data.domain.attributes))
+
+    def test_input_features_by_name(self):
+        data = Table("zoo")
+        in_features = AttributeList([DiscreteVariable(attr.name, attr.values)
+                                     for attr in data.domain.attributes])
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, False, True)
+        self.assertVariableCountsEqual(0, 16, 1, 1)
+        self.assertListEqual(self.get_output(self.widget.Outputs.features),
+                             list(data.domain.attributes))
+
+    def test_input_features_same_domain(self):
+        data = Table("zoo")
+        in_features = AttributeList(data.domain.variables + data.domain.metas)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, False, True)
+        self.assertVariableCountsEqual(0, 16, 1, 1)
+        self.assertListEqual(self.get_output(self.widget.Outputs.features),
+                             list(data.domain.attributes))
+
+    def test_input_features_sub_domain(self):
+        data = Table("zoo")
+        in_features = AttributeList(data.domain.attributes[::3])
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, True, True)
+        self.assertVariableCountsEqual(10, 6, 1, 1)
+        self.assertListEqual(self.get_output(self.widget.Outputs.features),
+                             in_features)
+
+    def test_input_features_by_name_sub_domain(self):
+        data = Table("zoo")
+        in_features = AttributeList([DiscreteVariable(attr.name, attr.values)
+                                     for attr in data.domain.attributes[:5]])
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, True, True)
+        self.assertVariableCountsEqual(11, 5, 1, 1)
+        self.assertListEqual(self.get_output(self.widget.Outputs.features),
+                             list(data.domain.attributes[:5]))
+
+    def test_input_features_diff_domain(self):
+        zoo = Table("zoo")
+        in_features = AttributeList(Table("iris").domain.attributes)
+        self.send_signal(self.widget.Inputs.data, zoo)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 16, 1, 1)
+        self.assertListEqual(self.get_output(self.widget.Outputs.features),
+                             list(zoo.domain.attributes))
+        self.assertTrue(self.widget.Warning.mismatching_domain.is_shown())
+        self.send_signal(self.widget.Inputs.features, None)
+        self.assertFalse(self.widget.Warning.mismatching_domain.is_shown())
+
+    def test_input_features_no_data(self):
+        data = Table("zoo")
+        in_features = AttributeList(data.domain.variables + data.domain.metas)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 0, 0, 0)
+        self.assertIsNone(self.get_output(self.widget.Outputs.features))
+
+    def test_input_combinations(self):
+        data = Table("iris")
+        in_features = AttributeList(data.domain.attributes[:2])
+
+        # check initial state
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 0, 0, 0)
+        self.assertIsNone(self.get_output(self.widget.Outputs.features))
+
+        # send data
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 4, 1, 0)
+        self.assertEqual(len(self.get_output(self.widget.Outputs.features)), 4)
+
+        # send features
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, True, True)
+        self.assertVariableCountsEqual(2, 2, 1, 0)
+        self.assertEqual(len(self.get_output(self.widget.Outputs.features)), 2)
+
+        # remove data
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 0, 0, 0)
+        self.assertIsNone(self.get_output(self.widget.Outputs.features))
+
+        # remove features
+        self.send_signal(self.widget.Inputs.features, None)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 0, 0, 0)
+        self.assertIsNone(self.get_output(self.widget.Outputs.features))
+
+        # send features
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(0, 0, 0, 0)
+        self.assertIsNone(self.get_output(self.widget.Outputs.features))
+
+        # send data
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertControlsEnabled(True, False, True)
+        self.assertVariableCountsEqual(2, 2, 1, 0)
+        self.assertEqual(len(self.get_output(self.widget.Outputs.features)), 2)
+
+        # remove features
+        self.send_signal(self.widget.Inputs.features, None)
+        self.assertControlsEnabled(True, False, False)
+        self.assertVariableCountsEqual(2, 2, 1, 0)
+        self.assertEqual(len(self.get_output(self.widget.Outputs.features)), 2)
+
+    def test_input_features_from_rank(self):
+        data = Table("iris")
+        owrank = self.create_widget(OWRank)
+        self.send_signal(owrank.Inputs.data, data, widget=owrank)
+        rank_features = self.get_output(owrank.Outputs.features, widget=owrank)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, rank_features)
+        self.assertControlsEnabled(True, True, True)
+        features = self.get_output(self.widget.Outputs.features)
+        self.assertListEqual(rank_features, features)
+
+    def test_use_features_checked(self):
+        data = Table("iris")
+        attrs = data.domain.attributes
+
+        # prepare stored settings (check "Use input features")
+        in_features = AttributeList(attrs[:2])
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, in_features)
+        self.widget.use_features_box.checkbox.setChecked(True)
+        self.assertControlsEnabled(False, False, True)
+        out_features = self.get_output(self.widget.Outputs.features)
+        self.assertListEqual(out_features, in_features)
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+
+        # "Use input features" is checked by default
+        widget = self.create_widget(OWSelectAttributes, settings)
+        in_features = AttributeList(attrs[:3])
+        self.send_signal(widget.Inputs.data, data, widget=widget)
+        self.send_signal(widget.Inputs.features, in_features, widget=widget)
+        self.assertControlsEnabled(False, False, True, widget)
+        out_features = self.get_output(widget.Outputs.features, widget=widget)
+        self.assertListEqual(out_features, in_features)
+
+        # reset "Features"
+        widget.reset()
+        out_features = self.get_output(widget.Outputs.features, widget=widget)
+        self.assertFalse(widget.use_features_box.checkbox.isChecked())
+        self.assertListEqual(out_features, AttributeList(attrs))
+        self.assertControlsEnabled(True, True, True, widget)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Enable filtering dataset using selected features.
Implements #3300

##### Description of changes
- Upgrade Select Columns widget to accept Features on the input (as AttributeList). One can choose between using input features and data domain features to obtain output data. New button "Use input features" is added for this purpose. When features appear on the input, the button enables. After the features have been used, the "Features" list box disables.
The initial state is can be obtained by clicking "Reset" button.

- Upgrade Rank widget to output Features (as AttributeList).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
