### PR TITLE
[FIX] Warning about a window title without a placeholder

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -230,7 +230,7 @@ class CanvasMainWindow(QMainWindow):
         frame.setWidget(self.scheme_widget)
 
         # Window 'title'
-        self.setWindowFilePath(self.scheme_widget.path())
+        self.setWindowFilePath(self.scheme_widget.path() or " ")
         self.scheme_widget.pathChanged.connect(self.setWindowFilePath)
         self.scheme_widget.modificationChanged.connect(self.setWindowModified)
 


### PR DESCRIPTION
##### Issue
Fixes #3267

##### Description of changes
Append "[*]" placeholder to the window title (if it's not already present) before calling setWindowTitle.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
