### PR TITLE
[FIX] condainstall.bat: Add conda.bat and activate.bat scripts again

### DIFF
--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -6,6 +6,10 @@ rem Target install prefix
 set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
+rem Path to base conda env
+for /f %%f in ( '"%CONDA%" info --root' ) do (
+    set "CONDA_BASE_PREFIX=%%f"
+)
 
 if not exist "%PREFIX%\python.exe" (
     echo Creating a conda env in "%PREFIX%"
@@ -27,6 +31,21 @@ echo Appending conda-forge channel
 echo channels:         > "%PREFIX%\.condarc"
 echo   - conda-forge  >> "%PREFIX%\.condarc"
 echo   - defaults     >> "%PREFIX%\.condarc"
+
+rem # `conda create` (at least since 4.5) does not add the conda.bat script,
+rem # so we create it manually (has different env activation pattern).
+set "CONDA_BAT=%PREFIX%\Scripts\conda.bat"
+if not exist "%CONDA_BAT%" (
+    echo @echo off>                    "%CONDA_BAT%"
+    echo call "%CONDA%" %%*>>          "%CONDA_BAT%"
+)
+
+rem # same for activate.bat
+set "ACTIVATE_BAT=%PREFIX%\Scripts\activate.bat"
+if not exist "%ACTIVATE_BAT%" (
+    echo @echo off >  "%ACTIVATE_BAT%"
+    echo call "%CONDA_BASE_PREFIX%\Scripts\activate.bat" "%PREFIX%" >> "%ACTIVATE_BAT%"
+)
 
 for %%f in ( *.tar.bz2 ) do (
     echo Installing: %%f


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

conda 4.5 no longer installs activate.bat and conda.bat in the created environment.

Fixes gh-3375

##### Description of changes

Add conda.bat and activate.bat scripts again.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
