### PR TITLE
 Set requirements to fastTSNE==0.2.13, scikit-learn>=0.20.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
-    - fasttsne      >=0.2.12
+    - fasttsne      ==0.2.13
 
 test:
   # Python imports

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -18,4 +18,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE>=0.2.12
+fastTSNE==0.2.13


### PR DESCRIPTION
##### Issue
The next version of fastTSNE (not yet released) includes a slight API change, which would cause tests to fail in current master.

##### Description of changes
To avoid any failing tests, I fix `fastTSNE==0.2.13` here (this is the latest release).

Once this is merged, I can release a new fastTSNE version, update the wrapper here and update the requirements.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
