### PR TITLE
[ENH] Pythagorean Tree: children order

### DIFF
--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -120,8 +120,7 @@ class OWPythagorasTree(OWWidget):
             box_plot, self, 'show_legend', label='Show legend',
             callback=self.update_show_legend)
 
-        button_redraw = gui.button(
-            self.controlArea, self, label="Redraw", callback=self.redraw)
+        gui.button(self.controlArea, self, label="Redraw", callback=self.redraw)
 
         # Stretch to fit the rest of the unsused area
         gui.rubber(self.controlArea)

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -120,6 +120,9 @@ class OWPythagorasTree(OWWidget):
             box_plot, self, 'show_legend', label='Show legend',
             callback=self.update_show_legend)
 
+        button_redraw = gui.button(
+            self.controlArea, self, label="Redraw", callback=self.redraw)
+
         # Stretch to fit the rest of the unsused area
         gui.rubber(self.controlArea)
 
@@ -222,6 +225,10 @@ class OWPythagorasTree(OWWidget):
     def update_size_calc(self):
         """When the tree size calculation is updated."""
         self._update_log_scale_slider()
+        self.invalidate_tree()
+
+    def redraw(self):
+        self.tree_adapter.shuffle_children()
         self.invalidate_tree()
 
     def invalidate_tree(self):

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -135,7 +135,7 @@ class OWPythagorasTree(OWWidget):
         self.view.setRenderHint(QPainter.Antialiasing, True)
         self.mainArea.layout().addWidget(self.view)
 
-        self.ptree = PythagorasTreeViewer()
+        self.ptree = PythagorasTreeViewer(self)
         self.scene.addItem(self.ptree)
         self.view.set_central_widget(self.ptree)
 

--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -137,9 +137,10 @@ class PythagorasTreeViewer(QGraphicsWidget):
         """
         self.clear_tree()
         self.tree_adapter = tree_adapter
+        self.weight_adjustment = weight_adjustment
 
         if self.tree_adapter is not None:
-            self.root = self._calculate_tree(self.tree_adapter, weight_adjustment)
+            self.root = self._calculate_tree(self.tree_adapter, self.weight_adjustment)
             self.set_depth_limit(tree_adapter.max_depth)
             self.target_class_changed(target_class_index)
             self._draw_tree(self.root)
@@ -147,7 +148,8 @@ class PythagorasTreeViewer(QGraphicsWidget):
     def set_size_calc(self, weight_adjustment):
         """Set the weight adjustment on the tree. Redraws the whole tree."""
         # Since we have to redraw the whole tree anyways, just call `set_tree`
-        self.set_tree(self.tree_adapter, weight_adjustment,
+        self.weight_adjustment = weight_adjustment
+        self.set_tree(self.tree_adapter, self.weight_adjustment,
                       self._target_class_index)
 
     def set_depth_limit(self, depth):
@@ -466,6 +468,11 @@ class InteractiveSquareGraphicsItem(SquareGraphicsItem):
             fnc(parent)
             # propagate up the tree
             self._propagate_to_parents(parent, fnc, other_fnc)
+
+    def mouseDoubleClickEvent(self, event):
+        self.tree_node.tree.reverse_children(self.tree_node.label)
+        p = self.parentWidget()
+        p.set_tree(p.tree_adapter, p.weight_adjustment, p._target_class_index)
 
     def selection_changed(self):
         """Handle selection changed."""

--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -472,7 +472,7 @@ class InteractiveSquareGraphicsItem(SquareGraphicsItem):
     def mouseDoubleClickEvent(self, event):
         self.tree_node.tree.reverse_children(self.tree_node.label)
         p = self.parentWidget()
-        p.set_tree(p.tree_adapter, p.weight_adjustment, p._target_class_index)
+        p.set_tree(p.tree_adapter, p.weight_adjustment, self.tree_node.target_class_index)
 
     def selection_changed(self):
         """Handle selection changed."""

--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -89,7 +89,8 @@ class PythagorasTreeViewer(QGraphicsWidget):
 
     def __init__(self, parent=None, adapter=None, depth_limit=0, padding=0,
                  **kwargs):
-        super().__init__(parent)
+        super().__init__()
+        self.parent = parent
 
         # In case a tree was passed, it will be handled at the end of init
         self.tree_adapter = None
@@ -471,8 +472,10 @@ class InteractiveSquareGraphicsItem(SquareGraphicsItem):
 
     def mouseDoubleClickEvent(self, event):
         self.tree_node.tree.reverse_children(self.tree_node.label)
-        p = self.parentWidget()
+        p = self.parentWidget()  # PythagorasTreeViewer
         p.set_tree(p.tree_adapter, p.weight_adjustment, self.tree_node.target_class_index)
+        widget = p.parent  # OWPythagorasTree
+        widget._update_main_area()
 
     def selection_changed(self):
         """Handle selection changed."""

--- a/Orange/widgets/visualize/utils/tree/skltreeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/skltreeadapter.py
@@ -1,5 +1,6 @@
 """Tree adapter class for sklearn trees."""
 from collections import OrderedDict
+import random
 
 import numpy as np
 from Orange.widgets.visualize.utils.tree.treeadapter import BaseTreeAdapter
@@ -62,6 +63,15 @@ class SklTreeAdapter(BaseTreeAdapter):
 
     def __right_child(self, node):
         return self._tree.children_right[node]
+
+    def reverse_children(self, node):
+        self._tree.children_left[node], self._tree.children_right[node] = \
+            self._tree.children_right[node], self._tree.children_left[node]
+
+    def shuffle_children(self):
+        for i in range(self.num_nodes):
+            if random.randrange(2) == 0:
+                self.reverse_children(i)
 
     @memoize_method(maxsize=1024)
     def get_distribution(self, node):

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -296,6 +296,9 @@ class TreeAdapter(BaseTreeAdapter):
     def children(self, node):
         return [child for child in node.children if child is not None]
 
+    def reverse_children(self, node):
+        node.children = node.children[::-1]
+
     def shuffle_children(self):
         def _shuffle_children(node):
             if node and node.children:

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -118,6 +118,20 @@ class BaseTreeAdapter(metaclass=ABCMeta):
         """
         pass
 
+    def reverse_children(self, node):
+        """Reverse children of a given node.
+
+        Parameters
+        ----------
+        node : object
+        """
+        pass
+
+    def shuffle_children(self):
+        """Randomly shuffle node's children in the entire tree.
+        """
+        pass
+
     @abstractmethod
     def get_distribution(self, node):
         """Get the distribution of types for a given node.

--- a/Orange/widgets/visualize/utils/tree/treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/treeadapter.py
@@ -2,6 +2,7 @@
 from abc import ABCMeta, abstractmethod
 from functools import reduce
 from operator import add
+import random
 
 
 class BaseTreeAdapter(metaclass=ABCMeta):
@@ -294,6 +295,14 @@ class TreeAdapter(BaseTreeAdapter):
 
     def children(self, node):
         return [child for child in node.children if child is not None]
+
+    def shuffle_children(self):
+        def _shuffle_children(node):
+            if node and node.children:
+                random.shuffle(node.children)
+                for c in node.children:
+                    _shuffle_children(c)
+        _shuffle_children(self.root)
 
     def get_distribution(self, node):
         return [node.value]


### PR DESCRIPTION
##### Issue
Fixes #3330.

##### Description of changes
Implemented two new features that should enable visualizations of Pythagorean trees with less overlap:
- Add a button to completely redraw the tree with a random left/right ordering of children (this should give a user a good starting point).
- Double click on a node reverses the order of its children (for manual fine-tuning).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
