### PR TITLE
[FIX] OWTable: Include attributes from meta attributes in header row labels

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -689,7 +689,8 @@ class OWDataTable(widget.OWWidget):
                 RichTableModel.Labels | RichTableModel.Name)
 
             labelnames = set()
-            for a in model.source.domain.variables:
+            domain = model.source.domain
+            for a in itertools.chain(domain.metas, domain.variables):
                 labelnames.update(a.attributes.keys())
             labelnames = sorted(
                 [label for label in labelnames if not label.startswith("_")])

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -1,8 +1,8 @@
-# Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+from unittest.mock import Mock
+
 from Orange.widgets.data.owtable import OWDataTable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
-from Orange.data import Table
+from Orange.data import Table, Domain
 
 
 class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
@@ -43,3 +43,16 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
         self.widget.selected_rows = list(range(0, len(self.data.domain), 10))
         self.widget.set_selection()
         return self.widget.selected_rows
+
+    def test_attrs_appear_in_corner_text(self):
+        iris = Table("iris")
+        domain = iris.domain
+        new_domain = Domain(
+            domain.attributes[1:], iris.domain.class_var, domain.attributes[:1])
+        new_domain.metas[0].attributes = {"c": "foo"}
+        new_domain.attributes[0].attributes = {"a": "bar", "c": "baz"}
+        new_domain.class_var.attributes = {"b": "foo"}
+        self.widget.set_corner_text = Mock()
+        self.send_signal(self.widget.Inputs.data, iris.transform(new_domain))
+        self.assertEqual(
+            self.widget.set_corner_text.call_args[0][1], "\na\nb\nc")


### PR DESCRIPTION
##### Issue

Fixes #2777

##### Includes
- [X] Code changes
- [X] Tests