### PR TITLE
Fix: Neighbours: Compare tables with domains that only differ in metas and class_var

### DIFF
--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -115,14 +115,21 @@ class OWNeighbors(OWWidget):
                 or self.reference is None or len(self.reference) == 0:
             self.distances = None
             return
-        if self.reference.domain != self.data.domain:
+        if set(self.reference.domain.attributes) != \
+                set(self.data.domain.attributes):
             self.Error.diff_domains()
             self.distances = None
             return
 
         distance = METRICS[self.distance_index][1]
         n_ref = len(self.reference)
-        all_data = Table.concatenate([self.reference, self.data], 0)
+
+        # comparing only attributes, no metas and class-vars
+        new_domain = Domain(self.data.domain.attributes)
+        reference = self.reference.transform(new_domain)
+        data = self.data.transform(new_domain)
+
+        all_data = Table.concatenate([reference, data], 0)
         pp_all_data = Impute()(RemoveNaNColumns()(all_data))
         pp_reference, pp_data = pp_all_data[:n_ref], pp_all_data[n_ref:]
         self.distances = distance(pp_data, pp_reference).min(axis=1)

--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -44,7 +44,7 @@ class OWNeighbors(OWWidget):
             Msg("Every data instance is same as some reference")
 
     class Error(OWWidget.Error):
-        diff_domains = Msg("Data and reference have different domains.")
+        diff_domains = Msg("Data and reference have different features")
 
     n_neighbors = Setting(10)
     distance_index = Setting(0)

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -396,6 +396,63 @@ class TestOWNeighbors(WidgetTest):
         self.send_signal(w.Inputs.reference, None)
         self.assertFalse(w.Error.diff_domains.is_shown())
 
+    def test_different_metas(self):
+        """
+        Test weather widget do not show error when data and a reference have
+        domain that differ only in metas
+        """
+        w = self.widget
+
+        domain = Domain([ContinuousVariable("a"), ContinuousVariable("b")],
+                        metas=[ContinuousVariable("c")])
+        data = Table(
+            domain, np.random.rand(2, len(domain.attributes)),
+            metas=np.random.rand(2, len(domain.metas)))
+
+        # same domain with same metas no error
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, data[:1])
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        # same domain with different metas no error
+        domain_ref = Domain(domain.attributes,
+                            metas=[ContinuousVariable("d")])
+        reference = Table(
+            domain_ref, np.random.rand(1, len(domain_ref.attributes)),
+            metas=np.random.rand(1, len(domain.metas)))
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        # same domain with different order - no error
+        domain_ref = Domain(domain.attributes[::-1])
+        reference = Table(
+            domain_ref, np.random.rand(1, len(domain_ref.attributes)))
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        # same domain with different number of metas no error
+        domain_ref = Domain(
+            domain.attributes,
+            metas=[ContinuousVariable("d"), ContinuousVariable("e")])
+        reference = Table(
+            domain_ref, np.random.rand(1, len(domain_ref.attributes)),
+            metas=np.random.rand(1, len(domain_ref.metas)))
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertFalse(w.Error.diff_domains.is_shown())
+
+        # different domain with same metas - error shown
+        domain_ref = Domain(domain.attributes + (ContinuousVariable("e"),),
+                            metas=[ContinuousVariable("c")])
+        reference = Table(
+            domain_ref, np.random.rand(1, len(domain_ref.attributes)),
+            metas=np.random.rand(1, len(domain_ref.metas)))
+        self.send_signal(w.Inputs.data, data)
+        self.send_signal(w.Inputs.reference, reference)
+        self.assertTrue(w.Error.diff_domains.is_shown())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When comparing the data and reference with domains that are different only in meats widget trigger the different domain error. https://github.com/biolab/lookalike-demo/issues/6

##### Description of changes
Comparing only the attribute part of the domain. The error is triggered only when attributes differ. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
