### PR TITLE
image export: show custom error dialog only for OSError

### DIFF
--- a/Orange/widgets/utils/saveplot.py
+++ b/Orange/widgets/utils/saveplot.py
@@ -24,7 +24,7 @@ def save_plot(data, file_formats, filename=""):
         return
     try:
         writer.write(filename, data)
-    except Exception as e:
+    except OSError as e:
         mb = QMessageBox(
             None,
             windowTitle="Error",


### PR DESCRIPTION
##### Issue
Any errors in image export open a custom dialog and they can not be reported to sentry. 

##### Description of changes
Catch OSError as suggested in #3497. This still reports user-dependent errors (wrong permissions, out of disk space) to the user but our errors will open Orange's standard error dialogue.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation