### PR TITLE
[MNT] Tests: add support for multi-database tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 
 dist: xenial
 
+services:
+  - docker
+
 matrix:
     include:
         - env: RUN_PYLINT=true

--- a/.travis/install_mssql.sh
+++ b/.travis/install_mssql.sh
@@ -1,0 +1,7 @@
+sudo docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=YourStrong!Passw0rd' \
+   -p 1433:1433 -d microsoft/mssql-server-linux:2017-latest
+
+export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1
+pip install pymssql
+
+export ORANGE_TEST_DB_URI="${ORANGE_TEST_DB_URI}|mssql://SA:YourStrong!Passw0rd@0.0.0.0:1433"

--- a/.travis/stage_install.sh
+++ b/.travis/stage_install.sh
@@ -4,6 +4,7 @@
 for script in \
     install_orange.sh    \
     install_postgres.sh  \
+    install_mssql.sh    \
     install_pyqt.sh
 do
     foldable source $TRAVIS_BUILD_DIR/.travis/$script

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -75,8 +75,8 @@ class SqlTable(Table):
                 try:
                     self.backend = backend(connection_params)
                     break
-                except BackendError as ex:
-                    print(ex)
+                except BackendError:
+                    pass
             else:
                 raise ValueError("No backend could connect to server")
         else:

--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -1,32 +1,14 @@
-import contextlib
 import os
 import string
 import unittest
 from urllib import parse
-import uuid
+import random
+import inspect
 
-import Orange
-from Orange.data.sql.table import SqlTable
+import numpy as np
 
-
-def sql_test(f):
-    try:
-        import psycopg2  # pylint: disable=import-error
-        return unittest.skipIf(not sql_version, "Database is not running.")(f)
-    except:
-        return unittest.skip("Psycopg2 is required for sql tests.")(f)
-
-
-def connection_params():
-    return parse_uri(get_dburi())
-
-
-def get_dburi():
-    dburi = os.environ.get('ORANGE_TEST_DB_URI')
-    if dburi:
-        return dburi
-    else:
-        return "postgres://localhost/test"
+from Orange.data import Table
+from Orange.data.sql.backend import PymssqlBackend, Psycopg2Backend
 
 
 def parse_uri(uri):
@@ -51,42 +33,7 @@ def parse_uri(uri):
     ))
     if table:
         params['table'] = table
-    return params
-
-
-try:
-    import psycopg2  # pylint: disable=import-error
-    with psycopg2.connect(**connection_params()) as conn:
-        sql_version = conn.server_version
-except:
-    sql_version = 0
-
-
-def create_iris():
-    iris = Orange.data.Table("iris")
-    with psycopg2.connect(**connection_params()) as conn:
-        cur = conn.cursor()
-        cur.execute("DROP TABLE IF EXISTS iris")
-        cur.execute("""
-            CREATE TABLE iris (
-                "sepal length" float,
-                "sepal width" float,
-                "petal length" float,
-                "petal width" float,
-                "iris" varchar(15)
-            )
-        """)
-        for row in iris:
-            values = []
-            for i, val in enumerate(row):
-                if i != 4:
-                    values.append(str(val))
-                else:
-                    values.append(iris.domain.class_var.values[int(val)])
-            cur.execute("""INSERT INTO iris VALUES
-            (%s, %s, %s, %s, '%s')""" % tuple(values))
-        cur.execute("ANALYZE iris")
-    return get_dburi(), 'iris'
+    return parsed_uri.scheme, params
 
 
 class TestParseUri(unittest.TestCase):
@@ -144,81 +91,34 @@ class TestParseUri(unittest.TestCase):
         self.fail(self._formatMessage(msg, standardMsg))
 
 
-@sql_test
-class PostgresTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        from psycopg2.pool import ThreadedConnectionPool  # pylint: disable=import-error
-        from Orange.data.sql.backend.postgres import Psycopg2Backend
+def connection_params():
+    dburi = os.environ.get('ORANGE_TEST_DB_URI', 'postgres://localhost/test')
+    return dict(parse_uri(uri) for uri in dburi.split("|"))
 
-        Psycopg2Backend.connection_pool = \
-            ThreadedConnectionPool(1, 1, **connection_params())
-        cls.backend = Psycopg2Backend(connection_params())
-        cls.conn, cls.iris = create_iris()
 
-    @classmethod
-    def tearDownClass(cls):
-        from Orange.data.sql.backend.postgres import Psycopg2Backend
-        Psycopg2Backend.connection_pool.closeall()
-        Psycopg2Backend.connection_pool = None
+class DBTestConnection:
+    """Used to prepare the connection to the database"""
+    uri_name = ""
+    module = ""
 
-    def create_sql_table(self, data, columns=None):
-        table_name = self._create_sql_table(data, columns)
-        return connection_params(), table_name
+    def __init__(self, params):
+        self._params = params
+        self.is_module = False
+        self.is_active = False
+        self.try_connection()
 
-    @contextlib.contextmanager
-    def sql_table_from_data(self, data, guess_values=True):
-        from Orange.data.sql.backend.postgres import Psycopg2Backend
-        assert Psycopg2Backend.connection_pool is not None
+    @property
+    def params(self):
+        return self._params.copy()
 
-        table_name = self._create_sql_table(data)
-        yield SqlTable(connection_params(), table_name,
-                       inspect_values=guess_values)
-        self.drop_sql_table(table_name)
+    def try_connection(self):
+        raise NotImplementedError()
 
     def _create_sql_table(self, data, sql_column_types=None):
-        data = list(data)
-        if sql_column_types is None:
-            column_size = self._get_column_types(data)
-            sql_column_types = [
-                'float' if size == 0 else 'varchar(%s)' % size
-                for size in column_size
-            ]
-        table_name = uuid.uuid4()
-        create_table_sql = """
-            CREATE TEMPORARY TABLE "%(table_name)s" (
-                %(columns)s
-            )
-        """ % dict(
-            table_name=table_name,
-            columns=",\n".join(
-                'col%d %s' % (i, t)
-                for i, t in enumerate(sql_column_types)
-            )
-        )
-        with self.backend.execute_sql_query(create_table_sql):
-            pass
-        for row in data:
-            values = []
-            for v, t in zip(row, sql_column_types):
-                if v is None:
-                    values.append('NULL')
-                elif t == 0:
-                    values.append(str(v))
-                else:
-                    values.append("'%s'" % v)
-            insert_sql = """
-            INSERT INTO "%(table_name)s" VALUES
-                (%(values)s)
-            """ % dict(
-                table_name=table_name,
-                values=', '.join(values)
-            )
-            with self.backend.execute_sql_query(insert_sql):
-                pass
-        return str(table_name)
+        raise NotImplementedError()
 
-    def _get_column_types(self, data):
+    @staticmethod
+    def _get_column_types(data):
         if not data:
             return [0] * 3
         column_size = [0] * len(data[0])
@@ -226,17 +126,278 @@ class PostgresTest(unittest.TestCase):
             for i, value in enumerate(row):
                 if isinstance(value, str):
                     column_size[i] = max(len(value), column_size[i])
+
         return column_size
 
-    def drop_sql_table(self, table_name):
-        with self.backend.execute_sql_query('DROP TABLE "%s" ' % table_name):
+    def _drop_sql_table(self, table_name):
+        raise NotImplementedError
+
+
+class PostgresTestConnection(DBTestConnection):
+    uri_name = "postgres"
+    module = "psycopg2"
+
+    def try_connection(self):
+        try:
+            import psycopg2
+            self.is_module = True
+            with psycopg2.connect(**self.params) as conn:
+                self.is_active = True
+                self.version = conn.server_version
+        except:
             pass
 
-    def float_variable(self, size):
-        return [i*.1 for i in range(size)]
+    def _create_sql_table(self, data, sql_column_types=None,
+                          sql_column_names=None, table_name=None):
+        data = list(data)
 
-    def discrete_variable(self, size):
-        return ["mf"[i % 2] for i in range(size)]
+        if table_name is None:
+            table_name = ''.join(random.choices(string.ascii_lowercase, k=16))
 
-    def string_variable(self, size):
-        return string.ascii_letters[:size]
+        if sql_column_types is None:
+            column_size = self._get_column_types(data)
+            sql_column_types = [
+                'float' if size == 0 else 'varchar({})'.format(size)
+                for size in column_size
+            ]
+
+        if sql_column_names is None:
+            sql_column_names = ["col{}".format(i)
+                                for i in range(len(sql_column_types))]
+        else:
+            sql_column_names = map(lambda x: '"{}"'.format(x), sql_column_names)
+
+        drop_table_sql = "DROP TABLE IF EXISTS {}".format(table_name)
+
+        create_table_sql = "CREATE TABLE {} ({})".format(
+            table_name,
+            ", ".join('{} {}'.format(n, t)
+                      for n, t in zip(sql_column_names, sql_column_types)))
+
+        insert_values = ", ".join(
+            "({})".format(
+                ", ".join("NULL" if v is None else "'{}'".format(v)
+                          for v, t in zip(row, sql_column_types))
+            ) for row in data
+        )
+
+        insert_sql = "INSERT INTO {} VALUES {}".format(table_name,
+                                                       insert_values)
+
+        import psycopg2
+        with psycopg2.connect(**self.params) as conn:
+            with conn.cursor() as curs:
+                curs.execute(drop_table_sql)
+            with conn.cursor() as curs:
+                curs.execute(create_table_sql)
+            if insert_values:
+                with conn.cursor() as curs:
+                    curs.execute(insert_sql)
+
+        return self.params, table_name
+
+    def _drop_sql_table(self, table_name):
+        import psycopg2
+        with psycopg2.connect(**self.params) as conn:
+            with conn.cursor() as curs:
+                curs.execute("DROP TABLE {}".format(table_name))
+
+    def _get_backend(self):
+        return Psycopg2Backend(self.params)
+
+
+class MicrosoftTestConnection(DBTestConnection):
+    uri_name = "mssql"
+    module = "pymssql"
+
+    def try_connection(self):
+        try:
+            import pymssql
+            self.is_module = True
+            with pymssql.connect(**self.params):
+                self.is_active = True
+        except:
+            pass
+
+    def _create_sql_table(self, data, sql_column_types=None,
+                          sql_column_names=None, table_name=None):
+        data = list(data)
+
+        if table_name is None:
+            table_name = ''.join(random.choices(string.ascii_lowercase, k=16))
+
+        if sql_column_types is None:
+            column_size = self._get_column_types(data)
+            sql_column_types = [
+                'float' if size == 0 else 'varchar({})'.format(size)
+                for size in column_size
+            ]
+
+        if sql_column_names is None:
+            sql_column_names = ["col{}".format(i)
+                                for i in range(len(sql_column_types))]
+        else:
+            sql_column_names = map(lambda x: '"{}"'.format(x), sql_column_names)
+
+        drop_table_sql = "DROP TABLE IF EXISTS {}".format(table_name)
+
+        create_table_sql = "CREATE TABLE {} ({})".format(
+            table_name,
+            ", ".join('{} {}'.format(n, t)
+                      for n, t in zip(sql_column_names, sql_column_types)))
+
+        insert_values = ", ".join(
+            "({})".format(
+                ", ".join("NULL" if v is None else "'{}'".format(v)
+                          for v, t in zip(row, sql_column_types))
+            ) for row in data
+        )
+
+        insert_sql = "INSERT INTO {} VALUES {}".format(table_name,
+                                                       insert_values)
+
+        import pymssql
+        with pymssql.connect(**self.params) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(drop_table_sql)
+                cursor.execute(create_table_sql)
+                if insert_values:
+                    cursor.execute(insert_sql)
+            conn.commit()
+
+        return self.params, table_name
+
+    def _drop_sql_table(self, table_name):
+        import pymssql
+        with pymssql.connect(**self.params) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("DROP TABLE {}".format(table_name))
+            conn.commit()
+
+    def _get_backend(self):
+        return PymssqlBackend(self.params)
+
+
+def dbs():
+    
+    test_connections = {
+        PostgresTestConnection.uri_name: PostgresTestConnection,
+        MicrosoftTestConnection.uri_name: MicrosoftTestConnection
+    }
+
+    params = connection_params()
+
+    db_conn = {}
+    for c in params:
+        db_conn[c] = test_connections[c](params[c])
+
+    return db_conn
+
+
+class DataBaseTest:
+
+    db_conn = dbs()
+    
+    @classmethod
+    def _check_db(cls, db):
+        if ">" in db:
+            i = db.find(">")
+            if db[:i] in cls.db_conn and \
+                    cls.db_conn[db[:i]].version <= int(db[i + 1:]):
+                raise unittest.SkipTest(
+                    "This test is only run database version higher then {}"
+                        .format(db[i + 1:]))
+            else:
+                db = db[:i]
+        elif "<" in db:
+            i = db.find("<")
+            if db[:i] in cls.db_conn and \
+                    cls.db_conn[db[:i]].version >= int(db[i + 1:]):
+                raise unittest.SkipTest(
+                    "This test is only run on database version lower then {}"
+                        .format(db[i + 1:]))
+            else:
+                db = db[:i]
+
+        if db in cls.db_conn:
+            if not cls.db_conn[db].is_module:
+                raise unittest.SkipTest(
+                    "{} module is required for this database".format(
+                        cls.db_conn[db].module))
+
+            elif not cls.db_conn[db].is_active:
+                raise unittest.SkipTest("Database is not running")
+        else:
+                raise Exception("Unsupported database")
+
+        return db
+
+    @classmethod
+    def _setup_test_with(cls, test, db):
+        """This is used to setup the `db` database and run `test` on it"""
+        def new_test(test_self, *args):
+            new_db = cls._check_db(db)
+
+            test_self.create_sql_table = cls.db_conn[new_db]._create_sql_table
+            test_self.drop_sql_table = cls.db_conn[new_db]._drop_sql_table
+            test_self.backend = cls.db_conn[new_db]._get_backend()
+            
+            error = None
+            if hasattr(test_self, "setUpDB"):
+                test_self.setUpDB()
+            try:
+                test(test_self, *args)
+            except Exception as ex:
+                error = ex
+            finally:
+                if hasattr(test_self, "tearDownDB"):
+                    test_self.tearDownDB()
+            
+            if error is not None:
+                raise error
+            
+        return new_test
+
+    @classmethod
+    def run_on(cls, dbs):
+        """Decorator used to create new test for every given database"""
+        def decorator(function):
+            if function.__name__.startswith("test_db_"):
+                return function
+
+            stack = inspect.stack()
+            frame = stack[1]
+            frame_locals = frame[0].f_locals
+
+            for db in dbs:
+                name = 'test_db_' + db + '_' + function.__name__[5:]
+                frame_locals[name] = cls._setup_test_with(function, db)
+                frame_locals[name].__name__ = name
+                frame_locals[name].place_as = function
+                if function.__doc__ is not None:
+                    frame_locals[name].__doc__ = 'On ' + db + ' run: ' + \
+                                                 function.__doc__
+
+            function.__test__ = False
+
+        return decorator
+
+    def create_sql_table(self, data, sql_column_types=None,
+                          sql_column_names=None, table_name=None):
+        raise NotImplementedError
+
+    def drop_sql_table(self, table_name):
+        raise NotImplementedError
+
+    def create_iris_sql_tabel(self):
+        iris = Table("iris")
+        cn = ["sepal length", "sepal width", "petal length", "petal width",
+              "iris"]
+        ct = ["float", "float", "float", "float", "varchar(15)"]
+        Y = np.array(iris.domain.class_var.values)[iris.Y.astype(int)]
+        data = [list(x) + [y] for x, y in zip(iris.X, Y)]
+        return self.create_sql_table(data, table_name="iris",
+                                     sql_column_names=cn, sql_column_types=ct)
+
+    def drop_iris_sql_tabel(self):
+        self.drop_sql_table("iris")

--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -8,7 +8,6 @@ import inspect
 import numpy as np
 
 from Orange.data import Table
-from Orange.data.sql.backend import PymssqlBackend, Psycopg2Backend
 
 
 def parse_uri(uri):
@@ -203,6 +202,7 @@ class PostgresTestConnection(DBTestConnection):
                 curs.execute("DROP TABLE {}".format(table_name))
 
     def _get_backend(self):
+        from Orange.data.sql.backend import Psycopg2Backend
         return Psycopg2Backend(self.params)
 
 
@@ -275,6 +275,7 @@ class MicrosoftTestConnection(DBTestConnection):
             conn.commit()
 
     def _get_backend(self):
+        from Orange.data.sql.backend import PymssqlBackend
         return PymssqlBackend(self.params)
 
 

--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -404,10 +404,12 @@ class DataBaseTest:
 
     def create_sql_table(self, data, sql_column_types=None,
                          sql_column_names=None, table_name=None):
-        raise NotImplementedError
+        """This is reassigned according to the db currently being tested"""
+        return {}, ""
 
     def drop_sql_table(self, table_name):
-        raise NotImplementedError
+        """This is reassigned according to the db currently being tested"""
+        return {}, ""
 
     def create_iris_sql_tabel(self):
         iris = Table("iris")

--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -372,9 +372,7 @@ class DataBaseTest:
         def new_test(test_self, *args):
             new_db = cls._check_db(db)
 
-            test_self.create_sql_table = cls.db_conn[new_db].create_sql_table
-            test_self.drop_sql_table = cls.db_conn[new_db].drop_sql_table
-            test_self.backend = cls.db_conn[new_db].get_backend()
+            test_self.current_db = new_db
 
             error = None
             if hasattr(test_self, "setUpDB"):
@@ -425,14 +423,23 @@ class DataBaseTest:
 
         return decorator
 
+    @property
+    def backend(self):
+        """This is according to the db currently being tested"""
+        return self.db_conn[self.current_db].get_backend()
+
     def create_sql_table(self, data, sql_column_types=None,
                          sql_column_names=None, table_name=None):
-        """This is reassigned according to the db currently being tested"""
-        return {}, ""
+        """This is according to the db currently being tested"""
+        return self.db_conn[self.current_db]\
+            .create_sql_table(data, sql_column_types=sql_column_types,
+                              sql_column_names=sql_column_names,
+                              table_name=table_name)
 
     def drop_sql_table(self, table_name):
-        """This is reassigned according to the db currently being tested"""
-        return {}, ""
+        """This is according to the db currently being tested"""
+        return self.db_conn[self.current_db]\
+            .drop_sql_table(table_name=table_name)
 
     def create_iris_sql_table(self):
         iris = Table("iris")

--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -411,7 +411,7 @@ class DataBaseTest:
         """This is reassigned according to the db currently being tested"""
         return {}, ""
 
-    def create_iris_sql_tabel(self):
+    def create_iris_sql_table(self):
         iris = Table("iris")
         cn = ["sepal length", "sepal width", "petal length", "petal width",
               "iris"]
@@ -421,5 +421,5 @@ class DataBaseTest:
         return self.create_sql_table(data, table_name="iris",
                                      sql_column_names=cn, sql_column_types=ct)
 
-    def drop_iris_sql_tabel(self):
+    def drop_iris_sql_table(self):
         self.drop_sql_table("iris")

--- a/Orange/tests/sql/test_filter.py
+++ b/Orange/tests/sql/test_filter.py
@@ -1,6 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-# pylint: disable=abstract-method
 
 import unittest
 

--- a/Orange/tests/sql/test_filter.py
+++ b/Orange/tests/sql/test_filter.py
@@ -1,15 +1,15 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
+import unittest
+
 from Orange.data.sql.table import SqlTable, SqlRowInstance
 from Orange.data import filter, domain
+from Orange.tests.sql.base import DataBaseTest as dbt
 
-from Orange.tests.sql.base import PostgresTest, sql_test
 
-
-@sql_test
-class TestIsDefinedSql(PostgresTest):
-    def setUp(self):
+class TestIsDefinedSql(unittest.TestCase, dbt):
+    def setUpDB(self):
         self.data = [
             [1, 2, 3, None, 'm'],
             [2, 3, 1, 4, 'f'],
@@ -19,9 +19,10 @@ class TestIsDefinedSql(PostgresTest):
         conn, self.table_name = self.create_sql_table(self.data)
         self.table = SqlTable(conn, self.table_name, inspect_values=True)
 
-    def tearDown(self):
+    def tearDownDB(self):
         self.drop_sql_table(self.table_name)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_all_columns(self):
         filtered_data = filter.IsDefined()(self.table)
         correct_data = [row for row in self.data if all(row)]
@@ -29,6 +30,7 @@ class TestIsDefinedSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_selected_columns(self):
         filtered_data = filter.IsDefined(columns=[0])(self.table)
         correct_data = [row for row in self.data if row[0]]
@@ -36,6 +38,7 @@ class TestIsDefinedSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_all_columns_negated(self):
         filtered_data = filter.IsDefined(negate=True)(self.table)
         correct_data = [row for row in self.data if not all(row)]
@@ -43,6 +46,7 @@ class TestIsDefinedSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_selected_columns_negated(self):
         filtered_data = \
             filter.IsDefined(negate=True, columns=[4])(self.table)
@@ -51,6 +55,7 @@ class TestIsDefinedSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_can_inherit_is_defined_filter(self):
         filtered_data = filter.IsDefined(columns=[1])(self.table)
         filtered_data = filtered_data[:, 4]
@@ -60,9 +65,8 @@ class TestIsDefinedSql(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
-class TestHasClass(PostgresTest):
-    def setUp(self):
+class TestHasClass(unittest.TestCase, dbt):
+    def setUpDB(self):
         self.data = [
             [1, 2, 3, None, 'm'],
             [2, 3, 1, 4, 'f'],
@@ -76,9 +80,10 @@ class TestHasClass(PostgresTest):
         new_table.domain = domain.Domain(variables[:-1], variables[-1:])
         self.table = new_table
 
-    def tearDown(self):
+    def tearDownDB(self):
         self.drop_sql_table(self.table_name)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_has_class(self):
         filtered_data = filter.HasClass()(self.table)
         correct_data = [row for row in self.data if row[-1]]
@@ -86,6 +91,7 @@ class TestHasClass(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_negated(self):
         filtered_data = filter.HasClass(negate=True)(self.table)
         correct_data = [row for row in self.data if not row[-1]]
@@ -94,9 +100,8 @@ class TestHasClass(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
-class TestSameValueSql(PostgresTest):
-    def setUp(self):
+class TestSameValueSql(unittest.TestCase, dbt):
+    def setUpDB(self):
         self.data = [
             [1, 2, 3, 'a', 'm'],
             [2, None, 1, 'a', 'f'],
@@ -106,9 +111,10 @@ class TestSameValueSql(PostgresTest):
         self.conn, self.table_name = self.create_sql_table(self.data)
         self.table = SqlTable(self.conn, self.table_name, inspect_values=True)
 
-    def tearDown(self):
+    def tearDownDB(self):
         self.drop_sql_table(self.table_name)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_continuous_attribute(self):
         filtered_data = filter.SameValue(0, 1)(self.table)
         correct_data = [row for row in self.data if row[0] == 1]
@@ -116,6 +122,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_continuous_attribute_with_unknowns(self):
         filtered_data = filter.SameValue(1, 2)(self.table)
         correct_data = [row for row in self.data if row[1] == 2]
@@ -123,6 +130,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_continuous_attribute_with_unknown_value(self):
         filtered_data = filter.SameValue(1, None)(self.table)
         correct_data = [row for row in self.data if row[1] is None]
@@ -130,6 +138,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_on_continuous_attribute_negated(self):
         filtered_data = filter.SameValue(0, 1, negate=True)(self.table)
         correct_data = [row for row in self.data if not row[0] == 1]
@@ -137,6 +146,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_discrete_attribute(self):
         filtered_data = filter.SameValue(3, 'a')(self.table)
         correct_data = [row for row in self.data if row[3] == 'a']
@@ -144,6 +154,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_discrete_attribute_with_unknown_value(self):
         filtered_data = filter.SameValue(4, None)(self.table)
         correct_data = [row for row in self.data if row[4] is None]
@@ -151,6 +162,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_discrete_attribute_with_unknowns(self):
         filtered_data = filter.SameValue(4, 'm')(self.table)
         correct_data = [row for row in self.data if row[4] == 'm']
@@ -158,6 +170,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_discrete_attribute_negated(self):
         filtered_data = filter.SameValue(3, 'a', negate=True)(self.table)
         correct_data = [row for row in self.data if not row[3] == 'a']
@@ -165,6 +178,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_discrete_attribute_value_passed_as_int(self):
         values = self.table.domain[3].values
         filtered_data = filter.SameValue(3, 0, negate=True)(self.table)
@@ -173,6 +187,7 @@ class TestSameValueSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_on_discrete_attribute_value_passed_as_float(self):
         values = self.table.domain[3].values
         filtered_data = filter.SameValue(3, 0., negate=True)(self.table)
@@ -182,9 +197,8 @@ class TestSameValueSql(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
-class TestValuesSql(PostgresTest):
-    def setUp(self):
+class TestValuesSql(unittest.TestCase, dbt):
+    def setUpDB(self):
         self.data = [
             [1, 2, 3, 'a', 'm'],
             [2, None, 1, 'a', 'f'],
@@ -194,13 +208,15 @@ class TestValuesSql(PostgresTest):
         conn, self.table_name = self.create_sql_table(self.data)
         self.table = SqlTable(conn, self.table_name, inspect_values=True)
 
-    def tearDown(self):
+    def tearDownDB(self):
         self.drop_sql_table(self.table_name)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_values_filter_with_no_conditions(self):
         with self.assertRaises(ValueError):
             filtered_data = filter.Values([])(self.table)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_discrete_value_filter(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterDiscrete(3, ['a'])
@@ -210,6 +226,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_discrete_value_filter_with_multiple_values(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterDiscrete(3, ['a', 'b'])
@@ -219,6 +236,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_discrete_value_filter_with_None(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterDiscrete(3, None)
@@ -228,6 +246,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_continuous_value_filter_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.Equal, 1)
@@ -237,6 +256,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_continuous_value_filter_not_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.NotEqual, 1)
@@ -246,6 +266,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_continuous_value_filter_less(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.Less, 2)
@@ -256,6 +277,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_continuous_value_filter_less_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.LessEqual, 2)
@@ -266,6 +288,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_continuous_value_filter_greater(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.Greater, 1)
@@ -276,6 +299,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_continuous_value_filter_greater_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.GreaterEqual, 1)
@@ -286,6 +310,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_continuous_value_filter_between(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.Between, 1, 2)
@@ -296,6 +321,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_continuous_value_filter_outside(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(0, filter.FilterContinuous.Outside, 2, 3)
@@ -306,6 +332,7 @@ class TestValuesSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_continuous_value_filter_isdefined(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterContinuous(1, filter.FilterContinuous.IsDefined)
@@ -316,9 +343,8 @@ class TestValuesSql(PostgresTest):
         self.assertSequenceEqual(filtered_data, correct_data)
 
 
-@sql_test
-class TestFilterStringSql(PostgresTest):
-    def setUp(self):
+class TestFilterStringSql(unittest.TestCase, dbt):
+    def setUpDB(self):
         self.data = [
             [w] for w in "Lorem ipsum dolor sit amet, consectetur adipiscing"
             "elit. Vestibulum vel dolor nulla. Etiam elit lectus, mollis nec"
@@ -334,9 +360,10 @@ class TestFilterStringSql(PostgresTest):
         self.conn, self.table_name = self.create_sql_table(self.data)
         self.table = SqlTable(self.conn, self.table_name)
 
-    def tearDown(self):
+    def tearDownDB(self):
         self.drop_sql_table(self.table_name)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_is_defined(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.IsDefined)
@@ -347,6 +374,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_filter_string_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Equal, 'in')
@@ -357,6 +385,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_equal_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Equal, 'In',
@@ -368,6 +397,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_equal_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Equal, 'donec',
@@ -379,6 +409,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_not_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.NotEqual, 'in')
@@ -389,6 +420,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_not_equal_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.NotEqual, 'In',
@@ -400,6 +432,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_not_equal_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.NotEqual, 'donec',
@@ -411,6 +444,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_filter_string_less(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Less, 'A')
@@ -422,6 +456,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_less_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Less, 'In',
@@ -434,6 +469,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_less_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Less, 'donec',
@@ -446,6 +482,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_filter_string_less_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.LessEqual, 'A')
@@ -457,6 +494,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_less_equal_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.LessEqual, 'In',
@@ -469,6 +507,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_less_equal_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.LessEqual, 'donec',
@@ -481,6 +520,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_filter_string_greater(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Greater, 'volutpat')
@@ -492,6 +532,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_greater_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Greater, 'In',
@@ -504,6 +545,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_greater_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Greater, 'donec',
@@ -516,6 +558,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_greater_equal(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.GreaterEqual, 'volutpat')
@@ -527,6 +570,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_greater_equal_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.GreaterEqual, 'In',
@@ -539,6 +583,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_greater_equal_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.GreaterEqual, 'donec',
@@ -551,6 +596,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_between(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Between, 'a', 'c')
@@ -562,6 +608,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_between_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Between, 'I', 'O',
@@ -574,6 +621,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_between_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Between, 'i', 'O',
@@ -586,6 +634,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_contains(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Contains, 'et')
@@ -597,6 +646,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_contains_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Contains, 'eT',
@@ -609,6 +659,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_contains_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Contains, 'do',
@@ -621,6 +672,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_outside(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Outside, 'am', 'di')
@@ -632,6 +684,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_outside_case_insensitive(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Outside, 'd', 'k',
@@ -644,6 +697,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_starts_with(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.StartsWith, 'D')
@@ -655,6 +709,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_starts_with_case_insensitive(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.StartsWith, 'D',
@@ -668,6 +723,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_ends_with(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.EndsWith, 's')
@@ -679,6 +735,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_ends_with_case_insensitive(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.EndsWith, 'S',
@@ -692,6 +749,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_list(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterStringList(-1, ['et', 'in'])
@@ -702,6 +760,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres"])
     def test_filter_string_list_case_insensitive_value(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterStringList(-1, ['Et', 'In'], case_sensitive=False)
@@ -712,6 +771,7 @@ class TestFilterStringSql(PostgresTest):
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_filter_string_list_case_insensitive_data(self):
         filtered_data = filter.Values(conditions=[
             filter.FilterStringList(-1, ['donec'], case_sensitive=False)
@@ -721,3 +781,7 @@ class TestFilterStringSql(PostgresTest):
 
         self.assertEqual(len(filtered_data), len(correct_data))
         self.assertSequenceEqual(filtered_data, correct_data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Orange/tests/sql/test_filter.py
+++ b/Orange/tests/sql/test_filter.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+# pylint: disable=abstract-method
 
 import unittest
 
@@ -214,7 +215,7 @@ class TestValuesSql(unittest.TestCase, dbt):
     @dbt.run_on(["postgres", "mssql"])
     def test_values_filter_with_no_conditions(self):
         with self.assertRaises(ValueError):
-            filtered_data = filter.Values([])(self.table)
+            filter.Values([])(self.table)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_discrete_value_filter(self):

--- a/Orange/tests/sql/test_misc.py
+++ b/Orange/tests/sql/test_misc.py
@@ -7,7 +7,7 @@ import unittest
 from Orange.data.sql.table import SqlTable
 from Orange.preprocess import Discretize
 from Orange.preprocess.discretize import EqualFreq
-from Orange.tests.sql.base import PostgresTest
+from Orange.tests.sql.base import DataBaseTest as dbt
 try:
     from Orange.widgets.visualize.owmosaic import get_conditional_distribution
     from Orange.widgets.visualize.utils.lac import \
@@ -18,12 +18,20 @@ else:
     no_widgets = False
 
 
-class MiscSqlTests(PostgresTest):
+class MiscSqlTests(unittest.TestCase, dbt):
+    def setUpDB(self):
+        self.conn, self.iris = self.create_iris_sql_tabel()
+
+    def tearDownDB(self):
+        self.drop_iris_sql_tabel()
+
+    @dbt.run_on(["postgres"])
     def test_discretization(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
         sepal_length = iris.domain["sepal length"]
         EqualFreq(n=4)(iris, sepal_length)
 
+    @dbt.run_on(["postgres"])
     @unittest.skipIf(no_widgets, "Cannot import widgets")
     def test_get_conditional_distribution(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
@@ -31,6 +39,7 @@ class MiscSqlTests(PostgresTest):
         get_conditional_distribution(iris, [sepal_length])
         get_conditional_distribution(iris, list(iris.domain.variables))
 
+    @dbt.run_on(["postgres"])
     @unittest.skipIf(no_widgets, "Cannot import widgets")
     def test_create_sql_contingency(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)

--- a/Orange/tests/sql/test_misc.py
+++ b/Orange/tests/sql/test_misc.py
@@ -2,6 +2,8 @@
 
 Please note that such use is deprecated.
 """
+# pylint: disable=abstract-method
+
 import unittest
 
 from Orange.data.sql.table import SqlTable

--- a/Orange/tests/sql/test_misc.py
+++ b/Orange/tests/sql/test_misc.py
@@ -20,10 +20,10 @@ else:
 
 class MiscSqlTests(unittest.TestCase, dbt):
     def setUpDB(self):
-        self.conn, self.iris = self.create_iris_sql_tabel()
+        self.conn, self.iris = self.create_iris_sql_table()
 
     def tearDownDB(self):
-        self.drop_iris_sql_tabel()
+        self.drop_iris_sql_table()
 
     @dbt.run_on(["postgres"])
     def test_discretization(self):

--- a/Orange/tests/sql/test_misc.py
+++ b/Orange/tests/sql/test_misc.py
@@ -2,8 +2,6 @@
 
 Please note that such use is deprecated.
 """
-# pylint: disable=abstract-method
-
 import unittest
 
 from Orange.data.sql.table import SqlTable

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -23,7 +23,8 @@ class NaiveBayesTest(unittest.TestCase, dbt):
                          type_hints=Domain([], DiscreteVariable("iris",
                                 values=['Iris-setosa', 'Iris-virginica',
                                         'Iris-versicolor'])))
-        table = preprocess.Discretize(table)
+        disc = preprocess.Discretize()
+        table = disc(table)
         bayes = nb.NaiveBayesLearner()
         clf = bayes(table)
         # Single instance prediction

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -7,20 +7,22 @@ from Orange import preprocess
 from Orange.data.sql.table import SqlTable
 from Orange.data import Domain
 from Orange.data.variable import DiscreteVariable
-from Orange.tests.sql.base import sql_test, connection_params
+from Orange.tests.sql.base import DataBaseTest as dbt
 
 
-@unittest.skip("Fails on travis.")
-@sql_test
-class NaiveBayesTest(unittest.TestCase):
+class NaiveBayesTest(unittest.TestCase, dbt):
+    def setUpDB(self):
+        self.conn, self.iris = self.create_iris_sql_tabel()
+
+    def tearDownDB(self):
+        self.drop_iris_sql_tabel()
+
+    @dbt.run_on(["postgres"])
     def test_NaiveBayes(self):
-        table = SqlTable(
-            connection_params(), 'iris',
-            type_hints=Domain(
-                [],
-                DiscreteVariable(
-                    "iris",
-                    values=['Iris-setosa', 'Iris-virginica', 'Iris-versicolor'])))
+        table = SqlTable(self.conn, self.iris,
+                         type_hints=Domain([], DiscreteVariable("iris",
+                                values=['Iris-setosa', 'Iris-virginica',
+                                        'Iris-versicolor'])))
         table = preprocess.Discretize(table)
         bayes = nb.NaiveBayesLearner()
         clf = bayes(table)

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -1,5 +1,3 @@
-# pylint: disable=abstract-method
-
 import unittest
 
 from numpy import array

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -12,10 +12,10 @@ from Orange.tests.sql.base import DataBaseTest as dbt
 
 class NaiveBayesTest(unittest.TestCase, dbt):
     def setUpDB(self):
-        self.conn, self.iris = self.create_iris_sql_tabel()
+        self.conn, self.iris = self.create_iris_sql_table()
 
     def tearDownDB(self):
-        self.drop_iris_sql_tabel()
+        self.drop_iris_sql_table()
 
     @dbt.run_on(["postgres"])
     def test_NaiveBayes(self):

--- a/Orange/tests/sql/test_naive_bayes_sql.py
+++ b/Orange/tests/sql/test_naive_bayes_sql.py
@@ -1,3 +1,5 @@
+# pylint: disable=abstract-method
+
 import unittest
 
 from numpy import array
@@ -19,10 +21,11 @@ class NaiveBayesTest(unittest.TestCase, dbt):
 
     @dbt.run_on(["postgres"])
     def test_NaiveBayes(self):
+        iris_v = ['Iris-setosa', 'Iris-virginica', 'Iris-versicolor']
         table = SqlTable(self.conn, self.iris,
-                         type_hints=Domain([], DiscreteVariable("iris",
-                                values=['Iris-setosa', 'Iris-virginica',
-                                        'Iris-versicolor'])))
+                         type_hints=Domain([],
+                                           DiscreteVariable("iris",
+                                                            values=iris_v)))
         disc = preprocess.Discretize()
         table = disc(table)
         bayes = nb.NaiveBayesLearner()

--- a/Orange/tests/sql/test_pca.py
+++ b/Orange/tests/sql/test_pca.py
@@ -9,10 +9,10 @@ from Orange.tests.sql.base import DataBaseTest as dbt
 
 class PCATest(unittest.TestCase, dbt):
     def setUpDB(self):
-        self.conn, self.iris = self.create_iris_sql_tabel()
+        self.conn, self.iris = self.create_iris_sql_table()
 
     def tearDownDB(self):
-        self.drop_iris_sql_tabel()
+        self.drop_iris_sql_table()
 
     @dbt.run_on(["postgres"])
     @patch("Orange.projection.pca.save_state", MagicMock())

--- a/Orange/tests/sql/test_pca.py
+++ b/Orange/tests/sql/test_pca.py
@@ -4,24 +4,23 @@ from unittest.mock import patch, MagicMock
 from Orange.data import DiscreteVariable, Domain
 from Orange.data.sql.table import SqlTable
 from Orange.projection.pca import RemotePCA
-from Orange.tests.sql.base import sql_test, connection_params
+from Orange.tests.sql.base import DataBaseTest as dbt
 
 
-@sql_test
-class PCATest(unittest.TestCase):
+class PCATest(unittest.TestCase, dbt):
+    def setUpDB(self):
+        self.conn, self.iris = self.create_iris_sql_tabel()
+
+    def tearDownDB(self):
+        self.drop_iris_sql_tabel()
+
+    @dbt.run_on(["postgres"])
     @patch("Orange.projection.pca.save_state", MagicMock())
     def test_PCA(self):
-        table = SqlTable(
-            connection_params(), 'iris',
-            type_hints=Domain(
-                [],
-                DiscreteVariable(
-                    "iris",
-                    values=['Iris-setosa', 'Iris-virginica', 'Iris-versicolor'])))
+        table = SqlTable(self.conn, self.iris,
+                         type_hints=Domain([], DiscreteVariable("iris",
+                                values=['Iris-setosa', 'Iris-virginica',
+                                        'Iris-versicolor'])))
         for batch_size in (50, 500):
             rpca = RemotePCA(table, batch_size, 20)
             self.assertEqual(rpca.components_.shape, (4, 4))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/Orange/tests/sql/test_pca.py
+++ b/Orange/tests/sql/test_pca.py
@@ -1,5 +1,3 @@
-# pylint: disable=abstract-method
-
 import unittest
 from unittest.mock import patch, MagicMock
 

--- a/Orange/tests/sql/test_pca.py
+++ b/Orange/tests/sql/test_pca.py
@@ -1,3 +1,5 @@
+# pylint: disable=abstract-method
+
 import unittest
 from unittest.mock import patch, MagicMock
 
@@ -17,10 +19,11 @@ class PCATest(unittest.TestCase, dbt):
     @dbt.run_on(["postgres"])
     @patch("Orange.projection.pca.save_state", MagicMock())
     def test_PCA(self):
+        iris_v = ['Iris-setosa', 'Iris-virginica', 'Iris-versicolor']
         table = SqlTable(self.conn, self.iris,
-                         type_hints=Domain([], DiscreteVariable("iris",
-                                values=['Iris-setosa', 'Iris-virginica',
-                                        'Iris-versicolor'])))
+                         type_hints=Domain([],
+                                           DiscreteVariable("iris",
+                                                            values=iris_v)))
         for batch_size in (50, 500):
             rpca = RemotePCA(table, batch_size, 20)
             self.assertEqual(rpca.components_.shape, (4, 4))

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -22,10 +22,10 @@ from Orange.tests.sql.base import DataBaseTest as dbt
 
 class TestSqlTable(unittest.TestCase, dbt):
     def setUpDB(self):
-        self.conn, self.iris = self.create_iris_sql_tabel()
+        self.conn, self.iris = self.create_iris_sql_table()
 
     def tearDownDB(self):
-        self.drop_iris_sql_tabel()
+        self.drop_iris_sql_table()
 
     def float_variable(self, size):
         return [i * .1 for i in range(size)]

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -1,6 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-# pylint: disable=abstract-method
 
 import pickle
 import contextlib

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -2,8 +2,9 @@
 # pylint: disable=missing-docstring
 
 import pickle
-import unittest
+import contextlib
 import unittest.mock
+import string
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -16,11 +17,34 @@ from Orange.preprocess.discretize import EqualWidth
 from Orange.statistics.basic_stats import BasicStats, DomainBasicStats
 from Orange.statistics.contingency import Continuous, Discrete, get_contingencies
 from Orange.statistics.distribution import get_distributions
-from Orange.tests.sql.base import PostgresTest, sql_version, sql_test
+from Orange.tests.sql.base import DataBaseTest as dbt
 
 
-@sql_test
-class TestSqlTable(PostgresTest):
+class TestSqlTable(unittest.TestCase, dbt):
+    def setUpDB(self):
+        self.conn, self.iris = self.create_iris_sql_tabel()
+
+    def tearDownDB(self):
+        self.drop_iris_sql_tabel()
+
+    def float_variable(self, size):
+        return [i * .1 for i in range(size)]
+
+    def discrete_variable(self, size):
+        return ["mf"[i % 2] for i in range(size)]
+
+    def string_variable(self, size):
+        return string.ascii_letters[:size]
+
+    @contextlib.contextmanager
+    def sql_table_from_data(self, data, guess_values=True):
+        params, table_name = self.create_sql_table(data)
+        yield SqlTable(params, table_name,
+                       inspect_values=guess_values)
+
+        self.drop_sql_table(table_name)
+
+    @dbt.run_on(["postgres"])
     def test_constructs_correct_attributes(self):
         data = list(zip(self.float_variable(21),
                         self.discrete_variable(21),
@@ -45,11 +69,13 @@ class TestSqlTable(PostgresTest):
             self.assertEqual(string_attr.name, "col2")
             self.assertTrue('"col2"' in string_attr.to_sql())
 
+    @dbt.run_on(["postgres"])
     def test_make_attributes(self):
         table1 = SqlTable(self.conn, self.iris)
         table2 = SqlTable(self.conn, self.iris)
         self.assertEqual(table1.domain[0], table2.domain[0])
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_len(self):
         with self.sql_table_from_data(zip(self.float_variable(26))) as table:
             self.assertEqual(len(table), 26)
@@ -57,12 +83,14 @@ class TestSqlTable(PostgresTest):
         with self.sql_table_from_data(zip(self.float_variable(0))) as table:
             self.assertEqual(len(table), 0)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_bool(self):
         with self.sql_table_from_data(()) as table:
             self.assertEqual(bool(table), False)
         with self.sql_table_from_data(zip(self.float_variable(1))) as table:
             self.assertEqual(bool(table), True)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_len_with_filter(self):
         data = zip(self.discrete_variable(26))
         with self.sql_table_from_data(data) as table:
@@ -75,6 +103,7 @@ class TestSqlTable(PostgresTest):
             filtered_table = filter.SameValue(table.domain[0], 'x')(table)
             self.assertEqual(len(filtered_table), 0)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_XY_small(self):
         mat = np.random.randint(0, 2, (20, 3))
         conn, table_name = self.create_sql_table(mat)
@@ -84,6 +113,7 @@ class TestSqlTable(PostgresTest):
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
 
+    @dbt.run_on(["postgres", "mssql"])
     @unittest.mock.patch("Orange.data.sql.table.AUTO_DL_LIMIT", 100)
     def test_XY_large(self):
         from Orange.data.sql.table import AUTO_DL_LIMIT as DLL
@@ -105,6 +135,7 @@ class TestSqlTable(PostgresTest):
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_download_data(self):
         mat = np.random.randint(0, 2, (20, 3))
         conn, table_name = self.create_sql_table(mat)
@@ -116,16 +147,19 @@ class TestSqlTable(PostgresTest):
         # has all necessary class members to create a standard Table
         Table(sql_table.domain, sql_table)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_query_all(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         results = list(table)
 
         self.assertEqual(len(results), 150)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_unavailable_row(self):
         table = SqlTable(self.conn, self.iris)
         self.assertRaises(IndexError, lambda: table[151])
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_query_subset_of_attributes(self):
         table = SqlTable(self.conn, self.iris)
         attributes = [
@@ -146,6 +180,7 @@ class TestSqlTable(PostgresTest):
              (5.0, 3.6, 7.2)]
         )
 
+    @dbt.run_on(["postgres"])
     def test_query_subset_of_rows(self):
         table = SqlTable(self.conn, self.iris)
         all_results = list(table._query())
@@ -166,11 +201,12 @@ class TestSqlTable(PostgresTest):
         self.assertEqual(len(results), 140)
         self.assertSequenceEqual(results, all_results[10:])
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_getitem_single_value(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         self.assertAlmostEqual(table[0, 0], 5.1)
 
-
+    @dbt.run_on(["postgres", "mssql"])
     def test_type_hints(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         self.assertEqual(len(table.domain), 5)
@@ -181,6 +217,7 @@ class TestSqlTable(PostgresTest):
         self.assertEqual(len(table.domain), 4)
         self.assertEqual(len(table.domain.metas), 1)
 
+    @dbt.run_on(["postgres"])
     def test_joins(self):
         table = SqlTable(
             self.conn,
@@ -213,6 +250,7 @@ class TestSqlTable(PostgresTest):
 
         return Attr
 
+    @dbt.run_on(["postgres"])
     def test_universal_table(self):
         _, table_name = self.construct_universal_table()
 
@@ -245,6 +283,7 @@ class TestSqlTable(PostgresTest):
     IRIS_VARIABLE = DiscreteVariable(
         "iris", values=['Iris-setosa', 'Iris-virginica', 'Iris-versicolor'])
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_class_var_type_hints(self):
         iris = SqlTable(self.conn, self.iris,
                         type_hints=Domain([], self.IRIS_VARIABLE))
@@ -252,6 +291,7 @@ class TestSqlTable(PostgresTest):
         self.assertEqual(len(iris.domain.class_vars), 1)
         self.assertEqual(iris.domain.class_vars[0].name, 'iris')
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_metas_type_hints(self):
         iris = SqlTable(self.conn, self.iris,
                         type_hints=Domain([], [], metas=[self.IRIS_VARIABLE]))
@@ -259,12 +299,14 @@ class TestSqlTable(PostgresTest):
         self.assertEqual(len(iris.domain.metas), 1)
         self.assertEqual(iris.domain.metas[0].name, 'iris')
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_select_all(self):
         iris = SqlTable(self.conn, "SELECT * FROM iris",
                         type_hints=Domain([], self.IRIS_VARIABLE))
 
         self.assertEqual(len(iris.domain), 5)
 
+    @dbt.run_on(["postgres"])
     def test_discrete_bigint(self):
         table = np.arange(6).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['bigint'])
@@ -275,6 +317,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_continous_bigint(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['bigint'])
@@ -285,6 +328,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres"])
     def test_discrete_int(self):
         table = np.arange(6).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['int'])
@@ -295,6 +339,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_continous_int(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['int'])
@@ -305,6 +350,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres"])
     def test_discrete_smallint(self):
         table = np.arange(6).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['smallint'])
@@ -315,6 +361,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_continous_smallint(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['smallint'])
@@ -325,6 +372,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres"])
     def test_boolean(self):
         table = np.array(['F', 'T', 0, 1, 'False', 'True']).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['boolean'])
@@ -335,6 +383,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_discrete_char(self):
         table = np.array(['M', 'F', 'M', 'F', 'M', 'F']).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['char(1)'])
@@ -345,6 +394,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
+    @dbt.run_on(["postgres"])
     def test_discrete_bigger_char(self):
         """Test if the discrete values are the same for bigger char fields"""
         table = np.array(['M', 'F', 'M', 'F', 'M', 'F']).reshape(-1, 1)
@@ -353,6 +403,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertSequenceEqual(sql_table.domain[0].values, ['F', 'M'])
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_meta_char(self):
         table = np.array(list('ABCDEFGHIJKLMNOPQRSTUVW')).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['char(1)'])
@@ -363,6 +414,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_discrete_varchar(self):
         table = np.array(['M', 'F', 'M', 'F', 'M', 'F']).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['varchar(1)'])
@@ -373,6 +425,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_meta_varchar(self):
         table = np.array(list('ABCDEFGHIJKLMNOPQRSTUVW')).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['varchar(1)'])
@@ -383,6 +436,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
 
+    @dbt.run_on(["postgres"])
     def test_time_date(self):
         table = np.array(['2014-04-12', '2014-04-13', '2014-04-14',
                           '2014-04-15', '2014-04-16']).reshape(-1, 1)
@@ -394,6 +448,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
 
+    @dbt.run_on(["postgres"])
     def test_time_time(self):
         table = np.array(['17:39:51', '11:51:48.46', '05:20:21.492149',
                           '21:47:06', '04:47:35.8']).reshape(-1, 1)
@@ -405,6 +460,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
 
+    @dbt.run_on(["postgres"])
     def test_time_timetz(self):
         table = np.array(['17:39:51+0200', '11:51:48.46+01', '05:20:21.4921',
                           '21:47:06-0600', '04:47:35.8+0330']).reshape(-1, 1)
@@ -416,6 +472,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
 
+    @dbt.run_on(["postgres"])
     def test_time_timestamp(self):
         table = np.array(['2014-07-15 17:39:51.348149',
                           '2008-10-05 11:51:48.468149',
@@ -430,6 +487,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
 
+    @dbt.run_on(["postgres"])
     def test_time_timestamptz(self):
         table = np.array(['2014-07-15 17:39:51.348149+0200',
                           '2008-10-05 11:51:48.468149+02',
@@ -444,6 +502,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_double_precision(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['double precision'])
@@ -454,6 +513,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_numeric(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['numeric(15, 2)'])
@@ -464,6 +524,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_real(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['real'])
@@ -474,6 +535,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres"])
     def test_serial(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['serial'])
@@ -484,8 +546,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
-    @unittest.skipIf(sql_version < 90200,
-                     "Type not supported on this server version.")
+    @dbt.run_on(["postgres>90200"])
     def test_smallserial(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['smallserial'])
@@ -496,8 +557,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
-    @unittest.skipIf(sql_version < 90200,
-                     "Type not supported on this server version.")
+    @dbt.run_on(["postgres>90200"])
     def test_bigserial(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['bigserial'])
@@ -508,6 +568,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
+    @dbt.run_on(["postgres"])
     def test_text(self):
         table = np.array(list('ABCDEFGHIJKLMNOPQRSTUVW')).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['text'])
@@ -518,6 +579,7 @@ class TestSqlTable(PostgresTest):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
 
+    @dbt.run_on(["postgres"])
     def test_other(self):
         table = np.array(['bcd4d9c0-361e-bad4-7ceb-0d171cdec981',
                           '544b7ddc-d861-0201-81c8-9f7ad0bbf531',
@@ -534,6 +596,7 @@ class TestSqlTable(PostgresTest):
         filters = filter.Values([filter.FilterString(-1, filter.FilterString.Equal, 'foo')])
         self.assertEqual(len(filters(sql_table)), 0)
 
+    @dbt.run_on(["postgres", "mssql"])
     def test_recovers_connection_after_sql_error(self):
         conn, table_name = self.create_sql_table(
             np.arange(25).reshape((-1, 1)))
@@ -552,6 +615,7 @@ class TestSqlTable(PostgresTest):
         with sql_table.backend.execute_sql_query(working_query) as cur:
             cur.fetchall()
 
+    @dbt.run_on(["postgres"])
     def test_basic_stats(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
         stats = BasicStats(iris, iris.domain['sepal length'])
@@ -571,14 +635,32 @@ class TestSqlTable(PostgresTest):
         self.assertEqual(stats.nans, 0)
         self.assertEqual(stats.non_nans, 150)
 
+    @dbt.run_on(["postgres"])
     @unittest.mock.patch("Orange.data.sql.table.LARGE_TABLE", 100)
     def test_basic_stats_on_large_data(self):
         # By setting LARGE_TABLE to 100, iris will be treated as
         # a large table and sampling will be used. As the table
         # is actually small, time base sampling should return
         # all rows, so the same assertions can be used.
-        self.test_basic_stats()
+        iris = SqlTable(self.conn, self.iris, inspect_values=True)
+        stats = BasicStats(iris, iris.domain['sepal length'])
+        self.assertAlmostEqual(stats.min, 4.3)
+        self.assertAlmostEqual(stats.max, 7.9)
+        self.assertAlmostEqual(stats.mean, 5.8, 1)
+        self.assertEqual(stats.nans, 0)
+        self.assertEqual(stats.non_nans, 150)
 
+        domain_stats = DomainBasicStats(iris, include_metas=True)
+        self.assertEqual(len(domain_stats.stats),
+                         len(iris.domain) + len(iris.domain.metas))
+        stats = domain_stats['sepal length']
+        self.assertAlmostEqual(stats.min, 4.3)
+        self.assertAlmostEqual(stats.max, 7.9)
+        self.assertAlmostEqual(stats.mean, 5.8, 1)
+        self.assertEqual(stats.nans, 0)
+        self.assertEqual(stats.non_nans, 150)
+
+    @dbt.run_on(["postgres", "mssql"])
     def test_distributions(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
 
@@ -589,6 +671,7 @@ class TestSqlTable(PostgresTest):
         self.assertAlmostEqual(dist.max(), 7.9)
         self.assertAlmostEqual(dist.mean(), 5.8, 1)
 
+    @dbt.run_on(["postgres"])
     def test_contingencies(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
         iris.domain = Domain(iris.domain[:2] + (EqualWidth()(iris, iris.domain['sepal width']),),
@@ -600,12 +683,14 @@ class TestSqlTable(PostgresTest):
         self.assertIsInstance(conts[1], Continuous)
         self.assertIsInstance(conts[2], Discrete)
 
+    @dbt.run_on(["postgres"])
     def test_pickling_restores_connection_pool(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
         iris2 = pickle.loads(pickle.dumps(iris))
 
         self.assertEqual(iris[0], iris2[0])
 
+    @dbt.run_on(["postgres"])
     def test_list_tables_with_schema(self):
         with self.backend.execute_sql_query("DROP SCHEMA IF EXISTS orange_tests CASCADE") as cur:
             cur.execute("CREATE SCHEMA orange_tests")

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+# pylint: disable=abstract-method
 
 import pickle
 import contextlib

--- a/Orange/widgets/data/tests/test_owsql.py
+++ b/Orange/widgets/data/tests/test_owsql.py
@@ -13,11 +13,11 @@ from Orange.tests.sql.base import DataBaseTest as dbt
 class TestOWSqlConnected(WidgetTest, dbt):
     def setUpDB(self):
         self.widget = self.create_widget(OWSql)
-        self.params, _ = self.create_iris_sql_tabel()
+        self.params, _ = self.create_iris_sql_table()
         self.iris = Table("iris")
 
     def tearDownDB(self):
-        self.drop_iris_sql_tabel()
+        self.drop_iris_sql_table()
 
     @dbt.run_on(["postgres"])
     def test_connection(self):

--- a/Orange/widgets/data/tests/test_owsql.py
+++ b/Orange/widgets/data/tests/test_owsql.py
@@ -7,17 +7,19 @@ from unittest import mock
 from Orange.data import Table
 from Orange.widgets.data.owsql import OWSql
 from Orange.widgets.tests.base import WidgetTest
-from Orange.tests.sql.base import create_iris, parse_uri, sql_test
+from Orange.tests.sql.base import DataBaseTest as dbt
 
 
-@sql_test
-class TestOWSqlConnected(WidgetTest):
-    def setUp(self):
+class TestOWSqlConnected(WidgetTest, dbt):
+    def setUpDB(self):
         self.widget = self.create_widget(OWSql)
-        params, _ = create_iris()
-        self.params = parse_uri(params)
+        self.params, _ = self.create_iris_sql_tabel()
         self.iris = Table("iris")
 
+    def tearDownDB(self):
+        self.drop_iris_sql_tabel()
+
+    @dbt.run_on(["postgres"])
     def test_connection(self):
         """Test if a connection to the database can be established"""
         self.set_connection_params()
@@ -28,6 +30,7 @@ class TestOWSqlConnected(WidgetTest):
         tables = ["Select a table", "Custom SQL"]
         self.assertTrue(set(self.widget.tables).issuperset(set(tables)))
 
+    @dbt.run_on(["postgres"])
     def test_output_iris(self):
         """Test if iris data can be fetched from database"""
         self.assertIsNone(self.get_output(self.widget.Outputs.data))

--- a/Orange/widgets/data/tests/test_owsql.py
+++ b/Orange/widgets/data/tests/test_owsql.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+# pylint: disable=abstract-method
 
 import unittest
 from unittest import mock

--- a/Orange/widgets/data/tests/test_owsql.py
+++ b/Orange/widgets/data/tests/test_owsql.py
@@ -1,6 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-# pylint: disable=abstract-method
 
 import unittest
 from unittest import mock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ environment:
     BUILD_GLOBAL_OPTIONS: build -j1
     BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.9.3 -r requirements-doc.txt
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
-    ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@0.0.0.0:1433'
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
+    ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'
 
   matrix:
     - PYTHON: C:\Python36-x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,12 +21,16 @@ environment:
     BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.9.3 -r requirements-doc.txt
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
     TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
+    ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@0.0.0.0:1433'
 
   matrix:
     - PYTHON: C:\Python36-x64
 
 cache:
   - '%LOCALAPPDATA%\pip\cache -> appveyor.yml'
+
+services:
+  - mssql2017
 
 install:
   # Configure pip: Add extra links url, force binary numpy, scipy, ...


### PR DESCRIPTION
##### Issue
Orange currently only supports testing for PostgresSQL although Microsoft SQL Server is also supported by Travis (#2839).
##### Description of changes
Extend testing so that one test can be run on multiple databases. Add testing for Microsoft SQL Server to Travis and AppVeyor.
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
