### PR TITLE
[FIX] python-framework.sh: Fix 'Current' symlink creation

### DIFF
--- a/scripts/macos/python-framework.sh
+++ b/scripts/macos/python-framework.sh
@@ -263,5 +263,5 @@ python-framework-relocate "${1:?}"/Python.framework
 (
     cd "${1:?}"/Python.framework/Versions
     shopt -s failglob
-    ln -sf ?.? ./Current  # assuming single version framework
+    ln -shf ?.? ./Current  # assuming single version framework
 )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

From https://github.com/biolab/orange3/issues/3370#issuecomment-437041569

> It looks to me that the python-framework.py script would create a new symlink inside the Current folder if the symlink already exists.

This is exactly what happens

##### Description of changes

Do not follow target if it already exists and points to a directory

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
