### PR TITLE
[DOC] Replace numpydoc with sphinx.ext.napoleon

### DIFF
--- a/doc/data-mining-library/source/conf.py
+++ b/doc/data-mining-library/source/conf.py
@@ -42,10 +42,9 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
-    'numpydoc',
+    'sphinx.ext.napoleon',
 ]
 
-numpydoc_show_class_members = False
 autodoc_member_order = "bysource"
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,4 +1,3 @@
 docutils
-numpydoc
 Sphinx>=1.3
 recommonmark


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Reference documentation fails to build with sphinx==2.0.1 and numpydoc==0.9.1. (raises `numpydoc.docscrape.ParseError: ...`)

##### Description of changes

Use sphinx.ext.napoleon instead of numpydoc

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
