### PR TITLE
[WIP] Report: Fail gently if WebKit/WebEngine are not available

### DIFF
--- a/Orange/widgets/report/owreport.py
+++ b/Orange/widgets/report/owreport.py
@@ -12,8 +12,8 @@ import pkg_resources
 from AnyQt.QtCore import Qt, QObject, pyqtSlot
 from AnyQt.QtGui import QIcon, QCursor, QStandardItemModel, QStandardItem
 from AnyQt.QtWidgets import (
-    QApplication, QDialog, QFileDialog, QTableView, QHeaderView
-)
+    QApplication, QDialog, QFileDialog, QTableView, QHeaderView,
+    QMessageBox)
 from AnyQt.QtPrintSupport import QPrinter, QPrintDialog
 
 from Orange.util import deprecated
@@ -28,8 +28,7 @@ from Orange.canvas.gui.utils import message_critical
 try:
     from Orange.widgets.utils.webview import WebviewWidget
 except ImportError:
-    from unittest.mock import Mock
-    WebviewWidget = Mock
+    WebviewWidget = None
 
 
 log = logging.getLogger(__name__)
@@ -453,6 +452,17 @@ class OWReport(OWWidget):
             DeprecationWarning, stacklevel=2
         )
         app_inst = QApplication.instance()
+        if WebviewWidget is None:
+            QMessageBox.critical(
+                None, "Missing Component",
+                "Your installation of Orange contains neither WebEngine nor "
+                "WebKit.\n\n"
+                "If you installed Orange with conda or pip, try using another "
+                "PyQt distribution.\n\n"
+                "If you installed Orange with a standard installer, please "
+                "report this bug."
+            )
+            return None
         if not hasattr(app_inst, "_report_window"):
             report = OWReport()
             app_inst._report_window = report

--- a/Orange/widgets/report/report.py
+++ b/Orange/widgets/report/report.py
@@ -48,8 +48,10 @@ class Report:
         """
         Raise the report window.
         """
-        self.create_report_html()
         report = self._get_designated_report_view()
+        if report is None:
+            return
+        self.create_report_html()
         # Should really have a signal `report_ready` or similar to decouple
         # the implementations.
         report.make_report(self)


### PR DESCRIPTION
##### Issue

Fixes #3661.

When neither WebKit nor WebEngine are available, report uses a Mock instead of a widget, and crashes when inserting it into the layout.

##### Description of changes

Show a dialog, explain what went wrong and suggest a fix.

##### Includes
- [X] Code changes


