### PR TITLE
[FIX] Send usage statistics in a thread at startup

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -276,8 +276,12 @@ def send_usage_statistics():
 
     class SendUsageStatistics(QThread):
         def run(self):
-            usage = UsageStatistics()
-            usage.send_statistics()
+            try:
+                usage = UsageStatistics()
+                usage.send_statistics()
+            except Exception:  # pylint: disable=broad-except
+                # exceptions in threads would crash Orange
+                log.warning("Failed to send usage statistics.")
 
     thread = SendUsageStatistics()
     thread.start()

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -34,6 +34,7 @@ from Orange.canvas.application.errorreporting import handle_exception
 from Orange.canvas.gui.splashscreen import SplashScreen
 from Orange.canvas.config import cache_dir
 from Orange.canvas import config
+from Orange.canvas.document.usagestatistics import UsageStatistics
 
 from Orange.canvas.registry import qt
 from Orange.canvas.registry import WidgetRegistry, set_global_registry
@@ -271,6 +272,16 @@ def check_for_updates():
         thread.start()
         return thread
 
+def send_usage_statistics():
+
+    class SendUsageStatistics(QThread):
+        def run(self):
+            usage = UsageStatistics()
+            usage.send_statistics()
+
+    thread = SendUsageStatistics()
+    thread.start()
+    return thread
 
 def main(argv=None):
     if argv is None:
@@ -545,6 +556,7 @@ def main(argv=None):
     # local references prevent destruction
     survey = show_survey()
     update_check = check_for_updates()
+    send_stat = send_usage_statistics()
 
     # Tee stdout and stderr into Output dock
     log_view = canvas_window.log_view()
@@ -577,6 +589,7 @@ def main(argv=None):
     del canvas_window
     del survey
     del update_check
+    del send_stat
 
     app.processEvents()
     app.flush()

--- a/Orange/canvas/document/usagestatistics.py
+++ b/Orange/canvas/document/usagestatistics.py
@@ -105,6 +105,26 @@ class UsageStatistics:
     def set_node_type(self, addition_type):
         self.__node_addition_type = addition_type
 
+    def send_statistics(self):
+        if release and config.settings()["error-reporting/send-statistics"]:
+            if os.path.isfile(statistics_path):
+                with open(statistics_path) as f:
+                    data = json.load(f)
+                try:
+                    r = requests.post(server_url, files={'file': json.dumps(data)})
+                    if r.status_code != 200:
+                        log.warning("Error communicating with server while attempting to send "
+                                    "usage statistics.")
+                        return
+                    # success - wipe statistics file
+                    log.info("Usage statistics sent.")
+                    with open(statistics_path, 'w') as f:
+                        json.dump([], f)
+                except (ConnectionError, requests.exceptions.RequestException):
+                    log.warning("Connection error while attempting to send usage statistics.")
+                except Exception:
+                    log.warning("Failed to send usage statistics.")
+
     def write_statistics(self):
         if not release:
             log.info("Not sending usage statistics (non-release version of Orange detected).")
@@ -134,24 +154,9 @@ class UsageStatistics:
 
         data.append(statistics)
 
-        def store_data(d):
-            with open(statistics_path, 'w') as f:
-                json.dump(d, f)
+        with open(statistics_path, 'w') as f:
+            json.dump(data, f)
 
-        try:
-            r = requests.post(server_url, files={'file': json.dumps(data)})
-            if r.status_code != 200:
-                log.warning("Error communicating with server while attempting to send "
-                            "usage statistics.")
-                store_data(data)
-                return
-            # success - wipe statistics file
-            log.info("Usage statistics sent.")
-            with open(statistics_path, 'w') as f:
-                json.dump([], f)
-        except (ConnectionError, requests.exceptions.RequestException):
-            log.warning("Connection error while attempting to send usage statistics.")
-            store_data(data)
 
     @staticmethod
     def set_last_search_query(query):

--- a/Orange/canvas/document/usagestatistics.py
+++ b/Orange/canvas/document/usagestatistics.py
@@ -122,8 +122,6 @@ class UsageStatistics:
                         json.dump([], f)
                 except (ConnectionError, requests.exceptions.RequestException):
                     log.warning("Connection error while attempting to send usage statistics.")
-                except Exception:
-                    log.warning("Failed to send usage statistics.")
 
     def write_statistics(self):
         if not release:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3597

##### Description of changes
When closing Orange, usage statistics are saved. Then, when starting Orange, usage statistics are sent in the background.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation