### PR TITLE
Set a fixed random state in Louvain clustering

### DIFF
--- a/Orange/clustering/louvain.py
+++ b/Orange/clustering/louvain.py
@@ -73,7 +73,7 @@ class Louvain:
             k_neighbors=30,
             metric="l2",
             resolution=1.0,
-            random_state=None,
+            random_state=0,
             preprocessors=None,
     ):
         """Louvain clustering for community detection in graphs.


### PR DESCRIPTION
##### Issue
Set a fixed random seed by default in Louvain clustering to promote reproducible results in scOrange.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
