### PR TITLE
[FIX] Transform: Replace 'Preprocess' input with 'Template Data' input

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -536,18 +536,6 @@ class Scale(Preprocess):
         return data.transform(domain)
 
 
-class ApplyDomain(Preprocess):
-    def __init__(self, domain, name):
-        self._domain = domain
-        self._name = name
-
-    def __call__(self, data):
-        return data.transform(self._domain)
-
-    def __str__(self):
-        return self._name
-
-
 class PreprocessorList(Preprocess):
     """
     Store a list of preprocessors and on call apply them to the dataset.

--- a/Orange/widgets/data/owtransform.py
+++ b/Orange/widgets/data/owtransform.py
@@ -12,11 +12,11 @@ from Orange.widgets.widget import OWWidget, Input, Output, Msg
 
 
 class OWTransform(OWWidget):
-    name = "Transform"
-    description = "Transform data table."
+    name = "Apply Domain"
+    description = "Applies template domain on data table."
     icon = "icons/Transform.svg"
     priority = 2110
-    keywords = []
+    keywords = ["transform"]
 
     retain_all_data = Setting(False)
 

--- a/Orange/widgets/data/tests/test_owtransform.py
+++ b/Orange/widgets/data/tests/test_owtransform.py
@@ -1,8 +1,11 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from unittest.mock import Mock
+
+from numpy import testing as npt
+
 from Orange.data import Table
 from Orange.preprocess import Discretize, Continuize
-from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets.data.owtransform import OWTransform
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owpca import OWPCA
@@ -12,39 +15,39 @@ class TestOWTransform(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWTransform)
         self.data = Table("iris")
-        self.preprocessor = Discretize()
+        self.disc_data = Discretize()(self.data)
 
     def test_output(self):
-        # send data and preprocessor
-        self.send_signal(self.widget.Inputs.data, self.data)
-        self.send_signal(self.widget.Inputs.preprocessor, self.preprocessor)
+        # send data and template data
+        self.send_signal(self.widget.Inputs.data, self.data[::15])
+        self.send_signal(self.widget.Inputs.template_data, self.disc_data)
         output = self.get_output(self.widget.Outputs.transformed_data)
-        self.assertIsInstance(output, Table)
-        self.assertEqual("Input data with 150 instances and 4 features.",
+        self.assertTableEqual(output, self.disc_data[::15])
+        self.assertEqual("Input data with 10 instances and 4 features.",
                          self.widget.input_label.text())
-        self.assertEqual("Preprocessor Discretize() applied.",
-                         self.widget.preprocessor_label.text())
+        self.assertEqual("Template domain applied.",
+                         self.widget.template_label.text())
         self.assertEqual("Output data includes 4 features.",
                          self.widget.output_label.text())
 
-        # remove preprocessor
-        self.send_signal(self.widget.Inputs.preprocessor, None)
+        # remove template data
+        self.send_signal(self.widget.Inputs.template_data, None)
         output = self.get_output(self.widget.Outputs.transformed_data)
         self.assertIsNone(output)
-        self.assertEqual("Input data with 150 instances and 4 features.",
+        self.assertEqual("Input data with 10 instances and 4 features.",
                          self.widget.input_label.text())
-        self.assertEqual("No preprocessor on input.",
-                         self.widget.preprocessor_label.text())
+        self.assertEqual("No template data on input.",
+                         self.widget.template_label.text())
         self.assertEqual("", self.widget.output_label.text())
 
-        # send preprocessor
-        self.send_signal(self.widget.Inputs.preprocessor, self.preprocessor)
+        # send template data
+        self.send_signal(self.widget.Inputs.template_data, self.disc_data)
         output = self.get_output(self.widget.Outputs.transformed_data)
-        self.assertIsInstance(output, Table)
-        self.assertEqual("Input data with 150 instances and 4 features.",
+        self.assertTableEqual(output, self.disc_data[::15])
+        self.assertEqual("Input data with 10 instances and 4 features.",
                          self.widget.input_label.text())
-        self.assertEqual("Preprocessor Discretize() applied.",
-                         self.widget.preprocessor_label.text())
+        self.assertEqual("Template domain applied.",
+                         self.widget.template_label.text())
         self.assertEqual("Output data includes 4 features.",
                          self.widget.output_label.text())
 
@@ -53,48 +56,55 @@ class TestOWTransform(WidgetTest):
         output = self.get_output(self.widget.Outputs.transformed_data)
         self.assertIsNone(output)
         self.assertEqual("No data on input.", self.widget.input_label.text())
-        self.assertEqual("Preprocessor Discretize() on input.",
-                         self.widget.preprocessor_label.text())
+        self.assertEqual("Template data includes 4 features.",
+                         self.widget.template_label.text())
         self.assertEqual("", self.widget.output_label.text())
 
-        # remove preprocessor
-        self.send_signal(self.widget.Inputs.preprocessor, None)
+        # remove template data
+        self.send_signal(self.widget.Inputs.template_data, None)
         self.assertEqual("No data on input.", self.widget.input_label.text())
-        self.assertEqual("No preprocessor on input.",
-                         self.widget.preprocessor_label.text())
+        self.assertEqual("No template data on input.",
+                         self.widget.template_label.text())
         self.assertEqual("", self.widget.output_label.text())
 
-    def test_input_pca_preprocessor(self):
+    def assertTableEqual(self, table1, table2):
+        self.assertIs(table1.domain, table2.domain)
+        npt.assert_array_equal(table1.X, table2.X)
+        npt.assert_array_equal(table1.Y, table2.Y)
+        npt.assert_array_equal(table1.metas, table2.metas)
+
+    def test_input_pca_output(self):
         owpca = self.create_widget(OWPCA)
         self.send_signal(owpca.Inputs.data, self.data, widget=owpca)
         owpca.components_spin.setValue(2)
-        pp = self.get_output(owpca.Outputs.preprocessor, widget=owpca)
-        self.assertIsNotNone(pp, Preprocess)
+        pca_out = self.get_output(owpca.Outputs.transformed_data, widget=owpca)
 
-        self.send_signal(self.widget.Inputs.data, self.data)
-        self.send_signal(self.widget.Inputs.preprocessor, pp)
+        self.send_signal(self.widget.Inputs.data, self.data[::10])
+        self.send_signal(self.widget.Inputs.template_data, pca_out)
         output = self.get_output(self.widget.Outputs.transformed_data)
-        self.assertIsInstance(output, Table)
-        self.assertEqual(output.X.shape, (len(self.data), 2))
+        npt.assert_array_equal(pca_out.X[::10], output.X)
 
     def test_retain_all_data(self):
         data = Table("zoo")
+        cont_data = Continuize()(data)
         self.send_signal(self.widget.Inputs.data, data)
-        self.send_signal(self.widget.Inputs.preprocessor, Continuize())
+        self.send_signal(self.widget.Inputs.template_data, cont_data)
         self.widget.controls.retain_all_data.click()
         output = self.get_output(self.widget.Outputs.transformed_data)
         self.assertIsInstance(output, Table)
         self.assertEqual(output.X.shape, (len(data), 16))
-        self.assertEqual(output.metas.shape, (len(data), 37))
+        self.assertEqual(output.metas.shape, (len(data), 38))
 
     def test_error_transforming(self):
-        self.send_signal(self.widget.Inputs.data, self.data)
-        self.send_signal(self.widget.Inputs.preprocessor, Preprocess())
-        self.assertTrue(self.widget.Error.pp_error.is_shown())
+        data = self.data[::10]
+        data.transform = Mock(side_effect=Exception())
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.template_data, self.disc_data)
+        self.assertTrue(self.widget.Error.error.is_shown())
         output = self.get_output(self.widget.Outputs.transformed_data)
         self.assertIsNone(output)
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Error.pp_error.is_shown())
+        self.assertFalse(self.widget.Error.error.is_shown())
 
     def test_send_report(self):
         self.send_signal(self.widget.Inputs.data, self.data)

--- a/Orange/widgets/data/tests/test_owtransform.py
+++ b/Orange/widgets/data/tests/test_owtransform.py
@@ -1,7 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from Orange.data import Table
-from Orange.preprocess import Discretize
+from Orange.preprocess import Discretize, Continuize
 from Orange.preprocess.preprocess import Preprocess
 from Orange.widgets.data.owtransform import OWTransform
 from Orange.widgets.tests.base import WidgetTest
@@ -33,7 +33,8 @@ class TestOWTransform(WidgetTest):
         self.assertIsNone(output)
         self.assertEqual("Input data with 150 instances and 4 features.",
                          self.widget.input_label.text())
-        self.assertEqual("No preprocessor on input.", self.widget.preprocessor_label.text())
+        self.assertEqual("No preprocessor on input.",
+                         self.widget.preprocessor_label.text())
         self.assertEqual("", self.widget.output_label.text())
 
         # send preprocessor
@@ -76,13 +77,15 @@ class TestOWTransform(WidgetTest):
         self.assertIsInstance(output, Table)
         self.assertEqual(output.X.shape, (len(self.data), 2))
 
-        # test retain data functionality
-        self.widget.retain_all_data = True
-        self.widget.apply()
+    def test_retain_all_data(self):
+        data = Table("zoo")
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.preprocessor, Continuize())
+        self.widget.controls.retain_all_data.click()
         output = self.get_output(self.widget.Outputs.transformed_data)
         self.assertIsInstance(output, Table)
-        self.assertEqual(output.X.shape, (len(self.data), 4))
-        self.assertEqual(output.metas.shape, (len(self.data), 2))
+        self.assertEqual(output.X.shape, (len(data), 16))
+        self.assertEqual(output.metas.shape, (len(data), 37))
 
     def test_error_transforming(self):
         self.send_signal(self.widget.Inputs.data, self.data)
@@ -98,3 +101,8 @@ class TestOWTransform(WidgetTest):
         self.widget.report_button.click()
         self.send_signal(self.widget.Inputs.data, None)
         self.widget.report_button.click()
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main()

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -31,7 +31,7 @@ from Orange.data import (
 )
 from Orange.modelling import Fitter
 from Orange.preprocess import RemoveNaNColumns, Randomize, Continuize
-from Orange.preprocess.preprocess import PreprocessorList, Preprocess
+from Orange.preprocess.preprocess import PreprocessorList
 from Orange.regression.base_regression import (
     LearnerRegression, ModelRegression
 )
@@ -1073,18 +1073,6 @@ class AnchorProjectionWidgetTestMixin(ProjectionWidgetTestMixin):
         # check new state
         self.assertEqual(len(self.widget.graph.scatterplot_item.data), nvalid)
         np.testing.assert_equal(self.widget.graph.selection, selection)
-
-    def test_output_preprocessor(self):
-        self.send_signal(self.widget.Inputs.data, self.data)
-        pp = self.get_output(self.widget.Outputs.preprocessor)
-        self.assertIsInstance(pp, Preprocess)
-        transformed = pp(self.data[::10])
-        self.assertIsInstance(transformed, Table)
-        self.assertEqual(transformed.X.shape, (len(self.data) / 10, 2))
-        output = self.get_output(self.widget.Outputs.annotated_data)
-        np.testing.assert_array_equal(transformed.X, output.metas[::10, :2])
-        self.assertEqual([a.name for a in transformed.domain.attributes],
-                         [m.name for m in output.domain.metas[:2]])
 
 
 class datasets:

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -40,7 +40,6 @@ class OWPCA(widget.OWWidget):
         transformed_data = Output("Transformed data", Table)
         components = Output("Components", Table)
         pca = Output("PCA", PCA, dynamic=False)
-        preprocessor = Output("Preprocessor", preprocess.Preprocess)
 
     settingsHandler = settings.DomainContextHandler()
 
@@ -265,7 +264,6 @@ class OWPCA(widget.OWWidget):
         self.Outputs.transformed_data.send(None)
         self.Outputs.components.send(None)
         self.Outputs.pca.send(self._pca_projector)
-        self.Outputs.preprocessor.send(None)
 
     def get_model(self):
         if self.rpca is None:
@@ -426,7 +424,7 @@ class OWPCA(widget.OWWidget):
         axis.setTicks([[(i, str(i+1)) for i in range(0, p, d)]])
 
     def commit(self):
-        transformed = components = pp = None
+        transformed = components = None
         if self._pca is not None:
             if self._transformed is None:
                 # Compute the full transform (MAX_COMPONENTS components) only once.
@@ -450,13 +448,10 @@ class OWPCA(widget.OWWidget):
                                metas=metas)
             components.name = 'components'
 
-            pp = preprocess.ApplyDomain(domain, "PCA")
-
         self._pca_projector.component = self.ncomponents
         self.Outputs.transformed_data.send(transformed)
         self.Outputs.components.send(components)
         self.Outputs.pca.send(self._pca_projector)
-        self.Outputs.preprocessor.send(pp)
 
     def send_report(self):
         if self.data is None:

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -14,7 +14,7 @@ from Orange.widgets.settings import Setting, SettingProvider
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
 from Orange.widgets.visualize.utils.widget import OWDataProjectionWidget
-from Orange.widgets.widget import Msg, Output
+from Orange.widgets.widget import Msg
 
 
 class TSNERunner:
@@ -85,9 +85,6 @@ class OWtSNE(OWDataProjectionWidget):
 
     #: Runtime state
     Running, Finished, Waiting, Paused = 1, 2, 3, 4
-
-    class Outputs(OWDataProjectionWidget.Outputs):
-        preprocessor = Output("Preprocessor", preprocess.Preprocess)
 
     class Error(OWDataProjectionWidget.Error):
         not_enough_rows = Msg("Input data needs at least 2 rows")
@@ -370,10 +367,6 @@ class OWtSNE(OWDataProjectionWidget):
         super().setup_plot()
         self.start()
 
-    def commit(self):
-        super().commit()
-        self.send_preprocessor()
-
     def _get_projection_data(self):
         if self.data is None:
             return None
@@ -388,12 +381,6 @@ class OWtSNE(OWDataProjectionWidget):
                 self.data.domain.class_vars,
                 self.data.domain.metas + self.projection.domain.attributes)
         return data
-
-    def send_preprocessor(self):
-        prep = None
-        if self.data is not None and self.projection is not None:
-            prep = preprocess.ApplyDomain(self.projection.domain, self.projection.name)
-        self.Outputs.preprocessor.send(prep)
 
     def clear(self):
         super().clear()

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from Orange.data import Table, Domain, ContinuousVariable, TimeVariable
 from Orange.preprocess import preprocess
-from Orange.preprocess.preprocess import Preprocess, Normalize
+from Orange.preprocess.preprocess import Normalize
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import table_dense_sparse
 from Orange.widgets.unsupervised.owpca import OWPCA
@@ -202,15 +202,3 @@ class TestOWPCA(WidgetTest):
         self.widget.set_data(data)
         ndata = Table("iris.tab")
         self.assertEqual(data.domain[0], ndata.domain[0])
-
-    def test_output_preprocessor(self):
-        self.send_signal(self.widget.Inputs.data, self.iris)
-        pp = self.get_output(self.widget.Outputs.preprocessor)
-        self.assertIsInstance(pp, Preprocess)
-        transformed_data = pp(self.iris[::10])
-        self.assertIsInstance(transformed_data, Table)
-        self.assertEqual(transformed_data.X.shape, (15, 2))
-        output = self.get_output(self.widget.Outputs.transformed_data)
-        np.testing.assert_array_equal(transformed_data.X, output.X[::10])
-        self.assertEqual([a.name for a in transformed_data.domain.attributes],
-                         [m.name for m in output.domain.attributes])

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import numpy as np
 
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain, Table
-from Orange.preprocess import Preprocess, Normalize
+from Orange.preprocess import Normalize
 from Orange.projection.manifold import TSNE
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, ProjectionWidgetTestMixin
@@ -110,28 +110,6 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin,
             if var.is_discrete:
                 self.assertNotIn(var, controls.attr_size.model())
                 self.assertIn(var, controls.attr_shape.model())
-
-    def test_output_preprocessor(self):
-        # To test the validity of the preprocessor, we'll have to actually
-        # compute the projections
-        self.restore_mocked_functions()
-
-        self.send_signal(self.widget.Inputs.data, self.data)
-        self.wait_until_stop_blocking(wait=20000)
-        output_data = self.get_output(self.widget.Outputs.annotated_data)
-
-        # We send the same data to the widget, we expect the point locations to
-        # be fairly close to their original ones
-        pp = self.get_output(self.widget.Outputs.preprocessor)
-        self.assertIsInstance(pp, Preprocess)
-
-        transformed_data = pp(self.data)
-        self.assertIsInstance(transformed_data, Table)
-        self.assertEqual(transformed_data.X.shape, (len(self.data), 2))
-        np.testing.assert_allclose(transformed_data.X, output_data.metas[:, :2],
-                                   rtol=1, atol=3)
-        self.assertEqual([a.name for a in transformed_data.domain.attributes],
-                         [m.name for m in output_data.domain.metas[:2]])
 
     def test_multiscale_changed(self):
         self.assertFalse(self.widget.controls.multiscale.isChecked())

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -10,7 +10,6 @@ from Orange.data import (
 )
 from Orange.data.util import get_unique_names, array_equal
 from Orange.data.sql.table import SqlTable
-from Orange.preprocess.preprocess import Preprocess, ApplyDomain
 from Orange.statistics.util import bincount
 
 from Orange.widgets import gui, report
@@ -624,7 +623,6 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget):
 
     class Outputs(OWDataProjectionWidget.Outputs):
         components = Output("Components", Table)
-        preprocessor = Output("Preprocessor", Preprocess)
 
     class Error(OWDataProjectionWidget.Error):
         sparse_data = Msg("Sparse data is not supported")
@@ -702,7 +700,6 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget):
     def commit(self):
         super().commit()
         self.send_components()
-        self.send_preprocessor()
 
     def send_components(self):
         components = None
@@ -720,12 +717,6 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget):
     def _send_components_metas(self):
         variable_names = [a.name for a in self.projection.domain.attributes]
         return np.array(variable_names, dtype=object)[:, None]
-
-    def send_preprocessor(self):
-        prep = None
-        if self.data is not None and self.projection is not None:
-            prep = ApplyDomain(self.projection.domain, self.projection.name)
-        self.Outputs.preprocessor.send(prep)
 
     def clear(self):
         super().clear()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3623 and #3675.

##### Description of changes
- remove 'Preprocessor' output from projection widgets (PCA, tSNE, Freeviz, Radviz, LinearProjection)
- OWTransform: use domain to transform data (instead of preprocessor)


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
