### PR TITLE
Add performance scores to Predictions widget

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -1,11 +1,9 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
-import collections
 import unittest
 
 import numpy as np
-from AnyQt.QtWidgets import QMenu
-from AnyQt.QtCore import QPoint, Qt
+from AnyQt.QtCore import Qt
 from AnyQt.QtTest import QTest
 
 from Orange.classification import MajorityLearner, LogisticRegressionLearner
@@ -18,6 +16,7 @@ from Orange.modelling import ConstantLearner
 from Orange.regression import MeanLearner
 from Orange.widgets.evaluate.owtestlearners import (
     OWTestLearners, results_one_vs_rest)
+from Orange.widgets.evaluate.utils import BUILTIN_SCORERS_ORDER
 from Orange.widgets.settings import (
     ClassValuesContextHandler, PerfectDomainContextHandler)
 from Orange.widgets.tests.base import WidgetTest
@@ -120,63 +119,6 @@ class TestOWTestLearners(WidgetTest):
         self.assertEqual(self.widget.resampling, OWTestLearners.KFold)
         self.assertFalse(self.widget.features_combo.isEnabled())
 
-    def test_update_shown_columns(self):
-        w = self.widget  #: OWTestLearners
-        all, shown = "MABDEFG", "ABDF"
-        header = w.view.horizontalHeader()
-        w.shown_scores = set(shown)
-        w.result_model.setHorizontalHeaderLabels(list(all))
-        w._update_shown_columns()
-        for i, name in enumerate(all):
-            self.assertEqual(name == "M" or name in shown,
-                             not header.isSectionHidden(i),
-                             msg="error in section {}({})".format(i, name))
-
-        w.shown_scores = set()
-        w._update_shown_columns()
-        for i, name in enumerate(all):
-            self.assertEqual(i == 0,
-                             not header.isSectionHidden(i),
-                             msg="error in section {}({})".format(i, name))
-
-    def test_show_column_chooser(self):
-        w = self.widget  #: OWTestLearners
-        all, shown = "MABDEFG", "ABDF"
-        header = w.view.horizontalHeader()
-        w.shown_scores = set(shown)
-        w.result_model.setHorizontalHeaderLabels(list(all))
-        w._update_shown_columns()
-
-        actions = collections.OrderedDict()
-        menu_add_action = QMenu.addAction
-
-        def addAction(menu, a):
-            action = menu_add_action(menu, a)
-            actions[a] = action
-            return action
-
-        def execmenu(*_):
-            self.assertEqual(list(actions), list(all)[1:])
-            for name, action in actions.items():
-                self.assertEqual(action.isChecked(), name in shown)
-            actions["E"].triggered.emit(True)
-            self.assertEqual(w.shown_scores, set("ABDEF"))
-            actions["B"].triggered.emit(False)
-            self.assertEqual(w.shown_scores, set("ADEF"))
-            for i, name in enumerate(all):
-                self.assertEqual(name == "M" or name in "ADEF",
-                                 not header.isSectionHidden(i),
-                                 msg="error in section {}({})".format(i, name))
-
-        # We must patch `QMenu.exec` because the Qt would otherwise (invisibly)
-        # show the popup and wait for the user.
-        # Assertions are made within `menuexec` since they check the
-        # instances of `QAction`, which are invalid (destroyed by Qt?) after
-        # `menuexec` finishes.
-        with unittest.mock.patch("AnyQt.QtWidgets.QMenu.addAction", addAction),\
-                unittest.mock.patch("AnyQt.QtWidgets.QMenu.exec", execmenu):
-            w.show_column_chooser(QPoint(0, 0))
-
     def test_migrate_removes_invalid_contexts(self):
         context_invalid = ClassValuesContextHandler().new_context([0, 1, 2])
         context_valid = PerfectDomainContextHandler().new_context(*[[]] * 4)
@@ -246,7 +188,7 @@ class TestOWTestLearners(WidgetTest):
             class NewRegressionScore(RegressionScore):
                 pass
 
-            builtins = self.widget.BUILTIN_ORDER
+            builtins = BUILTIN_SCORERS_ORDER
             self.send_signal("Data", Table("iris"))
             scorer_names = [scorer.name for scorer in self.widget.scorers]
             self.assertEqual(
@@ -275,22 +217,23 @@ class TestOWTestLearners(WidgetTest):
     def test_target_changing(self):
         data = Table("iris")
         w = self.widget  #: OWTestLearners
+        model = w.score_table.model
 
         w.n_folds = 2
         self.send_signal(self.widget.Inputs.train_data, data)
         self.send_signal(self.widget.Inputs.learner,
                          LogisticRegressionLearner(), 0, wait=5000)
 
-        average_auc = float(w.view.model().item(0, 1).text())
+        average_auc = float(model.item(0, 1).text())
 
         simulate.combobox_activate_item(w.controls.class_selection, "Iris-setosa")
-        setosa_auc = float(w.view.model().item(0, 1).text())
+        setosa_auc = float(model.item(0, 1).text())
 
         simulate.combobox_activate_item(w.controls.class_selection, "Iris-versicolor")
-        versicolor_auc = float(w.view.model().item(0, 1).text())
+        versicolor_auc = float(model.item(0, 1).text())
 
         simulate.combobox_activate_item(w.controls.class_selection, "Iris-virginica")
-        virginica_auc = float(w.view.model().item(0, 1).text())
+        virginica_auc = float(model.item(0, 1).text())
 
         self.assertGreater(average_auc, versicolor_auc)
         self.assertGreater(average_auc, virginica_auc)
@@ -326,31 +269,29 @@ class TestOWTestLearners(WidgetTest):
         self.send_signal(self.widget.Inputs.test_data, setosa, wait=5000)
 
         self.widget.show()
-        header = self.widget.view.horizontalHeader()
+        view = self.widget.score_table.view
+        header = view.horizontalHeader()
         QTest.mouseClick(header.viewport(), Qt.LeftButton)
 
         # Ensure that the click on header caused an ascending sort
         # Ascending sort means that wrong model should be listed first
         self.assertEqual(header.sortIndicatorOrder(), Qt.AscendingOrder)
-        self.assertEqual(
-            self.widget.view.model().item(0, 0).text(),
-            "VersicolorLearner")
+        self.assertEqual(view.model().item(0, 0).text(), "VersicolorLearner")
 
         self.send_signal(self.widget.Inputs.test_data, versicolor, wait=5000)
-        self.assertEqual(
-            self.widget.view.model().item(0, 0).text(),
-            "SetosaLearner")
+        self.assertEqual(view.model().item(0, 0).text(), "SetosaLearner")
 
         self.widget.hide()
 
     def _retrieve_scores(self):
         w = self.widget
-        auc = w.view.model().item(0, 1).text()
+        model = w.score_table.model
+        auc = model.item(0, 1).text()
         auc = float(auc) if auc != "" else None
-        ca = float(w.view.model().item(0, 2).text())
-        f1 = float(w.view.model().item(0, 3).text())
-        precision = float(w.view.model().item(0, 4).text())
-        recall = float(w.view.model().item(0, 5).text())
+        ca = float(model.item(0, 2).text())
+        f1 = float(model.item(0, 3).text())
+        precision = float(model.item(0, 4).text())
+        recall = float(model.item(0, 5).text())
         return auc, ca, f1, precision, recall
 
     def _test_scores(self, train_data, test_data, learner, sampling, n_folds):

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -1,0 +1,72 @@
+import unittest
+import collections
+
+from AnyQt.QtWidgets import QMenu
+from AnyQt.QtCore import QPoint
+
+from Orange.widgets.evaluate.utils import ScoreTable
+from Orange.widgets.tests.base import GuiTest
+
+
+class TestScoreTable(GuiTest):
+    def test_show_column_chooser(self):
+        score_table = ScoreTable(None)
+        view = score_table.view
+        all, shown = "MABDEFG", "ABDF"
+        header = view.horizontalHeader()
+        score_table.shown_scores = set(shown)
+        score_table.model.setHorizontalHeaderLabels(list(all))
+        score_table._update_shown_columns()
+
+        actions = collections.OrderedDict()
+        menu_add_action = QMenu.addAction
+
+        def addAction(menu, a):
+            action = menu_add_action(menu, a)
+            actions[a] = action
+            return action
+
+        def execmenu(*_):
+            self.assertEqual(list(actions), list(all)[1:])
+            for name, action in actions.items():
+                self.assertEqual(action.isChecked(), name in shown)
+            actions["E"].triggered.emit(True)
+            self.assertEqual(score_table.shown_scores, set("ABDEF"))
+            actions["B"].triggered.emit(False)
+            self.assertEqual(score_table.shown_scores, set("ADEF"))
+            for i, name in enumerate(all):
+                self.assertEqual(name == "M" or name in "ADEF",
+                                 not header.isSectionHidden(i),
+                                 msg="error in section {}({})".format(i, name))
+
+        # We must patch `QMenu.exec` because the Qt would otherwise (invisibly)
+        # show the popup and wait for the user.
+        # Assertions are made within `menuexec` since they check the
+        # instances of `QAction`, which are invalid (destroyed by Qt?) after
+        # `menuexec` finishes.
+        with unittest.mock.patch("AnyQt.QtWidgets.QMenu.addAction", addAction), \
+             unittest.mock.patch("AnyQt.QtWidgets.QMenu.exec", execmenu):
+            score_table.show_column_chooser(QPoint(0, 0))
+
+    def test_update_shown_columns(self):
+        score_table = ScoreTable(None)
+        view = score_table.view
+        all, shown = "MABDEFG", "ABDF"
+        header = view.horizontalHeader()
+        score_table.shown_scores = set(shown)
+        score_table.model.setHorizontalHeaderLabels(list(all))
+        score_table._update_shown_columns()
+        for i, name in enumerate(all):
+            self.assertEqual(name == "M" or name in shown,
+                             not header.isSectionHidden(i),
+                             msg="error in section {}({})".format(i, name))
+
+        score_table.shown_scores = set()
+        score_table._update_shown_columns()
+        for i, name in enumerate(all):
+            self.assertEqual(i == 0,
+                             not header.isSectionHidden(i),
+                             msg="error in section {}({})".format(i, name))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import unittest
 import collections
 

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -1,4 +1,19 @@
-import numpy
+import warnings
+from functools import partial
+from itertools import chain
+
+import numpy as np
+
+from AnyQt.QtWidgets import QHeaderView, QStyledItemDelegate, QMenu
+from AnyQt.QtGui import QStandardItemModel, QStandardItem
+from AnyQt.QtCore import Qt, QSize, QObject, pyqtSignal as Signal
+from sklearn.exceptions import UndefinedMetricWarning
+
+from Orange.data import Variable, DiscreteVariable, ContinuousVariable
+from Orange.evaluation import scoring
+from Orange.widgets import gui
+from Orange.widgets.gui import OWComponent
+from Orange.widgets.settings import Setting
 
 
 def check_results_adequacy(results, error_group, check_nan=True):
@@ -6,7 +21,7 @@ def check_results_adequacy(results, error_group, check_nan=True):
     error_group.invalid_results.clear()
 
     def anynan(a):
-        return numpy.any(numpy.isnan(a))
+        return np.any(np.isnan(a))
 
     if results is None:
         return None
@@ -24,6 +39,7 @@ def check_results_adequacy(results, error_group, check_nan=True):
             "Results contains invalid values")
     else:
         return results
+
 
 def results_for_preview(data_name=""):
     from Orange.data import Table
@@ -43,3 +59,113 @@ def results_for_preview(data_name=""):
     )
     results.learner_names = ["LR l2", "LR l1", "SVM", "Nu SVM"]
     return results
+
+
+BUILTIN_SCORERS_ORDER = {
+    DiscreteVariable: ("AUC", "CA", "F1", "Precision", "Recall"),
+    ContinuousVariable: ("MSE", "RMSE", "MAE", "R2")}
+
+
+def learner_name(learner):
+    """Return the value of `learner.name` if it exists, or the learner's type
+    name otherwise"""
+    return getattr(learner, "name", type(learner).__name__)
+
+
+def usable_scorers(target: Variable):
+    order = {name: i
+             for i, name in enumerate(BUILTIN_SCORERS_ORDER[type(target)])}
+    # 'abstract' is retrieved from __dict__ to avoid inheriting
+    usable = (cls for cls in scoring.Score.registry.values()
+              if cls.is_scalar and not cls.__dict__.get("abstract")
+              and isinstance(target, cls.class_types))
+    return sorted(usable, key=lambda cls: order.get(cls.name, 99))
+
+
+def scorer_caller(scorer, ovr_results, target=None):
+    def thunked():
+        with warnings.catch_warnings():
+            # F-score and Precision return 0 for labels with no predicted
+            # samples. We're OK with that.
+            warnings.filterwarnings(
+                "ignore", "((F-score|Precision)) is ill-defined.*",
+                UndefinedMetricWarning)
+            if scorer.is_binary:
+                return scorer(ovr_results, target=target, average='weighted')
+            else:
+                return scorer(ovr_results)
+
+    return thunked
+
+
+class ScoreTable(OWComponent, QObject):
+    shown_scores = \
+        Setting(set(chain(*BUILTIN_SCORERS_ORDER.values())))
+
+    shownScoresChanged = Signal()
+
+    class ItemDelegate(QStyledItemDelegate):
+        def sizeHint(self, *args):
+            size = super().sizeHint(*args)
+            return QSize(size.width(), size.height() + 6)
+
+    def __init__(self, master):
+        QObject.__init__(self)
+        OWComponent.__init__(self, master)
+
+        self.view = gui.TableView(
+            wordWrap=True, editTriggers=gui.TableView.NoEditTriggers
+        )
+        header = self.view.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        header.setDefaultAlignment(Qt.AlignCenter)
+        header.setStretchLastSection(False)
+        header.setContextMenuPolicy(Qt.CustomContextMenu)
+        header.customContextMenuRequested.connect(self.show_column_chooser)
+
+        self.model = QStandardItemModel(master)
+        self.model.setHorizontalHeaderLabels(["Method"])
+        self.view.setModel(self.model)
+        self.view.setItemDelegate(self.ItemDelegate())
+
+    def _column_names(self):
+        return (self.model.horizontalHeaderItem(section).data(Qt.DisplayRole)
+                for section in range(1, self.model.columnCount()))
+
+    def show_column_chooser(self, pos):
+        # pylint doesn't know that self.shown_scores is a set, not a Setting
+        # pylint: disable=unsupported-membership-test
+        def update(col_name, checked):
+            if checked:
+                self.shown_scores.add(col_name)
+            else:
+                self.shown_scores.remove(col_name)
+            self._update_shown_columns()
+
+        menu = QMenu()
+        header = self.view.horizontalHeader()
+        for col_name in self._column_names():
+            action = menu.addAction(col_name)
+            action.setCheckable(True)
+            action.setChecked(col_name in self.shown_scores)
+            action.triggered.connect(partial(update, col_name))
+        menu.exec(header.mapToGlobal(pos))
+
+    def _update_shown_columns(self):
+        # pylint doesn't know that self.shown_scores is a set, not a Setting
+        # pylint: disable=unsupported-membership-test
+        header = self.view.horizontalHeader()
+        for section, col_name in enumerate(self._column_names(), start=1):
+            header.setSectionHidden(section, col_name not in self.shown_scores)
+        self.view.resizeColumnsToContents()
+        self.shownScoresChanged.emit()
+
+    def update_header(self, scorers):
+        # Set the correct horizontal header labels on the results_model.
+        self.model.setColumnCount(1 + len(scorers))
+        self.model.setHorizontalHeaderItem(0, QStandardItem("Model"))
+        for col, score in enumerate(scorers, start=1):
+            item = QStandardItem(score.name)
+            item.setToolTip(score.long_name)
+            self.model.setHorizontalHeaderItem(col, item)
+        self._update_shown_columns()


### PR DESCRIPTION
##### Issue

Resolves #2191.

##### Description of changes

- Factor out the table with scores out of Test and Score; it's valuable mainly because column chooser
- Add the table to Predictions

##### Includes
- [X] Code changes
- [X] Some tests
- [ ] Documentation