### PR TITLE
[FIX] LinearProjectionVizRank: Add a necessary check

### DIFF
--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -164,6 +164,8 @@ class LinearProjectionVizRank(VizRankDialog, OWComponent):
         return [item]
 
     def on_selection_changed(self, selected, deselected):
+        if not selected.indexes():
+            return
         attrs = selected.indexes()[0].data(self._AttrRole)
         self.selectionChanged.emit([attrs])
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The Linear Projection vizrank crashed. 
To reproduce:
OWFile (iris) -> OWLinearProjection (Suggest Features -> Start -> Filter by a nonexistent string)
##### Description of changes
Add a check.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
