### PR TITLE
[ENH] Shared namespaces for PythonScript widgets

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -356,7 +356,7 @@ class WidgetTest(GuiTest):
         outputs = widget.outputs or widget.Outputs.__dict__.values()
         assert output in (out.name for out in outputs), \
             "widget {} has no output {}".format(widget.name, output)
-        return self.signal_manager.outputs.get((widget, output), None)
+        return widget.signalManager.outputs.get((widget, output), None)
 
     @contextmanager
     def modifiers(self, modifiers):


### PR DESCRIPTION
##### Issue

Fixes #3820.

##### Description of changes

PythonScript widgets on the same canvas now share namespaces. Consequently, namespaces are no longer cleared after execution and garbage is not collected.

This PR also fixes a glitch in the base widget test class.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
