### PR TITLE
[FIX] migrate_context: widgets crash when migrating context without version

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -663,9 +663,11 @@ class ContextHandler(SettingsHandler):
         """Call the inherited method, then add local contexts to the dict."""
         data = super().pack_data(widget)
         self.settings_from_widget(widget)
-        for context in widget.context_settings:
+        context_settings = [copy.copy(context) for context in
+                            widget.context_settings]
+        for context in context_settings:
             context.values[VERSION_KEY] = self.widget_class.settings_version
-        data["context_settings"] = widget.context_settings
+        data["context_settings"] = context_settings
         return data
 
     def update_defaults(self, widget):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Most widgets that implement migrate_context crash upon undo. 
To reproduce see #3600.

##### Description of changes
Add checks for required context values to all widget that implement migrate_context.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
