### PR TITLE
[ENH] PCA: Remove SVD & add normalization for sparse

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -395,10 +395,6 @@ class OWPCA(widget.OWWidget):
         self._pca_projector.component = self.ncomponents
         self._pca_preprocessors = PCA.preprocessors
 
-    def _update_decomposition(self):
-        self._init_projector()
-        self._update_normalize()
-
     def _nselected_components(self):
         """Return the number of selected components."""
         if self._pca is None:


### PR DESCRIPTION
##### Issue
Based on #3573, needed so zero-centering can be skipped.

Until recently, PCA didn't support sparse data, so SVD was used instead in the PCA widget. However, PCA now fully supports sparse data, so SVD is no longer necessary.

##### Description of changes
- Remove SVD from the PCA widget
- Add option to normalize sparse data

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
