### PR TITLE
[ENH] Preprocess: implement Select Relevant Feature's percentile

### DIFF
--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -16,10 +16,10 @@ __all__ = ["SelectBestFeatures", "SelectRandomFeatures"]
 class SelectBestFeatures(Reprable):
     """
     A feature selector that builds a new dataset consisting of either the top
-    `k` features (`k` can also represent a percentile value between 0.0 and 1.0)
-    or all those that exceed a given `threshold`. Features are scored using the
-    provided feature scoring `method`. By default it is assumed that feature
-    importance diminishes with decreasing scores.
+    `k` features (if `k` is an `int`) or a proportion (if `k` is a `float`
+    between 0.0 and 1.0), or all those that exceed a given `threshold`. Features
+    are scored using the provided feature scoring `method`. By default it is
+    assumed that feature importance decreases with decreasing scores.
 
     If both `k` and `threshold` are set, only features satisfying both
     conditions will be selected.
@@ -34,7 +34,7 @@ class SelectBestFeatures(Reprable):
         Univariate feature scoring method.
 
     k : int or float
-        The number of top features to select or percentile, above which features are selected.
+        The number or propotion of top features to select.
 
     threshold : float
         A threshold that a feature should meet according to the provided method.
@@ -53,9 +53,7 @@ class SelectBestFeatures(Reprable):
     def __call__(self, data):
         n_attrs = len(data.domain.attributes)
         if isinstance(self.k, float):
-            idx_attr = np.ceil(self.k * n_attrs).astype(int)
-            # edge case: 0th percentile would result in selection of `(n_attrs + 1)` attrs
-            effective_k = min(n_attrs - idx_attr + 1, n_attrs)
+            effective_k = np.round(self.k * n_attrs).astype(int) or 1
         else:
             effective_k = self.k
 
@@ -81,7 +79,7 @@ class SelectBestFeatures(Reprable):
             scores = self.score_only_nice_features(data, method)
         best = sorted(zip(scores, features), key=itemgetter(0),
                       reverse=self.decreasing)
-        if effective_k:
+        if self.k:
             best = best[:effective_k]
         if self.threshold:
             pred = ((lambda x: x[0] >= self.threshold) if self.decreasing else

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -16,9 +16,10 @@ __all__ = ["SelectBestFeatures", "SelectRandomFeatures"]
 class SelectBestFeatures(Reprable):
     """
     A feature selector that builds a new dataset consisting of either the top
-    `k` features or all those that exceed a given `threshold`. Features are
-    scored using the provided feature scoring `method`. By default it is
-    assumed that feature importance diminishes with decreasing scores.
+    `k` features (`k` can also represent a percentile value between 0.0 and 1.0)
+    or all those that exceed a given `threshold`. Features are scored using the
+    provided feature scoring `method`. By default it is assumed that feature
+    importance diminishes with decreasing scores.
 
     If both `k` and `threshold` are set, only features satisfying both
     conditions will be selected.
@@ -32,8 +33,8 @@ class SelectBestFeatures(Reprable):
     method : Orange.preprocess.score.ClassificationScorer, Orange.preprocess.score.SklScorer
         Univariate feature scoring method.
 
-    k : int
-        The number of top features to select.
+    k : int or float
+        The number of top features to select or percentile, above which features are selected.
 
     threshold : float
         A threshold that a feature should meet according to the provided method.
@@ -50,6 +51,12 @@ class SelectBestFeatures(Reprable):
         self.decreasing = decreasing
 
     def __call__(self, data):
+        n_attrs = len(data.domain.attributes)
+        if type(self.k) == float:
+            idx_attr = np.ceil(self.k * n_attrs).astype(int)
+            # edge case: 0th percentile would result in selection of `(n_attrs + 1)` attrs
+            self.k = min(n_attrs - idx_attr + 1, n_attrs)
+
         method = self.method
         # select default method according to the provided data
         if method is None:

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -55,7 +55,9 @@ class SelectBestFeatures(Reprable):
         if isinstance(self.k, float):
             idx_attr = np.ceil(self.k * n_attrs).astype(int)
             # edge case: 0th percentile would result in selection of `(n_attrs + 1)` attrs
-            self.k = min(n_attrs - idx_attr + 1, n_attrs)
+            effective_k = min(n_attrs - idx_attr + 1, n_attrs)
+        else:
+            effective_k = self.k
 
         method = self.method
         # select default method according to the provided data
@@ -79,8 +81,8 @@ class SelectBestFeatures(Reprable):
             scores = self.score_only_nice_features(data, method)
         best = sorted(zip(scores, features), key=itemgetter(0),
                       reverse=self.decreasing)
-        if self.k:
-            best = best[:self.k]
+        if effective_k:
+            best = best[:effective_k]
         if self.threshold:
             pred = ((lambda x: x[0] >= self.threshold) if self.decreasing else
                     (lambda x: x[0] <= self.threshold))
@@ -121,9 +123,12 @@ class SelectRandomFeatures(Reprable):
 
     def __call__(self, data):
         if isinstance(self.k, float):
-            self.k = int(len(data.domain.attributes) * self.k)
+            effective_k = int(len(data.domain.attributes) * self.k)
+        else:
+            effective_k = self.k
+
         domain = Orange.data.Domain(
             random.sample(data.domain.attributes,
-                          min(self.k, len(data.domain.attributes))),
+                          min(effective_k, len(data.domain.attributes))),
             data.domain.class_vars, data.domain.metas)
         return data.transform(domain)

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -52,7 +52,7 @@ class SelectBestFeatures(Reprable):
 
     def __call__(self, data):
         n_attrs = len(data.domain.attributes)
-        if type(self.k) == float:
+        if isinstance(self.k, float):
             idx_attr = np.ceil(self.k * n_attrs).astype(int)
             # edge case: 0th percentile would result in selection of `(n_attrs + 1)` attrs
             self.k = min(n_attrs - idx_attr + 1, n_attrs)
@@ -120,7 +120,7 @@ class SelectRandomFeatures(Reprable):
         self.k = k
 
     def __call__(self, data):
-        if type(self.k) == float:
+        if isinstance(self.k, float):
             self.k = int(len(data.domain.attributes) * self.k)
         domain = Orange.data.Domain(
             random.sample(data.domain.attributes,

--- a/Orange/tests/test_fss.py
+++ b/Orange/tests/test_fss.py
@@ -35,19 +35,30 @@ class TestFSS(unittest.TestCase):
         best = max((gini(self.titanic, f), f) for f in self.titanic.domain.attributes)[1]
         self.assertEqual(data2.domain.attributes[0], best)
 
-        # 0th percentile = selection of all top3 (all) attributes
-        sel2 = SelectBestFeatures(method=gini, k=0.0)
+        # no k and no threshold, select all attributes
+        sel2 = SelectBestFeatures(method=gini, k=0)
         data2 = sel2(self.titanic)
         self.assertEqual(len(data2.domain.attributes), len(self.titanic.domain.attributes))
 
-        # 35th percentile = selection of top2 (out of 3) attributes
+        # 31% = selection of top  (out of 3) attributes
+        sel3 = SelectBestFeatures(method=gini, k=0.31)
+        data2 = sel3(self.titanic)
+        self.assertEqual(len(data2.domain.attributes), 1)
+
+        # 35% = selection of top  (out of 3) attributes
         sel3 = SelectBestFeatures(method=gini, k=0.35)
         data2 = sel3(self.titanic)
-        self.assertEqual(len(data2.domain.attributes), 2)
+        self.assertEqual(len(data2.domain.attributes), 1)
+
+        # 1% = select one (out of 3) attributes
+        sel3 = SelectBestFeatures(method=gini, k=0.01)
+        data2 = sel3(self.titanic)
+        self.assertEqual(len(data2.domain.attributes), 1)
 
         # number of selected attrs should be relative to number of current input attrs
+        sel3 = SelectBestFeatures(method=gini, k=1.0)
         data2 = sel3(self.wine)
-        self.assertEqual(len(data2.domain.attributes), 9)
+        self.assertEqual(len(data2.domain.attributes), 13)
 
     def test_select_threshold(self):
         anova = ANOVA()

--- a/Orange/tests/test_fss.py
+++ b/Orange/tests/test_fss.py
@@ -45,6 +45,10 @@ class TestFSS(unittest.TestCase):
         data2 = sel3(self.titanic)
         self.assertEqual(len(data2.domain.attributes), 2)
 
+        # number of selected attrs should be relative to number of current input attrs
+        data2 = sel3(self.wine)
+        self.assertEqual(len(data2.domain.attributes), 9)
+
     def test_select_threshold(self):
         anova = ANOVA()
         t = 30

--- a/Orange/tests/test_fss.py
+++ b/Orange/tests/test_fss.py
@@ -27,6 +27,24 @@ class TestFSS(unittest.TestCase):
         best = max((gini(self.titanic, f), f) for f in self.titanic.domain.attributes)[1]
         self.assertEqual(data2.domain.attributes[0], best)
 
+    def test_select_2(self):
+        gini = Gini()
+        # 100th percentile = selection of top1 attribute
+        sel1 = SelectBestFeatures(method=gini, k=1.0)
+        data2 = sel1(self.titanic)
+        best = max((gini(self.titanic, f), f) for f in self.titanic.domain.attributes)[1]
+        self.assertEqual(data2.domain.attributes[0], best)
+
+        # 0th percentile = selection of all top3 (all) attributes
+        sel2 = SelectBestFeatures(method=gini, k=0.0)
+        data2 = sel2(self.titanic)
+        self.assertEqual(len(data2.domain.attributes), len(self.titanic.domain.attributes))
+
+        # 35th percentile = selection of top2 (out of 3) attributes
+        sel3 = SelectBestFeatures(method=gini, k=0.35)
+        data2 = sel3(self.titanic)
+        self.assertEqual(len(data2.domain.attributes), 2)
+
     def test_select_threshold(self):
         anova = ANOVA()
         t = 30

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -334,7 +334,7 @@ class UnivariateFeatureSelect(QWidget):
     edited = Signal()
 
     #: Strategy
-    Fixed, Percentile, FDR, FPR, FWE = 1, 2, 3, 4, 5
+    Fixed, Proportion, FDR, FPR, FWE = 1, 2, 3, 4, 5
 
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
@@ -370,17 +370,17 @@ class UnivariateFeatureSelect(QWidget):
         self.__spins[UnivariateFeatureSelect.Fixed] = kspin
         form.addRow(fixedrb, kspin)
 
-        percrb = QRadioButton("Percentile:")
-        group.addButton(percrb, UnivariateFeatureSelect.Percentile)
+        percrb = QRadioButton("Proportion:")
+        group.addButton(percrb, UnivariateFeatureSelect.Proportion)
         pspin = QDoubleSpinBox(
-            minimum=0.0, maximum=100.0, singleStep=0.5,
+            minimum=1.0, maximum=100.0, singleStep=0.5,
             value=self.__p, suffix="%",
-            enabled=self.__strategy == UnivariateFeatureSelect.Percentile
+            enabled=self.__strategy == UnivariateFeatureSelect.Proportion
         )
 
         pspin.valueChanged[float].connect(self.setP)
         pspin.editingFinished.connect(self.edited)
-        self.__spins[UnivariateFeatureSelect.Percentile] = pspin
+        self.__spins[UnivariateFeatureSelect.Proportion] = pspin
         form.addRow(percrb, pspin)
 
 #         form.addRow(QRadioButton("FDR"), QDoubleSpinBox())
@@ -420,9 +420,9 @@ class UnivariateFeatureSelect(QWidget):
     def setP(self, p):
         if self.__p != p:
             self.__p = p
-            spin = self.__spins[UnivariateFeatureSelect.Percentile]
+            spin = self.__spins[UnivariateFeatureSelect.Proportion]
             spin.setValue(p)
-            if self.__strategy == UnivariateFeatureSelect.Percentile:
+            if self.__strategy == UnivariateFeatureSelect.Proportion:
                 self.changed.emit()
 
     def setItems(self, itemlist):
@@ -508,8 +508,8 @@ class FeatureSelectEditor(BaseEditor):
         p = params.get("p", 75.0)
         if strategy == UnivariateFeatureSelect.Fixed:
             return preprocess.fss.SelectBestFeatures(score, k=k)
-        elif strategy == UnivariateFeatureSelect.Percentile:
-            return preprocess.fss.SelectBestFeatures(score, k=p/100)
+        elif strategy == UnivariateFeatureSelect.Proportion:
+            return preprocess.fss.SelectBestFeatures(score, k=p / 100)
         else:
             raise NotImplementedError
 

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -507,9 +507,9 @@ class FeatureSelectEditor(BaseEditor):
         k = params.get("k", 10)
         p = params.get("p", 75.0)
         if strategy == UnivariateFeatureSelect.Fixed:
-            return preprocess.fss.SelectBestFeatures(score, k=k)
+            return preprocess.fss.SelectBestFeatures(score(), k=k)
         elif strategy == UnivariateFeatureSelect.Proportion:
-            return preprocess.fss.SelectBestFeatures(score, k=p / 100)
+            return preprocess.fss.SelectBestFeatures(score(), k=p / 100)
         else:
             raise NotImplementedError
 

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -354,7 +354,7 @@ class UnivariateFeatureSelect(QWidget):
 
         self.layout().addWidget(box)
 
-        box = QGroupBox(title="Strategy", flat=True)
+        box = QGroupBox(title="Number of features", flat=True)
         self.__group = group = QButtonGroup(self, exclusive=True)
         self.__spins = {}
 
@@ -381,9 +381,6 @@ class UnivariateFeatureSelect(QWidget):
         pspin.valueChanged[float].connect(self.setP)
         pspin.editingFinished.connect(self.edited)
         self.__spins[UnivariateFeatureSelect.Percentile] = pspin
-        # Percentile controls disabled for now.
-        pspin.setEnabled(False)
-        percrb.setEnabled(False)
         form.addRow(percrb, pspin)
 
 #         form.addRow(QRadioButton("FDR"), QDoubleSpinBox())
@@ -508,10 +505,12 @@ class FeatureSelectEditor(BaseEditor):
         score = FeatureSelectEditor.MEASURES[score][1]
         strategy = params.get("strategy", UnivariateFeatureSelect.Fixed)
         k = params.get("k", 10)
+        p = params.get("p", 75.0)
         if strategy == UnivariateFeatureSelect.Fixed:
             return preprocess.fss.SelectBestFeatures(score, k=k)
+        elif strategy == UnivariateFeatureSelect.Percentile:
+            return preprocess.fss.SelectBestFeatures(score, k=p/100)
         else:
-            # TODO: implement top percentile selection
             raise NotImplementedError
 
     def __repr__(self):
@@ -534,7 +533,7 @@ class RandomFeatureSelectEditor(BaseEditor):
         self.__k = 10
         self.__p = 75.0
 
-        box = QGroupBox(title="Strategy", flat=True)
+        box = QGroupBox(title="Number of features", flat=True)
         self.__group = group = QButtonGroup(self, exclusive=True)
         self.__spins = {}
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3226.


##### Description of changes
Implements the "Percentile" option for Select Relevant Features preprocessor.  
The option enables the selection of all features that fall >= the entered percentile. The rank of the first feature to be taken is computed using [nearest-rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method). There are 2 "special" cases: 0th percentile is defined as all the features and 100th percentile is defined as the best feature.  
  
I've also renamed "Strategy" to "Number of features" in Select Random Features and Select Relevant Features as was suggested in the original issue.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
