### PR TITLE
[FIX] Scatter Plot: Always setup plot

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -407,8 +407,8 @@ class OWScatterPlot(OWDataProjectionWidget):
                 self.data.domain is not None and \
                 all(attr in self.data.domain for attr
                         in self.attribute_selection_list):
-            self.set_attr(self.attribute_selection_list[0],
-                          self.attribute_selection_list[1])
+            self.attr_x, self.attr_y = self.attribute_selection_list[:2]
+            self.attr_changed()
             self.attribute_selection_list = None
         else:
             super().handleNewSignals()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When inputing features and data into Scatterplot at the same time handleNewSignals() is invoked only once (handleNewSignals() then calls setup_plot()). Therefore attr_x and attr_y, set from settings, could be the same as input features and self.setup_plot() would never be called.

##### Description of changes
Always call self.attr_changed() when receiving Features on the input.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
