### PR TITLE
[MNT] Remove 'implements' from pr template [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ##### Issue
-<!-- E.g. Fixes #1, Implements #2, etc. -->
+<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
 <!-- Or a short description, if the issue does not exist. -->
 
 


### PR DESCRIPTION
##### Issue

Showing *Implements #2* besides *Fixes #1* is misleading because the latter closes #1 and the former does not.