### PR TITLE
Added settingsAboutToBePacked signal to OWWidget

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -21,7 +21,7 @@ from Orange.data import Table
 from Orange.base import Learner, Model
 from Orange.widgets import widget, gui
 from Orange.widgets.utils import itemmodels
-from Orange.widgets.settings import Setting, SettingsHandler
+from Orange.widgets.settings import Setting
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Input, Output
 
@@ -364,14 +364,6 @@ def select_row(view, row):
                     QItemSelectionModel.ClearAndSelect)
 
 
-class PrepareSavingSettingsHandler(SettingsHandler):
-    """Calls storeSpecificSettings, which is currently not called from non-context handlers."""
-
-    def pack_data(self, widget):
-        widget.storeSpecificSettings()
-        return super().pack_data(widget)
-
-
 class OWPythonScript(widget.OWWidget):
     name = "Python Script"
     description = "Write a Python script and run it on input data or models."
@@ -396,8 +388,6 @@ class OWPythonScript(widget.OWWidget):
         object = Output("Object", object, replaces=["out_object"])
 
     signal_names = ("data", "learner", "classifier", "object")
-
-    settingsHandler = PrepareSavingSettingsHandler()
 
     libraryListSource = \
         Setting([Script("Hello world", "print('Hello world')\n")])
@@ -528,6 +518,7 @@ class OWPythonScript(widget.OWWidget):
         select_row(self.libraryView, self.currentScriptIndex)
 
         self.restoreScriptText()
+        self.settingsAboutToBePacked.connect(self.saveScriptText)
 
         self.splitCanvas.setSizes([2, 1])
         if self.splitterState is not None:
@@ -536,9 +527,6 @@ class OWPythonScript(widget.OWWidget):
         self.splitCanvas.splitterMoved[int, int].connect(self.onSpliterMoved)
         self.controlArea.layout().addStretch(1)
         self.resize(800, 600)
-
-    def storeSpecificSettings(self):
-        self.saveScriptText()
 
     def restoreScriptText(self):
         if self.scriptText is not None:

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -177,6 +177,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     #: :type: list of :class:`Message`
     UserAdviceMessages = []
 
+    settingsAboutToBePacked = Signal()
     contextAboutToBeOpened = Signal(object)
     contextOpened = Signal()
     contextClosed = Signal()


### PR DESCRIPTION
##### Issue
storeSpecificSettings is only called with a ContextHandler. Also, it is called after packing normal settings and before packing context settings.

In #3529 I implemented a special SettingsHandler because I needed to prepare settings for saving just before saving them.

Then I tried, in #3541, to extend (store|retrieve)SpecificSettings to an ordinary SettingsHandler. I failed: they were designed and used in a way that I could not make them work with ordinary settings (and not break stuff).

Before, I thought making storeSpecificSettings would be easy and would not change the interface. But now the question is if something like this is useful enough to extend the OWWidget with. I only needed something like this twice.

##### Description of changes
Added a signal settingsAboutToBePacked.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
