### PR TITLE
[FIX] OWDataTable: reset selections on domain change

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -14,15 +14,14 @@ import numpy
 from scipy.sparse import issparse
 
 from AnyQt.QtWidgets import (
-    QTableView, QHeaderView, QAbstractButton, QAction, QApplication,
-    QStyleOptionHeader, QStyle, QStylePainter, QStyledItemDelegate
+    QTableView, QHeaderView, QAbstractButton, QApplication, QStyleOptionHeader,
+    QStyle, QStylePainter, QStyledItemDelegate
 )
-from AnyQt.QtGui import QColor, QKeySequence, QClipboard
+from AnyQt.QtGui import QColor, QClipboard
 from AnyQt.QtCore import (
     Qt, QSize, QEvent, QByteArray, QMimeData, QObject, QMetaObject,
     QAbstractProxyModel, QIdentityProxyModel, QModelIndex,
-    QItemSelectionModel, QItemSelection, QItemSelectionRange,
-    QT_VERSION
+    QItemSelectionModel, QItemSelection, QItemSelectionRange
 )
 from AnyQt.QtCore import pyqtSlot as Slot
 
@@ -33,8 +32,7 @@ from Orange.data.sql.table import SqlTable
 from Orange.statistics import basic_stats
 
 from Orange.widgets import widget, gui
-from Orange.widgets.settings import (Setting, ContextSetting,
-                                     DomainContextHandler)
+from Orange.widgets.settings import Setting, DomainContextHandler
 from Orange.widgets.widget import Input, Output
 from Orange.widgets.utils import datacaching
 from Orange.widgets.utils.annotated_data import (create_annotated_table,

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -390,13 +390,18 @@ class OWDataTable(widget.OWWidget):
     color_by_class = Setting(True)
     settingsHandler = DomainContextHandler(
         match_values=DomainContextHandler.MATCH_VALUES_ALL)
-    selected_rows = ContextSetting([])
-    selected_cols = ContextSetting([])
+    selected_rows = Setting([], schema_only=True)
+    selected_cols = Setting([], schema_only=True)
 
     def __init__(self):
         super().__init__()
 
         self._inputs = OrderedDict()
+
+        self.__pending_selected_rows = self.selected_rows
+        self.selected_rows = None
+        self.__pending_selected_cols = self.selected_cols
+        self.selected_cols = None
 
         self.dist_color = QColor(*self.dist_color_RGB)
 
@@ -514,9 +519,20 @@ class OWDataTable(widget.OWWidget):
                 self.set_info(current._input_slot.summary)
 
         self.tabs.tabBar().setVisible(self.tabs.count() > 1)
-        self.selected_rows = []
-        self.selected_cols = []
         self.openContext(data)
+
+        if self.__pending_selected_rows is not None:
+            self.selected_rows = self.__pending_selected_rows
+            self.__pending_selected_rows = None
+        else:
+            self.selected_rows = []
+
+        if self.__pending_selected_cols is not None:
+            self.selected_cols = self.__pending_selected_cols
+            self.__pending_selected_cols = None
+        else:
+            self.selected_cols = []
+
         self.set_selection()
         self.commit()
 

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 from Orange.widgets.data.owtable import OWDataTable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+from Orange.data import Table
 
 
 class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
@@ -29,6 +30,13 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, self.data, 1)
         self.assertEqual(self.widget.tabs.widget(0).model().rowCount(),
                          len(self.data))
+
+    def test_reset_select(self):
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self._select_data()
+        self.send_signal(self.widget.Inputs.data, Table('heart_disease'))
+        self.assertListEqual([], self.widget.selected_cols)
+        self.assertListEqual([], self.widget.selected_rows)
 
     def _select_data(self):
         self.widget.selected_cols = list(range(len(self.data.domain)))


### PR DESCRIPTION
##### Issue
Fixes #3261 
On domain change, selections should be reset.
##### Description of changes
Set selection settings to schema only.
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
