### PR TITLE
[ENH] t-SNE: Add Normalize data checkbox

### DIFF
--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -7,7 +7,7 @@ from AnyQt.QtWidgets import QFormLayout
 
 from Orange.data import Table, Domain
 from Orange.preprocess.preprocess import Preprocess, ApplyDomain
-from Orange.projection import PCA, TSNE, TruncatedSVD
+from Orange.projection import PCA, TSNE
 from Orange.projection.manifold import TSNEModel
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting, SettingProvider
@@ -216,11 +216,9 @@ class OWtSNE(OWDataProjectionWidget):
         self.__set_update_loop(self.tsne_iterator)
 
     def pca_preprocessing(self):
-        if self.pca_data is not None and \
-                self.pca_data.X.shape[1] == self.pca_components:
+        if self.pca_data is not None and self.pca_data.X.shape[1] == self.pca_components:
             return
-        cls = TruncatedSVD if self.data.is_sparse() else PCA
-        projector = cls(n_components=self.pca_components, random_state=0)
+        projector = PCA(n_components=self.pca_components, random_state=0)
         model = projector(self.data)
         self.pca_data = model(self.data)
 

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -1,10 +1,9 @@
 import unittest
+from unittest.mock import patch
 import numpy as np
 
-from AnyQt.QtTest import QSignalSpy
-
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain, Table
-from Orange.preprocess import Preprocess
+from Orange.preprocess import Preprocess, Normalize
 from Orange.projection.manifold import TSNE
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, ProjectionWidgetTestMixin
@@ -50,9 +49,9 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin,
         self.empty_domain = Domain([], class_vars=self.class_var)
 
     def tearDown(self):
-        self.reset_tsne()
+        self.restore_mocked_functions()
 
-    def reset_tsne(self):
+    def restore_mocked_functions(self):
         owtsne.TSNE.fit = self._fit
         owtsne.TSNEModel.transform = self._transform
         owtsne.TSNEModel.optimize = self._optimize
@@ -113,21 +112,26 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin,
                 self.assertIn(var, controls.attr_shape.model())
 
     def test_output_preprocessor(self):
-        self.reset_tsne()
+        # To test the validity of the preprocessor, we'll have to actually
+        # compute the projections
+        self.restore_mocked_functions()
+
         self.send_signal(self.widget.Inputs.data, self.data)
-        if self.widget.isBlocking():
-            spy = QSignalSpy(self.widget.blockingStateChanged)
-            self.assertTrue(spy.wait(20000))
+        self.wait_until_stop_blocking(wait=20000)
+        output_data = self.get_output(self.widget.Outputs.annotated_data)
+
+        # We send the same data to the widget, we expect the point locations to
+        # be fairly close to their original ones
         pp = self.get_output(self.widget.Outputs.preprocessor)
         self.assertIsInstance(pp, Preprocess)
-        transformed = pp(self.data)
-        self.assertIsInstance(transformed, Table)
-        self.assertEqual(transformed.X.shape, (len(self.data), 2))
-        output = self.get_output(self.widget.Outputs.annotated_data)
-        np.testing.assert_allclose(transformed.X, output.metas[:, :2],
-                                   rtol=1, atol=1)
-        self.assertEqual([a.name for a in transformed.domain.attributes],
-                         [m.name for m in output.domain.metas[:2]])
+
+        transformed_data = pp(self.data)
+        self.assertIsInstance(transformed_data, Table)
+        self.assertEqual(transformed_data.X.shape, (len(self.data), 2))
+        np.testing.assert_allclose(transformed_data.X, output_data.metas[:, :2],
+                                   rtol=1, atol=3)
+        self.assertEqual([a.name for a in transformed_data.domain.attributes],
+                         [m.name for m in output_data.domain.metas[:2]])
 
     def test_multiscale_changed(self):
         self.assertFalse(self.widget.controls.multiscale.isChecked())
@@ -139,6 +143,32 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin,
         w = self.create_widget(OWtSNE, stored_settings=settings)
         self.assertTrue(w.controls.multiscale.isChecked())
         self.assertFalse(w.perplexity_spin.isEnabled())
+
+    def test_normalize_data(self):
+        # Normalization should be checked by default
+        self.assertTrue(self.widget.controls.normalize.isChecked())
+        with patch("Orange.preprocess.preprocess.Normalize", wraps=Normalize) as normalize:
+            self.send_signal(self.widget.Inputs.data, self.data)
+            self.assertTrue(self.widget.controls.normalize.isEnabled())
+            normalize.assert_called_once()
+
+        # Disable checkbox
+        self.widget.controls.normalize.setChecked(False)
+        self.assertFalse(self.widget.controls.normalize.isChecked())
+        with patch("Orange.preprocess.preprocess.Normalize", wraps=Normalize) as normalize:
+            self.send_signal(self.widget.Inputs.data, self.data)
+            self.assertTrue(self.widget.controls.normalize.isEnabled())
+            normalize.assert_not_called()
+
+        # Normalization shouldn't work on sparse data
+        self.widget.controls.normalize.setChecked(True)
+        self.assertTrue(self.widget.controls.normalize.isChecked())
+
+        sparse_data = self.data.to_sparse()
+        with patch("Orange.preprocess.preprocess.Normalize", wraps=Normalize) as normalize:
+            self.send_signal(self.widget.Inputs.data, sparse_data)
+            self.assertFalse(self.widget.controls.normalize.isEnabled())
+            normalize.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### Issue
Fixes #3448


##### Description of changes
- The widget was still using SVD on sparse data. I have changed this to PCA, since our PCA does support sparse data since #3532
- I basically copied over the functionality from the PCA widget. PCA currently doesn't support normalization on sparse data, so this option is disabled on sparse data, just like in the PCA widget.

- Lastly, I increased the error margin on one test. The test does this: it embeds a data set using t-SNE then embeds the same data onto the existing embedding (transform). Unfortunately, the points are bound to be jittered around each original corresponding point, but also how far away is also determined by the neighborhoods, so there's no clean way to check for this. But if we visualize what this actually produces, we can see that the result is still correct. And given that the space spans from -20 to 20, increasing the error margin from 1 to 3 shouldn't really impact results too much.
![image](https://user-images.githubusercontent.com/5758119/52143512-fa9d4100-265b-11e9-8cdb-3b3d0df843c9.png)


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
