### PR TITLE
[ENH] Faster drawing in scatterplot

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -714,6 +714,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
 
         The method is called by `update_sizes`. It gets the sizes
         from the widget and performs the necessary scaling and sizing.
+        The output is rounded to half a pixel for faster drawing.
 
         Returns:
             (np.ndarray): sizes
@@ -732,7 +733,11 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             size_column /= mx
         else:
             size_column[:] = 0.5
-        return self.MinShapeSize + (5 + self.point_width) * size_column
+
+        sizes = self.MinShapeSize + (5 + self.point_width) * size_column
+        # round sizes to half pixel for smaller pyqtgraph's symbol pixmap atlas
+        sizes = (sizes * 2).round() / 2
+        return sizes
 
     def update_sizes(self):
         """

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -221,7 +221,20 @@ class OWScatterPlotGraph(OWScatterPlotGraphObs):
 
 
 class ScatterPlotItem(pg.ScatterPlotItem):
+    """PyQtGraph's ScatterPlotItem calls updateSpots at any change of sizes/colors/symbols,
+    which then rebuilds the stored pixmaps for each symbol. Because Orange calls
+    set* function in succession, we postpone updateSpots() to paint()."""
+
+    _update_spots_in_paint = False
+
+    def updateSpots(self, dataSet=None):  # pylint: disable=unused-argument
+        self._update_spots_in_paint = True
+        self.update()
+
     def paint(self, painter, option, widget=None):
+        if self._update_spots_in_paint:
+            self._update_spots_in_paint = False
+            super().updateSpots()
         painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
         super().paint(painter, option, widget)
 

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -202,13 +202,9 @@ class TestOWScatterPlotBase(WidgetTest):
         scatterplot_item = graph.scatterplot_item
         x, y = scatterplot_item.getData()
         data = scatterplot_item.data
-        s0, s1, s2, s3 = data["size"] - graph.MinShapeSize
-        np.testing.assert_almost_equal(
-            (s2 - s1) / (s1 - s0),
-            (x[2] - x[1]) / (x[1] - x[0]))
-        np.testing.assert_almost_equal(
-            (s2 - s1) / (s1 - s3),
-            (x[2] - x[1]) / (x[1] - x[3]))
+        s = data["size"] - graph.MinShapeSize
+        precise_s = (x - min(x)) / (max(x) - min(x)) * max(s)
+        np.testing.assert_almost_equal(s, precise_s, decimal=0)
         self.assertEqual(
             list(data["symbol"]),
             [graph.CurveSymbols[int(xi)] for xi in x])
@@ -358,16 +354,24 @@ class TestOWScatterPlotBase(WidgetTest):
         graph.reset_graph()
         scatterplot_item = graph.scatterplot_item
         size = scatterplot_item.data["size"]
-        diffs = [round(y - x, 2) for x, y in zip(size, size[1:])]
-        self.assertEqual(len(set(diffs)), 1)
-        self.assertGreater(diffs[0], 0)
+        np.testing.assert_equal(size, [6, 7.5, 9.5, 11, 12.5, 14.5, 16, 17.5, 19.5, 21])
 
         d = np.arange(10, 20, dtype=float)
         graph.update_sizes()
         self.assertIs(scatterplot_item, graph.scatterplot_item)
+        size2 = scatterplot_item.data["size"]
+        np.testing.assert_equal(size, size2)
+
+    def test_size_rounding_half_pixel(self):
+        graph = self.graph
+
+        self.master.get_size_data = lambda: d
+        d = np.arange(10, dtype=float)
+
+        graph.reset_graph()
+        scatterplot_item = graph.scatterplot_item
         size = scatterplot_item.data["size"]
-        diffs2 = [round(y - x, 2) for x, y in zip(size, size[1:])]
-        self.assertEqual(diffs, diffs2)
+        np.testing.assert_equal(size*2 - (size*2).round(), 0)
 
     def test_size_with_nans(self):
         graph = self.graph

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1278,6 +1278,11 @@ class TestOWScatterPlotBase(WidgetTest):
         self.assertFalse(spy[-1][0])
         self.assertFalse(bool(self.graph.labels))
 
+    def test_no_needless_buildatlas(self):
+        graph = self.graph
+        graph.reset_graph()
+        self.assertIsNone(graph.scatterplot_item.fragmentAtlas.atlas)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
##### Issue
Fixes #3589

##### Description of changes
1) Reused QPen, QBrush objects and rounded sizes to half a pixel so that the number of different symbols to draw is lower.
2) Deferred updateSpots() that gets called by pyqtgraph in set*() to paint(), where spot atlas is actually needed.

Now adult  with spots of same color, shape=occupation, size=fnlwgt displays in less than 1 second instead of 10.5s as before.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
