### PR TITLE
[MNT] Disable check for add unsubscriptable-object in pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,8 @@ disable=
     parameter-unpacking,long-suffix,cmp-method,using-cmp-argument,
     useless-suppression,import-error,
     empty-docstring,missing-docstring,redefined-outer-name,redefined-builtin,
-    attribute-defined-outside-init, no-else-return, len-as-condition, invalid-sequence-index
+    attribute-defined-outside-init, no-else-return, len-as-condition, invalid-sequence-index,
+    unsubscriptable-object
 
 
 [REPORTS]


### PR DESCRIPTION
Pylint 2.3.0 introduced a lot of new false positives for `unsubscriptable-object`.

We use pylint mostly as style checker, while unsubscriptable objects are/should/can be/must be properly detected by unit tests.