### PR TITLE
Data sampler: Allow selecting 100% of data, shuffle it

### DIFF
--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -100,6 +100,22 @@ class TestOWDataSampler(WidgetTest):
         self.set_fixed_sample_size(3, with_replacement=True)
         self.assertTrue(self.widget.Warning.bigger_sample.is_shown())
 
+    def test_shuffling(self):
+        self.send_signal('Data', self.iris)
+
+        self.set_fixed_sample_size(150)
+        self.assertFalse(self.widget.Warning.bigger_sample.is_shown())
+        sample = self.get_output("Data Sample")
+        self.assertTrue((self.iris.ids != sample.ids).any())
+        self.assertEqual(set(self.iris.ids), set(sample.ids))
+
+        self.select_sampling_type(self.widget.FixedProportion)
+        self.widget.sampleSizePercentage = 100
+        self.widget.commit()
+        sample = self.get_output("Data Sample")
+        self.assertTrue((self.iris.ids != sample.ids).any())
+        self.assertEqual(set(self.iris.ids), set(sample.ids))
+
     def set_fixed_sample_size(self, sample_size, with_replacement=False):
         """Set fixed sample size and return the number of gui spin.
 

--- a/doc/visual-programming/source/widgets/data/datasampler.md
+++ b/doc/visual-programming/source/widgets/data/datasampler.md
@@ -27,6 +27,8 @@ The **Data Sampler** widget implements several data sampling methods. It outputs
    input dataset.
 4. Press *Sample Data* to output the data sample.
 
+If all data instances are selected (by setting the proportion to 100 % or setting the fixed sample size to the entire data size), output instances are still shuffled.
+
 Examples
 --------
 


### PR DESCRIPTION
##### Issue

Closes #2035. 

##### Description of changes

#2035 required:

1. Modified DataSampler that allows selecting all instances (not just n-1)
2. DataSampler doc mentioning that the widget shuffles the dataset
3. A test that checks that DataSampler really shuffles the dataset
4. An example in Test & Score docs showcasing how this can be done (like #3245)

I've done them all, but I didn't have a good use case in 4. @ajdapretnar, in an already agitated state because of certain issues around #3722, told me in no uncertain terms to remove it. I'm married for 17 years, so I know better than to complain. On the contrary, I *must say* that I didn't like that text either, so I was very happy to remove it.

Documentation still explains that choosing the entire data set shuffles it, which, I must say, should suffice.

(Joke aside, it indeed does.)

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
