### PR TITLE
[FIX] Orange restart dialogs: Improve wording

### DIFF
--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -28,7 +28,7 @@ from AnyQt.QtWidgets import (
     QWidget, QDialog, QLabel, QLineEdit, QTreeView, QHeaderView,
     QTextBrowser, QDialogButtonBox, QProgressDialog,
     QVBoxLayout, QStyle, QStyledItemDelegate, QStyleOptionViewItem,
-    QApplication, QHBoxLayout, QPushButton, QFormLayout
+    QApplication, QHBoxLayout, QPushButton, QFormLayout, QMessageBox
 )
 
 from AnyQt.QtGui import (
@@ -41,9 +41,11 @@ from AnyQt.QtCore import (
     QSettings)
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
 
-from ..gui.utils import message_warning, message_information, \
-                        message_critical as message_error, \
-                        OSX_NSURL_toLocalFile
+from ..gui.utils import (
+    message_warning, message_critical as message_error,
+    OSX_NSURL_toLocalFile
+)
+
 from ..help.manager import get_dist_meta, trim, parse_meta
 
 
@@ -774,9 +776,25 @@ class AddonManagerDialog(QDialog):
         self.reject()
 
     def __on_installer_finished(self):
-        message = "Please restart Orange for changes to take effect."
-        message_information(message, parent=self)
-        self.accept()
+
+        def message_restart(parent):
+            icon = QMessageBox.Information
+            buttons = QMessageBox.Ok | QMessageBox.Cancel
+            title = 'Information'
+            text = 'A restart of the application is necessary for the ' \
+                   'changes to take effect.'
+
+            msg_box = QMessageBox(icon, title, text, buttons, parent)
+            msg_box.setDefaultButton(QMessageBox.Ok)
+            msg_box.button(QMessageBox.Ok).setText('Restart now')
+            msg_box.button(QMessageBox.Cancel).setText('Restart later')
+            return msg_box.exec_()
+
+        if QMessageBox.Ok == message_restart(self):
+            self.accept()
+            self.parent().close()
+        else:
+            self.reject()
 
 
 def list_available_versions():

--- a/Orange/canvas/application/addons.py
+++ b/Orange/canvas/application/addons.py
@@ -781,13 +781,13 @@ class AddonManagerDialog(QDialog):
             icon = QMessageBox.Information
             buttons = QMessageBox.Ok | QMessageBox.Cancel
             title = 'Information'
-            text = 'A restart of the application is necessary for the ' \
-                   'changes to take effect.'
+            text = 'Orange needs to be restarted for the changes to take effect.'
 
             msg_box = QMessageBox(icon, title, text, buttons, parent)
             msg_box.setDefaultButton(QMessageBox.Ok)
-            msg_box.button(QMessageBox.Ok).setText('Restart now')
-            msg_box.button(QMessageBox.Cancel).setText('Restart later')
+            msg_box.setInformativeText('Press OK to close Orange now.')
+
+            msg_box.button(QMessageBox.Cancel).setText('Close later')
             return msg_box.exec_()
 
         if QMessageBox.Ok == message_restart(self):

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1707,11 +1707,10 @@ class CanvasMainWindow(QMainWindow):
 
     def reset_widget_settings(self):
         res = message_question(
-            "Clear all widget settings on next restart",
+            "A restart of the application is necessary for the " +
+            "changes to take effect.",
             title="Clear settings",
-            informative_text=(
-                "A restart of the application is necessary " +
-                "for the changes to take effect"),
+            informative_text="Press OK to restart.",
             buttons=QMessageBox.Ok | QMessageBox.Cancel,
             default_button=QMessageBox.Ok,
             parent=self

--- a/Orange/canvas/application/canvasmain.py
+++ b/Orange/canvas/application/canvasmain.py
@@ -1706,11 +1706,10 @@ class CanvasMainWindow(QMainWindow):
         return dlg.exec_()
 
     def reset_widget_settings(self):
-        res = message_question(
-            "A restart of the application is necessary for the " +
-            "changes to take effect.",
+        res = message_information(
+            "Orange needs to be restarted for the changes to take effect.",
             title="Clear settings",
-            informative_text="Press OK to restart.",
+            informative_text="Press OK to close Orange now.",
             buttons=QMessageBox.Ok | QMessageBox.Cancel,
             default_button=QMessageBox.Ok,
             parent=self


### PR DESCRIPTION
##### Issue
Fixes #2581

##### Description of changes

Reset widget settings:
![clear_settings](https://user-images.githubusercontent.com/15876321/52867723-d5bbca00-3141-11e9-9f14-453b4079e215.png)

Also for add-on manager:
![add-ons](https://user-images.githubusercontent.com/15876321/52867735-db191480-3141-11e9-8c20-03c209dc96e1.png)





##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation