### PR TITLE
Projections: Move OWPlotGUI instance from graph to widget

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -169,16 +169,17 @@ class OWMDS(OWDataProjectionWidget):
 
         self.graph.pause_drawing_pairs()
 
-        g = self.graph.gui
-        self.size_model = g.points_models[2]
-        self.size_model.order = g.points_models[2].order[:1] + ("Stress", ) + \
-                                g.points_models[2].order[1:]
+        self.size_model = self.gui.points_models[2]
+        self.size_model.order = \
+            self.gui.points_models[2].order[:1] \
+            + ("Stress", ) + \
+            self.gui.points_models[2].order[1:]
         # self._initialize()
 
     def _add_controls(self):
         self._add_controls_optimization()
         super()._add_controls()
-        self.graph.gui.add_control(
+        self.gui.add_control(
             self._effects_box, gui.hSlider, "Show similar pairs:",
             master=self.graph, value="connected_pairs", minValue=0,
             maxValue=20, createLabel=False, callback=self._on_connected_changed

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -81,7 +81,7 @@ class OWtSNE(OWDataProjectionWidget):
         # showing all attributes in combo boxes can cause problems
         # QUICKFIX: Remove a separator and attributes from order
         # (leaving just the class and metas)
-        self.models = self.graph.gui.points_models
+        self.models = self.gui.points_models
         for model in self.models:
             model.order = model.order[:-2]
 

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -438,9 +438,9 @@ class OWPlotGUI:
 
     JITTER_SIZES = [0, 0.1, 0.5, 1, 2, 3, 4, 5, 7, 10]
 
-
-    def __init__(self, plot):
-        self._plot = plot
+    def __init__(self, master):
+        self._master = master
+        self._plot = master.graph
         self.color_model = DomainModel(
             placeholder="(Same color)", valid_types=DomainModel.PRIMITIVE)
         self.shape_model = DomainModel(
@@ -599,17 +599,17 @@ class OWPlotGUI:
 
     def tooltip_shows_all_check_box(self, widget):
         gui.checkBox(
-            widget=widget, master=self._plot.master, value="tooltip_shows_all",
+            widget=widget, master=self._master, value="tooltip_shows_all",
             label='Show all data on mouse hover')
 
     def class_density_check_box(self, widget):
-        self._plot.master.cb_class_density = \
+        self._master.cb_class_density = \
             self._check_box(widget=widget, value="class_density",
                             label="Show color regions",
                             cb_name=self._plot.update_density)
 
     def regression_line_check_box(self, widget):
-        self._plot.master.cb_reg_line = \
+        self._master.cb_reg_line = \
             self._check_box(widget=widget, value="show_reg_line",
                             label="Show regression line",
                             cb_name=self._plot.update_regression_line)
@@ -651,7 +651,7 @@ class OWPlotGUI:
             widget, gui.hSlider, label,
             master=self._plot, value=value, minValue=min_value,
             maxValue=max_value, step=step, createLabel=show_number,
-            callback=self._get_callback(cb_name, self._plot.master))
+            callback=self._get_callback(cb_name, self._master))
 
     def point_size_slider(self, widget, label="Symbol size:   "):
         '''
@@ -668,8 +668,8 @@ class OWPlotGUI:
     def _combo(self, widget, value, label, cb_name, items=(), model=None):
         return self.add_control(
             widget, gui.comboBox, label,
-            master=self._plot.master, value=value, items=items, model=model,
-            callback=self._get_callback(cb_name, self._plot.master),
+            master=self._master, value=value, items=items, model=model,
+            callback=self._get_callback(cb_name, self._master),
             orientation=Qt.Horizontal, valueType=str,
             sendSelectedValue=True, contentsLength=12,
             labelWidth=50)
@@ -885,3 +885,19 @@ class OWPlotGUI:
         c.addItem('Light')
         c.addItem('Dark')
         return c
+
+    def box_zoom_select(self, parent):
+        box_zoom_select = gui.vBox(parent, "Zoom/Select")
+        zoom_select_toolbar = self.zoom_select_toolbar(
+            box_zoom_select, nomargin=True,
+            buttons=[self.StateButtonsBegin,
+                     self.SimpleSelect, self.Pan, self.Zoom,
+                     self.StateButtonsEnd,
+                     self.ZoomReset]
+        )
+        buttons = zoom_select_toolbar.buttons
+        buttons[self.Zoom].clicked.connect(self._plot.zoom_button_clicked)
+        buttons[self.Pan].clicked.connect(self._plot.pan_button_clicked)
+        buttons[self.SimpleSelect].clicked.connect(self._plot.select_button_clicked)
+        buttons[self.ZoomReset].clicked.connect(self._plot.reset_button_clicked)
+        return box_zoom_select

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -246,7 +246,7 @@ class OWFreeViz(OWAnchorProjectionWidget):
     def _add_controls(self):
         self.__add_controls_start_box()
         super()._add_controls()
-        self.graph.gui.add_control(
+        self.gui.add_control(
             self._effects_box, gui.hSlider, "Hide radius:", master=self.graph,
             value="hide_radius", minValue=0, maxValue=100, step=10,
             createLabel=False, callback=self.__radius_slider_changed

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -283,7 +283,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         self._add_controls_variables()
         self._add_controls_placement()
         super()._add_controls()
-        self.graph.gui.add_control(
+        self.gui.add_control(
             self._effects_box, gui.hSlider, "Hide radius:", master=self.graph,
             value="hide_radius", minValue=0, maxValue=100, step=10,
             createLabel=False, callback=self.__radius_slider_changed

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -231,12 +231,12 @@ class OWScatterPlot(OWDataProjectionWidget):
         self._add_controls_axis()
         self._add_controls_sampling()
         super()._add_controls()
-        self.graph.gui.add_widget(self.graph.gui.JitterNumericValues,
-                                  self._effects_box)
-        self.graph.gui.add_widgets([self.graph.gui.ShowGridLines,
-                                    self.graph.gui.ToolTipShowsAll,
-                                    self.graph.gui.RegressionLine],
-                                   self._plot_box)
+        self.gui.add_widget(self.gui.JitterNumericValues, self._effects_box)
+        self.gui.add_widgets(
+            [self.gui.ShowGridLines,
+             self.gui.ToolTipShowsAll,
+             self.gui.RegressionLine],
+            self._plot_box)
 
     def _add_controls_axis(self):
         common_options = dict(
@@ -298,17 +298,13 @@ class OWScatterPlot(OWDataProjectionWidget):
         if isinstance(self.attr_y, str):
             self.attr_y = findvar(self.attr_y, self.xy_model)
         if isinstance(self.attr_label, str):
-            self.attr_label = findvar(
-                self.attr_label, self.graph.gui.label_model)
+            self.attr_label = findvar(self.attr_label, self.gui.label_model)
         if isinstance(self.attr_color, str):
-            self.attr_color = findvar(
-                self.attr_color, self.graph.gui.color_model)
+            self.attr_color = findvar(self.attr_color, self.gui.color_model)
         if isinstance(self.attr_shape, str):
-            self.attr_shape = findvar(
-                self.attr_shape, self.graph.gui.shape_model)
+            self.attr_shape = findvar(self.attr_shape, self.gui.shape_model)
         if isinstance(self.attr_size, str):
-            self.attr_size = findvar(
-                self.attr_size, self.graph.gui.size_model)
+            self.attr_size = findvar(self.attr_size, self.gui.size_model)
 
     def check_data(self):
         self.clear_messages()

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -26,7 +26,7 @@ from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils import classdensity
 from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
-from Orange.widgets.utils.plot import OWPalette, OWPlotGUI
+from Orange.widgets.utils.plot import OWPalette
 from Orange.widgets.visualize.owscatterplotgraph_obsolete import (
     OWScatterPlotGraph as OWScatterPlotGraphObs
 )
@@ -386,7 +386,6 @@ class OWScatterPlotBase(gui.OWComponent):
         self.sample_size = None
         self.sample_indices = None
 
-        self.gui = OWPlotGUI(self)
         self.palette = None
 
         self.shape_legend = self._create_legend(((1, 0), (1, 0)))
@@ -1249,21 +1248,6 @@ class OWScatterPlotBase(gui.OWComponent):
             return True
         else:
             return False
-
-    def box_zoom_select(self, parent):
-        g = self.gui
-        box_zoom_select = gui.vBox(parent, "Zoom/Select")
-        zoom_select_toolbar = g.zoom_select_toolbar(
-            box_zoom_select, nomargin=True,
-            buttons=[g.StateButtonsBegin, g.SimpleSelect, g.Pan, g.Zoom,
-                     g.StateButtonsEnd, g.ZoomReset]
-        )
-        buttons = zoom_select_toolbar.buttons
-        buttons[g.Zoom].clicked.connect(self.zoom_button_clicked)
-        buttons[g.Pan].clicked.connect(self.pan_button_clicked)
-        buttons[g.SimpleSelect].clicked.connect(self.select_button_clicked)
-        buttons[g.ZoomReset].clicked.connect(self.reset_button_clicked)
-        return box_zoom_select
 
 
 class HelpEventDelegate(EventDelegate):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -23,6 +23,7 @@ from Orange.widgets.utils.annotated_data import (
 from Orange.widgets.utils.colorpalette import (
     ColorPaletteGenerator, ContinuousPaletteGenerator, DefaultRGBColors
 )
+from Orange.widgets.utils.plot import OWPlotGUI
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
 from Orange.widgets.visualize.utils.component import OWGraphWithAnchors
@@ -387,14 +388,16 @@ class OWDataProjectionWidget(OWProjectionWidgetBase):
         box.layout().addWidget(self.graph.plot_widget)
 
     def _add_controls(self):
-        self._point_box = self.graph.gui.point_properties_box(self.controlArea)
-        self._effects_box = self.graph.gui.effects_box(self.controlArea)
-        self._plot_box = self.graph.gui.plot_properties_box(self.controlArea)
-        self.control_area_stretch = gui.widgetBox(self.controlArea)
+        self.gui = OWPlotGUI(self)
+        area = self.controlArea
+        self._point_box = self.gui.point_properties_box(area)
+        self._effects_box = self.gui.effects_box(area)
+        self._plot_box = self.gui.plot_properties_box(area)
+        self.control_area_stretch = gui.widgetBox(area)
         self.control_area_stretch.layout().addStretch(100)
-        self.graph.box_zoom_select(self.controlArea)
-        gui.auto_commit(self.controlArea, self, "auto_commit",
-                        "Send Selection", "Send Automatically")
+        self.gui.box_zoom_select(area)
+        gui.auto_commit(
+            area, self, "auto_commit", "Send Selection", "Send Automatically")
 
     @property
     def effective_variables(self):


### PR DESCRIPTION
After reimplementing projections, the reference to an instance of `OWPlotGui` remained on the plot although it is actually used by the widget. This PR moves it where it belongs.

Justification for the move is obvious from the diff. :)

##### Includes
- [X] Code changes
