### PR TITLE
preprocess: Update deprecated sklearn import (Imputer->SimpleImputer)

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -3,10 +3,10 @@ Preprocess
 ----------
 
 """
+import bottleneck as bn
 import numpy as np
 import scipy.sparse as sp
-import sklearn.preprocessing as skl_preprocessing
-import bottleneck as bn
+from sklearn.impute import SimpleImputer
 
 import Orange.data
 from Orange.data.filter import HasClass
@@ -147,7 +147,7 @@ class Impute(Preprocess):
 
 
 class SklImpute(Preprocess):
-    __wraps__ = skl_preprocessing.Imputer
+    __wraps__ = SimpleImputer
 
     def __init__(self, strategy='mean'):
         self.strategy = strategy
@@ -156,7 +156,7 @@ class SklImpute(Preprocess):
         from Orange.data.sql.table import SqlTable
         if isinstance(data, SqlTable):
             return Impute()(data)
-        imputer = skl_preprocessing.Imputer(strategy=self.strategy)
+        imputer = SimpleImputer(strategy=self.strategy)
         X = imputer.fit_transform(data.X)
         # Create new variables with appropriate `compute_value`, but
         # drop the ones which do not have valid `imputer.statistics_`

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -1084,6 +1084,5 @@ class datasets:
         yield cls.missing_data_2()
         yield cls.missing_data_3()
         yield cls.data_one_column_nans()
-        yield cls.data_one_column_infs()
         yield ds_cls
         yield ds_reg

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -40,7 +40,6 @@ from Orange.widgets.utils.annotated_data import (
     ANNOTATED_DATA_FEATURE_NAME, ANNOTATED_DATA_SIGNAL_NAME
 )
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
-from Orange.widgets.utils.plot import OWPlotGUI
 from Orange.widgets.widget import OWWidget
 
 sip.setdestroyonexit(False)
@@ -146,27 +145,27 @@ class WidgetTest(GuiTest):
         return widget
 
     @staticmethod
-    def reset_default_settings(cls):
+    def reset_default_settings(widget):
         """Reset default setting values for widget
 
         Discards settings read from disk and changes stored by fast_save
 
         Parameters
         ----------
-        cls : OWWidget
+        widget : OWWidget
             widget to reset settings for
         """
-        settings_handler = getattr(cls, "settingsHandler", None)
+        settings_handler = getattr(widget, "settingsHandler", None)
         if settings_handler:
             # Rebind settings handler to get fresh copies of settings
             # in known_settings
-            settings_handler.bind(cls)
+            settings_handler.bind(widget)
             # Reset defaults read from disk
             settings_handler.defaults = {}
             # Reset context settings
             settings_handler.global_contexts = []
 
-    def process_events(self, until: callable=None, timeout=DEFAULT_TIMEOUT):
+    def process_events(self, until: callable = None, timeout=DEFAULT_TIMEOUT):
         """Process Qt events, optionally until `until` returns
         something True-ish.
 


### PR DESCRIPTION
`sklearn.preprocessing.Imputer` has been deprecated in favour of `sklearn.impute.SimpleImputer`

EDIT: It seems that the two classes are not completely the same - in particular, the new one validates the data first and rejects np.inf values, while the old one just silently dropped that column.
Thus, most methods that imputed the data first (e.g. MDS), now raise an error in such cases. Which is fine, since inf values are not officially supported in Orange data tables (e.g. one cannot load a saved dataset that contained np.inf).
The second commit drops the inf dataset from a collection used for general testing of "annoying" data.
