### PR TITLE
[FIX] owheatmap: Fix group label size policy

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -975,6 +975,7 @@ class OWHeatMap(widget.OWWidget):
             if rowitem.title:
                 title = QGraphicsSimpleTextItem(rowitem.title, widget)
                 item = GraphicsSimpleTextLayoutItem(title, parent=grid)
+                item.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
                 grid.addItem(item, Row0 + i * 2, Col0)
 
             if rowitem.cluster:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-3678

##### Description of changes

Fix size policy for group title label.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
