### PR TITLE
setup.py: fix generating coverage output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Thumbs.db
 # PyLint, Coverage reports
 .pylint_cache/*
 htmlcov/*
+.coverage
+.coverage.*

--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ class CoverageCommand(Command):
         sys.exit(subprocess.call(r'''
         coverage run --source=Orange -m unittest -v Orange.tests
         echo; echo
+        coverage combine
         coverage report
         coverage html &&
             { echo; echo "See also: file://$(pwd)/htmlcov/index.html"; echo; }


### PR DESCRIPTION
##### Issue
`python setup.py coverage` did not generate anything.

##### Description of changes
I added `coverage combine` into setup.py. I guess that command was probably necessary since we added concurrency to .coveragerc.

I was thinking of adding widget tests to the coverage command but I opted not to, because `python setup.py test` does not run them either.