### PR TITLE
[FIX] Test & Score: hide warnings for hidden scores.

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -525,6 +525,7 @@ class OWTestLearners(OWWidget):
         for section in range(1, model.columnCount()):
             col_name = model.horizontalHeaderItem(section).data(Qt.DisplayRole)
             header.setSectionHidden(section, col_name not in self.shown_scores)
+        self.view.resizeColumnsToContents()
 
     def _update_stats_model(self):
         # Update the results_model with up to date scores.

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -526,6 +526,7 @@ class OWTestLearners(OWWidget):
             col_name = model.horizontalHeaderItem(section).data(Qt.DisplayRole)
             header.setSectionHidden(section, col_name not in self.shown_scores)
         self.view.resizeColumnsToContents()
+        self._update_stats_model()  # updates warnings for displayed columns
 
     def _update_stats_model(self):
         # Update the results_model with up to date scores.
@@ -584,13 +585,14 @@ class OWTestLearners(OWWidget):
                 stats = slot.stats
 
             if stats is not None:
-                for stat in stats:
+                for stat, scorer in zip(stats, self.scorers):
                     item = QStandardItem()
                     if stat.success:
                         item.setText("{:.3f}".format(stat.value[0]))
                     else:
                         item.setToolTip(str(stat.exception))
-                        has_missing_scores = True
+                        if scorer.name in self.shown_scores:
+                            has_missing_scores = True
                     row.append(item)
 
             model.appendRow(row)


### PR DESCRIPTION
##### Issue
Fixes #2088

A user sees a warning although all displayed scores are successfully computed. The problematic score is not AUC but LogLoss, which the widget tries to compute (and fails) but is not displayed by default.

##### Description of changes

- hide warnings for hidden scores
- fix an error where the user couldn't display additional scores on Windows

We might want to consider fixing LogLoss for the case described in #2088.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
