### PR TITLE
[FIX] owmds: Fix test for error display/activate

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owmds.py
+++ b/Orange/widgets/unsupervised/tests/test_owmds.py
@@ -102,16 +102,14 @@ class TestOWMDS(WidgetTest, ProjectionWidgetTestMixin,
     @patch("Orange.projection.MDS.__call__", Mock(side_effect=MemoryError))
     def test_out_of_memory(self):
         with patch("sys.excepthook", Mock()) as hook:
-            self.send_signal(self.widget.Inputs.data, self.data)
-            self.process_events()
+            self.send_signal(self.widget.Inputs.data, self.data, wait=1000)
             hook.assert_not_called()
             self.assertTrue(self.widget.Error.out_of_memory.is_shown())
 
     @patch("Orange.projection.MDS.__call__", Mock(side_effect=ValueError))
     def test_other_error(self):
         with patch("sys.excepthook", Mock()) as hook:
-            self.send_signal(self.widget.Inputs.data, self.data)
-            self.process_events()
+            self.send_signal(self.widget.Inputs.data, self.data, wait=1000)
             hook.assert_not_called()
             self.assertTrue(self.widget.Error.optimization_error.is_shown())
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

OWMDS tests fail sporadically (e.g. https://ci.appveyor.com/project/ales-erjavec/orange3-installers/builds/24690873/job/8h2c2s0ya7qd5d7c)

##### Description of changes

Properly wait for the widget to complete.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
