### PR TITLE
distance.py: Fix zero division in Jaccard

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -442,8 +442,11 @@ class JaccardModel(FittedDistanceModel):
         for i in range(n):
             xi_ind = set(x1[i].indices)
             for j in range(i if symmetric else m):
-                jacc = 1 - len(xi_ind.intersection(x2[j].indices))\
-                           / len(set(x1[i].indices).union(x1[j].indices))
+                union = len(xi_ind.union(x2[j].indices))
+                if union:
+                    jacc = 1 - len(xi_ind.intersection(x2[j].indices)) / union
+                else:
+                    jacc = 0
                 matrix[i, j] = jacc
                 if symmetric:
                     matrix[j, i] = jacc

--- a/Orange/distance/tests/test_distance.py
+++ b/Orange/distance/tests/test_distance.py
@@ -892,6 +892,20 @@ class JaccardDistanceTest(unittest.TestCase, CommonFittedTests):
                           [0.4, 1, 5/12],
                           [0.25, 5/12, 1]]))
 
+    def test_zero_instances(self):
+        "Test all zero instances"
+        domain = Domain([ContinuousVariable(c) for c in "abc"])
+        dense_data = Table.from_list(
+            domain, [[0, 0, 0], [0, 0, 0], [0, 0, 1]])
+        sparse_data = Table(domain, csr_matrix(dense_data.X))
+        dist_dense = self.Distance(dense_data)
+        dist_sparse = self.Distance(sparse_data)
+
+        self.assertEqual(dist_dense[0][1], 0)
+        self.assertEqual(dist_sparse[0][1], 0)
+        self.assertEqual(dist_dense[0][2], 1)
+        self.assertEqual(dist_sparse[0][2], 1)
+
 class HammingDistanceTest(FittedDistanceTest):
     Distance = distance.Hamming
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Jaccard did not handle two all zero instances.

##### Description of changes
Check to avoid division by zero. Add tests for all distances.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
