### PR TITLE
LearnerScorer: join derived features by max value

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -154,7 +154,7 @@ class LearnerScorer(Scorer):
 
     def score_data(self, data, feature=None):
 
-        def average_scores(scores):
+        def join_derived_features(scores):
             """ Obtain scores for original attributes.
 
             If a learner preprocessed the data before building a model, current scores do not
@@ -167,7 +167,7 @@ class LearnerScorer(Scorer):
                 while not (attr in data.domain) and getattr(attr, 'compute_value', False):
                     attr = getattr(attr.compute_value, 'variable', attr)
                 scores_grouped[attr].append(score)
-            return [sum(scores_grouped[attr]) / len(scores_grouped[attr])
+            return [max(scores_grouped[attr])
                     if attr in scores_grouped else 0
                     for attr in data.domain.attributes]
 
@@ -179,7 +179,7 @@ class LearnerScorer(Scorer):
                         self.domain)
 
         if data.domain != model_domain:
-            scores = np.array([average_scores(row) for row in scores])
+            scores = np.array([join_derived_features(row) for row in scores])
 
         return scores[:, data.domain.attributes.index(feature)] \
             if feature else scores

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -86,13 +86,13 @@ class TestLogisticRegressionLearner(unittest.TestCase):
         attr = self.zoo.domain.attributes
         learner = LogisticRegressionLearner()
         scores = learner.score_data(self.zoo)
-        self.assertEqual('aquatic', attr[np.argmax(scores[0])].name)
-        self.assertEqual('feathers', attr[np.argmax(scores[1])].name)
-        self.assertEqual('fins', attr[np.argmax(scores[2])].name)
-        self.assertEqual('backbone', attr[np.argmax(scores[3])].name)
-        self.assertEqual('backbone', attr[np.argmax(scores[4])].name)
-        self.assertEqual('milk', attr[np.argmax(scores[5])].name)
-        self.assertEqual('hair', attr[np.argmax(scores[6])].name)
+        self.assertEqual('aquatic', attr[np.argmax(scores[0])].name)  # amphibian
+        self.assertEqual('feathers', attr[np.argmax(scores[1])].name)  # bird
+        self.assertEqual('fins', attr[np.argmax(scores[2])].name)  # fish
+        self.assertEqual('legs', attr[np.argmax(scores[3])].name)  # insect
+        self.assertEqual('backbone', attr[np.argmax(scores[4])].name)  # invertebrate
+        self.assertEqual('milk', attr[np.argmax(scores[5])].name)  # mammal
+        self.assertEqual('hair', attr[np.argmax(scores[6])].name)  # reptile
         self.assertEqual(scores.shape,
                          (len(self.zoo.domain.class_var.values), len(attr)))
 


### PR DESCRIPTION
##### Issue
I first noticed this issue on Kickstarted data (from the Datasets). There Rank with Random forest produced strange results. The feature "Type", has 7 values, is the root of a decision tree built on these data. But then, surprisingly, it gets very low rankings with Random forest. 

As often, this problem is caused by RandomForestsLearner not supporting nominal features. They are continuized. For learners that need continuization, a discrete feature is transformed to multiple continuous features. A learner then returns scores for each continuous feature, which need to be joined somehow. Currently, Orange uses mean value to join them, which seems not to be such a good idea.

##### Description of changes
This commit changes the joining function to max. because a feature is at least as important as its most important value. Does anyone have a better idea what to do in this case?

Now "Type" gets the second place on Kickstarter. If I used sum() instead of max() it would leave all the other is the dust, but that seems a bit aggressive. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
