### PR TITLE
[FIX] Scatterplot's VizRank no longer crashes in presence of nonprimitive metas

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -84,7 +84,7 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         assert self.attr_color is not None
         master_domain = self.master.data.domain
         vars = [v for v in chain(master_domain.variables, master_domain.metas)
-                if v is not self.attr_color]
+                if v is not self.attr_color and v.is_primitive()]
         domain = Domain(attributes=vars, class_vars=self.attr_color)
         data = self.master.data.transform(domain)
         relief = ReliefF if isinstance(domain.class_var, DiscreteVariable) \

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -383,6 +383,14 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
                                     [True, False, True, False, True]):
             assert_vizrank_enabled(data, is_enabled)
 
+    def test_vizrank_nonprimitives(self):
+        """VizRank does not try to include non primitive attributes"""
+        data = Table("zoo")
+        self.send_signal(self.widget.Inputs.data, data)
+        with patch("Orange.widgets.visualize.owscatterplot.ReliefF",
+                   new=lambda *_1, **_2: lambda data: np.arange(len(data))):
+            self.widget.vizrank.score_heuristic()
+
     def test_auto_send_selection(self):
         """
         Scatter Plot automatically sends selection only when the checkbox Send automatically


### PR DESCRIPTION
##### Issue

VizRank crashes when the data includes non-primitive meta attributes. Most notably, it crashes on Brown data!

When reimplementing projections, we removed the obsolete `graph.scaled_data`. Vizrank, which used to get the attributes from `graph.scaled_data.domain`, now takes them from widget's `data.domain`, but does not filter out primitive attributes (which it didn't have to do before, since `scaled_data` did not include them).

##### Description of changes

Add the check and the tests.

##### Includes
- [X] Code changes
- [X] Tests
