### PR TITLE
[FIX] Scatterplot Vizrank: Don't use discrete variables

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -83,7 +83,7 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         assert self.attr_color is not None
         master_domain = self.master.data.domain
         vars = [v for v in chain(master_domain.variables, master_domain.metas)
-                if v is not self.attr_color and v.is_primitive()]
+                if v is not self.attr_color and v.is_continuous]
         domain = Domain(attributes=vars, class_vars=self.attr_color)
         data = self.master.data.transform(domain)
         relief = ReliefF if isinstance(domain.class_var, DiscreteVariable) \

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -67,13 +67,24 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
 
     def test_score_heuristics(self):
         domain = Domain([ContinuousVariable(c) for c in "abcd"],
-                        DiscreteVariable("c", values="ab"))
+                        DiscreteVariable("e", values="ab"))
         a = np.arange(10).reshape((10, 1))
         data = Table(domain, np.hstack([a, a, a, a]), a >= 5)
         self.send_signal(self.widget.Inputs.data, data)
         vizrank = ScatterPlotVizRank(self.widget)
         self.assertEqual([x.name for x in vizrank.score_heuristic()],
                          list("abcd"))
+
+    def test_score_heuristics_no_disc(self):
+        domain = Domain([ContinuousVariable(c) for c in "abc"] +
+                        [DiscreteVariable("d", values="abcdefghij")],
+                        DiscreteVariable("e", values="ab"))
+        a = np.arange(10).reshape((10, 1))
+        data = Table(domain, np.hstack([a, a, a, a]), a >= 5)
+        self.send_signal(self.widget.Inputs.data, data)
+        vizrank = ScatterPlotVizRank(self.widget)
+        self.assertEqual([x.name for x in vizrank.score_heuristic()],
+                         list("abc"))
 
     def test_optional_combos(self):
         domain = self.data.domain


### PR DESCRIPTION
##### Issue

Scatterplot's Vizrank still adds discrete attributes, but scatter plot crashes when they're chosen.

##### Description of changes

Change the condition in vizrank filter from `is_primitive()` to `is_continuous`.

##### Includes
- [X] Code changes
- [X] Tests
