### PR TITLE
Stop suppressing ".*the matrix subclass.* warnings

### DIFF
--- a/Orange/__init__.py
+++ b/Orange/__init__.py
@@ -53,10 +53,3 @@ except:  # pylint: disable=bare-except
     pass
 finally:
     del ctypes
-
-
-# scipy.sparse uses matrix
-# we can't do anything about it, so we silence it until scipy is fixed
-import warnings
-warnings.filterwarnings(
-    "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -3,7 +3,6 @@
 
 import unittest
 from unittest.mock import Mock
-import warnings
 
 import numpy as np
 import scipy.sparse as sp
@@ -98,18 +97,12 @@ class TestNaiveBayesLearner(unittest.TestCase):
         self._test_predictions_with_absent_class(sparse=None)
 
     def test_predictions_csr_matrix(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
-            self._test_predictions(sparse=sp.csr_matrix)
-            self._test_predictions_with_absent_class(sparse=sp.csr_matrix)
+        self._test_predictions(sparse=sp.csr_matrix)
+        self._test_predictions_with_absent_class(sparse=sp.csr_matrix)
 
     def test_predictions_csc_matrix(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
-            self._test_predictions(sparse=sp.csc_matrix)
-            self._test_predictions_with_absent_class(sparse=sp.csc_matrix)
+        self._test_predictions(sparse=sp.csc_matrix)
+        self._test_predictions_with_absent_class(sparse=sp.csc_matrix)
 
     def _test_predictions(self, sparse):
         x = np.array([

--- a/Orange/tests/test_orange.py
+++ b/Orange/tests/test_orange.py
@@ -1,8 +1,4 @@
 import unittest
-import warnings
-import os
-
-import scipy.sparse as sp
 
 
 class TestOrange(unittest.TestCase):
@@ -14,16 +10,3 @@ class TestOrange(unittest.TestCase):
         for _, name, __ in pkgutil.iter_modules(Orange.__path__):
             if name not in unimported:
                 self.assertIn(name, Orange.__dict__)
-
-    @unittest.skipUnless(
-        os.environ.get("TRAVIS"),
-        "Travis has latest versions; Appveyor doesn't, and users don't care")
-    def test_remove_matrix_deprecation_filter(self):
-        # Override filter in Orange.__init__
-        warnings.filterwarnings(
-            "once", ".*the matrix subclass.*", PendingDeprecationWarning)
-        with self.assertWarns(
-                PendingDeprecationWarning,
-                msg="Remove filter for PendingDeprecationWarning of np.matrix "
-                    "from Orange.__init__"):
-            sp.lil_matrix([1, 2, 3])

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -1,5 +1,4 @@
 import datetime
-import warnings
 from collections import namedtuple
 from functools import partial
 from itertools import chain
@@ -180,9 +179,6 @@ class TestVariousDataSets(WidgetTest):
         self.widget = self.create_widget(
             OWFeatureStatistics, stored_settings={'auto_commit': False}
         )
-        # scipy.sparse uses matrix; this filter can be removed when it stops
-        warnings.filterwarnings(
-            "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
 
     def force_render_table(self):
         """Some fields e.g. histograms are only initialized when they actually

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -1,4 +1,3 @@
-import warnings
 from contextlib import contextmanager
 import os
 import pickle
@@ -1018,10 +1017,6 @@ class ProjectionWidgetTestMixin:
 
     def test_sparse_data(self, timeout=DEFAULT_TIMEOUT):
         """Test widget for sparse data"""
-        # scipy.sparse uses matrix; this filter can be removed when it stops
-        warnings.filterwarnings(
-            "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
-
         table = Table("iris").to_sparse()
         self.assertTrue(sp.issparse(table.X))
         self.send_signal(self.widget.Inputs.data, table)

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -1,6 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-import warnings
 from unittest import skip
 from unittest.mock import patch, Mock
 
@@ -22,9 +21,6 @@ class TestOWManifoldLearning(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(
             OWManifoldLearning, stored_settings={"auto_apply": False})  # type: OWManifoldLearning
-        # scipy.sparse uses matrix; this filter can be removed when it's fixed
-        warnings.filterwarnings(
-            "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
 
     def test_input_data(self):
         """Check widget's data"""

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -1,6 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-import warnings
 import unittest
 from unittest.mock import Mock
 
@@ -30,13 +29,6 @@ class TestOWFreeViz(WidgetTest, AnchorProjectionWidgetTestMixin,
 
     def setUp(self):
         self.widget = self.create_widget(OWFreeViz)
-
-    def test_sparse_data(self):
-        """Test widget for sparse data"""
-        # scipy.sparse uses matrix; this filter can be removed when it's fixed
-        warnings.filterwarnings(
-            "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
-        super().test_sparse_data()
 
     def test_error_msg(self):
         data = self.data[:, list(range(len(self.data.domain.attributes)))]

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -140,10 +140,6 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         """
         Sparse support.
         """
-        # scipy.sparse uses matrix; this filter can be removed when it's fixed
-        warnings.filterwarnings(
-            "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
-
         self.send_signal(self.widget.Inputs.data, self.iris)
         self.assertEqual(len(self.widget.discrete_data.domain),
                          len(self.iris.domain))

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -2,7 +2,6 @@
 # pylint: disable=missing-docstring
 
 import unittest
-import warnings
 from collections import defaultdict
 
 import numpy as np
@@ -208,9 +207,6 @@ class GroupTableIndicesTest(unittest.TestCase):
         self.assertEqual(varying_between(data, idvar=data.domain.metas[0]),
                          [variables[2], variables[3], metas[3], metas[4], metas[5], metas[6]])
 
-        # scipy.sparse uses matrix; this filter can be removed when it's fixed
-        warnings.filterwarnings(
-            "ignore", ".*the matrix subclass.*", PendingDeprecationWarning)
         data = Table.from_numpy(X=sp.csr_matrix(X), domain=domain, metas=M)
         self.assertEqual(varying_between(data, idvar=data.domain.metas[0]),
                          [variables[2], variables[3], metas[3], metas[4], metas[5], metas[6]])


### PR DESCRIPTION
Since Scipy==1.3.0, which was released on 17 May 2019, these warnings stopped appearing.