### PR TITLE
[FIX] ScatterplotGraph: Use mapToView instead of mapRectFromParent

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1233,10 +1233,10 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         if self.scatterplot_item is not None:
             self.select(points)
 
-    def select_by_rectangle(self, value_rect):
+    def select_by_rectangle(self, rect):
         if self.scatterplot_item is not None:
-            x0, y0 = value_rect.topLeft().x(), value_rect.topLeft().y()
-            x1, y1 = value_rect.bottomRight().x(), value_rect.bottomRight().y()
+            x0, x1 = sorted((rect.topLeft().x(), rect.bottomRight().x()))
+            y0, y1 = sorted((rect.topLeft().y(), rect.bottomRight().y()))
             x, y = self.master.get_coordinates_data()
             indices = np.flatnonzero(
                 (x0 <= x) & (x <= x1) & (y0 <= y) & (y <= y1))


### PR DESCRIPTION
##### Issue

Fixes #2789.

##### Description of changes

- To show selection rectangle, (pyqtgraph's) `ViewBox.updateScaleBox` is overloaded to use `self.mapToView` instead of `self.childgroup.mapRectFromParent`. This may not be equivalent if there are multiple viewboxes in the same view or something similarly complicated, but we don't have this.
- To fix selection, (our) `mouseDragEvent` is modified in the same way
- An unrelated fix: `select_by_rectangle` assumed that the top left corner is above and to the left of the bottom right. This was true only if the user dragged in this direction. `select_by_rectangle` now sorts the coordinates.

The PR doesn't pass the diff coverage threshold, but I won't write any tests because they would involve simulating user interaction with mouse, yet at the end there wouldn't be anything to actually test.

##### Includes
- [X] Code changes
