### PR TITLE
Remove sparse support for Hamming

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -662,7 +662,7 @@ class MahalanobisDistance:
         return Mahalanobis(axis=axis).fit(data)
 
 class Hamming(Distance):
-    supports_sparse = True
+    supports_sparse = False
     supports_missing = False
     supports_normalization = False
     supports_discrete = True

--- a/Orange/distance/tests/test_distance.py
+++ b/Orange/distance/tests/test_distance.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from math import sqrt
 
 import numpy as np
+from scipy.sparse import csr_matrix
 
 from Orange.data import ContinuousVariable, DiscreteVariable, Domain, Table
 from Orange import distance
@@ -23,6 +24,14 @@ class CommonTests:
         np.testing.assert_almost_equal(
             self.Distance(Table(self.domain), self.data),
             np.zeros((0, n)))
+
+    def test_sparse(self):
+        """Test sparse support in distances."""
+        sparse_iris = csr_matrix(Table('iris').X)
+        if not self.Distance.supports_sparse:
+            self.assertRaises(TypeError, self.Distance, sparse_iris)
+        else:
+            self.Distance(sparse_iris)
 
 
 class CommonFittedTests(CommonTests):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Hamming distance does not support sparse as stated in [sklearn documentation](https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise_distances.html).

##### Description of changes
Set support_sparse to False. Add test to ensure error is raised when trying to compute distances with metrics that do not support sparse.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
