### PR TITLE
[FIX] util: Fix bincount for object arrays

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -82,7 +82,7 @@ def sparse_implicit_zero_weights(x, weights):
 def bincount(x, weights=None, max_val=None, minlength=0):
     """Return counts of values in array X.
 
-    Works kind of like np.bincount(), except that it also supports floating
+    Works kind of like np.bincount(), except that it also supports
     arrays with nans.
 
     Parameters
@@ -132,8 +132,8 @@ def bincount(x, weights=None, max_val=None, minlength=0):
 
         x = x.data
 
-    x = np.asanyarray(x)
-    if x.dtype.kind == 'f' and bn.anynan(x):
+    x = np.asanyarray(x, dtype=float)
+    if bn.anynan(x):
         nonnan = ~np.isnan(x)
         x = x[nonnan]
         if weights is not None:

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -517,6 +517,13 @@ class TestBincount(unittest.TestCase):
 
         np.testing.assert_equal(bincount(x)[1], expected)
 
+    # object arrays cannot be converted to sparse, so test only for dense
+    def test_count_nans_objectarray(self):
+        x = np.array([0, 0, 1, 2, np.nan, 2], dtype=object)
+        expected = 1
+
+        np.testing.assert_equal(bincount(x)[1], expected)
+
     @dense_sparse
     def test_adds_empty_bins(self, array):
         x = array([0, 1, 3, 5])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`bincount` failed for object arrays that contained `np.nan`, but worked on both float arrays with nans and object arrays without them.
This was a problem since metas are often stored as object arrays and contain primitive variables, for which bincount should work (even if there are missing values).

##### Description of changes
The array must contain numbers anyway (since it is later converted to int32 for np.bincount), so it should not hurt to cast it to float before checking for nans. Almost all arrays in Orange are either float or object anyway, so this should be a noop for float arrays and a fix for object arrays.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
