### PR TITLE
[ENH] OwLouvain: Add normalize data checkbox to PCA preprocessing

### DIFF
--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -11,21 +11,24 @@ class Normalizer(Reprable):
     def __init__(self,
                  zero_based=True,
                  norm_type=Normalize.NormalizeBySD,
-                 transform_class=False):
+                 transform_class=False,
+                 center=True):
         self.zero_based = zero_based
         self.norm_type = norm_type
         self.transform_class = transform_class
+        self.center = center
 
     def __call__(self, data):
-
         dists = distribution.get_distributions(data)
         new_attrs = [self.normalize(dists[i], var) for
                      (i, var) in enumerate(data.domain.attributes)]
+
         new_class_vars = data.domain.class_vars
         if self.transform_class:
             attr_len = len(data.domain.attributes)
             new_class_vars = [self.normalize(dists[i + attr_len], var) for
                               (i, var) in enumerate(data.domain.class_vars)]
+
         domain = Domain(new_attrs, new_class_vars, data.domain.metas)
         return data.transform(domain)
 
@@ -41,7 +44,17 @@ class Normalizer(Reprable):
         avg, sd = (dist.mean(), dist.standard_deviation()) if dist.size else (0, 1)
         if sd == 0:
             sd = 1
-        return ContinuousVariable(var.name, compute_value=Norm(var, avg, 1 / sd), sparse=var.sparse)
+
+        if self.center:
+            compute_val = Norm(var, avg, 1 / sd)
+        else:
+            compute_val = Norm(var, 0, 1 / sd)
+
+        return ContinuousVariable(
+            var.name,
+            compute_value=compute_val,
+            sparse=var.sparse,
+        )
 
     def normalize_by_span(self, dist, var):
         dma, dmi = dist.max(), dist.min()

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -269,11 +269,11 @@ class Normalize(Preprocess):
     Parameters
     ----------
     zero_based : bool (default=True)
+        Only used when `norm_type=NormalizeBySpan`.
+
         Determines the value used as the “low” value of the variable.
         It determines the interval for normalized continuous variables
         (either [-1, 1] or [0, 1]).
-
-        This has no effect when `norm_type` is set to `NormalizeBySD`.
 
     norm_type : NormTypes (default: Normalize.NormalizeBySD)
         Normalization type. If Normalize.NormalizeBySD, the values are
@@ -289,6 +289,8 @@ class Normalize(Preprocess):
         If True the class is normalized as well.
 
     center : bool (default=True)
+        Only used when `norm_type=NormalizeBySD`.
+
         Whether or not to center the data so it has mean zero.
 
     Examples

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -273,6 +273,8 @@ class Normalize(Preprocess):
         It determines the interval for normalized continuous variables
         (either [-1, 1] or [0, 1]).
 
+        This has no effect when `norm_type` is set to `NormalizeBySD`.
+
     norm_type : NormTypes (default: Normalize.NormalizeBySD)
         Normalization type. If Normalize.NormalizeBySD, the values are
         replaced with standardized values by subtracting the average
@@ -285,6 +287,9 @@ class Normalize(Preprocess):
 
     transform_class : bool (default=False)
         If True the class is normalized as well.
+
+    center : bool (default=True)
+        Whether or not to center the data so it has mean zero.
 
     Examples
     --------
@@ -301,10 +306,12 @@ class Normalize(Preprocess):
     def __init__(self,
                  zero_based=True,
                  norm_type=NormalizeBySD,
-                 transform_class=False):
+                 transform_class=False,
+                 center=True):
         self.zero_based = zero_based
         self.norm_type = norm_type
         self.transform_class = transform_class
+        self.center = center
 
     def __call__(self, data):
         """
@@ -334,7 +341,9 @@ class Normalize(Preprocess):
         normalizer = normalize.Normalizer(
             zero_based=self.zero_based,
             norm_type=self.norm_type,
-            transform_class=self.transform_class)
+            transform_class=self.transform_class,
+            center=self.center,
+        )
         return normalizer(data)
 
 

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -13,6 +13,23 @@ import scipy.stats.stats
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
 
+def sparse_array_equal(x1, x2):
+    """Check if two sparse arrays are equal."""
+    if not sp.issparse(x1):
+        raise TypeError("`x1` must be sparse.")
+    if not sp.issparse(x2):
+        raise TypeError("`x2` must be sparse.")
+
+    return x1.shape == x2.shape and (x1 != x2).nnz == 0
+
+
+def array_equal(x1, x2):
+    """Equivalent of np.array_equal that properly handles sparse matrices."""
+    if sp.issparse(x1) and sp.issparse(x2):
+        return sparse_array_equal(x1, x2)
+    return np.array_equal(x1, x2)
+
+
 def _count_nans_per_row_sparse(X, weights, dtype=None):
     """ Count the number of nans (undefined) values per row. """
     if weights is not None:

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -9,7 +9,7 @@ from scipy.sparse import csr_matrix, issparse, lil_matrix, csc_matrix, \
 
 from Orange.statistics.util import bincount, countnans, contingency, digitize, \
     mean, nanmax, nanmean, nanmedian, nanmin, nansum, nanunique, stats, std, \
-    unique, var, nanstd, nanvar, nanmode
+    unique, var, nanstd, nanvar, nanmode, array_equal
 from sklearn.utils import check_random_state
 
 
@@ -588,6 +588,25 @@ class TestUnique(unittest.TestCase):
         expected = [2, 6, 2, 1, 2, 1, 1, 1]
 
         np.testing.assert_equal(nanunique(x, return_counts=True)[1], expected)
+
+
+class TestArrayEqual(unittest.TestCase):
+    @dense_sparse
+    def test_same_matrices(self, array):
+        x = array([0, 1, 0, 0, 2])
+        self.assertTrue(array_equal(x, x))
+
+    @dense_sparse
+    def test_with_different_shapes(self, array):
+        x = array(np.eye(4))
+        y = array(np.eye(5))
+        self.assertFalse(array_equal(x, y))
+
+    @dense_sparse
+    def test_with_different_values(self, array):
+        x = array([0, 1, 0, 0, 2])
+        y = array([0, 3, 0, 0, 2])
+        self.assertFalse(array_equal(x, y))
 
 
 class TestNanModeAppVeyor(unittest.TestCase):

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -1,9 +1,9 @@
 import datetime
 import warnings
 from collections import namedtuple
-from functools import wraps, partial
+from functools import partial
 from itertools import chain
-from typing import Callable, List
+from typing import List
 
 import numpy as np
 from AnyQt.QtCore import QItemSelection, QItemSelectionRange, \
@@ -12,7 +12,7 @@ from AnyQt.QtCore import QItemSelection, QItemSelectionRange, \
 from Orange.data import Table, Domain, StringVariable, ContinuousVariable, \
     DiscreteVariable, TimeVariable
 from Orange.widgets.tests.base import WidgetTest, datasets
-from Orange.widgets.tests.utils import simulate
+from Orange.widgets.tests.utils import simulate, table_dense_sparse
 from Orange.widgets.data.owfeaturestatistics import \
     OWFeatureStatistics
 
@@ -173,18 +173,6 @@ def make_table(attributes, target=None, metas=None):
         Domain(attribute_vars, class_vars=target_vars, metas=meta_vars),
         X=attribute_vals, Y=target_vals, metas=meta_vals,
     )
-
-
-def table_dense_sparse(test_case):
-    # type: (Callable) -> Callable
-    """Run a single test case on both dense and sparse Orange tables."""
-
-    @wraps(test_case)
-    def _wrapper(self):
-        test_case(self, lambda table: table.to_dense())
-        test_case(self, lambda table: table.to_sparse())
-
-    return _wrapper
 
 
 class TestVariousDataSets(WidgetTest):

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -1,4 +1,6 @@
 import sys
+from functools import wraps
+
 import warnings
 import contextlib
 
@@ -317,3 +319,24 @@ def mouseMove(widget, pos=QPoint(), delay=-1):  # pragma: no-cover
         QTest.qWait(delay)
 
     QApplication.sendEvent(widget, me)
+
+
+def table_dense_sparse(test_case):
+    # type: (Callable) -> Callable
+    """Run a single test case on both dense and sparse Orange tables.
+
+    Examples
+    --------
+    >>> @table_dense_sparse
+    ... def test_something(self, prepare_table):
+    ...     data: Table  # The table you want to test on
+    ...     data = prepare_table(data)  # This converts the table to dense/sparse
+
+    """
+
+    @wraps(test_case)
+    def _wrapper(self):
+        test_case(self, lambda table: table.to_dense())
+        test_case(self, lambda table: table.to_sparse())
+
+    return _wrapper

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -19,6 +19,7 @@ from Orange.data import Table, DiscreteVariable
 from Orange.data.util import get_unique_names
 from Orange import preprocess
 from Orange.projection import PCA
+from Orange.statistics import util as ut
 from Orange.widgets import widget, gui, report
 from Orange.widgets.settings import DomainContextHandler, ContextSetting, \
     Setting
@@ -407,8 +408,7 @@ class OWLouvainClustering(widget.OWWidget):
         # Make sure to properly enable/disable slider based on `apply_pca` setting
         self.controls.pca_components.setEnabled(self.apply_pca)
 
-        # If X hasn't changed, there's no reason to recompute clusters
-        if prev_data and self.data and np.array_equal(self.data.X, prev_data.X):
+        if prev_data and self.data and ut.array_equal(prev_data.X, self.data.X):
             if self.auto_commit:
                 self._send_data()
             return

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -110,7 +110,7 @@ class OWLouvainClustering(widget.OWWidget):
         )  # type: QCheckBox
         self.apply_pca_cbx = gui.checkBox(
             preprocessing_box, self, "apply_pca", label="Apply PCA preprocessing",
-            callback=self._invalidate_graph,
+            callback=self._apply_pca_changed,
         )  # type: QCheckBox
         self.pca_components_slider = gui.hSlider(
             preprocessing_box, self, "pca_components", label="PCA Components: ", minValue=2,
@@ -144,6 +144,10 @@ class OWLouvainClustering(widget.OWWidget):
             commit=lambda: self.commit(),
             callback=lambda: self._on_auto_commit_changed(),
         )  # type: QWidget
+
+    def _apply_pca_changed(self):
+        self.controls.pca_components.setEnabled(self.apply_pca)
+        self._invalidate_graph()
 
     def _invalidate_preprocessed_data(self):
         self.preprocessed_data = None
@@ -399,12 +403,13 @@ class OWLouvainClustering(widget.OWWidget):
 
     @Inputs.data
     def set_data(self, data):
-        # pylint: disable=too-many-branches
         self.closeContext()
         self.Error.clear()
 
         prev_data, self.data = self.data, data
         self.openContext(self.data)
+        # Make sure to properly enable/disable slider based on `apply_pca` setting
+        self.controls.pca_components.setEnabled(self.apply_pca)
 
         # If X hasn't changed, there's no reason to recompute clusters
         if prev_data and self.data and np.array_equal(self.data.X, prev_data.X):

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -17,6 +17,7 @@ from AnyQt.QtWidgets import QSlider, QCheckBox, QWidget, QLabel
 from Orange.clustering.louvain import table_to_knn_graph, Louvain
 from Orange.data import Table, DiscreteVariable
 from Orange.data.util import get_unique_names
+from Orange import preprocess
 from Orange.projection import PCA
 from Orange.widgets import widget, gui, report
 from Orange.widgets.settings import DomainContextHandler, ContextSetting, \
@@ -66,6 +67,7 @@ class OWLouvainClustering(widget.OWWidget):
 
     apply_pca = ContextSetting(True)
     pca_components = ContextSetting(_DEFAULT_PCA_COMPONENTS)
+    normalize = ContextSetting(True)
     metric_idx = ContextSetting(0)
     k_neighbors = ContextSetting(_DEFAULT_K_NEIGHBORS)
     resolution = ContextSetting(1.)
@@ -101,13 +103,17 @@ class OWLouvainClustering(widget.OWWidget):
         info_box = gui.vBox(self.controlArea, "Info")
         self.info_label = gui.widgetLabel(info_box, "No data on input.")  # type: QLabel
 
-        pca_box = gui.vBox(self.controlArea, "PCA Preprocessing")
+        preprocessing_box = gui.vBox(self.controlArea, "Preprocessing")
+        self.normalize_cbx = gui.checkBox(
+            preprocessing_box, self, "normalize", label="Normalize data",
+            callback=self._invalidate_preprocessed_data,
+        )  # type: QCheckBox
         self.apply_pca_cbx = gui.checkBox(
-            pca_box, self, "apply_pca", label="Apply PCA preprocessing",
+            preprocessing_box, self, "apply_pca", label="Apply PCA preprocessing",
             callback=self._invalidate_graph,
         )  # type: QCheckBox
         self.pca_components_slider = gui.hSlider(
-            pca_box, self, "pca_components", label="Components: ", minValue=2,
+            preprocessing_box, self, "pca_components", label="PCA Components: ", minValue=2,
             maxValue=_MAX_PCA_COMPONENTS,
             callback=self._invalidate_pca_projection, tracking=False
         )  # type: QSlider
@@ -138,6 +144,14 @@ class OWLouvainClustering(widget.OWWidget):
             commit=lambda: self.commit(),
             callback=lambda: self._on_auto_commit_changed(),
         )  # type: QWidget
+
+    def _invalidate_preprocessed_data(self):
+        self.preprocessed_data = None
+        self._invalidate_pca_projection()
+        # If we don't apply PCA, this still invalidates the graph, otherwise
+        # this change won't be propagated further
+        if not self.apply_pca:
+            self._invalidate_graph()
 
     def _invalidate_pca_projection(self):
         self.pca_projection = None
@@ -190,6 +204,7 @@ class OWLouvainClustering(widget.OWWidget):
         self.__set_state_ready()
 
     def commit(self):
+        # pylint: disable=too-many-branches
         self.__commit_timer.stop()
         self.__invalidated = False
         self._set_modified(False)
@@ -215,8 +230,11 @@ class OWLouvainClustering(widget.OWWidget):
 
         # Preprocess the dataset
         if self.preprocessed_data is None:
-            louvain = Louvain(random_state=0)
-            self.preprocessed_data = louvain.preprocess(self.data)
+            if self.normalize:
+                normalizer = preprocess.Normalize(center=False)
+                self.preprocessed_data = normalizer(self.data)
+            else:
+                self.preprocessed_data = self.data
 
         state = TaskState(self)
 
@@ -243,8 +261,8 @@ class OWLouvainClustering(widget.OWWidget):
         if graph is None:
             task = partial(
                 run_on_data, data, pca_components=pca_components,
-                k_neighbors=k_neighbors, metric=metric,
-                resolution=self.resolution, state=state
+                normalize=self.normalize, k_neighbors=k_neighbors,
+                metric=metric, resolution=self.resolution, state=state,
             )
         else:
             task = partial(
@@ -381,6 +399,7 @@ class OWLouvainClustering(widget.OWWidget):
 
     @Inputs.data
     def set_data(self, data):
+        # pylint: disable=too-many-branches
         self.closeContext()
         self.Error.clear()
 
@@ -439,6 +458,7 @@ class OWLouvainClustering(widget.OWWidget):
             pca += report.plural(", {number} component{s}", self.pca_components)
 
         self.report_items((
+            ("Normalize data", report.bool_str(self.normalize)),
             ("PCA preprocessing", pca),
             ("Metric", METRICS[self.metric_idx][0]),
             ("k neighbors", self.k_neighbors),
@@ -520,6 +540,7 @@ class InteruptRequested(BaseException):
 class Results(namespace):
     pca_projection = None    # type: Optional[Table]
     pca_components = None    # type: Optional[int]
+    normalize = None         # type: Optional[bool]
     k_neighbors = None       # type: Optional[int]
     metric = None            # type: Optional[str]
     graph = None             # type: Optional[nx.Graph]
@@ -527,8 +548,8 @@ class Results(namespace):
     partition = None         # type: Optional[np.ndarray]
 
 
-def run_on_data(data, pca_components, k_neighbors, metric, resolution, state):
-    # type: (Table, Optional[int], int, str, float, TaskState) -> Results
+def run_on_data(data, normalize, pca_components, k_neighbors, metric, resolution, state):
+    # type: (Table, Optional[int], int, str, float, bool, TaskState) -> Results
     """
     Run the louvain clustering on `data`.
 
@@ -539,6 +560,8 @@ def run_on_data(data, pca_components, k_neighbors, metric, resolution, state):
     ----------
     data : Table
         Data table
+    normalize : bool
+        If `True`, the data is first normalized before computing PCA.
     pca_components : Optional[int]
         If not `None` then the data is first projected onto first
         `pca_components` principal components.
@@ -556,16 +579,18 @@ def run_on_data(data, pca_components, k_neighbors, metric, resolution, state):
     """
     state = state  # type: TaskState
     res = Results(
-        pca_components=pca_components, k_neighbors=k_neighbors, metric=metric,
-        resolution=resolution,
+        normalize=normalize, pca_components=pca_components,
+        k_neighbors=k_neighbors, metric=metric, resolution=resolution,
     )
     step = 0
     if state.is_interuption_requested():
         return res
+
     if pca_components is not None:
         steps = 3
         state.set_status("Computing PCA...")
         pca = PCA(n_components=pca_components, random_state=0)
+
         data = res.pca_projection = pca(data)(data)
         assert isinstance(data, Table)
         state.set_partial_results(("pca_projection", res.pca_projection))
@@ -578,6 +603,13 @@ def run_on_data(data, pca_components, k_neighbors, metric, resolution, state):
 
     state.set_progress_value(100. * step / steps)
     state.set_status("Building graph...")
+
+    # Apply Louvain preprocessing before converting the table into a graph
+    louvain = Louvain(resolution=resolution, random_state=0)
+    data = louvain.preprocess(data)
+
+    if state.is_interuption_requested():
+        return res
 
     def pcallback(val):
         state.set_progress_value((100. * step + 100 * val) / steps)
@@ -600,7 +632,6 @@ def run_on_data(data, pca_components, k_neighbors, metric, resolution, state):
     if state.is_interuption_requested():
         return res
 
-    louvain = Louvain(resolution=resolution, random_state=0)
     res.partition = louvain.fit_predict(graph)
     state.set_partial_results(("partition", res.partition))
     return res


### PR DESCRIPTION
*Edited on 4.2.2019*

##### Issue
In #3448 we found that normalizing the data can have beneficial effects for t-SNE. This likely also holds for Louvain clustering, when PCA preprocessing is applied. It also makes little sense to enable data normalization for PCA in one widget, but not another.


##### Description of changes

I tried to separate the PCA specific parameters from the "Enable PCA preprocessing" by adding an indent. IMO it looks better than if there we no indent, but it's not very pretty.

![image](https://user-images.githubusercontent.com/5758119/52221834-535e1b00-28a2-11e9-98b5-8afc42680008.png)

Description of changes:
- 024d125721c88c54b5a8dfedeeb5625fd8313804 Add the option to skip zero centering to the normalization preprocessor. This will also be necessary later on, when I add normalization for sparse matrices.

  This is already implemented in `Orange.preprocess.preprocess.Scale`, which seems to do exactly the same thing as `Orange.preprocess.preprocess.Normalize`. Indeed, it seems as though `Scale` actually uses the same normalization implementation. This is very confusing, as `Normalize` is just a slightly less powerful version of `Scale`, but having a much better name. It also seems that the only place `Scale` is used is in the Preprocess widget, while `Normalize` is used all over the place.

  This is very confusing and IMO `Scale` should be renamed to `Normalize`, since they do the same thing, but `Scale` does it better. In any case, I am using `Normalize` here, mainly because I found `Scale` after implementing this.

- 495dfa8a814667de3571131570492cc5dd39b672 Moved `table_dense_sparse` decorator into `Orange.widget.testing.utils`. It's quite handy.

- e1d91ef2cafb3691a39c0799feb708d0d10fd02a Add normalization support for sparse data. This is included here because this is not PCA specific. We only scale by SD. For PCA, this is fine, because centering is applied in PCA. This is also allright where PCA is not used, because the table is directly used for computing pairwise distances between samples. Euclidean and Manhattan distance are independent of the position i.e. they are the same if the points are centered or not. So applying only scaling is all right here as well.

  Note that this is only correct as long as the distances are independent of absolute position. If we ever add other distances, this needs to be considered e.g. the cosine distance doesn't have this property.

- bb1f3e05c140b9731810d282e3ed3f97c6c63d54 Disable PCA components slider if Apply PCA is not checked; it makes little sense to be enabled.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
