### PR TITLE
Extend list_tables_query to show views

### DIFF
--- a/Orange/data/sql/backend/mssql.py
+++ b/Orange/data/sql/backend/mssql.py
@@ -29,8 +29,8 @@ class PymssqlBackend(Backend):
             raise BackendError("Incorrect format of connection details")
 
     def list_tables_query(self, schema=None):
-        return """        
-   SELECT [TABLE_SCHEMA], [TABLE_NAME]
+        return """
+        SELECT [TABLE_SCHEMA], [TABLE_NAME]
           FROM information_schema.tables
          WHERE TABLE_TYPE in ('VIEW' ,'BASE TABLE')
       ORDER BY [TABLE_NAME]

--- a/Orange/data/sql/backend/mssql.py
+++ b/Orange/data/sql/backend/mssql.py
@@ -29,10 +29,10 @@ class PymssqlBackend(Backend):
             raise BackendError("Incorrect format of connection details")
 
     def list_tables_query(self, schema=None):
-        return """
-        SELECT [TABLE_SCHEMA], [TABLE_NAME]
+        return """        
+   SELECT [TABLE_SCHEMA], [TABLE_NAME]
           FROM information_schema.tables
-         WHERE TABLE_TYPE='BASE TABLE'
+         WHERE TABLE_TYPE in ('VIEW' ,'BASE TABLE')
       ORDER BY [TABLE_NAME]
         """
 


### PR DESCRIPTION
Views should be supported for analysis in Orange Canvas

##### Issue

SQL Table widget in Orange Canvas only displays tables. However, most database servers have  very useful views.

You could argue that why not just use "custom SQL", but the "custom SQL" part of the widget can become too complicated for large SQLs, and it does not support CTEs.

##### Description of changes
Extended select query from information_schema.tables to include views in addition to table

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
