### PR TITLE
[FIX] owlouvainclustering: Fix race conditions

### DIFF
--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -269,9 +269,9 @@ class OWLouvainClustering(widget.OWWidget):
         assert self.__task is not None
         assert self.__task.future is future
         assert self.__task.watcher.future() is future
-        self.__task.deleteLater()
-        self.__task.setParent(None)
-        self.__task = None
+        self.__task, task = None, self.__task
+        task.deleteLater()
+
         self.__set_state_ready()
         try:
             result = future.result()

--- a/Orange/widgets/unsupervised/tests/test_owlouvain.py
+++ b/Orange/widgets/unsupervised/tests/test_owlouvain.py
@@ -21,11 +21,16 @@ class TestOWLouvain(WidgetTest):
         self.widget.onDeleteWidget()
         super().tearDown()
 
+    def commit_and_wait(self, widget=None):
+        widget = self.widget if widget is None else widget
+        widget.commit()
+        self.wait_until_stop_blocking(widget)
+
     def test_removing_data(self):
         self.send_signal(self.widget.Inputs.data, self.iris)
-        self.commit_and_wait()
+        self.commit_and_wait(self.widget)
         self.send_signal(self.widget.Inputs.data, None)
-        self.commit_and_wait()
+        self.commit_and_wait(self.widget)
 
     def test_clusters_ordered_by_size(self):
         """Cluster names should be sorted based on the number of instances."""
@@ -80,7 +85,7 @@ class TestOWLouvain(WidgetTest):
         table3 = table1.copy()
         table3.X[:, 0] = 1
 
-        with patch.object(self.widget, 'commit') as commit:
+        with patch.object(self.widget, '_invalidate_output') as commit:
             self.send_signal(self.widget.Inputs.data, table1)
             self.commit_and_wait()
             call_count = commit.call_count

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -13,7 +13,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtCore import (
     Qt, QRect, QMargins, QByteArray, QDataStream, QBuffer, QSettings,
-    QUrl, pyqtSignal as Signal
+    QUrl, QThread, pyqtSignal as Signal
 )
 from AnyQt.QtGui import QIcon, QKeySequence, QDesktopServices
 
@@ -774,6 +774,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         This is a short status string to be displayed inline next to
         the instantiated widget icon in the canvas.
         """
+        assert QThread.currentThread() == self.thread()
         if self.__statusMessage != text:
             self.__statusMessage = text
             self.statusMessageChanged.emit(text)
@@ -820,6 +821,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         .. note::
             Failure to clear this flag will block dependent nodes forever.
         """
+        assert QThread.currentThread() is self.thread()
         if self.__blocking != state:
             self.__blocking = state
             self.blockingStateChanged.emit(state)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ skip_commits:
     - benchmark
     - tutorials
 
-shallow_clone: true
 clone_depth: 30
 
 matrix:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

There are race conditions in the Louvain clustering widget. 

The `pca_projection`, `graph` and `partitions` attributes are accessed and set directly from threads. In particular from the already 'cancelled' jobs. The code does not wait for cancelled jobs to finish, but they do modify the computed partial results. This can lead to undefined final results
on the output.

I can trigger this reliably by:
<img width="420" alt="screen shot 2018-10-19 at 11 24 41" src="https://user-images.githubusercontent.com/4716745/47209858-bb3f3300-d391-11e8-886a-6e9b52327e3d.png">

File: *wdbc.tab*
Louvain Clustering (both):
* Apply PCA is checked: 20 components
* Euclidean distance
* k neighbors: 10
* Resolution 2.5
* Apply automatically is checked

Python script contents:
```python
import numpy as np
d1, d2 = in_datas

c1, _ = d1.get_column_view("Cluster")
c2, _ = d2.get_column_view("Cluster")
assert np.array_equal(c1, c2)
```
In one of the Louvain clustering widgets tab to *k neighbors* spin box and enter 50, then quickly press down key on the keyboard a few times then even quicker enter 10 (you might copy 10 to clipboard and just paste it).

##### Description of changes

* Refactor the code to eliminate race conditions in the access/setting of `pca_projection`, `graph` and `partitions`.

* Limit the number of executing tasks to one.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
