### PR TITLE
[FIX] Projections: Retain embedding if non-relevant variables change

### DIFF
--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -66,7 +66,6 @@ class OWtSNE(OWDataProjectionWidget):
         super().__init__()
         self.pca_data = None
         self.projection = None
-        self.__invalidated = True
         self.__update_loop = None
         # timer for scheduling updates
         self.__timer = QTimer(self, singleShot=True, interval=1,
@@ -111,11 +110,6 @@ class OWtSNE(OWDataProjectionWidget):
         gui.separator(box, 10)
         gui.hSlider(box, self, "pca_components", label="PCA components:",
                     minValue=2, maxValue=50, step=1)
-
-    def set_data(self, data):
-        self.__invalidated = not (self.data and data and
-                                  np.array_equal(self.data.X, data.X))
-        super().set_data(data)
 
     def check_data(self):
         def error(err):
@@ -251,14 +245,9 @@ class OWtSNE(OWDataProjectionWidget):
 
         self.__in_next_step = False
 
-    def handleNewSignals(self):
-        if self.__invalidated:
-            self.__invalidated = False
-            self.setup_plot()
-            self.start()
-        else:
-            self.graph.update_point_props()
-        self.commit()
+    def setup_plot(self):
+        super().setup_plot()
+        self.start()
 
     def commit(self):
         super().commit()
@@ -281,12 +270,11 @@ class OWtSNE(OWDataProjectionWidget):
         self.Outputs.preprocessor.send(prep)
 
     def clear(self):
-        if self.__invalidated:
-            super().clear()
-            self.__set_update_loop(None)
-            self.__state = OWtSNE.Waiting
-            self.pca_data = None
-            self.projection = None
+        super().clear()
+        self.__set_update_loop(None)
+        self.__state = OWtSNE.Waiting
+        self.pca_data = None
+        self.projection = None
 
     @classmethod
     def migrate_settings(cls, settings, version):

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -1,8 +1,6 @@
 import unittest
 import numpy as np
 
-from AnyQt.QtTest import QSignalSpy
-
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain, Table
 from Orange.preprocess import Preprocess
 from Orange.widgets.tests.base import (
@@ -97,23 +95,6 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin,
                                    rtol=1, atol=1)
         self.assertEqual([a.name for a in transformed.domain.attributes],
                          [m.name for m in output.domain.metas[:2]])
-
-    def test_invalidated_embedding(self):
-        self.widget.graph.update_coordinates = unittest.mock.Mock()
-        self.widget.graph.update_point_props = unittest.mock.Mock()
-        self.send_signal(self.widget.Inputs.data, self.data)
-        self.widget.graph.update_coordinates.assert_called_once()
-        self.widget.graph.update_point_props.assert_called_once()
-
-        if self.widget.isBlocking():
-            spy = QSignalSpy(self.widget.blockingStateChanged)
-            self.assertTrue(spy.wait(5000))
-
-        self.widget.graph.update_coordinates.reset_mock()
-        self.widget.graph.update_point_props.reset_mock()
-        self.send_signal(self.widget.Inputs.data, self.data)
-        self.widget.graph.update_coordinates.assert_not_called()
-        self.widget.graph.update_point_props.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -496,6 +496,7 @@ class PyListModel(QAbstractListModel):
     """
     MIME_TYPE = "application/x-Orange-PyListModelData"
     Separator = object()
+    removed = Signal()
 
     def __init__(self, iterable=None, parent=None,
                  flags=Qt.ItemIsSelectable | Qt.ItemIsEnabled,
@@ -616,6 +617,7 @@ class PyListModel(QAbstractListModel):
         """
         if not parent.isValid():
             del self[row:row + count]
+            self.removed.emit()
             return True
         else:
             return False

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -271,8 +271,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
 
     def __init__(self):
         self.model_selected = VariableListModel(enable_dnd=True)
-        self.model_selected.rowsInserted.connect(self.__model_selected_changed)
-        self.model_selected.rowsRemoved.connect(self.__model_selected_changed)
+        self.model_selected.removed.connect(self.__model_selected_changed)
         self.model_other = VariableListModel(enable_dnd=True)
 
         self.vizrank, self.btn_vizrank = LinearProjectionVizRank.add_vizrank(
@@ -296,6 +295,8 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         self.variables_selection = VariablesSelection(
             self, self.model_selected, self.model_other, self.controlArea
         )
+        self.variables_selection.added.connect(self.__model_selected_changed)
+        self.variables_selection.removed.connect(self.__model_selected_changed)
         self.variables_selection.add_remove.layout().addWidget(
             self.btn_vizrank
         )
@@ -328,6 +329,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         self.model_selected[:] = attrs[:]
         self.model_other[:] = [var for var in self.continuous_variables
                                if var not in attrs]
+        self.__model_selected_changed()
 
     def __model_selected_changed(self):
         self.selected_vars = [(var.name, vartype(var)) for var
@@ -368,6 +370,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
 
         self._check_options()
         self._init_vizrank()
+        self.init_projection()
 
     def _check_options(self):
         buttons = self.radio_placement.buttons
@@ -423,8 +426,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         self.selected_vars = []
 
     def init_projection(self):
-        if not len(self.effective_variables):
-            return
         if self.placement == self.Placement.Circular:
             self.projector = CircularPlacement()
         elif self.placement == self.Placement.LDA:

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -287,8 +287,7 @@ class OWRadviz(OWAnchorProjectionWidget):
 
     def __init__(self):
         self.model_selected = VariableListModel(enable_dnd=True)
-        self.model_selected.rowsInserted.connect(self.__model_selected_changed)
-        self.model_selected.rowsRemoved.connect(self.__model_selected_changed)
+        self.model_selected.removed.connect(self.__model_selected_changed)
         self.model_other = VariableListModel(enable_dnd=True)
 
         self.vizrank, self.btn_vizrank = RadvizVizRank.add_vizrank(
@@ -300,6 +299,8 @@ class OWRadviz(OWAnchorProjectionWidget):
         self.variables_selection = VariablesSelection(
             self, self.model_selected, self.model_other, self.controlArea
         )
+        self.variables_selection.added.connect(self.__model_selected_changed)
+        self.variables_selection.removed.connect(self.__model_selected_changed)
         self.variables_selection.add_remove.layout().addWidget(
             self.btn_vizrank
         )
@@ -325,6 +326,7 @@ class OWRadviz(OWAnchorProjectionWidget):
         self.model_selected[:] = attrs[:]
         self.model_other[:] = [var for var in self.primitive_variables
                                if var not in attrs]
+        self.__model_selected_changed()
 
     def __model_selected_changed(self):
         self.selected_vars = [(var.name, vartype(var)) for var
@@ -359,6 +361,7 @@ class OWRadviz(OWAnchorProjectionWidget):
             self.model_other[:] = variables[5:] + class_var
 
         self._init_vizrank()
+        self.init_projection()
 
     def _init_vizrank(self):
         is_enabled = self.data is not None and \

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -262,6 +262,10 @@ class OWScatterPlot(OWDataProjectionWidget):
             callback=self.switch_sampling, commit=lambda: self.add_data(1))
         self.sampling.setVisible(False)
 
+    @property
+    def effective_variables(self):
+        return [self.attr_x, self.attr_y]
+
     def _vizrank_color_change(self):
         self.vizrank.initialize()
         is_enabled = self.data is not None and not self.data.is_sparse() and \

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -169,8 +169,6 @@ class LinProjVizRankTests(WidgetTest):
     def setUpClass(cls):
         super().setUpClass()
         cls.data = Table("iris")
-        # dom = Domain(cls.iris.domain.attributes, [])
-        # cls.iris_no_class = Table(dom, cls.iris)
 
     def setUp(self):
         self.widget = self.create_widget(OWLinearProjection)
@@ -192,6 +190,7 @@ class LinProjVizRankTests(WidgetTest):
     def test_set_attrs(self):
         self.send_signal(self.widget.Inputs.data, self.data)
         model_selected = self.widget.model_selected[:]
+        c1 = self.get_output(self.widget.Outputs.components)
         self.vizrank.toggle()
         self.process_events(until=lambda: not self.vizrank.keep_running)
         self.assertEqual(len(self.vizrank.scores), self.vizrank.state_count())
@@ -200,3 +199,5 @@ class LinProjVizRankTests(WidgetTest):
             QItemSelectionModel.ClearAndSelect
         )
         self.assertNotEqual(self.widget.model_selected[:], model_selected)
+        c2 = self.get_output(self.widget.Outputs.components)
+        self.assertNotEqual(c1.domain.attributes, c2.domain.attributes)

--- a/Orange/widgets/visualize/tests/test_owradviz.py
+++ b/Orange/widgets/visualize/tests/test_owradviz.py
@@ -63,10 +63,12 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
     def test_saved_features(self):
         self.send_signal(self.widget.Inputs.data, self.data)
         self.widget.model_selected.pop(0)
+        self.widget.variables_selection.removed.emit()
+        selected = [a.name for a in self.widget.model_selected]
+
         settings = self.widget.settingsHandler.pack_data(self.widget)
         w = self.create_widget(OWRadviz, stored_settings=settings)
-        self.send_signal(self.widget.Inputs.data, self.data, widget=w)
-        selected = [a.name for a in self.widget.model_selected]
+        self.send_signal(w.Inputs.data, self.data, widget=w)
         self.assertListEqual(selected, [a.name for a in w.model_selected])
         self.send_signal(self.widget.Inputs.data, self.heart_disease)
         selected = [a.name for a in self.widget.model_selected]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Embedding was recalculated and the graph reploted even though the variables used remain the same with new input data.

##### Description of changes
Adjust OWDataProjectionWidget not to recalculate the embedding. 
Consider MDS separately since it takes two inputs (DataTable, DistMatrix).
Fix OWRadViz and OWLinearProjection not to plot data until available features list box is set.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
