### PR TITLE
Variable: Remove attribute base_value

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -214,15 +214,10 @@ class TestDiscreteVariable(VariableTest):
         self.assertEqual(
             repr(var),
             "DiscreteVariable(name='a', values=['F', 'M'])")
-        var.base_value = 1
-        self.assertEqual(
-            repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'], base_value=1)")
         var.ordered = True
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'], "
-            "ordered=True, base_value=1)")
+            "DiscreteVariable(name='a', values=['F', 'M'], ordered=True)")
 
         var = DiscreteVariable.make("a", values="1234567")
         self.assertEqual(
@@ -454,9 +449,6 @@ PickleDiscreteVariable = create_pickling_tests(
     ("ordered", lambda: DiscreteVariable(name="Feature 0",
                                          values=["F", "M"],
                                          ordered=True)),
-    ("with_base_value", lambda: DiscreteVariable(name="Feature 0",
-                                                 values=["F", "M"],
-                                                 base_value=0))
 )
 
 

--- a/Orange/preprocess/continuize.py
+++ b/Orange/preprocess/continuize.py
@@ -47,7 +47,7 @@ class DomainContinuizer(_RefuseDataInConstructor, Reprable):
                 base = -1
             elif treat in (Continuize.FirstAsBase,
                            Continuize.RemoveMultinomial):
-                base = max(var.base_value, 0)
+                base = 0
             else:
                 base = dists[var_ptr].modus()
             ind_class = [Indicator1, Indicator][self.zero_based]

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -242,7 +242,6 @@ class AsValue(BaseImputeMethod):
             var = Orange.data.DiscreteVariable(
                 fmt.format(var=variable),
                 values=variable.values + [value],
-                base_value=variable.base_value,
                 compute_value=Lookup(
                     variable,
                     np.arange(len(variable.values), dtype=int),

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -246,15 +246,8 @@ def remove_unused_values(var, data):
     translation_table = np.array([np.NaN] * len(var.values))
     translation_table[unique] = range(len(used_values))
 
-    base_value = -1
-    if 0 <= var.base_value < len(var.values):
-        base = translation_table[var.base_value]
-        if np.isfinite(base):
-            base_value = int(base)
-
     return DiscreteVariable("{}".format(var.name),
                             values=used_values,
-                            base_value=base_value,
                             compute_value=Lookup(var, translation_table),
                             sparse=var.sparse)
 

--- a/Orange/tests/test_continuize.py
+++ b/Orange/tests/test_continuize.py
@@ -94,27 +94,6 @@ class TestDomainContinuizer(unittest.TestCase):
             self.assertEqual(dat2[1], [0, 0, 1, 1, 0, "b"])
             self.assertEqual(dat2[2], [2, 2, 1, 0, 1, "c"])
 
-    def test_multi_lowest_base_base(self):
-        self.data.domain[4].base_value = 1
-        for inp in (self.data, self.data.domain):
-            dom = DomainContinuizer(multinomial_treatment=Continuize.FirstAsBase)
-            dom = dom(inp)
-            self.assertTrue(all(attr.is_continuous
-                                for attr in dom.attributes))
-            self.assertIs(dom.class_var, self.data.domain.class_var)
-            self.assertIs(dom[0], self.data.domain[0])
-            self.assertIs(dom[1], self.data.domain[1])
-            self.assertEqual([attr.name for attr in dom.attributes],
-                             ["c1", "c2", "d2=b", "d3=a", "d3=c"])
-            self.assertIsInstance(dom[2].compute_value,
-                                  transformation.Indicator)
-
-            dat2 = Table(dom, self.data)
-            # c1 c2  d2 d3    cl1
-            self.assertEqual(dat2[0], [1, -2, 0, 1, 0, "a"])
-            self.assertEqual(dat2[1], [0, 0, 1, 0, 0, "b"])
-            self.assertEqual(dat2[2], [2, 2, 1, 0, 1, "c"])
-
     def test_multi_ignore(self):
         dom = DomainContinuizer(multinomial_treatment=Continuize.Remove)
         dom = dom(self.data.domain)

--- a/Orange/tests/test_impute.py
+++ b/Orange/tests/test_impute.py
@@ -127,20 +127,15 @@ class TestDefault(unittest.TestCase):
 
     def test_default(self):
         nan = np.nan
-        X = [
-            [1.0, nan, 0.0],
-            [2.0, 1.0, 3.0],
-            [nan, nan, nan]
+        X = [[nan, 0.0],
+             [1.0, 3.0],
+             [nan, nan]
         ]
         domain = data.Domain(
-            (data.DiscreteVariable("A", values=["0", "1", "2"],
-                                   base_value=2),
-             data.DiscreteVariable("B", values=["a", "b", "c"]),
+            (data.DiscreteVariable("B", values=["a", "b", "c"]),
              data.ContinuousVariable("C"))
         )
         table = data.Table.from_numpy(domain, np.array(X))
-        v1 = impute.Default(1)(table, domain["A"])
-        self.assertEqual(v1.compute_value.value, 1)
 
         v2 = impute.Default(42)(table, domain["C"])
         self.assertEqual(v2.compute_value.value, 42)

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -44,7 +44,7 @@ class OWContinuize(widget.OWWidget):
     autosend = Setting(True)
 
     multinomial_treats = (
-        ("Target or first value as base", Continuize.FirstAsBase),
+        ("First value as base", Continuize.FirstAsBase),
         ("Most frequent value as base", Continuize.FrequentAsBase),
         ("One attribute per value", Continuize.Indicators),
         ("Ignore multinomial attributes", Continuize.RemoveMultinomial),
@@ -186,11 +186,8 @@ def make_indicator_var(source, value_ind, weight=None, zero_based=True):
     )
 
 
-def dummy_coding(var, base_value=-1, zero_based=True):
+def dummy_coding(var, base_value=0, zero_based=True):
     N = len(var.values)
-    if base_value == -1:
-        base_value = var.base_value if var.base_value >= 0 else 0
-    assert 0 <= base_value < len(var.values)
     return [make_indicator_var(var, i, zero_based=zero_based)
             for i in range(N) if i != base_value]
 

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -47,7 +47,7 @@ ContinuousDescriptor = \
                ["name", "expression", "number_of_decimals"])
 DiscreteDescriptor = \
     namedtuple("DiscreteDescriptor",
-               ["name", "expression", "values", "base_value", "ordered"])
+               ["name", "expression", "values", "ordered"])
 
 StringDescriptor = namedtuple("StringDescriptor", ["name", "expression"])
 
@@ -63,7 +63,6 @@ def make_variable(descriptor, compute_value):
             descriptor.name,
             values=descriptor.values,
             ordered=descriptor.ordered,
-            base_value=descriptor.base_value,
             compute_value=compute_value)
     elif isinstance(descriptor, StringDescriptor):
         return Orange.data.StringVariable(
@@ -255,7 +254,6 @@ class DiscreteFeatureEditor(FeatureEditor):
         return DiscreteDescriptor(
             name=self.nameedit.text(),
             values=values,
-            base_value=-1,
             ordered=False,
             expression=self.expressionedit.text()
         )

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -41,7 +41,7 @@ class TestReport(TestCase):
         self.assertIn("b", r)
 
     def test_categories_mapping(self):
-        var = Categorical("C", ("a", "b", "c"), None, ())
+        var = Categorical("C", ("a", "b", "c"), ())
         tr = CategoriesMapping(
             (("a", "aa"),
              ("b", None),
@@ -55,7 +55,7 @@ class TestReport(TestCase):
         self.assertIn("<s>", r)
 
     def test_categorical_merge_mapping(self):
-        var = Categorical("C", ("a", "b1", "b2"), None, ())
+        var = Categorical("C", ("a", "b1", "b2"), ())
         tr = CategoriesMapping(
             (("a", "a"),
              ("b1", "b"),
@@ -66,7 +66,7 @@ class TestReport(TestCase):
         self.assertIn('b', r)
 
     def test_change_ordered(self):
-        var = Categorical("C", ("a", "b"), None, ())
+        var = Categorical("C", ("a", "b"), ())
         tr = ChangeOrdered(True)
         r = report_transform(var, [tr])
         self.assertIn("ordered", r)
@@ -245,8 +245,7 @@ class TestEditors(GuiTest):
         w = DiscreteVariableEditor()
         self.assertEqual(w.get_data(), (None, []))
 
-        v = Categorical("C", ("a", "b", "c"), None,
-                        (("A", "1"), ("B", "b")))
+        v = Categorical("C", ("a", "b", "c"), (("A", "1"), ("B", "b")))
         w.set_data(v)
 
         self.assertEqual(w.name_edit.text(), v.name)
@@ -302,7 +301,7 @@ class TestEditors(GuiTest):
 
     def test_discrete_editor_add_remove_action(self):
         w = DiscreteVariableEditor()
-        v = Categorical("C", ("a", "b", "c"), None,
+        v = Categorical("C", ("a", "b", "c"),
                         (("A", "1"), ("B", "b")))
         w.set_data(v)
         action_add = w.add_new_item
@@ -340,7 +339,7 @@ class TestEditors(GuiTest):
 
     def test_discrete_editor_merge_action(self):
         w = DiscreteVariableEditor()
-        v = Categorical("C", ("a", "b", "c"), None,
+        v = Categorical("C", ("a", "b", "c"),
                         (("A", "1"), ("B", "b")))
         w.set_data(v)
         action = w.merge_items
@@ -429,7 +428,7 @@ class TestTransforms(TestCase):
         self.assertFalse(Do.ordered)
 
     def test_discrete_add_drop(self):
-        D = DiscreteVariable("D", values=("2", "3", "1", "0"), base_value=1)
+        D = DiscreteVariable("D", values=("2", "3", "1", "0"))
         mapping = (
             ("0", None),
             ("1", "1"),
@@ -443,7 +442,6 @@ class TestTransforms(TestCase):
         self._assertLookupEquals(
             DD.compute_value, Lookup(D, np.array([1, np.nan, 0, np.nan]))
         )
-        self.assertEqual(DD.base_value, -1)
 
     def test_discrete_merge(self):
         D = DiscreteVariable("D", values=("2", "3", "1", "0"))
@@ -459,7 +457,6 @@ class TestTransforms(TestCase):
         self._assertLookupEquals(
             DD.compute_value, Lookup(D, np.array([0, 1, 1, 0]))
         )
-        self.assertEqual(DD.base_value, -1)
 
     def _assertLookupEquals(self, first, second):
         self.assertIsInstance(first, Lookup)

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -31,7 +31,7 @@ class FeatureConstructorTest(unittest.TestCase):
         values = ('iris one', 'iris two', 'iris three')
         desc = PyListModel(
             [DiscreteDescriptor(name=name, expression=expression,
-                                values=values, base_value=-1, ordered=False)]
+                                values=values, ordered=False)]
         )
         data = Table(Domain(list(data.domain.attributes) +
                             construct_variables(desc, data.domain.variables),

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -744,7 +744,6 @@ def copy_descriptor(descriptor, newname=None):
         newf = Orange.data.DiscreteVariable(
             newname,
             values=descriptor.values,
-            base_value=descriptor.base_value,
             ordered=descriptor.ordered,
         )
         newf.attributes = dict(descriptor.attributes)

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -9,7 +9,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from Orange.data import (Table, Domain, StringVariable,
-                         DiscreteVariable, ContinuousVariable)
+                         DiscreteVariable, ContinuousVariable, Variable)
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.utils.annotated_data import (ANNOTATED_DATA_FEATURE_NAME)
 from Orange.widgets.visualize.owvenndiagram import (reshape_wide,
@@ -17,7 +17,8 @@ from Orange.widgets.visualize.owvenndiagram import (reshape_wide,
                                                     varying_between,
                                                     drop_columns,
                                                     OWVennDiagram,
-                                                    group_table_indices)
+                                                    group_table_indices,
+                                                    copy_descriptor)
 from Orange.tests import test_filename
 
 
@@ -226,3 +227,49 @@ class GroupTableIndicesTest(unittest.TestCase):
         dd["oh yeah"] = [6]
         dd["3"] = [7]
         self.assertEqual(dd, group_table_indices(table, "g"))
+
+
+class TestVennUtilities(unittest.TestCase):
+    def test_copy_descriptor_discrete(self):
+        var = DiscreteVariable("foo", values=list("abc"), ordered=True)
+        var.attributes = {"bar": 42, "baz": 13}
+        copied = copy_descriptor(var)
+        self.assertIsInstance(copied, DiscreteVariable)
+        self.assertEqual(copied.name, "foo")
+        self.assertEqual(list(copied.values), list("abc"))
+        self.assertTrue(copied.ordered)
+        self.assertEqual(copied.attributes, var.attributes)
+        self.assertIsNot(copied.attributes, var.attributes)
+
+        var = DiscreteVariable("foo", values=list("abc"), ordered=False)
+        copied = copy_descriptor(var, "cux")
+        self.assertEqual(copied.name, "cux")
+        self.assertFalse(copied.ordered)
+
+    def test_copy_descriptor_continuous(self):
+        var = ContinuousVariable("foo", number_of_decimals=42)
+        var.attributes = {"bar": 42, "baz": 13}
+        copied = copy_descriptor(var)
+        self.assertIsInstance(copied, ContinuousVariable)
+        self.assertEqual(copied.name, "foo")
+        self.assertEqual(copied.number_of_decimals, 42)
+        self.assertEqual(copied.attributes, var.attributes)
+        self.assertIsNot(copied.attributes, var.attributes)
+
+        var = ContinuousVariable("foo", number_of_decimals=42)
+        copied = copy_descriptor(var, "cux")
+        self.assertEqual(copied.name, "cux")
+
+    def test_copy_descriptor_other_types(self):
+        class SomeVariable(Variable):
+            pass
+        var = SomeVariable("foo")
+        var.attributes = {"bar": 42, "baz": 13}
+        copied = copy_descriptor(var)
+        self.assertIsInstance(copied, SomeVariable)
+        self.assertEqual(copied.name, "foo")
+        self.assertEqual(copied.attributes, var.attributes)
+        self.assertIsNot(copied.attributes, var.attributes)
+
+        copied = copy_descriptor(var, "cux")
+        self.assertEqual(copied.name, "cux")

--- a/doc/data-mining-library/source/reference/preprocess.rst
+++ b/doc/data-mining-library/source/reference/preprocess.rst
@@ -192,10 +192,6 @@ Continuization
            indicators in the transformed data instance are 0, the original
            instance had the first value of the corresponding variable.
 
-           If the variable descriptor defines the
-           :obj:`~Orange.data.DiscreteVariable.base_value`, the
-           specified value is used as base instead of the first one.
-
            Continuizing the variable "status" with this setting gives variables
            "status=first", "status=second" and "status=third". If all of them
            were 0, the status of the original data instance was "crew".

--- a/doc/visual-programming/source/widgets/data/continuize.md
+++ b/doc/visual-programming/source/widgets/data/continuize.md
@@ -15,9 +15,9 @@ The **Continuize** widget receives a data set in the input and outputs the same 
 
 ![](images/Continuize-stamped.png)
 
-1. [Continuization methods](https://en.wikipedia.org/wiki/Continuity_correction), which define the treatment of multivalued discrete attributes. Say that we have a discrete attribute status with the values low, middle and high, listed in that order. Options for their transformation are:  
+1. [Continuization methods](https://en.wikipedia.org/wiki/Continuity_correction), which define the treatment of multivalued discrete attributes. Say that we have a discrete attribute status with the values low, middle and high, listed in that order. Options for their transformation are:
 
-   - **Target or First value as base**: the attribute will be transformed into two continuous attributes, status=middle with values 0 or 1 signifying whether the original attribute had value middle on a particular example, and similarly, status=high. Hence, a three-valued attribute is transformed into two continuous attributes, corresponding to all except the first value of the attribute.
+   - **First value as base**: the attribute will be transformed into two continuous attributes, status=middle with values 0 or 1 signifying whether the original attribute had value middle on a particular example, and similarly, status=high. Hence, a three-valued attribute is transformed into two continuous attributes, corresponding to all except the first value of the attribute.
    - **Most frequent value as base**: similar to the above, except that the data is analyzed and the most frequent value is used as a base. So, if most examples have the value middle, the two newly constructed continuous attributes will be status=low and status=high.
    - **One attribute per value**: this would construct three continuous attributes out of a three-valued discrete one.
    - **Ignore multinominal attributes**: removes the multinominal attributes from the data.


### PR DESCRIPTION
##### Issue

Closes #3690.

##### Description of changes

`base_value` was almost unused, and also not settable in the canvas, so we decided to remove it.

##### Includes
- [X] Code changes