### PR TITLE
[FIX] LearnerScorer: fix for preprocessed data

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -155,10 +155,16 @@ class LearnerScorer(Scorer):
     def score_data(self, data, feature=None):
 
         def average_scores(scores):
+            """ Obtain scores for original attributes.
+
+            If a learner preprocessed the data before building a model, current scores do not
+            directly correspond to the domain. For example, continuization creates multiple
+            features from a discrete feature. """
             scores_grouped = defaultdict(list)
             for attr, score in zip(model_domain.attributes, scores):
-                # Go up the chain of preprocessors to obtain the original variable
-                while getattr(attr, 'compute_value', False):
+                # Go up the chain of preprocessors to obtain the original variable, but no further
+                # than the data.domain, because the data is perhaphs already preprocessed.
+                while not (attr in data.domain) and getattr(attr, 'compute_value', False):
                     attr = getattr(attr.compute_value, 'variable', attr)
                 scores_grouped[attr].append(score)
             return [sum(scores_grouped[attr]) / len(scores_grouped[attr])

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -74,6 +74,14 @@ class TestLogisticRegressionLearner(unittest.TestCase):
             score = learner.score_data(self.voting, attr)
             np.testing.assert_array_almost_equal(score, scores[:, i])
 
+    def test_learner_scorer_previous_transformation(self):
+        learner = LogisticRegressionLearner()
+        from Orange.preprocess import Discretize
+        data = Discretize()(self.iris)
+        scores = learner.score_data(data)
+        # scores should be defined and positive
+        self.assertTrue(np.all(scores > 0))
+
     def test_learner_scorer_multiclass(self):
         attr = self.zoo.domain.attributes
         learner = LogisticRegressionLearner()

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -7,8 +7,10 @@ import numpy as np
 
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange import preprocess
+from Orange.modelling import RandomForestLearner
 from Orange.preprocess.score import InfoGain, GainRatio, Gini, Chi2, ANOVA,\
     UnivariateLinearRegression, ReliefF, FCBF, RReliefF
+
 
 
 class FeatureScoringTest(unittest.TestCase):
@@ -150,3 +152,11 @@ class FeatureScoringTest(unittest.TestCase):
                      np.r_[0., 1])
         weights = scorer(data, None)
         np.testing.assert_equal(weights, np.nan)
+
+    def test_learner_with_transformation(self):
+        learner = RandomForestLearner(random_state=0)
+        from Orange.projection import PCA
+        iris = Table("iris")
+        data = PCA(n_components=2)(iris)(iris)
+        scores = learner.score_data(data)
+        np.testing.assert_almost_equal(scores, [[0.7760495, 0.2239505]])


### PR DESCRIPTION
##### Issue
Ranking with a Scores did not work if the data was preprocessed with PCA (or anything else). Saving and loading the data (and thus obtaining primitive features) helped.

##### Description of changes
Search for original attributes in score-joining function used to go all the way up to primitive features. Now it stops when it comes to a feature from the input data.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
