### PR TITLE
[FIX] LinearProjection: Disable LDA for less than three classes

### DIFF
--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -383,7 +383,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
 
         if self.data is not None:
             has_discrete_class = self.data.domain.has_discrete_class
-            if not has_discrete_class or len(np.unique(self.data.Y)) < 2:
+            if not has_discrete_class or len(np.unique(self.data.Y)) < 3:
                 buttons[self.Placement.LDA].setEnabled(False)
                 if self.placement == self.Placement.LDA:
                     self.placement = self.Placement.Circular

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -183,6 +183,11 @@ class TestOWLinearProjection(WidgetTest, AnchorProjectionWidgetTestMixin,
         self.send_signal(self.widget.Inputs.data, self.data)
         self.widget.setup_plot.assert_called_once()
 
+    def test_two_classes_dataset(self):
+        self.widget.radio_placement.buttons[1].click()
+        self.send_signal(self.widget.Inputs.data, Table("heart_disease"))
+        self.assertFalse(self.widget.radio_placement.buttons[1].isEnabled())
+
 
 class LinProjVizRankTests(WidgetTest):
     """


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget crashed when feed a dataset with two classes.
To reproduce: File(heart_disease) -> LinearProjection(Select Linear Discriminant Analysis) 

##### Description of changes
Disable Linear Discriminant Analysis when dataset has target with less than three classes.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
