### PR TITLE
Orange.base.Model: Return 1d predictions for 1d data

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -271,10 +271,7 @@ class Model(Reprable):
             if not isinstance(data[0], (list, tuple)):
                 data = [data]
                 one_d = True
-            data = Table(
-                self.original_domain,
-                data,
-                np.zeros((len(data), len(self.original_domain.class_vars))))
+            data = Table.from_list(self.original_domain, data)
             data = data.transform(self.domain)
             prediction = self.predict_storage(data)
         else:

--- a/Orange/base.py
+++ b/Orange/base.py
@@ -209,12 +209,16 @@ class Model(Reprable):
     Probs = 1
     ValueProbs = 2
 
-    def __init__(self, domain=None):
+    def __init__(self, domain=None, original_domain=None):
         if isinstance(self, Learner):
             domain = None
         elif domain is None:
             raise ValueError("unspecified domain")
         self.domain = domain
+        if original_domain is not None:
+            self.original_domain = original_domain
+        else:
+            self.original_domain = domain
 
     def predict(self, X):
         if type(self).predict_storage is Model.predict_storage:
@@ -234,19 +238,25 @@ class Model(Reprable):
                         .format(type(data).__name__))
 
     def __call__(self, data, ret=Value):
+        def fix_dim(x):
+            return x[0] if one_d else x
+
         if not 0 <= ret <= 2:
             raise ValueError("invalid value of argument 'ret'")
         if ret > 0 and any(v.is_continuous for v in self.domain.class_vars):
             raise ValueError("cannot predict continuous distributions")
 
         # Call the predictor
+        one_d = False
         if isinstance(data, np.ndarray):
+            one_d = data.ndim == 1
             prediction = self.predict(np.atleast_2d(data))
         elif isinstance(data, scipy.sparse.csr.csr_matrix):
             prediction = self.predict(data)
         elif isinstance(data, (Table, Instance)):
             if isinstance(data, Instance):
                 data = Table(data.domain, [data])
+                one_d = True
             if data.domain != self.domain:
                 if self.original_domain.attributes != data.domain.attributes \
                         and data.X.size \
@@ -260,7 +270,11 @@ class Model(Reprable):
         elif isinstance(data, (list, tuple)):
             if not isinstance(data[0], (list, tuple)):
                 data = [data]
-            data = Table(self.original_domain, data)
+                one_d = True
+            data = Table(
+                self.original_domain,
+                data,
+                np.zeros((len(data), len(self.original_domain.class_vars))))
             data = data.transform(self.domain)
             prediction = self.predict_storage(data)
         else:
@@ -292,19 +306,19 @@ class Model(Reprable):
             else:
                 probs = one_hot(value)
             if ret == Model.ValueProbs:
-                return value, probs
+                return fix_dim(value), fix_dim(probs)
             else:
-                return probs
+                return fix_dim(probs)
 
         # Return what we need to
         if ret == Model.Probs:
-            return probs
+            return fix_dim(probs)
         if isinstance(data, Instance) and not multitarget:
             value = Value(self.domain.class_var, value[0])
         if ret == Model.Value:
-            return value
+            return fix_dim(value)
         else:  # ret == Model.ValueProbs
-            return value, probs
+            return fix_dim(value), fix_dim(probs)
 
     def __getstate__(self):
         """Skip (possibly large) data when pickling models"""

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -10,6 +10,7 @@ import traceback
 import warnings
 
 import numpy as np
+from scipy import sparse as sp
 from sklearn.exceptions import ConvergenceWarning
 
 from Orange.base import SklLearner
@@ -72,6 +73,37 @@ class ModelTest(unittest.TestCase):
         pred = []
         for row in table:
             pred.append(clf(row))
+
+    def test_prediction_dimensions(self):
+        class MockModel(Model):
+            def predict(self, data):
+                return np.zeros((data.shape[0], len(domain.class_var.values)))
+
+        x = np.zeros((42, 5))
+        y = np.zeros(42)
+        domain = Domain([ContinuousVariable(n) for n in "abcde"],
+                        DiscreteVariable("y", values=["a", "b"]))
+        data = Table.from_numpy(domain, x, y)
+        a_list = [[0] * 5] * 42
+        a_tuple = ((0, ) * 5,) * 42
+        m = MockModel(domain)
+
+        for inp in (data, x, sp.csr_matrix(x), a_list, a_tuple):
+            msg = f"in test for type '{type(inp)}'"
+            # two-dimensional
+            self.assertEqual(m(inp, ret=m.Value).shape, (42, ), msg)
+            self.assertEqual(m(inp, ret=m.Probs).shape, (42, 2), msg)
+            values, probs = m(inp, ret=m.ValueProbs)
+            self.assertEqual(values.shape, (42, ), msg)
+            self.assertEqual(probs.shape, (42, 2), msg)
+
+            # one-dimensional
+            if not isinstance(inp, sp.csr_matrix):
+                self.assertEqual(m(inp[0], ret=m.Value).shape, (), msg)
+                self.assertEqual(m(inp[0], ret=m.Probs).shape, (2, ), msg)
+                values, probs = m(inp[0], ret=m.ValueProbs)
+                self.assertEqual(values.shape, (), msg)
+                self.assertEqual(probs.shape, (2, ), msg)
 
     def test_learner_adequacy(self):
         table = Table("housing")

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -115,7 +115,7 @@ class TestLogisticRegressionLearner(unittest.TestCase):
         m = lr(self.zoo)
         probs = m(self.zoo[50], m.Probs)
         probs2 = m(self.zoo[50, :], m.Probs)
-        np.testing.assert_almost_equal(probs, probs2)
+        np.testing.assert_almost_equal(probs, probs2[0])
 
     def test_single_class(self):
         t = self.iris[60:90]

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -193,11 +193,11 @@ class TestNaiveBayesLearner(unittest.TestCase):
         # Test prediction on instances
         for inst, exp_prob in zip(test_data, exp_probs):
             np.testing.assert_almost_equal(
-                model(inst, ret=model.Probs)[0],
+                model(inst, ret=model.Probs),
                 exp_prob)
             self.assertEqual(model(inst), np.argmax(exp_prob))
             value, prob = model(inst, ret=model.ValueProbs)
-            np.testing.assert_almost_equal(prob[0], exp_prob)
+            np.testing.assert_almost_equal(prob, exp_prob)
             self.assertEqual(value, np.argmax(exp_prob))
 
         # Test prediction by directly calling predict. This is needed to test

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -294,11 +294,11 @@ class TestNaiveBayesLearner(unittest.TestCase):
         # Test prediction on instances
         for inst, exp_prob in zip(test_data, exp_probs):
             np.testing.assert_almost_equal(
-                model(inst, ret=model.Probs)[0],
+                model(inst, ret=model.Probs),
                 exp_prob)
             self.assertEqual(model(inst), np.argmax(exp_prob))
             value, prob = model(inst, ret=model.ValueProbs)
-            np.testing.assert_almost_equal(prob[0], exp_prob)
+            np.testing.assert_almost_equal(prob, exp_prob)
             self.assertEqual(value, np.argmax(exp_prob))
 
         # Test prediction by directly calling predict. This is needed to test

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -99,7 +99,7 @@ class TestSimpleTreeLearner(unittest.TestCase):
         for ins in data[::20]:
             clf(ins)
             val, prob = clf(ins, clf.ValueProbs)
-            self.assertEqual(sum(prob[0]), 1)
+            self.assertEqual(sum(prob), 1)
 
     def test_SimpleTree_to_string_classification(self):
         domain = Domain([DiscreteVariable(name='d1', values='ef'),

--- a/doc/data-mining-library/source/tutorial/code/classification-classifier1.py
+++ b/doc/data-mining-library/source/tutorial/code/classification-classifier1.py
@@ -6,5 +6,5 @@ classifier = learner(data)
 c_values = data.domain.class_var.values
 for d in data[5:8]:
     c = classifier(d)
-    print("{}, originally {}".format(c_values[int(classifier(d)[0])],
+    print("{}, originally {}".format(c_values[int(classifier(d))],
                                      d.get_class()))

--- a/doc/data-mining-library/source/tutorial/code/classification-other.py
+++ b/doc/data-mining-library/source/tutorial/code/classification-other.py
@@ -21,4 +21,4 @@ c_values = data.domain.class_var.values
 for d in test:
     print(("{:<15}" + " {:.3f}"*len(classifiers)).format(
         c_values[int(d.get_class())],
-        *(c(d, 1)[0][target] for c in classifiers)))
+        *(c(d, 1)[target] for c in classifiers)))

--- a/doc/data-mining-library/source/tutorial/code/regression-other.py
+++ b/doc/data-mining-library/source/tutorial/code/regression-other.py
@@ -19,4 +19,4 @@ print("y   ", " ".join("%5s" % l.name for l in regressors))
 for d in test:
     print(("{:<5}" + " {:5.1f}"*len(regressors)).format(
         d.get_class(),
-        *(r(d)[0] for r in regressors)))
+        *(r(d) for r in regressors)))

--- a/doc/data-mining-library/source/tutorial/code/regression.py
+++ b/doc/data-mining-library/source/tutorial/code/regression.py
@@ -6,4 +6,4 @@ model = learner(data)
 
 print("predicted, observed:")
 for d in data[:3]:
-    print("%.1f, %.1f" % (model(d)[0], d.get_class()))
+    print("%.1f, %.1f" % (model(d), d.get_class()))


### PR DESCRIPTION
##### Issue

Fixes #3561.

Interestingly, documentation for scripting indexed the result from the model (`[0]`) without explaining why.

##### Description of changes

`Instance` is not the only kind of 1d data that can be passed to `Model.__call__`: one can also pass a 1d array, list or tuple. The trick with recursion was thus inconvenient, also because the method can return either a single value or a pair, in which case going back to 1d requires taking the first element of each element in the pair.

The method now remembers whether the data was 1d, and turns it back into 1d at the end.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation