### PR TITLE
OWScatterplotGraph: Emit signals when resizing data points

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -340,6 +340,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
     (in methods `get_<something>`).
     """
     too_many_labels = Signal(bool)
+    begin_resizing = Signal()
+    step_resizing = Signal()
+    end_resizing = Signal()
 
     label_only_selected = Setting(False)
     point_width = Setting(10)
@@ -766,17 +769,24 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
                         size = size_data
                     widget.scatterplot_item.setSize(size)
                     widget.scatterplot_item_sel.setSize(size + SELECTION_WIDTH)
+                    if widget.timer is None:
+                        widget.end_resizing.emit()
+                    else:
+                        widget.step_resizing.emit()
 
             if self.n_valid <= MAX_N_VALID_SIZE_ANIMATE and \
                     np.all(current_size_data > 0) and np.any(diff != 0):
                 # If encountered any strange behaviour when updating sizes,
                 # implement it with threads
+                self.begin_resizing.emit()
                 self.timer = QTimer(self.scatterplot_item, interval=50)
                 self.timer.timeout.connect(Timeout())
                 self.timer.start()
             else:
+                self.begin_resizing.emit()
                 self.scatterplot_item.setSize(size_data)
                 self.scatterplot_item_sel.setSize(size_data + SELECTION_WIDTH)
+                self.end_resizing.emit()
 
     update_point_size = update_sizes  # backward compatibility (needed?!)
     update_size = update_sizes

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -458,7 +458,16 @@ class TestOWScatterPlotBase(WidgetTest):
     @patch("Orange.widgets.visualize.owscatterplotgraph"
            ".MAX_N_VALID_SIZE_ANIMATE", 5)
     def test_size_animation(self):
+        begin_resizing = QSignalSpy(self.graph.begin_resizing)
+        step_resizing = QSignalSpy(self.graph.step_resizing)
+        end_resizing = QSignalSpy(self.graph.end_resizing)
         self._update_sizes_for_points(5)
+        # first end_resizing is triggered in reset, thus wait for step_resizing
+        step_resizing.wait(200)
+        end_resizing.wait(200)
+        self.assertEqual(len(begin_resizing), 2)  # reset and update
+        self.assertEqual(len(step_resizing), 5)
+        self.assertEqual(len(end_resizing), 2)  # reset and update
         self.assertEqual(self.graph.scatterplot_item.setSize.call_count, 6)
         self._update_sizes_for_points(6)
         self.graph.scatterplot_item.setSize.assert_called_once()


### PR DESCRIPTION
##### Issue

In Network Explorer, I wanted to draw lines to the edge of the circles, not to the center. I tried to override `update_sizes` to call `self.update_edges()` after `super().update_sizes()`... but this didn't work because `update_size` does not change sizes immediately but updates them from a separate thread.

Furthermore, it would be nice if edges were animated together with circles.

##### Description of changes

I added signals that are emitted at the start and end of resize, and at each step.

##### Includes
- [X] Code changes
- [X] Tests