### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,29 +48,18 @@ Installing with pip
 To install Orange with pip, run the following.
 
     # Install some build requirements via your system's package manager
-    sudo apt install virtualenv git build-essential python3-dev
+    sudo apt install virtualenv build-essential python3-dev
 
     # Create a separate Python environment for Orange and its dependencies ...
     virtualenv --python=python3 --system-site-packages orange3venv
     # ... and make it the active one
     source orange3venv/bin/activate
 
-    # Clone the repository and move into it
-    git clone https://github.com/biolab/orange3.git
-    cd orange3
-
     # Install Qt dependencies for the GUI
     pip install PyQt5 PyQtWebEngine
 
-    # Install other minimum required dependencies
-    pip install -r requirements-core.txt  # For Orange Python library
-    pip install -r requirements-gui.txt   # For Orange GUI
-
-    pip install -r requirements-sql.txt   # To use SQL support
-    pip install -r requirements-opt.txt   # Optional dependencies, may fail
-
-    # Finally install Orange in editable/development mode.
-    pip install -e .
+    # Install Orange
+    pip install orange3
 
 Starting Orange GUI
 -------------------

--- a/README.md
+++ b/README.md
@@ -71,22 +71,3 @@ To start Orange GUI from the command line, run:
     python3 -m Orange.canvas
 
 Append `--help` for a list of program options.
-
-
-Compiling on Windows
---------------------
-
-Get appropriate wheels for missing libraries. You will need [numpy+mkl] and [scipy].
-
-[numpy+mkl]: http://www.lfd.uci.edu/~gohlke/pythonlibs/#numpy
-[scipy]: http://www.lfd.uci.edu/~gohlke/pythonlibs/#scipy
-
-Install them with
-
-    pip install <wheel name>.whl
-
-Install [Visual Studio compiler]. Then go to Orange3 folder and run:
-
-[Visual Studio compiler]: https://developer.microsoft.com/en-us/windows/downloads
-
-    python setup.py build_ext -i --compiler=msvc install

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To install Orange with pip, run the following.
     cd orange3
 
     # Install Qt dependencies for the GUI
-    pip install PyQt5
+    pip install PyQt5 PyQtWebEngine
 
     # Install other minimum required dependencies
     pip install -r requirements-core.txt  # For Orange Python library
@@ -71,18 +71,6 @@ To install Orange with pip, run the following.
 
     # Finally install Orange in editable/development mode.
     pip install -e .
-
-Installation of SciPy and qt-graph-helpers is sometimes challenging because of
-their non-python dependencies that have to be installed manually. More
-detailed, if mostly obsolete, guides for some platforms can be found in
-the [wiki].
-
-[wiki]: https://github.com/biolab/orange3/wiki
-
-### Missing WebKit/WebEngine
-
-Some distributions of PyQt5 come without WebKit or WebEngine, required by some
-add-ons and for reporting. Running `pip install PyQtWebEngine` may solve this issue.
 
 Starting Orange GUI
 -------------------


### PR DESCRIPTION
"Installing with pip" section now installs released version, as the conda section does. I also added pyqtwebengine to main instructions. Then, I removed some obsolete information about Windows.