### PR TITLE
Test and Score: Warn about transformation, raise error if all is nan

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -44,6 +44,10 @@ _conversion_cache = None
 _conversion_cache_lock = RLock()
 
 
+class DomainTransformationError(Exception):
+    pass
+
+
 class RowInstance(Instance):
     sparse_x = None
     sparse_y = None

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -19,6 +19,7 @@ from Orange.classification import (Learner, Model, NaiveBayesLearner,
 from Orange.classification.rules import _RuleLearner
 from Orange.data import (ContinuousVariable, DiscreteVariable,
                          Domain, Table, Variable)
+from Orange.data.table import DomainTransformationError
 from Orange.evaluation import CrossValidation
 from Orange.tests.dummy_learners import DummyLearner, DummyMulticlassLearner
 from Orange.tests import test_filename
@@ -144,6 +145,13 @@ class ModelTest(unittest.TestCase):
         y2, probs = clf(x, ret=Model.ValueProbs)
         self.assertEqual(y2.shape, y.shape)
         self.assertEqual(probs.shape, (nrows, 2, 4))
+
+    def test_incompatible_domain(self):
+        iris = Table("iris")
+        titanic = Table("titanic")
+        clf = DummyLearner()(iris)
+        with self.assertRaises(DomainTransformationError):
+            clf(titanic)
 
 
 class ExpandProbabilitiesTest(unittest.TestCase):

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -23,6 +23,7 @@ import Orange.evaluation
 
 from Orange.base import Model
 from Orange.data import ContinuousVariable, DiscreteVariable, Value
+from Orange.data.table import DomainTransformationError
 from Orange.widgets import gui, settings
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.widgets.utils.itemmodels import TableModel
@@ -265,7 +266,7 @@ class OWPredictions(OWWidget):
                     or numpy.isnan(pred.results[0]).all():
                 try:
                     results = self.predict(pred.predictor, self.data)
-                except ValueError as err:
+                except (ValueError, DomainTransformationError) as err:
                     results = "{}: {}".format(pred.predictor.name, err)
                 self.predictors[inputid] = pred._replace(results=results)
 

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -76,6 +76,22 @@ class TestOWTestLearners(WidgetTest):
         self.widget.resampling = OWTestLearners.TestOnTest
         self.send_signal(self.widget.Inputs.test_data, data)
 
+    def test_testOnTest_incompatible_domain(self):
+        iris = Table("iris")
+        self.send_signal(self.widget.Inputs.train_data, iris)
+        self.send_signal(self.widget.Inputs.learner, LogisticRegressionLearner(), 0)
+        self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
+        self.assertFalse(self.widget.Error.test_data_incompatible.is_shown())
+        self.widget.resampling = OWTestLearners.TestOnTest
+        # test data with the same class (otherwise the widget shows a different error)
+        # and a non-nan X
+        iris_test = iris.transform(Domain([ContinuousVariable()],
+                                          class_vars=iris.domain.class_vars))
+        iris_test.X[:, 0] = 1
+        self.send_signal(self.widget.Inputs.test_data, iris_test)
+        self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
+        self.assertTrue(self.widget.Error.test_data_incompatible.is_shown())
+
     def test_CrossValidationByFeature(self):
         data = Table("iris")
         attrs = data.domain.attributes


### PR DESCRIPTION
##### Issue

- Domain transformations in Test and Score (and Predictions?) are implicit. Users should be informed about them.

##### Description of changes

- Test and Score shows this exception as a user-readable error (without mentioning "domains")
- If train and test data have different domains but transformation does not result in all-nans, an information about the transformation appears.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
