### PR TITLE
Fix PyQt5 to version 5.11.3 on travis, until 5.12 issues are solved

### DIFF
--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -7,6 +7,9 @@ if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install pandas==0.20.3; fi
 
 pip install numba==0.41.0 llvmlite==0.26.0
 
+# Temporary fix until platform plugin issues are solved on 5.12
+pip install PyQt5==5.11.3
+
 # Install dependencies sequentially
 cat requirements-core.txt \
     requirements-gui.txt \


### PR DESCRIPTION
Since PyQt5 version 5.12 there are problems on travis:
`qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.`

Until resolved, fix PyQt5 version to 5.11.3 on travis.
