### PR TITLE
[FIX] Louvain clustering fails when Table or ndarray on input.

### DIFF
--- a/Orange/clustering/louvain.py
+++ b/Orange/clustering/louvain.py
@@ -41,8 +41,8 @@ def table_to_knn_graph(data, k_neighbors, metric, progress_callback=None):
 
     """
     # We do k + 1 because each point is closest to itself, which is not useful
-    knn = NearestNeighbors(n_neighbors=k_neighbors, metric=metric).fit(data.X)
-    nearest_neighbors = knn.kneighbors(data.X, return_distance=False)
+    knn = NearestNeighbors(n_neighbors=k_neighbors, metric=metric).fit(data)
+    nearest_neighbors = knn.kneighbors(data, return_distance=False)
     # Convert to list of sets so jaccard can be computed efficiently
     nearest_neighbors = list(map(set, nearest_neighbors))
     num_nodes = len(nearest_neighbors)
@@ -148,3 +148,10 @@ class Louvain:
     def fit_predict(self, X, y=None):
         self.fit(X, y)
         return self.labels
+
+
+if __name__ == "__main__":
+    # clustering run on iris data - orange table
+    data = Table("iris")
+    louvain = Louvain(2)
+    louvain.fit(data)

--- a/Orange/tests/test_louvain.py
+++ b/Orange/tests/test_louvain.py
@@ -1,0 +1,26 @@
+# Test methods with long descriptive names can omit docstrings
+# pylint: disable=missing-docstring
+
+import unittest
+import numpy as np
+
+from Orange.data import Table
+from Orange.clustering.louvain import Louvain
+
+
+class TestSVMLearner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = Table('iris')
+        cls.louvain = Louvain()
+
+    def test_orange_table(self):
+        self.assertIsNone(self.louvain.fit(self.data))
+        clusters = self.louvain.fit_predict(self.data)
+        self.assertIn(type(clusters), [list, np.ndarray])
+
+    def test_np_array(self):
+        data_np = self.data.X
+        self.assertIsNone(self.louvain.fit(data_np))
+        clusters = self.louvain.fit_predict(data_np)
+        self.assertIn(type(clusters), [list, np.ndarray])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When Louvain clustering got `Orange.Table` or `ndarray` on the input it fails when convertin table to graph. 

The way to reproduce: 

    data = Table("iris")
    louvain = Louvain(2)
    louvain.fit(data)

##### Description of changes

Fixed to accept `Table` or `ndarray`.
Added tests.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
