### PR TITLE
[FIX] OWWidget: Fix an error on mouse press when widget has no basic layout

### DIFF
--- a/Orange/widgets/tests/test_widget.py
+++ b/Orange/widgets/tests/test_widget.py
@@ -5,10 +5,10 @@ import weakref
 
 from unittest.mock import patch, MagicMock
 
-from AnyQt.QtCore import QRect, QByteArray, QObject, pyqtSignal
+from AnyQt.QtCore import Qt, QPoint, QRect, QByteArray, QObject, pyqtSignal
 from AnyQt.QtGui import QShowEvent
 from AnyQt.QtWidgets import QAction
-from AnyQt.QtTest import QSignalSpy
+from AnyQt.QtTest import QSignalSpy, QTest
 
 from Orange.widgets.gui import OWComponent
 from Orange.widgets.settings import Setting, SettingProvider
@@ -92,6 +92,7 @@ class WidgetTestCase(WidgetTest):
 
         w = TestWidget2()
         w.showEvent(QShowEvent())
+        QTest.mousePress(w, Qt.LeftButton, Qt.NoModifier, QPoint(1, 1))
 
     def test_store_restore_layout_geom(self):
         class Widget(OWWidget):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -827,7 +827,8 @@ class OWWidget(QDialog, OWComponent, Report, ProgressBarMixin,
 
     def mousePressEvent(self, event):
         """ Flash message bar icon on mouse press """
-        self.message_bar.flashIcon()
+        if self.message_bar is not None:
+            self.message_bar.flashIcon()
         event.ignore()
 
     def setVisible(self, visible):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

If a widget has no basic layout (`want_basic_layout = False`) and error is raised on a mouse press
in an empty widget area.
```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/widget.py", line 830, in mousePressEvent
    self.message_bar.flashIcon()
AttributeError: 'NoneType' object has no attribute 'flashIcon'
-------------------------------------------------------------------------------
```

##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
