### PR TITLE
requirements-core: Bump scikit-learn version

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,7 +1,7 @@
 pip>=9.0
 numpy>=1.13.0
 scipy>=0.16.1
-scikit-learn>=0.18.1
+scikit-learn>=0.20.0
 bottleneck>=1.0.0
 # Reading Excel files
 xlrd>=0.9.2


### PR DESCRIPTION
Bump the required version of scikit-learn to 0.20.
(Contains the new impute module among other things...)