### PR TITLE
Replace statistics.util.array_equal with data.util.array_equal

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -7,28 +7,18 @@ It also patches bottleneck to contain these functions.
 import warnings
 from typing import Iterable
 
-import numpy as np
 import bottleneck as bn
-from scipy import sparse as sp
+import numpy as np
 import scipy.stats.stats
+from scipy import sparse as sp
+
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
+from Orange.data.util import array_equal
+from Orange.util import deprecated
 
-def sparse_array_equal(x1, x2):
-    """Check if two sparse arrays are equal."""
-    if not sp.issparse(x1):
-        raise TypeError("`x1` must be sparse.")
-    if not sp.issparse(x2):
-        raise TypeError("`x2` must be sparse.")
-
-    return x1.shape == x2.shape and (x1 != x2).nnz == 0
-
-
-def array_equal(x1, x2):
-    """Equivalent of np.array_equal that properly handles sparse matrices."""
-    if sp.issparse(x1) and sp.issparse(x2):
-        return sparse_array_equal(x1, x2)
-    return np.array_equal(x1, x2)
+# For backwards compatibility
+array_equal = deprecated("Orange.data.util.array_equal")(array_equal)
 
 
 def _count_nans_per_row_sparse(X, weights, dtype=None):

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -336,7 +336,11 @@ def table_dense_sparse(test_case):
 
     @wraps(test_case)
     def _wrapper(self):
+        # Make sure to call setUp and tearDown methods in between test runs so
+        # any widget state doesn't interfere between tests
         test_case(self, lambda table: table.to_dense())
+        self.tearDown()
+        self.setUp()
         test_case(self, lambda table: table.to_sparse())
 
     return _wrapper

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -10,7 +10,7 @@ from AnyQt.QtWidgets import QGridLayout, QTableView
 from Orange.clustering import KMeans
 from Orange.clustering.kmeans import KMeansModel, SILHOUETTE_MAX_SAMPLES
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
-from Orange.data.util import get_unique_names
+from Orange.data.util import get_unique_names, array_equal
 from Orange.preprocess.impute import ReplaceUnknowns
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting
@@ -526,7 +526,7 @@ class OWKMeans(widget.OWWidget):
         self.data, old_data = data, self.data
 
         # Do not needlessly recluster the data if X hasn't changed
-        if old_data and self.data and np.array_equal(self.data.X, old_data.X):
+        if old_data and self.data and array_equal(self.data.X, old_data.X):
             if self.auto_commit:
                 self.send_data()
         else:

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -16,10 +16,9 @@ from AnyQt.QtWidgets import QSlider, QCheckBox, QWidget, QLabel
 
 from Orange.clustering.louvain import table_to_knn_graph, Louvain
 from Orange.data import Table, DiscreteVariable
-from Orange.data.util import get_unique_names
+from Orange.data.util import get_unique_names, array_equal
 from Orange import preprocess
 from Orange.projection import PCA
-from Orange.statistics import util as ut
 from Orange.widgets import widget, gui, report
 from Orange.widgets.settings import DomainContextHandler, ContextSetting, \
     Setting
@@ -408,7 +407,7 @@ class OWLouvainClustering(widget.OWWidget):
         # Make sure to properly enable/disable slider based on `apply_pca` setting
         self.controls.pca_components.setEnabled(self.apply_pca)
 
-        if prev_data and self.data and ut.array_equal(prev_data.X, self.data.X):
+        if prev_data and self.data and array_equal(prev_data.X, self.data.X):
             if self.auto_commit:
                 self._send_data()
             return

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -9,6 +9,7 @@ from AnyQt.QtCore import Qt
 import pyqtgraph as pg
 
 from Orange.data import ContinuousVariable, Domain, Table, StringVariable
+from Orange.data.util import array_equal
 from Orange.distance import Euclidean
 from Orange.misc import DistMatrix
 from Orange.projection.manifold import torgerson, MDS
@@ -323,8 +324,7 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
         self.openContext(self.data)
         self._invalidated = not (matrix_existed and
                                  self.effective_matrix is not None and
-                                 np.array_equal(effective_matrix,
-                                                self.effective_matrix))
+                                 array_equal(effective_matrix, self.effective_matrix))
         if self._invalidated:
             self.clear()
         self.graph.set_effective_matrix(self.effective_matrix)


### PR DESCRIPTION
##### Issue
Some time ago, I introduced [`statistics.util.array_equal`](https://github.com/biolab/orange3/blob/master/Orange/statistics/util.py#L17-L31), unaware of the existing [`data.util.array_equal`](https://github.com/biolab/orange3/blob/master/Orange/data/util.py#L101-L114). The latter is better because it treats NaNs equally i.e. normally NaN != NaN.

Louvain used my implementation (which would treat NaNs incorrectly), while MDS and kMeans used `np.array_equal`, which triggers a `SparseEfficiencyWarning` when comparing two sparse matrices.


##### Description of changes

1. Remove `statistics.utils.array_equal` in favour of the better implementation.
2. Louvain, MDS and kMeans now use the better implementation.

EDIT: In the process, I realised that the helper decorators for `dense_sparse` weren't resetting the state between different runs of the test. This has never come up until now, so I made sure that both the decorator functions now call the appropriate `setUp` and `tearDown` methods between test calls.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
