### PR TITLE
[ENH] Mosaic: Wrap legend

### DIFF
--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -98,7 +98,8 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         assertCount(1, [0, 1, 1, 1], 0)
 
     @patch('Orange.widgets.visualize.owmosaic.CanvasRectangle')
-    def test_different_number_of_attributes(self, canvas_rectangle):
+    @patch('Orange.widgets.visualize.owmosaic.QGraphicsItemGroup.addToGroup')
+    def test_different_number_of_attributes(self, _, canvas_rectangle):
         domain = Domain([DiscreteVariable(c, values="01") for c in "abcd"])
         data = Table.from_list(
             domain,


### PR DESCRIPTION
##### Issue

Fixes #3052.

The function for wrapping the legend is put into module `plotutil`, so it can also be used elsewhere.

~~*TODO*: When decreasing the widget height, the legend can fall out of view at the bottom, despite my attempts to correctly compute the maximal square size.~~

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
