### PR TITLE
[DOC] Add a requirements file for readthedocs

### DIFF
--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,0 +1,4 @@
+-r requirements-core.txt
+-r requirements-doc.txt
+-r requirements-gui.txt
+PyQt5


### PR DESCRIPTION
##### Issue
Fixed #3754

##### Description
Here I built test documentation from this branch:
https://test-123-or-wid.readthedocs.io/en/latest/gui.html

Compare with
https://orange-development.readthedocs.io/gui.html

After this is merged, we also need to set requirements file on ReadTheDocs to "requirements-readthedocs.txt"
