### PR TITLE
[FIX] OWLinePlot: legible bottom axis labels

### DIFF
--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -91,6 +91,25 @@ class LinePlotStyle:
     MEAN_DARK_FACTOR = 110
 
 
+class LinePlotAxisItem(pg.AxisItem):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._ticks = None
+
+    def set_ticks(self, ticks):
+        self._ticks = dict(enumerate(ticks, 1)) if ticks else None
+
+    def tickStrings(self, values, scale, spacing):
+        if not self._ticks:
+            return []
+        strings = []
+        for v in values:
+            v = v * scale
+            if float(v).is_integer():
+                strings.append(self._ticks.get(int(v), ""))
+        return strings
+
+
 class LinePlotViewBox(ViewBox):
     selection_changed = Signal(np.ndarray)
 
@@ -172,8 +191,10 @@ class LinePlotViewBox(ViewBox):
 
 class LinePlotGraph(pg.PlotWidget):
     def __init__(self, parent):
+        self.bottom_axis = LinePlotAxisItem(orientation="bottom")
         super().__init__(parent, viewBox=LinePlotViewBox(),
-                         background="w", enableMenu=False)
+                         background="w", enableMenu=False,
+                         axisItems={"bottom": self.bottom_axis})
         self.view_box = self.getViewBox()
         self.selection = set()
         self.legend = self._create_legend(((1, 0), (1, 0)))
@@ -213,7 +234,7 @@ class LinePlotGraph(pg.PlotWidget):
         self.selection = set()
         self.view_box.reset()
         self.clear()
-        self.getAxis('bottom').setTicks(None)
+        self.getAxis('bottom').set_ticks(None)
         self.legend.hide()
 
     def select_button_clicked(self):
@@ -593,8 +614,8 @@ class OWLinePlot(OWWidget):
         if self.data is None:
             return
 
-        ticks = [[(i, a.name) for i, a in enumerate(self.graph_variables, 1)]]
-        self.graph.getAxis('bottom').setTicks(ticks)
+        ticks = [a.name for a in self.graph_variables]
+        self.graph.getAxis("bottom").set_ticks(ticks)
         self.plot_groups()
         self.apply_selection()
         self.graph.view_box.enableAutoRange()

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -94,20 +94,13 @@ class LinePlotStyle:
 class LinePlotAxisItem(pg.AxisItem):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._ticks = None
+        self._ticks = {}
 
     def set_ticks(self, ticks):
-        self._ticks = dict(enumerate(ticks, 1)) if ticks else None
+        self._ticks = dict(enumerate(ticks, 1)) if ticks else {}
 
     def tickStrings(self, values, scale, spacing):
-        if not self._ticks:
-            return []
-        strings = []
-        for v in values:
-            v = v * scale
-            if float(v).is_integer():
-                strings.append(self._ticks.get(int(v), ""))
-        return strings
+        return [self._ticks.get(v * scale, "") for v in values]
 
 
 class LinePlotViewBox(ViewBox):

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -290,3 +290,7 @@ class TestSegmentsIntersection(unittest.TestCase):
                           for i in range(y.shape[1])])
         i = line_intersects_profiles(a, b, table)
         np.testing.assert_array_equal(np.array([False, True, True, True]), i)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #3741

##### Description of changes
Subclass `pg.AxisItem` and override `tickStrings()` to display feature's names.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
