### PR TITLE
Travis stage_after_success.sh fails.

### DIFF
--- a/.travis/build_doc.sh
+++ b/.travis/build_doc.sh
@@ -38,4 +38,4 @@ XVFBARGS="-screen 0 1280x1024x24"
 catchsegv xvfb-run -a -s "$XVFBARGS" \
     python $TRAVIS_BUILD_DIR/scripts/create_widget_catalog.py \
         --output build/html/ \
-        --url-prefix "http://docs.orange.biolab.si/3/visual-programming/"
+        --url-prefix "http://docs.biolab.si/3/visual-programming/"

--- a/.travis/upload_doc.sh
+++ b/.travis/upload_doc.sh
@@ -10,9 +10,9 @@ cp -r doc/data-mining-library/build/html doc/orange3doc/data-mining-library
 cp -r doc/development/build/html doc/orange3doc/development
 cp -r doc/visual-programming/build/html doc/orange3doc/visual-programming
 > ~/.ssh/config echo "
-Host orange.biolab.si
+Host biolab.si
     StrictHostKeyChecking no
     User uploaddocs
     IdentityFile $TRAVIS_BUILD_DIR/.travis/key.private
 "
-rsync -a --delete doc/orange3doc/ orange.biolab.si:/orange3doc/
+rsync -a --delete doc/orange3doc/ biolab.si:/orange3doc/


### PR DESCRIPTION
Updated travis scripts to fix the following error:
ssh: connect to host orange.biolab.si port 22: Cannot assign requested address

SSH to orange.biolab.si failed, because traffic is routed through Cloudflare.
It is replaced with a different domain that points directly to virtual machine (no proxies).
orange.biolab.si -> biolab.si

Additional fix: Cloudflare does not support subsubdomains, replaced with a subdomain with equivalent config (redirect to orange.biolab.si/docs).
docs.orange.biolab.si -> docs.biolab.si

##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
