### PR TITLE
[ENH] Use %g (including sci notation) if number of decimals is not set

### DIFF
--- a/Orange/classification/simple_tree.py
+++ b/Orange/classification/simple_tree.py
@@ -274,35 +274,36 @@ class SimpleTreeModel(Model):
                 node = self.node
         n = node.contents
         if self.type == Classification:
-            decimals = 1
+            format_str = format_leaf = format_node = None
         else:
-            decimals = self.domain.class_var.number_of_decimals
+            format_str = f"({self.domain.class_var.format_str}: %s)"
+            format_leaf = " --> " + format_str
+            format_node = "%s " + format_str
         if n.children_size == 0:
             if self.type == Classification:
-                node_cont = [round(n.dist[i], decimals)
+                node_cont = [round(n.dist[i], 1)
                              for i in range(self.cls_vals)]
                 index = node_cont.index(max(node_cont))
                 major_class = self.cls_vars[0].values[index]
                 return ' --> %s (%s)' % (major_class, node_cont)
             else:
-                node_cont = str(round(n.sum / n.n, decimals)) + ': ' + str(n.n)
-                return ' --> (%s)' % node_cont
+                return format_leaf % (n.sum / n.n, n.n)
         else:
             attr = self.dom_attr[n.split_attr]
             node_desc = attr.name
+            indent = '\n' + '   ' * level
             if self.type == Classification:
-                node_cont = [round(n.dist[i], decimals)
+                node_cont = [round(n.dist[i], 1)
                              for i in range(self.cls_vals)]
+                ret_str = indent + '%s (%s)' % (node_desc, node_cont)
             else:
-                node_cont = str(round(n.sum / n.n, decimals)) + ': ' + str(n.n)
-            ret_str = '\n' + '   ' * level + '%s (%s)' % (node_desc,
-                                                          node_cont)
+                ret_str = indent + format_node % (node_desc, n.sum / n.n, n.n)
             for i in range(n.children_size):
                 if attr.is_continuous:
                     split = '<=' if i % 2 == 0 else '>'
-                    split += str(round(n.split, attr.number_of_decimals))
-                    ret_str += '\n' + '   ' * level + ': %s' % split
+                    split += attr.format_str % n.split
+                    ret_str += indent + ': %s' % split
                 else:
-                    ret_str += '\n' + '   ' * level + ': %s' % attr.values[i]
+                    ret_str += indent + ': %s' % attr.values[i]
                 ret_str += self.to_string(n.children[i], level + 1)
             return ret_str

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -301,13 +301,13 @@ class TestContinuousVariable(VariableTest):
 
     def test_adjust_decimals(self):
         a = ContinuousVariable("a")
-        self.assertEqual(a.str_val(4.654321), "4.654")
+        self.assertEqual(a.str_val(4.65432), "4.65432")
         a.val_from_str_add("5")
-        self.assertEqual(a.str_val(4.654321), "5")
+        self.assertEqual(a.str_val(4.65432), "5")
         a.val_from_str_add("  5.12    ")
-        self.assertEqual(a.str_val(4.654321), "4.65")
+        self.assertEqual(a.str_val(4.65432), "4.65")
         a.val_from_str_add("5.1234")
-        self.assertEqual(a.str_val(4.654321), "4.6543")
+        self.assertEqual(a.str_val(4.65432), "4.6543")
 
     def test_colors(self):
         a = ContinuousVariable("a")

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -523,14 +523,19 @@ class ContinuousVariable(Variable):
         """
         super().__init__(name, compute_value, sparse=sparse)
         if number_of_decimals is None:
-            self.number_of_decimals = 3
+            self._number_of_decimals = 3
             self.adjust_decimals = 2
+            self._format_str = "%g"
         else:
             self.number_of_decimals = number_of_decimals
 
     @property
     def number_of_decimals(self):
         return self._number_of_decimals
+
+    @property
+    def format_str(self):
+        return self._format_str
 
     @property
     def colors(self):
@@ -554,7 +559,7 @@ class ContinuousVariable(Variable):
     def number_of_decimals(self, x):
         self._number_of_decimals = x
         self.adjust_decimals = 0
-        self._out_format = "%.{}f".format(self.number_of_decimals)
+        self._format_str = "%.{}f".format(self.number_of_decimals)
 
     def to_val(self, s):
         """
@@ -577,7 +582,7 @@ class ContinuousVariable(Variable):
         """
         if isnan(val):
             return "?"
-        return self._out_format % val
+        return self._format_str % val
 
     str_val = repr_val
 

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -512,8 +512,6 @@ class Scale(Preprocess):
             factor = 1 / s
             transformed_var = var.copy(
                 compute_value=transformation.Normalizer(var, c, factor))
-            if s != 1:
-                transformed_var.number_of_decimals = 3
             return transformed_var
 
         newvars = []

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -229,36 +229,36 @@ class TestInstance(unittest.TestCase):
     def test_str(self):
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")])
         inst = Instance(domain, [42, 0])
-        self.assertEqual(str(inst), "[42.000, M]")
+        self.assertEqual(str(inst), "[42, M]")
 
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")],
                                     [DiscreteVariable("y", values="ABC")])
         inst = Instance(domain, [42, "M", "B"])
-        self.assertEqual(str(inst), "[42.000, M | B]")
+        self.assertEqual(str(inst), "[42, M | B]")
 
         domain = self.create_domain(["x", DiscreteVariable("g", values="MF")],
                                     [DiscreteVariable("y", values="ABC")],
                                     self.metas)
         inst = Instance(domain, [42, "M", "B", "X", 43, "Foo"])
-        self.assertEqual(str(inst), "[42.000, M | B] {X, 43.000, Foo}")
+        self.assertEqual(str(inst), "[42, M | B] {X, 43, Foo}")
 
         domain = self.create_domain([],
                                     [DiscreteVariable("y", values="ABC")],
                                     self.metas)
         inst = Instance(domain, ["B", "X", 43, "Foo"])
-        self.assertEqual(str(inst), "[ | B] {X, 43.000, Foo}")
+        self.assertEqual(str(inst), "[ | B] {X, 43, Foo}")
 
         domain = self.create_domain([],
                                     [],
                                     self.metas)
         inst = Instance(domain, ["X", 43, "Foo"])
-        self.assertEqual(str(inst), "[] {X, 43.000, Foo}")
+        self.assertEqual(str(inst), "[] {X, 43, Foo}")
 
         domain = self.create_domain(self.attributes)
         inst = Instance(domain, range(len(self.attributes)))
         self.assertEqual(
             str(inst),
-            "[{}]".format(", ".join("{:.3f}".format(x)
+            "[{}]".format(", ".join(f"{x:g}"
                                     for x in range(len(self.attributes)))))
 
         for attr in domain.variables:
@@ -271,6 +271,10 @@ class TestInstance(unittest.TestCase):
     def test_repr(self):
         domain = self.create_domain(self.attributes)
         inst = Instance(domain, range(len(self.attributes)))
+        self.assertEqual(repr(inst), "[0, 1, 2, 3, 4, ...]")
+
+        for attr in domain.variables:
+            attr.number_of_decimals = 3
         self.assertEqual(repr(inst), "[0.000, 1.000, 2.000, 3.000, 4.000, ...]")
 
         for attr in domain.variables:

--- a/Orange/tests/test_orangetree.py
+++ b/Orange/tests/test_orangetree.py
@@ -394,11 +394,11 @@ class TestTreeModel(unittest.TestCase):
 
     def test_print(self):
         model = TreeModel(self.data, self.root)
-        self.assertEqual(model.print_tree(), """             [ 1 42] v1 ≤ 13.000
+        self.assertEqual(model.print_tree(), """             [ 1 42] v1 ≤ 13
              [ 2 42]     v2 a
              [ 3 42]     v2 b
              [ 4 42]     v2 c
-             [ 5 42] v1 > 13.000
+             [ 5 42] v1 > 13
              [ 6 42]     v3 f
              [ 7 42]     v3 d or e
 """)

--- a/Orange/tests/test_simple_tree.py
+++ b/Orange/tests/test_simple_tree.py
@@ -140,15 +140,15 @@ class TestSimpleTreeLearner(unittest.TestCase):
         reg = lrn(data)
         reg_str = reg.to_string()
         res = '\n' \
-              'd1 (20.0: 6.0)\n' \
+              'd1 (20: 6.0)\n' \
               ': e\n' \
-              '   c1 (15.0: 4.0)\n' \
+              '   c1 (15: 4.0)\n' \
               '   : <=2.5\n' \
-              '      c1 (16.667: 3.0)\n' \
-              '      : <=1.5 --> (15.0: 2.0)\n' \
-              '      : >1.5 --> (20.0: 1.0)\n' \
-              '   : >2.5 --> (10.0: 1.0)\n' \
-              ': f --> (30.0: 2.0)'
+              '      c1 (16.6667: 3.0)\n' \
+              '      : <=1.5 --> (15: 2.0)\n' \
+              '      : >1.5 --> (20: 1.0)\n' \
+              '   : >2.5 --> (10: 1.0)\n' \
+              ': f --> (30: 2.0)'
         self.assertEqual(reg_str, res)
 
     def test_SimpleTree_to_string_cls_decimals(self):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2393,10 +2393,10 @@ class TestTableTranspose(unittest.TestCase):
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
-        att[0].attributes = {"cls": "4.000"}
-        att[1].attributes = {"cls": "3.000"}
-        att[2].attributes = {"cls": "2.000"}
-        att[3].attributes = {"cls": "1.000"}
+        att[0].attributes = {"cls": "4"}
+        att[1].attributes = {"cls": "3"}
+        att[2].attributes = {"cls": "2"}
+        att[3].attributes = {"cls": "1"}
         domain = Domain(att, metas=[StringVariable("Feature name")])
         result = Table(domain, np.arange(8).reshape((4, 2)).T,
                        metas=np.array(["c1", "c2"])[:, None])
@@ -2419,9 +2419,9 @@ class TestTableTranspose(unittest.TestCase):
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
-        att[1].attributes = {"cls": "3.000"}
-        att[2].attributes = {"cls": "2.000"}
-        att[3].attributes = {"cls": "1.000"}
+        att[1].attributes = {"cls": "3"}
+        att[2].attributes = {"cls": "2"}
+        att[3].attributes = {"cls": "1"}
         domain = Domain(att, metas=[StringVariable("Feature name")])
         result = Table(domain, np.arange(8).reshape((4, 2)).T,
                        metas=np.array(["c1", "c2"])[:, None])
@@ -2445,10 +2445,10 @@ class TestTableTranspose(unittest.TestCase):
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
-        att[0].attributes = {"cls1": "0.000", "cls2": "1.000"}
-        att[1].attributes = {"cls1": "2.000", "cls2": "3.000"}
-        att[2].attributes = {"cls1": "4.000", "cls2": "5.000"}
-        att[3].attributes = {"cls1": "6.000", "cls2": "7.000"}
+        att[0].attributes = {"cls1": "0", "cls2": "1"}
+        att[1].attributes = {"cls1": "2", "cls2": "3"}
+        att[2].attributes = {"cls1": "4", "cls2": "5"}
+        att[3].attributes = {"cls1": "6", "cls2": "7"}
         domain = Domain(att, metas=[StringVariable("Feature name")])
         result = Table(domain, np.arange(8).reshape((4, 2)).T,
                        metas=np.array(["c1", "c2"])[:, None])
@@ -2529,10 +2529,10 @@ class TestTableTranspose(unittest.TestCase):
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
-        att[0].attributes = {"m1": "0.000"}
-        att[1].attributes = {"m1": "1.000"}
-        att[2].attributes = {"m1": "0.000"}
-        att[3].attributes = {"m1": "1.000"}
+        att[0].attributes = {"m1": "0"}
+        att[1].attributes = {"m1": "1"}
+        att[2].attributes = {"m1": "0"}
+        att[3].attributes = {"m1": "1"}
         domain = Domain(att, metas=[StringVariable("Feature name")])
         result = Table(domain, np.arange(8).reshape((4, 2)).T,
                        metas=np.array(["c1", "c2"])[:, None])
@@ -2613,10 +2613,10 @@ class TestTableTranspose(unittest.TestCase):
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
-        att[0].attributes = {"cls": "1.000", "m1": "aa", "m2": "aaa"}
-        att[1].attributes = {"cls": "2.000", "m1": "bb", "m2": "bbb"}
-        att[2].attributes = {"cls": "3.000", "m1": "cc", "m2": "ccc"}
-        att[3].attributes = {"cls": "4.000", "m1": "dd", "m2": "ddd"}
+        att[0].attributes = {"cls": "1", "m1": "aa", "m2": "aaa"}
+        att[1].attributes = {"cls": "2", "m1": "bb", "m2": "bbb"}
+        att[2].attributes = {"cls": "3", "m1": "cc", "m2": "ccc"}
+        att[3].attributes = {"cls": "4", "m1": "dd", "m2": "ddd"}
         domain = Domain(att, metas=[StringVariable("Feature name")])
         result = Table(domain, np.arange(8).reshape((4, 2)).T,
                        metas=np.array(["c1", "c2"])[:, None])
@@ -2660,8 +2660,8 @@ class TestTableTranspose(unittest.TestCase):
 
     def test_transpose_attributes_of_attributes_continuous(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
-        attrs[0].attributes = {"attr1": "1.100", "attr2": "1.300"}
-        attrs[1].attributes = {"attr1": "2.200", "attr2": "2.300"}
+        attrs[0].attributes = {"attr1": "1.1", "attr2": "1.3"}
+        attrs[1].attributes = {"attr1": "2.2", "attr2": "2.3"}
         domain = Domain(attrs)
         data = Table(domain, np.arange(8).reshape((4, 2)))
 
@@ -2683,7 +2683,7 @@ class TestTableTranspose(unittest.TestCase):
 
         # original should not change
         self.assertDictEqual(data.domain.attributes[0].attributes,
-                             {"attr1": "1.100", "attr2": "1.300"})
+                             {"attr1": "1.1", "attr2": "1.3"})
 
     def test_transpose_attributes_of_attributes_missings(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2724,10 +2724,10 @@ class TestTableTranspose(unittest.TestCase):
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
-        att[0].attributes = {"cls": "1.000", "m1": "aa", "m2": "aaa"}
-        att[1].attributes = {"cls": "2.000", "m1": "bb", "m2": "bbb"}
-        att[2].attributes = {"cls": "3.000", "m1": "cc", "m2": "ccc"}
-        att[3].attributes = {"cls": "4.000", "m1": "dd", "m2": "ddd"}
+        att[0].attributes = {"cls": "1", "m1": "aa", "m2": "aaa"}
+        att[1].attributes = {"cls": "2", "m1": "bb", "m2": "bbb"}
+        att[2].attributes = {"cls": "3", "m1": "cc", "m2": "ccc"}
+        att[3].attributes = {"cls": "4", "m1": "dd", "m2": "ddd"}
         metas = [StringVariable("Feature name"),
                  DiscreteVariable("attr1", values=("a1", "b1")),
                  DiscreteVariable("attr2", values=("aa1", "bb1"))]

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -430,8 +430,7 @@ class OWPredictions(OWWidget):
         return delegate
 
     def _setup_delegate_continuous(self, delegate):
-        delegate.setFormat(
-            "{{value:.{}f}}".format(self.class_var.number_of_decimals))
+        delegate.setFormat("{{value:{}}}".format(self.class_var.format_str[1:]))
 
     def _update_spliter(self):
         if self.data is None:

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -134,8 +134,7 @@ class OWLinearRegression(OWBaseLearner):
         coef_table = None
         if self.model is not None:
             domain = Domain(
-                [ContinuousVariable("coef", number_of_decimals=7)],
-                metas=[StringVariable("name")])
+                [ContinuousVariable("coef")], metas=[StringVariable("name")])
             coefs = [self.model.intercept] + list(self.model.coefficients)
             names = ["intercept"] + \
                     [attr.name for attr in self.model.domain.attributes]

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -99,8 +99,8 @@ def create_coef_table(classifier):
         values = [classifier.domain.class_var.values[int(i)] for i in classifier.used_vals[0]]
     else:
         values = [classifier.domain.class_var.values[int(classifier.used_vals[0][1])]]
-    domain = Domain([ContinuousVariable(value, number_of_decimals=7)
-                     for value in values], metas=[StringVariable("name")])
+    domain = Domain([ContinuousVariable(value) for value in values],
+                    metas=[StringVariable("name")])
     coefs = np.vstack((i.reshape(1, len(i)), c.T))
     names = [[attr.name] for attr in classifier.domain.attributes]
     names = [["intercept"]] + names

--- a/Orange/widgets/model/owsgd.py
+++ b/Orange/widgets/model/owsgd.py
@@ -311,7 +311,7 @@ class OWSGD(OWBaseLearner):
             if self.model.domain.class_var.is_discrete:
                 coeffs = create_coef_table(self.model)
             else:
-                attrs = [ContinuousVariable("coef", number_of_decimals=7)]
+                attrs = [ContinuousVariable("coef")]
                 domain = Domain(attrs, metas=[StringVariable("name")])
                 cfs = list(self.model.intercept) + list(self.model.coefficients)
                 names = ["intercept"] + \

--- a/Orange/widgets/visualize/utils/tree/tests/test_treeadapter.py
+++ b/Orange/widgets/visualize/utils/tree/tests/test_treeadapter.py
@@ -53,7 +53,7 @@ class TestTreeAdapter(unittest.TestCase):
         np.testing.assert_almost_equal(
             adapt.get_distribution(self.left),
             np.array([[1, 42]]))
-        self.assertEqual(adapt.rules(self.right), ["v1 > 13.000"])
+        self.assertEqual(adapt.rules(self.right), ["v1 > 13"])
         self.assertIs(adapt.attribute(self.root), self.v1)
         self.assertEqual(adapt.leaves(self.left), self.left.children)
         self.assertEqual(adapt.leaves(self.right), [self.right.children[0]])


### PR DESCRIPTION
##### Issue

Fixes #2692.

Numeric variables are currently printed with three decimals, unless the number is set to another default. The latter most often happens when the data is read from text file (tab, csv, but not Excel). Consequently, values close to 0 are printed as 0. To fix this, some code sets the number of decimals to 7, which defeats the purpose and even doesn't help for values below 1e-7.

##### Description of changes

- When number of decimals is not set (as in regression coefficients, variables constructed by PCA...), `%g` is now used for formatting, as suggested by @markotoplak. This will print a reasonable number of decimals or switch to scientific notation.
- When the number of decimals is set, nothing changes.

Some code used `Variable.number_of_decimals` to construct own format strings instead of calling `Variable.val_to_str`. `Variable` now exposes `format_str`, which can be either `%g` or `%f` with prescribed number of decimals. I tried to hunt down the code where this change was appropriate.

The change is backward incompatible in the sense that some outputs changed. Some tests had to be fixed accordingly.

##### Includes
- [X] Code changes
- [X] Tests
