### PR TITLE
travis: Update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ matrix:
           env: PYQT4=true
         - python: '3.6'
           env: UPLOAD_COVERAGE=true
-        - python: '3.7'
-          sudo: required
-          dist: xenial
     fast_finish: true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,18 @@ dist: trusty
 matrix:
     include:
         - env: RUN_PYLINT=true
-          python: '3.4'
+          python: '3.6'
           cache: {}
         - env: BUILD_DOCS=true
-          python: '3.5'
+          python: '3.6'
           script: source $TRAVIS_BUILD_DIR/.travis/build_doc.sh
-
-        - python: '3.4'
-          env: PYQT4=true
         - python: '3.5'
-          env: UPLOAD_COVERAGE=true
+          env: PYQT4=true
         - python: '3.6'
+          env: UPLOAD_COVERAGE=true
+        - python: '3.7'
+          sudo: required
+          dist: xenial
     fast_finish: true
 
 cache:


### PR DESCRIPTION
Updates the travis test matrix as follows:

Remove travis testing for Python 3.4.
Py3.5 is used only in conjunction with PyQt4 in a single "legacy" test.
The main testing is done using Py3.6.
There is also a Py3.7 test, which requires some additional travis parameters (see https://github.com/travis-ci/travis-ci/issues/9815).

Fixes #3341 
