### PR TITLE
[FIX] setup.py: Specify python-louvain version constraint

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -16,6 +16,6 @@ keyrings.alt    # for alternative keyring implementations
 setuptools>=36.3
 serverfiles		# for Data Sets synchronization
 networkx
-python-louvain
+python-louvain>=0.13
 requests
 openTSNE>=0.3.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

python-louvain version >= 0.13 is required for the 'random_state' parameter (gh-3492).

##### Description of changes

Update `requirements-core.txt`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
