### PR TITLE
Spearman distances: Return 0 when comparing a single row to itself

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -433,7 +433,9 @@ class SpearmanModel(CorrelationDistanceModel):
     def compute_correlation(self, x1, x2):
         if x2 is None:
             n1 = x1.shape[1 - self.axis]
-            if n1 == 2:
+            if n1 == 1:
+                rho = 1.0
+            elif n1 == 2:
                 # Special case to properly fill degenerate self correlations
                 # (nan, inf on the diagonals)
                 rho = stats.spearmanr(x1, x1, axis=self.axis)[0]


### PR DESCRIPTION
##### Issue

Spearman distance fails on Scipy 1.2 because of stats.spearmanr failing when given a single matrix with a single row.

##### Description of changes

This distance should always return 0, so we can just hard code it.

##### Includes
- [X] Code changes
