### PR TITLE
OWFile: Make url combobox case sensitive.

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -7,7 +7,7 @@ from typing import List
 import numpy as np
 from AnyQt.QtWidgets import \
     QStyle, QComboBox, QMessageBox, QGridLayout, QLabel, \
-    QLineEdit, QSizePolicy as Policy
+    QLineEdit, QSizePolicy as Policy, QCompleter
 from AnyQt.QtCore import Qt, QTimer, QSize
 
 from Orange.canvas.gui.utils import OSX_NSURL_toLocalFile
@@ -203,6 +203,11 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         url_edit.setTextMargins(l + 5, t, r, b)
         layout.addWidget(url_combo, 3, 1, 3, 3)
         url_combo.activated.connect(self._url_set)
+        # whit completer we set that combo box is case sensitive when
+        # matching the history
+        completer = QCompleter()
+        completer.setCaseSensitivity(Qt.CaseSensitive)
+        url_combo.setCompleter(completer)
 
         box = gui.vBox(self.controlArea, "Info")
         self.infolabel = gui.widgetLabel(box, 'No data loaded.')


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/3538

##### Description of changes

Since URLs are case sensitive this PR I set the completer of the QComboBox to be case sensitive. With this setting, the combo box does not replace partly upper case URLs with lower case URLs from history and vice versa. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
