### PR TITLE
Table: Warn about pending deprecation of methods that resize Table

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1,5 +1,6 @@
 import operator
 import os
+import warnings
 import zlib
 from collections import MutableSequence, Iterable, Sequence, Sized
 from functools import reduce
@@ -42,6 +43,11 @@ chaining of domain conversions also works with caching even with descendants
 of Table."""
 _conversion_cache = None
 _conversion_cache_lock = RLock()
+
+
+def pending_deprecation_resize(name):
+    warnings.warn(f"Method Table.{name} will be removed in Orange 3.24",
+                  PendingDeprecationWarning)
 
 
 class DomainTransformationError(Exception):
@@ -829,6 +835,7 @@ class Table(MutableSequence, Storage):
                 self.metas[row_idx, meta_cols] = value
 
     def __delitem__(self, key):
+        pending_deprecation_resize("__delitem__(key)")
         if not self._check_all_dense():
             raise ValueError("Rows of sparse data cannot be deleted")
         if key is ...:
@@ -857,6 +864,7 @@ class Table(MutableSequence, Storage):
 
     def clear(self):
         """Remove all rows from the table."""
+        pending_deprecation_resize("clear()")
         if not self._check_all_dense():
             raise ValueError("Tables with sparse data cannot be cleared")
         del self[...]
@@ -868,6 +876,7 @@ class Table(MutableSequence, Storage):
         :param instance: a data instance
         :type instance: Orange.data.Instance or a sequence of values
         """
+        pending_deprecation_resize("append(inst)")
         self.insert(len(self), instance)
 
     def insert(self, row, instance):
@@ -879,6 +888,7 @@ class Table(MutableSequence, Storage):
         :param instance: a data instance
         :type instance: Orange.data.Instance or a sequence of values
         """
+        pending_deprecation_resize("insert(i, inst)")
         if row < 0:
             row += len(self)
         if row < 0 or row > len(self):
@@ -915,6 +925,7 @@ class Table(MutableSequence, Storage):
         :param instances: additional instances
         :type instances: Orange.data.Table or a sequence of instances
         """
+        pending_deprecation_resize("extend(insts)")
         if isinstance(instances, Table) and instances.domain == self.domain:
             self.X = vstack((self.X, instances.X))
             self._Y = vstack((self._Y, instances._Y))
@@ -982,6 +993,7 @@ class Table(MutableSequence, Storage):
                 conc.attributes.update(table.attributes)
             return conc
         elif axis == CONCAT_COLS:
+            pending_deprecation_resize("concatenate with axis=1")
             if reduce(operator.iand,
                       (set(map(operator.attrgetter('name'),
                                chain(t.domain.variables, t.domain.metas)))

--- a/Orange/tests/test_sparse_table.py
+++ b/Orange/tests/test_sparse_table.py
@@ -1,14 +1,13 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
-from unittest import skip
-
 import numpy as np
 from scipy.sparse import csr_matrix
 
 from Orange import data
 from Orange.data import Table
 from Orange.tests import test_table as tabletests
+from Orange.tests.test_table import skip_deprecated_length
 
 
 class InterfaceTest(tabletests.InterfaceTest):
@@ -20,27 +19,27 @@ class InterfaceTest(tabletests.InterfaceTest):
             csr_matrix(self.table.Y),
         )
 
-    @skip("method will be deprecated; it fails on Python 3.7 on travis")
+    @skip_deprecated_length
     def test_append_rows(self):
         with self.assertRaises(Exception):
             super().test_append_rows()
 
-    @skip("method will be deprecated; it fails on Python 3.7 on travis")
+    @skip_deprecated_length
     def test_insert_rows(self):
         with self.assertRaises(Exception):
             super().test_insert_rows()
 
-    @skip("method will be deprecated; it fails on Python 3.7 on travis")
+    @skip_deprecated_length
     def test_insert_view(self):
         with self.assertRaises(Exception):
             super().test_insert_view()
 
-    @skip("method will be deprecated; it fails on Python 3.7 on travis")
+    @skip_deprecated_length
     def test_delete_rows(self):
         with self.assertRaises(ValueError):
             super().test_delete_rows()
 
-    @skip("method will be deprecated; it fails on Python 3.7 on travis")
+    @skip_deprecated_length
     def test_clear(self):
         with self.assertRaises(ValueError):
             super().test_clear()


### PR DESCRIPTION
##### Issue

#3501, which will be merged in 3.24 (this is negotiable) will remove methods that change the length of `Table`. People have a right to know.

##### Description of changes

Add deprecation warnings.

Change the `skip` decorators for the tests so that they will raise exceptions in >3.24, so we'll remember to remove the methods and we also won't forget the tests.

##### Includes
- [X] Code changes
