### PR TITLE
Orange.evaluation.tests: Fix pylint issues

### DIFF
--- a/Orange/widgets/evaluate/tests/base.py
+++ b/Orange/widgets/evaluate/tests/base.py
@@ -3,13 +3,7 @@ from Orange.data import Table
 
 
 class EvaluateTest:
-
     def test_many_evaluation_results(self):
-        """
-        Now works with more than 9 evaluation results.
-        GH-2394 (ROC Analysis)
-        GH-2522 (Lift Curve, Calibration Plot)
-        """
         data = Table("iris")
         learners = [
             classification.MajorityLearner(),
@@ -24,4 +18,5 @@ class EvaluateTest:
             classification.SGDClassificationLearner()
         ]
         res = evaluation.CrossValidation(data, learners, k=2, store_data=True)
+        # this is a mixin; pylint: disable=no-member
         self.send_signal("Evaluation Results", res)

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -18,6 +18,7 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
 
         bayes = NaiveBayesLearner()
         tree = TreeLearner()
+        # `data` is defined in WidgetOutputsTestMixin, pylint: disable=no-member
         cls.iris = cls.data
         titanic = Table("titanic")
         common = dict(k=3, store_data=True)
@@ -78,6 +79,7 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.evaluation_results, results)
         self.widget.select_correct()
         selected = self.get_output(self.widget.Outputs.selected_data)
+        # pylint: disable=unsubscriptable-object
         correct = np.equal(results.actual, results.predicted)[0]
         correct_indices = results.row_indices[correct]
         self.assertSetEqual(set(self.iris[correct_indices].ids),

--- a/Orange/widgets/evaluate/tests/test_owrocanalysis.py
+++ b/Orange/widgets/evaluate/tests/test_owrocanalysis.py
@@ -40,6 +40,7 @@ class TestROC(unittest.TestCase):
 
         # fixed random seed because otherwise it could happen that data sample
         # contained only instances of two classes (and the test then fails)
+        # Pylint complains about RandomState; pylint: disable=no-member
         data = data[np.random.RandomState(0).choice(len(data), size=20)]
         res = Orange.evaluation.LeaveOneOut(data, learners)
 

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -194,8 +194,8 @@ class TestOWTestLearners(WidgetTest):
         self.assertFalse(self.widget.Error.memory_error.is_shown())
 
         with unittest.mock.patch(
-            "Orange.evaluation.testing.Results.get_augmented_data",
-            side_effect=MemoryError):
+                "Orange.evaluation.testing.Results.get_augmented_data",
+                side_effect=MemoryError):
             self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0, wait=5000)
             self.assertTrue(self.widget.Error.memory_error.is_shown())
 
@@ -237,6 +237,7 @@ class TestOWTestLearners(WidgetTest):
 
     def test_addon_scorers(self):
         try:
+            # These classes are registered, pylint: disable=unused-variable
             class NewScore(Score):
                 class_types = (DiscreteVariable, ContinuousVariable)
 
@@ -268,9 +269,9 @@ class TestOWTestLearners(WidgetTest):
             self.send_signal("Data", None)
             self.assertEqual(self.widget.scorers, [])
         finally:
-            del Score.registry["NewScore"]
-            del Score.registry["NewClassificationScore"]
-            del Score.registry["NewRegressionScore"]
+            del Score.registry["NewScore"]  # pylint: disable=no-member
+            del Score.registry["NewClassificationScore"]  # pylint: disable=no-member
+            del Score.registry["NewRegressionScore"]  # pylint: disable=no-member
 
     def test_target_changing(self):
         data = Table("iris")


### PR DESCRIPTION
Disable false positives, fix whitespace.