### PR TITLE
Easier selection of variables in Radviz, Linear projection and similar

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1077,12 +1077,12 @@ class ListViewWithSizeHint(QListView):
 
 
 def listView(widget, master, value=None, model=None, box=None, callback=None,
-             sizeHint=None, **misc):
+             sizeHint=None, *, viewType=ListViewWithSizeHint, **misc):
     if box:
         bg = vBox(widget, box, addToLayout=False)
     else:
         bg = widget
-    view = ListViewWithSizeHint(preferred_size=sizeHint)
+    view = viewType(preferred_size=sizeHint)
     view.setModel(model)
     if value is not None:
         connectControl(master, value, callback,

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -453,7 +453,7 @@ class SettingsHandler:
                 self.write_defaults_file(settings_file)
             except (EOFError, IOError, pickle.PicklingError) as ex:
                 log.error("Could not write default settings for %s (%s).",
-                          self.widget_class, type(ex).__name__)
+                          self.widget_class, ex)
                 settings_file.close()
                 os.remove(filename)
             else:

--- a/Orange/widgets/utils/listfilter.py
+++ b/Orange/widgets/utils/listfilter.py
@@ -169,7 +169,8 @@ class CompleterNavigator(QObject):
             return False
 
 
-def variables_filter(model, parent=None, accepted_type=Orange.data.Variable):
+def variables_filter(model, parent=None, accepted_type=Orange.data.Variable,
+                     view_type=VariablesListItemView):
     """
     GUI components: ListView with a lineedit which works as a filter. One can write
     a variable name in a edit box and possible matches are then shown in a listview.
@@ -221,7 +222,7 @@ def variables_filter(model, parent=None, accepted_type=Orange.data.Variable):
 
     proxy = VariableFilterProxyModel()
     proxy.setSourceModel(model)
-    view = VariablesListItemView(acceptedType=accepted_type)
+    view = view_type(acceptedType=accepted_type)
     view.setModel(proxy)
 
     model.dataChanged.connect(update_completer_model)

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -259,7 +259,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
                        Placement.LDA: "Linear Discriminant Analysis",
                        Placement.PCA: "Principal Component Analysis"}
 
-    settings_version = 5
+    settings_version = 6
 
     placement = Setting(Placement.Circular)
     selected_vars = ContextSetting([])
@@ -322,7 +322,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         # Ugly, but the alternative is to have yet another signal to which
         # the view will have to connect
         self.model_selected.selection_changed.emit()
-        self.__model_selected_changed()
 
     def __model_selected_changed(self):
         self.projection = None
@@ -471,6 +470,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
 
     @classmethod
     def migrate_context(cls, context, version):
+        values = context.values
         if version < 2:
             domain = context.ordered_domain
             c_domain = [t for t in context.ordered_domain if t[1] == 2]
@@ -479,20 +479,25 @@ class OWLinearProjection(OWAnchorProjectionWidget):
                                         (d_domain, "shape_index", "attr_shape"),
                                         (c_domain, "size_index", "attr_size")):
                 index = context.values[old_val][0] - 1
-                context.values[new_val] = (d[index][0], d[index][1] + 100) \
+                values[new_val] = (d[index][0], d[index][1] + 100) \
                     if 0 <= index < len(d) else None
         if version < 3:
-            context.values["graph"] = {
-                "attr_color": context.values["attr_color"],
-                "attr_shape": context.values["attr_shape"],
-                "attr_size": context.values["attr_size"]
+            values["graph"] = {
+                "attr_color": values["attr_color"],
+                "attr_shape": values["attr_shape"],
+                "attr_size": values["attr_size"]
             }
         if version == 3:
-            values = context.values
             values["attr_color"] = values["graph"]["attr_color"]
             values["attr_size"] = values["graph"]["attr_size"]
             values["attr_shape"] = values["graph"]["attr_shape"]
             values["attr_label"] = values["graph"]["attr_label"]
+        if version < 6 and "selected_vars" in values:
+            values["selected_vars"] = (values["selected_vars"], -3)
+
+    # for backward compatibility with settings < 6, pull the enum from global
+    # namespace into class
+    Placement = Placement
 
 
 def column_data(table, var, dtype):

--- a/Orange/widgets/visualize/tests/test_owradviz.py
+++ b/Orange/widgets/visualize/tests/test_owradviz.py
@@ -56,17 +56,16 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
 
     def test_saved_features(self):
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.widget.model_selected.pop(0)
-        self.widget.variables_selection.removed.emit()
-        selected = [a.name for a in self.widget.model_selected]
+        del self.widget.selected_vars[0]
+        selected = self.widget.selected_vars[:]
 
         settings = self.widget.settingsHandler.pack_data(self.widget)
         w = self.create_widget(OWRadviz, stored_settings=settings)
         self.send_signal(w.Inputs.data, self.data, widget=w)
-        self.assertListEqual(selected, [a.name for a in w.model_selected])
+        self.assertListEqual(selected, self.widget.selected_vars)
         self.send_signal(self.widget.Inputs.data, self.heart_disease)
-        selected = [a.name for a in self.widget.model_selected]
-        names = [a.name for a in self.heart_disease.domain.attributes
+        selected = self.widget.selected_vars[:]
+        names = [a for a in self.heart_disease.domain.attributes
                  if a.is_continuous or a.is_discrete and len(a.values) == 2]
         self.assertListEqual(selected, names[:5])
 
@@ -99,15 +98,15 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
     def test_saved_selected_vars(self):
         self.send_signal(self.widget.Inputs.data, self.data)
 
-        self.widget.model_selected[:] = self.data.domain[:1]
-        self.widget.variables_selection.removed.emit()
+        self.widget.selected_vars[:] = self.data.domain[:1]
+        self.widget.model_selected.selection_changed.emit()
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.assertEqual(len(self.widget.model_selected[:]), 1)
+        self.assertEqual(len(self.widget.selected_vars[:]), 1)
 
-        self.widget.model_selected[:] = self.data.domain[:0]
-        self.widget.variables_selection.removed.emit()
+        self.widget.selected_vars[:] = self.data.domain[:0]
+        self.widget.model_selected.selection_changed.emit()
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.assertEqual(len(self.widget.model_selected[:]), 4)
+        self.assertEqual(len(self.widget.selected_vars[:]), 0)
 
     def test_invalidated_model_selected(self):
         self.widget.setup_plot = Mock()
@@ -115,16 +114,16 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
         self.widget.setup_plot.assert_called_once()
 
         self.widget.setup_plot.reset_mock()
-        self.widget.model_selected[:] = self.data.domain[2:]
-        self.widget.variables_selection.removed.emit()
+        self.widget.selected_vars[:] = self.data.domain[2:]
+        self.widget.model_selected.selection_changed.emit()
         self.widget.setup_plot.assert_called_once()
 
         self.widget.setup_plot.reset_mock()
         self.send_signal(self.widget.Inputs.data, self.data[:, 2:])
         self.widget.setup_plot.assert_not_called()
 
-        self.widget.model_selected[:] = self.data.domain[3:]
-        self.widget.variables_selection.removed.emit()
+        self.widget.selected_vars[:] = self.data.domain[3:]
+        self.widget.model_selected.selection_changed.emit()
         self.widget.setup_plot.assert_called_once()
 
         self.widget.setup_plot.reset_mock()

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -433,7 +433,6 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         if not same_domain:
             self.init_attr_values()
         self.openContext(self.data)
-        self.use_context()
         self._invalidated = not (
             data_existed and self.data is not None and
             array_equal(effective_data.X, self.effective_data.X))
@@ -443,9 +442,6 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
 
     def check_data(self):
         self.clear_messages()
-
-    def use_context(self):
-        pass
 
     def enable_controls(self):
         self.cb_class_density.setEnabled(self.can_draw_density())


### PR DESCRIPTION
##### Issue

We had two listviews which took too much space. So we switched to +/- buttons, which are better require more clicks and are somewhat inconsistent (to remove, you select and click -, while to add you click + and select) although similar to other dialogs (at least on macOS).

##### Description of changes

I propose a single list view in which the user can add and remove. I recorded three alternative visual indications; other suggestions welcome. The user can also drag a variable from shown to hidden or the opposite, which I forgot to record.

I don't particularly like the second one. I lean towards the third.

(Yes, I know, the indicator does not disappear when mouse leaves the view. It will. Settings and tests are also broken.)

Below the list view, we can add buttons Clear and Reset.

![radviz1](https://user-images.githubusercontent.com/2387315/50558968-913fb080-0cf2-11e9-9d76-ea500cf89c52.gif)

![radviz2](https://user-images.githubusercontent.com/2387315/50558905-0c549700-0cf2-11e9-87db-4454fe18fa00.gif)

![radviz3](https://user-images.githubusercontent.com/2387315/50558909-14143b80-0cf2-11e9-8e11-be92388660a9.gif)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
