### PR TITLE
[FIX] Neighbours: Show error when data and reference have different domain.

### DIFF
--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -43,6 +43,9 @@ class OWNeighbors(OWWidget):
         all_data_as_reference = \
             Msg("Every data instance is same as some reference")
 
+    class Error(OWWidget.Error):
+        diff_domains = Msg("Data and reference have different domains.")
+
     n_neighbors = Setting(10)
     distance_index = Setting(0)
     exclude_reference = Setting(True)
@@ -107,10 +110,16 @@ class OWNeighbors(OWWidget):
         self.apply()
 
     def compute_distances(self):
+        self.Error.diff_domains.clear()
         if self.data is None or len(self.data) == 0 \
                 or self.reference is None or len(self.reference) == 0:
             self.distances = None
             return
+        if self.reference.domain != self.data.domain:
+            self.Error.diff_domains()
+            self.distances = None
+            return
+
         distance = METRICS[self.distance_index][1]
         n_ref = len(self.reference)
         all_data = Table.concatenate([self.reference, self.data], 0)

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -356,6 +356,16 @@ class TestOWNeighbors(WidgetTest):
         reference = Table(
             domain_ref, np.random.rand(1, len(domain_ref)))
 
+        # no error if one or both of the signals is missing
+        self.send_signal(w.Inputs.data, data)
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        self.send_signal(w.Inputs.data, None)
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        self.send_signal(w.Inputs.reference, data[:1])
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
         # same domain - no error
         self.send_signal(w.Inputs.data, data)
         self.send_signal(w.Inputs.reference, data[:1])
@@ -370,9 +380,21 @@ class TestOWNeighbors(WidgetTest):
         domain_ref = Domain([ContinuousVariable("a"), ContinuousVariable("b")])
         reference = Table(domain_ref, np.random.rand(1, len(domain_ref)))
 
+        # error disappears when data is set to None
         self.send_signal(w.Inputs.data, data)
         self.send_signal(w.Inputs.reference, reference)
         self.assertTrue(w.Error.diff_domains.is_shown())
+
+        self.send_signal(w.Inputs.data, None)
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        # error disappears when reference is set to None
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertTrue(w.Error.diff_domains.is_shown())
+
+        self.send_signal(w.Inputs.reference, None)
+        self.assertFalse(w.Error.diff_domains.is_shown())
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from Orange.data import Table, Domain
+from Orange.data import Table, Domain, ContinuousVariable
 from Orange.widgets.data.owneighbors import OWNeighbors, METRICS
 from Orange.widgets.tests.base import WidgetTest, ParameterMapping
 
@@ -342,6 +342,37 @@ class TestOWNeighbors(WidgetTest):
         widget.apply()
         self.assertFalse(widget.Warning.all_data_as_reference.is_shown())
         self.assertIsNotNone(self.get_output(widget.Outputs.data))
+
+    def test_different_domains(self):
+        """
+        Test weather widget show error when data and a reference have different
+        domains.
+        """
+        w = self.widget
+
+        domain = Domain([ContinuousVariable("a")])
+        domain_ref = Domain([ContinuousVariable("b")])
+        data = Table(domain, np.random.rand(2, len(domain)))
+        reference = Table(
+            domain_ref, np.random.rand(1, len(domain_ref)))
+
+        # same domain - no error
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, data[:1])
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        # one attribute different attribute name
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertTrue(w.Error.diff_domains.is_shown())
+
+        # different number of attributes
+        domain_ref = Domain([ContinuousVariable("a"), ContinuousVariable("b")])
+        reference = Table(domain_ref, np.random.rand(1, len(domain_ref)))
+
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertTrue(w.Error.diff_domains.is_shown())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Neighbours chrashes when data and reference has different domains. 

##### Description of changes
It shows an error instead of a crash now. 

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
