### PR TITLE
Settings cleanup

### DIFF
--- a/Orange/widgets/evaluate/contexthandlers.py
+++ b/Orange/widgets/evaluate/contexthandlers.py
@@ -19,14 +19,14 @@ class EvaluationResultsContextHandler(settings.ContextHandler):
         elif name == self.selectedAttr:
             context.selectedClassifiers = list(value)
 
-    def settings_from_widget(self, widget):
-        super().settings_from_widget(widget)
+    def settings_from_widget(self, widget, *args):
+        super().settings_from_widget(widget, *args)
         context = widget.current_context
         context.targetClass = getdeepattr(widget, self.targetAttr)
         context.selectedClassifiers = list(getdeepattr(self.selectedAttr))
 
-    def settings_to_widget(self, widget):
-        super().settings_to_widget(widget)
+    def settings_to_widget(self, widget, *args):
+        super().settings_to_widget(widget, *args)
         context = widget.current_context
         if context.targetClass is not None:
             setattr(widget, self.targetAttr, context.targetClass)

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -739,23 +739,9 @@ class ContextHandler(SettingsHandler):
         widget.current_context, is_new = \
             self.find_or_create_context(widget, *args)
         if is_new:
-            try:
-                self.settings_from_widget(widget, *args)
-            except TypeError:
-                warnings.warn("settings_from_widget in {} does not accept *args.\n"
-                              "Support for this will be dropped in Orange 3.10"
-                              .format(type(self)),
-                              DeprecationWarning)
-                self.settings_from_widget(widget)
+            self.settings_from_widget(widget, *args)
         else:
-            try:
-                self.settings_to_widget(widget, *args)
-            except TypeError:
-                warnings.warn("settings_to_widget {} does not accept *args.\n"
-                              "Support for this will be dropped in Orange 3.10"
-                              .format(type(self)),
-                              DeprecationWarning)
-                self.settings_to_widget(widget)
+            self.settings_to_widget(widget, *args)
 
     def match(self, context, *args):
         """Return the degree to which the stored `context` matches the data

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -969,11 +969,9 @@ class DomainContextHandler(ContextHandler):
 
     def open_context(self, widget, domain):
         if domain is None:
-            return None, False
-
+            return
         if not isinstance(domain, Domain):
             domain = domain.domain
-
         super().open_context(widget, domain, *self.encode_domain(domain))
 
     def filter_value(self, setting, data, domain, attrs, metas):
@@ -1093,7 +1091,7 @@ class DomainContextHandler(ContextHandler):
         returns a tuple containing number of matched and all values.
         """
         matched = 0
-        for i, item in enumerate(value):
+        for item in value:
             if self.is_valid_item(setting, item, attrs, metas):
                 matched += 1
             elif setting.required == ContextSetting.REQUIRED:
@@ -1125,7 +1123,6 @@ class DomainContextHandler(ContextHandler):
 
 class IncompatibleContext(Exception):
     """Raised when a required variable in context is not available in data."""
-    pass
 
 
 class ClassValuesContextHandler(ContextHandler):
@@ -1227,8 +1224,8 @@ class SettingsPrinter(pprint.PrettyPrinter):
 
     def _format(self, obj, stream, indent, allowance, context, level):
         if not isinstance(obj, Context):
-            return super()._format(obj, stream, indent,
-                                   allowance, context, level)
+            super()._format(obj, stream, indent, allowance, context, level)
+            return
 
         stream.write("Context(")
         for key, value in sorted(obj.__dict__.items(), key=itemgetter(0)):

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -609,10 +609,9 @@ class ContextSetting(Setting):
     # something with the attributes. Large majority does, so this greatly
     # simplifies the declaration of settings in widget at no (visible)
     # cost to those settings that don't need it
-    def __init__(self, default, *, not_attribute=False, required=2,
+    def __init__(self, default, *, required=2,
                  exclude_attributes=False, exclude_metas=False, **data):
         super().__init__(default, **data)
-        self.not_attribute = not_attribute
         self.exclude_attributes = exclude_attributes
         self.exclude_metas = exclude_metas
         self.required = required

--- a/Orange/widgets/tests/test_class_values_context_handler.py
+++ b/Orange/widgets/tests/test_class_values_context_handler.py
@@ -65,7 +65,7 @@ class TestClassValuesContextHandler(TestCase):
 
 
 class SimpleWidget:
-    text = ContextSetting("", not_attribute=True)
+    text = ContextSetting("")
     with_metas = ContextSetting([])
     required = ContextSetting("", required=ContextSetting.REQUIRED)
 

--- a/Orange/widgets/tests/test_class_values_context_handler.py
+++ b/Orange/widgets/tests/test_class_values_context_handler.py
@@ -68,9 +68,6 @@ class SimpleWidget:
     text = ContextSetting("", not_attribute=True)
     with_metas = ContextSetting([])
     required = ContextSetting("", required=ContextSetting.REQUIRED)
-    if_selected = ContextSetting([], required=ContextSetting.IF_SELECTED,
-                                 selected='selected')
-    selected = ""
 
     def retrieveSpecificSettings(self):
         pass

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -108,20 +108,6 @@ class TestDomainContextHandler(TestCase):
                                    with_metas=('d1', Discrete)))
         self.assertEqual(0, self.handler.match(context, *self.args))
 
-        # selected if_selected
-        context = Mock(values=dict(with_metas=('d1', Discrete),
-                                   if_selected=[('u', Discrete)],
-                                   selected=[0]))
-        self.assertEqual(0, self.handler.match(context, *self.args))
-
-        # unselected if_selected
-        context = Mock(values=dict(with_metas=('d1', Discrete),
-                                   if_selected=[('u', Discrete),
-                                                ('d1', Discrete)],
-                                   selected=[1]))
-        self.assertAlmostEqual(0.667, self.handler.match(context, *self.args),
-                               places=2)
-
     def test_clone_context(self):
         self.handler.bind(SimpleWidget)
         context = self.create_context(self.domain, dict(
@@ -166,10 +152,7 @@ class TestDomainContextHandler(TestCase):
         context = self.create_context(None, dict(
             text=('u', -2),
             with_metas=[('d1', Discrete), ('d1', Continuous),
-                        ('c1', Continuous), ('c1', Discrete)],
-            if_selected=[('c1', Discrete), ('c1', Continuous),
-                         ('d1', Discrete), ('d1', Continuous)],
-            selected=[2],
+                        ('c1', Continuous), ('c1', Discrete)]
         ))
         self.handler.global_contexts = \
             [Mock(values={}), context, Mock(values={})]
@@ -185,9 +168,6 @@ class TestDomainContextHandler(TestCase):
         self.assertEqual(widget.text, 'u')
         self.assertEqual(widget.with_metas, [('d1', Discrete),
                                              ('c1', Continuous)])
-        self.assertEqual(widget.if_selected, [('c1', Continuous),
-                                              ('d1', Discrete)])
-        self.assertEqual(widget.selected, [1])
 
     def test_open_context_with_no_match(self):
         self.handler.bind(SimpleWidget)
@@ -310,9 +290,6 @@ class SimpleWidget:
     text = ContextSetting("", not_attribute=True)
     with_metas = ContextSetting([], required=ContextSetting.OPTIONAL)
     required = ContextSetting("", required=ContextSetting.REQUIRED)
-    if_selected = ContextSetting([], required=ContextSetting.IF_SELECTED,
-                                 selected='selected')
-    selected = ""
 
     def retrieveSpecificSettings(self):
         pass

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -287,7 +287,7 @@ class TestDomainContextHandler(TestCase):
 
 
 class SimpleWidget:
-    text = ContextSetting("", not_attribute=True)
+    text = ContextSetting("")
     with_metas = ContextSetting([], required=ContextSetting.OPTIONAL)
     required = ContextSetting("", required=ContextSetting.REQUIRED)
 

--- a/Orange/widgets/tests/test_perfect_domain_context_handler.py
+++ b/Orange/widgets/tests/test_perfect_domain_context_handler.py
@@ -48,6 +48,7 @@ class TestPerfectDomainContextHandler(TestCase):
         context = Context()
         context.attributes = ()
         context.class_vars = ()
+        context.metas = ()
         self.handler.new_context = Mock(return_value=context)
         self.handler.open_context(self.widget, self.domain)
         self.handler.new_context.assert_called_with(*self.args)

--- a/Orange/widgets/tests/test_setting_provider.py
+++ b/Orange/widgets/tests/test_setting_provider.py
@@ -159,7 +159,7 @@ class SettingProviderTestCase(unittest.TestCase):
     def test_traverse_settings_works_without_instance_or_data(self):
         settings = set()
 
-        for setting, data, instance in default_provider.traverse_settings():
+        for setting, data, _ in default_provider.traverse_settings():
             settings.add(setting.name)
 
         self.assertEqual(settings, {
@@ -177,7 +177,7 @@ class SettingProviderTestCase(unittest.TestCase):
                     GRAPH: graph_data,
                     ZOOM_TOOLBAR: zoom_data}
 
-        for setting, data, instance in default_provider.traverse_settings(all_data):
+        for setting, data, _ in default_provider.traverse_settings(all_data):
             settings[setting.name] = data
 
         self.assertEqual(
@@ -200,7 +200,7 @@ class SettingProviderTestCase(unittest.TestCase):
         graph_data = {SHOW_LABELS: 3, SHOW_X_AXIS: 4}
         all_data = {SHOW_GRAPH: 1, SHOW_ZOOM_TOOLBAR: 2, GRAPH: graph_data}
 
-        for setting, data, instance in default_provider.traverse_settings(all_data):
+        for setting, data, _ in default_provider.traverse_settings(all_data):
             settings[setting.name] = data
 
         self.assertEqual(
@@ -222,7 +222,8 @@ class SettingProviderTestCase(unittest.TestCase):
         settings = {}
         widget = Widget()
 
-        for setting, data, instance in default_provider.traverse_settings(instance=widget):
+        for setting, _, instance in \
+                default_provider.traverse_settings(instance=widget):
             settings[setting.name] = instance
 
         self.assertEqual(
@@ -245,7 +246,8 @@ class SettingProviderTestCase(unittest.TestCase):
         widget = Widget()
         widget.graph = None
 
-        for setting, data, instance in default_provider.traverse_settings(instance=widget):
+        for setting, _, instance in \
+                default_provider.traverse_settings(instance=widget):
             settings[setting.name] = instance
 
         self.assertEqual(


### PR DESCRIPTION
##### Issue

Context settings contain obsolete unused undocumented code that can be removed or deprecated (and removed).

##### Description of changes

- Remove 'selected' flag that could be used (but was not used in Orange 3) for storing selections in list views.
- Remove attribute `not_attribute`.
- Warn that support for variables stored as string settings will be removed in 3.26.
- Require that `settings_to_widget` and `settings_from_widget` support `*args`; exception for those not accepting it was supposed to be removed in 3.10.
- PyLint.

##### Includes
- [X] Code changes
- [X] Tests