### PR TITLE
[FIX] Save Data: Remove extra file extensions

### DIFF
--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -185,11 +185,23 @@ class OWSave(widget.OWWidget):
 
     @staticmethod
     def _replace_extension(filename, extension):
-        known_extensions = map(OWSave._extension_from_filter, OWSave.filters)
-        for known_ext in sorted(known_extensions, key=len, reverse=True):
-            if filename.endswith(known_ext):
-                filename = filename[:-len(known_ext)]
+        """
+        Remove all extensions that appear in any filter.
+
+        Double extensions are broken in different weird ways across all systems,
+        including omitting some, like turning iris.tab.gz to iris.gz. This
+        function removes anything that can appear anywhere.
+        """
+        known_extensions = set()
+        for filt in OWSave.filters:
+            known_extensions |= \
+                set(OWSave._extension_from_filter(filt).split("."))
+        known_extensions.remove("")
+        while True:
+            base, ext = os.path.splitext(filename)
+            if ext[1:] not in known_extensions:
                 break
+            filename = base
         return filename + extension
 
     @staticmethod

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -431,6 +431,9 @@ class TestOWSaveLinuxDialog(TestOWSaveBase):
         dialog.selectFile("high.tab.gz")
         self.assertTrue(dialog.selectedFiles()[0].endswith("/high.csv"))
 
+        dialog.selectFile("high.tab.gz.tab.tab.gz")
+        self.assertTrue(dialog.selectedFiles()[0].endswith("/high.csv"))
+
     def test_save_file_dialog_uses_valid_filters_linux(self):
         widget = self.widget
         widget._valid_filters = lambda: ["a (*.a)", "b (*.b)"]


### PR DESCRIPTION
##### Issue

Fixes #3667.

##### Description of changes

Qt's non-native file save dialog was giving wrong extensions: instead of iris.tab.gz it had iris.gz, or, sometimes, apparently iris.tab.tab.

Now the function for removing extensions chips away any parts of extension that can appear in any filter.

##### Includes
- [X] Code changes
- [X] Tests