### PR TITLE
[FIX] Scatter Plot: Replot when input Features

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -411,10 +411,11 @@ class OWScatterPlot(OWDataProjectionWidget):
                 self.data.domain is not None and \
                 all(attr in self.data.domain for attr
                         in self.attribute_selection_list):
-            self.attr_x = self.attribute_selection_list[0]
-            self.attr_y = self.attribute_selection_list[1]
-        self.attribute_selection_list = None
-        super().handleNewSignals()
+            self.set_attr(self.attribute_selection_list[0],
+                          self.attribute_selection_list[1])
+            self.attribute_selection_list = None
+        else:
+            super().handleNewSignals()
         self._vizrank_color_change()
         self.cb_reg_line.setEnabled(self.can_draw_regresssion_line())
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -427,8 +427,9 @@ class OWScatterPlot(OWDataProjectionWidget):
             self.attribute_selection_list = None
 
     def set_attr(self, attr_x, attr_y):
-        self.attr_x, self.attr_y = attr_x, attr_y
-        self.attr_changed()
+        if attr_x != self.attr_x or attr_y != self.attr_y:
+            self.attr_x, self.attr_y = attr_x, attr_y
+            self.attr_changed()
 
     def attr_changed(self):
         self.cb_reg_line.setEnabled(self.can_draw_regresssion_line())

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -320,10 +320,16 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
     def test_features_and_data(self):
         data = Table("iris")
         self.send_signal(self.widget.Inputs.data, data)
+        x, y = self.widget.graph.scatterplot_item.getData()
+        np.testing.assert_array_equal(x, data.X[:, 0])
+        np.testing.assert_array_equal(y, data.X[:, 1])
         self.send_signal(self.widget.Inputs.features,
                          AttributeList(data.domain[2:]))
         self.assertIs(self.widget.attr_x, data.domain[2])
         self.assertIs(self.widget.attr_y, data.domain[3])
+        x, y = self.widget.graph.scatterplot_item.getData()
+        np.testing.assert_array_equal(x, data.X[:, 2])
+        np.testing.assert_array_equal(y, data.X[:, 3])
 
     def test_output_features(self):
         data = Table("iris")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The plot was not repainted when the widget received Features on the input.

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
