### PR TITLE
util.get_unique_names: Add more flexible arguments

### DIFF
--- a/Orange/data/tests/test_util.py
+++ b/Orange/data/tests/test_util.py
@@ -1,0 +1,51 @@
+import unittest
+
+from Orange.data import Domain, ContinuousVariable
+from Orange.data.util import get_unique_names
+
+
+class TestGetUniqueNames(unittest.TestCase):
+    def test_get_unique_names(self):
+        names = ["foo", "bar", "baz", "baz (3)"]
+        self.assertEqual(get_unique_names(names, ["qux"]), ["qux"])
+        self.assertEqual(get_unique_names(names, ["foo"]), ["foo (1)"])
+        self.assertEqual(get_unique_names(names, ["baz"]), ["baz (4)"])
+        self.assertEqual(get_unique_names(names, ["baz (3)"]), ["baz (3) (1)"])
+        self.assertEqual(
+            get_unique_names(names, ["qux", "quux"]), ["qux", "quux"])
+        self.assertEqual(
+            get_unique_names(names, ["bar", "baz"]), ["bar (4)", "baz (4)"])
+        self.assertEqual(
+            get_unique_names(names, ["qux", "baz"]), ["qux (4)", "baz (4)"])
+        self.assertEqual(
+            get_unique_names(names, ["qux", "bar"]), ["qux (1)", "bar (1)"])
+
+        self.assertEqual(get_unique_names(names, "qux"), "qux")
+        self.assertEqual(get_unique_names(names, "foo"), "foo (1)")
+        self.assertEqual(get_unique_names(names, "baz"), "baz (4)")
+
+        self.assertEqual(get_unique_names(tuple(names), "baz"), "baz (4)")
+
+    def test_get_unique_names_with_domain(self):
+        a, b, c, d = map(ContinuousVariable, ["foo", "bar", "baz", "baz (3)"])
+        domain = Domain([a, b], c, [d])
+        self.assertEqual(get_unique_names(domain, ["qux"]), ["qux"])
+        self.assertEqual(get_unique_names(domain, ["foo"]), ["foo (1)"])
+        self.assertEqual(get_unique_names(domain, ["baz"]), ["baz (4)"])
+        self.assertEqual(get_unique_names(domain, ["baz (3)"]), ["baz (3) (1)"])
+        self.assertEqual(
+            get_unique_names(domain, ["qux", "quux"]), ["qux", "quux"])
+        self.assertEqual(
+            get_unique_names(domain, ["bar", "baz"]), ["bar (4)", "baz (4)"])
+        self.assertEqual(
+            get_unique_names(domain, ["qux", "baz"]), ["qux (4)", "baz (4)"])
+        self.assertEqual(
+            get_unique_names(domain, ["qux", "bar"]), ["qux (1)", "bar (1)"])
+
+        self.assertEqual(get_unique_names(domain, "qux"), "qux")
+        self.assertEqual(get_unique_names(domain, "foo"), "foo (1)")
+        self.assertEqual(get_unique_names(domain, "baz"), "baz (4)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -2,6 +2,8 @@
 Data-manipulation utilities.
 """
 import re
+from itertools import chain
+
 import numpy as np
 import bottleneck as bn
 from scipy import sparse as sp
@@ -139,15 +141,42 @@ def get_indices(names, name):
 
 def get_unique_names(names, proposed):
     """
-    Returns unique names of variables. Variables which are duplicate get appended by
-    unique index which is the same in all proposed variable names in a list.
-    :param names: list of strings
-    :param proposed: list of strings
-    :return: list of strings
+    Returns unique names for variables
+
+    Proposed is a list of names (or a string with a single name). If any name
+    already appears in `names`, the function appends an index in parentheses,
+    which is one higher than the highest index at these variables. Also, if
+    `names` contains any of the names with index in parentheses, this counts
+    as an occurence of the name. For instance, if `names` does not contain
+    `x` but it contains `x (3)`, `get_unique_names` will replace `x` with
+    `x (4)`.
+
+    If argument `names` is domain, the method observes all variables and metas.
+
+    Function returns a string if `proposed` is a string, and a list if it's a
+    list.
+
+    The method is used in widgets like MDS, which adds two variables (`x` and
+    `y`). It is desired that they have the same index. If `x`, `x (1)` and
+    `x (2)` and `y` (but no other `y`'s already exist in the domain, MDS
+    should append `x (3)` and `y (3)`, not `x (3)` and y (1)`.
+
+    Args:
+        names (Domain or list of str): used names
+        proposed (str or list of str): proposed name
+
+    Return:
+        str or list of str
     """
-    if len([name for name in proposed if name in names]):
-        max_index = max([max(get_indices(names, name),
-                             default=1) for name in proposed], default=1)
-        for i, name in enumerate(proposed):
-            proposed[i] = "{} ({})".format(name, max_index + 1)
-    return proposed
+    from Orange.data import Domain  # prevent cyclic import
+    if isinstance(names, Domain):
+        names = [var.name for var in chain(names.variables, names.metas)]
+    if isinstance(proposed, str):
+        return get_unique_names(names, [proposed])[0]
+    indicess = [indices
+                for indices in (get_indices(names, name) for name in proposed)
+                if indices]
+    if not (set(proposed) & set(names) or indicess):
+        return proposed
+    max_index = max(map(max, indicess), default=0) + 1
+    return [f"{name} ({max_index})" for name in proposed]

--- a/Orange/projection/base.py
+++ b/Orange/projection/base.py
@@ -143,8 +143,7 @@ class DomainProjection(Projection):
     def _get_var_names(self, n):
         postfixes = ["x", "y"] if n == 2 else [str(i) for i in range(1, n + 1)]
         names = [f"{self.var_prefix}-{postfix}" for postfix in postfixes]
-        domain = self.orig_domain.variables + self.orig_domain.metas
-        return get_unique_names([v.name for v in domain], names)
+        return get_unique_names(self.orig_domain, names)
 
 
 class LinearProjector(Projector):

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -73,8 +73,7 @@ class PCAModel(DomainProjection, metaclass=WrapperMeta):
 
     def _get_var_names(self, n):
         names = [f"{self.var_prefix}{postfix}" for postfix in range(1, n + 1)]
-        domain = self.orig_domain.variables + self.orig_domain.metas
-        return get_unique_names([v.name for v in domain], names)
+        return get_unique_names(self.orig_domain, names)
 
 
 class IncrementalPCA(SklProjector):

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -10,9 +10,10 @@ from AnyQt.QtWidgets import QGridLayout, QTableView
 from Orange.clustering import KMeans
 from Orange.clustering.kmeans import KMeansModel, SILHOUETTE_MAX_SAMPLES
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
+from Orange.data.util import get_unique_names
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
-from Orange.widgets.utils.annotated_data import get_next_name, \
+from Orange.widgets.utils.annotated_data import \
     ANNOTATED_DATA_SIGNAL_NAME, add_columns
 from Orange.widgets.utils.concurrent import ThreadExecutor, FutureSetWatcher
 from Orange.widgets.utils.sql import check_sql_input
@@ -463,11 +464,12 @@ class OWKMeans(widget.OWWidget):
 
         domain = self.data.domain
         cluster_var = DiscreteVariable(
-            get_next_name(domain, "Cluster"),
+            get_unique_names(domain, "Cluster"),
             values=["C%d" % (x + 1) for x in range(km.k)]
         )
         clust_ids = km(self.data)
-        silhouette_var = ContinuousVariable(get_next_name(domain, "Silhouette"))
+        silhouette_var = ContinuousVariable(
+            get_unique_names(domain, "Silhouette"))
         if km.silhouette_samples is not None:
             self.Warning.no_silhouettes.clear()
             scores = np.arctan(km.silhouette_samples) / np.pi + 0.5

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -16,11 +16,12 @@ from AnyQt.QtWidgets import QSlider, QCheckBox, QWidget
 
 from Orange.clustering.louvain import table_to_knn_graph, Louvain
 from Orange.data import Table, DiscreteVariable
+from Orange.data.util import get_unique_names
 from Orange.projection import PCA
 from Orange.widgets import widget, gui, report
 from Orange.widgets.settings import DomainContextHandler, ContextSetting, \
     Setting
-from Orange.widgets.utils.annotated_data import get_next_name, add_columns, \
+from Orange.widgets.utils.annotated_data import add_columns, \
     ANNOTATED_DATA_SIGNAL_NAME
 from Orange.widgets.utils.concurrent import FutureWatcher
 from Orange.widgets.utils.signals import Input, Output
@@ -358,7 +359,7 @@ class OWLouvainClustering(widget.OWWidget):
         new_partition = list(map(index_map.get, self.partition))
 
         cluster_var = DiscreteVariable(
-            get_next_name(domain, 'Cluster'),
+            get_unique_names(domain, 'Cluster'),
             values=['C%d' % (i + 1) for i, _ in enumerate(np.unique(new_partition))]
         )
 

--- a/Orange/widgets/utils/annotated_data.py
+++ b/Orange/widgets/utils/annotated_data.py
@@ -1,8 +1,6 @@
-from itertools import chain
-
 import numpy as np
 from Orange.data import Domain, DiscreteVariable
-from Orange.data.util import get_indices
+from Orange.data.util import get_unique_names
 
 ANNOTATED_DATA_SIGNAL_NAME = "Data"
 ANNOTATED_DATA_FEATURE_NAME = "Selected"
@@ -32,28 +30,8 @@ def add_columns(domain, attributes=(), class_vars=(), metas=()):
     return Domain(attributes, class_vars, metas)
 
 
-def get_next_name(names, name):
-    """
-    Returns next 'possible' attribute name. The name should not be duplicated
-    and is generated using name parameter, appended by smallest possible index.
-
-    :param names: list
-    :param name: str
-    :return: str
-    """
-    if isinstance(names, Domain):
-        names = [
-            var.name
-            for var in chain(names.attributes, names.class_vars, names.metas)
-        ]
-    indexes = get_indices(names, name)
-    if name not in names and not indexes:
-        return name
-    return "{} ({})".format(name, max(indexes, default=0) + 1)
-
-
 def _table_with_annotation_column(data, values, column_data, var_name):
-    var = DiscreteVariable(get_next_name(data.domain, var_name), values)
+    var = DiscreteVariable(get_unique_names(data.domain, var_name), values)
     class_vars, metas = data.domain.class_vars, data.domain.metas
     if not data.domain.class_vars:
         class_vars += (var, )

--- a/Orange/widgets/utils/tests/test_annotated_data.py
+++ b/Orange/widgets/utils/tests/test_annotated_data.py
@@ -5,19 +5,9 @@ import numpy as np
 
 from Orange.data import Table, Variable
 from Orange.data.filter import SameValue
-from Orange.data.util import get_unique_names
 from Orange.widgets.utils.annotated_data import (
-    create_annotated_table, get_next_name,
-    create_groups_table, ANNOTATED_DATA_FEATURE_NAME
+    create_annotated_table, create_groups_table, ANNOTATED_DATA_FEATURE_NAME
 )
-
-
-class TestGetNextName(unittest.TestCase):
-    def test_get_var_name(self):
-        self.assertEqual(get_next_name(["a"], "XX"), "XX")
-        self.assertEqual(get_next_name(["a", "XX"], "XX"), "XX (1)")
-        self.assertEqual(get_next_name(["a", "XX (4)"], "XX"), "XX (5)")
-        self.assertEqual(get_next_name(["a", "XX", "XX (4)"], "XX"), "XX (5)")
 
 
 class TestAnnotatedData(unittest.TestCase):

--- a/Orange/widgets/utils/tests/test_annotated_data.py
+++ b/Orange/widgets/utils/tests/test_annotated_data.py
@@ -113,12 +113,6 @@ class TestAnnotatedData(unittest.TestCase):
         self.assertEqual(data.domain.metas[1].name,
                          "{} ({})".format(ANNOTATED_DATA_FEATURE_NAME, 4))
 
-    def test_get_unique_names(self):
-        names = ["charlie", "bravo", "charlie (2)", "charlie (3)", "bravo (2)", "charlie (4)",
-                 "bravo (3)"]
-        self.assertEqual(get_unique_names(names, ["bravo", "charlie"]),
-                         ["bravo (5)", "charlie (5)"])
-
     def test_create_groups_table_include_unselected(self):
         group_indices = random.sample(range(0, len(self.zoo)), 20)
         selection = np.zeros(len(self.zoo), dtype=np.uint8)

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -541,11 +541,8 @@ class OWDataProjectionWidget(OWProjectionWidgetBase):
         return data
 
     def _get_projection_variables(self):
-        domain = self.data.domain
         names = get_unique_names(
-            [v.name for v in domain.variables + domain.metas],
-            self.embedding_variables_names
-        )
+            self.data.domain, self.embedding_variables_names)
         return ContinuousVariable(names[0]), ContinuousVariable(names[1])
 
     @staticmethod


### PR DESCRIPTION
##### Issue

`Orange.data.util.get_unique_names` accept a list of used names. When we call it, we almost always have a domain. Let the function accept a domain, too.

While at it, the second argument could also be a string, not a list of strings.

While at it, write some tests.

Fixes #3495, too.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
