### PR TITLE
[FIX] canvas/widgetsscheme: Remove use of QObject.destroyed for logging

### DIFF
--- a/Orange/canvas/scheme/widgetsscheme.py
+++ b/Orange/canvas/scheme/widgetsscheme.py
@@ -23,6 +23,7 @@ import enum
 import itertools
 from collections import namedtuple, deque
 from urllib.parse import urlencode
+from weakref import finalize
 from typing import List, Tuple
 import sip
 
@@ -513,11 +514,9 @@ class WidgetManager(QObject):
             widget.deleteLater()
             name = "{} '{}'".format(type(widget).__name__, widget.captionTitle)
             if log.isEnabledFor(logging.DEBUG):
-                widget.destroyed.connect(
-                    lambda: log.debug("Destroyed: %s", name))
-                widget.__marker = QObject()
-                widget.__marker.destroyed.connect(
-                    lambda: log.debug("Destroyed namespace: %s", name))
+                finalize(
+                    widget, log.debug, "Destroyed namespace: %s", name
+                )
             del self.__widget_processing_state[widget]
 
     def create_widget_instance(self, node):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

An occasional `NameError: free variable 'name' referenced before assignment in enclosing scope` can be observed when running with debug logging level.

##### Description of changes

Remove use of QObject.destroyed for logging. Use weakref.finalize instead.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
