### PR TITLE
[MNT] Confuse pylint to stop checking type for Setting

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -90,6 +90,24 @@ class Setting:
         return (self.default, )
 
 
+# Pylint ignores type annotations in assignments. For
+#
+#    x: int = Setting(0)
+#
+# it ignores `int` and assumes x is of type `Setting`. Annotations in
+# comments ( # type: int) also don't work. The only way to annotate x is
+#
+#    x: int
+#    x = Setting(0)
+#
+# but we don't want to clutter the code with extra lines of annotations. Hence
+# we disable checking the type of `Setting` by confusing pylint with an extra
+# definition that is never executed.
+if 1 == 0:
+    class Setting:  # pylint: disable=function-redefined
+        pass
+
+
 class SettingProvider:
     """A hierarchical structure keeping track of settings belonging to
     a class and child setting providers.


### PR DESCRIPTION
#3637, @lanzagar argued against extra annotation needed to tell pylint that `Setting(0)` is an `int`. I agree. Without a better solution, we can only disable checking the type by confusing pylint with a fake annotation that is never executed.

The code has no side-effects, and should not have detrimental side-effects for pylint: currently it *thinks* it knows the type of setting, and after the PR it apparently *knows it doesn't*.