### PR TITLE
In-place settings, and proper encoding and matching of lists of variables

### DIFF
--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -235,6 +235,32 @@ class TestDomainContextHandler(TestCase):
         val = self.handler.encode_setting(None, setting, var)
         self.assertEqual(val, (var.name, 100 + vartype(var)))
 
+    def test_encode_list_settings(self):
+        setting = ContextSetting(None)
+
+        var1, var2 = self.domain[:2]
+        val = self.handler.encode_setting(None, setting, [None, var1, var2])
+        self.assertEqual(
+            val,
+            ([None,
+              (var1.name, 100 + vartype(var1)),
+              (var2.name, 100 + vartype(var2))], -3))
+
+        a_list = [1, 2, 3]
+        val = self.handler.encode_setting(None, setting, a_list)
+        self.assertEqual(val, [1, 2, 3])
+        self.assertIsNot(val, a_list)
+
+        a_list = []
+        val = self.handler.encode_setting(None, setting, a_list)
+        self.assertEqual(val, [])
+        self.assertIsNot(val, a_list)
+
+        a_list = [None, None]
+        val = self.handler.encode_setting(None, setting, a_list)
+        self.assertEqual(val, [None, None])
+        self.assertIsNot(val, a_list)
+
     def test_decode_setting(self):
         setting = ContextSetting(None)
 
@@ -247,6 +273,21 @@ class TestDomainContextHandler(TestCase):
         val = self.handler.decode_setting(setting, (var.name, 100 + vartype(var)),
                                           all_metas_domain)
         self.assertIs(val, var)
+
+    def test_decode_list_setting(self):
+        setting = ContextSetting(None)
+
+        var1, var2 = self.domain[:2]
+        val = self.handler.decode_setting(
+            setting,
+            ([None,
+              (var1.name, 100 + vartype(var1)),
+              (var2.name, 100 + vartype(var2))], -3),
+            self.domain)
+        self.assertEqual(val, [None, var1, var2])
+
+        val = self.handler.decode_setting(setting, [1, 2, 3], self.domain)
+        self.assertEqual(val, [1, 2, 3])
 
     def test_backward_compatible_params(self):
         with warnings.catch_warnings(record=True) as w:

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -149,11 +149,13 @@ class TestDomainContextHandler(TestCase):
 
         widget = SimpleWidget()
         self.handler.initialize(widget)
+        old_metas_list = widget.with_metas
         self.handler.open_context(widget, self.args[0])
 
         context = widget.current_context
         self.assertEqual(context.attributes, self.args[1])
         self.assertEqual(context.metas, self.args[2])
+        self.assertIs(old_metas_list, widget.with_metas)
 
         self.assertEqual(widget.text, 'u')
         self.assertEqual(widget.with_metas, [('d1', Discrete),

--- a/Orange/widgets/tests/test_setting_provider.py
+++ b/Orange/widgets/tests/test_setting_provider.py
@@ -9,6 +9,9 @@ SHOW_LABELS = "show_labels"
 SHOW_X_AXIS = "show_x_axis"
 SHOW_Y_AXIS = "show_y_axis"
 ALLOW_ZOOMING = "allow_zooming"
+A_LIST = "a_list"
+A_SET = "a_set"
+A_DICT = "a_dict"
 
 
 class SettingProviderTestCase(unittest.TestCase):
@@ -43,6 +46,9 @@ class SettingProviderTestCase(unittest.TestCase):
 
         self.assertEqual(widget.show_graph, True)
         self.assertEqual(widget.show_zoom_toolbar, True)
+        self.assertEqual(widget.graph.a_list, [])
+        self.assertEqual(widget.graph.a_set, {1, 2, 3})
+        self.assertEqual(widget.graph.a_dict, {1: 2, 3: 4})
         self.assertEqual(widget.graph.show_labels, True)
         self.assertEqual(widget.graph.show_x_axis, True)
         self.assertEqual(widget.graph.show_y_axis, True)
@@ -105,6 +111,9 @@ class SettingProviderTestCase(unittest.TestCase):
                 SHOW_LABELS: True,
                 SHOW_X_AXIS: True,
                 SHOW_Y_AXIS: False,
+                A_LIST: [],
+                A_SET: {1, 2, 3},
+                A_DICT: {1: 2, 3: 4}
             },
             ZOOM_TOOLBAR: {
                 ALLOW_ZOOMING: True,
@@ -128,6 +137,25 @@ class SettingProviderTestCase(unittest.TestCase):
         self.assertEqual(widget.graph.show_y_axis, False)
         self.assertEqual(widget.zoom_toolbar.allow_zooming, True)
 
+    def test_mutables_are_unpacked_in_place(self):
+        widget = Widget()
+        a_list = widget.graph.a_list
+        a_set = widget.graph.a_set
+        a_dict = widget.graph.a_dict
+        default_provider.unpack(widget, {
+            GRAPH: {
+                A_LIST: [1, 2, 3],
+                A_SET: {4, 5},
+                A_DICT: {6: 7}
+            },
+        })
+        self.assertIs(a_list, widget.graph.a_list)
+        self.assertEqual(a_list, [1, 2, 3])
+        self.assertIs(a_set, widget.graph.a_set)
+        self.assertEqual(a_set, {4, 5})
+        self.assertIs(a_dict, widget.graph.a_dict)
+        self.assertEqual(a_dict, {6: 7})
+
     def test_traverse_settings_works_without_instance_or_data(self):
         settings = set()
 
@@ -136,12 +164,13 @@ class SettingProviderTestCase(unittest.TestCase):
 
         self.assertEqual(settings, {
             SHOW_ZOOM_TOOLBAR, SHOW_GRAPH,
-            SHOW_LABELS, SHOW_X_AXIS, SHOW_Y_AXIS,
+            SHOW_LABELS, SHOW_X_AXIS, SHOW_Y_AXIS, A_LIST, A_SET, A_DICT,
             ALLOW_ZOOMING})
 
     def test_traverse_settings_selects_correct_data(self):
         settings = {}
-        graph_data = {SHOW_LABELS: 3, SHOW_X_AXIS: 4, SHOW_Y_AXIS: 5}
+        graph_data = {SHOW_LABELS: 3, SHOW_X_AXIS: 4, SHOW_Y_AXIS: 5,
+                      A_LIST: [], A_SET: {1, 2, 3}, A_DICT: {1: 2, 3: 4}}
         zoom_data = {ALLOW_ZOOMING: 6}
         all_data = {SHOW_GRAPH: 1,
                     SHOW_ZOOM_TOOLBAR: 2,
@@ -159,6 +188,9 @@ class SettingProviderTestCase(unittest.TestCase):
                 SHOW_LABELS: graph_data,
                 SHOW_X_AXIS: graph_data,
                 SHOW_Y_AXIS: graph_data,
+                A_LIST: graph_data,
+                A_SET: graph_data,
+                A_DICT: graph_data,
                 ALLOW_ZOOMING: zoom_data,
             }
         )
@@ -179,6 +211,9 @@ class SettingProviderTestCase(unittest.TestCase):
                 SHOW_LABELS: graph_data,
                 SHOW_X_AXIS: graph_data,
                 SHOW_Y_AXIS: graph_data,
+                A_LIST: graph_data,
+                A_SET: graph_data,
+                A_DICT: graph_data,
                 ALLOW_ZOOMING: {},
             }
         )
@@ -197,6 +232,9 @@ class SettingProviderTestCase(unittest.TestCase):
                 SHOW_LABELS: widget.graph,
                 SHOW_X_AXIS: widget.graph,
                 SHOW_Y_AXIS: widget.graph,
+                A_LIST: widget.graph,
+                A_SET: widget.graph,
+                A_DICT: widget.graph,
                 ALLOW_ZOOMING: widget.zoom_toolbar,
             },
             settings
@@ -218,6 +256,9 @@ class SettingProviderTestCase(unittest.TestCase):
                 SHOW_LABELS: None,
                 SHOW_X_AXIS: None,
                 SHOW_Y_AXIS: None,
+                A_LIST: None,
+                A_SET: None,
+                A_DICT: None,
                 ALLOW_ZOOMING: widget.zoom_toolbar,
             }
         )
@@ -251,6 +292,9 @@ class BaseGraph:
 class Graph(BaseGraph):
     show_x_axis = Setting(True)
     show_y_axis = Setting(True)
+    a_list = Setting([])
+    a_set = Setting({1, 2, 3})
+    a_dict = Setting({1: 2, 3: 4})
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
##### Issue

If setting is a list, writing it to the widget does not change the list in place but replaces it with a new list. This is a problem if the list is (wrapped in a) model. In particular, models behind list views wrap a setting, and they are not updated when settings are changed.

I encountered the problem in RadViz and Linear projection. The base projection widget, which is common to all projections (scatter plot, mds, tsne, networks...) has a conspicuous method `use_context`, which is there just to be overridden in Radviz and Linear projection. Currently it is more complicated, but after #3508 it will have to do something like

```
def use_context(self):
    self.selection_model.wrap(self.selected_variables)
```

where `selected_variables` is a setting (and a list behind the model at the same time). `use_context` is essentially a fix after application of a context.

##### Description of changes

- Class `Setting` has an additional flag `inplace`. If `True`, the setting is changed in-place. This requires (and checks) that the setting is a `list`, `dict` or `set`.
- `setattr`'s are replaced by calling a `Settings`'s method `apply_to_widget` that sets the setting in-place or not; handler's initialize still uses `setattr` and it already deep-copies mutable values
 
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
