### PR TITLE
[FIX] setup.cfg: Change the default for with-htmlhelp config option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [config]
 # applies to sdist and build commands
-with-htmlhelp = 1
+with-htmlhelp=
 
 [aliases]
 # build a sdist and a wheel release with included widget help


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The default configuration option for `with-htmlhelp` (gh-3345) is wrong.

##### Description of changes

Only run the command when explicitly requested.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
