### PR TITLE
[FIX] VerticalItemDelegate: Do not cut long vertical labels

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -3084,6 +3084,10 @@ class VerticalItemDelegate(QStyledItemDelegate):
     # Extra text top/bottom margin.
     Margin = 6
 
+    def __init__(self, extend=False):
+        super().__init__()
+        self._extend = extend  # extend text over cell borders
+
     def sizeHint(self, option, index):
         sh = super().sizeHint(option, index)
         return QtCore.QSize(sh.height() + self.Margin * 2, sh.width())
@@ -3121,6 +3125,8 @@ class VerticalItemDelegate(QStyledItemDelegate):
                 offset = -offset
 
             textrect.translate(0, offset)
+            if self._extend and brect.width() > itemrect.width():
+                textrect.setWidth(brect.width())
 
         painter.translate(option.rect.x(), option.rect.bottom())
         painter.rotate(-90)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Long vertical labels (i.e. labels for table's vertical header) are cut off: 
<img width="433" alt="Screen Shot 2019-05-15 at 11 17 06" src="https://user-images.githubusercontent.com/12524972/57765022-ee1d8f80-7704-11e9-8d77-f4b0acdf1f04.png">

##### Description of changes
Show the whole label.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
