### PR TITLE
[FIX] OWAnchorProjectionWidget: Retain valid_data when reloading dataset

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -1080,6 +1080,8 @@ class AnchorProjectionWidgetTestMixin(ProjectionWidgetTestMixin):
         output = self.get_output(ANNOTATED_DATA_SIGNAL_NAME)
         embedding_mask = np.all(np.isnan(output.metas[:, :2]), axis=1)
         np.testing.assert_array_equal(~embedding_mask, self.widget.valid_data)
+        # reload
+        self.send_signal(self.widget.Inputs.data, table)
 
     def test_sparse_data(self):
         table = Table("iris")

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -267,7 +267,7 @@ class OWFreeViz(OWAnchorProjectionWidget, ConcurrentWidgetMixin):
                 error(self.Error.features_exceeds_instances)
             elif not np.sum(np.std(self.data.X, axis=0)):
                 error(self.Error.constant_data)
-            elif np.sum(self.valid_data) > self.MAX_INSTANCES:
+            elif np.sum(np.all(np.isfinite(self.data.X), axis=1)) > self.MAX_INSTANCES:
                 error(self.Error.too_many_data_instances)
             else:
                 if len(self.effective_variables) < len(domain.attributes):

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -407,7 +407,7 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         elif len([v for v in self.continuous_variables
                   if v is not self.attr_color]) < 3:
             msg = "Not enough available continuous variables"
-        elif len(self.data[self.valid_data]) < 2:
+        elif np.sum(np.all(np.isfinite(self.data.X), axis=1)) < 2:
             msg = "Not enough valid data instances"
         else:
             is_enabled = not np.isnan(self.data.get_column_view(

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -368,7 +368,7 @@ class OWRadviz(OWAnchorProjectionWidget):
             self.attr_color is not None and \
             not np.isnan(self.data.get_column_view(
                 self.attr_color)[0].astype(float)).all() and \
-            len(self.data[self.valid_data]) > 1 and \
+            np.sum(np.all(np.isfinite(self.data.X), axis=1)) > 1 and \
             np.all(np.nan_to_num(np.nanstd(self.data.X, 0)) != 0)
         self.btn_vizrank.setEnabled(is_enabled)
         if is_enabled:

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -341,7 +341,7 @@ class OWScatterPlot(OWDataProjectionWidget):
             self.attr_size = findvar(self.attr_size, self.gui.size_model)
 
     def check_data(self):
-        self.clear_messages()
+        super().check_data()
         self.__timer.stop()
         self.sampling.setVisible(False)
         self.sql_data = None

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -442,7 +442,6 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         self.enable_controls()
 
     def check_data(self):
-        self.valid_data = None
         self.clear_messages()
 
     def use_context(self):
@@ -649,8 +648,7 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget, openclass=True):
             elif len(self.data) < 2:
                 error(self.Error.no_instances)
             else:
-                self.valid_data = np.all(np.isfinite(self.data.X), axis=1)
-                if not np.sum(self.valid_data):
+                if not np.sum(np.all(np.isfinite(self.data.X), axis=1)):
                     error(self.Error.no_valid_data)
 
     def init_projection(self):
@@ -663,6 +661,7 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget, openclass=True):
             self.Error.proj_error(ex)
 
     def get_embedding(self):
+        self.valid_data = None
         if self.data is None or self.projection is None:
             return None
         embedding = self.projection(self.data).X


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3717

In case dataset with missing values was reloaded, `valid_data` was not properly set, because `get_embedding() `was not invoked.

To reproduce: OWFile(heart_disease) -> OWRadviz -> OWFile(click Reload)

##### Description of changes
- set `valid_data` only in `get_embedding()`. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
