### PR TITLE
Sieve, Mosaic, CanvasText: Elide long labels

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -675,14 +675,9 @@ class OWMosaicDisplay(OWWidget):
                           y0 - self.ATTR_VAL_OFFSET,
                           y0 + currpos + height * 0.5 * perc]
 
-                    text = CanvasText(
-                        self.canvas, val, xs[side], ys[side], align)
-                    if side == 0 and text.boundingRect().width() > rwidth:
-                        text.setToolTip(val)
-                        while val and text.boundingRect().width() > rwidth:
-                            val = val[:-1]
-                            text.setPlainText(val + "...")
-                            text.setPos(xs[0], ys[0])
+                    CanvasText(
+                        self.canvas, val, xs[side], ys[side], align,
+                        max_width=rwidth if side == 0 else None)
                     space = height if side % 2 else width
                     currpos += perc * space + spacing * (total_attrs - side)
 

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -333,7 +333,12 @@ class OWSieveDiagram(OWWidget):
         """Update the graph."""
 
         def text(txt, *args, **kwargs):
-            return CanvasText(self.canvas, "", html_text=to_html(txt),
+            text = html_text = None
+            if "max_width" in kwargs:
+                text = txt
+            else:
+                html_text = to_html(txt)
+            return CanvasText(self.canvas, text, html_text=html_text,
                               *args, **kwargs)
 
         def width(txt):
@@ -488,7 +493,7 @@ class OWSieveDiagram(OWWidget):
                 curr_y += height
 
             xl = text(xval_name, curr_x + width / 2, y_off + square_size,
-                      Qt.AlignHCenter | Qt.AlignTop)
+                      Qt.AlignHCenter | Qt.AlignTop, max_width=width)
             max_xlabel_h = max(int(xl.boundingRect().height()), max_xlabel_h)
             curr_x += width
 

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -558,7 +558,8 @@ class CanvasText(QGraphicsTextItem):
     """
     def __init__(self, scene, text="", x=0, y=0,
                  alignment=Qt.AlignLeft | Qt.AlignTop, bold=False, font=None,
-                 z=0, html_text=None, tooltip=None, show=True, vertical=False):
+                 z=0, html_text=None, tooltip=None, show=True, vertical=False,
+                 max_width=None):
         QGraphicsTextItem.__init__(self, text, None)
 
         if font:
@@ -580,6 +581,10 @@ class CanvasText(QGraphicsTextItem):
         self.setZValue(z)
         if tooltip:
             self.setToolTip(tooltip)
+        if max_width is not None:
+            assert not html_text
+            self.elide(max_width)
+
         if show:
             self.show()
         else:
@@ -587,6 +592,18 @@ class CanvasText(QGraphicsTextItem):
 
         if scene is not None:
             scene.addItem(self)
+
+    def elide(self, max_width):
+        if self.boundingRect().width() <= max_width:
+            return
+        short = self.toPlainText()
+        if not self.toolTip():
+            self.setToolTip(short)
+        while short and self.boundingRect().width() > max_width:
+            short = short[:-1]
+            self.setPlainText(short + "...")
+            # apparently this has to be called to reset position
+            self.setPos(self.x, self.y)
 
     def setPos(self, x, y):
         """setPos with adjustment for alignment"""


### PR DESCRIPTION
##### Issue

Fixes #3742 (eliding of long labels for Sieve)

Moves code from #3845 (eliding for Mosaic) to `CanvasText`, so it can be used in other widgets (like Sieve), too.

##### Description of changes


##### Includes
- [X] Code changes
