### PR TITLE
OWNeighbors: PyLint

### DIFF
--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -46,6 +46,9 @@ class OWNeighbors(OWWidget):
     class Error(OWWidget.Error):
         diff_domains = Msg("Data and reference have different features")
 
+    n_neighbors: int
+    distance_index: int
+
     n_neighbors = Setting(10)
     distance_index = Setting(0)
     exclude_reference = Setting(True)
@@ -121,7 +124,7 @@ class OWNeighbors(OWWidget):
             self.distances = None
             return
 
-        distance = METRICS[self.distance_index][1]
+        metric = METRICS[self.distance_index][1]
         n_ref = len(self.reference)
 
         # comparing only attributes, no metas and class-vars
@@ -132,7 +135,7 @@ class OWNeighbors(OWWidget):
         all_data = Table.concatenate([reference, data], 0)
         pp_all_data = Impute()(RemoveNaNColumns()(all_data))
         pp_reference, pp_data = pp_all_data[:n_ref], pp_all_data[n_ref:]
-        self.distances = distance(pp_data, pp_reference).min(axis=1)
+        self.distances = metric(pp_data, pp_reference).min(axis=1)
 
     def apply(self):
         indices = self._compute_indices()
@@ -174,7 +177,7 @@ class OWNeighbors(OWWidget):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    data = Table("iris.tab")
+    iris = Table("iris.tab")
     WidgetPreview(OWNeighbors).run(
-        set_data=data,
-        set_ref=data[:1])
+        set_data=iris,
+        set_ref=iris[:1])


### PR DESCRIPTION
Now passes pylint with disabling only `missing-docstring`, `no-name-in-module`, `too-many-ancestors`, `no-else-return`.

... except for taking a length of a data table.