### PR TITLE
[FIX] Change normalization to Scaling in SVM

### DIFF
--- a/Orange/classification/svm.py
+++ b/Orange/classification/svm.py
@@ -2,13 +2,13 @@ import sklearn.svm as skl_svm
 
 from Orange.classification import SklLearner, SklModel
 from Orange.base import SklLearner as SklLearnerBase
-from Orange.preprocess import Normalize
+from Orange.preprocess import Scale
 
 __all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner",
            "OneClassSVMLearner"]
 
 
-svm_pps = SklLearner.preprocessors + [Normalize()]
+svm_pps = SklLearner.preprocessors + [Scale(center=Scale.NoCentering)]
 
 
 class SVMClassifier(SklModel):

--- a/Orange/classification/svm.py
+++ b/Orange/classification/svm.py
@@ -2,13 +2,12 @@ import sklearn.svm as skl_svm
 
 from Orange.classification import SklLearner, SklModel
 from Orange.base import SklLearner as SklLearnerBase
-from Orange.preprocess import Scale
+from Orange.preprocess import SmartNormalize
 
 __all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner",
            "OneClassSVMLearner"]
 
-
-svm_pps = SklLearner.preprocessors + [Scale(center=Scale.NoCentering)]
+svm_pps = SklLearner.preprocessors + [SmartNormalize()]
 
 
 class SVMClassifier(SklModel):

--- a/Orange/classification/svm.py
+++ b/Orange/classification/svm.py
@@ -2,12 +2,12 @@ import sklearn.svm as skl_svm
 
 from Orange.classification import SklLearner, SklModel
 from Orange.base import SklLearner as SklLearnerBase
-from Orange.preprocess import SmartNormalize
+from Orange.preprocess import AdaptiveNormalize
 
 __all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner",
            "OneClassSVMLearner"]
 
-svm_pps = SklLearner.preprocessors + [SmartNormalize()]
+svm_pps = SklLearner.preprocessors + [AdaptiveNormalize()]
 
 
 class SVMClassifier(SklModel):

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -18,7 +18,7 @@ from . import impute, discretize, transformation
 __all__ = ["Continuize", "Discretize", "Impute", "RemoveNaNRows",
            "SklImpute", "Normalize", "Randomize", "Preprocess",
            "RemoveConstant", "RemoveNaNClasses", "RemoveNaNColumns",
-           "ProjectPCA", "ProjectCUR", "Scale", "SmartNormalize"]
+           "ProjectPCA", "ProjectCUR", "Scale", "AdaptiveNormalize"]
 
 
 class Preprocess(_RefuseDataInConstructor, Reprable):
@@ -570,12 +570,15 @@ class PreprocessorList(Preprocess):
         return data
 
 
-class SmartNormalize(Preprocess):
+class AdaptiveNormalize(Preprocess):
     """
     Construct a preprocessors that normalizes or merely scales the data.
     If the input is sparse, data is only scaled, to avoid turning it to
     dense. Parameters are diveded to those passed to Normalize or Scale
-    class. For more details, check those classes.
+    class. Scaling takes only scale parameter.
+     If the user wants to have more options with scaling,
+    they should use the preprocessing widget.
+    For more details, check Scale and Normalize widget.
 
     Parameters
     ----------
@@ -589,13 +592,13 @@ class SmartNormalize(Preprocess):
     transform_class : bool (default=False)
         passed to Normalize
 
-    center :
-        passed to Normalize as boolean and to Scale as recieved in constructor
+    center : bool(default=True)
+        passed to Normalize
 
     normalize_datetime : bool (default=False)
         passed to Normalize
 
-    scale : ScaleTypes (default: Scale.NoCentering)
+    scale : ScaleTypes (default: Scale.Span)
         passed to Scale
     """
 
@@ -604,12 +607,12 @@ class SmartNormalize(Preprocess):
                  norm_type=Normalize.NormalizeBySD,
                  transform_class=False,
                  normalize_datetime=False,
-                 center=Scale.Mean,
-                 scale=Scale.Std):
+                 center=True,
+                 scale=Scale.Span):
         self.normalize_pps = Normalize(zero_based,
                                        norm_type,
                                        transform_class,
-                                       ~(center is not False),
+                                       center,
                                        normalize_datetime)
         self.scale_pps = Scale(center=Scale.NoCentering, scale=scale)
 

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -118,8 +118,7 @@ class Normalizer(Transformation):
     def transform(self, c):
         if sp.issparse(c):
             if self.offset != 0:
-                raise ValueError('Non-zero offset in normalization '
-                                 'of sparse data')
+                raise ValueError('Normalization does not work for sparse data.')
             return c * self.factor
         else:
             return (c - self.offset) * self.factor

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -14,7 +14,7 @@ from Orange.preprocess import EntropyMDL, DoNotImpute, Default, Average, \
     SelectRandomFeatures, EqualFreq, RemoveNaNColumns, DropInstances, \
     EqualWidth, SelectBestFeatures, RemoveNaNRows, Preprocess, Scale, \
     Randomize, Continuize, Discretize, Impute, SklImpute, Normalize, \
-    ProjectCUR, ProjectPCA, RemoveConstant, SmartNormalize
+    ProjectCUR, ProjectPCA, RemoveConstant, AdaptiveNormalize
 from Orange.util import OrangeDeprecationWarning
 
 
@@ -168,7 +168,7 @@ class TestEnumPickling(unittest.TestCase):
         self.assertIs(c1.scale, c.scale)
 
 
-class TestSmartNormalize(unittest.TestCase):
+class TestAdaptiveNormalize(unittest.TestCase):
     """
     Checks if output for sparse data is the same as for Scale
     preprocessor. For dense data the output should match that
@@ -180,12 +180,12 @@ class TestSmartNormalize(unittest.TestCase):
 
     def test_dense_pps(self):
         true_out = Normalize()(self.data)
-        out = SmartNormalize()(self.data)
+        out = AdaptiveNormalize()(self.data)
         np.testing.assert_array_equal(out, true_out)
 
     def test_sparse_pps(self):
         self.data.X = csr_matrix(self.data.X)
-        out = SmartNormalize()(self.data)
-        true_out = Scale(center=Scale.NoCentering)(self.data)
+        out = AdaptiveNormalize()(self.data)
+        true_out = Scale(center=Scale.NoCentering, scale=Scale.Span)(self.data)
         np.testing.assert_array_equal(out, true_out)
         self.data = self.data.X.toarray()

--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -2,16 +2,16 @@ from collections import OrderedDict
 
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QLabel, QGridLayout
+import scipy.sparse as sp
 
 from Orange.data import Table
 from Orange.modelling import SVMLearner, NuSVMLearner
 from Orange.widgets import gui
+from Orange.widgets.widget import OWWidget, Msg
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 from Orange.widgets.utils.signals import Output
 from Orange.widgets.utils.widgetpreview import WidgetPreview
-from Orange.classification import SklLearner
-from Orange.preprocess import Scale
 
 
 class OWSVM(OWBaseLearner):
@@ -28,14 +28,12 @@ class OWSVM(OWBaseLearner):
 
     LEARNER = SVMLearner
 
-    pps = SklLearner.preprocessors
-    scaling = [Scale(center=Scale.NoCentering)]
-
-    def __init__(self):
-        super().__init__(SklLearner.preprocessors)
-
     class Outputs(OWBaseLearner.Outputs):
         support_vectors = Output("Support vectors", Table, explicit=True)
+
+    class Warning(OWWidget.Warning):
+        sparse_data = Msg('Input data is sparse, default preprocessing is to scale it.')
+        outdated_learner = Msg("Press Apply to submit changes.")
 
     #: Different types of SVMs
     SVM, Nu_SVM = range(2)
@@ -64,21 +62,12 @@ class OWSVM(OWBaseLearner):
     limit_iter = Setting(True)
     #: maximum number of iterations
     max_iter = Setting(100)
-    #: scaling of data
-    scale_data = Setting(True)
 
     _default_gamma = "auto"
     kernels = (("Linear", "x⋅y"),
                ("Polynomial", "(g x⋅y + c)<sup>d</sup>"),
                ("RBF", "exp(-g|x-y|²)"),
                ("Sigmoid", "tanh(g x⋅y + c)"))
-
-    def set_preprocessor(self, preprocessor):
-        if preprocessor is None:
-            self.preprocessors = self.pps
-        else:
-            self.preprocessors = preprocessor
-        self.apply()
 
     def add_main_layout(self):
         self._add_type_box()
@@ -193,10 +182,6 @@ class OWSVM(OWBaseLearner):
             alignment=Qt.AlignRight, controlWidth=100,
             callback=self.settings_changed,
             checkCallback=self.settings_changed)
-        self.scaling_box = gui.checkBox(
-            self.optimization_box, self,
-            'scale_data', label='Scale data',
-            callback=self.settings_changed)
 
     def _show_right_kernel(self):
         enabled = [[False, False, False],  # linear
@@ -221,6 +206,12 @@ class OWSVM(OWBaseLearner):
         self._show_right_kernel()
         self.settings_changed()
 
+    def set_data(self, data):
+        self.Warning.sparse_data.clear()
+        super().set_data(data)
+        if self.data and sp.issparse(self.data.X):
+            self.Warning.sparse_data()
+
     def create_learner(self):
         kernel = ["linear", "poly", "rbf", "sigmoid"][self.kernel_type]
         common_args = {
@@ -231,7 +222,7 @@ class OWSVM(OWBaseLearner):
             'probability': True,
             'tol': self.tol,
             'max_iter': self.max_iter if self.limit_iter else -1,
-            'preprocessors': list(self.preprocessors) + self.scaling if self.scale_data else self.preprocessors
+            'preprocessors': self.preprocessors
         }
         if self.svm_type == self.SVM:
             return SVMLearner(C=self.C, epsilon=self.epsilon, **common_args)

--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -7,7 +7,7 @@ import scipy.sparse as sp
 from Orange.data import Table
 from Orange.modelling import SVMLearner, NuSVMLearner
 from Orange.widgets import gui
-from Orange.widgets.widget import OWWidget, Msg
+from Orange.widgets.widget import Msg
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 from Orange.widgets.utils.signals import Output
@@ -31,9 +31,8 @@ class OWSVM(OWBaseLearner):
     class Outputs(OWBaseLearner.Outputs):
         support_vectors = Output("Support vectors", Table, explicit=True)
 
-    class Warning(OWWidget.Warning):
+    class Warning(OWBaseLearner.Warning):
         sparse_data = Msg('Input data is sparse, default preprocessing is to scale it.')
-        outdated_learner = Msg("Press Apply to submit changes.")
 
     #: Different types of SVMs
     SVM, Nu_SVM = range(2)

--- a/Orange/widgets/model/tests/test_owsvm.py
+++ b/Orange/widgets/model/tests/test_owsvm.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+from scipy.sparse import csr_matrix
+
 from Orange.widgets.model.owsvm import OWSVM
 from Orange.widgets.tests.base import (
     WidgetTest,
@@ -7,6 +9,7 @@ from Orange.widgets.tests.base import (
     ParameterMapping,
     WidgetLearnerTestMixin
 )
+from Orange.data import Table
 
 
 class TestOWSVMClassification(WidgetTest, WidgetLearnerTestMixin):
@@ -87,3 +90,15 @@ class TestOWSVMClassification(WidgetTest, WidgetLearnerTestMixin):
             self.widget.kernel_box.buttons[i].click()
             self.assertEqual([self.widget._kernel_params[j].box.isHidden()
                               for j in range(3)], hidden)
+
+    def test_sparse_warning(self):
+        """Check if the user is warned about sparse input"""
+        data = Table("iris")
+        data.X = csr_matrix(data.X)
+        self.send_signal("Data", data)
+        self.assertTrue(self.widget.Warning.sparse_data.is_shown())
+
+    def test_dense_input(self):
+        data = Table("iris")
+        self.send_signal("Data", data)
+        self.assertFalse(self.widget.Warning.sparse_data.is_shown())

--- a/Orange/widgets/model/tests/test_owsvm.py
+++ b/Orange/widgets/model/tests/test_owsvm.py
@@ -94,11 +94,8 @@ class TestOWSVMClassification(WidgetTest, WidgetLearnerTestMixin):
     def test_sparse_warning(self):
         """Check if the user is warned about sparse input"""
         data = Table("iris")
+        self.send_signal("Data", data)
+        self.assertFalse(self.widget.Warning.sparse_data.is_shown())
         data.X = csr_matrix(data.X)
         self.send_signal("Data", data)
         self.assertTrue(self.widget.Warning.sparse_data.is_shown())
-
-    def test_dense_input(self):
-        data = Table("iris")
-        self.send_signal("Data", data)
-        self.assertFalse(self.widget.Warning.sparse_data.is_shown())

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -90,7 +90,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
 
     OUTPUT_MODEL_NAME = Outputs.model.name  # Attr for backcompat w/ self.send() code
 
-    def __init__(self):
+    def __init__(self, preprocessors=None):
         super().__init__()
         self.data = None
         self.valid_data = False
@@ -98,7 +98,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         if self.learner_name is None:
             self.learner_name = self.name
         self.model = None
-        self.preprocessors = None
+        self.preprocessors = preprocessors
         self.outdated_settings = False
 
         self.setup_layout()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes  #3202

##### Description of changes
SVM was failing because Corpus widget outputs sparse matrix which must be then turned to dense, if we want to mean shift it. We would like to avoid that, so the current proposal is to just scale the data. The user can opt out trough a check box. Currently the check box is in the optimization parameters box, perhaps something else is needed.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
