### PR TITLE
[FIX] OWFeatureStatistics: Don't attempt to sort when no data on input

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -807,7 +807,7 @@ class OWFeatureStatistics(widget.OWWidget):
     def __restore_sorting(self):
         """Restore the sort column and order from saved settings."""
         sort_column, sort_order = self.sorting
-        if sort_column < self.model.columnCount():
+        if self.data is not None and sort_column < self.model.columnCount():
             self.model.sort(sort_column, sort_order)
             self.table_view.horizontalHeader().setSortIndicator(sort_column, sort_order)
 


### PR DESCRIPTION
##### Issue
An issue popped up on sentry where Feature Statistics was crashing. This can be reproduced in the following way:
1. Open a workflow and connect File with some data to Feature Statistics and save the workflow
2. Remove/rename the data file in question so that the File widget can no longer find it
3. Re-open the workflow in Orange → Feature statistics crash

##### Description of changes
Fixes the bug. I have no idea how to test this, or indeed, how this even happened because this issue never occurred when disconnecting data. In both cases, the input signal data was set to `None`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
