### PR TITLE
[ENH] Improve Save widget's gui

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -987,7 +987,7 @@ class ExcelReader(FileFormat):
     """Reader for excel files"""
     EXTENSIONS = ('.xlsx',)
     DESCRIPTION = 'Microsoft Excel spreadsheet'
-    SUPPORT_COMPRESSED = True
+    SUPPORT_COMPRESSED = False
     SUPPORT_SPARSE_DATA = False
 
     def __init__(self, filename):

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -1,30 +1,20 @@
 import os.path
-import pathlib
 
-from AnyQt.QtWidgets import QFormLayout
 from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QBrush
+from AnyQt.QtWidgets import QGridLayout
 
 from Orange.data.table import Table
-from Orange.data.io import Compression, FileFormat, TabReader, CSVReader, PickleReader, \
-    ExcelReader
+from Orange.data.io import TabReader, CSVReader, PickleReader, ExcelReader
 from Orange.widgets import gui, widget
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils import filedialogs
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input
 
-FILE_TYPES = [
-    ("{} ({})".format(w.DESCRIPTION, w.EXTENSIONS[0]),
-     w.EXTENSIONS[0],
-     w.SUPPORT_SPARSE_DATA)
-    for w in (TabReader, CSVReader, PickleReader, ExcelReader)
-]
 
-COMPRESSIONS = [
-    ("gzip ({})".format(Compression.GZIP), Compression.GZIP),
-    ("bzip2 ({})".format(Compression.BZIP2), Compression.BZIP2),
-    ("lzma ({})".format(Compression.XZ), Compression.XZ),
-]
+FILE_WRITERS = (TabReader, CSVReader, PickleReader, ExcelReader)
+FILE_FORMATS = [f"{w.DESCRIPTION} ({w.EXTENSIONS[0]})" for w in FILE_WRITERS]
 
 
 class OWSave(widget.OWWidget):
@@ -38,166 +28,145 @@ class OWSave(widget.OWWidget):
         data = Input("Data", Table)
 
     class Error(widget.OWWidget.Error):
-        unsupported_extension = widget.Msg("Selected extension is not supported.")
+        unsupported_sparse = \
+            widget.Msg("This file format does not support sparse data.")
+        general_error = widget.Msg("{}")
 
     want_main_area = False
     resizing_enabled = False
 
+    filetype = Setting(0)
     last_dir = Setting("")
-    auto_save = Setting(False)
-    filetype = Setting(FILE_TYPES[0][0])
-    compression = Setting(COMPRESSIONS[0][0])
-    compress = Setting(False)
+    compression = Setting(False)
     add_type_annotations = Setting(True)
+    auto_save = Setting(False)
 
     def __init__(self):
         super().__init__()
         self.data = None
-        self.filename = ""
         self.basename = ""
-        self.type_ext = ""
-        self.compress_ext = ""
-
-        form = QFormLayout(
-            labelAlignment=Qt.AlignLeft,
-            formAlignment=Qt.AlignLeft,
-            rowWrapPolicy=QFormLayout.WrapLongRows,
-            verticalSpacing=10,
-        )
+        self.dirty = False
 
         box = gui.vBox(self.controlArea, "Format")
-
         gui.comboBox(
-            box, self, "filetype",
-            callback=self._update_text,
-            items=[item for item, _, _ in FILE_TYPES],
-            sendSelectedValue=True,
-        )
-        form.addRow("File type", self.controls.filetype, )
-
-        gui.comboBox(
-            box, self, "compression",
-            callback=self._update_text,
-            items=[item for item, _ in COMPRESSIONS],
-            sendSelectedValue=True,
-        )
+            box, self, "filetype", items=FILE_FORMATS,
+            callback=self._set_dirty, addSpace=2)
+        box2 = gui.indentedBox(box, sep=10)
         gui.checkBox(
-            box, self, "compress", label="Use compression",
-            callback=self._update_text,
-        )
+            box2, self, "compression", "Compress file (as gzip)",
+            callback=self._set_dirty, addSpace=2)
+        gui.checkBox(
+            box2, self, "add_type_annotations", label="Add type annotations",
+            callback=self._set_dirty)
 
-        form.addRow(self.controls.compress, self.controls.compression)
-
-        box.layout().addLayout(form)
-
-        self.annotations_cb = gui.checkBox(
-            None, self, "add_type_annotations", label="Add type annotations",
-        )
-        form.addRow(self.annotations_cb, None)
-
-        self.save = gui.auto_commit(
-            self.controlArea, self, "auto_save", "Save", box=False,
-            commit=self.save_file, callback=self.adjust_label,
-            disabled=True, addSpace=True
-        )
+        grid = QGridLayout()
+        gui.widgetBox(self.controlArea, box=True, orientation=grid)
+        self.save = gui.button(None, self, "Save", callback=self.save_file)
         self.save_as = gui.button(
-            self.controlArea, self, "Save As...",
-            callback=self.save_file_as, disabled=True
-        )
-        self.save_as.setMinimumWidth(220)
+            None, self, "Save as ...", callback=self.save_file_as)
+        grid.addWidget(self.save, 0, 0)
+        grid.addWidget(self.save_as, 0, 1)
+        grid.setRowMinimumHeight(1, 8)
+        grid.addWidget(
+            gui.checkBox(
+                None, self, "auto_save", "Autosave when receiving new data"),
+            2, 0, 2, 2)
         self.adjustSize()
-
-    def get_writer_selected(self):
-        writer = FileFormat.get_reader(self.type_ext)
-
-        ext = self.type_ext + self.compress_ext
-        if ext not in writer.EXTENSIONS:
-            self.Error.unsupported_extension()
-            return None
-        writer.EXTENSIONS = [ext]
-        return writer
-
-    @classmethod
-    def remove_extensions(cls, filename):
-        if not filename:
-            return None
-        for ext in pathlib.PurePosixPath(filename).suffixes:
-            filename = filename.replace(ext, '')
-        return filename
-
-    def adjust_label(self):
-        if self.filename:
-            text = "Auto save as '{}'" if self.auto_save else "Save as '{}'"
-            self.save.button.setText(
-                text.format(self.basename + self.type_ext + self.compress_ext))
+        self._update_controls()
 
     @Inputs.data
     def dataset(self, data):
+        self.Error.clear()
         self.data = data
-        self.save.setDisabled(data is None)
-        self.save_as.setDisabled(data is None)
-        if data is None:
-            return
-
-        items = [item for item, _, supports_sparse in FILE_TYPES
-                 if supports_sparse or not data.is_sparse()]
-        if items != [self.controls.filetype.itemText(i) for i in
-                     range(self.controls.filetype.count())]:
-            self.controls.filetype.clear()
-            self.controls.filetype.insertItems(0, items)
-            self.update_extension()
-
-        self.save_file()
+        self.dirty = data is not None
+        self._update_combo_colors()
+        if self.auto_save and self.basename:
+            self.save_file()
+        self._update_controls()
 
     def save_file_as(self):
-        file_name = self.remove_extensions(self.filename) or os.path.join(
-            self.last_dir or os.path.expanduser("~"),
-            getattr(self.data, 'name', ''))
-        self.update_extension()
-        writer = self.get_writer_selected()
-        if not writer:
-            return
-
-        filename, writer, _ = filedialogs.open_filename_dialog_save(
-            file_name, '', [writer],
-        )
+        start_path = self.basename \
+            or os.path.join(self.last_dir or os.path.expanduser("~"),
+                            getattr(self.data, 'name', ''))
+        filename, _, _ = filedialogs.open_filename_dialog_save(
+            start_path, '', [FILE_WRITERS[self.filetype]])
         if not filename:
             return
 
-        self.filename = filename
-        self.last_dir = os.path.split(self.filename)[0]
-        self.basename = os.path.basename(self.remove_extensions(filename))
-        self.unconditional_save_file()
-        self.adjust_label()
+        self.last_dir, filename = os.path.split(filename)
+        self.basename, _ = os.path.splitext(filename)
+        self.save_file()
+        self._update_controls()
 
     def save_file(self):
-        if self.data is None:
+        writer = FILE_WRITERS[self.filetype]
+        if self.data is None \
+                or self.data.is_sparse() and not writer.SUPPORT_SPARSE_DATA:
             return
-        if not self.filename:
+        if not self.basename:
             self.save_file_as()
+            return
+        try:
+            filename = os.path.join(self.last_dir, self._fullname)
+            writer.write(filename, self.data, self.add_type_annotations)
+        except Exception as err_value:
+            self.Error.general_error(str(err_value))
         else:
-            try:
-                self.get_writer_selected().write(
-                    os.path.join(
-                        self.last_dir,
-                        self.basename + self.type_ext + self.compress_ext),
-                    self.data, self.add_type_annotations)
+            self.Error.general_error.clear()
+            self.dirty = False
+            self._update_controls()
 
-            except Exception as err_value:
-                self.error(str(err_value))
+    @property
+    def _fullname(self):
+        writer = FILE_WRITERS[self.filetype]
+        return self.basename \
+            + writer.EXTENSIONS[0] \
+            + ".gzip" * (self.compression and writer.SUPPORT_COMPRESSED)
+
+    def _update_combo_colors(self):
+        sparse_data = self.data is not None and self.data.is_sparse()
+        combo = self.controls.filetype
+        brushes = QBrush(Qt.gray), QBrush(Qt.black)
+        for i, writer in enumerate(FILE_WRITERS):
+            combo.setItemData(
+                i, brushes[not sparse_data or writer.SUPPORT_SPARSE_DATA],
+                Qt.TextColorRole)
+
+    def _set_dirty(self):
+        self.dirty = True
+        self._update_controls()
+
+    def _update_controls(self):
+        ctrl = self.controls
+        writer = FILE_WRITERS[self.filetype]
+
+        self.Error.unsupported_sparse(
+            shown=self.data is not None
+                  and self.data.is_sparse()
+                  and not writer.SUPPORT_SPARSE_DATA)
+        ctrl.add_type_annotations.setEnabled(writer.OPTIONAL_TYPE_ANNOTATIONS)
+        ctrl.compression.setEnabled(writer.SUPPORT_COMPRESSED)
+
+        self.save.setText(
+            f"Save as '{self._fullname}'" if self.basename else "Save")
+        enable_save = self.data is not None \
+            and (not self.data.is_sparse() or writer.SUPPORT_SPARSE_DATA)
+        self.save.setVisible(self.dirty and bool(self.basename))
+        self.save.setEnabled(enable_save)
+        self.save_as.setEnabled(enable_save)
+        ctrl.auto_save.setEnabled(enable_save and bool(self.basename))
+
+    @classmethod
+    def migrate_settings(cls, settings, version=0):
+        return
+        if version < 2:
+            for i, (compr, _) in enumerate(COMPRESSIONS):
+                if compr == settings["compression"]:
+                    settings["compression"] = i
+                    break
             else:
-                self.error()
-
-    def update_extension(self):
-        self.type_ext = [ext for name, ext, _ in FILE_TYPES if name == self.filetype][0]
-        self.annotations_cb.setEnabled(False)
-        if self.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
-            self.annotations_cb.setEnabled(True)
-        self.compress_ext = dict(COMPRESSIONS)[self.compression] if self.compress else ''
-
-    def _update_text(self):
-        self.update_extension()
-        self.adjust_label()
+                settings["compression"] = 0
+            settings["filetype"] = FILE_FORMATS.index(settings["filetype"])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -1,20 +1,14 @@
 import os.path
 
+from AnyQt.QtWidgets import QFileDialog
 from AnyQt.QtCore import Qt
-from AnyQt.QtGui import QBrush
-from AnyQt.QtWidgets import QGridLayout
 
 from Orange.data.table import Table
 from Orange.data.io import TabReader, CSVReader, PickleReader, ExcelReader
 from Orange.widgets import gui, widget
 from Orange.widgets.settings import Setting
-from Orange.widgets.utils import filedialogs
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input
-
-
-FILE_WRITERS = (TabReader, CSVReader, PickleReader, ExcelReader)
-FILE_FORMATS = [f"{w.DESCRIPTION} ({w.EXTENSIONS[0]})" for w in FILE_WRITERS]
 
 
 class OWSave(widget.OWWidget):
@@ -24,53 +18,60 @@ class OWSave(widget.OWWidget):
     category = "Data"
     keywords = []
 
+    settings_version = 2
+
+    writers = [TabReader, CSVReader, PickleReader, ExcelReader]
+    filters = [f"{w.DESCRIPTION} ({w.EXTENSIONS[0]})" for w in writers]
+    filt_ext = {filter: w.EXTENSIONS[0] for filter, w in zip(filters, writers)}
+    userhome = os.path.expanduser(f"~{os.sep}")
+
     class Inputs:
         data = Input("Data", Table)
 
     class Error(widget.OWWidget.Error):
-        unsupported_sparse = \
-            widget.Msg("This file format does not support sparse data.")
+        # This message is short to (almost) fit into the widget's width
+        unsupported_sparse = widget.Msg("Format can't store sparse data.")
+        general_error = widget.Msg("{}")
+
+    class Warning(widget.OWWidget.Warning):
+        no_file_name = widget.Msg("Set the file name.")
         general_error = widget.Msg("{}")
 
     want_main_area = False
     resizing_enabled = False
 
+    compress: bool
+    add_type_annotations: bool
+
     filetype = Setting(0)
     last_dir = Setting("")
-    compression = Setting(False)
+    filter = Setting(filters[0])
+    compress = Setting(False)
     add_type_annotations = Setting(True)
     auto_save = Setting(False)
 
     def __init__(self):
         super().__init__()
         self.data = None
-        self.basename = ""
-        self.dirty = False
+        self.filename = ""
+        self.writer = self.writers[0]
 
-        box = gui.vBox(self.controlArea, "Format")
-        gui.comboBox(
-            box, self, "filetype", items=FILE_FORMATS,
-            callback=self._set_dirty, addSpace=2)
-        box2 = gui.indentedBox(box, sep=10)
+        box = gui.vBox(self.controlArea, True)
+        box.layout().setSpacing(8)
+        self.lb_filename = gui.widgetLabel(box)
         gui.checkBox(
-            box2, self, "compression", "Compress file (as gzip)",
-            callback=self._set_dirty, addSpace=2)
+            box, self, "add_type_annotations", "Save with type annotations")
         gui.checkBox(
-            box2, self, "add_type_annotations", label="Add type annotations",
-            callback=self._set_dirty)
+            box, self, "compress", "Compress file (gzip)")
+        self.bt_set_file = gui.button(
+            None, self, "Set File Name", callback=self.set_file_name)
+        box.layout().addWidget(self.bt_set_file, Qt.AlignRight)
 
-        grid = QGridLayout()
-        gui.widgetBox(self.controlArea, box=True, orientation=grid)
-        self.save = gui.button(None, self, "Save", callback=self.save_file)
-        self.save_as = gui.button(
-            None, self, "Save as ...", callback=self.save_file_as)
-        grid.addWidget(self.save, 0, 0)
-        grid.addWidget(self.save_as, 0, 1)
-        grid.setRowMinimumHeight(1, 8)
-        grid.addWidget(
-            gui.checkBox(
-                None, self, "auto_save", "Autosave when receiving new data"),
-            2, 0, 2, 2)
+        box = gui.vBox(self.controlArea, box=True)
+        box.layout().setSpacing(8)
+        gui.checkBox(
+            box, self, "auto_save", "Autosave when receiving new data")
+        self.bt_save = gui.button(box, self, "Save", callback=self.save_file)
         self.adjustSize()
         self._update_controls()
 
@@ -78,95 +79,95 @@ class OWSave(widget.OWWidget):
     def dataset(self, data):
         self.Error.clear()
         self.data = data
-        self.dirty = data is not None
-        self._update_combo_colors()
-        if self.auto_save and self.basename:
+        if self.auto_save and self.filename:
             self.save_file()
-        self._update_controls()
 
-    def save_file_as(self):
-        start_path = self.basename \
-            or os.path.join(self.last_dir or os.path.expanduser("~"),
-                            getattr(self.data, 'name', ''))
-        filename, _, _ = filedialogs.open_filename_dialog_save(
-            start_path, '', [FILE_WRITERS[self.filetype]])
-        if not filename:
+        self._update_controls()
+        if self.data is None:
+            self.info.set_input_summary(self.info.NoInput)
+        else:
+            self.info.set_input_summary(
+                str(len(self.data)),
+                f"Data set {self.data.name or '(no name)'} "
+                f"with {len(self.data)} instances")
+
+    def set_file_name(self):
+        if self.filename:
+            start_dir = self.filename
+        else:
+            data_name = getattr(self.data, 'name', '')
+            if data_name:
+                data_name += self.filt_ext[self.filter]
+            start_dir = os.path.join(self.last_dir or self.userhome, data_name)
+
+        dlg = QFileDialog(None, "Set File", start_dir, ";;".join(self.filters))
+        dlg.setLabelText(dlg.Accept, "Select")
+        dlg.setAcceptMode(dlg.AcceptSave)
+        dlg.setSupportedSchemes(["file"])
+        dlg.selectNameFilter(self.filter)
+        if dlg.exec() == dlg.Rejected:
             return
 
-        self.last_dir, filename = os.path.split(filename)
-        self.basename, _ = os.path.splitext(filename)
-        self.save_file()
+        self.filename = dlg.selectedFiles()[0]
+        self.last_dir = os.path.split(self.filename)[0]
+        self.filter = dlg.selectedNameFilter()
+        self.writer = self.writers[self.filters.index(self.filter)]
         self._update_controls()
 
     def save_file(self):
-        writer = FILE_WRITERS[self.filetype]
-        if self.data is None \
-                or self.data.is_sparse() and not writer.SUPPORT_SPARSE_DATA:
+        self.Error.general_error.clear()
+        if not self._can_save():
             return
-        if not self.basename:
-            self.save_file_as()
-            return
+        name = self.filename \
+            + ".gz" * self.writer.SUPPORT_COMPRESSED * self.compress
         try:
-            filename = os.path.join(self.last_dir, self._fullname)
-            writer.write(filename, self.data, self.add_type_annotations)
-        except Exception as err_value:
+            self.writer.write(name, self.data, self.add_type_annotations)
+        except IOError as err_value:
             self.Error.general_error(str(err_value))
-        else:
-            self.Error.general_error.clear()
-            self.dirty = False
-            self._update_controls()
-
-    @property
-    def _fullname(self):
-        writer = FILE_WRITERS[self.filetype]
-        return self.basename \
-            + writer.EXTENSIONS[0] \
-            + ".gzip" * (self.compression and writer.SUPPORT_COMPRESSED)
-
-    def _update_combo_colors(self):
-        sparse_data = self.data is not None and self.data.is_sparse()
-        combo = self.controls.filetype
-        brushes = QBrush(Qt.gray), QBrush(Qt.black)
-        for i, writer in enumerate(FILE_WRITERS):
-            combo.setItemData(
-                i, brushes[not sparse_data or writer.SUPPORT_SPARSE_DATA],
-                Qt.TextColorRole)
-
-    def _set_dirty(self):
-        self.dirty = True
-        self._update_controls()
 
     def _update_controls(self):
-        ctrl = self.controls
-        writer = FILE_WRITERS[self.filetype]
+        has_file = bool(self.filename)
+        self.lb_filename.setVisible(has_file)
+        self.Warning.no_file_name(shown=not has_file)
+        if self.filename:
+            name = self.filename
+            if name.startswith(self.userhome):
+                name = name[len(self.userhome):]
+            self.lb_filename.setText(f"Save to: {name}")
+
+        self.controls.add_type_annotations.setVisible(
+            has_file and self.writer.OPTIONAL_TYPE_ANNOTATIONS)
+        self.controls.compress.setVisible(
+            has_file and self.writer.SUPPORT_COMPRESSED)
 
         self.Error.unsupported_sparse(
-            shown=self.data is not None
-                  and self.data.is_sparse()
-                  and not writer.SUPPORT_SPARSE_DATA)
-        ctrl.add_type_annotations.setEnabled(writer.OPTIONAL_TYPE_ANNOTATIONS)
-        ctrl.compression.setEnabled(writer.SUPPORT_COMPRESSED)
+            shown=self.data is not None and self.data.is_sparse()
+            and self.filename
+            and not self.writer.SUPPORT_SPARSE_DATA)
+        self.bt_save.setEnabled(self._can_save())
 
-        self.save.setText(
-            f"Save as '{self._fullname}'" if self.basename else "Save")
-        enable_save = self.data is not None \
-            and (not self.data.is_sparse() or writer.SUPPORT_SPARSE_DATA)
-        self.save.setVisible(self.dirty and bool(self.basename))
-        self.save.setEnabled(enable_save)
-        self.save_as.setEnabled(enable_save)
-        ctrl.auto_save.setEnabled(enable_save and bool(self.basename))
+    def _can_save(self):
+        return self.data is not None \
+            and bool(self.filename) \
+            and (not self.data.is_sparse() or self.writer.SUPPORT_SPARSE_DATA)
+
+    def send_report(self):
+        self.report_data_brief(self.data)
+        writer = self.writer
+        noyes = ["No", "Yes"]
+        self.report_items((
+            ("File name", self.filename or "not set"),
+            ("Format", writer.DESCRIPTION),
+            ("Compression", writer.SUPPORT_COMPRESSED and noyes[self.compress]),
+            ("Type annotations",
+             writer.OPTIONAL_TYPE_ANNOTATIONS
+             and noyes[self.add_type_annotations])
+        ))
 
     @classmethod
     def migrate_settings(cls, settings, version=0):
-        return
         if version < 2:
-            for i, (compr, _) in enumerate(COMPRESSIONS):
-                if compr == settings["compression"]:
-                    settings["compression"] = i
-                    break
-            else:
-                settings["compression"] = 0
-            settings["filetype"] = FILE_FORMATS.index(settings["filetype"])
+            settings["filter"] = settings.pop("filetype")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -63,7 +63,8 @@ class OWSave(widget.OWWidget):
             0, 1)
         grid.addWidget(
             gui.checkBox(None, self, "auto_save",
-                         "Autosave when receiving new data"),
+                         "Autosave when receiving new data",
+                         callback=self._update_controls),
             1, 0, 1, 2)
         grid.addWidget(QWidget(), 2, 0, 1, 2)
 
@@ -142,7 +143,7 @@ class OWSave(widget.OWWidget):
                 f"Save as {os.path.split(self._fullname())[1]}")
         else:
             self.bt_save.setText("Save")
-        self.Error.no_file_name(shown=not self.filename)
+        self.Error.no_file_name(shown=not self.filename and self.auto_save)
 
         self.Error.unsupported_sparse(
             shown=self.data is not None and self.data.is_sparse()

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -38,10 +38,6 @@ class OWSave(widget.OWWidget):
         no_file_name = widget.Msg("File name is not set.")
         general_error = widget.Msg("{}")
 
-    class Warning(widget.OWWidget.Warning):
-        type_annotation_ignored = widget.Msg(
-            "Type annotation setting is ignored for this format.")
-
     want_main_area = False
     resizing_enabled = False
 
@@ -60,7 +56,11 @@ class OWSave(widget.OWWidget):
         grid.addWidget(
             gui.checkBox(
                 None, self, "add_type_annotations",
-                "Save with type annotations", callback=self._update_messages),
+                "Add type annotations to header",
+                tooltip=
+                "Some formats (Tab-delimited, Comma-separated) can include \n"
+                "additional information about variables types in header rows.",
+                callback=self._update_messages),
             0, 0, 1, 2)
         grid.setRowMinimumHeight(1, 8)
         grid.addWidget(
@@ -125,10 +125,6 @@ class OWSave(widget.OWWidget):
         self.Error.unsupported_sparse(
             shown=self.data is not None and self.data.is_sparse()
             and self.filename and not self.writer.SUPPORT_SPARSE_DATA)
-        self.Warning.type_annotation_ignored(
-            shown=self.data is not None and self.filename
-            and self.add_type_annotations
-            and not self.writer.OPTIONAL_TYPE_ANNOTATIONS)
 
     def _update_status(self):
         if self.data is None:
@@ -177,8 +173,6 @@ class OWSave(widget.OWWidget):
 
         if version < 2:
             migrate_to_version_2()
-
-
 
     def _initial_start_dir(self):
         if self.filename and os.path.exists(os.path.split(self.filename)[0]):

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -185,11 +185,11 @@ class OWSave(widget.OWWidget):
 
     @staticmethod
     def _replace_extension(filename, extension):
-        if filename.endswith(extension):  # it may contain dots before extension
-            return filename
-        last_fn = None
-        while last_fn != filename:
-            last_fn, filename = filename, os.path.splitext(filename)[0]
+        known_extensions = map(OWSave._extension_from_filter, OWSave.filters)
+        for known_ext in sorted(known_extensions, key=len, reverse=True):
+            if filename.endswith(known_ext):
+                filename = filename[:-len(known_ext)]
+                break
         return filename + extension
 
     @staticmethod

--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -1,6 +1,8 @@
 import os.path
+import sys
+import re
 
-from AnyQt.QtWidgets import QFileDialog, QGridLayout, QWidget
+from AnyQt.QtWidgets import QFileDialog, QGridLayout, QMessageBox
 
 from Orange.data.table import Table
 from Orange.data.io import TabReader, CSVReader, PickleReader, ExcelReader
@@ -9,10 +11,6 @@ from Orange.widgets.settings import Setting
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input
 
-class FileDialog(QFileDialog):
-    def changeEvent(self, e):
-        print(e)
-        super().selectFile(e)
 
 class OWSave(widget.OWWidget):
     name = "Save Data"
@@ -24,74 +22,115 @@ class OWSave(widget.OWWidget):
     settings_version = 2
 
     writers = [TabReader, CSVReader, PickleReader, ExcelReader]
-    filters = [f"{w.DESCRIPTION} (*.*)" for w in writers]
-    filt_ext = {filter: w.EXTENSIONS[0] for filter, w in zip(filters, writers)}
+    filters = {
+        **{f"{w.DESCRIPTION} (*{w.EXTENSIONS[0]})": w
+           for w in writers},
+        **{f"Compressed {w.DESCRIPTION} (*{w.EXTENSIONS[0]}.gz)": w
+           for w in writers if w.SUPPORT_COMPRESSED}
+    }
     userhome = os.path.expanduser(f"~{os.sep}")
 
     class Inputs:
         data = Input("Data", Table)
 
     class Error(widget.OWWidget.Error):
-        unsupported_sparse = widget.Msg("Use .pkl format for sparse data.")
+        unsupported_sparse = widget.Msg("Use Pickle format for sparse data.")
         no_file_name = widget.Msg("File name is not set.")
         general_error = widget.Msg("{}")
 
     class Warning(widget.OWWidget.Warning):
-        ignored_flag = widget.Msg("{} ignored for this format.")
+        type_annotation_ignored = widget.Msg(
+            "Type annotation setting is ignored for this format.")
 
     want_main_area = False
     resizing_enabled = False
 
-    compress: bool
-    add_type_annotations: bool
-
     last_dir = Setting("")
-    filter = Setting(filters[0])
-    compress = Setting(False)
+    filter = Setting(next(iter(filters)))
+    filename = Setting("", schema_only=True)
     add_type_annotations = Setting(True)
     auto_save = Setting(False)
 
     def __init__(self):
         super().__init__()
         self.data = None
-        self.filename = ""
-        self.writer = self.writers[0]
 
         grid = QGridLayout()
-        gui.widgetBox(self.controlArea, box=True, orientation=grid)
-        grid.setSpacing(8)
-        self.bt_save = gui.button(None, self, "Save", callback=self.save_file)
-        grid.addWidget(self.bt_save, 0, 0)
-        grid.addWidget(
-            gui.button(None, self, "Save as ...", callback=self.save_file_as),
-            0, 1)
-        grid.addWidget(
-            gui.checkBox(None, self, "auto_save",
-                         "Autosave when receiving new data",
-                         callback=self._update_controls),
-            1, 0, 1, 2)
-        grid.addWidget(QWidget(), 2, 0, 1, 2)
-
+        gui.widgetBox(self.controlArea, orientation=grid)
         grid.addWidget(
             gui.checkBox(
                 None, self, "add_type_annotations",
-                "Save with type annotations", callback=self._update_controls),
-            3, 0, 1, 2)
+                "Save with type annotations", callback=self._update_messages),
+            0, 0, 1, 2)
+        grid.setRowMinimumHeight(1, 8)
         grid.addWidget(
             gui.checkBox(
-                None, self, "compress", "Compress file (gzip)",
-                callback=self._update_controls),
-            4, 0, 1, 2)
+                None, self, "auto_save", "Autosave when receiving new data",
+                callback=self._update_messages),
+            2, 0, 1, 2)
+        grid.setRowMinimumHeight(3, 8)
+        self.bt_save = gui.button(None, self, "Save", callback=self.save_file)
+        grid.addWidget(self.bt_save, 4, 0)
+        grid.addWidget(
+            gui.button(None, self, "Save as ...", callback=self.save_file_as),
+            4, 1)
 
         self.adjustSize()
-        self._update_controls()
+        self._update_messages()
+
+    @property
+    def writer(self):
+        return self.filters[self.filter]
 
     @Inputs.data
     def dataset(self, data):
         self.Error.clear()
         self.data = data
+        self._update_status()
+        self._update_messages()
+        if self.auto_save and self.filename:
+            self.save_file()
 
-        self._update_controls()
+    def save_file(self):
+        if not self.filename:
+            self.save_file_as()
+            return
+
+        self.Error.general_error.clear()
+        if self.data is None \
+                or not self.filename \
+                or (self.data.is_sparse()
+                        and not self.writer.SUPPORT_SPARSE_DATA):
+            return
+        try:
+            self.writer.write(
+                self.filename, self.data, self.add_type_annotations)
+        except IOError as err_value:
+            self.Error.general_error(str(err_value))
+
+    def save_file_as(self):
+        filename, selected_filter = self.get_save_filename()
+        if not filename:
+            return
+        self.filename = filename
+        self.filter = selected_filter
+        self.last_dir = os.path.split(self.filename)[0]
+        self.bt_save.setText(f"Save as {os.path.split(filename)[1]}")
+        self._update_messages()
+        self.save_file()
+
+    def _update_messages(self):
+        self.Error.no_file_name(
+            shown=not self.filename and self.auto_save)
+        self.Error.unsupported_sparse(
+            shown=self.data is not None and self.data.is_sparse()
+            and self.filename and not self.writer.SUPPORT_SPARSE_DATA)
+        self.Warning.type_annotation_ignored(
+            shown=self.data is not None and self.filename
+            and self.add_type_annotations
+            and not self.writer.OPTIONAL_TYPE_ANNOTATIONS)
+
+    def _update_status(self):
         if self.data is None:
             self.info.set_input_summary(self.info.NoInput)
         else:
@@ -100,95 +139,6 @@ class OWSave(widget.OWWidget):
                 f"Data set {self.data.name or '(no name)'} "
                 f"with {len(self.data)} instances")
 
-        if self.auto_save and self.filename:
-            self.save_file()
-
-    def save_file_as(self):
-        if self.filename:
-            start_dir = self.filename
-        else:
-            data_name = getattr(self.data, 'name', '')
-            if data_name:
-                data_name += self.filt_ext[self.filter]
-            start_dir = os.path.join(self.last_dir or self.userhome, data_name)
-
-        dlg = FileDialog(None, "Set File", start_dir, ";;".join(self.filters))
-        dlg.setLabelText(dlg.Accept, "Select")
-        dlg.setAcceptMode(dlg.AcceptSave)
-        dlg.setSupportedSchemes(["file"])
-        dlg.selectNameFilter(self.filter)
-        dlg.setOption(QFileDialog.HideNameFilterDetails)
-        dlg.currentChanged.connect(print)
-        if dlg.exec() == dlg.Rejected:
-            return
-
-        filename = dlg.selectedFiles()[0]
-        selected_filter = dlg.selectedNameFilter()
-
-#        filename, selected_filter = QFileDialog.getSaveFileName(
- #           self, "Save data", start_dir, ";;".join(self.filters), self.filter,
-  #          QFileDialog.HideNameFilterDetails)
-        if not filename:
-            return
-
-        self.filename = filename
-        self.last_dir = os.path.split(filename)[0]
-        self.filter = selected_filter
-        self.writer = self.writers[self.filters.index(self.filter)]
-        self._update_controls()
-        self.save_file()
-
-    def save_file(self):
-        if not self.filename:
-            self.save_file_as()
-            return
-        self.Error.general_error.clear()
-        if not self._can_save():
-            return
-        try:
-            self.writer.write(
-                self._fullname(), self.data, self.add_type_annotations)
-        except IOError as err_value:
-            self.Error.general_error(str(err_value))
-
-    def _fullname(self):
-        return self.filename \
-               + ".gz" * self.writer.SUPPORT_COMPRESSED * self.compress
-
-    def _update_controls(self):
-        if self.filename:
-            self.bt_save.setText(
-                f"Save as {os.path.split(self._fullname())[1]}")
-        else:
-            self.bt_save.setText("Save")
-        self.Error.no_file_name(shown=not self.filename and self.auto_save)
-
-        self.Error.unsupported_sparse(
-            shown=self.data is not None and self.data.is_sparse()
-            and self.filename and not self.writer.SUPPORT_SPARSE_DATA)
-
-        if self.data is None or not self.filename:
-            self.Warning.ignored_flag.clear()
-        else:
-            no_compress = self.compress \
-                          and not self.writer.SUPPORT_COMPRESSED
-            no_anotation = self.add_type_annotations \
-                           and not self.writer.OPTIONAL_TYPE_ANNOTATIONS
-            ignored = [
-                "",
-                "Compression flag is",
-                "Type annotation flag is",
-                "Compression and type annotation flags are"
-            ][no_compress + 2 * no_anotation]
-            self.Warning.ignored_flag(ignored, shown=bool(ignored))
-
-    def _can_save(self):
-        return not (
-            self.data is None
-            or not self.filename
-            or self.data.is_sparse() and not self.writer.SUPPORT_SPARSE_DATA
-        )
-
     def send_report(self):
         self.report_data_brief(self.data)
         writer = self.writer
@@ -196,7 +146,6 @@ class OWSave(widget.OWWidget):
         self.report_items((
             ("File name", self.filename or "not set"),
             ("Format", writer.DESCRIPTION),
-            ("Compression", writer.SUPPORT_COMPRESSED and noyes[self.compress]),
             ("Type annotations",
              writer.OPTIONAL_TYPE_ANNOTATIONS
              and noyes[self.add_type_annotations])
@@ -204,9 +153,136 @@ class OWSave(widget.OWWidget):
 
     @classmethod
     def migrate_settings(cls, settings, version=0):
-        settings.filter = next(iter(cls.filt_ext))
-#        if version < 2:
- #           settings["filter"] = settings.pop("filetype")
+        def migrate_to_version_2():
+            # Set the default; change later if possible
+            settings.pop("compression", None)
+            settings["filter"] = next(iter(cls.filters))
+            filetype = settings.pop("filetype", None)
+            if filetype is None:
+                return
+
+            ext = cls._extension_from_filter(filetype)
+            if settings.pop("compress", False):
+                for afilter in cls.filters:
+                    if ext + ".gz" in afilter:
+                        settings["filter"] = afilter
+                        return
+                # If not found, uncompressed may have been erroneously set
+                # for a writer that didn't support if (such as .xlsx), so
+                # fall through to uncompressed
+            for afilter in cls.filters:
+                if ext in afilter:
+                    settings["filter"] = afilter
+                    return
+
+        if version < 2:
+            migrate_to_version_2()
+
+
+
+    def _initial_start_dir(self):
+        if self.filename and os.path.exists(os.path.split(self.filename)[0]):
+            return self.filename
+        else:
+            data_name = getattr(self.data, 'name', '')
+            if data_name:
+                data_name += self.writer.EXTENSIONS[0]
+            return os.path.join(self.last_dir or self.userhome, data_name)
+
+    @staticmethod
+    def _replace_extension(filename, extension):
+        if filename.endswith(extension):  # it may contain dots before extension
+            return filename
+        last_fn = None
+        while last_fn != filename:
+            last_fn, filename = filename, os.path.splitext(filename)[0]
+        return filename + extension
+
+    @staticmethod
+    def _extension_from_filter(selected_filter):
+        return re.search(r".*\(\*?(\..*)\)$", selected_filter).group(1)
+
+    # As of Qt 5.9, QFileDialog.setDefaultSuffix does not support double
+    # suffixes, not even in non-native dialogs. We handle each OS separately.
+    if sys.platform == "darwin":
+        # On macOS, is double suffixes are passed to the dialog, they are
+        # appended multiple times even if already present (QTBUG-44227).
+        # The only known workaround with native dialog is to use suffix *.*.
+        # We add the correct suffix after closing the dialog and only then check
+        # if the file exists and ask whether to override.
+        # It is a bit confusing that the user does not see the final name in the
+        # dialog, but I see no better solution.
+        def get_save_filename(self):  # pragma: no cover
+            def no_suffix(filt):
+                return filt.split("(")[0] + "(*.*)"
+
+            mac_filters = {no_suffix(f): f for f in self.filters}
+            filename = self._initial_start_dir()
+            while True:
+                dlg = QFileDialog(
+                    None, "Save File", filename, ";;".join(mac_filters))
+                dlg.setAcceptMode(dlg.AcceptSave)
+                dlg.selectNameFilter(no_suffix(self.filter))
+                dlg.setOption(QFileDialog.HideNameFilterDetails)
+                dlg.setOption(QFileDialog.DontConfirmOverwrite)
+                if dlg.exec() == QFileDialog.Rejected:
+                    return "", ""
+                filename = dlg.selectedFiles()[0]
+                selected_filter = mac_filters[dlg.selectedNameFilter()]
+                filename = self._replace_extension(
+                    filename, self._extension_from_filter(selected_filter))
+                if not os.path.exists(filename) or QMessageBox.question(
+                        self, "Overwrite file?",
+                        f"File {os.path.split(filename)[1]} already exists.\n"
+                        "Overwrite?") == QMessageBox.Yes:
+                    return filename, selected_filter
+
+    elif sys.platform == "win32":
+        # TODO: This is not tested!!!
+        # Windows native dialog may work correctly; if not, we may do the same
+        # as for macOS?
+        def get_save_filename(self):  # pragma: no cover
+            return QFileDialog.getSaveFileName(
+                self, "Save File", self._initial_start_dir(),
+                ";;".join(self.filters), self.filter)
+
+    else:  # Linux and any unknown platforms
+        # Qt does not use a native dialog on Linux, so we can connect to
+        # filterSelected and to overload selectFile to change the extension
+        # while the dialog is open.
+        # For unknown platforms (which?), we also use the non-native dialog to
+        # be sure we know what happens.
+        class SaveFileDialog(QFileDialog):
+            # pylint: disable=protected-access
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.setAcceptMode(QFileDialog.AcceptSave)
+                self.setOption(QFileDialog.DontUseNativeDialog)
+                self.filterSelected.connect(self.updateDefaultExtension)
+
+            def selectNameFilter(self, selected_filter):
+                super().selectNameFilter(selected_filter)
+                self.updateDefaultExtension(selected_filter)
+
+            def updateDefaultExtension(self, selected_filter):
+                self.suffix = OWSave._extension_from_filter(selected_filter)
+                files = self.selectedFiles()
+                if files and not os.path.isdir(files[0]):
+                    self.selectFile(files[0].split(".")[0])
+
+            def selectFile(self, filename):
+                filename = OWSave._replace_extension(filename, self.suffix)
+                super().selectFile(filename)
+
+        def get_save_filename(self):
+            dlg = self.SaveFileDialog(
+                None, "Save File", self._initial_start_dir(),
+                ";;".join(self.filters))
+            dlg.selectNameFilter(self.filter)
+            if dlg.exec() == QFileDialog.Rejected:
+                return "", ""
+            else:
+                return dlg.selectedFiles()[0], dlg.selectedNameFilter()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -290,34 +290,6 @@ class TestOWSave(WidgetTest):
         widget._update_messages()
         self.assertFalse(err.is_shown())
 
-    def test_ignored_annotation_warning(self):
-        widget = self.widget
-
-        widget.writer = ExcelReader
-        widget.add_type_annotations = True
-        widget._update_messages()
-        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
-
-        widget.filename = "test.xlsx"
-        widget._update_messages()
-        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
-
-        self.send_signal(widget.Inputs.data, self.iris)
-        widget._update_messages()
-        self.assertTrue(widget.Warning.type_annotation_ignored.is_shown())
-
-        widget.add_type_annotations = False
-        widget._update_messages()
-        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
-
-        widget.add_type_annotations = True
-        widget._update_messages()
-        self.assertTrue(widget.Warning.type_annotation_ignored.is_shown())
-
-        widget.writer = TabReader
-        widget._update_messages()
-        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
-
     def test_send_report(self):
         widget = self.widget
 

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -1,145 +1,352 @@
-# Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring, protected-access
+import unittest
 from unittest.mock import patch, Mock
-import itertools
+import os
+
+from AnyQt.QtWidgets import QDialog
+
+import scipy.sparse as sp
 
 from Orange.data import Table
-from Orange.data.io import Compression, CSVReader, TabReader, PickleReader, \
-    ExcelReader, FileFormat
+from Orange.data.io import CSVReader, TabReader, PickleReader, ExcelReader
 from Orange.tests import named_file
 from Orange.widgets.tests.base import WidgetTest
-from Orange.widgets.utils.filedialogs import format_filter
 from Orange.widgets.data.owsave import OWSave
 
-FILE_TYPES = [
-    ("{} ({})".format(w.DESCRIPTION, w.EXTENSIONS[0]),
-     w.EXTENSIONS[0],
-     w.SUPPORT_SPARSE_DATA)
-    for w in (TabReader, CSVReader, PickleReader, ExcelReader)
-]
 
-COMPRESSIONS = [
-    ("gzip ({})".format(Compression.GZIP), Compression.GZIP),
-    ("bzip2 ({})".format(Compression.BZIP2), Compression.BZIP2),
-    ("lzma ({})".format(Compression.XZ), Compression.XZ),
-]
+FILE_TYPES = [("{} ({})".format(w.DESCRIPTION, w.EXTENSIONS[0]), w)
+              for w in (TabReader, CSVReader, PickleReader, ExcelReader)]
 
 
-class AddedFormat(FileFormat):
-    EXTENSIONS = ('.234',)
-    DESCRIPTION = "Test if a dialog format works after reading OWSave"
-
-    def write_file(self):
-        pass
+# Yay, MS Windows!
+# This is not the proper general way to do it, but it's simplest and sufficient
+# Short name is suitable for the functions, purpose
+def _w(s):  # pylint: disable=invalid-name
+    return s.replace("/", os.sep)
 
 
 class TestOWSave(WidgetTest):
-
     def setUp(self):
         self.widget = self.create_widget(OWSave)  # type: OWSave
+        self.iris = Table("iris")
 
-    def test_writer(self):
-        compressions = [self.widget.controls.compression.itemText(i) for i in
-                        range(self.widget.controls.compression.count())]
-        types = [self.widget.controls.filetype.itemText(i)
-                 for i in range(self.widget.controls.filetype.count())]
-        for t, c, d in itertools.product(types, compressions, [True, False]):
-            self.widget.compression = c
-            self.widget.compress = d
-            self.widget.filetype = t
-            self.widget.update_extension()
-            self.assertEqual(
-                len(self.widget.get_writer_selected().EXTENSIONS), 1)
+    def test_dataset(self):
+        widget = self.widget
+        insum = widget.info.set_input_summary = Mock()
+        savefile = widget.save_file = Mock()
 
-    def test_ordinary_save(self):
-        self.send_signal(self.widget.Inputs.data, Table("iris"))
+        datasig = widget.Inputs.data
+        self.send_signal(datasig, self.iris)
+        self.assertEqual(insum.call_args[0][0], "150")
+        self.assertFalse(widget.bt_save.isEnabled())
+        insum.reset_mock()
+        savefile.reset_mock()
 
-        for ext, suffix, _ in FILE_TYPES:
-            self.widget.filetype = ext
-            self.widget.update_extension()
-            writer = self.widget.get_writer_selected()
-            with named_file("", suffix=suffix) as filename:
-                def choose_file(a, b, c, d, e, fn=filename, w=writer):
-                    return fn, format_filter(w)
+        widget.filename = "foo.tab"
+        widget.writer = TabReader
+        widget.auto_save = False
+        self.send_signal(datasig, self.iris)
+        self.assertEqual(insum.call_args[0][0], "150")
+        self.assertTrue(widget.bt_save.isEnabled())
+        savefile.assert_not_called()
 
-                with patch("AnyQt.QtWidgets.QFileDialog.getSaveFileName", choose_file):
-                    self.widget.save_file_as()
-                self.assertEqual(len(Table(filename)), 150)
+        widget.auto_save = True
+        self.send_signal(datasig, self.iris)
+        self.assertEqual(insum.call_args[0][0], "150")
+        self.assertTrue(widget.bt_save.isEnabled())
+        savefile.assert_called()
 
-    @patch('Orange.data.io.FileFormat.write')
-    def test_annotations(self, write):
+        self.send_signal(datasig, None)
+        insum.assert_called_with(widget.info.NoInput)
+        self.assertFalse(widget.bt_save.isEnabled())
+
+    @patch("Orange.widgets.data.owsave.QFileDialog")
+    def test_set_file_name_start_dir(self, filedialog):
         widget = self.widget
 
-        self.send_signal(widget.Inputs.data, Table("iris"))
-        widget.filetype = FILE_TYPES[1][0]
-        widget.filename = 'foo.csv'
-        widget.update_extension()
+        dlginst = filedialog.return_value
+        dlginst.exec.return_value = dlginst.Rejected = QDialog.Rejected
 
-        widget.add_type_annotations = False
-        widget.unconditional_save_file()
-        write.assert_called()
-        self.assertFalse(write.call_args[0][2])
+        widget.filename = _w("/usr/foo/bar.csv")
+        widget.filter = FILE_TYPES[1][0]
+        widget.set_file_name()
+        self.assertEqual(filedialog.call_args[0][2], widget.filename)
 
+        widget.filename = ""
+        widget.last_dir = _w("/usr/bar")
+        widget.set_file_name()
+        self.assertEqual(filedialog.call_args[0][2], _w("/usr/bar/"))
+
+        self.send_signal(widget.Inputs.data, self.iris)
+        widget.last_dir = _w("/usr/bar")
+        widget.set_file_name()
+        self.assertEqual(filedialog.call_args[0][2], _w("/usr/bar/iris.csv"))
+
+        widget.last_dir = ""
+        widget.set_file_name()
+        self.assertEqual(filedialog.call_args[0][2],
+                         os.path.expanduser(_w("~/iris.csv")))
+
+    @patch("Orange.widgets.data.owsave.QFileDialog")
+    def test_set_file_name(self, filedialog):
+        widget = self.widget
+        widget.filename = _w("/usr/foo/bar.csv")
+        widget.last_dir = _w("/usr/foo/")
+        widget.writer = widget.writers[1]
+        widget.filter = FILE_TYPES[1][0]
+
+        widget._update_controls = Mock()
+
+        dlginst = filedialog.return_value
+        dlginst.selectedFiles.return_value = [_w("/bar/baz.csv")]
+        dlginst.selectedNameFilter.return_value = FILE_TYPES[0][0]
+
+        dlginst.exec.return_value = dlginst.Rejected = QDialog.Rejected
+        widget.set_file_name()
+        self.assertEqual(widget.filename, _w("/usr/foo/bar.csv"))
+        self.assertEqual(widget.last_dir, _w("/usr/foo/"))
+        self.assertEqual(widget.filter, FILE_TYPES[1][0])
+        self.assertIs(widget.writer, widget.writers[1])
+        widget._update_controls.assert_not_called()
+
+        dlginst.exec.return_value = dlginst.Accepted = QDialog.Accepted
+        widget.set_file_name()
+        self.assertEqual(widget.filename, _w("/bar/baz.csv"))
+        self.assertEqual(widget.last_dir, _w("/bar"))
+        self.assertEqual(widget.filter, FILE_TYPES[0][0])
+        self.assertIs(widget.writer, widget.writers[0])
+        widget._update_controls.assert_called()
+
+    def set_mock_writer(self):
+        widget = self.widget
+        writer = widget.writer = Mock()
+        writer.write = Mock()
+        writer.SUPPORT_COMPRESSED = True
+        writer.SUPPORT_SPARSE_DATA = False
+        writer.OPTIONAL_TYPE_ANNOTATIONS = False
+
+    def test_save_file_check_can_save(self):
+        widget = self.widget
+        self.set_mock_writer()
+
+        widget.save_file()
+        widget.writer.write.assert_not_called()
+
+        widget.filename = "foo"
+        widget.save_file()
+        widget.writer.write.assert_not_called()
+
+        widget.filename = ""
+        self.send_signal(widget.Inputs.data, self.iris)
+        widget.save_file()
+        widget.writer.write.assert_not_called()
+
+        widget.filename = "foo"
+        widget.save_file()
+        widget.writer.write.assert_called()
+        widget.writer.reset_mock()
+
+        self.iris.X = sp.csr_matrix(self.iris.X)
+        widget.save_file()
+        widget.writer.write.assert_not_called()
+
+        widget.writer.SUPPORT_SPARSE_DATA = True
+        widget.save_file()
+        widget.writer.write.assert_called()
+
+    def test_save_file_write_errors(self):
+        widget = self.widget
+        datasig = widget.Inputs.data
+
+        widget.auto_save = True
+        widget.filename = _w("bar/foo")
+        self.set_mock_writer()
+
+        widget.writer.write.side_effect = IOError
+        self.send_signal(datasig, self.iris)
+        self.assertTrue(widget.Error.general_error.is_shown())
+
+        widget.writer.write.side_effect = None
+        self.send_signal(datasig, self.iris)
+        self.assertFalse(widget.Error.general_error.is_shown())
+
+        widget.writer.write.side_effect = IOError
+        self.send_signal(datasig, self.iris)
+        self.assertTrue(widget.Error.general_error.is_shown())
+
+        widget.writer.write.side_effect = None
+        self.send_signal(datasig, None)
+        self.assertFalse(widget.Error.general_error.is_shown())
+
+        widget.writer.write.side_effect = ValueError
+        self.assertRaises(ValueError, self.send_signal, datasig, self.iris)
+
+    def test_save_file_write(self):
+        widget = self.widget
+        datasig = widget.Inputs.data
+
+        self.set_mock_writer()
+        widget.auto_save = True
+
+        widget.filename = _w("bar/foo.csv")
+        widget.compress = False
         widget.add_type_annotations = True
-        widget.unconditional_save_file()
-        self.assertTrue(write.call_args[0][2])
+        self.send_signal(datasig, self.iris)
+        widget.writer.write.assert_called_with(
+            _w("bar/foo.csv"), self.iris, True)
 
-    def test_disable_checkbox(self):
+        widget.compress = True
+        self.send_signal(datasig, self.iris)
+        widget.writer.write.assert_called_with(
+            _w("bar/foo.csv.gz"), self.iris, True)
+
+        widget.writer.SUPPORT_COMPRESSED = False
+        self.send_signal(datasig, self.iris)
+        widget.writer.write.assert_called_with(
+            _w("bar/foo.csv"), self.iris, True)
+
+    def test_file_label(self):
         widget = self.widget
-        for type_ in FILE_TYPES:
-            widget.filetype = type_[0]
-            widget.update_extension()
-            if widget.get_writer_selected().OPTIONAL_TYPE_ANNOTATIONS:
-                self.assertTrue(widget.annotations_cb.isEnabled())
-            else:
-                self.assertFalse(widget.annotations_cb.isEnabled())
 
-    def test_compression(self):
-        self.send_signal(self.widget.Inputs.data, Table("iris"))
+        widget.filename = ""
+        widget._update_controls()
+        self.assertTrue(widget.lb_filename.isHidden())
+        self.assertTrue(widget.Warning.no_file_name.is_shown())
 
-        self.widget.compress = True
-        for type, compression in itertools.product([[x, ext] for x, ext, _ in FILE_TYPES],
-                                                   COMPRESSIONS):
-            self.widget.filetype = type[0]
-            self.widget.compression = compression[0]
-            self.widget.update_extension()
-            writer = self.widget.get_writer_selected()
-            with named_file("",
-                            suffix=type[1] + compression[1]) as filename:
-                def choose_file(a, b, c, d, e, fn=filename, w=writer):
-                    return fn, format_filter(w)
+        widget.filename = _w("/foo/bar/baz.csv")
+        widget._update_controls()
+        self.assertFalse(widget.lb_filename.isHidden())
+        self.assertIn(
+            widget.lb_filename.text(), _w("Save to: /foo/bar/baz.csv"))
+        self.assertFalse(widget.Warning.no_file_name.is_shown())
 
-                with patch("AnyQt.QtWidgets.QFileDialog.getSaveFileName", choose_file):
-                    self.widget.save_file_as()
+        widget.filename = os.path.expanduser(_w("~/baz/bar/foo.csv"))
+        widget._update_controls()
+        self.assertFalse(widget.lb_filename.isHidden())
+        self.assertEqual(
+            widget.lb_filename.text(), _w("Save to: baz/bar/foo.csv"))
+
+    def test_annotation_checkbox(self):
+        widget = self.widget
+        for _, widget.writer in FILE_TYPES:
+            widget.filename = f"foo.{widget.writer.EXTENSIONS[0]}"
+            widget._update_controls()
+            self.assertIsNot(widget.controls.add_type_annotations.isHidden(),
+                             widget.writer.OPTIONAL_TYPE_ANNOTATIONS,
+                             msg=f"for {widget.writer}")
+            self.assertIsNot(widget.controls.compress.isHidden(),
+                             widget.writer.SUPPORT_COMPRESSED,
+                             msg=f"for {widget.writer}")
+
+        widget.writer = TabReader
+        widget.filename = ""
+        self.widget._update_controls()
+        self.assertFalse(widget.controls.add_type_annotations.isVisible())
+        self.assertFalse(widget.controls.compress.isVisible())
+
+    def test_sparse_error(self):
+        widget = self.widget
+        err = widget.Error.unsupported_sparse
+
+        widget.writer = ExcelReader
+        widget.filename = "foo.xlsx"
+        widget.data = self.iris
+
+        widget._update_controls()
+        self.assertFalse(err.is_shown())
+
+        widget.data.X = sp.csr_matrix(widget.data.X)
+        widget._update_controls()
+        self.assertTrue(err.is_shown())
+
+        widget.writer = PickleReader
+        widget._update_controls()
+        self.assertFalse(err.is_shown())
+
+        widget.writer = ExcelReader
+        widget._update_controls()
+        self.assertTrue(err.is_shown())
+
+        widget.data = None
+        widget._update_controls()
+        self.assertFalse(err.is_shown())
+
+    def test_send_report(self):
+        widget = self.widget
+
+        widget.report_items = Mock()
+        for _, writer in FILE_TYPES:
+            widget.writer = writer
+            for widget.compress in (False, True):
+                for widget.add_type_annotations in (False, True):
+                    widget.filename = f"foo.{writer.EXTENSIONS[0]}"
+                    widget.send_report()
+                    items = dict(widget.report_items.call_args[0][0])
+                    msg = f"for {widget.writer}, " \
+                        f"annotations={widget.add_type_annotations}, " \
+                        f"compress={widget.compress}"
+                    self.assertEqual(items["File name"],
+                                     f"foo.{writer.EXTENSIONS[0]}", msg=msg)
+                    if writer.SUPPORT_COMPRESSED:
+                        self.assertEqual(
+                            items["Compression"],
+                            ["No", "Yes"][widget.compress],
+                            msg=msg)
+                    else:
+                        self.assertFalse(items["Compression"], msg=msg)
+                    if writer.OPTIONAL_TYPE_ANNOTATIONS:
+                        self.assertEqual(
+                            items["Type annotations"],
+                            ["No", "Yes"][widget.add_type_annotations],
+                            msg=msg)
+                    else:
+                        self.assertFalse(items["Type annotations"], msg=msg)
+
+
+class TestFunctionalOWSave(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWSave)  # type: OWSave
+        self.iris = Table("iris")
+
+    @patch("Orange.widgets.data.owsave.QFileDialog")
+    def test_save_uncompressed(self, filedialog):
+        widget = self.widget
+        widget.auto_save = False
+
+        dlg = filedialog.return_value
+        dlg.exec.return_value = dlg.Accepted = QDialog.Accepted
+        dlg = filedialog.return_value
+
+        spiris = Table("iris")
+        spiris.X = sp.csr_matrix(spiris.X)
+
+        for dlg.selectedNameFilter.return_value, writer in FILE_TYPES:
+            widget.write = writer
+            ext = writer.EXTENSIONS[0]
+            with named_file("", suffix=ext) as filename:
+                dlg.selectedFiles.return_value = [filename]
+
+                self.send_signal(widget.Inputs.data, self.iris)
+                widget.bt_set_file.click()
+                widget.bt_save.click()
                 self.assertEqual(len(Table(filename)), 150)
 
-    def test_format_combo(self):
-        widget = self.widget
-        filetype = widget.controls.filetype
+                if writer.SUPPORT_SPARSE_DATA:
+                    self.send_signal(widget.Inputs.data, spiris)
+                    widget.bt_set_file.click()
+                    widget.bt_save.click()
+                    self.assertEqual(len(Table(filename)), 150)
 
-        widget.save_file = Mock()
+            if writer.SUPPORT_COMPRESSED:
+                with named_file("", suffix=ext + ".gz") as filename:
+                    widget.compress = True
+                    dlg.selectedFiles.return_value = [filename[:-3]]
+                    self.send_signal(widget.Inputs.data, self.iris)
+                    widget.bt_set_file.click()
+                    widget.bt_save.click()
+                    self.assertEqual(len(Table(filename)), 150)
+                    widget.compress = False
 
-        data = Table("iris")
-        sparse_data = Table("iris")
-        sparse_data.is_sparse = Mock(return_value=True)
 
-        self.send_signal(widget.Inputs.data, data)
-        n_nonsparse = filetype.count()
-
-        self.send_signal(widget.Inputs.data, sparse_data)
-        n_sparse = filetype.count()
-        self.assertGreater(n_nonsparse, n_sparse)
-
-        self.send_signal(widget.Inputs.data, sparse_data)
-        self.assertEqual(filetype.count(), n_sparse)
-
-        self.send_signal(widget.Inputs.data, data)
-        self.assertEqual(filetype.count(), n_nonsparse)
-
-        self.send_signal(widget.Inputs.data, None)
-        self.send_signal(widget.Inputs.data, data)
-        self.assertEqual(filetype.count(), n_nonsparse)
-
-        self.send_signal(widget.Inputs.data, None)
-        self.send_signal(widget.Inputs.data, sparse_data)
-        self.assertEqual(filetype.count(), n_sparse)
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -402,20 +402,23 @@ class TestFunctionalOWSave(WidgetTest):
 class TestOWSaveUtils(unittest.TestCase):
     def test_replace_extension(self):
         replace = OWSave._replace_extension
-        fname = "/bing.bada.boom/foo.bar.baz"
-        self.assertEqual(replace(fname, ".baz"), fname)
-        self.assertEqual(replace(fname, ".bar.baz"), fname)
-        self.assertEqual(replace(fname, ".txt"), "/bing.bada.boom/foo.txt")
+        fname = "/bing.bada.boom/foo.1942.tab"
+        self.assertEqual(
+            replace(fname, ".tab"), "/bing.bada.boom/foo.1942.tab")
+        self.assertEqual(
+            replace(fname, ".tab.gz"), "/bing.bada.boom/foo.1942.tab.gz")
+        self.assertEqual(
+            replace(fname, ".xlsx"), "/bing.bada.boom/foo.1942.xlsx")
 
-        fname = "foo.bar.baz"
-        self.assertEqual(replace(fname, ".baz"), fname)
-        self.assertEqual(replace(fname, ".bar.baz"), fname)
-        self.assertEqual(replace(fname, ".txt"), "foo.txt")
-        self.assertEqual(replace(fname, ".bar.txt"), "foo.bar.txt")
+        fname = "foo.tab.gz"
+        self.assertEqual(replace(fname, ".tab"), "foo.tab")
+        self.assertEqual(replace(fname, ".tab.gz"), "foo.tab.gz")
+        self.assertEqual(replace(fname, ".csv"), "foo.csv")
+        self.assertEqual(replace(fname, ".csv.gz"), "foo.csv.gz")
 
         fname = "/bing.bada.boom/foo"
-        self.assertEqual(replace(fname, ".baz"), fname + ".baz")
-        self.assertEqual(replace(fname, ".bar.baz"), fname + ".bar.baz")
+        self.assertEqual(replace(fname, ".tab"), fname + ".tab")
+        self.assertEqual(replace(fname, ".tab.gz"), fname + ".tab.gz")
 
     def test_extension_from_filter(self):
         self.assertEqual(

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -2,18 +2,16 @@
 import unittest
 from unittest.mock import patch, Mock
 import os
+import sys
 
 import scipy.sparse as sp
+from AnyQt.QtWidgets import QFileDialog
 
 from Orange.data import Table
-from Orange.data.io import CSVReader, TabReader, PickleReader, ExcelReader
+from Orange.data.io import TabReader, PickleReader, ExcelReader
 from Orange.tests import named_file
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.data.owsave import OWSave
-
-
-FILE_TYPES = [("{} (*{})".format(w.DESCRIPTION, w.EXTENSIONS[0]), w)
-              for w in (TabReader, CSVReader, PickleReader, ExcelReader)]
 
 
 # Yay, MS Windows!
@@ -25,11 +23,19 @@ def _w(s):  # pylint: disable=invalid-name
 
 class TestOWSave(WidgetTest):
     def setUp(self):
-        self.widget = self.create_widget(OWSave)  # type: OWSave
+        class OWSaveMockWriter(OWSave):
+            writer = Mock()
+            writer.EXTENSIONS = [".csv"]
+            writer.SUPPORT_COMPRESSED = True
+            writer.SUPPORT_SPARSE_DATA = False
+            writer.OPTIONAL_TYPE_ANNOTATIONS = False
+
+        self.widget = self.create_widget(OWSaveMockWriter)  # type: OWSave
         self.iris = Table("iris")
 
     def test_dataset(self):
         widget = self.widget
+        widget.auto_save = True
         insum = widget.info.set_input_summary = Mock()
         savefile = widget.save_file = Mock()
 
@@ -54,73 +60,130 @@ class TestOWSave(WidgetTest):
         self.send_signal(datasig, None)
         insum.assert_called_with(widget.info.NoInput)
 
-    @patch("Orange.widgets.data.owsave.QFileDialog.getSaveFileName")
-    def test_save_file_as_start_dir(self, filedialog):
+    @unittest.skipUnless(sys.platform == "linux", "Test Qt's non-native dialog")
+    def test_get_save_filename_non_native(self):
+        widget = self.widget
+        widget._initial_start_dir = lambda: "baz"
+        widget.filters = dict.fromkeys("abc")
+        widget.filter = "b"
+        dlg = widget.SaveFileDialog = Mock()  # pylint: disable=invalid-name
+        instance = dlg.return_value
+        instance.selectedFiles.return_value = ["foo"]
+        instance.selectedNameFilter.return_value = "bar"
+        self.assertEqual(widget.get_save_filename(), ("foo", "bar"))
+        self.assertEqual(dlg.call_args[0][2], "baz")
+        self.assertEqual(dlg.call_args[0][3], "a;;b;;c")
+        instance.selectNameFilter.assert_called_with("b")
+
+        instance.exec.return_value = QFileDialog.Rejected
+        self.assertEqual(widget.get_save_filename(), ("", ""))
+
+    @unittest.skipUnless(sys.platform == "linux", "Test Qt's non-native dialog")
+    def test_save_file_dialog_enforces_extension(self):
+        dialog = OWSave.SaveFileDialog(
+            None, "Save File", "high.txt",
+            "Bar files (*.bar);;Low files (*.low)")
+
+        dialog.selectNameFilter("Low files (*.low)")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/high.low"))
+
+        dialog.selectFile("high.txt")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/high.low"))
+
+        dialog.selectNameFilter("Bar files (*.bar)")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/high.bar"))
+
+        dialog.selectFile("middle.txt")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/middle.bar"))
+
+        dialog.filterSelected.emit("Low files (*.low)")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/middle.low"))
+
+        dialog.selectFile("high.txt")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/high.low"))
+
+    def test_initial_start_dir(self):
         widget = self.widget
         widget.filename = _w("/usr/foo/bar.csv")
-        widget.filter = FILE_TYPES[1][0]
+        self.assertEqual(widget._initial_start_dir(),
+                         _w(os.path.expanduser("~/")))
 
-        filedialog.return_value = "", FILE_TYPES[0][0]
+        with patch("os.path.exists", return_value=True):
+            widget.filename = _w("/usr/foo/bar.csv")
+            self.assertEqual(widget._initial_start_dir(), widget.filename)
 
-        widget.save_file_as()
-        self.assertEqual(filedialog.call_args[0][2], widget.filename)
+            widget.filename = ""
+            widget.last_dir = _w("/usr/bar")
+            self.assertEqual(widget._initial_start_dir(), _w("/usr/bar/"))
 
-        widget.filename = ""
-        widget.last_dir = _w("/usr/bar")
-        widget.save_file_as()
-        self.assertEqual(filedialog.call_args[0][2], _w("/usr/bar/"))
+            widget.last_dir = _w("/usr/bar")
+            self.send_signal(widget.Inputs.data, self.iris)
+            self.assertEqual(widget._initial_start_dir(),
+                             _w("/usr/bar/iris.csv"))
 
-        self.send_signal(widget.Inputs.data, self.iris)
-        widget.last_dir = _w("/usr/bar")
-        widget.save_file_as()
-        self.assertEqual(filedialog.call_args[0][2], _w("/usr/bar/iris.csv"))
-
-        widget.last_dir = ""
-        widget.save_file_as()
-        self.assertEqual(filedialog.call_args[0][2],
-                         os.path.expanduser(_w("~/iris.csv")))
+            widget.last_dir = ""
+            self.assertEqual(widget._initial_start_dir(),
+                             os.path.expanduser(_w("~/iris.csv")))
 
     @patch("Orange.widgets.data.owsave.QFileDialog.getSaveFileName")
-    def test_save_file_as_name(self, filedialog):
+    def test_save_file_sets_name(self, filedialog):
         widget = self.widget
+        filters = iter(widget.filters)
+        filter1 = next(filters)
+        filter2 = next(filters)
+
         widget.filename = _w("/usr/foo/bar.csv")
         widget.last_dir = _w("/usr/foo/")
-        widget.writer = widget.writers[1]
-        widget.filter = FILE_TYPES[1][0]
+        widget.filter = filter1
 
-        widget._update_controls = Mock()
+        widget._update_messages = Mock()
         widget.save_file = Mock()
 
-        filedialog.return_value = "", FILE_TYPES[0][0]
+        widget.get_save_filename = Mock(return_value=("", filter2))
         widget.save_file_as()
         self.assertEqual(widget.filename, _w("/usr/foo/bar.csv"))
         self.assertEqual(widget.last_dir, _w("/usr/foo/"))
-        self.assertEqual(widget.filter, FILE_TYPES[1][0])
-        self.assertIs(widget.writer, widget.writers[1])
-        widget._update_controls.assert_not_called()
+        self.assertEqual(widget.filter, filter1)
+        widget._update_messages.assert_not_called()
         widget.save_file.assert_not_called()
 
-        filedialog.return_value = _w("/bar/baz.csv"), FILE_TYPES[0][0]
+        widget.get_save_filename = \
+            Mock(return_value=(_w("/bar/bar.csv"), filter2))
         widget.save_file_as()
-        self.assertEqual(widget.filename, _w("/bar/baz.csv"))
+        self.assertEqual(widget.filename, _w("/bar/bar.csv"))
         self.assertEqual(widget.last_dir, _w("/bar"))
-        self.assertEqual(widget.filter, FILE_TYPES[0][0])
-        self.assertIs(widget.writer, widget.writers[0])
-        widget._update_controls.assert_called()
+        self.assertEqual(widget.filter, filter2)
+        self.assertIn("bar.csv", widget.bt_save.text())
+        widget._update_messages.assert_called()
         widget.save_file.assert_called()
 
-    def set_mock_writer(self):
-        widget = self.widget
-        writer = widget.writer = Mock()
-        writer.write = Mock()
-        writer.SUPPORT_COMPRESSED = True
-        writer.SUPPORT_SPARSE_DATA = False
-        writer.OPTIONAL_TYPE_ANNOTATIONS = False
+        widget.get_save_filename = Mock(return_value=("", filter2))
+        widget.save_file_as()
+        self.assertEqual(widget.filename, _w("/bar/bar.csv"))
+        self.assertEqual(widget.last_dir, _w("/bar"))
+        self.assertEqual(widget.filter, filter2)
+        self.assertIn("bar.csv", widget.bt_save.text())
+        widget._update_messages.assert_called()
+        widget.save_file.assert_called()
 
-    def test_save_file_check_can_save(self):
+    def test_save_file_calls_save_as(self):
         widget = self.widget
-        widget.save_file_as = Mock(return_value=("", 0))
-        self.set_mock_writer()
+        widget.save_file_as = Mock()
+
+        self.send_signal(widget.Inputs.data, self.iris)
+
+        widget.filename = ""
+        widget.save_file()
+        widget.save_file_as.assert_called()
+        widget.save_file_as.reset_mock()
+
+        widget.filename = "bar.csv"
+        widget.save_file()
+        widget.save_file_as.assert_not_called()
+
+    def test_save_file_checks_can_save(self):
+        widget = self.widget
+        widget.get_save_filename = Mock(return_value=("", 0))
 
         widget.save_file()
         widget.writer.write.assert_not_called()
@@ -153,7 +216,6 @@ class TestOWSave(WidgetTest):
 
         widget.auto_save = True
         widget.filename = _w("bar/foo")
-        self.set_mock_writer()
 
         widget.writer.write.side_effect = IOError
         self.send_signal(datasig, self.iris)
@@ -178,32 +240,28 @@ class TestOWSave(WidgetTest):
         widget = self.widget
         datasig = widget.Inputs.data
 
-        self.set_mock_writer()
         widget.auto_save = True
 
         widget.filename = _w("bar/foo.csv")
-        widget.compress = False
         widget.add_type_annotations = True
         self.send_signal(datasig, self.iris)
         widget.writer.write.assert_called_with(
             _w("bar/foo.csv"), self.iris, True)
 
-        widget.compress = True
-        self.send_signal(datasig, self.iris)
-        widget.writer.write.assert_called_with(
-            _w("bar/foo.csv.gz"), self.iris, True)
-
     def test_file_name_label(self):
         widget = self.widget
 
         widget.filename = ""
-        widget._update_controls()
+        widget._update_messages()
+        self.assertFalse(widget.Error.no_file_name.is_shown())
+
+        widget.auto_save = True
+        widget._update_messages()
         self.assertTrue(widget.Error.no_file_name.is_shown())
 
         widget.filename = _w("/foo/bar/baz.csv")
-        widget._update_controls()
+        widget._update_messages()
         self.assertFalse(widget.Error.no_file_name.is_shown())
-        self.assertIn("baz.csv", widget.bt_save.text())
 
     def test_sparse_error(self):
         widget = self.widget
@@ -213,92 +271,131 @@ class TestOWSave(WidgetTest):
         widget.filename = "foo.xlsx"
         widget.data = self.iris
 
-        widget._update_controls()
+        widget._update_messages()
         self.assertFalse(err.is_shown())
 
         widget.data.X = sp.csr_matrix(widget.data.X)
-        widget._update_controls()
+        widget._update_messages()
         self.assertTrue(err.is_shown())
 
         widget.writer = PickleReader
-        widget._update_controls()
+        widget._update_messages()
         self.assertFalse(err.is_shown())
 
         widget.writer = ExcelReader
-        widget._update_controls()
+        widget._update_messages()
         self.assertTrue(err.is_shown())
 
         widget.data = None
-        widget._update_controls()
+        widget._update_messages()
         self.assertFalse(err.is_shown())
 
-    def test_ignored_flags_warnings(self):
+    def test_ignored_annotation_warning(self):
         widget = self.widget
 
         widget.writer = ExcelReader
-        widget.compress = True
         widget.add_type_annotations = True
-        widget._update_controls()
-        self.assertFalse(widget.Warning.ignored_flag.is_shown())
+        widget._update_messages()
+        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
 
         widget.filename = "test.xlsx"
-        widget._update_controls()
-        self.assertFalse(widget.Warning.ignored_flag.is_shown())
+        widget._update_messages()
+        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
 
         self.send_signal(widget.Inputs.data, self.iris)
-        widget._update_controls()
-        self.assertTrue(widget.Warning.ignored_flag.is_shown())
-
-        widget.compress = False
-        widget._update_controls()
-        self.assertTrue(widget.Warning.ignored_flag.is_shown())
+        widget._update_messages()
+        self.assertTrue(widget.Warning.type_annotation_ignored.is_shown())
 
         widget.add_type_annotations = False
-        widget._update_controls()
-        self.assertFalse(widget.Warning.ignored_flag.is_shown())
+        widget._update_messages()
+        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
 
-        widget.writer = PickleReader
-        widget.filename = "test.pkl"
         widget.add_type_annotations = True
-        widget.compress = False
-        widget._update_controls()
-        self.assertTrue(widget.Warning.ignored_flag.is_shown())
+        widget._update_messages()
+        self.assertTrue(widget.Warning.type_annotation_ignored.is_shown())
 
-        widget.add_type_annotations = False
-        widget.compress = True
-        widget._update_controls()
-        self.assertFalse(widget.Warning.ignored_flag.is_shown())
+        widget.writer = TabReader
+        widget._update_messages()
+        self.assertFalse(widget.Warning.type_annotation_ignored.is_shown())
 
     def test_send_report(self):
         widget = self.widget
 
         widget.report_items = Mock()
-        for _, writer in FILE_TYPES:
+        for writer in widget.filters.values():
             widget.writer = writer
-            for widget.compress in (False, True):
-                for widget.add_type_annotations in (False, True):
-                    widget.filename = f"foo.{writer.EXTENSIONS[0]}"
-                    widget.send_report()
-                    items = dict(widget.report_items.call_args[0][0])
-                    msg = f"for {widget.writer}, " \
-                        f"annotations={widget.add_type_annotations}, " \
-                        f"compress={widget.compress}"
-                    self.assertEqual(items["File name"],
-                                     f"foo.{writer.EXTENSIONS[0]}", msg=msg)
-                    if writer.SUPPORT_COMPRESSED:
-                        self.assertEqual(
-                            items["Compression"],
-                            ["No", "Yes"][widget.compress],
-                            msg=msg)
-                    else:
-                        self.assertFalse(items["Compression"], msg=msg)
-                    if writer.OPTIONAL_TYPE_ANNOTATIONS:
-                        self.assertEqual(
-                            items["Type annotations"],
-                            ["No", "Yes"][widget.add_type_annotations],
-                            msg=msg)
-                    else:
-                        self.assertFalse(items["Type annotations"], msg=msg)
+            for widget.add_type_annotations in (False, True):
+                widget.filename = f"foo.{writer.EXTENSIONS[0]}"
+                widget.send_report()
+                items = dict(widget.report_items.call_args[0][0])
+                msg = f"for {writer}, annotations={widget.add_type_annotations}"
+                self.assertEqual(items["File name"], widget.filename, msg=msg)
+                if writer.OPTIONAL_TYPE_ANNOTATIONS:
+                    self.assertEqual(
+                        items["Type annotations"],
+                        ["No", "Yes"][widget.add_type_annotations], msg=msg)
+                else:
+                    self.assertFalse(items["Type annotations"], msg=msg)
+
+    def test_migration_to_version_2(self):
+        const_settings = {
+            'add_type_annotations': True, 'auto_save': False,
+            'controlAreaVisible': True, 'last_dir': '/home/joe/Desktop',
+            '__version__': 1}
+
+        # No compression, Tab-separated values
+        settings = {**const_settings,
+                    'compress': False, 'compression': 'gzip (.gz)',
+                    'filetype': 'Tab-separated values (.tab)'}
+        OWSave.migrate_settings(settings)
+        self.assertEqual(
+            settings,
+            {**const_settings,
+             "filter": "Tab-separated values (*.tab)"})
+
+        # Compression; ignore compression format (.xz is no longer supported)
+        settings = {**const_settings,
+                    'compress': True, 'compression': 'lzma (.xz)',
+                    'filetype': 'Tab-separated values (.tab)'}
+        OWSave.migrate_settings(settings)
+        self.assertEqual(
+            settings,
+            {**const_settings,
+             "filter": "Compressed Tab-separated values (*.tab.gz)"})
+
+        # No compression, Excel
+        settings = {**const_settings,
+                    'compress': False, 'compression': 'lzma (.xz)',
+                    'filetype': 'Microsoft Excel spreadsheet (.xlsx)'}
+        OWSave.migrate_settings(settings)
+        self.assertEqual(
+            settings,
+            {**const_settings,
+             "filter": "Microsoft Excel spreadsheet (*.xlsx)"})
+
+        # Excel with compression - compression must be ignored
+        settings = {**const_settings,
+                    'compress': True, 'compression': 'lzma (.xz)',
+                    'filetype': 'Microsoft Excel spreadsheet (.xlsx)'}
+        OWSave.migrate_settings(settings)
+        self.assertEqual(
+            settings,
+            {**const_settings,
+             "filter": "Microsoft Excel spreadsheet (*.xlsx)"})
+
+        # Missing filetype (is this possible?)
+        settings = {**const_settings,
+                    'compress': True, 'compression': 'lzma (.xz)'}
+        OWSave.migrate_settings(settings)
+        self.assertTrue(settings["filter"] in OWSave.filters)
+
+        # Unsupported file format (is this possible?)
+        settings = {**const_settings,
+                    'compress': True, 'compression': 'lzma (.xz)',
+                    'filetype': 'Bar file (.bar)'}
+        OWSave.migrate_settings(settings)
+        self.assertTrue(settings["filter"] in OWSave.filters)
+
 
 
 class TestFunctionalOWSave(WidgetTest):
@@ -306,19 +403,19 @@ class TestFunctionalOWSave(WidgetTest):
         self.widget = self.create_widget(OWSave)  # type: OWSave
         self.iris = Table("iris")
 
-    @patch("Orange.widgets.data.owsave.QFileDialog.getSaveFileName")
-    def test_save_uncompressed(self, filedialog):
+    def test_save_uncompressed(self):
         widget = self.widget
         widget.auto_save = False
 
         spiris = Table("iris")
         spiris.X = sp.csr_matrix(spiris.X)
 
-        for selected_filter, writer in FILE_TYPES:
+        for selected_filter, writer in widget.filters.items():
             widget.write = writer
             ext = writer.EXTENSIONS[0]
             with named_file("", suffix=ext) as filename:
-                filedialog.return_value = filename, selected_filter
+                widget.get_save_filename = Mock(
+                    return_value=(filename, selected_filter))
 
                 self.send_signal(widget.Inputs.data, self.iris)
                 widget.save_file_as()
@@ -329,14 +426,34 @@ class TestFunctionalOWSave(WidgetTest):
                     widget.save_file()
                     self.assertEqual(len(Table(filename)), 150)
 
-            if writer.SUPPORT_COMPRESSED:
-                with named_file("", suffix=ext + ".gz") as filename:
-                    filedialog.return_value = filename[:-3], selected_filter
-                    widget.compress = True
-                    self.send_signal(widget.Inputs.data, self.iris)
-                    widget.save_file_as()
-                    self.assertEqual(len(Table(filename)), 150)
-                    widget.compress = False
+
+class TestOWSaveUtils(unittest.TestCase):
+    def test_replace_extension(self):
+        replace = OWSave._replace_extension
+        fname = "/bing.bada.boom/foo.bar.baz"
+        self.assertEqual(replace(fname, ".baz"), fname)
+        self.assertEqual(replace(fname, ".bar.baz"), fname)
+        self.assertEqual(replace(fname, ".txt"), "/bing.bada.boom/foo.txt")
+
+        fname = "foo.bar.baz"
+        self.assertEqual(replace(fname, ".baz"), fname)
+        self.assertEqual(replace(fname, ".bar.baz"), fname)
+        self.assertEqual(replace(fname, ".txt"), "foo.txt")
+        self.assertEqual(replace(fname, ".bar.txt"), "foo.bar.txt")
+
+        fname = "/bing.bada.boom/foo"
+        self.assertEqual(replace(fname, ".baz"), fname + ".baz")
+        self.assertEqual(replace(fname, ".bar.baz"), fname + ".bar.baz")
+
+    def test_extension_from_filter(self):
+        self.assertEqual(
+            OWSave._extension_from_filter("Description (*.ext)"), ".ext")
+        self.assertEqual(
+            OWSave._extension_from_filter("Description (*.foo.ba)"), ".foo.ba")
+        self.assertEqual(
+            OWSave._extension_from_filter("Description (.ext)"), ".ext")
+        self.assertEqual(
+            OWSave._extension_from_filter("Description (.foo.bar)"), ".foo.bar")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Fixes #3539.

OWSave widget didn't age well.

<img width="423" alt="screenshot 2019-01-21 at 10 26 23" src="https://user-images.githubusercontent.com/2387315/51465897-2faab900-1d69-11e9-9304-0afdf37fe04c.png">

- **Choosing the format in a separate combo box instead of in the save dialog?** The GUI of its previous incarnation was clear to his creator (me), but I would have to explain it at workshops - not a good sign. But it made sense for as long as one set the format with "Save as". The current incarnation required setting the format in a combo and then use Save as (or Save) to set the name -- the save dialog was passed the filter chosen in the combo. Unusual and cumbersome.

- **Compression options.** I suppose this complication was needed because of the "Compression" checkbox, which the user would have to decide before clicking Save (and it's availability depended on the format). The widget offered three different compressions, one of which was even new to me. Gzip should suffice.

- **Auto save checkbox didn't follow the usual semantics.** Auto-apply buttons apply the changes in the widgets, while input data is always handled, disregarding the checkbox. In this widget, it was the opposite.

- **Ugly Save and Save As buttons.** The previous layout had a single line, with Save button, that included the file name, being arbitrarily long. Additional controls required a more standard layout, resulting in ugly wide buttons.

- **Selection of filters depended on data sparsity..** Sparse data was handled by reducing the number of available formats in the combo. The code for this was complicated and could, I suppose, switch the file format behind the user's back. Perhaps a better way is to just show an user error message.
  
- **Mess under the hood.** Contrived GUI resulted in contrived code.  (This was not a result of a single coder; every change made the widget more complex.) One notable self-inflicted injury was that the widget had to manage the base name (chosen in the save dialog - extension was thrown away!) and then two extensions (file format and compression) controlled by the checkboxes. To maintain this `update_extension` was called in various places. The code became dangerous to touch.

##### Description of changes

<img width="259" alt="screenshot 2019-01-21 at 10 24 56" src="https://user-images.githubusercontent.com/2387315/51466514-b2804380-1d6a-11e9-82f6-d1e490c6c90e.png">

<img width="259" alt="screenshot 2019-01-21 at 10 24 42" src="https://user-images.githubusercontent.com/2387315/51466501-a5635480-1d6a-11e9-9d98-da502510c8d4.png">

I decided to discard Save As, which confused the user and have "Set File Name" instead. This also sets the file format. Visibility of checkboxes for compression and type annotations depend upon the format (I generally oppose hiding controls because they change the widget size and confuse the user, but in this case it does no such harm.)

The function of the auto save checkbox is stated explicitly.

There is only a single option for compression.

I also added report and info in the status bar.

The code is now rather simple -- the widget contains a constructor, input data handler, two handlers for push buttons, a method that updates GUI and a method checking whether to enable saving.

Setting migrations are minimal (one renamed setting).

**There are two commits in the PR.** The first contains an interim design that mostly just shuffled the controls in the interface. The picture below does not contain the save button - it appears after the file is set (with Save As). While this looks nice, it still contains all the problems listed above and was impossible to improve on. I will squash the commits before the PR is merged.

<img width="271" alt="screenshot 2019-01-21 at 10 30 28" src="https://user-images.githubusercontent.com/2387315/51467653-6256b080-1d6d-11e9-936d-d3f27529e453.png">



##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
