### PR TITLE
WidgetPreview: Terminate when receiving SIGINT

### DIFF
--- a/Orange/widgets/utils/widgetpreview.py
+++ b/Orange/widgets/utils/widgetpreview.py
@@ -1,6 +1,7 @@
 import sys
 import logging
 import gc
+import signal
 
 from AnyQt.QtWidgets import QApplication
 
@@ -18,6 +19,8 @@ class WidgetPreview:
         self.widget_cls = widget_cls
         self.widget = None
         logging.basicConfig()
+        # Allow termination with CTRL + C
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     def run(self, input_data=None, *, no_exec=False, no_exit=False, **kwargs):
         """


### PR DESCRIPTION
##### Issue

When canvas is run from shell, it can be quit by Ctrl-C. Widgets can't.

Also, when widget is run from PyCharm, the "stop" button does not really terminate it (at least not on macOs). The widget is done only when clicked on in Dock, and even then it crashes.

Running a widget multiple times from PyCharm opens n copies of widgets instead of closing them.

**Includes a commit from #3491. Merge #3491 first.**

##### Description of changes

Set the default signal handler for `SIGINT`.

Canvas' `__main__` already has this.

##### Includes
- [X] Code changes
