### PR TITLE
OWFile: PyLint

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -82,7 +82,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     keywords = ["file", "load", "read", "open"]
 
     class Outputs:
-        data = Output("Data", Table, doc="Attribute-valued dataset read from the input file.")
+        data = Output("Data", Table,
+                      doc="Attribute-valued dataset read from the input file.")
 
     want_main_area = False
 
@@ -237,7 +238,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         QTimer.singleShot(0, self.load_data)
 
-    def sizeHint(self):
+    @staticmethod
+    def sizeHint():
         return QSize(600, 550)
 
     def select_file(self, n):
@@ -277,7 +279,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             start_file = self.last_path() or os.path.expanduser("~/")
 
         readers = [f for f in FileFormat.formats
-                   if getattr(f, 'read', None) and getattr(f, "EXTENSIONS", None)]
+                   if getattr(f, 'read', None)
+                   and getattr(f, "EXTENSIONS", None)]
         filename, reader, _ = open_filename_dialog(start_file, None, readers)
         if not filename:
             return
@@ -344,13 +347,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         self.apply_domain_edit()  # sends data
         return None
 
-    def _get_reader(self):
-        """
-
-        Returns
-        -------
-        FileFormat
-        """
+    def _get_reader(self) -> FileFormat:
         if self.source == self.LOCAL_FILE:
             path = self.last_path()
             if path is None:
@@ -393,7 +390,14 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         else:
             self.sheet_combo.setCurrentIndex(0)
 
-    def _describe(self, table):
+    @staticmethod
+    def _describe(table):
+        def missing_prop(prop):
+            if prop:
+                return f"({prop * 100:.1f}% missing values)"
+            else:
+                return "(no missing values)"
+
         domain = table.domain
         text = ""
 
@@ -401,36 +405,35 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         descs = [attrs[desc]
                  for desc in ("Name", "Description") if desc in attrs]
         if len(descs) == 2:
-            descs[0] = "<b>{}</b>".format(descs[0])
+            descs[0] = f"<b>{descs[0]}</b>"
         if descs:
-            text += "<p>{}</p>".format("<br/>".join(descs))
-        # Instances
-        text += "<p>{} instance(s)".format(len(table))
-        # Attributes
-        missing_attr = "({:.1f}% missing values)".format(table.get_nan_frequency_attribute() * 100) \
-            if table.has_missing_attribute() else "(no missing values)"
-        text += "<br/>{} feature(s) {}".format(len(domain.attributes), missing_attr)
-        # Classes
-        missing_class = "({:.1f}% missing values)".format(table.get_nan_frequency_class() * 100) \
-            if table.has_missing_class() else "(no missing values)"
+            text += f"<p>{'<br/>'.join(descs)}</p>"
+
+        text += f"<p>{len(table)} instance(s)"
+
+        missing_in_attr = missing_prop(table.has_missing_attribute()
+                                       and table.get_nan_frequency_attribute())
+        missing_in_class = missing_prop(table.has_missing_class()
+                                        and table.get_nan_frequency_class())
+        text += f"<br/>{len(domain.attributes)} feature(s) {missing_in_attr}"
         if domain.has_continuous_class:
-            text += "<br/>Regression; numerical class {}".format(missing_class)
+            text += f"<br/>Regression; numerical class {missing_in_class}"
         elif domain.has_discrete_class:
-            text += "<br/>Classification; categorical class with {} values {}".format(
-                len(domain.class_var.values), missing_class)
+            text += "<br/>Classification; categorical class " \
+                f"with {len(domain.class_var.values)} values {missing_in_class}"
         elif table.domain.class_vars:
-            text += "<br/>Multi-target; {} target variables {}".format(
-                len(table.domain.class_vars), missing_class)
+            text += "<br/>Multi-target; " \
+                f"{len(table.domain.class_vars)} target variables " \
+                f"{missing_in_class}"
         else:
             text += "<br/>Data has no target variable."
-        # Metas
-        text += "<br/>{} meta attribute(s)".format(len(domain.metas))
+        text += f"<br/>{len(domain.metas)} meta attribute(s)"
         text += "</p>"
 
         if 'Timestamp' in table.domain:
             # Google Forms uses this header to timestamp responses
-            text += '<p>First entry: {}<br/>Last entry: {}</p>'.format(
-                table[0, 'Timestamp'], table[-1, 'Timestamp'])
+            text += f"<p>First entry: {table[0, 'Timestamp']}<br/>" \
+                f"Last entry: {table[-1, 'Timestamp']}</p>"
         return text
 
     def storeSpecificSettings(self):
@@ -481,7 +484,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             else:
                 name = self.loaded_file
             if self.sheet_combo.isVisible():
-                name += " ({})".format(self.sheet_combo.currentText())
+                name += f" ({self.sheet_combo.currentText()})"
             self.report_items("File", [("File name", name),
                                        ("Format", get_ext_name(name))])
         else:
@@ -490,7 +493,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         self.report_data("Data", self.data)
 
-    def dragEnterEvent(self, event):
+    @staticmethod
+    def dragEnterEvent(event):
         """Accept drops of valid file urls"""
         urls = event.mimeData().urls()
         if urls:


### PR DESCRIPTION
`OWFile` now almost passes pylint with disabling only `missing-docstring,  no-name-in-module,  too-many-ancestors, no-else-return`. The only remaning issue is redefinining the built-in `vars`.

Most of this PR is however about breaking long lines, and at the same time I converted formatting strings to f-strings, refactoring the corresponding code to something simpler.