### PR TITLE
Scatterplotgraph: Do not animate resizing

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -37,6 +37,7 @@ from Orange.widgets.visualize.utils.plotutils import (
 
 
 SELECTION_WIDTH = 5
+MAX_N_VALID_SIZE_ANIMATE = 1000
 
 
 class PaletteItemSample(ItemSample):
@@ -766,7 +767,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
                     widget.scatterplot_item.setSize(size)
                     widget.scatterplot_item_sel.setSize(size + SELECTION_WIDTH)
 
-            if np.sum(current_size_data) / self.n_valid != -1 and np.sum(diff):
+            if self.n_valid <= MAX_N_VALID_SIZE_ANIMATE and \
+                    np.all(current_size_data > 0) and np.any(diff != 0):
                 # If encountered any strange behaviour when updating sizes,
                 # implement it with threads
                 self.timer = QTimer(self.scatterplot_item, interval=50)

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -455,6 +455,26 @@ class TestOWScatterPlotBase(WidgetTest):
             - graph.scatterplot_item.data["size"],
             SELECTION_WIDTH)
 
+    @patch("Orange.widgets.visualize.owscatterplotgraph"
+           ".MAX_N_VALID_SIZE_ANIMATE", 5)
+    def test_size_animation(self):
+        self._update_sizes_for_points(5)
+        self.assertEqual(self.graph.scatterplot_item.setSize.call_count, 6)
+        self._update_sizes_for_points(6)
+        self.graph.scatterplot_item.setSize.assert_called_once()
+
+    def _update_sizes_for_points(self, n: int):
+        arr = np.arange(n, dtype=float)
+        self.master.get_coordinates_data = lambda: (arr, arr)
+        self.master.get_size_data = lambda: arr
+        self.graph.reset_graph()
+        self.graph.scatterplot_item.setSize = Mock(
+            wraps=self.graph.scatterplot_item.setSize)
+        self.master.get_size_data = lambda: arr[::-1]
+        self.graph.update_sizes()
+        self.process_events(until=lambda: not (
+            self.graph.timer is not None and self.graph.timer.isActive()))
+
     def test_colors_discrete(self):
         self.master.is_continuous_color = lambda: False
         palette = self.master.get_palette()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3442

##### Description of changes
Maximum data size to animate resizing is now set to 1000.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
