### PR TITLE
[FIX] Minor improvements to pythagorean trees

### DIFF
--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -224,6 +224,8 @@ class OWPythagorasTree(OWWidget):
         self.invalidate_tree()
 
     def redraw(self):
+        if self.data is None:
+            return
         self.tree_adapter.shuffle_children()
         self.invalidate_tree()
 

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -57,6 +57,8 @@ class OWPythagorasTree(OWWidget):
     graph_name = 'scene'
 
     # Settings
+    settingsHandler = settings.DomainContextHandler()
+
     depth_limit = settings.ContextSetting(10)
     target_class_index = settings.ContextSetting(0)
     size_calc_idx = settings.Setting(0)
@@ -194,7 +196,9 @@ class OWPythagorasTree(OWWidget):
             #     self.depth_limit = model.meta_depth_limit
             #     self.update_depth()
 
-        self.Outputs.annotated_data.send(create_annotated_table(self.instances, None))
+        self.openContext(self.model)
+
+        self.Outputs.annotated_data.send(create_annotated_table(self.data, None))
 
     def clear(self):
         """Clear all relevant data from the widget."""

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -172,24 +172,23 @@ class OWPythagorasTree(OWWidget):
 
             self._update_main_area()
 
-            # The target class can also be passed from the meta properties
-            # This must be set after `_update_target_class_combo`
-            if hasattr(model, 'meta_target_class_index'):
-                self.target_class_index = model.meta_target_class_index
-                self.update_colors()
-
-            # Get meta variables describing what the settings should look like
-            # if the tree is passed from the Pythagorean forest widget.
-            if hasattr(model, 'meta_size_calc_idx'):
-                self.size_calc_idx = model.meta_size_calc_idx
-                self.update_size_calc()
-
-            # TODO There is still something wrong with this
-            # if hasattr(model, 'meta_depth_limit'):
-            #     self.depth_limit = model.meta_depth_limit
-            #     self.update_depth()
-
         self.openContext(self.model)
+
+        self.update_depth()
+
+        # The forest widget sets the following attributes on the tree,
+        # describing the settings on the forest widget. To keep the tree
+        # looking the same as on the forest widget, we prefer these settings to
+        # context settings, if set.
+        if hasattr(model, "meta_target_class_index"):
+            self.target_class_index = model.meta_target_class_index
+            self.update_colors()
+        if hasattr(model, "meta_size_calc_idx"):
+            self.size_calc_idx = model.meta_size_calc_idx
+            self.update_size_calc()
+        if hasattr(model, "meta_depth_limit"):
+            self.depth_limit = model.meta_depth_limit
+            self.update_depth()
 
         self.Outputs.annotated_data.send(create_annotated_table(self.data, None))
 

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -203,7 +203,6 @@ class OWPythagoreanForest(OWWidget):
         self.rf_model = None
         self.forest = None
         self.instances = None
-        self.clf_dataset = None
 
         self.color_palette = None
 
@@ -276,13 +275,7 @@ class OWPythagoreanForest(OWWidget):
         if model is not None:
             self.forest = self._get_forest_adapter(self.rf_model)
             self.forest_model[:] = self.forest.trees
-
             self.instances = model.instances
-            # This bit is important for the regression classifier
-            if self.instances is not None and self.instances.domain != model.domain:
-                self.clf_dataset = self.instances.transform(self.rf_model.domain)
-            else:
-                self.clf_dataset = self.instances
 
             self._update_info_box()
             self._update_target_class_combo()

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -383,3 +383,15 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
             square.setSelected(True)
             tab = self.get_output(tree_w.Outputs.selected_data, widget=tree_w)
             self.assertGreater(len(tab), 0)
+
+    def test_changing_data_restores_depth_from_previous_settings(self):
+        titanic_data = Table("titanic")[::50]
+        forest = RandomForestLearner(n_estimators=3)(titanic_data)
+        forest.instances = titanic_data
+
+        self.send_signal(self.widget.Inputs.tree, forest.trees[0])
+        self.widget.controls.depth_limit.setValue(1)
+
+        # The domain is still the same, so restore the depth limit from before
+        self.send_signal(self.widget.Inputs.tree, forest.trees[1])
+        self.assertEqual(self.widget.ptree._depth_limit, 1)


### PR DESCRIPTION
##### Description of changes
This fixes a couple of minor things I came across while reviewing #3775.

1. Remember selection in the Pythagorean forest widget so that reopening a workflow won't clear selection.
2. Remove some dead code from both widgets
3. Properly use context settings in Pythagorean tree and forest widget (before, it wasn't using the domain context settings handler.
4. The tree widget would crash if there was no data and we clicked "Redraw".

The tree widget does not currently remember selection (both when reopening a workflow or when redrawing), and this will be a bit trickier to implement, since Orange trees have no identifier for each node.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
