### PR TITLE
[FIX] Rare quickmenu crash fix

### DIFF
--- a/Orange/canvas/document/quickmenu.py
+++ b/Orange/canvas/document/quickmenu.py
@@ -340,6 +340,10 @@ class SortFilterProxyModel(QSortFilterProxyModel):
         flat_model = self.sourceModel()
         index = flat_model.index(row, self.filterKeyColumn(), parent)
         description = flat_model.data(index, role=QtWidgetRegistry.WIDGET_DESC_ROLE)
+        if description is None:
+            log.error("Could not retrieve a widget's description from model")
+            return False
+
         name = description.name
         keywords = description.keywords
 


### PR DESCRIPTION
##### Issue
When using certain add-ons, upon opening a quickmenu, Orange will crash and be stuck in a crash loop. 

##### Description of changes
After retrieving description from item model, null-check.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
