### PR TITLE
[FIX] Rank: Fix crash on dataset with missing values

### DIFF
--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -8,7 +8,6 @@ from scipy.sparse import issparse
 import Orange
 from Orange.util import Reprable
 from Orange.preprocess.preprocess import Preprocess
-from Orange.preprocess.score import ANOVA, GainRatio, UnivariateLinearRegression
 
 __all__ = ["SelectBestFeatures", "RemoveNaNColumns", "SelectRandomFeatures"]
 
@@ -57,6 +56,10 @@ class SelectBestFeatures(Reprable):
             discr_ratio = (sum(a.is_discrete
                                for a in data.domain.attributes)
                            / len(data.domain.attributes))
+
+            from Orange.preprocess.score import ANOVA, GainRatio, \
+                UnivariateLinearRegression
+
             if data.domain.has_discrete_class:
                 if discr_ratio >= 0.5:
                     method = GainRatio()

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -10,7 +10,7 @@ from Orange.classification import LogisticRegressionLearner
 from Orange.regression import LinearRegressionLearner
 from Orange.projection import PCA
 from Orange.widgets.data.owrank import OWRank, ProblemType, CLS_SCORES, REG_SCORES
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.base import WidgetTest, datasets
 from Orange.widgets.widget import AttributeList
 
 
@@ -347,3 +347,9 @@ class TestOWRank(WidgetTest):
         self.assertTrue(self.widget.Error.no_attributes.is_shown())
         self.send_signal(self.widget.Inputs.data, data)
         self.assertFalse(self.widget.Error.no_attributes.is_shown())
+
+    def test_dataset(self):
+        for method in CLS_SCORES + REG_SCORES:
+            self._get_checkbox(method.shortname).setChecked(True)
+        for ds in datasets.datasets():
+            self.send_signal(self.widget.Inputs.data, ds)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
OWRank crashed when input dataset with missing values (i.e. testing_dataset_cls, testing_dataset_reg).

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
