### PR TITLE
Statistics.utils: Fixup bincount numpy deprecation warning

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -69,7 +69,7 @@ def sparse_implicit_zero_weights(x, weights):
         )
 
 
-def bincount(x, weights=None, max_val=None, minlength=None):
+def bincount(x, weights=None, max_val=None, minlength=0):
     """Return counts of values in array X.
 
     Works kind of like np.bincount(), except that it also supports floating
@@ -134,24 +134,21 @@ def bincount(x, weights=None, max_val=None, minlength=None):
     else:
         nans = 0. if x.ndim == 1 else np.zeros(x.shape[1], dtype=float)
 
-    if minlength is None and max_val is not None:
+    if minlength == 0 and max_val is not None:
         minlength = max_val + 1
 
-    if minlength is not None and minlength <= 0:
-        bc = np.array([])
-    else:
-        bc = np.bincount(
-            x.astype(np.int32, copy=False), weights=weights, minlength=minlength
-        ).astype(float)
-        # Since `csr_matrix.values` only contain non-zero values or explicit
-        # zeros, we must count implicit zeros separately and add them to the
-        # explicit ones found before
-        if sp.issparse(x_original):
-            # If x contains only NaNs, then bc will be an empty array
-            if zero_weights and bc.size == 0:
-                bc = [zero_weights]
-            elif zero_weights:
-                bc[0] += zero_weights
+    bc = np.bincount(
+        x.astype(np.int32, copy=False), weights=weights, minlength=minlength
+    ).astype(float)
+    # Since `csr_matrix.values` only contain non-zero values or explicit
+    # zeros, we must count implicit zeros separately and add them to the
+    # explicit ones found before
+    if sp.issparse(x_original):
+        # If x contains only NaNs, then bc will be an empty array
+        if zero_weights and bc.size == 0:
+            bc = [zero_weights]
+        elif zero_weights:
+            bc[0] += zero_weights
 
     return bc, nans
 


### PR DESCRIPTION
##### Issue
`Orange.statistics.util.bincount` was raising a deprecation warning
```
Orange/statistics/util.py:144: DeprecationWarning: 0 should be passed as minlength instead of None; this will error in future.
  x.astype(np.int32, copy=False), weights=weights, minlength=minlength
```

##### Description of changes
Fixup deprecation warning.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
