### PR TITLE
[ENH] OWScatterPlotBase: don't use special color for selection

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -993,17 +993,11 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             pen = [nopen] * self.n_shown
         else:
             sels = np.max(self.selection)
-            if sels == 1:
-                pen = np.where(
-                    self._filter_visible(self.selection),
-                    _make_pen(QColor(255, 190, 0, 255), SELECTION_WIDTH + 1),
-                    nopen)
-            else:
-                palette = ColorPaletteGenerator(number_of_colors=sels + 1)
-                pen = np.choose(
-                    self._filter_visible(self.selection),
-                    [nopen] + [_make_pen(palette[i], SELECTION_WIDTH + 1)
-                               for i in range(sels)])
+            palette = ColorPaletteGenerator(number_of_colors=sels + 1)
+            pen = np.choose(
+                self._filter_visible(self.selection),
+                [nopen] + [_make_pen(palette[i], SELECTION_WIDTH + 1)
+                           for i in range(sels)])
         return pen, [QBrush(QColor(255, 255, 255, 0))] * self.n_shown
 
     # Labels


### PR DESCRIPTION
##### Issue
When selecting some data in the scatter plot the starting color is orange. When the user selects an additional group the color of the previously selected points changes to blue and the newly selected points are red. When selecting the fourth group the same orange from the being is reused. 
I find the color change confusing and thought that it was a bug. Perhaps I am the only one who finds it strange.
##### Description of changes
Use the same color pallet from the beginning. The first selection becomes blue.
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
