### PR TITLE
OWProjectionWidgetBase: Move checking of subsets to handleNewSignals

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -959,7 +959,7 @@ class ProjectionWidgetTestMixin:
             spy = QSignalSpy(self.widget.blockingStateChanged)
             self.assertTrue(spy.wait(timeout))
         self.send_signal(self.widget.Inputs.data_subset, table[::30])
-        self.assertEqual(len(self.widget.subset_indices), 5)
+        self.assertEqual(len(self.widget.subset_data), 5)
 
     def test_invalidated_embedding(self, timeout=DEFAULT_TIMEOUT):
         """Check if graph has been replotted when sending same data"""
@@ -1016,7 +1016,7 @@ class AnchorProjectionWidgetTestMixin(ProjectionWidgetTestMixin):
         self.send_signal(self.widget.Inputs.data, table)
         self.assertTrue(self.widget.Error.sparse_data.is_shown())
         self.send_signal(self.widget.Inputs.data_subset, table[::30])
-        self.assertEqual(len(self.widget.subset_indices), 5)
+        self.assertEqual(len(self.widget.subset_data), 5)
         self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.sparse_data.is_shown())
 


### PR DESCRIPTION
##### Issue

#3507 introduced checking of subsets in `get_subset_data`.

- `handleNewSignals` is a better place because this is where one would expect such test.
- checking the length of the mask was not the best idea because data instances appear multiple times; it's better to subtract the two sets
- checks need to be done on entire data not just `valid_data` to prevent false warnings.

##### Description of changes

Code is changed, but existing tests remain valid.

##### Includes
- [X] Code changes
