### PR TITLE
[ENH] Label subset

### DIFF
--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -616,7 +616,7 @@ class OWPlotGUI:
 
     def label_only_selected_check_box(self, widget):
         self._check_box(widget=widget, value="label_only_selected",
-                        label="Label only selected points",
+                        label="Label only selection and subset",
                         cb_name=self._plot.update_labels)
 
     def filled_symbols_check_box(self, widget):


### PR DESCRIPTION
##### Issue

Fixes #3376: subsets are similar to selections, so it would make sense to label the subset data instances, too.

**Based on #3500 for faster CI testing, but otherwise unrelated.** If reviews are positive, I'll rebase to master so it can be merged.

##### Description of changes

To keep the GUI simple, this PR does not introduce another checkbox, but just adds subset instances to those that are labelled. Checkbox is renamed from *Label only selected points* to *Label only selection and subset*.

![out](https://user-images.githubusercontent.com/2387315/50496695-19dbf980-0a32-11e9-845f-29809d0e2f26.gif)


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
