### PR TITLE
[ENH] Edit Domain: Merge categorical values

### DIFF
--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -518,7 +518,7 @@ class CountedListModel(itemmodels.PyListModel):
             key = self.key(index)
             try:
                 counts[key] += 1
-            except TypeError:
+            except TypeError:  # pragma: no cover
                 warnings.warn(f"key value '{key}' is not hashable")
         self.__counts_cache = counts
         return self.__counts_cache
@@ -900,7 +900,7 @@ class DiscreteVariableEditor(VariableEditor):
         view = self.values_edit
         rows = view.selectionModel().selectedRows(0)
         if not rows:
-            return
+            return  # pragma: no cover
         for index in rows:
             model = index.model()
             state = index.data(EditStateRole)
@@ -953,7 +953,7 @@ class DiscreteVariableEditor(VariableEditor):
         model = view.model()  # type: QAbstractItemModel
         rows = view.selectedIndexes()  # type: List[QModelIndex]
         if not len(rows) >= 2:
-            return
+            return  # pragma: no cover
         first_row = rows[0]
 
         def mapRectTo(widget, parent, rect):

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -992,14 +992,14 @@ class DiscreteVariableEditor(VariableEditor):
 
         cb.addItems(
             list(unique(str(row.data(Qt.EditRole)) for row in rows)))
-        rows = [QPersistentModelIndex(row) for row in rows]
+        prows = [QPersistentModelIndex(row) for row in rows]
 
         def complete_merge(text):
             # write the new text for edit role in all rows
             with disconnected(model.dataChanged, self.on_values_changed):
-                for row in rows:
-                    index = row.sibling(row.row(), row.column())
-                    model.setData(index, text, Qt.EditRole)
+                for prow in prows:
+                    if prow.isValid():
+                        model.setData(QModelIndex(prow), text, Qt.EditRole)
             cb.close()
             self.variable_changed.emit()
 

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -21,8 +21,7 @@ from AnyQt.QtWidgets import (
     QWidget, QListView, QTreeView, QVBoxLayout, QHBoxLayout, QFormLayout,
     QToolButton, QLineEdit, QAction, QActionGroup, QStackedWidget, QGroupBox,
     QStyledItemDelegate, QStyleOptionViewItem, QStyle, QSizePolicy, QToolTip,
-    QDialogButtonBox, QPushButton, QCheckBox,
-    QComboBox
+    QDialogButtonBox, QPushButton, QCheckBox, QComboBox, QShortcut
 )
 from AnyQt.QtGui import QStandardItemModel, QStandardItem, QKeySequence, QIcon
 from AnyQt.QtCore import (
@@ -986,6 +985,8 @@ class DiscreteVariableEditor(VariableEditor):
 
         cb = QComboBox(editable=True, insertPolicy=QComboBox.InsertAtBottom)
         cb.setAttribute(Qt.WA_DeleteOnClose)
+        sh = QShortcut(QKeySequence(QKeySequence.Cancel), cb)
+        sh.activated.connect(cb.close)
         cb.setParent(self, Qt.Popup)
         cb.move(vrect.topLeft())
 

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -498,10 +498,6 @@ class CountedListModel(itemmodels.PyListModel):
         super().endRemoveRows()
         self.invalidateCounts()
 
-    def beginResetModel(self) -> None:
-        super().beginResetModel()
-        self.invalidateCounts()
-
     def endResetModel(self) -> None:
         super().endResetModel()
         self.invalidateCounts()

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -37,10 +37,18 @@ import Orange.data
 
 from Orange.preprocess.transformation import Identity, Lookup
 from Orange.widgets import widget, gui, settings
-from Orange.widgets.data.owconcatenate import unique
 from Orange.widgets.utils import itemmodels
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input, Output
+
+
+def unique(sequence):
+    """
+    Return unique elements in `sequence`, preserving their (first seen) order.
+    """
+    # depending on Python >= 3.6 'ordered' dict implementation detail.
+    return iter(dict.fromkeys(sequence))
+
 
 #: An ordered sequence of key, value pairs (variable annotations)
 AnnotationsType = Tuple[Tuple[str, str], ...]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Implements gh-3371

Also fixes and assertion error when two values are renamed to the same value.
```
Traceback (most recent call last):
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Orange/widgets/data/oweditdomain.py", line 1165, in commit
    var = apply_transform(v, tr)
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/functools.py", line 803, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Orange/widgets/data/oweditdomain.py", line 1430, in apply_transform_discete
    dest_codes = positions(dest_values)
  File "/Applications/Orange3.app/Contents/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Orange/widgets/data/oweditdomain.py", line 1427, in positions
    assert len(rval) == len(values)
AssertionError
```

##### Description of changes

Implement merging of categorical values.

Merging can be achieved by simply renaming individual values to the same name, or by selecting multiple values and pressing the merge button (shortcut <kbd>ctrl + =</kbd>) and entering/selecting a name in an editable combo box.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
