### PR TITLE
Projections: Remove locks from ScatterPlotItem

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1,7 +1,6 @@
 import sys
 import itertools
 import warnings
-import threading
 from xml.sax.saxutils import escape
 from math import log10, floor, ceil
 
@@ -219,18 +218,10 @@ class OWScatterPlotGraph(OWScatterPlotGraphObs):
 
 
 class ScatterPlotItem(pg.ScatterPlotItem):
-    def __init__(self, *args, **kwargs):
-        self.lock = threading.Lock()
-        super().__init__(*args, **kwargs)
-
     def paint(self, painter, option, widget=None):
-        with self.lock:
-            painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
-            super().paint(painter, option, widget)
+        painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
+        super().paint(painter, option, widget)
 
-    def setData(self, *args, **kwargs):
-        with self.lock:
-            super().setData(*args ,**kwargs)
 
 def _define_symbols():
     """


### PR DESCRIPTION
When reimplementing networks, I have put locks on `ScatterPlotItem`'s `paint` (see the [commit](https://github.com/janezd/orange3/commit/0c8080401b181f6bb2d5338c23c7723ffe468a99)). As @ales-erjavec explained later, Qt's graphics' paint must execute in the main thread, so this lock has no effect. This PR reverts the change.

##### Includes
- [X] Code changes