### PR TITLE
[FIX] appveyor: Bump scipy to 1.2.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
     BUILD_GLOBAL_OPTIONS: build -j1
     BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.9.3 sphinx==1.8.2
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.2.0 scikit-learn pandas==0.21.1
 
   matrix:
     - PYTHON: C:\Python36-x64


### PR DESCRIPTION
##### Issue
Scipy.stats.mode handles nans incorrectly in version 1.0 (see https://github.com/biolab/orange3/pull/3480#issuecomment-454775335)

##### Description of changes
Bump scipy version to 1.2.0 on appveyor.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
