### PR TITLE
[FIX] OWDistances: Use only binary features for Jaccard distance

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -3,4 +3,5 @@ from .distance import (Distance, DistanceModel,
                        SpearmanR, SpearmanRAbsolute, PearsonR, PearsonRAbsolute,
                        Mahalanobis, MahalanobisDistance, Hamming)
 
-from .base import _preprocess, remove_discrete_features, impute
+from .base import (
+    _preprocess, remove_discrete_features, remove_nonbinary_features, impute)

--- a/Orange/distance/base.py
+++ b/Orange/distance/base.py
@@ -38,6 +38,15 @@ def remove_discrete_features(data):
     return data.transform(new_domain)
 
 
+def remove_nonbinary_features(data):
+    """Remove non-binary columns from the data."""
+    new_domain = Domain(
+        [a for a in data.domain.attributes
+         if a.is_discrete and len(a.values) == 2],
+        data.domain.class_vars,
+        data.domain.metas)
+    return data.transform(new_domain)
+
 def impute(data):
     """Impute missing values."""
     return SklImpute()(data)

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -53,12 +53,14 @@ class OWDistances(OWWidget):
 
     class Error(OWWidget.Error):
         no_continuous_features = Msg("No numeric features")
+        no_binary_features = Msg("No binary features")
         dense_metric_sparse_data = Msg("{} requires dense data.")
         distances_memory_error = Msg("Not enough memory")
         distances_value_error = Msg("Problem in calculation:\n{}")
 
     class Warning(OWWidget.Warning):
         ignoring_discrete = Msg("Ignoring categorical features")
+        ignoring_nonbinary = Msg("Ignoring non-binary features")
         imputing_data = Msg("Missing values were imputed")
 
     def __init__(self):
@@ -112,30 +114,47 @@ class OWDistances(OWWidget):
             if issparse(data.X) and not metric.supports_sparse:
                 self.Error.dense_metric_sparse_data(METRICS[self.metric_idx][0])
                 return False
+            return True
 
         def _fix_discrete():
             nonlocal data
             if data.domain.has_discrete_attributes() and (
                     issparse(data.X) and getattr(metric, "fallback", None)
                     or not metric.supports_discrete
-                    or self.axis == 1):
+                    or self.axis == 1 and metric is not distance.Jaccard):
                 if not data.domain.has_continuous_attributes():
                     self.Error.no_continuous_features()
                     return False
                 self.Warning.ignoring_discrete()
                 data = distance.remove_discrete_features(data)
+            return True
+
+        def _fix_nonbinary():
+            nonlocal data
+            if metric is distance.Jaccard:
+                nbinary = sum(a.is_discrete and len(a.values) == 2
+                              for a in data.domain.attributes)
+                if not nbinary:
+                    self.Error.no_binary_features()
+                    return False
+                elif nbinary < len(data.domain.attributes):
+                    self.Warning.ignoring_nonbinary()
+                    data = distance.remove_nonbinary_features(data)
+            return True
 
         def _fix_missing():
             nonlocal data
             if not metric.supports_missing and bn.anynan(data.X):
                 self.Warning.imputing_data()
                 data = distance.impute(data)
+            return True
 
         self.clear_messages()
         if data is None:
             return
-        for check in (_check_sparse, _fix_discrete, _fix_missing):
-            if check() is False:
+        for check in (_check_sparse,
+                      _fix_discrete, _fix_missing, _fix_nonbinary):
+            if not check():
                 return
         try:
             if metric.supports_normalization and self.normalized_dist:


### PR DESCRIPTION
##### Issue

Fixes #3559.

##### Description of changes

Other distances are similar and their errors, warnings and selection of attributes is handled through flags. Jaccard is specific, so I have not introduced more new flags to distances (because this flag would be used only for Jaccard, at least for now) but instead added a Jaccard-specific check to the widget.

##### Includes
- [X] Code changes
- [X] Tests
