### PR TITLE
Orange.widget.model: pylint

### DIFF
--- a/Orange/widgets/model/owadaboost.py
+++ b/Orange/widgets/model/owadaboost.py
@@ -45,6 +45,7 @@ class OWAdaBoost(OWBaseLearner):
         no_weight_support = Msg('The base learner does not support weights.')
 
     def add_main_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.widgetBox(self.controlArea, "Parameters")
         self.base_estimator = self.DEFAULT_BASE_ESTIMATOR
         self.base_label = gui.label(
@@ -89,6 +90,8 @@ class OWAdaBoost(OWBaseLearner):
 
     @Inputs.learner
     def set_base_learner(self, learner):
+        # base_estimator is defined in add_main_layout
+        # pylint: disable=attribute-defined-outside-init
         self.Error.no_weight_support.clear()
         if learner and not learner.supports_weights:
             # Clear the error and reset to default base learner

--- a/Orange/widgets/model/owknn.py
+++ b/Orange/widgets/model/owknn.py
@@ -30,6 +30,7 @@ class OWKNNLearner(OWBaseLearner):
     weight_index = Setting(0)
 
     def add_main_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.vBox(self.controlArea, "Neighbors")
         self.n_neighbors_spin = gui.spin(
             box, self, "n_neighbors", 1, 100, label="Number of neighbors:",

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -52,6 +52,7 @@ class OWLinearRegression(OWBaseLearner):
                         range(100, 1001, 100)))
 
     def add_main_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.hBox(self.controlArea, "Regularization")
         gui.radioButtons(box, self, "reg_type",
                          btnLabels=self.REGULARIZATION_TYPES,
@@ -156,7 +157,7 @@ class OWLinearRegression(OWBaseLearner):
                               .format(self.alphas[self.alpha_index],
                                       self.l2_ratio,
                                       1 - self.l2_ratio))
-        return ("Regularization", regularization),
+        return (("Regularization", regularization), )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -45,6 +45,7 @@ class OWLogisticRegression(OWBaseLearner):
     penalty_types_short = ["l1", "l2"]
 
     def add_main_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.widgetBox(self.controlArea, box=True)
         self.penalty_combo = gui.comboBox(
             box, self, "penalty_type", label="Regularization type: ",
@@ -64,6 +65,7 @@ class OWLogisticRegression(OWBaseLearner):
         self.set_c()
 
     def set_c(self):
+        # called from init, pylint: disable=attribute-defined-outside-init
         self.strength_C = self.C_s[self.C_index]
         fmt = "C={}" if self.strength_C >= 1 else "C={:.3f}"
         self.c_label.setText(fmt.format(self.strength_C))

--- a/Orange/widgets/model/owneuralnetwork.py
+++ b/Orange/widgets/model/owneuralnetwork.py
@@ -95,6 +95,7 @@ class OWNNLearner(OWBaseLearner):
                         range(100, 1001, 50)))
 
     def add_main_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         form = QFormLayout()
         form.setFieldGrowthPolicy(form.AllNonFixedFieldsGrow)
         form.setVerticalSpacing(25)
@@ -141,10 +142,12 @@ class OWNNLearner(OWBaseLearner):
         form.addRow(gui.separator(None))
         form.addRow(
             gui.checkBox(
-                None, self, "replicable", label="Replicable training", callback=self.settings_changed),
+                None, self, "replicable", label="Replicable training",
+                callback=self.settings_changed),
         )
 
     def set_alpha(self):
+        # called from init, pylint: disable=attribute-defined-outside-init
         self.strength_C = self.alphas[self.alpha_index]
         self.reg_label.setText("Regularization, α={}:".format(self.strength_C))
 
@@ -153,6 +156,7 @@ class OWNNLearner(OWBaseLearner):
         return self.alphas[self.alpha_index]
 
     def setup_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         super().setup_layout()
 
         self._task = None  # type: Optional[Task]
@@ -212,7 +216,7 @@ class OWNNLearner(OWBaseLearner):
         lastemitted = 0.
 
         def callback(iteration):
-            nonlocal task  # type: Task
+            nonlocal task
             nonlocal lastemitted
             if task.isInterruptionRequested():
                 raise CancelTaskException()
@@ -238,7 +242,9 @@ class OWNNLearner(OWBaseLearner):
         task.done.connect(self._task_finished)
         task.progressChanged.connect(self.setProgressValue)
 
+        # set in setup_layout; pylint: disable=attribute-defined-outside-init
         self._task = task
+
         self.progressBarInit()
         self.setBlocking(True)
 
@@ -255,7 +261,7 @@ class OWNNLearner(OWBaseLearner):
         assert self._task.future is f
         assert f.done()
         self._task.deleteLater()
-        self._task = None
+        self._task = None  # pylint: disable=attribute-defined-outside-init
         self.setBlocking(False)
         self.progressBarFinished()
 
@@ -284,7 +290,7 @@ class OWNNLearner(OWBaseLearner):
             self._task.done.disconnect(self._task_finished)
             self._task.progressChanged.disconnect(self.setProgressValue)
             self._task.deleteLater()
-            self._task = None
+            self._task = None  # pylint: disable=attribute-defined-outside-init
 
         self.progressBarFinished()
         self.setBlocking(False)

--- a/Orange/widgets/model/owrandomforest.py
+++ b/Orange/widgets/model/owrandomforest.py
@@ -35,6 +35,7 @@ class OWRandomForest(OWBaseLearner):
         not_enough_features = Msg("Insufficient number of attributes ({})")
 
     def add_main_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.vBox(self.controlArea, 'Basic Properties')
         self.n_estimators_spin = gui.spin(
             box, self, "n_estimators", minv=1, maxv=10000, controlWidth=80,

--- a/Orange/widgets/model/owsgd.py
+++ b/Orange/widgets/model/owsgd.py
@@ -93,6 +93,7 @@ class OWSGD(OWBaseLearner):
         self._add_learning_params_to_layout()
 
     def _add_algorithm_to_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.widgetBox(self.controlArea, 'Algorithm')
         # Classfication loss function
         self.cls_loss_function_combo = gui.comboBox(
@@ -124,6 +125,7 @@ class OWSGD(OWBaseLearner):
         self._on_reg_loss_change()
 
     def _add_regularization_to_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.widgetBox(self.controlArea, 'Regularization')
         self.penalty_combo = gui.comboBox(
             box, self, 'penalty_index', label='Regularization method: ',
@@ -142,6 +144,7 @@ class OWSGD(OWBaseLearner):
         self._on_regularization_change()
 
     def _add_learning_params_to_layout(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         box = gui.widgetBox(self.controlArea, 'Learning parameters')
         self.learning_rate_combo = gui.comboBox(
             box, self, 'learning_rate_index', label='Learning rate: ',
@@ -324,10 +327,10 @@ class OWSGD(OWBaseLearner):
         self.Outputs.coefficients.send(coeffs)
 
     @classmethod
-    def migrate_settings(cls, settings_, version):
+    def migrate_settings(cls, settings, version):
         if version < 2:
-            settings_["max_iter"] = settings_.pop("n_iter", 5)
-            settings_["tol_enabled"] = False
+            settings["max_iter"] = settings.pop("n_iter", 5)
+            settings["tol_enabled"] = False
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/model/owstack.py
+++ b/Orange/widgets/model/owstack.py
@@ -31,7 +31,7 @@ class OWStackedLearner(OWBaseLearner):
         pass
 
     @Inputs.learners
-    def set_learners(self, learner, id):
+    def set_learners(self, learner, id):  # pylint: disable=redefined-builtin
         if id in self.learners and learner is None:
             del self.learners[id]
         elif learner is not None:

--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -34,10 +34,10 @@ class OWSVM(OWBaseLearner):
     #: SVM type
     svm_type = Setting(SVM)
 
-    C = Setting(1.)
+    C = Setting(1.)  # pylint: disable=invalid-name
     epsilon = Setting(.1)
     nu_C = Setting(1.)
-    nu = Setting(.5)
+    nu = Setting(.5)  # pylint: disable=invalid-name
 
     #: Kernel types
     Linear, Poly, RBF, Sigmoid = range(4)
@@ -70,6 +70,7 @@ class OWSVM(OWBaseLearner):
         self._show_right_kernel()
 
     def _add_type_box(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         form = QGridLayout()
         self.type_box = box = gui.radioButtonsInBox(
             self.controlArea, self, "svm_type", [], box="SVM Type",
@@ -77,7 +78,7 @@ class OWSVM(OWBaseLearner):
 
         self.epsilon_radio = gui.appendRadioButton(
             box, "SVM", addToLayout=False)
-        self.C_spin = gui.doubleSpin(
+        self.c_spin = gui.doubleSpin(
             box, self, "C", 0.1, 512.0, 0.1, decimals=2,
             alignment=Qt.AlignRight, addToLayout=False,
             callback=self.settings_changed)
@@ -87,7 +88,7 @@ class OWSVM(OWBaseLearner):
             callback=self.settings_changed)
         form.addWidget(self.epsilon_radio, 0, 0, Qt.AlignLeft)
         form.addWidget(QLabel("Cost (C):"), 0, 1, Qt.AlignRight)
-        form.addWidget(self.C_spin, 0, 2)
+        form.addWidget(self.c_spin, 0, 2)
         form.addWidget(QLabel(
             "Regression loss epsilon (ε):"), 1, 1, Qt.AlignRight)
         form.addWidget(self.epsilon_spin, 1, 2)
@@ -113,18 +114,19 @@ class OWSVM(OWBaseLearner):
     def _update_type(self):
         # Enable/disable SVM type parameters depending on selected SVM type
         if self.svm_type == self.SVM:
-            self.C_spin.setEnabled(True)
+            self.c_spin.setEnabled(True)
             self.epsilon_spin.setEnabled(True)
             self.nu_C_spin.setEnabled(False)
             self.nu_spin.setEnabled(False)
         else:
-            self.C_spin.setEnabled(False)
+            self.c_spin.setEnabled(False)
             self.epsilon_spin.setEnabled(False)
             self.nu_C_spin.setEnabled(True)
             self.nu_spin.setEnabled(True)
         self.settings_changed()
 
     def _add_kernel_box(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         # Initialize with the widest label to measure max width
         self.kernel_eq = self.kernels[-1][1]
 
@@ -160,6 +162,7 @@ class OWSVM(OWBaseLearner):
         box.setMinimumWidth(box.sizeHint().width())
 
     def _add_optimization_box(self):
+        # this is part of init, pylint: disable=attribute-defined-outside-init
         self.optimization_box = gui.vBox(
             self.controlArea, "Optimization Parameters")
         self.tol_spin = gui.doubleSpin(
@@ -180,6 +183,7 @@ class OWSVM(OWBaseLearner):
                    [True, False, False],  # rbf
                    [True, True, False]]  # sigmoid
 
+        # set in _add_kernel_box, pylint: disable=attribute-defined-outside-init
         self.kernel_eq = self.kernels[self.kernel_type][1]
         mask = enabled[self.kernel_type]
         for spin, enabled in zip(self._kernel_params, mask):

--- a/Orange/widgets/model/tests/test_owsvm.py
+++ b/Orange/widgets/model/tests/test_owsvm.py
@@ -32,7 +32,7 @@ class TestOWSVMClassification(WidgetTest, WidgetLearnerTestMixin):
                 gamma_spin.setValue(value)
 
         self.parameters = [
-            ParameterMapping("C", self.widget.C_spin),
+            ParameterMapping("C", self.widget.c_spin),
             ParameterMapping("gamma", self.widget._kernel_params[0],
                              values=values, setter=setter, getter=getter),
             ParameterMapping("coef0", self.widget._kernel_params[1]),


### PR DESCRIPTION
Almost all issues in widgets/model are due to attributes being defined in methods called by `__init__` instead of in `__init__`. Most other issues are related to names that follow the usual names of parameters for models.