### PR TITLE
[ENH] Error Animations

### DIFF
--- a/Orange/canvas/canvas/items/nodeitem.py
+++ b/Orange/canvas/canvas/items/nodeitem.py
@@ -615,7 +615,7 @@ class GraphicsIconItem(QGraphicsWidget):
         self.anim.setKeyValueAt(0.5, 0)
         self.anim.setEndValue(1)
         self.anim.setEasingCurve(QEasingCurve.OutQuad)
-        self.anim.setLoopCount(2)
+        self.anim.setLoopCount(5)
 
     def setIcon(self, icon):
         """

--- a/Orange/widgets/utils/messagewidget.py
+++ b/Orange/widgets/utils/messagewidget.py
@@ -369,7 +369,7 @@ class MessagesWidget(QWidget):
         self.anim.setKeyValueAt(0.5, 0)
         self.anim.setEndValue(1)
         self.anim.setEasingCurve(QEasingCurve.OutQuad)
-        self.anim.setLoopCount(2)
+        self.anim.setLoopCount(5)
 
     def sizeHint(self):
         sh = super().sizeHint()

--- a/Orange/widgets/utils/messagewidget.py
+++ b/Orange/widgets/utils/messagewidget.py
@@ -9,7 +9,7 @@ from typing import (
     NamedTuple, Tuple, List, Dict, Iterable, Union, Optional, Hashable
 )
 
-from AnyQt.QtCore import Qt, QSize, QBuffer
+from AnyQt.QtCore import Qt, QSize, QBuffer, QPropertyAnimation, QEasingCurve, Property
 from AnyQt.QtGui import (
     QIcon, QPixmap, QPainter, QPalette, QLinearGradient, QBrush, QPen
 )
@@ -363,6 +363,14 @@ class MessagesWidget(QWidget):
         self.__textlabel.setAttribute(Qt.WA_MacSmallSize)
         self.__defaultStyleSheet = defaultStyleSheet
 
+        self.anim = QPropertyAnimation(self.__iconwidget, b"opacity")
+        self.anim.setDuration(350)
+        self.anim.setStartValue(1)
+        self.anim.setKeyValueAt(0.5, 0)
+        self.anim.setEndValue(1)
+        self.anim.setEasingCurve(QEasingCurve.OutQuad)
+        self.anim.setLoopCount(2)
+
     def sizeHint(self):
         sh = super().sizeHint()
         h = self.style().pixelMetric(QStyle.PM_SmallIconSize)
@@ -514,6 +522,7 @@ class MessagesWidget(QWidget):
         icon = message_icon(summary)
         self.__iconwidget.setIcon(icon)
         self.__iconwidget.setVisible(not (summary.isEmpty() or icon.isNull()))
+        self.anim.start(QPropertyAnimation.KeepWhenStopped)
         self.__textlabel.setTextFormat(summary.textFormat)
         self.__textlabel.setText(summary.text)
         self.__textlabel.setVisible(bool(summary.text))
@@ -614,6 +623,7 @@ class IconWidget(QWidget):
         sizePolicy = kwargs.pop("sizePolicy", QSizePolicy(QSizePolicy.Fixed,
                                                           QSizePolicy.Fixed))
         super().__init__(parent, **kwargs)
+        self._opacity = 1
         self.__icon = QIcon(icon)
         self.__iconSize = QSize(iconSize)
         self.setSizePolicy(sizePolicy)
@@ -624,6 +634,15 @@ class IconWidget(QWidget):
             self.__icon = QIcon(icon)
             self.updateGeometry()
             self.update()
+
+    def getOpacity(self):
+        return self._opacity
+
+    def setOpacity(self, o):
+        self._opacity = o
+        self.update()
+
+    opacity = Property(float, fget=getOpacity, fset=setOpacity)
 
     def icon(self):
         # type: () -> QIcon
@@ -652,6 +671,7 @@ class IconWidget(QWidget):
 
     def paintEvent(self, event):
         painter = QStylePainter(self)
+        painter.setOpacity(self._opacity)
         opt = QStyleOption()
         opt.initFrom(self)
         painter.drawPrimitive(QStyle.PE_Widget, opt)

--- a/Orange/widgets/utils/messagewidget.py
+++ b/Orange/widgets/utils/messagewidget.py
@@ -505,6 +505,12 @@ class MessagesWidget(QWidget):
         else:
             return Message()
 
+    def flashIcon(self):
+        for message in self.messages():
+            if message.severity != Severity.Information:
+                self.anim.start(QPropertyAnimation.KeepWhenStopped)
+                break
+
     @staticmethod
     def __styled(css, html):
         # Prepend css style sheet before a html fragment.

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -17,8 +17,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtCore import (
     Qt, QObject, QEvent, QRect, QMargins, QByteArray, QDataStream, QBuffer,
-    QSettings, QUrl, QThread, pyqtSignal as Signal, QSize,
-    QPropertyAnimation)
+    QSettings, QUrl, QThread, pyqtSignal as Signal, QSize)
 from AnyQt.QtGui import QIcon, QKeySequence, QDesktopServices, QPainter
 
 from Orange.data import FileFormat
@@ -290,7 +289,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
     @classmethod
     def get_widget_description(cls):
         if not cls.name:
-            return
+            return None
         properties = {name: getattr(cls, name) for name in
                       ("name", "icon", "description", "priority", "keywords",
                        "help", "help_ref", "url",
@@ -298,8 +297,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         properties["id"] = cls.id or cls.__module__
         properties["inputs"] = cls.get_signals("inputs")
         properties["outputs"] = cls.get_signals("outputs")
-        properties["qualified_name"] = \
-            "{}.{}".format(cls.__module__, cls.__name__)
+        properties["qualified_name"] = f"{cls.__module__}.{cls.__name__}"
         return properties
 
     @classmethod
@@ -924,7 +922,6 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         attributes. See :obj:`Orange.widgets.data.owcolor.OWColor` for an
         example.
         """
-        pass
 
     def storeSpecificSettings(self):
         """
@@ -936,7 +933,6 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         attributes. See :obj:`Orange.widgets.data.owcolor.OWColor` for an
         example.
         """
-        pass
 
     def saveSettings(self):
         """
@@ -953,7 +949,6 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         If possible, subclasses should gracefully cancel any currently
         executing tasks.
         """
-        pass
 
     def handleNewSignals(self):
         """
@@ -963,7 +958,6 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         Reimplement this method in order to coalesce updates from
         multiple updated inputs.
         """
-        pass
 
     #: Widget's status message has changed.
     statusMessageChanged = Signal(str)
@@ -1054,7 +1048,6 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
         The default implementation does nothing.
         """
-        pass
 
     def saveGeometryAndLayoutState(self):
         # type: () -> QByteArray
@@ -1253,7 +1246,7 @@ class _StatusBar(QStatusBar):
         painter.end()
 
 
-class Message(object):
+class Message:
     """
     A user message.
 

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -17,8 +17,8 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtCore import (
     Qt, QObject, QEvent, QRect, QMargins, QByteArray, QDataStream, QBuffer,
-    QSettings, QUrl, QThread, pyqtSignal as Signal, QSize
-)
+    QSettings, QUrl, QThread, pyqtSignal as Signal, QSize,
+    QPropertyAnimation)
 from AnyQt.QtGui import QIcon, QKeySequence, QDesktopServices, QPainter
 
 from Orange.data import FileFormat
@@ -826,6 +826,11 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
         if self.save_position and self.isVisible():
             self.__updateSavedGeometry()
         QDialog.closeEvent(self, event)
+
+    def mousePressEvent(self, event):
+        """ Flash message bar icon on mouse press """
+        self.message_bar.anim.start(QPropertyAnimation.KeepWhenStopped)
+        event.ignore()
 
     def setVisible(self, visible):
         # type: (bool) -> None

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -829,7 +829,7 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     def mousePressEvent(self, event):
         """ Flash message bar icon on mouse press """
-        self.message_bar.anim.start(QPropertyAnimation.KeepWhenStopped)
+        self.message_bar.flashIcon()
         event.ignore()
 
     def setVisible(self, visible):


### PR DESCRIPTION
##### Issue
Resolves #3377, #3699 

##### Description of changes
Using QPropertyAnimation and an opacity property, makes warnings and errors flash on update.

In nodeitem.py, GraphicsIconItem now subclasses QGraphicsWidget instead of QGraphicsItem (to allow QPropertyAnimation). I've not tested this change extensively, and am not aware of its implications.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
