### PR TITLE
data.io.sanitize_variable: Remove deprecated arguments

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -170,19 +170,8 @@ def guess_data_type(orig_values, namask=None):
 
 
 def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
-                      domain_vars=None, existing_var=None, new_var_name=None, data=None, name=None):
+                      name=None):
     assert issubclass(coltype, Variable)
-
-    if name is None or existing_var is not None or new_var_name is not None:
-        name = existing_var.strip() if existing_var else new_var_name
-        raise DeprecationWarning("Arguments 'existing_var' and 'new_var_name' are "\
-                                 "deprecated since 3.16; use 'name' instead")
-
-    if domain_vars is not None:
-        raise DeprecationWarning("Argument 'domain_vars' is deprecated since 3.16")
-
-    if data is not None:
-        raise DeprecationWarning("Argument 'data' is deprecated since 3.16")
 
     def get_number_of_decimals(values):
         len_ = len

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -7,11 +7,8 @@ import tempfile
 import shutil
 import io
 
-from Orange.data import ContinuousVariable
-from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader, \
-    sanitize_variable
+from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader
 from Orange.data.table import get_sample_datasets_dir
-from Orange.version import version
 
 
 class WildcardReader(FileFormat):
@@ -118,12 +115,3 @@ class TestReader(unittest.TestCase):
         self.assertEqual(len(table.domain.attributes), 2)
         self.assertEqual(cm.warning.args[0],
                          "Columns with no headers were removed.")
-
-
-class TestIo(unittest.TestCase):
-    def test_sanitize_variable_deprecated_params(self):
-        """In version 3.18 deprecation warnings in function 'sanitize_variable'
-        should be removed along with unused parameters."""
-        if version > "3.18":
-            _, _ = sanitize_variable(None, None, None, ContinuousVariable,
-                                     {}, name="name", data="data")


### PR DESCRIPTION
Tests on all PRs will fail until this is merged, I guess. (Except for PRs based on this one).

##### Issue

From 3.18, tests fail because of deprecated arguments.

##### Description of changes

Remove deprecated arguments and the tests that were made to trigger a failure in 3.18.


##### Includes
- [X] Code changes
- [X] De-tests
