### PR TITLE
OwTSNE: Don't catch errors during optimization

### DIFF
--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -94,7 +94,6 @@ class OWtSNE(OWDataProjectionWidget):
         constant_data = Msg("Input data is constant")
         no_attributes = Msg("Data has no attributes")
         out_of_memory = Msg("Out of memory")
-        optimization_error = Msg("Error during optimization\n{}")
         no_valid_data = Msg("No projection due to no valid data")
 
     def __init__(self):
@@ -338,7 +337,6 @@ class OWtSNE(OWDataProjectionWidget):
 
         loop = self.__update_loop
         self.Error.out_of_memory.clear()
-        self.Error.optimization_error.clear()
         try:
             projection, progress = next(self.__update_loop)
             assert self.__update_loop is loop
@@ -350,10 +348,10 @@ class OWtSNE(OWDataProjectionWidget):
             self.Error.out_of_memory()
             self.__state = OWtSNE.Finished
             self.__set_update_loop(None)
-        except Exception as exc:
-            self.Error.optimization_error(str(exc))
+        except Exception:
             self.__state = OWtSNE.Finished
             self.__set_update_loop(None)
+            raise
         else:
             self.progressBarSet(100.0 * progress, processEvents=None)
             self.projection = projection

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain, Table
 from Orange.preprocess import Preprocess, Normalize
-from Orange.projection.manifold import TSNE
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, ProjectionWidgetTestMixin
 )
@@ -30,8 +29,9 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin,
         def transform(*args, **_):
             return np.ones((len(args[1]), 2), float)
 
-        def optimize(*_, **__):
-            return TSNE()()
+        def optimize(tsne_model, *_, **__):
+            # Optimize needs to return a valid `TSNEModel` instance
+            return tsne_model
 
         self._fit = owtsne.TSNE.fit
         self._transform = owtsne.TSNEModel.transform


### PR DESCRIPTION


##### Issue
Fixes #3548.

Catching errors during optimization and showing them in the error
message bar makes them difficult to report. Furthermore, no exceptions
should be thrown during optimization and if something does go wrong, we
need to fix it.

##### Description of changes
Remove the `optimization_error`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
