### PR TITLE
Linear Projection: Setup model_selected before calculating __invalidated

### DIFF
--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -358,6 +358,13 @@ class OWLinearProjection(OWAnchorProjectionWidget):
 
     def set_data(self, data):
         super().set_data(data)
+        self._check_options()
+        self._init_vizrank()
+        self.init_projection()
+
+    def use_context(self):
+        self.model_selected.clear()
+        self.model_other.clear()
         if self.data is not None and len(self.selected_vars):
             d, selected = self.data.domain, [v[0] for v in self.selected_vars]
             self.model_selected[:] = [d[attr] for attr in selected]
@@ -367,10 +374,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         elif self.data is not None:
             self.model_selected[:] = self.continuous_variables[:3]
             self.model_other[:] = self.continuous_variables[3:]
-
-        self._check_options()
-        self._init_vizrank()
-        self.init_projection()
 
     def _check_options(self):
         buttons = self.radio_placement.buttons
@@ -462,13 +465,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
             ("Size", self._get_caption_var_name(self.attr_size)),
             ("Jittering", self.graph.jitter_size != 0 and
              "{} %".format(self.graph.jitter_size))))
-
-    def clear(self):
-        if self.model_selected:
-            self.model_selected.clear()
-        if self.model_other:
-            self.model_other.clear()
-        super().clear()
 
     @classmethod
     def migrate_settings(cls, settings_, version):

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from unittest.mock import Mock
 import numpy as np
 
 from AnyQt.QtCore import QItemSelectionModel
@@ -158,6 +159,28 @@ class TestOWLinearProjection(WidgetTest, AnchorProjectionWidgetTestMixin,
         w = self.widget
         self.send_signal(w.Inputs.data, None)
         w.controls.graph.hide_radius.setSliderPosition(3)
+
+    def test_invalidated_model_selected(self):
+        self.widget.setup_plot = Mock()
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.widget.setup_plot.assert_called_once()
+
+        self.widget.setup_plot.reset_mock()
+        self.widget.model_selected[:] = self.data.domain[2:]
+        self.widget.variables_selection.removed.emit()
+        self.widget.setup_plot.assert_called_once()
+
+        self.widget.setup_plot.reset_mock()
+        self.send_signal(self.widget.Inputs.data, self.data[:, 2:])
+        self.widget.setup_plot.assert_not_called()
+
+        self.widget.model_selected[:] = self.data.domain[3:]
+        self.widget.variables_selection.removed.emit()
+        self.widget.setup_plot.assert_called_once()
+
+        self.widget.setup_plot.reset_mock()
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.widget.setup_plot.assert_called_once()
 
 
 class LinProjVizRankTests(WidgetTest):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Variables in list box should be set before self.__invalidated flag is calculated.
Rebase to master when #3444 is merged.

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
