### PR TITLE
Densify sparse targets when fitting models

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -204,6 +204,8 @@ class Table(MutableSequence, Storage):
             value = value[:, None]
         if sp.issparse(value) and len(self) != value.shape[0]:
             value = value.T
+        if sp.issparse(value):
+            value = value.toarray()
         self._Y = value
 
     def __new__(cls, *args, **kwargs):

--- a/Orange/tests/test_sparse_table.py
+++ b/Orange/tests/test_sparse_table.py
@@ -67,7 +67,7 @@ class InterfaceTest(tabletests.InterfaceTest):
         assert iris.Y.shape == (150,)
         iris.Y = csr_matrix(iris.Y)
         # We expect the Y shape to match the X shape, which is (150, 4) in iris
-        self.assertEqual(iris.Y.shape, (150, 1))
+        self.assertEqual(iris.Y.shape, (150,))
 
     def test_Y_setter_2d(self):
         iris = Table('iris')

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2810,7 +2810,7 @@ class TestTableSparseDense(unittest.TestCase):
 
         iris_sparse = iris.to_sparse(sparse_attributes=True, sparse_class=True)
         self.assertTrue(sp.issparse(iris_sparse.X))
-        self.assertTrue(sp.issparse(iris_sparse.Y))
+        self.assertFalse(sp.issparse(iris_sparse.Y))
         self.assertFalse(sp.issparse(iris_sparse.metas))
 
         dense_iris = iris_sparse.to_dense()

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
 
-import numpy as np
-
 from AnyQt.QtCore import QTimer, Qt
 
 from Orange.data import Table
 from Orange.modelling import Fitter, Learner, Model
 from Orange.preprocess.preprocess import Preprocess
+from Orange.statistics import util as ut
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils import getmembers
@@ -133,6 +132,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         """Set the input train dataset."""
         self.Error.data_error.clear()
         self.data = data
+
         if data is not None and data.domain.class_var is None:
             self.Error.data_error("Data has no target variable.")
             self.data = None
@@ -181,7 +181,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
                 self.Error.data_error(self.learner.learner_adequacy_err_msg)
             elif not len(self.data):
                 self.Error.data_error("Dataset is empty.")
-            elif len(np.unique(self.data.Y)) < 2:
+            elif len(ut.unique(self.data.Y)) < 2:
                 self.Error.data_error("Data contains a single target value.")
             elif self.data.X.size == 0:
                 self.Error.data_error("Data has no features to learn from.")


### PR DESCRIPTION
##### Description of changes
Fixes #2498.

`Table` now automatically densifies `Y`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
