### PR TITLE
OWDataProjectionWidget: Set 'left_side_scrolling' on the parent

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -181,8 +181,6 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
     graph = SettingProvider(OWMDSGraph)
     embedding_variables_names = ("mds-x", "mds-y")
 
-    left_side_scrolling = True
-
     class Error(OWDataProjectionWidget.Error):
         not_enough_rows = Msg("Input data needs at least 2 rows")
         matrix_too_small = Msg("Input matrix must be at least 2x2")

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -267,8 +267,6 @@ class OWtSNE(OWDataProjectionWidget, ConcurrentWidgetMixin):
     graph = SettingProvider(OWtSNEGraph)
     embedding_variables_names = ("t-SNE-x", "t-SNE-y")
 
-    left_side_scrolling = True
-
     # Use `invalidated` descriptor so we don't break the usage of
     # `_invalidated` in `OWDataProjectionWidget`, but still allow finer control
     # over which parts of the embedding to invalidate

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -136,8 +136,6 @@ class OWFreeViz(OWAnchorProjectionWidget, ConcurrentWidgetMixin):
     GRAPH_CLASS = OWFreeVizGraph
     graph = settings.SettingProvider(OWFreeVizGraph)
 
-    left_side_scrolling = True
-
     class Error(OWAnchorProjectionWidget.Error):
         no_class_var = widget.Msg("Data has no target variable")
         not_enough_class_vars = widget.Msg(

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -269,8 +269,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
     GRAPH_CLASS = OWLinProjGraph
     graph = SettingProvider(OWLinProjGraph)
 
-    left_side_scrolling = True
-
     class Error(OWAnchorProjectionWidget.Error):
         no_cont_features = Msg("Plotting requires numeric features")
 

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -278,8 +278,6 @@ class OWRadviz(OWAnchorProjectionWidget):
     GRAPH_CLASS = OWRadvizGraph
     graph = SettingProvider(OWRadvizGraph)
 
-    left_side_scrolling = True
-
     class Warning(OWAnchorProjectionWidget.Warning):
         invalid_embedding = widget.Msg("No projection for selected features")
         removed_vars = widget.Msg("Categorical variables with more than"

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -226,8 +226,6 @@ class OWScatterPlot(OWDataProjectionWidget):
     graph = SettingProvider(OWScatterPlotGraph)
     embedding_variables_names = None
 
-    left_side_scrolling = True
-
     xy_changed_manually = Signal(Variable, Variable)
 
     class Warning(OWDataProjectionWidget.Warning):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -376,6 +376,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
     graph = SettingProvider(OWScatterPlotBase)
     graph_name = "graph.plot_widget.plotItem"
     embedding_variables_names = ("proj-x", "proj-y")
+    left_side_scrolling = True
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The property `left_side_scrolling` should be set on parent widget.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
