### PR TITLE
IO: Remove deprecated params from sanitize_variable

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -169,20 +169,8 @@ def guess_data_type(orig_values, namask=None):
     return valuemap, values, coltype
 
 
-def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
-                      domain_vars=None, existing_var=None, new_var_name=None, data=None, name=None):
+def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs, name=None):
     assert issubclass(coltype, Variable)
-
-    if name is None or existing_var is not None or new_var_name is not None:
-        name = existing_var.strip() if existing_var else new_var_name
-        raise DeprecationWarning("Arguments 'existing_var' and 'new_var_name' are "\
-                                 "deprecated since 3.16; use 'name' instead")
-
-    if domain_vars is not None:
-        raise DeprecationWarning("Argument 'domain_vars' is deprecated since 3.16")
-
-    if data is not None:
-        raise DeprecationWarning("Argument 'data' is deprecated since 3.16")
 
     def get_number_of_decimals(values):
         len_ = len

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -118,12 +118,3 @@ class TestReader(unittest.TestCase):
         self.assertEqual(len(table.domain.attributes), 2)
         self.assertEqual(cm.warning.args[0],
                          "Columns with no headers were removed.")
-
-
-class TestIo(unittest.TestCase):
-    def test_sanitize_variable_deprecated_params(self):
-        """In version 3.18 deprecation warnings in function 'sanitize_variable'
-        should be removed along with unused parameters."""
-        if version > "3.18":
-            _, _ = sanitize_variable(None, None, None, ContinuousVariable,
-                                     {}, name="name", data="data")


### PR DESCRIPTION
##### Issue
Tests are failing. The culprit:

```
ERROR: test_sanitize_variable_deprecated_params (Orange.tests.test_io.TestIo)
In version 3.18 deprecation warnings in function 'sanitize_variable'
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/biolab/orange3/build/travis-test/Orange/tests/test_io.py", line 129, in test_sanitize_variable_deprecated_params
    {}, name="name", data="data")
  File "/home/travis/build/biolab/orange3/build/travis-test/Orange/data/io.py", line 185, in sanitize_variable
    raise DeprecationWarning("Argument 'data' is deprecated since 3.16")
DeprecationWarning: Argument 'data' is deprecated since 3.16
```


##### Description of changes
Remove test and deprecated params. I've never dealt with this module before, but all the tests seem to pass, and the instructions were fairly straightforward.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
