### PR TITLE
image export: export PDF directly for Qt >= 5.12

### DIFF
--- a/Orange/widgets/tests/test_io.py
+++ b/Orange/widgets/tests/test_io.py
@@ -77,6 +77,32 @@ class TestPng(GuiTest):
             os.unlink(fname)
 
 
+class TestPdf(GuiTest):
+
+    def test_pyqtgraph(self):
+        fd, fname = tempfile.mkstemp('.pdf')
+        os.close(fd)
+        graph = pyqtgraph.PlotWidget()
+        try:
+            imgio.PdfFormat.write(fname, graph)
+            with open(fname, "rb") as f:
+                self.assertTrue(f.read().startswith(b'%PDF'))
+        finally:
+            os.unlink(fname)
+
+    def test_other(self):
+        fd, fname = tempfile.mkstemp('.pdf')
+        os.close(fd)
+        sc = QGraphicsScene()
+        sc.addItem(QGraphicsRectItem(0, 0, 3, 3))
+        try:
+            imgio.PdfFormat.write(fname, sc)
+            with open(fname, "rb") as f:
+                self.assertTrue(f.read().startswith(b'%PDF'))
+        finally:
+            os.unlink(fname)
+
+
 class TestMatplotlib(WidgetTest):
 
     def test_python(self):

--- a/Orange/widgets/utils/PDFExporter.py
+++ b/Orange/widgets/utils/PDFExporter.py
@@ -1,0 +1,49 @@
+from pyqtgraph.exporters.Exporter import Exporter
+
+from AnyQt.QtGui import QPainter, QGraphicsItem, QDesktopWidget
+from AnyQt.QtCore import QMarginsF, Qt, QSizeF, QRectF
+
+
+class PDFExporter(Exporter):
+    """A pdf exporter for pyqtgraph graphs. Based on pyqtgraph's
+     ImageExporter.
+
+     There is a bug in Qt<5.12 that makes Qt wrongly use a cosmetic pen
+     (QTBUG-68537). Workaround: do not use completely opaque colors.
+
+     There is also a bug in Qt<5.12 with bold fonts that then remain bold.
+     To see it, save the OWNomogram output."""
+
+    def __init__(self, item):
+        Exporter.__init__(self, item)
+        if isinstance(item, QGraphicsItem):
+            scene = item.scene()
+        else:
+            scene = item
+        bgbrush = scene.views()[0].backgroundBrush()
+        bg = bgbrush.color()
+        if bgbrush.style() == Qt.NoBrush:
+            bg.setAlpha(0)
+        self.background = bg
+
+    def export(self, filename=None):
+        from AnyQt.QtGui import QPdfWriter
+
+        pw = QPdfWriter(filename)
+        dpi = QDesktopWidget().logicalDpiX()
+        pw.setResolution(dpi)
+        pw.setPageMargins(QMarginsF(0, 0, 0, 0))
+        pw.setPageSizeMM(QSizeF(self.getTargetRect().size()) / dpi * 25.4)
+
+        painter = QPainter(pw)
+        try:
+            self.setExportMode(True, {'antialias': True,
+                                      'background': self.background,
+                                      'painter': painter})
+            painter.setRenderHint(QPainter.Antialiasing, True)
+            self.getScene().render(painter,
+                                   QRectF(self.getTargetRect()),
+                                   QRectF(self.getSourceRect()))
+        finally:
+            self.setExportMode(False)
+        painter.end()

--- a/Orange/widgets/utils/saveplot.py
+++ b/Orange/widgets/utils/saveplot.py
@@ -19,7 +19,7 @@ def save_plot(data, file_formats, filename=""):
         start_dir = os.path.expanduser("~")
     last_filter = settings.value(_LAST_FILTER_KEY, "")
     filename, writer, filter = \
-        filedialogs.get_file_name(start_dir, last_filter, file_formats)
+        filedialogs.open_filename_dialog_save(start_dir, last_filter, file_formats)
     if not filename:
         return
     try:

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -249,8 +249,7 @@ class OWScatterPlot(OWDataProjectionWidget):
         # manually register Matplotlib file writers
         self.graph_writers = self.graph_writers.copy()
         for w in [MatplotlibFormat, MatplotlibPDFFormat]:
-            for ext in w.EXTENSIONS:
-                self.graph_writers[ext] = w
+            self.graph_writers.append(w)
 
     def _add_controls(self):
         self._add_controls_axis()

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -145,7 +145,9 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     want_message_bar = True
     #: Widget painted by `Save graph` button
     graph_name = None
-    graph_writers = FileFormat.img_writers
+    graph_writers = [f for f in FileFormat.formats
+                     if getattr(f, 'write_image', None)
+                     and getattr(f, "EXTENSIONS", None)]
 
     save_position = True
 


### PR DESCRIPTION
##### Issue
Fixes #2887 for Qt >= 5.12.

##### Description of changes
Use Qt's PDF Writer for output on Qt >= 5.12, because some bugs with line widths and fonts prevent this to work properly on older Qt version.

A potential problem: because I wanted to support multiple formats with the same extension, I changed the format of OWWidget.graph_writers from dict to a list. This could crash unknown add-ons that were touching it. I do not see a good workaround though.

##### Includes
- [X] Code changes
- [X] (Some) tests
- [ ] Documentation
