### PR TITLE
Update conda recipe scikit-learn version to >=0.20

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - setuptools
     - numpy         >=1.9.0
     - scipy
-    - scikit-learn  >=0.18
+    - scikit-learn  >=0.20
     - bottleneck    >=1.0.0
     - chardet       >=2.3.0
     - docutils


### PR DESCRIPTION
##### Issue

https://github.com/biolab/orange3/issues/3438#issuecomment-443900519

##### Description of changes
Like I mention in a lower comment, the changes probably need to be applied to the orange3 conda forge feedstock as well.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
