### PR TITLE
OWScatterplotGraph: Use get_color_labels to return number formatter

### DIFF
--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1093,6 +1093,7 @@ class TestOWScatterPlotBase(WidgetTest):
 
         master.is_continuous_color = lambda: True
         master.get_color_data = lambda: np.arange(10, dtype=float)
+        master.get_color_labels = lambda: None
         graph.update_colors()
         self.assertTrue(shape_legend.call_args[0][0])
         self.assertTrue(color_legend.call_args[0][0])

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -196,6 +196,10 @@ class OWProjectionWidgetBase(OWWidget, openclass=True):
         Returns:
             (list of str): labels
         """
+        if self.attr_color is None:
+            return None
+        if not self.attr_color.is_discrete:
+            return self.attr_color.str_val
         return self.get_column(self.attr_color, merge_infrequent=True,
                                return_labels=True)
 


### PR DESCRIPTION
##### Issue

Fixes #3746 - displaying of datetime variables in visualization legends, as well as, probably, weird number of decimals for other numeric attributes.

##### Description of changes

Labels for color legend are created by palette, which is not aware of attributes. Palette is called by `OWScatterplotGraph`, which also doesn't know about attributes. On the other hand, the widget, which provides labels for discrete attributes (via `get_color_labels`), doesn't know how the graph will discretize continuous values, hence it can't provide a list.

A reasonable solution is that `get_color_labels`, which currently returns `None` for continuous variables, returns a formatter, that is, function that takes a number and returns a string. For most cases, this will be variables `str_val`. If it returns `None`, the widget uses the same formatter as it did before (a certain number of decimals, computed based on God knows what),

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
