### PR TITLE
[FIX] t-SNE speed-ups

### DIFF
--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -73,7 +73,7 @@ class OWtSNE(OWDataProjectionWidget):
     settings_version = 3
     max_iter = Setting(300)
     perplexity = Setting(30)
-    multiscale = Setting(True)
+    multiscale = Setting(False)
     exaggeration = Setting(1)
     pca_components = Setting(20)
     normalize = Setting(True)

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -281,7 +281,8 @@ class OWtSNE(OWDataProjectionWidget):
             n_components=2, perplexity=perplexity, multiscale=self.multiscale,
             early_exaggeration_iter=0, n_iter=0, initialization=initialization,
             exaggeration=self.exaggeration, neighbors=neighbor_method,
-            negative_gradient_method=gradient_method, random_state=0
+            negative_gradient_method=gradient_method, random_state=0,
+            theta=0.8,
         )(self.pca_data)
 
         self.tsne_runner = TSNERunner(self.projection, step_size=50)

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -258,6 +258,9 @@ class OWtSNE(OWDataProjectionWidget):
     def __start(self):
         self.pca_preprocessing()
 
+        # Dirty flag indicating whether the embedding has been drawn at least once
+        self.needs_to_draw = True
+
         # We call PCA through fastTSNE because it involves scaling. Instead of
         # worrying about this ourselves, we'll let the library worry for us.
         initialization = TSNE.default_initialization(
@@ -285,7 +288,7 @@ class OWtSNE(OWDataProjectionWidget):
             theta=0.8,
         )(self.pca_data)
 
-        self.tsne_runner = TSNERunner(self.projection, step_size=50)
+        self.tsne_runner = TSNERunner(self.projection, step_size=20)
         self.tsne_iterator = self.tsne_runner.run_optimization()
         self.__set_update_loop(self.tsne_iterator)
         self.progressBarInit(processEvents=None)
@@ -343,8 +346,10 @@ class OWtSNE(OWDataProjectionWidget):
         else:
             self.progressBarSet(100.0 * progress, processEvents=None)
             self.projection = projection
-            self.graph.update_coordinates()
-            self.graph.update_density()
+            if progress == 1 or self.needs_to_draw:
+                self.graph.update_coordinates()
+                self.graph.update_density()
+                self.needs_to_draw = False
             # schedule next update
             self.__timer.start()
 

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -110,6 +110,13 @@ class OWtSNE(OWDataProjectionWidget):
         self.__in_next_step = False
         self.__draw_similar_pairs = False
 
+        def reset_needs_to_draw():
+            self.needs_to_draw = True
+
+        self.needs_to_draw = True
+        self.__timer_draw = QTimer(self, interval=2000,
+                                   timeout=reset_needs_to_draw)
+
     def _add_controls(self):
         self._add_controls_start_box()
         super()._add_controls()
@@ -258,7 +265,6 @@ class OWtSNE(OWDataProjectionWidget):
     def __start(self):
         self.pca_preprocessing()
 
-        # Dirty flag indicating whether the embedding has been drawn at least once
         self.needs_to_draw = True
 
         # We call PCA through fastTSNE because it involves scaling. Instead of
@@ -309,6 +315,7 @@ class OWtSNE(OWDataProjectionWidget):
             self.runbutton.setText("Stop")
             self.__state = OWtSNE.Running
             self.__timer.start()
+            self.__timer_draw.start()
         else:
             self.setBlocking(False)
             self.setStatusMessage("")
@@ -317,6 +324,7 @@ class OWtSNE(OWDataProjectionWidget):
             if self.__state == OWtSNE.Paused:
                 self.runbutton.setText("Resume")
             self.__timer.stop()
+            self.__timer_draw.stop()
 
     def __next_step(self):
         if self.__update_loop is None:

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -366,15 +366,16 @@ class OWtSNE(OWDataProjectionWidget):
     def _get_projection_data(self):
         if self.data is None:
             return None
-        if self.projection is None:
-            variables = self._get_projection_variables()
-        else:
-            variables = self.projection.domain.attributes
         data = self.data.transform(
             Domain(self.data.domain.attributes,
                    self.data.domain.class_vars,
-                   self.data.domain.metas + variables))
+                   self.data.domain.metas + self._get_projection_variables()))
         data.metas[:, -2:] = self.get_embedding()
+        if self.projection is not None:
+            data.domain = Domain(
+                self.data.domain.attributes,
+                self.data.domain.class_vars,
+                self.data.domain.metas + self.projection.domain.attributes)
         return data
 
     def send_preprocessor(self):


### PR DESCRIPTION
##### Issue
t-SNE was slow

##### Description of changes
- The multiscale option makes things slow for larger data sets, so turn it off by default.
- Use faster approximation setting for Barnes-Hut
- Update t-SNE plot only at the start and at the end, avoiding potentially many redraws
- Selecting data in t-SNE was slow because `transform` was being called. Avoid this.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
