### PR TITLE
[FIX] Update output on new input, even if auto commit is disabled

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -189,7 +189,6 @@ class ContColorTableModel(ColorTableModel):
         self.dataChanged.emit(self.index(0, 1), self.index(self.n_rows(), 1))
 
 
-
 class ColorTable(QTableView):
     """The base table view for discrete and continuous attributes."""
 
@@ -369,7 +368,7 @@ class OWColor(widget.OWWidget):
             self.cont_model.set_data(self.cont_colors)
             self.disc_view.resizeColumnsToContents()
             self.cont_view.resizeColumnsToContents()
-        self.commit()
+        self.unconditional_commit()
 
     def storeSpecificSettings(self):
         # Store the colors that were changed -- but not others

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -153,7 +153,7 @@ class OWConcatenate(widget.OWWidget):
 
     def handleNewSignals(self):
         self.mergebox.setDisabled(self.primary_data is not None)
-        self.apply()
+        self.unconditional_apply()
 
     def apply(self):
         tables, domain, source_var = [], None, None

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -90,13 +90,13 @@ class OWMergeData(widget.OWWidget):
             model[:] = [getattr(self, 'attr_{}_data'.format(merge_type))]
             extra_model[:] = [getattr(self, 'attr_{}_extra'.format(merge_type))]
             cb = gui.comboBox(box, self, 'attr_{}_data'.format(merge_type),
-                              contentsLength=12, callback=self._invalidate,
+                              contentsLength=12, callback=self.commit,
                               model=model)
             cb.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
             cb.setFixedWidth(190)
             gui.widgetLabel(box, between_label)
             cb = gui.comboBox(box, self, 'attr_{}_extra'.format(merge_type),
-                              contentsLength=12, callback=self._invalidate,
+                              contentsLength=12, callback=self.commit,
                               model=extra_model)
             cb.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
             cb.setFixedWidth(190)
@@ -126,7 +126,7 @@ class OWMergeData(widget.OWWidget):
 
     def change_merging(self):
         self.set_merging()
-        self._invalidate()
+        self.commit()
 
     @staticmethod
     def _set_unique_model(data, model):
@@ -226,7 +226,7 @@ class OWMergeData(widget.OWWidget):
         self._find_best_match()
 
     def handleNewSignals(self):
-        self._invalidate()
+        self.unconditional_commit()
 
     @staticmethod
     def dataInfoText(data):
@@ -251,9 +251,6 @@ class OWMergeData(widget.OWWidget):
                 if len(set(var_names)) != len(var_names):
                     self.Warning.duplicate_names()
         self.Outputs.data.send(merged_data)
-
-    def _invalidate(self):
-        self.commit()
 
     def send_report(self):
         # pylint: disable=invalid-sequence-index

--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -106,7 +106,8 @@ class OWNeighbors(OWWidget):
         self._set_label_text("reference")
 
     def handleNewSignals(self):
-        self.recompute()
+        self.compute_distances()
+        self.unconditional_apply()
 
     def recompute(self):
         self.compute_distances()

--- a/Orange/widgets/data/owrandomize.py
+++ b/Orange/widgets/data/owrandomize.py
@@ -88,7 +88,7 @@ class OWRandomize(OWWidget):
     @Inputs.data
     def set_data(self, data):
         self.data = data
-        self.apply()
+        self.unconditional_apply()
 
     def apply(self):
         data = None

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -93,7 +93,7 @@ class OWTranspose(OWWidget):
         self.set_controls()
         if self.feature_model:
             self.openContext(data)
-        self.apply()
+        self.unconditional_apply()
 
     def set_controls(self):
         self.feature_model.set_domain(self.data and self.data.domain)

--- a/Orange/widgets/data/tests/test_owcolor.py
+++ b/Orange/widgets/data/tests/test_owcolor.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from unittest.mock import patch
+
 from Orange.data import Table, ContinuousVariable, Domain
 from Orange.widgets.data.owcolor import OWColor
 from Orange.widgets.tests.base import WidgetTest
@@ -27,3 +29,10 @@ class TestOWColor(WidgetTest):
         t = Table(Domain([a]))
 
         self.send_signal(self.widget.Inputs.data, t)
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_commit') as commit:
+            self.widget.auto_apply = False
+            commit.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.iris)
+            commit.assert_called()

--- a/Orange/widgets/data/tests/test_owconcatenate.py
+++ b/Orange/widgets/data/tests/test_owconcatenate.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -108,6 +109,13 @@ class TestOWConcatenate(WidgetTest):
         self.assertFalse(self.widget.mergebox.isEnabled())
         self.send_signal(self.widget.Inputs.primary_data, None)
         self.assertTrue(self.widget.mergebox.isEnabled())
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_apply') as apply:
+            self.widget.auto_commit = False
+            apply.reset_mock()
+            self.send_signal(self.widget.Inputs.primary_data, self.iris)
+            apply.assert_called()
 
 
 class TestTools(unittest.TestCase):

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -142,7 +142,8 @@ class TestOWNeighbors(WidgetTest):
         """Check compute distances and apply are called when receiving signal"""
         widget = self.widget
         cdist = widget.compute_distances = Mock()
-        apply = widget.apply = Mock()
+        apply = widget.unconditional_apply = Mock()
+        self.widget.auto_apply = False
         data = Table("iris")
         self.send_signal(widget.Inputs.data, data)
         cdist.assert_called()

--- a/Orange/widgets/data/tests/test_owrandomize.py
+++ b/Orange/widgets/data/tests/test_owrandomize.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from unittest.mock import patch
 
 import numpy as np
 
@@ -72,3 +73,10 @@ class TestOWRandomize(WidgetTest):
         np.testing.assert_array_equal(output.X, output2.X)
         np.testing.assert_array_equal(output.Y, output2.Y)
         np.testing.assert_array_equal(output.metas, output2.metas)
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_apply') as apply:
+            self.widget.auto_apply = False
+            apply.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.zoo)
+            apply.assert_called()

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -288,7 +288,7 @@ class OWDistanceMatrix(widget.OWWidget):
             self.openContext(distances, annotations)
             self._update_labels()
             self.tableview.resizeColumnsToContents()
-        self.commit()
+        self.unconditional_commit()
 
     def _invalidate_annotations(self):
         if self.distances is not None:

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -422,14 +422,17 @@ class OWKMeans(widget.OWWidget):
 
         QTimer.singleShot(100, self.adjustSize)
 
-    def invalidate(self):
+    def invalidate(self, unconditional=False):
         self.cancel()
         self.Error.clear()
         self.Warning.clear()
         self.clusterings = {}
         self.table_model.clear_scores()
 
-        self.commit()
+        if unconditional:
+            self.unconditional_commit()
+        else:
+            self.commit()
 
     def update_results(self):
         scores = [
@@ -530,7 +533,7 @@ class OWKMeans(widget.OWWidget):
             if self.auto_commit:
                 self.send_data()
         else:
-            self.invalidate()
+            self.invalidate(unconditional=True)
 
     def send_report(self):
         # False positives (Setting is not recognized as int)

--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -269,7 +269,7 @@ class OWManifoldLearning(OWWidget):
             alignment=Qt.AlignRight, callbackOnReturn=True,
             callback=self.settings_changed)
         self.apply_button = gui.auto_commit(
-            output_box, self, "auto_apply", "&Apply",
+            self.controlArea, self, "auto_apply", "&Apply",
             box=False, commit=self.apply)
 
     def manifold_method_changed(self):
@@ -286,10 +286,11 @@ class OWManifoldLearning(OWWidget):
         self.data = data
         self.n_components_spin.setMaximum(len(self.data.domain.attributes)
                                           if self.data else 10)
-        self.apply()
+        self.unconditional_apply()
 
     def apply(self):
         builtin_warn = warnings.warn
+
         def _handle_disconnected_graph_warning(msg, *args, **kwargs):
             if msg.startswith("Graph is not fully connected"):
                 self.Warning.graph_not_connected()
@@ -351,4 +352,4 @@ class OWManifoldLearning(OWWidget):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    WidgetPreview(OWManifoldLearning).run(Table("ionosphere"))
+    WidgetPreview(OWManifoldLearning).run(Table("brown-selected"))

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -1,30 +1,38 @@
+from unittest.mock import patch
+
 from Orange.data import Table
 from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owdistancematrix import OWDistanceMatrix
 
+
 class TestOWDistanceMatrix(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWDistanceMatrix)
+        self.iris = Table("iris")[:5]
+        self.distances = Euclidean(self.iris)
 
     def test_set_distances(self):
         assert isinstance(self.widget, OWDistanceMatrix)
 
-        iris = Table("iris")[:5]
-        distances = Euclidean(iris)
-
         # Distances with row data
-        self.widget.set_distances(distances)
-        self.assertIn(iris.domain[0], self.widget.annot_combo.model())
+        self.widget.set_distances(self.distances)
+        self.assertIn(self.iris.domain[0], self.widget.annot_combo.model())
 
         # Distances without row data
-        distances.row_items = None
-        self.widget.set_distances(distances)
-        self.assertNotIn(iris.domain[0], self.widget.annot_combo.model())
+        self.distances.row_items = None
+        self.widget.set_distances(self.distances)
+        self.assertNotIn(self.iris.domain[0], self.widget.annot_combo.model())
 
     def test_context_attribute(self):
-        iris = Table("iris")
-        distances = Euclidean(iris, axis=0)
+        distances = Euclidean(self.iris, axis=0)
         annotations = ["None", "Enumerate"]
         self.widget.set_distances(distances)
         self.widget.openContext(distances, annotations)
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_commit') as commit:
+            self.widget.auto_commit = False
+            commit.reset_mock()
+            self.send_signal(self.widget.Inputs.distances, self.distances)
+            commit.assert_called()

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -443,25 +443,24 @@ class TestOWKMeans(WidgetTest):
         table3 = table1.copy()
         table3.X[:, 0] = 1
 
-        with patch.object(self.widget, 'commit') as commit:
+        with patch.object(self.widget, 'unconditional_commit') as commit:
             self.send_signal(self.widget.Inputs.data, table1)
             self.commit_and_wait()
-            call_count = commit.call_count
+            commit.reset_mock()
 
             # Sending data with same X should not recompute the clustering
             self.send_signal(self.widget.Inputs.data, table2)
-            self.commit_and_wait()
-            self.assertEqual(call_count, commit.call_count)
+            commit.assert_not_called()
 
             # Sending data with different X should recompute the clustering
             self.send_signal(self.widget.Inputs.data, table3)
-            self.commit_and_wait()
-            self.assertEqual(call_count + 1, commit.call_count)
+            commit.assert_called_once()
 
     def test_correct_smart_init(self):
         # due to a bug where wrong init was passed to _compute_clustering
         self.send_signal(self.widget.Inputs.data, self.iris[::10], wait=5000)
         self.widget.smart_init = 0
+        self.widget.clusterings = {}
         with patch.object(self.widget, "_compute_clustering",
                           wraps=self.widget._compute_clustering) as compute:
             self.commit_and_wait()

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -143,3 +143,10 @@ class TestOWManifoldLearning(WidgetTest):
             self.widget.manifold_methods_combo.activated.emit(1)
             self.widget.apply_button.button.click()
             self.assertTrue(self.widget.Error.out_of_memory.is_shown())
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_apply') as apply:
+            self.widget.auto_apply = False
+            apply.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.iris)
+            apply.assert_called()

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -161,7 +161,6 @@ class OWBoxPlot(widget.OWWidget):
     stretched = Setting(True)
     show_labels = Setting(True)
     sort_freqs = Setting(False)
-    auto_commit = Setting(True)
 
     _sorting_criteria_attrs = {
         CompareNone: "", CompareMedians: "median", CompareMeans: "mean"
@@ -258,9 +257,6 @@ class OWBoxPlot(widget.OWWidget):
             box, self, 'sort_freqs', "Sort by subgroup frequencies",
             callback=self.display_changed)
         gui.rubber(box)
-
-        gui.auto_commit(self.controlArea, self, "auto_commit",
-                        "Send Selection", "Send Automatically")
 
         gui.vBox(self.mainArea, addSpace=True)
         self.box_scene = QGraphicsScene()

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 from AnyQt.QtCore import QItemSelectionModel
@@ -231,6 +232,12 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
             if m.data(idx) == value:
                 list.selectionModel().setCurrentIndex(
                     idx, QItemSelectionModel.ClearAndSelect)
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'commit') as apply:
+            apply.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.zoo)
+            apply.assert_called()
 
 
 class TestUtils(unittest.TestCase):


### PR DESCRIPTION
##### Issue

Fixes #3761.

##### Description of changes

Call `unconditional_apply` instead of `apply`; remove the pointless auto commit checkbox in box plot.

##### Includes
- [X] Code changes
- [X] Tests
