### PR TITLE
[FIX] DistMatrix should return numpy datatypes

### DIFF
--- a/Orange/misc/distmatrix.py
+++ b/Orange/misc/distmatrix.py
@@ -51,7 +51,7 @@ class DistMatrix(np.ndarray):
 
     def __array_wrap__(self, out_arr, context=None):
         if out_arr.ndim == 0:  # a single scalar
-            return out_arr.item()
+            return out_arr[()]
         return np.ndarray.__array_wrap__(self, out_arr, context)
 
     """

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -186,6 +186,17 @@ class TestDistMatrix(TestCase):
                              ["danny", "eve", "frank"])
             self.assertEqual(m.axis, 0)
 
+    def test_numpy_type(self):
+        """GH-3658"""
+        data1 = np.array([1, 2], dtype=np.int64)
+        data2 = np.array([2, 3], dtype=np.int64)
+        dm1, dm2 = DistMatrix(data1), DistMatrix(data2)
+
+        self.assertIsInstance(dm1.max(), np.int64)
+        self.assertNotIsInstance(dm1.max(), int)
+        with self.assertRaises(AssertionError):
+            np.testing.assert_array_equal(dm1, dm2)
+
 
 # noinspection PyTypeChecker
 class TestEuclidean(TestCase):


### PR DESCRIPTION
##### Issue
Fixes #3658
Due to DistMatrix.max() returning Python int objects, numpy functions like np.testing.assert_array_equal fail unexpectedly.
##### Description of changes
When returning zero dimensional array use indexing to get a numpy datatype.
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
