### PR TITLE
Make Results (more like) a dataclass, separate Validation hierarchy

### DIFF
--- a/Orange/evaluation/clustering.py
+++ b/Orange/evaluation/clustering.py
@@ -78,24 +78,14 @@ class ClusteringEvaluation(Validation):
         The number of runs.
 
     """
-    # pylint: disable=arguments-differ, unused-argument
-    def __new__(cls, data=None, learners=None, k=1,
-                store_data=False, store_models=False, preprocessor=None,
-                callback=None, n_jobs=1):
-        return super().__new__(
-            cls,
-            data, learners, preprocessor=preprocessor, callback=callback, k=k,
-            store_data=True, store_models=store_models)
-
     # pylint: disable=unused-argument
     def __init__(self, data=None, learners=None, k=1,
                  store_data=False, store_models=False, preprocessor=None,
                  callback=None, n_jobs=1):
-        super().__init__()
+        super().__init__(store_data=store_data, store_models=store_models)
         self.k = k
 
-    def fit(self, learners, preprocessor, data, test_data=None,
-            *, callback=None):
+    def __call__(self, data, learners, preprocessor=None, *, callback=None):
         res = ClusteringResults()
         res.data = data
         res.predicted = np.empty((len(learners), self.k, len(data)))

--- a/Orange/evaluation/clustering.py
+++ b/Orange/evaluation/clustering.py
@@ -32,12 +32,13 @@ class ClusteringResults(Results):
 class ClusteringScore(Score):
     considers_actual = False
 
+    # pylint: disable=arguments-differ
     def from_predicted(self, results, score_function):
         # Clustering scores from labels
         # This warning filter can be removed in scikit 0.22
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore", "The behavior of AMI will change in version 0\.22.*")
+                "ignore", "The behavior of AMI will change in version 0\\.22.*")
             if self.considers_actual:
                 return np.fromiter(
                     (score_function(results.actual.flatten(),

--- a/Orange/evaluation/clustering.py
+++ b/Orange/evaluation/clustering.py
@@ -78,10 +78,7 @@ class ClusteringEvaluation(Validation):
         The number of runs.
 
     """
-    # pylint: disable=unused-argument
-    def __init__(self, data=None, learners=None, k=1,
-                 store_data=False, store_models=False, preprocessor=None,
-                 callback=None, n_jobs=1):
+    def __init__(self, k=1, store_data=False, store_models=False):
         super().__init__(store_data=store_data, store_models=store_models)
         self.k = k
 

--- a/Orange/evaluation/clustering.py
+++ b/Orange/evaluation/clustering.py
@@ -79,7 +79,7 @@ class ClusteringEvaluation(Validation):
 
     """
     # pylint: disable=arguments-differ, unused-argument
-    def __new__(cls, data, learners, k=1,
+    def __new__(cls, data=None, learners=None, k=1,
                 store_data=False, store_models=False, preprocessor=None,
                 callback=None, n_jobs=1):
         return super().__new__(
@@ -88,10 +88,10 @@ class ClusteringEvaluation(Validation):
             store_data=True, store_models=store_models)
 
     # pylint: disable=unused-argument
-    def __init__(self, data, learners, k=1,
+    def __init__(self, data=None, learners=None, k=1,
                  store_data=False, store_models=False, preprocessor=None,
                  callback=None, n_jobs=1):
-        super().__init__(self)
+        super().__init__()
         self.k = k
 
     def fit(self, learners, preprocessor, data, test_data=None,

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -2,7 +2,7 @@
 # pylint: disable=unused-argument
 # __new__ methods have different arguments
 # pylint: disable=arguments-differ
-import warnings
+from warnings import warn
 from collections import namedtuple
 
 import numpy as np
@@ -345,9 +345,9 @@ class Validation:
                                  "and train_data are omitted")
             return self
 
-        warnings.warn("calling Validation's constructor with data and learners"
-                      "is deprecated;\nconstruct an instance and call it",
-                      DeprecationWarning, stacklevel=2)
+        warn("calling Validation's constructor with data and learners"
+             "is deprecated;\nconstruct an instance and call it",
+             DeprecationWarning, stacklevel=2)
 
         # Explicitly call __init__ because Python won't
         self.__init__(store_data=store_data, store_models=store_models,
@@ -367,8 +367,8 @@ class Validation:
         self.store_models = store_models
 
     def fit(self, *args, **kwargs):
-        warnings.warn("Validation.fit is deprecated; use the call operator",
-                      DeprecationWarning)
+        warn("Validation.fit is deprecated; use the call operator",
+             DeprecationWarning)
         return self(*args, **kwargs)
 
     def __call__(self, data, learners, preprocessor=None, *, callback=None):
@@ -574,6 +574,7 @@ class ShuffleSplit(Validation):
 
 
 class TestOnTestData(Validation):
+    # get_indices is not needed in this class, pylint: disable=abstract-method
     def __new__(cls, data=None, test_data=None, learners=None,
                 preprocessor=None, **kwargs):
         if "train_data" in kwargs:
@@ -618,6 +619,8 @@ class TestOnTestData(Validation):
 
 
 class TestOnTrainingData(TestOnTestData):
+    # get_indices is not needed in this class, pylint: disable=abstract-method
+    # signature is such as on the base class, pylint: disable=signature-differs
     def __new__(cls, data=None, learners=None, preprocessor=None, **kwargs):
         return super().__new__(
             cls,

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -26,7 +26,7 @@ def _mp_worker(fold_i, train_data, test_data, learner_i, learner,
                store_models):
     predicted, probs, model, failed = None, None, None, False
     try:
-        if len(train_data) == 0 or len(test_data) == 0:
+        if not train_data or not test_data:
             raise RuntimeError('Test fold is empty')
         model = learner(train_data)
         if train_data.domain.has_discrete_class:
@@ -526,14 +526,14 @@ class CrossValidationFeature(Validation):
         super().__init__(store_data=store_data, store_models=store_models)
         self.feature = feature
 
-    def get_indices(self, data, _test_data):
+    def get_indices(self, data, test_data):
         data = Table(Domain([self.feature], None), data)
         values = data[:, self.feature].X
         indices = []
         for v in range(len(self.feature.values)):
             test_index = np.where(values == v)[0]
             train_index = np.where((values != v) & (~np.isnan(values)))[0]
-            if len(test_index) and len(train_index):
+            if test_index.size and train_index.size:
                 indices.append((train_index, test_index))
         if not indices:
             raise ValueError("No folds could be created from the given feature.")
@@ -686,11 +686,11 @@ def sample(table, n=0.7, stratified=False, replace=False,
             rgen = np.random
         else:
             rgen = np.random.mtrand.RandomState(random_state)
-        sample = rgen.randint(0, len(table), n)
+        a_sample = rgen.randint(0, len(table), n)
         o = np.ones(len(table))
-        o[sample] = 0
+        o[a_sample] = 0
         others = np.nonzero(o)[0]
-        return table[sample], table[others]
+        return table[a_sample], table[others]
 
     n = len(table) - n
     if stratified and table.domain.has_discrete_class:

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -149,20 +149,23 @@ class Results:
             domain, [data is not None and data.domain],
             "mismatching domain")
         self.nrows = nrows = set_or_raise(
-            nrows, [data is not None and len(data),
-                    actual is not None and len(actual),
+            nrows, [actual is not None and len(actual),
                     row_indices is not None and len(row_indices),
                     predicted is not None and predicted.shape[1],
                     probabilities is not None and probabilities.shape[1]],
             "mismatching number of rows")
+        if domain is not None and domain.has_continuous_class:
+            if nclasses is not None:
+                raise ValueError(
+                    "regression results cannot have non-None 'nclasses'")
+            if probabilities is not None:
+                raise ValueError(
+                    "regression results cannot have 'probabilities'")
         nclasses = set_or_raise(
-            nclasses, [len(domain.class_var.values)
-                       if domain is not None and domain.has_discrete_class
-                       else None,
+            nclasses, [domain is not None and domain.has_discrete_class and
+                       len(domain.class_var.values),
                        probabilities is not None and probabilities.shape[2]],
             "mismatching number of class values")
-        if nclasses is None and probabilities is not None:
-            raise ValueError("regression results cannot have 'probabilities'")
         nmethods = set_or_raise(
             nmethods, [learners is not None and len(learners),
                        models is not None and len(models),

--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -1,5 +1,3 @@
-# __init__ methods have all kinds of unused arguments to match signatures
-# pylint: disable=unused-argument
 # __new__ methods have different arguments
 # pylint: disable=arguments-differ
 from warnings import warn
@@ -120,8 +118,8 @@ class Results:
             actual (np.ndarray): see class documentation
             predicted (np.ndarray): see class documentation
             probabilities (np.ndarray): see class documentation
-            store_data (bool): ignored; kept for backward compabitility
-            store_models (bool): ignored; kept for backward compabitility
+            store_data (bool): ignored; kept for backward compatibility
+            store_models (bool): ignored; kept for backward compatibility
         """
 
         # Set given data directly from arguments
@@ -352,7 +350,7 @@ class Validation:
     def __new__(cls,
                 data=None, learners=None, preprocessor=None, test_data=None,
                 *, callback=None, store_data=False, store_models=False,
-                **kwargs):
+                n_jobs=None, **kwargs):
         self = super().__new__(cls)
 
         if (learners is None) != (data is None):
@@ -373,7 +371,7 @@ class Validation:
 
         # Explicitly call __init__ because Python won't
         self.__init__(store_data=store_data, store_models=store_models,
-                      callback=callback, **kwargs)
+                      **kwargs)
         if test_data is not None:
             test_data_kwargs = {"test_data": test_data}
         else:
@@ -382,7 +380,7 @@ class Validation:
                     callback=callback, **test_data_kwargs)
 
     # Note: this will be called only if __new__ doesn't have data and learners
-    def __init__(self, *, store_data=False, store_models=False, **kwargs):
+    def __init__(self, *, store_data=False, store_models=False):
         self.store_data = store_data
         self.store_models = store_models
 
@@ -528,13 +526,10 @@ class CrossValidation(Validation):
             validataion and adds a list `warning` with a warning message(s) to
             the `Result`.
     """
-    # TODO: Remove arguments that go to call and swallow them in **kwargs?
     # TODO: list `warning` contains just repetitions of the same message
     #       replace with a flag in `Results`?
-    def __init__(self, data=None, learners=None,
-                 k=10, stratified=True, random_state=0,
-                 store_data=False, store_models=False, preprocessor=None,
-                 callback=None, warnings=None, n_jobs=1):
+    def __init__(self, k=10, stratified=True, random_state=0,
+                 store_data=False, store_models=False, warnings=None):
         super().__init__(store_data=store_data, store_models=store_models)
         self.k = k
         self.stratified = stratified
@@ -565,9 +560,8 @@ class CrossValidationFeature(Validation):
     Attributes:
         feature (Orange.data.Variable): the feature defining the folds
     """
-    def __init__(self, data=None, learners=None, feature=None,
-                 store_data=False, store_models=False, preprocessor=None,
-                 callback=None, warnings=None, n_jobs=1):
+    def __init__(self, feature=None,
+                 store_data=False, store_models=False, warnings=None):
         super().__init__(store_data=store_data, store_models=store_models)
         self.feature = feature
 
@@ -634,11 +628,9 @@ class ShuffleSplit(Validation):
             a different seed is used each time
 
     """
-    def __init__(self, data=None, learners=None,
-                 n_resamples=10, train_size=None, test_size=0.1,
+    def __init__(self, n_resamples=10, train_size=None, test_size=0.1,
                  stratified=True, random_state=0,
-                 store_data=False, store_models=False,
-                 preprocessor=None, callback=None, n_jobs=1):
+                 store_data=False, store_models=False):
         super().__init__(store_data=store_data, store_models=store_models)
         self.n_resamples = n_resamples
         self.train_size = train_size

--- a/Orange/tests/test_evaluation_clustering.py
+++ b/Orange/tests/test_evaluation_clustering.py
@@ -8,11 +8,12 @@ import numpy as np
 import Orange
 from Orange.evaluation.clustering import Silhouette, \
     AdjustedMutualInfoScore, ClusteringEvaluation, ClusteringResults
-from Orange.clustering.kmeans import KMeans
+from Orange.clustering.kmeans import KMeans, KMeansModel
 
 
-class TestClusteringEvaluation(unittest.TestCase):
-    def test_init(self):
+class TestClusteringResults(unittest.TestCase):
+    @staticmethod
+    def test_init():
         data = Orange.data.Table(np.arange(100).reshape((100, 1)))
         res = ClusteringResults(data=data, nmethods=2, nrows=100)
         res.actual[:50] = 0
@@ -20,6 +21,12 @@ class TestClusteringEvaluation(unittest.TestCase):
         res.predicted = np.vstack((res.actual, res.actual))
         expected = [1.0, 1.0]
         np.testing.assert_almost_equal(AdjustedMutualInfoScore(res), expected)
+
+
+class TestClusteringEvaluation(unittest.TestCase):
+    def test_init(self):
+        res = ClusteringEvaluation(k=42)
+        self.assertEqual(res.k, 42)
 
     def test_kmeans(self):
         table = Orange.data.Table('iris')
@@ -31,3 +38,10 @@ class TestClusteringEvaluation(unittest.TestCase):
         expected = [0.51936073, 0.74837231, 0.59178896]
         np.testing.assert_almost_equal(AdjustedMutualInfoScore(cr),
                                        expected, decimal=2)
+        self.assertIsNone(cr.models)
+
+        cr = ClusteringEvaluation(table, learners=[KMeans(n_clusters=2)], k=3,
+                                  store_models=True)
+        self.assertEqual(cr.models.shape, (3, 1))
+        self.assertTrue(all(isinstance(m, KMeansModel)
+                            for m in cr.models.flatten()))

--- a/Orange/tests/test_evaluation_clustering.py
+++ b/Orange/tests/test_evaluation_clustering.py
@@ -30,9 +30,9 @@ class TestClusteringEvaluation(unittest.TestCase):
 
     def test_kmeans(self):
         table = Orange.data.Table('iris')
-        cr = ClusteringEvaluation(table, learners=[KMeans(n_clusters=2),
-                                                   KMeans(n_clusters=3),
-                                                   KMeans(n_clusters=5)], k=3)
+        cr = ClusteringEvaluation(k=3)(table, learners=[KMeans(n_clusters=2),
+                                                        KMeans(n_clusters=3),
+                                                        KMeans(n_clusters=5)])
         expected = [0.68081362, 0.55259194, 0.48851755]
         np.testing.assert_almost_equal(Silhouette(cr), expected, decimal=2)
         expected = [0.51936073, 0.74837231, 0.59178896]
@@ -40,8 +40,8 @@ class TestClusteringEvaluation(unittest.TestCase):
                                        expected, decimal=2)
         self.assertIsNone(cr.models)
 
-        cr = ClusteringEvaluation(table, learners=[KMeans(n_clusters=2)], k=3,
-                                  store_models=True)
+        cr = ClusteringEvaluation(k=3, store_models=True)(
+            table, learners=[KMeans(n_clusters=2)])
         self.assertEqual(cr.models.shape, (3, 1))
         self.assertTrue(all(isinstance(m, KMeansModel)
                             for m in cr.models.flatten()))

--- a/Orange/tests/test_evaluation_scoring.py
+++ b/Orange/tests/test_evaluation_scoring.py
@@ -56,7 +56,7 @@ class TestPrecision(unittest.TestCase):
 
     def test_precision_iris(self):
         learner = LogisticRegressionLearner(preprocessors=[])
-        res = TestOnTrainingData(self.iris, [learner])
+        res = TestOnTrainingData()(self.iris, [learner])
         self.assertAlmostEqual(self.score(res, average='weighted')[0],
                                0.96189, 5)
         self.assertAlmostEqual(self.score(res, target=1)[0], 0.97826, 5)
@@ -115,7 +115,7 @@ class TestRecall(unittest.TestCase):
 
     def test_recall_iris(self):
         learner = LogisticRegressionLearner(preprocessors=[])
-        res = TestOnTrainingData(self.iris, [learner])
+        res = TestOnTrainingData()(self.iris, [learner])
         self.assertAlmostEqual(self.score(res, average='weighted')[0], 0.96, 5)
         self.assertAlmostEqual(self.score(res, target=1)[0], 0.9, 5)
         self.assertAlmostEqual(self.score(res, target=1, average=None)[0],
@@ -173,7 +173,7 @@ class TestF1(unittest.TestCase):
 
     def test_recall_iris(self):
         learner = LogisticRegressionLearner(preprocessors=[])
-        res = TestOnTrainingData(self.iris, [learner])
+        res = TestOnTrainingData()(self.iris, [learner])
         self.assertAlmostEqual(self.score(res, average='weighted')[0],
                                0.959935, 5)
         self.assertAlmostEqual(self.score(res, target=1)[0], 0.9375, 5)
@@ -257,11 +257,11 @@ class TestCA(unittest.TestCase):
         t = Discretize(
             method=discretize.EqualWidth(n=3))(t)
         nb = NaiveBayesLearner()
-        res = TestOnTrainingData(t, [nb])
+        res = TestOnTrainingData()(t, [nb])
         np.testing.assert_almost_equal(CA(res), [1])
 
         t.Y[-20:] = 1 - t.Y[-20:]
-        res = TestOnTrainingData(t, [nb])
+        res = TestOnTrainingData()(t, [nb])
         self.assertGreaterEqual(CA(res)[0], 0.75)
         self.assertLess(CA(res)[0], 1)
 
@@ -273,19 +273,19 @@ class TestAUC(unittest.TestCase):
 
     def test_tree(self):
         tree = SklTreeLearner()
-        res = CrossValidation(self.iris, [tree], k=2)
+        res = CrossValidation(k=2)(self.iris, [tree])
         self.assertGreater(AUC(res)[0], 0.8)
         self.assertLess(AUC(res)[0], 1.)
 
     def test_constant_prob(self):
         maj = MajorityLearner()
-        res = TestOnTrainingData(self.iris, [maj])
+        res = TestOnTrainingData()(self.iris, [maj])
         self.assertEqual(AUC(res)[0], 0.5)
 
     def test_multiclass_auc_multi_learners(self):
         learners = [LogisticRegressionLearner(),
                     MajorityLearner()]
-        res = CrossValidation(self.iris, learners, k=10)
+        res = CrossValidation(k=10)(self.iris, learners)
         self.assertGreater(AUC(res)[0], 0.6)
         self.assertLess(AUC(res)[1], 0.6)
         self.assertGreater(AUC(res)[1], 0.4)
@@ -295,11 +295,11 @@ class TestAUC(unittest.TestCase):
         lenses = Table(test_filename('datasets/lenses.tab'))[:100]
         majority = MajorityLearner()
 
-        results = TestOnTrainingData(lenses, [majority])
+        results = TestOnTrainingData()(lenses, [majority])
         auc = AUC(results)
         self.assertEqual(auc.ndim, 1)
 
-        results = TestOnTrainingData(titanic, [majority])
+        results = TestOnTrainingData()(titanic, [majority])
         auc = AUC(results)
         self.assertEqual(auc.ndim, 1)
 
@@ -343,7 +343,7 @@ class TestLogLoss(unittest.TestCase):
     def test_log_loss(self):
         data = Table('iris')
         majority = MajorityLearner()
-        results = TestOnTrainingData(data, [majority])
+        results = TestOnTrainingData()(data, [majority])
         ll = LogLoss(results)
         self.assertAlmostEqual(ll[0], - np.log(1 / 3))
 
@@ -355,7 +355,7 @@ class TestLogLoss(unittest.TestCase):
     def test_log_loss_calc(self):
         data = Table('titanic')
         learner = LogisticRegressionLearner()
-        results = TestOnTrainingData(data, [learner])
+        results = TestOnTrainingData()(data, [learner])
 
         actual = np.copy(results.actual)
         actual = actual.reshape(actual.shape[0], 1)

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -140,12 +140,14 @@ class TestValidation(unittest.TestCase):
 
         data = self.data
         learners = [MajorityLearner(), MajorityLearner()]
-        kwargs = dict(foo=42, store_data=43, store_models=44, callback=45)
+        kwargs = dict(foo=42, store_data=43, store_models=44, callback=45, n_jobs=46)
         self.assertWarns(
             DeprecationWarning,
             MockValidation, data, learners=learners,
             **kwargs)
         self.assertEqual(MockValidation.args, ())
+        kwargs.pop("n_jobs")  # do not pass n_jobs and callback from __new__ to __init__
+        kwargs.pop("callback")
         self.assertEqual(MockValidation.kwargs, kwargs)
 
         cargs, ckwargs = validation_call.call_args
@@ -183,7 +185,7 @@ class TestCrossValidation(TestSampling):
         self.check_folds(res, 10, nrows)
 
     def test_continuous(self):
-        res = CrossValidation(k=3, n_jobs=1)(
+        res = CrossValidation(k=3)(
             self.housing, [LinearRegressionLearner()])
         self.assertLess(RMSE(res), 5)
 

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -97,7 +97,8 @@ class TestSampling(unittest.TestCase):
             for model, learner in zip(models, learners):
                 self.assertIsInstance(model, learner.__returns__)
 
-    def _callback_values(self, iterations):
+    @staticmethod
+    def _callback_values(iterations):
         return np.hstack((np.linspace(0., .99, iterations + 1)[1:], [1]))
 
 
@@ -111,7 +112,7 @@ class TestCrossValidation(TestSampling):
         cls.random_table = random_data(cls.nrows, cls.ncols)
 
     def test_results(self):
-        nrows, ncols = self.random_table.X.shape
+        nrows, _ = self.random_table.X.shape
         res = CrossValidation(self.random_table, [NaiveBayesLearner()], k=10,
                               stratified=False)
         y = self.random_table.Y
@@ -131,7 +132,7 @@ class TestCrossValidation(TestSampling):
         self.check_folds(res, 5, self.nrows)
 
     def test_call_5(self):
-        nrows, ncols = self.random_table.X.shape
+        nrows, _ = self.random_table.X.shape
         res = CrossValidation(self.random_table, [NaiveBayesLearner()], k=5,
                               stratified=False)
         y = self.random_table.Y
@@ -184,7 +185,8 @@ class TestCrossValidation(TestSampling):
         self.assertTrue((probs[:, :, 0] < probs[:, :, 2]).all())
         self.assertTrue((probs[:, :, 2] < probs[:, :, 1]).all())
 
-    def test_miss_majority(self):
+    @staticmethod
+    def test_miss_majority():
         x = np.zeros((50, 3))
         y = x[:, -1]
         x[-4:] = np.ones((4, 3))
@@ -198,8 +200,8 @@ class TestCrossValidation(TestSampling):
 
     def test_too_many_folds(self):
         w = []
-        res = CrossValidation(self.iris, [MajorityLearner()],
-                              k=len(self.iris) // 2, warnings=w)
+        CrossValidation(self.iris, [MajorityLearner()],
+                        k=len(self.iris) // 2, warnings=w)
         self.assertGreater(len(w), 0)
 
     def test_failed(self):
@@ -262,7 +264,8 @@ class TestCrossValidation(TestSampling):
 
 class TestCrossValidationFeature(TestSampling):
 
-    def add_meta_fold(self, data, f):
+    @staticmethod
+    def add_meta_fold(data, f):
         fat = DiscreteVariable(name="fold", values=[str(a) for a in range(f)])
         domain = Domain(data.domain.attributes, data.domain.class_var, metas=[fat])
         ndata = Table(domain, data)
@@ -347,7 +350,8 @@ class TestLeaveOneOut(TestSampling):
         self.assertTrue((probs[:, :, 0] < probs[:, :, 2]).all())
         self.assertTrue((probs[:, :, 2] < probs[:, :, 1]).all())
 
-    def test_miss_majority(self):
+    @staticmethod
+    def test_miss_majority():
         x = np.zeros((50, 3))
         y = x[:, -1]
         x[49] = 1
@@ -377,7 +381,7 @@ class TestLeaveOneOut(TestSampling):
 
 class TestTestOnTrainingData(TestSampling):
     def test_results(self):
-        nrows, ncols = self.random_table.X.shape
+        nrows, _ = self.random_table.X.shape
         t = self.random_table
         res = TestOnTrainingData(t, [NaiveBayesLearner()])
         y = t.Y
@@ -418,7 +422,8 @@ class TestTestOnTrainingData(TestSampling):
         self.assertTrue((probs[:, :, 0] < probs[:, :, 2]).all())
         self.assertTrue((probs[:, :, 2] < probs[:, :, 1]).all())
 
-    def test_miss_majority(self):
+    @staticmethod
+    def test_miss_majority():
         x = np.zeros((50, 3))
         y = x[:, -1]
         x[49] = 1
@@ -447,7 +452,7 @@ class TestTestOnTrainingData(TestSampling):
 
 class TestTestOnTestData(TestSampling):
     def test_results(self):
-        nrows, ncols = self.random_table.X.shape
+        nrows, _ = self.random_table.X.shape
         t = self.random_table
         res = TestOnTestData(t, t, [NaiveBayesLearner()])
         y = t.Y
@@ -501,7 +506,8 @@ class TestTestOnTestData(TestSampling):
         res = TestOnTestData(train, test, learners, store_models=True)
         self.check_models(res, learners, 1)
 
-    def test_miss_majority(self):
+    @staticmethod
+    def test_miss_majority():
         x = np.zeros((50, 3))
         y = x[:, -1]
         x[49] = 1

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -198,7 +198,8 @@ class TestCrossValidation(TestSampling):
 
     def test_too_many_folds(self):
         w = []
-        res = CrossValidation(self.iris, [MajorityLearner()], k=len(self.iris)/2, warnings=w)
+        res = CrossValidation(self.iris, [MajorityLearner()],
+                              k=len(self.iris) // 2, warnings=w)
         self.assertGreater(len(w), 0)
 
     def test_failed(self):
@@ -603,12 +604,9 @@ class TestShuffleSplit(TestSampling):
                            train_size=.5, test_size=.5,
                            n_resamples=3, stratified=True, random_state=0)
 
-        strata_samples = []
-        for train, test in res.indices:
-            strata_samples.append(np.count_nonzero(train < n) == n/2)
-            strata_samples.append(np.count_nonzero(train < 2 * n) == n)
-
-        self.assertTrue(all(strata_samples))
+        for fold in res.folds:
+            self.assertEqual(np.count_nonzero(res.row_indices[fold] < n), n // 2)
+            self.assertEqual(np.count_nonzero(res.row_indices[fold] < 2 * n), n)
 
     def test_not_stratified(self):
         # strata size
@@ -618,8 +616,9 @@ class TestShuffleSplit(TestSampling):
                            n_resamples=3, stratified=False, random_state=0)
 
         strata_samples = []
-        for train, test in res.indices:
-            strata_samples.append(np.count_nonzero(train < n) == n/2)
-            strata_samples.append(np.count_nonzero(train < 2 * n) == n)
+        for fold in res.folds:
+            strata_samples += [
+                np.count_nonzero(res.row_indices[fold] < n) == n // 2,
+                np.count_nonzero(res.row_indices[fold] < 2 * n) == n]
 
         self.assertTrue(not all(strata_samples))

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -88,7 +88,7 @@ class Try(abc.ABC):
             return "{}({!r})".format(self.__class__.__qualname__,
                                      self.exception)
 
-        def map(self, fn):
+        def map(self, _fn):
             return self
 
     def __new__(cls, f, *args, **kwargs):
@@ -283,7 +283,8 @@ class OWTestLearners(OWWidget):
         box = gui.vBox(self.mainArea, "Evaluation Results")
         box.layout().addWidget(self.score_table.view)
 
-    def sizeHint(self):
+    @staticmethod
+    def sizeHint():
         return QSize(780, 1)
 
     def _update_controls(self):
@@ -333,7 +334,7 @@ class OWTestLearners(OWWidget):
         self.Error.too_many_classes.clear()
         self.Error.no_class_values.clear()
         self.Error.only_one_class_var_value.clear()
-        if data is not None and not len(data):
+        if data is not None and not data:
             self.Error.train_data_empty()
             data = None
         if data:
@@ -392,7 +393,7 @@ class OWTestLearners(OWWidget):
         """
         self.Information.test_data_sampled.clear()
         self.Error.test_data_empty.clear()
-        if data is not None and not len(data):
+        if data is not None and not data:
             self.Error.test_data_empty()
             data = None
         if data and not data.domain.class_var:
@@ -888,7 +889,6 @@ class UserInterrupt(BaseException):
     """
     A BaseException subclass used for cooperative task/thread cancellation
     """
-    pass
 
 
 def results_add_by_model(x, y):
@@ -991,21 +991,20 @@ class Task:
 
 if __name__ == "__main__":  # pragma: no cover
     filename = "iris"
-    data = Table(filename)
-    class_var = data.domain.class_var
-    if class_var.is_discrete:
-        learners = [lambda data: 1 / 0,
-                    Orange.classification.LogisticRegressionLearner(),
-                    Orange.classification.MajorityLearner(),
-                    Orange.classification.NaiveBayesLearner()]
+    preview_data = Table(filename)
+    if preview_data.domain.class_var.is_discrete:
+        prev_learners = [lambda data: 1 / 0,
+                         Orange.classification.LogisticRegressionLearner(),
+                         Orange.classification.MajorityLearner(),
+                         Orange.classification.NaiveBayesLearner()]
     else:
-        learners = [lambda data: 1 / 0,
-                    Orange.regression.MeanLearner(),
-                    Orange.regression.KNNRegressionLearner(),
-                    Orange.regression.RidgeRegressionLearner()]
+        prev_learners = [lambda data: 1 / 0,
+                         Orange.regression.MeanLearner(),
+                         Orange.regression.KNNRegressionLearner(),
+                         Orange.regression.RidgeRegressionLearner()]
 
     WidgetPreview(OWTestLearners).run(
-        set_train_data=data,
-        set_test_data=data,
-        set_learner=[(learner, i) for i, learner in enumerate(learners)]
+        set_train_data=preview_data,
+        set_test_data=preview_data,
+        set_learner=[(learner, i) for i, learner in enumerate(prev_learners)]
     )

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -386,7 +386,7 @@ class TestHelpers(unittest.TestCase):
     def test_results_one_vs_rest(self):
         data = Table(test_filename("datasets/lenses.tab"))
         learners = [MajorityLearner()]
-        res = TestOnTestData(data[1::2], data[::2], learners=learners)
+        res = TestOnTestData()(data[1::2], data[::2], learners=learners)
         r1 = results_one_vs_rest(res, pos_index=0)
         r2 = results_one_vs_rest(res, pos_index=1)
         r3 = results_one_vs_rest(res, pos_index=2)

--- a/pylintrc
+++ b/pylintrc
@@ -28,7 +28,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=Orange.distance._distance
+extension-pkg-whitelist=Orange.distance._distance,numpy.random.mtrand
 
 # Allow optimization of some AST trees. This will activate a peephole AST
 # optimizer, which will apply various small optimizations. For instance, it can


### PR DESCRIPTION
Fixes #3857.

`Results` stores results of validation, but derived classes also perform the validation. A vaguely remember making this (bad) decision at our retreat in Bohinj. :)

These changes break the backward compatibility with `Results` class, but the class itself has been broken for five years, so I doubt anybody used it. To my observation, all code calls `Results()` without arguments.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
