### PR TITLE
[FIX] DBSCAN: Fix predicted labels

### DIFF
--- a/Orange/clustering/dbscan.py
+++ b/Orange/clustering/dbscan.py
@@ -1,5 +1,5 @@
 import sklearn.cluster as skl_cluster
-from numpy import ndarray
+from numpy import ndarray, unique
 
 from Orange.data import Table, DiscreteVariable, Domain, Instance
 from Orange.projection import SklProjector, Projection
@@ -38,11 +38,11 @@ class DBSCANModel(Projection):
             if data.domain is not self.pre_domain:
                 data = data.transform(self.pre_domain)
             y = self.proj.fit_predict(data.X)
-            vals = [-1] + list(self.proj.core_sample_indices_)
+            vals, indices = unique(y, return_inverse=True)
             c = DiscreteVariable(name='Core sample index',
                                  values=[str(v) for v in vals])
             domain = Domain([c])
-            return Table(domain, y.reshape(len(y), 1))
+            return Table(domain, indices.reshape(len(y), 1))
 
         elif isinstance(data, Instance):
             if data.domain is not self.pre_domain:

--- a/Orange/tests/test_clustering_dbscan.py
+++ b/Orange/tests/test_clustering_dbscan.py
@@ -29,3 +29,19 @@ class TestDBSCAN(unittest.TestCase):
         c = dbscan(self.iris)
         X = self.iris.X[::20]
         p = c(X)
+
+    def test_values(self):
+        dbscan = DBSCAN(eps=1)  # it clusters data in two classes
+        c = dbscan(self.iris)
+        table = self.iris
+        p = c(table)
+
+        self.assertEqual(2, len(p.domain[0].values))
+        self.assertSetEqual({"0", "1"}, set(p.domain[0].values))
+
+        table.X[0] = [100, 100, 100, 100]  # we add a big outlier
+
+        p = c(table)
+
+        self.assertEqual(3, len(p.domain[0].values))
+        self.assertSetEqual({"-1", "0", "1"}, set(p.domain[0].values))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
DBSCAN has wrong mapping of indices when make a Table. The first class is maped at `-1` group, `-1` is a group for nonclustered items. 

##### Description of changes
There will be a complete fix when https://github.com/biolab/orange3/pull/3814 will be merged. Since it will take some time I am proposing a quick fix.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
