### PR TITLE
Remove domain from model

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -90,7 +90,6 @@ class Learner(ReprableWithPreprocessors):
             self.preprocessors = tuple(preprocessors)
         elif preprocessors:
             self.preprocessors = (preprocessors,)
-        self.__tls = threading.local()
 
     def fit(self, X, Y, W=None):
         raise RuntimeError(
@@ -117,7 +116,6 @@ class Learner(ReprableWithPreprocessors):
             raise TypeError("%s doesn't support multiple class variables" %
                             self.__class__.__name__)
 
-        self.domain = data.domain
         model = self._fit_model(data)
         model.used_vals = [np.unique(y) for y in data.Y[:, None].T]
         model.domain = data.domain
@@ -172,31 +170,6 @@ class Learner(ReprableWithPreprocessors):
     @name.setter
     def name(self, value):
         self.__name = value
-
-    # Learners implemented using `fit` access the `domain` through the
-    # instance attribute. This makes (or it would) make it impossible to
-    # be implemented in a thread-safe manner. So the domain is made a
-    # property descriptor utilizing thread local storage behind the scenes.
-    @property
-    def domain(self):
-        return self.__tls.domain
-
-    @domain.setter
-    def domain(self, domain):
-        self.__tls.domain = domain
-
-    @domain.deleter
-    def domain(self):
-        del self.__tls.domain
-
-    def __getstate__(self):
-        state = dict(self.__dict__)
-        del state["_Learner__tls"]
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self.__tls = threading.local()
 
     def __str__(self):
         return self.name

--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -20,7 +20,7 @@ class _FeatureScorerMixin(LearnerScorer):
     def score(self, data):
         data = Normalize()(data)
         model = self(data)
-        return np.abs(model.coefficients)
+        return np.abs(model.coefficients), model.domain.attributes
 
 
 class LogisticRegressionClassifier(SklModel):

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -15,7 +15,7 @@ class _FeatureScorerMixin(LearnerScorer):
 
     def score(self, data):
         model = self(data)
-        return model.skl_model.feature_importances_
+        return model.skl_model.feature_importances_, model.domain.attributes
 
 
 class RandomForestClassifier(SklModel, RandomForestModel):

--- a/Orange/classification/rules.py
+++ b/Orange/classification/rules.py
@@ -11,9 +11,9 @@ import operator
 from copy import copy
 from hashlib import sha1
 from collections import namedtuple
-import bottleneck as bn
 import numpy as np
 from scipy.stats import chi2
+import bottleneck as bn
 
 from Orange.classification import Learner, Model
 from Orange.data import Table, _contingency
@@ -803,7 +803,6 @@ class RuleHuntress:
     """
     An experimental implementation of the CN2-R algorithm.
     """
-    pass
 
 
 class RuleHunter:

--- a/Orange/modelling/linear.py
+++ b/Orange/modelling/linear.py
@@ -15,7 +15,8 @@ class _FeatureScorerMixin(LearnerScorer):
 
     def score(self, data):
         model = self.get_learner(data)(data)
-        return np.atleast_2d(np.abs(model.skl_model.coef_)).mean(0)
+        return (np.atleast_2d(np.abs(model.skl_model.coef_)).mean(0),
+                model.domain.attributes)
 
 
 class SGDLearner(SklFitter, _FeatureScorerMixin):

--- a/Orange/modelling/randomforest.py
+++ b/Orange/modelling/randomforest.py
@@ -14,7 +14,7 @@ class _FeatureScorerMixin(LearnerScorer):
 
     def score(self, data):
         model = self.get_learner(data)(data)
-        return model.skl_model.feature_importances_
+        return model.skl_model.feature_importances_, model.domain.attributes
 
 
 class RandomForestLearner(SklFitter, _FeatureScorerMixin):

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -170,7 +170,7 @@ class LearnerScorer(Scorer):
             directly correspond to the domain. For example, continuization creates multiple
             features from a discrete feature. """
             scores_grouped = defaultdict(list)
-            for attr, score in zip(model_domain.attributes, scores):
+            for attr, score in zip(model_attributes, scores):
                 # Go up the chain of preprocessors to obtain the original variable, but no further
                 # than the data.domain, because the data is perhaphs already preprocessed.
                 while not (attr in data.domain) and getattr(attr, 'compute_value', False):
@@ -180,14 +180,9 @@ class LearnerScorer(Scorer):
                     if attr in scores_grouped else 0
                     for attr in data.domain.attributes]
 
-        scores = np.atleast_2d(self.score(data))
-
-        from Orange.modelling import Fitter  # Avoid recursive import
-        model_domain = (self.get_learner(data).domain
-                        if isinstance(self, Fitter) else
-                        self.domain)
-
-        if data.domain != model_domain:
+        scores, model_attributes = self.score(data)
+        scores = np.atleast_2d(scores)
+        if data.domain.attributes != model_attributes:
             scores = np.array([join_derived_features(row) for row in scores])
 
         return scores[:, data.domain.attributes.index(feature)] \

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -243,8 +243,10 @@ class _FeatureScorerMixin(LearnerScorer):
 
     def score(self, data):
         model = self(data)
-        return np.abs(model.components_[:self.component]) \
-            if self.component else np.abs(model.components_)
+        return (
+            np.abs(model.components_[:self.component]) if self.component
+            else np.abs(model.components_),
+            model.orig_domain.attributes)
 
 
 class PCA(SklProjector, _FeatureScorerMixin):

--- a/Orange/projection/pca.py
+++ b/Orange/projection/pca.py
@@ -154,19 +154,19 @@ class ImprovedPCA(skl_decomposition.PCA):
                 "n_components=%r cannot be a string with svd_solver='%s'" %
                 (n_components, svd_solver)
             )
-        elif not 1 <= n_components <= min(n_samples, n_features):
+        if not 1 <= n_components <= min(n_samples, n_features):
             raise ValueError(
                 "n_components=%r must be between 1 and min(n_samples, "
                 "n_features)=%r with svd_solver='%s'" % (
                     n_components, min(n_samples, n_features), svd_solver
                 )
             )
-        elif not isinstance(n_components, (numbers.Integral, np.integer)):
+        if not isinstance(n_components, (numbers.Integral, np.integer)):
             raise ValueError(
                 "n_components=%r must be of type int when greater than or "
                 "equal to 1, was of type=%r" % (n_components, type(n_components))
             )
-        elif svd_solver == "arpack" and n_components == min(n_samples, n_features):
+        if svd_solver == "arpack" and n_components == min(n_samples, n_features):
             raise ValueError(
                 "n_components=%r must be strictly less than min(n_samples, "
                 "n_features)=%r with svd_solver='%s'" % (

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -31,7 +31,7 @@ class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):
     def __init__(self, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
 
-    def fit(self, X, Y, W):
+    def fit(self, X, Y, W=None):
         model = super().fit(X, Y, W)
         return LinearModel(model.skl_model)
 
@@ -114,7 +114,7 @@ class PolynomialLearner(Learner):
         self.degree = degree
         self.learner = learner
 
-    def fit(self, X, Y, W):
+    def fit(self, X, Y, W=None):
         polyfeatures = skl_preprocessing.PolynomialFeatures(self.degree)
         X = polyfeatures.fit_transform(X)
         clf = self.learner

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -22,7 +22,7 @@ class _FeatureScorerMixin(LearnerScorer):
     def score(self, data):
         data = Normalize()(data)
         model = self(data)
-        return np.abs(model.coefficients)
+        return np.abs(model.coefficients), model.domain.attributes
 
 
 class LinearRegressionLearner(SklLearner, _FeatureScorerMixin):

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -15,7 +15,7 @@ class _FeatureScorerMixin(LearnerScorer):
 
     def score(self, data):
         model = self(data)
-        return model.skl_model.feature_importances_
+        return model.skl_model.feature_importances_, model.domain.attributes
 
 
 class RandomForestRegressor(SklModel, RandomForestModel):

--- a/Orange/widgets/model/owrules.py
+++ b/Orange/widgets/model/owrules.py
@@ -276,13 +276,13 @@ class OWRuleLearner(OWBaseLearner):
         # bottom-level search procedure (search bias)
         middle_box = gui.vBox(widget=self.controlArea, box="Rule search")
 
-        evaluation_measure_box = gui.comboBox(
+        gui.comboBox(
             widget=middle_box, master=self, value="evaluation_measure",
             label="Evaluation measure:", orientation=Qt.Horizontal,
             items=("Entropy", "Laplace accuracy", "WRAcc"),
             callback=self.settings_changed, contentsLength=3)
 
-        beam_width_box = gui.spin(
+        gui.spin(
             widget=middle_box, master=self, value="beam_width", minv=1,
             maxv=100, step=1, label="Beam width:", orientation=Qt.Horizontal,
             callback=self.settings_changed, alignment=Qt.AlignRight,
@@ -291,26 +291,26 @@ class OWRuleLearner(OWBaseLearner):
         # bottom-level search procedure (over-fitting avoidance bias)
         bottom_box = gui.vBox(widget=self.controlArea, box="Rule filtering")
 
-        min_covered_examples_box = gui.spin(
+        gui.spin(
             widget=bottom_box, master=self, value="min_covered_examples", minv=1,
             maxv=10000, step=1, label="Minimum rule coverage:",
             orientation=Qt.Horizontal, callback=self.settings_changed,
             alignment=Qt.AlignRight, controlWidth=80)
 
-        max_rule_length_box = gui.spin(
+        gui.spin(
             widget=bottom_box, master=self, value="max_rule_length",
             minv=1, maxv=100, step=1, label="Maximum rule length:",
             orientation=Qt.Horizontal, callback=self.settings_changed,
             alignment=Qt.AlignRight, controlWidth=80)
 
-        default_alpha_spin = gui.doubleSpin(
+        gui.doubleSpin(
             widget=bottom_box, master=self, value="default_alpha", minv=0.0,
             maxv=1.0, step=0.01, label="Statistical significance\n(default α):",
             orientation=Qt.Horizontal, callback=self.settings_changed,
             alignment=Qt.AlignRight, controlWidth=80,
             checked="checked_default_alpha")
 
-        parent_alpha_spin = gui.doubleSpin(
+        gui.doubleSpin(
             widget=bottom_box, master=self, value="parent_alpha", minv=0.0,
             maxv=1.0, step=0.01, label="Relative significance\n(parent α):",
             orientation=Qt.Horizontal, callback=self.settings_changed,

--- a/Orange/widgets/model/owrules.py
+++ b/Orange/widgets/model/owrules.py
@@ -150,7 +150,7 @@ class CustomRuleLearner(_RuleLearner):
         # while data allows, continuously find new rules,
         # break the loop if min. requirements cannot be met,
         # after finding a rule, remove the instances covered
-        while not self.data_stopping(X, Y, W, target_class):
+        while not self.data_stopping(X, Y, W, target_class, domain):
 
             # remember the distribution to correctly update progress
             temp_class_dist = get_dist(Y, W, domain)
@@ -180,28 +180,30 @@ class CustomRuleLearner(_RuleLearner):
 
         return rule_list
 
-    def fit(self, X, Y, W=None):
+    def fit_storage(self, data):
         rule_list = []
+        X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
         Y = Y.astype(dtype=int)
         if self.rule_ordering == "ordered":
             rule_list = self.find_rules_and_measure_progress(
                 X, Y, np.copy(W) if W is not None else None, None,
-                self.base_rules, self.domain, progress_amount=1)
+                self.base_rules, data.domain, progress_amount=1)
             # add the default rule, if required
             if (not rule_list or rule_list and rule_list[-1].length > 0 or
                     self.covering_algorithm == "weighted"):
-                rule_list.append(self.generate_default_rule(X, Y, W, self.domain))
+                rule_list.append(
+                    self.generate_default_rule(X, Y, W, data.domain))
 
         elif self.rule_ordering == "unordered":
-            for curr_class in range(len(self.domain.class_var.values)):
+            for curr_class in range(len(data.domain.class_var.values)):
                 rule_list.extend(self.find_rules_and_measure_progress(
                     X, Y, np.copy(W) if W is not None else None,
-                    curr_class, self.base_rules, self.domain,
-                    progress_amount=1/len(self.domain.class_var.values)))
+                    curr_class, self.base_rules, data.domain,
+                    progress_amount=1/len(data.domain.class_var.values)))
             # add the default rule
-            rule_list.append(self.generate_default_rule(X, Y, W, self.domain))
+            rule_list.append(self.generate_default_rule(X, Y, W, data.domain))
 
-        return CustomRuleClassifier(domain=self.domain, rule_list=rule_list,
+        return CustomRuleClassifier(domain=data.domain, rule_list=rule_list,
                                     params=self.params)
 
 


### PR DESCRIPTION
##### Issue

Fixes #3384.

##### Description of changes

To my observation, `domain` was used in two places:

- Rule learner implemented `fit` instead of `fit_storage` and, besides, it's methods retrieved the domain from an attribute instead of passing it as an argument ("attribute instead of argument" is basically the same as "global instead of argument"!). I replaced `fit` with `fit_storage` and moved `domain` to arguments.

- When learners are used as scorers, and if they preprocess the data so that the number of attributes is increased (e.g. one-hot-encoding) they need domain to "project" the scores back to original attributes. These domains were retrieved from models. Now, domain is returned as part of result, together with scores.

##### Includes
- [X] Code changes
