### PR TITLE
[MNT] travis: Fix in-place install for building widget catalog

### DIFF
--- a/.travis/build_doc.sh
+++ b/.travis/build_doc.sh
@@ -22,7 +22,7 @@ done < <(echo "$images")
 echo -e 'all ok\n'
 
 # build Orange inplace (needed for docs to build)
-python setup.py build_ext --inplace
+python setup.py egg_info build_ext --inplace
 
 cd $TRAVIS_BUILD_DIR/doc/development
 make html


### PR DESCRIPTION

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

See: https://github.com/biolab/orange3/pull/3345#issuecomment-437463620

Probable cause:

egg_info command used to be invoked during .travis/install_orange.sh
(as a sub-command of setuptool's sdist; since gh-3345 plain distutils
sdist is used)


##### Description of changes

Run egg_info command during in-place install

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
