### PR TITLE
Update check: keep showing at startup until explicitly rejected

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -290,7 +290,7 @@ def check_for_updates():
                                           rejectLabel="Skip this Version")
 
             def handle_click(b):
-                if question.buttonRole(b) != question.DismissRole:
+                if question.buttonRole(b) == question.RejectRole:
                     settings.setValue('startup/latest-skipped-version', latest)
                 if question.buttonRole(b) == question.AcceptRole:
                     QDesktopServices.openUrl(QUrl("https://orange.biolab.si/download/"))


### PR DESCRIPTION
##### Issue
The user could perhaps download a new version and then forgot to install it.


##### Description of changes
Notify users about new versions unless they explicitly reject a specific update.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
