### PR TITLE
[FIX] Removed header types and flags from .csv and .tab

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -377,6 +377,7 @@ class FileFormat(metaclass=FileFormatMeta):
     # Priority when multiple formats support the same extension. Also
     # the sort order in file open/save combo boxes. Lower is better.
     PRIORITY = 10000
+    OPTIONAL_TYPE_ANNOTATIONS = False
 
     def __init__(self, filename):
         """
@@ -798,7 +799,7 @@ class FileFormat(metaclass=FileFormatMeta):
                                                   zip(repeat('meta'), data.domain.metas)))))
 
     @classmethod
-    def write_headers(cls, write, data, with_annotations):
+    def write_headers(cls, write, data, with_annotations=True):
         """`write` is a callback that accepts an iterable"""
         write(cls.header_names(data))
         if with_annotations:
@@ -857,6 +858,7 @@ class CSVReader(FileFormat):
     SUPPORT_COMPRESSED = True
     SUPPORT_SPARSE_DATA = False
     PRIORITY = 20
+    OPTIONAL_TYPE_ANNOTATIONS = True
 
     def read(self):
         for encoding in (lambda: ('us-ascii', None),                 # fast
@@ -1060,7 +1062,7 @@ class DotReader(FileFormat):
         tree.export_graphviz(graph, out_file=cls.open(filename, 'wt'))
 
     @classmethod
-    def write(cls, filename, tree, with_annotations):
+    def write(cls, filename, tree, with_annotations=True):
         if type(tree) == dict:
             tree = tree['tree']
         cls.write_graph(filename, tree)

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -1026,7 +1026,7 @@ class ExcelReader(FileFormat):
         return table
 
     @classmethod
-    def write_file(cls, filename, data):
+    def write_file(cls, filename, data, with_annotations=True):
         vars = list(chain((ContinuousVariable('_w'),) if data.has_weights() else (),
                           data.domain.attributes,
                           data.domain.class_vars,

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -922,6 +922,10 @@ class CSVReader(FileFormat):
             cls.write_data(writer.writerow, data)
         cls.write_table_metadata(filename, data)
 
+    @classmethod
+    def write_headers(cls, write, data):
+        write(cls.header_names(data))
+
 
 class TabReader(CSVReader):
     """Reader for tab separated files"""

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -926,7 +926,6 @@ class CSVReader(FileFormat):
             writer = csv.writer(file, delimiter=cls.DELIMITERS[0])
             cls.write_headers(writer.writerow, data, with_annotations)
             cls.write_data(writer.writerow, data)
-        if with_annotations:
             cls.write_table_metadata(filename, data)
 
 

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -433,7 +433,10 @@ class FileFormat(metaclass=FileFormatMeta):
 
     @classmethod
     def write(cls, filename, data, with_annotations=True):
-        return cls.write_file(filename, data, with_annotations)
+        if cls.OPTIONAL_TYPE_ANNOTATIONS:
+            return cls.write_file(filename, data, with_annotations)
+        else:
+            return cls.write_file(filename, data)
 
     @classmethod
     def write_table_metadata(cls, filename, data):
@@ -951,7 +954,7 @@ class PickleReader(FileFormat):
                 return table
 
     @classmethod
-    def write_file(cls, filename, data, with_annotations=True):
+    def write_file(cls, filename, data):
         with cls.open(filename, 'wb') as f:
             pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
 
@@ -1028,7 +1031,7 @@ class ExcelReader(FileFormat):
         return table
 
     @classmethod
-    def write_file(cls, filename, data, with_annotations=True):
+    def write_file(cls, filename, data):
         vars = list(chain((ContinuousVariable('_w'),) if data.has_weights() else (),
                           data.domain.attributes,
                           data.domain.class_vars,
@@ -1062,7 +1065,7 @@ class DotReader(FileFormat):
         tree.export_graphviz(graph, out_file=cls.open(filename, 'wt'))
 
     @classmethod
-    def write(cls, filename, tree, with_annotations=True):
+    def write(cls, filename, tree):
         if type(tree) == dict:
             tree = tree['tree']
         cls.write_graph(filename, tree)

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -7,12 +7,10 @@ import os
 import tempfile
 import shutil
 import io
-import csv
 
 from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader
 from Orange.data.table import get_sample_datasets_dir
 from Orange.data import Table
-
 
 
 class WildcardReader(FileFormat):
@@ -86,11 +84,11 @@ class TestLocate(unittest.TestCase):
         fn = os.path.join(tempdir, "t.wild8")
         with open(fn, "wt") as f:
             f.write("\n")
-        l = FileFormat.locate("t.wild8", search_dirs=[tempdir])
-        self.assertEqual(l, fn)
+        location = FileFormat.locate("t.wild8", search_dirs=[tempdir])
+        self.assertEqual(location, fn)
         # test extension adding
-        l = FileFormat.locate("t", search_dirs=[tempdir])
-        self.assertEqual(l, fn)
+        location = FileFormat.locate("t", search_dirs=[tempdir])
+        self.assertEqual(location, fn)
         shutil.rmtree(tempdir)
 
 
@@ -141,8 +139,8 @@ class TestReader(unittest.TestCase):
     @patch('csv.DictWriter.writerow')
     def test_header_call(self, writer):
         CSVReader.write_headers(writer, Table("iris"), False)
-        self.assertEquals(len(writer.call_args_list), 1)
+        self.assertEqual(len(writer.call_args_list), 1)
 
         writer.reset_mock()
         CSVReader.write_headers(writer, Table("iris"), True)
-        self.assertEquals(len(writer.call_args_list), 3)
+        self.assertEqual(len(writer.call_args_list), 3)

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -48,6 +48,7 @@ class OWSave(widget.OWWidget):
     filetype = Setting(FILE_TYPES[0][0])
     compression = Setting(COMPRESSIONS[0][0])
     compress = Setting(False)
+    with_annotations = Setting(True)
 
     def __init__(self):
         super().__init__()
@@ -88,6 +89,10 @@ class OWSave(widget.OWWidget):
         form.addRow(self.controls.compress, self.controls.compression)
 
         box.layout().addLayout(form)
+
+        self.annotations_cb = gui.checkBox(
+            self.controlArea, self, "with_annotations", label="Save with Orange annotations",
+        )
 
         self.save = gui.auto_commit(
             self.controlArea, self, "auto_save", "Save", box=False,
@@ -175,7 +180,8 @@ class OWSave(widget.OWWidget):
                     os.path.join(
                         self.last_dir,
                         self.basename + self.type_ext + self.compress_ext),
-                    self.data)
+                    self.data, self.with_annotations,
+                    )
             except Exception as err_value:
                 self.error(str(err_value))
             else:
@@ -183,6 +189,9 @@ class OWSave(widget.OWWidget):
 
     def update_extension(self):
         self.type_ext = [ext for name, ext, _ in FILE_TYPES if name == self.filetype][0]
+        self.annotations_cb.setEnabled(True)
+        if self.type_ext == '.pkl':
+            self.annotations_cb.setEnabled(False)
         self.compress_ext = dict(COMPRESSIONS)[self.compression] if self.compress else ''
 
     def _update_text(self):

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -177,11 +177,10 @@ class OWSave(widget.OWWidget):
         else:
             try:
                 self.get_writer_selected().write(
-                        os.path.join(
-                            self.last_dir,
-                            self.basename + self.type_ext + self.compress_ext),
-                        self.data, self.add_type_annotations,
-                        )
+                    os.path.join(
+                        self.last_dir,
+                        self.basename + self.type_ext + self.compress_ext),
+                    self.data, self.add_type_annotations)
 
             except Exception as err_value:
                 self.error(str(err_value))

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -91,8 +91,9 @@ class OWSave(widget.OWWidget):
         box.layout().addLayout(form)
 
         self.annotations_cb = gui.checkBox(
-            self.controlArea, self, "add_type_annotations", label="Add type annotations",
+            None, self, "add_type_annotations", label="Add type annotations",
         )
+        form.addRow(self.annotations_cb, None)
 
         self.save = gui.auto_commit(
             self.controlArea, self, "auto_save", "Save", box=False,

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -48,7 +48,7 @@ class OWSave(widget.OWWidget):
     filetype = Setting(FILE_TYPES[0][0])
     compression = Setting(COMPRESSIONS[0][0])
     compress = Setting(False)
-    with_annotations = Setting(True)
+    add_type_annotations = Setting(True)
 
     def __init__(self):
         super().__init__()
@@ -91,7 +91,7 @@ class OWSave(widget.OWWidget):
         box.layout().addLayout(form)
 
         self.annotations_cb = gui.checkBox(
-            self.controlArea, self, "with_annotations", label="Add type annotations",
+            self.controlArea, self, "add_type_annotations", label="Add type annotations",
         )
 
         self.save = gui.auto_commit(
@@ -176,19 +176,11 @@ class OWSave(widget.OWWidget):
             self.save_file_as()
         else:
             try:
-                if self.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
-                    self.get_writer_selected().write(
+                self.get_writer_selected().write(
                         os.path.join(
                             self.last_dir,
                             self.basename + self.type_ext + self.compress_ext),
-                        self.data, self.with_annotations,
-                        )
-                else:
-                    self.get_writer_selected().write(
-                        os.path.join(
-                            self.last_dir,
-                            self.basename + self.type_ext + self.compress_ext),
-                        self.data,
+                        self.data, self.add_type_annotations,
                         )
 
             except Exception as err_value:

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -190,7 +190,7 @@ class OWSave(widget.OWWidget):
     def update_extension(self):
         self.type_ext = [ext for name, ext, _ in FILE_TYPES if name == self.filetype][0]
         self.annotations_cb.setEnabled(True)
-        if self.type_ext == '.pkl':
+        if self.type_ext in ['.pkl', '.xlsx']:
             self.annotations_cb.setEnabled(False)
         self.compress_ext = dict(COMPRESSIONS)[self.compression] if self.compress else ''
 

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -91,7 +91,7 @@ class OWSave(widget.OWWidget):
         box.layout().addLayout(form)
 
         self.annotations_cb = gui.checkBox(
-            self.controlArea, self, "with_annotations", label="Save with Orange annotations",
+            self.controlArea, self, "with_annotations", label="Add type annotations",
         )
 
         self.save = gui.auto_commit(
@@ -176,12 +176,21 @@ class OWSave(widget.OWWidget):
             self.save_file_as()
         else:
             try:
-                self.get_writer_selected().write(
-                    os.path.join(
-                        self.last_dir,
-                        self.basename + self.type_ext + self.compress_ext),
-                    self.data, self.with_annotations,
-                    )
+                if self.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
+                    self.get_writer_selected().write(
+                        os.path.join(
+                            self.last_dir,
+                            self.basename + self.type_ext + self.compress_ext),
+                        self.data, self.with_annotations,
+                        )
+                else:
+                    self.get_writer_selected().write(
+                        os.path.join(
+                            self.last_dir,
+                            self.basename + self.type_ext + self.compress_ext),
+                        self.data,
+                        )
+
             except Exception as err_value:
                 self.error(str(err_value))
             else:
@@ -189,9 +198,9 @@ class OWSave(widget.OWWidget):
 
     def update_extension(self):
         self.type_ext = [ext for name, ext, _ in FILE_TYPES if name == self.filetype][0]
-        self.annotations_cb.setEnabled(True)
-        if self.type_ext in ['.pkl', '.xlsx']:
-            self.annotations_cb.setEnabled(False)
+        self.annotations_cb.setEnabled(False)
+        if self.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
+            self.annotations_cb.setEnabled(True)
         self.compress_ext = dict(COMPRESSIONS)[self.compression] if self.compress else ''
 
     def _update_text(self):

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -66,6 +66,34 @@ class TestOWSave(WidgetTest):
                     self.widget.save_file_as()
                 self.assertEqual(len(Table(filename)), 150)
 
+    @patch('Orange.data.io.FileFormat.write')
+    def test_annotations(self, write):
+        widget = self.widget
+
+        self.send_signal(widget.Inputs.data, Table("iris"))
+        widget.filetype = FILE_TYPES[1][0]
+        widget.filename = 'foo.csv'
+        widget.update_extension()
+
+        widget.add_type_annotations = False
+        widget.unconditional_save_file() 
+        write.assert_called()
+        self.assertFalse(write.call_args[0][2])
+
+        widget.add_type_annotations = True
+        widget.unconditional_save_file()
+        self.assertTrue(write.call_args[0][2])
+
+    def test_disable_checkbox(self):
+        widget = self.widget
+        for type_ in FILE_TYPES:
+            widget.filetype=type_[0]
+            widget.update_extension()
+            if  widget.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
+                self.assertTrue(widget.annotations_cb.isEnabled())
+            else:
+                self.assertFalse(widget.annotations_cb.isEnabled())
+
     def test_compression(self):
         self.send_signal(self.widget.Inputs.data, Table("iris"))
 

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -76,7 +76,7 @@ class TestOWSave(WidgetTest):
         widget.update_extension()
 
         widget.add_type_annotations = False
-        widget.unconditional_save_file() 
+        widget.unconditional_save_file()
         write.assert_called()
         self.assertFalse(write.call_args[0][2])
 
@@ -87,9 +87,9 @@ class TestOWSave(WidgetTest):
     def test_disable_checkbox(self):
         widget = self.widget
         for type_ in FILE_TYPES:
-            widget.filetype=type_[0]
+            widget.filetype = type_[0]
             widget.update_extension()
-            if  widget.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
+            if widget.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
                 self.assertTrue(widget.annotations_cb.isEnabled())
             else:
                 self.assertFalse(widget.annotations_cb.isEnabled())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Addreses #2717. 

##### Description of changes
When saving, header types and flags are no loger saved in .csv and .tab.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
