### PR TITLE
[FIX] OWWidget: Remove wheelEvent reimplementation

### DIFF
--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -815,14 +815,6 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
             self.__was_shown = True
         self.__quicktipOnce()
 
-    def wheelEvent(self, event):
-        """Silently accept the wheel event.
-
-        This is to ensure combo boxes and other controls that have focus
-        don't receive this event unless the cursor is over them.
-        """
-        event.accept()
-
     def setCaption(self, caption):
         # save caption title in case progressbar will change it
         self.captionTitle = str(caption)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-3152

##### Description of changes

Remove wheelEvent reimplementation.

It was probably an attempt to interrupt the windows behavior where the wheel events are delivered to the widget with the keyboard focus even when the cursor is not over them.

It can however interfere with phased/inertial scrolling.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
