### PR TITLE
Projections: Assign missing values to embedding

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -944,6 +944,15 @@ class ProjectionWidgetTestMixin:
 
 
 class AnchorProjectionWidgetTestMixin(ProjectionWidgetTestMixin):
+    def test_embedding_missing_values(self):
+        table = Table("heart_disease")
+        table.X[0] = np.nan
+        self.send_signal(self.widget.Inputs.data, table)
+        self.assertFalse(np.all(self.widget.valid_data))
+        output = self.get_output(ANNOTATED_DATA_SIGNAL_NAME)
+        embedding_mask = np.all(np.isnan(output.metas[:, :2]), axis=1)
+        np.testing.assert_array_equal(~embedding_mask, self.widget.valid_data)
+
     def test_sparse_data(self):
         table = Table("iris")
         table.X = sp.csr_matrix(table.X)

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -372,7 +372,7 @@ class OWFreeViz(OWAnchorProjectionWidget):
             return None
         EX = np.dot(self._X, self.projection)
         EX /= np.max(np.linalg.norm(EX, axis=1)) or 1
-        embedding = np.zeros((len(self.data), 2), dtype=np.float)
+        embedding = np.full((len(self.data), 2), np.nan)
         embedding[self.valid_data] = EX
         return embedding
 

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -479,7 +479,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
             self.Error.no_valid_data()
             return None
 
-        embedding = np.zeros((len(self.data), 2), dtype=np.float)
+        embedding = np.full((len(self.data), 2), np.nan)
         embedding[self.valid_data] = ec
         return embedding
 

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -394,7 +394,7 @@ class OWRadviz(OWAnchorProjectionWidget):
             self.Warning.invalid_embedding()
             return None
 
-        embedding = np.zeros((len(self.data), 2), dtype=np.float)
+        embedding = np.full((len(self.data), 2), np.nan)
         embedding[self.valid_data] = ec
         return embedding
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
If the original data had missing values, and the embedding is therefore not available for all points, missing values should be assigned to those points instead of zeros.

##### Description of changes
Assign np.nan-s to embedding instead of zeros.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
