### PR TITLE
[FIX] OWDataProjectionWidget: Consider tables with nan-s equal

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -896,9 +896,10 @@ class ProjectionWidgetTestMixin:
 
     def test_plot_once(self, timeout=DEFAULT_TIMEOUT):
         """Test if data is plotted only once but committed on every input change"""
+        table = Table("heart_disease")
         self.widget.setup_plot = Mock()
         self.widget.commit = Mock()
-        self.send_signal(self.widget.Inputs.data, self.data)
+        self.send_signal(self.widget.Inputs.data, table)
         self.widget.setup_plot.assert_called_once()
         self.widget.commit.assert_called_once()
 
@@ -907,7 +908,7 @@ class ProjectionWidgetTestMixin:
             self.assertTrue(spy.wait(timeout))
 
         self.widget.commit.reset_mock()
-        self.send_signal(self.widget.Inputs.data_subset, self.data[::10])
+        self.send_signal(self.widget.Inputs.data_subset, table[::10])
         self.widget.setup_plot.assert_called_once()
         self.widget.commit.assert_called_once()
 

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -420,9 +420,11 @@ class OWDataProjectionWidget(OWProjectionWidgetBase):
         if not same_domain:
             self.init_attr_values()
         self.openContext(self.data)
-        self.__invalidated = not (data_existed and self.data is not None and
-                                  np.array_equal(effective_data.X,
-                                                 self.effective_data.X))
+        self.__invalidated = not (
+            data_existed and self.data is not None and
+            effective_data.X.shape == self.effective_data.X.shape and
+            np.allclose(effective_data.X,
+                        self.effective_data.X, equal_nan=True))
         if self.__invalidated:
             self.clear()
         self.cb_class_density.setEnabled(self.can_draw_density())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When widget received (unchanged) data with missing values on the input (i.e. Reloading the file) the embedding was recalculated.

##### Description of changes
When comparing previous and current table.X, consider np.nan-s equal.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
