### PR TITLE
OWScatterplot: Remove checking the checksum in set_data

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -314,8 +314,6 @@ class OWScatterPlot(OWDataProjectionWidget):
         self.vizrank_button.setToolTip(text)
 
     def set_data(self, data):
-        if self.data and data and self.data.checksum() == data.checksum():
-            return
         super().set_data(data)
 
         def findvar(name, iterable):


### PR DESCRIPTION
##### Issue

Fixes #3684.

##### Description of changes

`OWScatterPlot.set_data` compared data sets by their check sums. This remained from before Orange had context settings. It is now no longer needed and ignores that attributes were edited and Edit domain.

##### Includes
- [X] Code changes
