### PR TITLE
test_owfreeviz: Shutdown when finished

### DIFF
--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -28,7 +28,12 @@ class TestOWFreeViz(WidgetTest, AnchorProjectionWidgetTestMixin,
         cls.heart_disease = Table("heart_disease")
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(OWFreeViz)
+
+    def tearDown(self):
+        self.widget.onDeleteWidget()
+        super().tearDown()
 
     def test_error_msg(self):
         data = self.data[:, list(range(len(self.data.domain.attributes)))]

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -67,7 +67,7 @@ class TestOWFreeViz(WidgetTest, AnchorProjectionWidgetTestMixin,
         self.assertEqual(self.widget.run_button.text(), "Stop")
 
     def test_optimization_finish(self):
-        self.send_signal(self.widget.Inputs.data, self.data)
+        self.send_signal(self.widget.Inputs.data, self.data[::10].copy())
         output1 = self.get_output(self.widget.Outputs.components)
         self.widget.run_button.click()
         self.assertEqual(self.widget.run_button.text(), "Stop")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Freeviz test do not shutdown/stop the concurrent task, starting new ones when old have not finished.

##### Description of changes

Shutdown in test's tearDown.

A small speed up from ~7s to ~4.5s when running `test_owfreeviz`

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
