### PR TITLE
[FIX] Fix wrong indices in tooltips in projection when some data was invalid

### DIFF
--- a/Orange/widgets/visualize/tests/test_owprojectionwidget.py
+++ b/Orange/widgets/visualize/tests/test_owprojectionwidget.py
@@ -102,6 +102,16 @@ class TestOWProjectionWidget(WidgetTest):
         np.testing.assert_almost_equal(get_column(disc), x)
         self.assertEqual(get_column(disc, return_labels=True), disc.values)
 
+    def test_get_tooltip(self):
+        widget = self.widget
+        domain = Domain([ContinuousVariable("v")])
+        widget.data = Table.from_numpy(domain, [[1], [2], [3]])
+        widget.valid_data = np.array([True, False, True])
+        self.assertTrue("3" in widget.get_tooltip([1]))
+        self.assertTrue("1" in widget.get_tooltip([0, 1])
+                        and "3" in widget.get_tooltip([0, 1]))
+        self.assertEqual(widget.get_tooltip([]), "")
+
 
 class TestableDataProjectionWidget(OWDataProjectionWidget):
     def get_embedding(self):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -320,6 +320,8 @@ class OWProjectionWidgetBase(OWWidget):
         Returns:
             (str):
         """
+        point_ids = \
+            np.flatnonzero(self.valid_data)[np.asarray(point_ids, dtype=int)]
         text = "<hr/>".join(self._point_tooltip(point_id)
                             for point_id in point_ids[:MAX_POINTS_IN_TOOLTIP])
         if len(point_ids) > MAX_POINTS_IN_TOOLTIP:


### PR DESCRIPTION
Fixes #3353.

`OWProjectionWidgetBase.get_tooltip` is called with indices of valid data points only, and the method did not skip invalid data.

##### Includes
- [X] Code changes
- [X] Tests
