### PR TITLE
[ENH] Implement better randomized PCA

### DIFF
--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -1,5 +1,13 @@
+import numbers
+
+import six
 import numpy as np
-import sklearn.decomposition as skl_decomposition
+import scipy.sparse as sp
+from scipy.linalg import lu, qr, svd
+from sklearn import decomposition as skl_decomposition
+from sklearn.utils import check_array, check_random_state
+from sklearn.utils.extmath import svd_flip, safe_sparse_dot
+from sklearn.utils.validation import check_is_fitted
 
 try:
     from orangecontrib.remote import aborted, save_state
@@ -11,6 +19,7 @@ except ImportError:
         pass
 
 import Orange.data
+from Orange.statistics import util as ut
 from Orange.data import Variable
 from Orange.data.util import get_unique_names
 from Orange.misc.wrapper_meta import WrapperMeta
@@ -19,6 +28,217 @@ from Orange.preprocess.score import LearnerScorer
 from Orange.projection import SklProjector, DomainProjection
 
 __all__ = ["PCA", "SparsePCA", "IncrementalPCA", "TruncatedSVD"]
+
+
+def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
+                   flip_sign=True, random_state=0):
+    """Compute the randomized PCA decomposition of a given matrix.
+
+    This method differs from the scikit-learn implementation in that it supports
+    and handles sparse matrices well.
+
+    """
+    if n_iter == "auto":
+        # Checks if the number of iterations is explicitly specified
+        # Adjust n_iter. 7 was found a good compromise for PCA. See sklearn #5299
+        n_iter = 7 if n_components < .1 * min(A.shape) else 4
+
+    n_samples, n_features = A.shape
+
+    c = np.atleast_2d(A.mean(axis=0))
+
+    if n_samples >= n_features:
+        Q = random_state.normal(size=(n_features, n_components + n_oversamples))
+        Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
+
+        # Normalized power iterations
+        for _ in range(n_iter):
+            Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+            Q, _ = lu(Q, permute_l=True)
+            Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
+            Q, _ = lu(Q, permute_l=True)
+
+        Q, _ = qr(Q, mode="economic")
+
+        QA = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+        R, s, V = svd(QA.T, full_matrices=False)
+        U = Q.dot(R)
+
+    else:  # n_features > n_samples
+        Q = random_state.normal(size=(n_samples, n_components + n_oversamples))
+        Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+
+        # Normalized power iterations
+        for _ in range(n_iter):
+            Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
+            Q, _ = lu(Q, permute_l=True)
+            Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
+            Q, _ = lu(Q, permute_l=True)
+
+        Q, _ = qr(Q, mode="economic")
+
+        QA = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
+        U, s, R = svd(QA, full_matrices=False)
+        V = R.dot(Q.T)
+
+    if flip_sign:
+        U, V = svd_flip(U, V)
+
+    return U[:, :n_components], s[:n_components], V[:n_components, :]
+
+
+class ImprovedPCA(skl_decomposition.PCA):
+    """Patch sklearn PCA learner to include randomized PCA for sparse matrices.
+
+    Scikit-learn does not currently support sparse matrices at all, even though
+    efficient methods exist for PCA. This class patches the default scikit-learn
+    implementation to properly handle sparse matrices.
+
+    Notes
+    -----
+      - This should be removed once scikit-learn releases a version which
+        implements this functionality.
+
+    """
+    # pylint: disable=too-many-branches
+    def _fit(self, X):
+        """Dispatch to the right submethod depending on the chosen solver."""
+        X = check_array(
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
+            ensure_2d=True,
+            copy=self.copy,
+        )
+
+        # Handle n_components==None
+        if self.n_components is None:
+            if self.svd_solver != "arpack":
+                n_components = min(X.shape)
+            else:
+                n_components = min(X.shape) - 1
+        else:
+            n_components = self.n_components
+
+        # Handle svd_solver
+        self._fit_svd_solver = self.svd_solver
+        if self._fit_svd_solver == "auto":
+            # Sparse data can only be handled with the randomized solver
+            if sp.issparse(X):
+                self._fit_svd_solver = "randomized"
+            # Small problem or n_components == 'mle', just call full PCA
+            elif max(X.shape) <= 500 or n_components == "mle":
+                self._fit_svd_solver = "full"
+            elif 1 <= n_components < .8 * min(X.shape):
+                self._fit_svd_solver = "randomized"
+            # This is also the case of n_components in (0,1)
+            else:
+                self._fit_svd_solver = "full"
+
+        # Ensure we don't try call arpack or full on a sparse matrix
+        if sp.issparse(X) and self._fit_svd_solver != "randomized":
+            raise ValueError("only the randomized solver supports sparse matrices")
+
+        # Call different fits for either full or truncated SVD
+        if self._fit_svd_solver == "full":
+            return self._fit_full(X, n_components)
+        elif self._fit_svd_solver in ["arpack", "randomized"]:
+            return self._fit_truncated(X, n_components, self._fit_svd_solver)
+        else:
+            raise ValueError(
+                "Unrecognized svd_solver='{0}'".format(self._fit_svd_solver)
+            )
+
+    def _fit_truncated(self, X, n_components, svd_solver):
+        """Fit the model by computing truncated SVD (by ARPACK or randomized) on X"""
+        n_samples, n_features = X.shape
+
+        if isinstance(n_components, six.string_types):
+            raise ValueError(
+                "n_components=%r cannot be a string with svd_solver='%s'" %
+                (n_components, svd_solver)
+            )
+        elif not 1 <= n_components <= min(n_samples, n_features):
+            raise ValueError(
+                "n_components=%r must be between 1 and min(n_samples, "
+                "n_features)=%r with svd_solver='%s'" % (
+                    n_components, min(n_samples, n_features), svd_solver
+                )
+            )
+        elif not isinstance(n_components, (numbers.Integral, np.integer)):
+            raise ValueError(
+                "n_components=%r must be of type int when greater than or "
+                "equal to 1, was of type=%r" % (n_components, type(n_components))
+            )
+        elif svd_solver == "arpack" and n_components == min(n_samples, n_features):
+            raise ValueError(
+                "n_components=%r must be strictly less than min(n_samples, "
+                "n_features)=%r with svd_solver='%s'" % (
+                    n_components, min(n_samples, n_features), svd_solver
+                )
+            )
+
+        random_state = check_random_state(self.random_state)
+
+        self.mean_ = X.mean(axis=0)
+        total_var = ut.var(X, axis=0, ddof=1)
+
+        if svd_solver == "arpack":
+            # Center data
+            X -= self.mean_
+            # random init solution, as ARPACK does it internally
+            v0 = random_state.uniform(-1, 1, size=min(X.shape))
+            U, S, V = sp.linalg.svds(X, k=n_components, tol=self.tol, v0=v0)
+            # svds doesn't abide by scipy.linalg.svd/randomized_svd
+            # conventions, so reverse its outputs.
+            S = S[::-1]
+            # flip eigenvectors' sign to enforce deterministic output
+            U, V = svd_flip(U[:, ::-1], V[::-1])
+
+        elif svd_solver == "randomized":
+            # sign flipping is done inside
+            U, S, V = randomized_pca(
+                X,
+                n_components=n_components,
+                n_iter=self.iterated_power,
+                flip_sign=True,
+                random_state=random_state,
+            )
+
+        self.n_samples_, self.n_features_ = n_samples, n_features
+        self.components_ = V
+        self.n_components_ = n_components
+
+        # Get variance explained by singular values
+        self.explained_variance_ = (S ** 2) / (n_samples - 1)
+        self.explained_variance_ratio_ = self.explained_variance_ / total_var.sum()
+        self.singular_values_ = S.copy()  # Store the singular values.
+
+        if self.n_components_ < min(n_features, n_samples):
+            self.noise_variance_ = (total_var.sum() - self.explained_variance_.sum())
+            self.noise_variance_ /= min(n_features, n_samples) - n_components
+        else:
+            self.noise_variance_ = 0
+
+        return U, S, V
+
+    def transform(self, X):
+        check_is_fitted(self, ["mean_", "components_"], all_or_any=all)
+
+        X = check_array(
+            X,
+            accept_sparse=["csr", "csc"],
+            dtype=[np.float64, np.float32],
+            ensure_2d=True,
+            copy=self.copy,
+        )
+
+        if self.mean_ is not None:
+            X = X - self.mean_
+        X_transformed = np.dot(X, self.components_.T)
+        if self.whiten:
+            X_transformed /= np.sqrt(self.explained_variance_)
+        return X_transformed
 
 
 class _FeatureScorerMixin(LearnerScorer):
@@ -32,9 +252,9 @@ class _FeatureScorerMixin(LearnerScorer):
 
 
 class PCA(SklProjector, _FeatureScorerMixin):
-    __wraps__ = skl_decomposition.PCA
+    __wraps__ = ImprovedPCA
     name = 'PCA'
-    supports_sparse = False
+    supports_sparse = True
 
     def __init__(self, n_components=None, copy=True, whiten=False,
                  svd_solver='auto', tol=0.0, iterated_power='auto',

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -428,20 +428,20 @@ def nanmean(x, axis=None):
     return _apply_func(x, np.nanmean, nanmean_sparse, axis=axis)
 
 
-def nanvar(x, axis=None):
+def nanvar(x, axis=None, ddof=0):
     """ Equivalent of np.nanvar that supports sparse or dense matrices. """
     def nanvar_sparse(x):
         n_vals = np.prod(x.shape) - np.sum(np.isnan(x.data))
         n_zeros = np.prod(x.shape) - len(x.data)
         mean = np.nansum(x.data) / n_vals
-        return (np.nansum((x.data - mean) ** 2) + mean ** 2 * n_zeros) / n_vals
+        return (np.nansum((x.data - mean) ** 2) + mean ** 2 * n_zeros) / (n_vals - ddof)
 
     return _apply_func(x, np.nanvar, nanvar_sparse, axis=axis)
 
 
-def nanstd(x, axis=None):
+def nanstd(x, axis=None, ddof=0):
     """ Equivalent of np.nanstd that supports sparse and dense matrices. """
-    return np.sqrt(nanvar(x, axis=axis))
+    return np.sqrt(nanvar(x, axis=axis, ddof=ddof))
 
 
 def nanmedian(x, axis=None):
@@ -555,16 +555,21 @@ def digitize(x, bins, right=False):
     return r
 
 
-def var(x, axis=None):
+def var(x, axis=None, ddof=0):
     """ Equivalent of np.var that supports sparse and dense matrices. """
     if not sp.issparse(x):
-        return np.var(x, axis)
+        return np.var(x, axis, ddof=ddof)
 
     result = x.multiply(x).mean(axis) - np.square(x.mean(axis))
     result = np.squeeze(np.asarray(result))
+
+    # Apply correction for degrees of freedom
+    n = np.prod(x.shape) if axis is None else x.shape[axis]
+    result *= n / (n - ddof)
+
     return result
 
 
-def std(x, axis=None):
+def std(x, axis=None, ddof=0):
     """ Equivalent of np.std that supports sparse and dense matrices. """
-    return np.sqrt(var(x, axis=axis))
+    return np.sqrt(var(x, axis=axis, ddof=ddof))

--- a/Orange/tests/test_pca.py
+++ b/Orange/tests/test_pca.py
@@ -6,8 +6,9 @@ import unittest
 
 import numpy as np
 from sklearn import __version__ as sklearn_version
+from sklearn.utils import check_random_state
 
-from Orange.data import Table
+from Orange.data import Table, Domain
 from Orange.preprocess import Continuize, Normalize
 from Orange.projection import PCA, SparsePCA, IncrementalPCA, TruncatedSVD
 
@@ -63,6 +64,82 @@ class TestPCA(unittest.TestCase):
         self.assertEqual((n_com, data.X.shape[1]), pca_model.components_.shape)
         proj = np.dot(data.X - pca_model.mean_, pca_model.components_.T)
         np.testing.assert_almost_equal(pca_model(data).X, proj)
+
+    def test_improved_randomized_pca_dense_data(self):
+        """Randomized PCA should work well on dense data."""
+        random_state = check_random_state(42)
+
+        # Let's take a tall, skinny matrix
+        x_ = random_state.normal(0, 1, (100, 20))
+        x = Table.from_numpy(Domain.from_numpy(x_), x_)
+
+        pca = PCA(10, svd_solver="full", random_state=random_state)(x)
+        rpca = PCA(10, svd_solver="randomized", random_state=random_state)(x)
+
+        np.testing.assert_almost_equal(
+            pca.components_, rpca.components_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.explained_variance_, rpca.explained_variance_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.singular_values_, rpca.singular_values_, decimal=8
+        )
+
+        # And take a short, fat matrix
+        x_ = random_state.normal(0, 1, (20, 100))
+        x = Table.from_numpy(Domain.from_numpy(x_), x_)
+
+        pca = PCA(10, svd_solver="full", random_state=random_state)(x)
+        rpca = PCA(10, svd_solver="randomized", random_state=random_state)(x)
+
+        np.testing.assert_almost_equal(
+            pca.components_, rpca.components_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.explained_variance_, rpca.explained_variance_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.singular_values_, rpca.singular_values_, decimal=8
+        )
+
+    def test_improved_randomized_pca_sparse_data(self):
+        """Randomized PCA should work well on dense data."""
+        random_state = check_random_state(42)
+
+        # Let's take a tall, skinny matrix
+        x_ = random_state.negative_binomial(1, 0.5, (100, 20))
+        x = Table.from_numpy(Domain.from_numpy(x_), x_).to_sparse()
+
+        pca = PCA(10, svd_solver="full", random_state=random_state)(x.to_dense())
+        rpca = PCA(10, svd_solver="randomized", random_state=random_state)(x)
+
+        np.testing.assert_almost_equal(
+            pca.components_, rpca.components_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.explained_variance_, rpca.explained_variance_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.singular_values_, rpca.singular_values_, decimal=8
+        )
+
+        # And take a short, fat matrix
+        x_ = random_state.negative_binomial(1, 0.5, (20, 100))
+        x = Table.from_numpy(Domain.from_numpy(x_), x_).to_sparse()
+
+        pca = PCA(10, svd_solver="full", random_state=random_state)(x.to_dense())
+        rpca = PCA(10, svd_solver="randomized", random_state=random_state)(x)
+
+        np.testing.assert_almost_equal(
+            pca.components_, rpca.components_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.explained_variance_, rpca.explained_variance_, decimal=8
+        )
+        np.testing.assert_almost_equal(
+            pca.singular_values_, rpca.singular_values_, decimal=8
+        )
 
     @unittest.skipIf(sklearn_version.startswith('0.20'),
                      "https://github.com/scikit-learn/scikit-learn/issues/12234")

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -192,6 +192,14 @@ class TestUtil(unittest.TestCase):
                     np.var(data, axis=axis)
                 )
 
+    def test_var_with_ddof(self):
+        x = np.random.uniform(0, 10, (20, 100))
+        for axis in [None, 0, 1]:
+            np.testing.assert_almost_equal(
+                np.var(x, axis=axis, ddof=10),
+                var(csr_matrix(x), axis=axis, ddof=10),
+            )
+
     @dense_sparse
     def test_nanvar(self, array):
         for X in self.data:
@@ -199,6 +207,15 @@ class TestUtil(unittest.TestCase):
             np.testing.assert_array_equal(
                 nanvar(X_sparse),
                 np.nanvar(X))
+
+    def test_nanvar_with_ddof(self):
+        x = np.random.uniform(0, 10, (20, 100))
+        np.fill_diagonal(x, np.nan)
+        for axis in [None, 0, 1]:
+            np.testing.assert_almost_equal(
+                np.nanvar(x, axis=axis, ddof=10),
+                nanvar(csr_matrix(x), axis=axis, ddof=10),
+            )
 
     def test_std(self):
         for data in self.data:
@@ -209,6 +226,14 @@ class TestUtil(unittest.TestCase):
                     np.std(data, axis=axis)
                 )
 
+    def test_std_with_ddof(self):
+        x = np.random.uniform(0, 10, (20, 100))
+        for axis in [None, 0, 1]:
+            np.testing.assert_almost_equal(
+                np.std(x, axis=axis, ddof=10),
+                std(csr_matrix(x), axis=axis, ddof=10),
+            )
+
     @dense_sparse
     def test_nanstd(self, array):
         for X in self.data:
@@ -216,6 +241,14 @@ class TestUtil(unittest.TestCase):
             np.testing.assert_array_equal(
                 nanstd(X_sparse),
                 np.nanstd(X))
+
+    def test_nanstd_with_ddof(self):
+        x = np.random.uniform(0, 10, (20, 100))
+        for axis in [None, 0, 1]:
+            np.testing.assert_almost_equal(
+                np.nanstd(x, axis=axis, ddof=10),
+                nanstd(csr_matrix(x), axis=axis, ddof=10),
+            )
 
 
 class TestDigitize(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Scikit-learn's PCA does not support sparse data. This PR implements randomized PCA which efficiently handles sparse matrices, without ever centering the original matrix. This means that running PCA is now feasible (and quite fast) for very large, sparse matrices, which would not fit into memory if densified.

This implementation should be removed once I get it merged into scikit-learn and once that's released.

There are two reference implementations of which I'm aware of and which were used to put together this code:
- https://github.com/KlugerLab/pcafast
- https://github.com/facebook/fbpca/ (I would just use this, but it's not being maintained and doesn't support random seeds)

##### Description of changes

- I added degrees of freedom to `var` and `std` to be consistent with scikit-learn's covariance. I made the minimal changes possible, and we still use scikit-learn's exact PCA - I've just replaced the `randomized` solver. This means that `ImprovedPCA` is mostly copied from scikit-learn's PCA, with slight changes in order to support sparse matrices. `randomized_pca` computes PCA. I've used parameter values from scikit-learn, but these seem to be on the safe side in terms of accuracy i.e. they prefer accuracy over speed. In practice, it's likely we could reduce the number of power iterations and the number of oversamples and still get decent results. 

I didn't need to touch `OWPCA`, but it already supports sparse matrices now. I've left truncated SVD inside for the time being. If anybody really wants to keep it, fine, but IMO there's no reason it should stay in the PCA widget or anywhere at all. Why would you ever run SVD when PCA is available?

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
