### PR TITLE
[WIP] (store|retrieve)SpecificSettings called by non-context settings

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -367,6 +367,8 @@ class OWColor(widget.OWWidget):
 
     def storeSpecificSettings(self):
         # Store the colors that were changed -- but not others
+        if self.current_context is None:
+            return
         self.current_context.disc_data = \
             [(var.name, var.values, "colors" in var.attributes and var.colors)
              for var in self.disc_colors]

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -434,6 +434,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         return text
 
     def storeSpecificSettings(self):
+        if self.current_context is None:
+            return
         self.current_context.modified_variables = self.variables[:]
 
     def retrieveSpecificSettings(self):

--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -21,7 +21,7 @@ from Orange.data import Table
 from Orange.base import Learner, Model
 from Orange.widgets import widget, gui
 from Orange.widgets.utils import itemmodels
-from Orange.widgets.settings import Setting, SettingsHandler
+from Orange.widgets.settings import Setting
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Input, Output
 
@@ -364,14 +364,6 @@ def select_row(view, row):
                     QItemSelectionModel.ClearAndSelect)
 
 
-class PrepareSavingSettingsHandler(SettingsHandler):
-    """Calls storeSpecificSettings, which is currently not called from non-context handlers."""
-
-    def pack_data(self, widget):
-        widget.storeSpecificSettings()
-        return super().pack_data(widget)
-
-
 class OWPythonScript(widget.OWWidget):
     name = "Python Script"
     description = "Write a Python script and run it on input data or models."
@@ -396,8 +388,6 @@ class OWPythonScript(widget.OWWidget):
         object = Output("Object", object, replaces=["out_object"])
 
     signal_names = ("data", "learner", "classifier", "object")
-
-    settingsHandler = PrepareSavingSettingsHandler()
 
     libraryListSource = \
         Setting([Script("Hello world", "print('Hello world')\n")])

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -489,6 +489,12 @@ class SettingsHandler:
         new_data.update(data)
         return new_data
 
+    def _prepare_defaults(self, widget):
+        self.defaults = self.provider.pack(widget)
+        for setting, data, _ in self.provider.traverse_settings(data=self.defaults):
+            if setting.schema_only:
+                data.pop(setting.name, None)
+
     def pack_data(self, widget):
         """
         Pack the settings for the given widget. This method is used when
@@ -504,6 +510,7 @@ class SettingsHandler:
         ----------
         widget : OWWidget
         """
+        widget.storeSpecificSettings()
         packed_settings = self.provider.pack(widget)
         packed_settings[VERSION_KEY] = self.widget_class.settings_version
         return packed_settings
@@ -517,10 +524,8 @@ class SettingsHandler:
         ----------
         widget : OWWidget
         """
-        self.defaults = self.provider.pack(widget)
-        for setting, data, _ in self.provider.traverse_settings(data=self.defaults):
-            if setting.schema_only:
-                data.pop(setting.name, None)
+        widget.storeSpecificSettings()
+        self._prepare_defaults(widget)
         self.write_defaults()
 
     def fast_save(self, widget, name, value):
@@ -675,6 +680,9 @@ class ContextHandler(SettingsHandler):
         Merge the widgets local contexts into the global contexts and persist
         the settings (including the contexts) to disk.
         """
+        # call storeSpecificSettings before settings_from_widget
+        widget.storeSpecificSettings()
+
         self.settings_from_widget(widget)
         globs = self.global_contexts
         assert widget.context_settings is not globs
@@ -683,7 +691,10 @@ class ContextHandler(SettingsHandler):
         globs.sort(key=lambda c: -c.time)
         del globs[self.MAX_SAVED_CONTEXTS:]
 
-        super().update_defaults(widget)
+        # Save non-context settings. We do not call super().update_defaults not
+        # to call storeSpecificSettings.
+        self._prepare_defaults(widget)
+        self.write_defaults()
 
     def new_context(self, *args):
         """Create a new context."""
@@ -837,8 +848,6 @@ class ContextHandler(SettingsHandler):
         context = widget.current_context
         if context is None:
             return
-
-        widget.storeSpecificSettings()
 
         def packer(setting, instance):
             if isinstance(setting, ContextSetting) and hasattr(instance, setting.name):

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -706,6 +706,7 @@ class ContextHandler(SettingsHandler):
         widget.current_context, is_new = \
             self.find_or_create_context(widget, *args)
         if is_new:
+            widget.storeSpecificSettings()
             try:
                 self.settings_from_widget(widget, *args)
             except TypeError:
@@ -818,6 +819,7 @@ class ContextHandler(SettingsHandler):
         if widget.current_context is None:
             return
 
+        widget.storeSpecificSettings()
         self.settings_from_widget(widget)
         widget.current_context = None
 

--- a/Orange/widgets/tests/test_context_handler.py
+++ b/Orange/widgets/tests/test_context_handler.py
@@ -22,6 +22,9 @@ class SimpleWidget:
     migrate_settings = Mock()
     migrate_context = Mock()
 
+    def __init__(self):
+        self.storeSpecificSettings = Mock()
+
 
 class DummyContext(Context):
     id = 0
@@ -174,7 +177,6 @@ class TestContextHandler(TestCase):
     def test_pack_settings_stores_version(self):
         handler = ContextHandler()
         handler.bind(SimpleWidget)
-
         widget = SimpleWidget()
         handler.initialize(widget)
         widget.context_setting = [DummyContext() for _ in range(3)]
@@ -183,6 +185,14 @@ class TestContextHandler(TestCase):
         self.assertIn("context_settings", settings)
         for c in settings["context_settings"]:
             self.assertIn(VERSION_KEY, c.values)
+
+    def test_pack_settings_storeSpecificSettings(self):
+        handler = ContextHandler()
+        handler.bind(SimpleWidget)
+        widget = SimpleWidget()
+        handler.initialize(widget)
+        handler.pack_data(widget)
+        self.assertEqual(1, widget.storeSpecificSettings.call_count)
 
     def test_write_defaults_stores_version(self):
         handler = ContextHandler()
@@ -202,11 +212,18 @@ class TestContextHandler(TestCase):
             for c in contexts:
                 self.assertEqual(c.values.get("__version__", 0xBAD), 1)
 
+    def test_update_defaults_storeSpecificSettings(self):
+        handler = ContextHandler()
+        handler.bind(SimpleWidget)
+        widget = SimpleWidget()
+        handler.initialize(widget)
+        handler.update_defaults(widget)
+        self.assertEqual(1, widget.storeSpecificSettings.call_count)
+
     def test_close_context(self):
         handler = ContextHandler()
         handler.bind(SimpleWidget)
         widget = SimpleWidget()
-        widget.storeSpecificSettings = Mock()
         handler.initialize(widget)
         widget.schema_only_setting = 0xD06F00D
         widget.current_context = handler.new_context()

--- a/Orange/widgets/tests/test_settings_handler.py
+++ b/Orange/widgets/tests/test_settings_handler.py
@@ -342,6 +342,22 @@ class SettingHandlerTestCase(unittest.TestCase):
         if os.path.isfile(filename):
             os.remove(filename)
 
+    def test_pack_settings_storeSpecificSettings(self):
+        handler = SettingsHandler()
+        handler.bind(SimpleWidget)
+        widget = SimpleWidget()
+        handler.initialize(widget)
+        handler.pack_data(widget)
+        self.assertEqual(1, widget.storeSpecificSettings.call_count)
+
+    def test_update_defaults_storeSpecificSettings(self):
+        handler = SettingsHandler()
+        handler.bind(SimpleWidget)
+        widget = SimpleWidget()
+        handler.initialize(widget)
+        handler.update_defaults(widget)
+        self.assertEqual(1, widget.storeSpecificSettings.call_count)
+
 
 class Component:
     int_setting = Setting(42)
@@ -360,6 +376,7 @@ class SimpleWidget:
 
     def __init__(self):
         self.component = Component()
+        self.storeSpecificSettings = Mock()
 
     migrate_settings = Mock()
     migrate_context = Mock()

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -875,8 +875,8 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         """
         Store data that is not registered as setting.
 
-        This method is called by
-        `Orange.widgets.settings.ContextHandler.settings_from_widget`.
+        This method is called before a widget storing data (by `pack_data`
+        or `update_defaults` from `Orange.widgets.settings.SettingHandler`).
         Widgets may define it to store any data that is not stored in widget
         attributes. See :obj:`Orange.widgets.data.owcolor.OWColor` for an
         example.


### PR DESCRIPTION
##### Issue
storeSpecificSettings was only called with a ContextHandler. Before, if was called after packing normal settings and before packing context settings.

In #3529 I implemented a special SettingsHandler because I needed to prepare settings for saving just before saving them.

##### Description of changes
storeSpecificSettings is not called in SettingsHandler

##### TODO
- [ ] test if they are really called before packing
- [ ] retrieveSpecificSettings

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
