### PR TITLE
[FIX] OWFeatureStatistics: Fix scipy.stats.mode crash on sparse data

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -5,6 +5,7 @@ TODO:
     or quartile coefficient of dispersion (Q3 - Q1) / (Q3 + Q1)
   - Standard deviation for nominal: try out Variation ratio (1 - n_mode/N)
 """
+
 import datetime
 import locale
 from enum import IntEnum
@@ -12,6 +13,7 @@ from typing import Any, Optional, Tuple, List
 
 import numpy as np
 import scipy.stats as ss
+import scipy.sparse as sp
 from AnyQt.QtCore import Qt, QSize, QRectF, QVariant, QModelIndex, pyqtSlot, \
     QRegExp, QItemSelection, QItemSelectionRange, QItemSelectionModel
 from AnyQt.QtGui import QPainter, QColor
@@ -236,9 +238,18 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
             continuous_f=lambda x: ut.nanmax(x, axis=0),
             time_f=lambda x: ut.nanmax(x, axis=0),
         )
+
+        # Since scipy apparently can't do mode on sparse matrices, cast it to
+        # dense. This can be very inefficient for large matrices, and should
+        # be changed
+        def __mode(x, *args, **kwargs):
+            if sp.issparse(x):
+                x = x.todense(order="C")
+            return ss.mode(x, *args, **kwargs)[0]
+
         self._center = self.__compute_stat(
             matrices,
-            discrete_f=lambda x: ss.mode(x)[0],
+            discrete_f=lambda x: __mode(x, axis=0),
             continuous_f=lambda x: ut.nanmean(x, axis=0),
             time_f=lambda x: ut.nanmean(x, axis=0),
         )


### PR DESCRIPTION
##### Issue
As of the latest versions of scipy, `scipy.stats.mode` does not work on sparse data.


##### Description of changes
A quick fix so the tests aren't constantly failing. Will work on a more efficient solution shortly.

@janezd 


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
