### PR TITLE
[ENH] PCA: Preserve f32s & reduce memory footprint when computing means

### DIFF
--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -1,9 +1,9 @@
 import numbers
-
 import six
 import numpy as np
 import scipy.sparse as sp
 from scipy.linalg import lu, qr, svd
+
 from sklearn import decomposition as skl_decomposition
 from sklearn.utils import check_array, check_random_state
 from sklearn.utils.extmath import svd_flip, safe_sparse_dot
@@ -45,10 +45,13 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
 
     n_samples, n_features = A.shape
 
-    c = np.atleast_2d(A.mean(axis=0))
+    c = np.atleast_2d(ut.nanmean(A, axis=0))
 
     if n_samples >= n_features:
         Q = random_state.normal(size=(n_features, n_components + n_oversamples))
+        if A.dtype.kind == "f":
+            Q = Q.astype(A.dtype, copy=False)
+
         Q = safe_sparse_dot(A, Q) - safe_sparse_dot(c, Q)
 
         # Normalized power iterations
@@ -66,6 +69,9 @@ def randomized_pca(A, n_components, n_oversamples=10, n_iter="auto",
 
     else:  # n_features > n_samples
         Q = random_state.normal(size=(n_samples, n_components + n_oversamples))
+        if A.dtype.kind == "f":
+            Q = Q.astype(A.dtype, copy=False)
+
         Q = safe_sparse_dot(A.T, Q) - safe_sparse_dot(c.T, Q.sum(axis=0)[None, :])
 
         # Normalized power iterations

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -10,6 +10,7 @@ from scipy.sparse import csr_matrix, issparse, lil_matrix, csc_matrix, \
 from Orange.statistics.util import bincount, countnans, contingency, digitize, \
     mean, nanmax, nanmean, nanmedian, nanmin, nansum, nanunique, stats, std, \
     unique, var, nanstd, nanvar, nanmode
+from sklearn.utils import check_random_state
 
 
 def dense_sparse(test_case):
@@ -166,13 +167,6 @@ class TestUtil(unittest.TestCase):
         with self.assertWarns(UserWarning):
             mean([1, np.nan, 0])
 
-    def test_nanmean(self):
-        for X in self.data:
-            X_sparse = csr_matrix(X)
-            np.testing.assert_array_equal(
-                nanmean(X_sparse),
-                np.nanmean(X))
-
     def test_nanmode(self):
         X = np.array([[np.nan, np.nan, 1, 1],
                       [2, np.nan, 1, 1]])
@@ -268,6 +262,31 @@ class TestUtil(unittest.TestCase):
                 np.nanstd(x, axis=axis, ddof=10),
                 nanstd(csr_matrix(x), axis=axis, ddof=10),
             )
+
+
+class TestNanmean(unittest.TestCase):
+    def setUp(self):
+        self.random_state = check_random_state(42)
+        self.x = self.random_state.uniform(size=(10, 5))
+        np.fill_diagonal(self.x, np.nan)
+
+    @dense_sparse
+    def test_axis_none(self, array):
+        np.testing.assert_almost_equal(
+            np.nanmean(self.x), nanmean(array(self.x))
+        )
+
+    @dense_sparse
+    def test_axis_0(self, array):
+        np.testing.assert_almost_equal(
+            np.nanmean(self.x, axis=0), nanmean(array(self.x), axis=0)
+        )
+
+    @dense_sparse
+    def test_axis_1(self, array):
+        np.testing.assert_almost_equal(
+            np.nanmean(self.x, axis=1), nanmean(array(self.x), axis=1)
+        )
 
 
 class TestDigitize(unittest.TestCase):


### PR DESCRIPTION
##### Issue
While working towards getting the improved PCA merged into scikit-learn, I've found two improvements.

##### Description of changes
1. `np.float32` are now preserved
2. Apparently, scipys sparse `x.mean` method isn't the most memory efficient, and scikit-learn's utility function `mean_variance_axis` is much better (see benchmarks [here](https://github.com/scikit-learn/scikit-learn/pull/12841#issuecomment-460238233))

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
