### PR TITLE
Switch index url for datasets widget.

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -135,7 +135,7 @@ class OWDataSets(widget.OWWidget):
     # The following constants can be overridden in a subclass
     # to reuse this widget for a different repository
     # Take care when refactoring! (used in e.g. single-cell)
-    INDEX_URL = "http://datasets.orange.biolab.si/"
+    INDEX_URL = "https://datasets.biolab.si/"
     DATASET_DIR = "datasets"
 
     # override HEADER_SCHEMA to define new columns


### PR DESCRIPTION
We have added support for HTTPS on domain datasets.biolab.si. Certificates are auto-renewed by Cloudflare, no more letsencrypt scripts. The datasets can be cached on Cloudflare.

This PR has to be merged before, otherwise urllib library will print warnings: https://github.com/biolab/serverfiles/pull/5

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
