### PR TITLE
[WIP] Projections: Clean-up

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -20,8 +20,8 @@ from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.widgets import gui, report
 from Orange.widgets.io import MatplotlibFormat, MatplotlibPDFFormat
 from Orange.widgets.settings import (
-    Setting, ContextSetting, SettingProvider
-)
+    Setting, ContextSetting, SettingProvider,
+    IncompatibleContext)
 from Orange.widgets.utils import get_variable_values_sorted
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
@@ -169,7 +169,7 @@ class OWScatterPlot(OWDataProjectionWidget):
     class Outputs(OWDataProjectionWidget.Outputs):
         features = Output("Features", AttributeList, dynamic=False)
 
-    settings_version = 3
+    settings_version = 4
     auto_sample = Setting(True)
     attr_x = ContextSetting(None)
     attr_y = ContextSetting(None)
@@ -448,12 +448,15 @@ class OWScatterPlot(OWDataProjectionWidget):
 
     @classmethod
     def migrate_context(cls, context, version):
+        values = context.values
         if version < 3:
-            values = context.values
             values["attr_color"] = values["graph"]["attr_color"]
             values["attr_size"] = values["graph"]["attr_size"]
             values["attr_shape"] = values["graph"]["attr_shape"]
             values["attr_label"] = values["graph"]["attr_label"]
+        if version < 4:
+            if values["attr_x"].is_discrete or values["attr_y"].is_discrete:
+                raise IncompatibleContext()
 
 
 def main(argv=None):

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -231,12 +231,12 @@ class OWScatterPlot(OWDataProjectionWidget):
         self._add_controls_axis()
         self._add_controls_sampling()
         super()._add_controls()
-        self.graph.gui.add_widget(self.graph.gui.JitterNumericValues,
-                                  self._effects_box)
-        self.graph.gui.add_widgets([self.graph.gui.ShowGridLines,
-                                    self.graph.gui.ToolTipShowsAll,
-                                    self.graph.gui.RegressionLine],
-                                   self._plot_box)
+        self.gui.add_widget(self.gui.JitterNumericValues, self._effects_box)
+        self.gui.add_widgets(
+            [self.gui.ShowGridLines,
+             self.gui.ToolTipShowsAll,
+             self.gui.RegressionLine],
+            self._plot_box)
 
     def _add_controls_axis(self):
         common_options = dict(
@@ -294,17 +294,13 @@ class OWScatterPlot(OWDataProjectionWidget):
         if isinstance(self.attr_y, str):
             self.attr_y = findvar(self.attr_y, self.xy_model)
         if isinstance(self.attr_label, str):
-            self.attr_label = findvar(
-                self.attr_label, self.graph.gui.label_model)
+            self.attr_label = findvar(self.attr_label, self.gui.label_model)
         if isinstance(self.attr_color, str):
-            self.attr_color = findvar(
-                self.attr_color, self.graph.gui.color_model)
+            self.attr_color = findvar(self.attr_color, self.gui.color_model)
         if isinstance(self.attr_shape, str):
-            self.attr_shape = findvar(
-                self.attr_shape, self.graph.gui.shape_model)
+            self.attr_shape = findvar(self.attr_shape, self.gui.shape_model)
         if isinstance(self.attr_size, str):
-            self.attr_size = findvar(
-                self.attr_size, self.graph.gui.size_model)
+            self.attr_size = findvar(self.attr_size, self.gui.size_model)
 
     def check_data(self):
         self.clear_messages()
@@ -497,7 +493,7 @@ def main(argv=None):
     if len(argv) > 1:
         filename = argv[1]
     else:
-        filename = "iris"
+        filename = "heart_disease"
 
     ow = OWScatterPlot()
     ow.show()

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1,7 +1,6 @@
 import sys
 import itertools
 import warnings
-import threading
 from xml.sax.saxutils import escape
 from math import log10, floor, ceil
 
@@ -219,18 +218,10 @@ class OWScatterPlotGraph(OWScatterPlotGraphObs):
 
 
 class ScatterPlotItem(pg.ScatterPlotItem):
-    def __init__(self, *args, **kwargs):
-        self.lock = threading.Lock()
-        super().__init__(*args, **kwargs)
-
     def paint(self, painter, option, widget=None):
-        with self.lock:
-            painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
-            super().paint(painter, option, widget)
+        painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
+        super().paint(painter, option, widget)
 
-    def setData(self, *args, **kwargs):
-        with self.lock:
-            super().setData(*args ,**kwargs)
 
 def _define_symbols():
     """

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -395,7 +395,6 @@ class OWScatterPlotBase(gui.OWComponent):
         self.sample_size = None
         self.sample_indices = None
 
-        self.gui = OWPlotGUI(self)
         self.palette = None
 
         self.shape_legend = self._create_legend(((1, 0), (1, 0)))
@@ -1258,21 +1257,6 @@ class OWScatterPlotBase(gui.OWComponent):
             return True
         else:
             return False
-
-    def box_zoom_select(self, parent):
-        g = self.gui
-        box_zoom_select = gui.vBox(parent, "Zoom/Select")
-        zoom_select_toolbar = g.zoom_select_toolbar(
-            box_zoom_select, nomargin=True,
-            buttons=[g.StateButtonsBegin, g.SimpleSelect, g.Pan, g.Zoom,
-                     g.StateButtonsEnd, g.ZoomReset]
-        )
-        buttons = zoom_select_toolbar.buttons
-        buttons[g.Zoom].clicked.connect(self.zoom_button_clicked)
-        buttons[g.Pan].clicked.connect(self.pan_button_clicked)
-        buttons[g.SimpleSelect].clicked.connect(self.select_button_clicked)
-        buttons[g.ZoomReset].clicked.connect(self.reset_button_clicked)
-        return box_zoom_select
 
 
 class HelpEventDelegate(EventDelegate):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -407,14 +407,16 @@ class OWDataProjectionWidget(OWProjectionWidgetBase):
         box.layout().addWidget(self.graph.plot_widget)
 
     def _add_controls(self):
-        self._point_box = self.graph.gui.point_properties_box(self.controlArea)
-        self._effects_box = self.graph.gui.effects_box(self.controlArea)
-        self._plot_box = self.graph.gui.plot_properties_box(self.controlArea)
-        self.control_area_stretch = gui.widgetBox(self.controlArea)
+        self.gui = OWPlotGUI(self, self.graph)
+        area = self.controlArea
+        self._point_box = self.gui.point_properties_box(area)
+        self._effects_box = self.gui.effects_box(area)
+        self._plot_box = self.gui.plot_properties_box(area)
+        self.control_area_stretch = gui.widgetBox(area)
         self.control_area_stretch.layout().addStretch(100)
-        self.graph.box_zoom_select(self.controlArea)
-        gui.auto_commit(self.controlArea, self, "auto_commit",
-                        "Send Selection", "Send Automatically")
+        self.gui.box_zoom_select(area)
+        gui.auto_commit(
+            area, self, "auto_commit", "Send Selection", "Send Automatically")
 
     # Input
     @Inputs.data


### PR DESCRIPTION
After reimplementing projections widgets in #3089 and #3260, a lot of old classes (like multiple implementations of legends etc) remained lying around. Naming of old and new classes is also rather bad. This PR will clean this up.

##### Description of changes

- The graph creates an instance of `OWPlotGUI.OWPlotGUI`, which is then used exclusively by the widget. The only exception is `box_zoom_select`, which is a method of the graph although other methods of this kind are in `OWPlotGUI`. https://github.com/biolab/orange3/commit/b66894423a324af48128bc689b14b5d287cec932 moves `box_zoom_select` to `OWPlotGUI` and the instance of `OWPlotGUI` to widget.

- ScatterPlotItem had locks to prevent setData during paint and vice versa. As @ales-erjavec explained in #3313, Qt Graphics framework is not thread safe and should be updated from main thread only, hence the lock is redundant. This PR removes it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
