### PR TITLE
Make widget classes final, unless explicitly declared open

### DIFF
--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -10,7 +10,7 @@ from AnyQt.QtWidgets import QFileDialog
 from Orange.data import Table
 from Orange.data.io import TabReader, PickleReader, ExcelReader
 from Orange.tests import named_file
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.base import WidgetTest, open_widget_classes
 from Orange.widgets.data.owsave import OWSave
 
 
@@ -23,12 +23,13 @@ def _w(s):  # pylint: disable=invalid-name
 
 class TestOWSaveBase(WidgetTest):
     def setUp(self):
-        class OWSaveMockWriter(OWSave):
-            writer = Mock()
-            writer.EXTENSIONS = [".csv"]
-            writer.SUPPORT_COMPRESSED = True
-            writer.SUPPORT_SPARSE_DATA = False
-            writer.OPTIONAL_TYPE_ANNOTATIONS = False
+        with open_widget_classes():
+            class OWSaveMockWriter(OWSave):
+                writer = Mock()
+                writer.EXTENSIONS = [".csv"]
+                writer.SUPPORT_COMPRESSED = True
+                writer.SUPPORT_SPARSE_DATA = False
+                writer.OPTIONAL_TYPE_ANNOTATIONS = False
 
         self.widget = self.create_widget(OWSaveMockWriter)  # type: OWSave
         self.iris = Table("iris")

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -1200,3 +1200,9 @@ class datasets:
         yield cls.data_one_column_nans()
         yield ds_cls
         yield ds_reg
+
+
+@contextmanager
+def open_widget_classes():
+    with patch.object(OWWidget, "__init_subclass__"):
+        yield

--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -1,7 +1,7 @@
-# Test methods with long descriptive names can omit docstrings
-# pylint: disable=all
+# pylint: disable=protected-access
 
 import gc
+import warnings
 import weakref
 
 from unittest.mock import patch, MagicMock
@@ -19,7 +19,7 @@ from Orange.widgets.utils.messagewidget import MessagesWidget
 
 
 class DummyComponent(OWComponent):
-    b = None
+    dummyattr = None
 
 
 class MyWidget(OWWidget):
@@ -43,8 +43,8 @@ class WidgetTestCase(WidgetTest):
         setattr(widget, 'field', 1)
         self.assertEqual(widget.field, 1)
 
-        setattr(widget, 'component.b', 2)
-        self.assertEqual(widget.component.b, 2)
+        setattr(widget, 'component.dummyattr', 2)
+        self.assertEqual(widget.component.dummyattr, 2)
 
         setattr(widget, 'widget.field', 3)
         self.assertEqual(widget.widget.field, 3)
@@ -192,6 +192,18 @@ class WidgetTestCase(WidgetTest):
         w.statusBar().hide()
         self.assertFalse(action.isChecked())
 
+    def test_widgets_cant_be_subclassed(self):
+        # pylint: disable=unused-variable
+        with self.assertWarns(RuntimeWarning):
+            class MySubWidget(MyWidget):
+                pass
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", ".*", RuntimeWarning)
+            class MyWidget2(OWWidget, openclass=True):
+                pass
+            class MySubWidget2(OWWidget):
+                pass
 
 class WidgetMsgTestCase(WidgetTest):
 

--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -1,7 +1,6 @@
 # pylint: disable=protected-access
 
 import gc
-import warnings
 import weakref
 
 from unittest.mock import patch, MagicMock
@@ -198,12 +197,16 @@ class WidgetTestCase(WidgetTest):
             class MySubWidget(MyWidget):
                 pass
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("error", ".*", RuntimeWarning)
+        with patch("warnings.warn") as warn:
+
             class MyWidget2(OWWidget, openclass=True):
                 pass
-            class MySubWidget2(OWWidget):
+
+            class MySubWidget2(MyWidget2):
                 pass
+
+            warn.assert_not_called()
+
 
 class WidgetMsgTestCase(WidgetTest):
 

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -25,7 +25,7 @@ class OWBaseLearnerMeta(WidgetMetaClass):
     its own Outputs class with output that match the corresponding
     learner.
     """
-    def __new__(cls, name, bases, attributes):
+    def __new__(cls, name, bases, attributes, **kwargs):
         def abstract_widget():
             return not attributes.get("name")
 
@@ -35,7 +35,7 @@ class OWBaseLearnerMeta(WidgetMetaClass):
                 setattr(result, name, deepcopy(signal))
             return result
 
-        obj = super().__new__(cls, name, bases, attributes)
+        obj = super().__new__(cls, name, bases, attributes, **kwargs)
         if abstract_widget():
             return obj
 
@@ -51,7 +51,7 @@ class OWBaseLearnerMeta(WidgetMetaClass):
         return obj
 
 
-class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta):
+class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
     """Abstract widget for classification/regression learners.
 
     Notes

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -40,7 +40,7 @@ class TestOWBaseLearner(WidgetTest):
         self.assertFalse(self.widget.Error.fitting_failed.is_shown())
 
     def test_subclasses_do_not_share_outputs(self):
-        class WidgetA(OWBaseLearner):
+        class WidgetA(OWBaseLearner, openclass=True):
             name = "A"
             LEARNER = KNNLearner
 

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -358,7 +358,7 @@ class TreeNavigator(QGraphicsView):
             self.master_view.mapToScene(self.master_view.viewport().rect()))
 
 
-class OWTreeViewer2D(OWWidget):
+class OWTreeViewer2D(OWWidget, openclass=True):
     zoom = Setting(5)
     line_width_method = Setting(2)
     max_tree_depth = Setting(0)

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -33,7 +33,7 @@ MAX_CATEGORIES = 11  # maximum number of colors or shapes (including Other)
 MAX_POINTS_IN_TOOLTIP = 5
 
 
-class OWProjectionWidgetBase(OWWidget):
+class OWProjectionWidgetBase(OWWidget, openclass=True):
     """
     Base widget for widgets that use attribute data to set the colors, labels,
     shapes and sizes of points.
@@ -343,7 +343,7 @@ class OWProjectionWidgetBase(OWWidget):
         self.graph.update_tooltip(event.modifiers())
 
 
-class OWDataProjectionWidget(OWProjectionWidgetBase):
+class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
     """
     Base widget for widgets that get Data and Data Subset (both
     Orange.data.Table) on the input, and output Selected Data and Data
@@ -615,7 +615,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase):
         self.graph.clear()
 
 
-class OWAnchorProjectionWidget(OWDataProjectionWidget):
+class OWAnchorProjectionWidget(OWDataProjectionWidget, openclass=True):
     """ Base widget for widgets with graphs with anchors. """
     SAMPLE_SIZE = 100
 


### PR DESCRIPTION
##### Issue

We always silently assume that widget classes are final. Without this, we wouldn't be able to redesign widgets, not even to change a badly named attribute.

Some widgets, like `OWDatasets` are, however, unexpectedly subclassed, as I was warned in #3642.

I propose to make all widgets final unless explicitly declared open. We will open abstract widgets like `OWWidget`, `OWProjectionWidgetBase`, `OWProjectionWidget`. If we really wish, we can also open non-abstract widgets, such as `OWDatasets`, but opening them will represent a commitment to avoid backward incompatible changes.

##### Description of changes

An open class shall be declared by adding `openclass=True` keyword to its definition, *e.g.* `class OWProjectionWidgetBase(OWWidget, openclass=True):`. Ordinary class attribute would not work because it would be inherited.

To implement this, metaclass puts a `_final_class` attribute into class namespace of final classes, and `__init_subclass__` hook in `OWWidget` checks it.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
