### PR TITLE
CI: Remove legacy testing (py 3.5, pyqt4)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
         - env: BUILD_DOCS=true
           python: '3.6'
           script: source $TRAVIS_BUILD_DIR/.travis/build_doc.sh
-        - python: '3.5'
-          env: PYQT4=true
         - python: '3.6'
           env: UPLOAD_COVERAGE=true
     fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,10 +23,6 @@ environment:
     TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
 
   matrix:
-    - PYTHON: C:\Python35
-
-    - PYTHON: C:\Python35-x64
-
     - PYTHON: C:\Python36
 
     - PYTHON: C:\Python36-x64


### PR DESCRIPTION
Since nobody objected and argued for support of older versions, we can remove the legacy test as well (py 3.5, pyqt4).
Currently everything should still work with those versions, but new features are coming that make use of pyqt5 (#3303) and conda is not building new packages for py 3.5 for over a month.
