### PR TITLE
[ENH] Correlations: Enhancements and fixes

### DIFF
--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -206,9 +206,11 @@ class OWCorrelations(OWWidget):
     correlation_type = Setting(0)
 
     class Information(OWWidget.Information):
+        removed_cons_feat = Msg("Constant features have been removed.")
+
+    class Warning(OWWidget.Warning):
         not_enough_vars = Msg("Need at least two continuous features.")
         not_enough_inst = Msg("Need at least two instances.")
-        removed_cons_feat = Msg("Constant features have been removed.")
 
     def __init__(self):
         super().__init__()
@@ -296,7 +298,7 @@ class OWCorrelations(OWWidget):
         self.selection = ()
         if data is not None:
             if len(data) < 2:
-                self.Information.not_enough_inst()
+                self.Warning.not_enough_inst()
             else:
                 domain = data.domain
                 cont_attrs = [a for a in domain.attributes if a.is_continuous]
@@ -307,7 +309,7 @@ class OWCorrelations(OWWidget):
                 if remover.attr_results["removed"]:
                     self.Information.removed_cons_feat()
                 if len(cont_data.domain.attributes) < 2:
-                    self.Information.not_enough_vars()
+                    self.Warning.not_enough_vars()
                 else:
                     self.cont_data = SklImpute()(cont_data)
         self.set_feature_model()

--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -53,7 +53,7 @@ class Cluster(SimpleNamespace):
 
 class KMeansCorrelationHeuristic:
     """
-    Heuristic to obtain the most promising attribute pairs, when there are to
+    Heuristic to obtain the most promising attribute pairs, when there are too
     many attributes to calculate correlations for all possible pairs.
     """
     def __init__(self, data):
@@ -221,8 +221,8 @@ class OWCorrelations(OWWidget):
         removed_cons_feat = Msg("Constant features have been removed.")
 
     class Warning(OWWidget.Warning):
-        not_enough_vars = Msg("Need at least two continuous features.")
-        not_enough_inst = Msg("Need at least two instances.")
+        not_enough_vars = Msg("At least two continuous features are needed.")
+        not_enough_inst = Msg("At least two instances are needed.")
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -237,9 +237,8 @@ class OWCorrelations(OWWidget):
         )
 
         self.feature_model = DomainModel(
-            separators=False, placeholder="(All combinations)",
-            valid_types=ContinuousVariable,
-        )
+            order=DomainModel.ATTRIBUTES, separators=False,
+            placeholder="(All combinations)", valid_types=ContinuousVariable)
         gui.comboBox(
             box, self, "feature", callback=self._feature_combo_changed,
             model=self.feature_model

--- a/Orange/widgets/data/tests/test_owcorrelations.py
+++ b/Orange/widgets/data/tests/test_owcorrelations.py
@@ -46,9 +46,9 @@ class TestOWCorrelations(WidgetTest):
     def test_input_data_disc(self):
         """Check correlation table for dataset with discrete attributes"""
         self.send_signal(self.widget.Inputs.data, self.data_disc)
-        self.assertTrue(self.widget.Information.not_enough_vars.is_shown())
+        self.assertTrue(self.widget.Warning.not_enough_vars.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Information.not_enough_vars.is_shown())
+        self.assertFalse(self.widget.Warning.not_enough_vars.is_shown())
 
     def test_input_data_mixed(self):
         """Check correlation table for dataset with continuous and discrete
@@ -68,9 +68,9 @@ class TestOWCorrelations(WidgetTest):
         time.sleep(0.1)
         self.process_events()
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
-        self.assertTrue(self.widget.Information.not_enough_vars.is_shown())
+        self.assertTrue(self.widget.Warning.not_enough_vars.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Information.not_enough_vars.is_shown())
+        self.assertFalse(self.widget.Warning.not_enough_vars.is_shown())
 
     def test_input_data_one_instance(self):
         """Check correlation table for dataset with one instance"""
@@ -79,9 +79,9 @@ class TestOWCorrelations(WidgetTest):
         self.process_events()
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
         self.assertFalse(self.widget.Information.removed_cons_feat.is_shown())
-        self.assertTrue(self.widget.Information.not_enough_inst.is_shown())
+        self.assertTrue(self.widget.Warning.not_enough_inst.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Information.not_enough_inst.is_shown())
+        self.assertFalse(self.widget.Warning.not_enough_inst.is_shown())
 
     def test_input_data_with_constant_features(self):
         """Check correlation table for dataset with a constant columns"""
@@ -109,7 +109,7 @@ class TestOWCorrelations(WidgetTest):
         time.sleep(0.1)
         self.process_events()
         self.assertEqual(self.widget.vizrank.rank_model.columnCount(), 0)
-        self.assertTrue(self.widget.Information.not_enough_vars.is_shown())
+        self.assertTrue(self.widget.Warning.not_enough_vars.is_shown())
         self.assertTrue(self.widget.Information.removed_cons_feat.is_shown())
 
         self.send_signal(self.widget.Inputs.data, None)

--- a/Orange/widgets/data/tests/test_owcorrelations.py
+++ b/Orange/widgets/data/tests/test_owcorrelations.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring, protected-access
 import time
+import unittest
 from unittest.mock import patch, Mock
 
 import numpy as np
@@ -194,7 +195,7 @@ class TestOWCorrelations(WidgetTest):
         heuristic = KMeansCorrelationHeuristic(self.data_cont)
         heuristic.n_clusters = 2
         self.assertListEqual(list(heuristic.get_states(None)),
-                             [(0, 2), (0, 3), (2, 3)])
+                             [(0, 2), (0, 3), (2, 3), (0, 1), (1, 2), (1, 3)])
 
     def test_heuristic_get_states(self):
         """Check attribute pairs after the widget has been paused"""
@@ -203,7 +204,7 @@ class TestOWCorrelations(WidgetTest):
         states = heuristic.get_states(None)
         _ = next(states)
         self.assertListEqual(list(heuristic.get_states(next(states))),
-                             [(0, 3), (2, 3)])
+                             [(0, 3), (2, 3), (0, 1), (1, 2), (1, 3)])
 
     def test_correlation_type(self):
         c_type = self.widget.controls.correlation_type
@@ -254,18 +255,14 @@ class TestOWCorrelations(WidgetTest):
                                  self.widget.Outputs.features)])
 
     @patch("Orange.widgets.data.owcorrelations.SIZE_LIMIT", 2000)
-    @patch("Orange.widgets.data.owcorrelations."
-           "KMeansCorrelationHeuristic.n_clusters", 2)
     def test_vizrank_use_heuristic(self):
         self.send_signal(self.widget.Inputs.data, self.data_cont)
         time.sleep(0.1)
         self.process_events()
-        self.assertEqual(self.widget.vizrank.rank_model.rowCount(),
-                         len(self.widget.cont_data.domain.attributes) - 1)
+        self.assertTrue(self.widget.vizrank.use_heuristic)
+        self.assertEqual(self.widget.vizrank.rank_model.rowCount(), 6)
 
     @patch("Orange.widgets.data.owcorrelations.SIZE_LIMIT", 2000)
-    @patch("Orange.widgets.data.owcorrelations."
-           "KMeansCorrelationHeuristic.n_clusters", 1)
     def test_select_feature_against_heuristic(self):
         """Never use heuristic if feature is selected"""
         feature_combo = self.widget.controls.feature
@@ -312,3 +309,36 @@ class TestCorrelationRank(WidgetTest):
         self.vizrank.sel_feature_index = 2
         states = self.vizrank.iterate_states_by_feature()
         self.assertListEqual([(2, 0), (2, 1), (2, 3)], list(states))
+
+    def test_state_count(self):
+        self.assertEqual(self.vizrank.state_count(), 6)
+        self.vizrank.sel_feature_index = 2
+        self.assertEqual(self.vizrank.state_count(), 3)
+
+
+class TestKMeansCorrelationHeuristic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = Table("wine")
+        cls.heuristic = KMeansCorrelationHeuristic(cls.data)
+
+    def test_n_clusters(self):
+        self.assertEqual(self.heuristic.n_clusters, 3)
+
+    def test_get_clusters_of_attributes(self):
+        clusters = self.heuristic.get_clusters_of_attributes()
+        self.assertListEqual([[5, 6, 8, 10, 11], [1, 2, 3, 7], [0, 4, 9, 12]],
+                             [c.instances for c in clusters])
+
+    def test_get_states(self):
+        n_attrs = len(self.data.domain.attributes)
+        states = set(self.heuristic.get_states(None))
+        self.assertEqual(len(states), n_attrs * (n_attrs - 1) / 2)
+        self.assertSetEqual(set((min(i, j), max(i, j)) for i in
+                                range(n_attrs) for j in range(i)), states)
+
+    def test_get_states_one_cluster(self):
+        heuristic = KMeansCorrelationHeuristic(Table("iris")[:, :2])
+        states = set(heuristic.get_states(None))
+        self.assertEqual(len(states), 1)
+        self.assertSetEqual(states, {(0, 1)})

--- a/Orange/widgets/data/tests/test_owcorrelations.py
+++ b/Orange/widgets/data/tests/test_owcorrelations.py
@@ -227,6 +227,9 @@ class TestOWCorrelations(WidgetTest):
                            if attr.is_continuous]
         self.assertEqual(len(feature_combo.model()), len(cont_attributes) + 1)
 
+        self.send_signal(self.widget.Inputs.data, Table("housing"))
+        self.assertEqual(len(feature_combo.model()), 14)
+
     def test_select_feature(self):
         """Test feature selection"""
         feature_combo = self.widget.controls.feature


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements the last part of #3504.

##### Description of changes
- Improve heuristic to return all possible attribute pairs in most promising order, i.e. returning pairs within clusters first, followed by pairs among clusters (starting with closest clusters)
- Show `Need at least two continuous features.` and `Need at least two instances.` messages as warnings
- Fix feature model to contain only attributes (exclude class)
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
