### PR TITLE
Discretization: Proper labels for discretized TimeVariable

### DIFF
--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -40,32 +42,28 @@ class Discretizer(Transformation):
             return np.array([], dtype=int)
 
     @staticmethod
-    def _fmt_interval(low, high, decimals):
+    def _fmt_interval(low, high, formatter):
         assert low is not None or high is not None
         assert low is None or high is None or low < high
-        assert decimals >= 0
-
-        def fmt_value(value):
-            if value is None or np.isinf(value):
-                return None
-            val = str(round(value, decimals))
-            if val.endswith(".0"):
-                return val[:-2]
-            return val
-
-        low, high = fmt_value(low), fmt_value(high)
-        if not low:
-            return "< {}".format(high)
-        if not high:
-            return "≥ {}".format(low)
-        return "{} - {}".format(low, high)
+        if low is None or np.isinf(low):
+            return f"< {formatter(high)}"
+        if high is None or np.isinf(high):
+            return f"≥ {formatter(low)}"
+        return f"{formatter(low)} - {formatter(high)}"
 
     @classmethod
     def create_discretized_var(cls, var, points):
+        def fmt(val):
+            sval = var.str_val(val)
+            # For decimal numbers, remove trailing 0's and . if no decimals left
+            if re.match(r"^\d+\.\d+", sval):
+                return sval.rstrip("0").rstrip(".")
+            return sval
+
         lpoints = list(points)
         if lpoints:
             values = [
-                cls._fmt_interval(low, high, var.number_of_decimals)
+                cls._fmt_interval(low, high, fmt)
                 for low, high in zip([-np.inf] + lpoints, lpoints + [np.inf])]
             to_sql = BinSql(var, lpoints)
         else:

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -3,7 +3,6 @@
 
 import random
 from unittest import TestCase
-from unittest.mock import Mock
 
 import numpy as np
 import scipy.sparse as sp
@@ -116,9 +115,7 @@ class TestEntropyMDL(TestCase):
 # noinspection PyPep8Naming
 class TestDiscretizer(TestCase):
     def setUp(self):
-        self.var = Mock(data.ContinuousVariable, number_of_decimals=1)
-        self.var.name = "x"
-        self.var.sparse = False
+        self.var = data.ContinuousVariable("x", number_of_decimals=1)
 
     def test_create_discretized_var(self):
         dvar = discretize.Discretizer.create_discretized_var(


### PR DESCRIPTION
##### Issue

Discretized `TimeVariable` has float-like labels instead of dates/times.

##### Changes

`Discretizer.create_discretized_var` now calls `str_val` to create labels for discretized variable.

This fixes the problem with `TimeVariable`.

Also, for numeric variables, it will properly format small numbers; current code circumvented the fix from 0a205f87cbe3faf68effb9e95eb8f5580f4711ed, which introduced formatting with `%g` when the number of decimals is too large. For normal numbers, the change should have not effect (although rounding is now replaced by stripping 0s and the dot).

##### Includes
- [X] Code changes
- [X] Updated tests
