### PR TITLE
testing.Results: Fix constructor

### DIFF
--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -72,8 +72,8 @@ class Results:
     score_by_folds = True
     # noinspection PyBroadException
     # noinspection PyNoneFunctionAssignment
-    def __init__(self, data=None, nmethods=0, *, learners=None, train_data=None,
-                 nrows=None, nclasses=None,
+    def __init__(self, data=None, nmethods=None, *, learners=None,
+                 train_data=None, nrows=None, nclasses=None,
                  store_data=False, store_models=False,
                  domain=None, actual=None, row_indices=None,
                  predicted=None, probabilities=None,
@@ -171,7 +171,7 @@ class Results:
                        else None,
                        probabilities is not None and probabilities.shape[2]],
             "mismatching number of class values")
-        if nclasses is not None and probabilities is not None:
+        if nclasses is None and probabilities is not None:
             raise ValueError("regression results cannot have 'probabilities'")
         nmethods = set_or_raise(
             nmethods, [predicted is not None and predicted.shape[0],


### PR DESCRIPTION
##### Issue

`Orange.evaluation.testing.Results.__init__` can be called with learners or with predictions and probabilities (which is admittedly ugly). 

This constructor is six years old and today it was the first time that somebody (me) tried to call it in the second way (and failed). This PR fixes two obvious bugs.

I provide no tests. See the proposal in #3857 instead.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
