### PR TITLE
[FIX] Don't add miniconda to path and register as system python

### DIFF
--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -396,7 +396,7 @@ Section "Miniconda ${MINICONDA_VERSION} (Python ${PYTHON_VERSION} ${BITS}-bit)" 
         # Why does executing "${TEMPDIR}\${PYINSTALLER}" directly hang the
         # Miniconda installer?
         ${If} ${Silent}
-            StrCpy $0 "/S"
+            StrCpy $0 "/S /AddToPath=0 /RegisterPython=0"
         ${Else}
             StrCpy $0 ""
         ${EndIf}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

When running the miniconda installer in silent mode, it might modify %PATH%, ... 

Ref gh-3524

##### Description of changes

Add `/AddToPath=0 /RegisterPython=0` to miniconda installer call when running in silent mode.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
