### PR TITLE
Update openTSNE version to >=0.3

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
-    - fasttsne      ==0.2.13
+    - opentsne      >=0.3.0
 
 test:
   # Python imports

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -18,4 +18,4 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain
 requests
-fastTSNE==0.2.13
+openTSNE>=0.3.0


### PR DESCRIPTION
##### Issue
Due to some breaking API changes in my t-SNE implementation, I had fixed the version to 0.2.13. There are likely not going to be any more API changes, so this shouldn't be an issue anymore.

##### Description of changes
fastTSNE has been renamed to openTSNE in the meantime. Also, I've fixed a bug here and there from v0.2.13. I had also changed the way openTSNE.initialization.random was called, so I changed this here.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
