### PR TITLE
test_linear_regression: Improve a test of equal coefficients

### DIFF
--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -105,10 +105,10 @@ class TestLinearRegressionLearner(unittest.TestCase):
         for a in alphas:
             lasso = LassoRegressionLearner(alpha=a)
             lasso_model = lasso(self.housing)
-            elastic = ElasticNetLearner(alpha=a, l1_ratio=1)
-            elastic_model = elastic(self.housing)
-            d = np.sum(lasso_model.coefficients - elastic_model.coefficients)
-            self.assertEqual(d, 0)
+            en = ElasticNetLearner(alpha=a, l1_ratio=1)
+            en_model = en(self.housing)
+            np.testing.assert_allclose(
+                lasso_model.coefficients, en_model.coefficients, atol=1e-07)
 
     def test_linear_regression_repr(self):
         learner = LinearRegressionLearner()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3355

##### Description of changes
Check that coefficients are (almost) equal directly instead of summing the difference.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
