### PR TITLE
[ENH] Added keyboard shortcuts for Align & Freeze/Unfreeze 

### DIFF
--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -632,9 +632,10 @@ class CanvasMainWindow(QMainWindow):
 
         self.freeze_action = \
             QAction(self.tr("Freeze"), self,
+                    shortcut=QKeySequence("Shift+F"),
                     objectName="signal-freeze-action",
                     checkable=True,
-                    toolTip=self.tr("Freeze signal propagation."),
+                    toolTip=self.tr("Freeze signal propagation. (Shift+F)"),
                     toggled=self.set_signal_freeze,
                     icon=canvas_icons("Pause.svg")
                     )

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -635,7 +635,7 @@ class CanvasMainWindow(QMainWindow):
                     shortcut=QKeySequence("Shift+F"),
                     objectName="signal-freeze-action",
                     checkable=True,
-                    toolTip=self.tr("Freeze signal propagation. (Shift+F)"),
+                    toolTip=self.tr("Freeze signal propagation (Shift+F)"),
                     toggled=self.set_signal_freeze,
                     icon=canvas_icons("Pause.svg")
                     )

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -185,7 +185,8 @@ class SchemeEditWidget(QWidget):
         self.__cleanUpAction = \
             QAction(self.tr("Clean Up"), self,
                     objectName="cleanup-action",
-                    toolTip=self.tr("Align widgets to a grid."),
+                    shortcut=QKeySequence("Shift+A"),
+                    toolTip=self.tr("Align widgets to a grid. (Shift+A)"),
                     triggered=self.alignToGrid,
                     )
 

--- a/Orange/canvas/document/schemeedit.py
+++ b/Orange/canvas/document/schemeedit.py
@@ -186,7 +186,7 @@ class SchemeEditWidget(QWidget):
             QAction(self.tr("Clean Up"), self,
                     objectName="cleanup-action",
                     shortcut=QKeySequence("Shift+A"),
-                    toolTip=self.tr("Align widgets to a grid. (Shift+A)"),
+                    toolTip=self.tr("Align widgets to a grid (Shift+A)"),
                     triggered=self.alignToGrid,
                     )
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #2942

##### Description of changes
- Added keyboard shortcut Shift+A for aligning widgets to a grid
- Added keyboard shortcut Shift+F for freezing signal propagation

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
