### PR TITLE
[FIX] Python script widget: prevent data loss 

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -463,14 +463,17 @@ class OWPythonScript(widget.OWWidget):
 
         new_from_file = QAction("Import Script from File", self)
         save_to_file = QAction("Save Selected Script to File", self)
+        restore_saved = QAction("Undo Changes to Selected Script", self)
         save_to_file.setShortcut(QKeySequence(QKeySequence.SaveAs))
 
         new_from_file.triggered.connect(self.onAddScriptFromFile)
         save_to_file.triggered.connect(self.saveScript)
+        restore_saved.triggered.connect(self.restoreSaved)
 
         menu = QMenu(w)
         menu.addAction(new_from_file)
         menu.addAction(save_to_file)
+        menu.addAction(restore_saved)
         action.setMenu(menu)
         button = w.addAction(action)
         button.setPopupMode(QToolButton.InstantPopup)
@@ -602,7 +605,6 @@ class OWPythonScript(widget.OWWidget):
     def documentForScript(self, script=0):
         if type(script) != Script:
             script = self.libraryList[script]
-
         if script not in self._cachedDocuments:
             doc = QTextDocument(self)
             doc.setDocumentLayout(QPlainTextDocumentLayout(doc))
@@ -629,6 +631,12 @@ class OWPythonScript(widget.OWWidget):
 
     def onSpliterMoved(self, pos, ind):
         self.splitterState = bytes(self.splitCanvas.saveState())
+
+    def restoreSaved(self):
+        index = self.selectedScriptIndex()
+        if index is not None:
+            self.text.document().setPlainText(self.libraryList[index].script)
+            self.text.document().setModified(False)
 
     def saveScript(self):
         index = self.selectedScriptIndex()

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -560,7 +560,7 @@ class OWPythonScript(widget.OWWidget):
         select_row(self.libraryView, index)
 
     def onAddScript(self, *args):
-        self.libraryList.append(Script("New script", "", 0))
+        self.libraryList.append(Script("New script", self.text.toPlainText(), 0))
         self.setSelectedScript(len(self.libraryList) - 1)
 
     def onAddScriptFromFile(self, *args):

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -392,6 +392,7 @@ class OWPythonScript(widget.OWWidget):
     libraryListSource = \
         Setting([Script("Hello world", "print('Hello world')\n")])
     currentScriptIndex = Setting(0)
+    scriptText = Setting(None, schema_only=True)
     splitterState = Setting(None)
 
     class Error(OWWidget.Error):
@@ -516,6 +517,9 @@ class OWPythonScript(widget.OWWidget):
 
         select_row(self.libraryView, self.currentScriptIndex)
 
+        self.restoreScriptText()
+        self.text.textChanged.connect(self.saveScriptText)  # after restoring
+
         self.splitCanvas.setSizes([2, 1])
         if self.splitterState is not None:
             self.splitCanvas.restoreState(QByteArray(self.splitterState))
@@ -523,6 +527,16 @@ class OWPythonScript(widget.OWWidget):
         self.splitCanvas.splitterMoved[int, int].connect(self.onSpliterMoved)
         self.controlArea.layout().addStretch(1)
         self.resize(800, 600)
+
+    def restoreScriptText(self):
+        if self.scriptText is not None:
+            current = self.text.toPlainText()
+            # do not mark scripts as modified
+            if self.scriptText != current:
+                self.text.document().setPlainText(self.scriptText)
+
+    def saveScriptText(self):
+        self.scriptText = self.text.toPlainText()
 
     def handle_input(self, obj, id, signal):
         id = id[0]

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -630,14 +630,6 @@ class OWPythonScript(widget.OWWidget):
     def onSpliterMoved(self, pos, ind):
         self.splitterState = bytes(self.splitCanvas.saveState())
 
-    def updateSelecetdScriptState(self):
-        index = self.selectedScriptIndex()
-        if index is not None:
-            script = self.libraryList[index]
-            self.libraryList[index] = Script(script.name,
-                                             self.text.toPlainText(),
-                                             0)
-
     def saveScript(self):
         index = self.selectedScriptIndex()
         if index is not None:

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -21,7 +21,7 @@ from Orange.data import Table
 from Orange.base import Learner, Model
 from Orange.widgets import widget, gui
 from Orange.widgets.utils import itemmodels
-from Orange.widgets.settings import Setting
+from Orange.widgets.settings import Setting, SettingsHandler
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Input, Output
 
@@ -364,6 +364,14 @@ def select_row(view, row):
                     QItemSelectionModel.ClearAndSelect)
 
 
+class PrepareSavingSettingsHandler(SettingsHandler):
+    """Calls storeSpecificSettings, which is currently not called from non-context handlers."""
+
+    def pack_data(self, widget):
+        widget.storeSpecificSettings()
+        return super().pack_data(widget)
+
+
 class OWPythonScript(widget.OWWidget):
     name = "Python Script"
     description = "Write a Python script and run it on input data or models."
@@ -388,6 +396,8 @@ class OWPythonScript(widget.OWWidget):
         object = Output("Object", object, replaces=["out_object"])
 
     signal_names = ("data", "learner", "classifier", "object")
+
+    settingsHandler = PrepareSavingSettingsHandler()
 
     libraryListSource = \
         Setting([Script("Hello world", "print('Hello world')\n")])
@@ -518,7 +528,6 @@ class OWPythonScript(widget.OWWidget):
         select_row(self.libraryView, self.currentScriptIndex)
 
         self.restoreScriptText()
-        self.text.textChanged.connect(self.saveScriptText)  # after restoring
 
         self.splitCanvas.setSizes([2, 1])
         if self.splitterState is not None:
@@ -527,6 +536,9 @@ class OWPythonScript(widget.OWWidget):
         self.splitCanvas.splitterMoved[int, int].connect(self.onSpliterMoved)
         self.controlArea.layout().addStretch(1)
         self.resize(800, 600)
+
+    def storeSpecificSettings(self):
+        self.saveScriptText()
 
     def restoreScriptText(self):
         if self.scriptText is not None:

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -117,3 +117,10 @@ class TestOWPythonScript(WidgetTest):
         self.widget.onAddScript()
         script = self.widget.text.toPlainText()
         self.assertEqual("42", script)
+
+    def test_restore_from_library(self):
+        before = self.widget.text.toPlainText()
+        self.widget.text.setPlainText("42")
+        self.widget.restoreSaved()
+        script = self.widget.text.toPlainText()
+        self.assertEqual(before, script)

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -111,3 +111,9 @@ class TestOWPythonScript(WidgetTest):
         click()
         self.assertIsNone(console_locals["in_data"])
         self.assertEqual(console_locals["in_datas"], [])
+
+    def test_store_new_script(self):
+        self.widget.text.setPlainText("42")
+        self.widget.onAddScript()
+        script = self.widget.text.toPlainText()
+        self.assertEqual("42", script)

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -124,3 +124,13 @@ class TestOWPythonScript(WidgetTest):
         self.widget.restoreSaved()
         script = self.widget.text.toPlainText()
         self.assertEqual(before, script)
+
+    def test_store_current_script(self):
+        self.widget.text.setPlainText("42")
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+        self.widget = self.create_widget(OWPythonScript)
+        script = self.widget.text.toPlainText()
+        self.assertNotEqual("42", script)
+        self.widget = self.create_widget(OWPythonScript, stored_settings=settings)
+        script = self.widget.text.toPlainText()
+        self.assertEqual("42", script)


### PR DESCRIPTION
##### Issue
Users were losing their scripts:
1. If they added a new enrty to the library (button "+") they lost the current script.
2. If they did not save the script into the library it got lots.

Fixes #3531

##### Description of changes
1. Adding an entry to the library initializes that script with the current script text.
2. The current script text is saved as a schema_only settings and is restored on load. I also added an option to restore the library version.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
