### PR TITLE
[FIX] Predictions: Fix failure after failed predictor

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -260,7 +260,9 @@ class OWPredictions(OWWidget):
 
     def _call_predictors(self):
         for inputid, pred in self.predictors.items():
-            if pred.results is None or numpy.isnan(pred.results[0]).all():
+            if pred.results is None \
+                    or isinstance(pred.results, str) \
+                    or numpy.isnan(pred.results[0]).all():
                 try:
                     results = self.predict(pred.predictor, self.data)
                 except ValueError as err:

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1,6 +1,9 @@
 """Tests for OWPredictions"""
 import io
+from unittest.mock import Mock
+
 import numpy as np
+from Orange.base import Model
 
 from Orange.data.io import TabReader
 from Orange.widgets.tests.base import WidgetTest
@@ -27,7 +30,6 @@ class TestOWPredictions(WidgetTest):
         data = self.iris[::10].copy()
         data.Y[1] = np.nan
         yvec, _ = data.get_column_view(data.domain.class_var)
-        nanmask = np.isnan(yvec)
         self.send_signal(self.widget.Inputs.data, data)
         self.send_signal(self.widget.Inputs.predictors, ConstantLearner()(data), 1)
         pred = self.get_output(self.widget.Outputs.predictions)
@@ -170,3 +172,13 @@ class TestOWPredictions(WidgetTest):
         cl_data = ConstantLearner()(data)
         self.send_signal(self.widget.Inputs.predictors, cl_data, 1)
         self.send_signal(self.widget.Inputs.data, data)
+
+    def test_predictor_fails(self):
+        titanic = Table("titanic")
+        failing_model = ConstantLearner()(titanic)
+        failing_model.predict = Mock(side_effect=ValueError("foo"))
+        self.send_signal(self.widget.Inputs.predictors, failing_model, 1)
+        self.send_signal(self.widget.Inputs.data, titanic)
+
+        model2 = ConstantLearner()(titanic)
+        self.send_signal(self.widget.Inputs.predictors, model2, 2)


### PR DESCRIPTION
##### Issue

I predictor fails, it sets results to a string describing an error. When `_call_predictors` is called again, it tests for ` pred.results is None or numpy.isnan(pred.results[0]).all()`, which crashes because `pred.results` is a string.

##### Description of changes

Test for `isinstance(pred.results, str)` and treat it as `None` or all nans.

##### Includes
- [X] Code changes
- [X] Tests
