### PR TITLE
[ENH] Merge data allows matching by multiple pairs of columns

### DIFF
--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -584,13 +584,20 @@ class OWMergeData(widget.OWWidget):
 
     @staticmethod
     def migrate_settings(settings, version=None):
+        def mig_value(x):
+            if x == "Position (index)":
+                return INDEX
+            if x == "Source position (index)":
+                return INSTANCEID
+            return x
+
         if not version:
             operations = ("augment", "merge", "combine")
-            oper = [settings["merging"]]
+            oper = operations[settings["merging"]]
             settings["attr_pairs"] = (
                 True, True,
-                [(settings[f"attr_{oper}_data"],
-                  settings[f"attr_{oper}_extra"])])
+                [(mig_value(settings[f"attr_{oper}_data"]),
+                  mig_value(settings[f"attr_{oper}_extra"]))])
             for oper in operations:
                 del settings[f"attr_{oper}_data"]
                 del settings[f"attr_{oper}_extra"]

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -1,12 +1,14 @@
-from enum import IntEnum
-from itertools import chain, product, tee
+from collections import namedtuple
+from itertools import chain, product
 
-from AnyQt.QtWidgets import QApplication, QStyle, QSizePolicy
+from AnyQt.QtCore import pyqtSignal as Signal
+from AnyQt.QtWidgets import QApplication, QStyle, QWidget, \
+    QLabel, QComboBox, QPushButton, QVBoxLayout, QHBoxLayout
 
 import numpy as np
 
 import Orange
-from Orange.data import StringVariable, ContinuousVariable
+from Orange.data import StringVariable, ContinuousVariable, Variable
 from Orange.data.util import hstack
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils import itemmodels
@@ -15,11 +17,112 @@ from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input, Output
 
 
-class MergeType(IntEnum):
-    LEFT_JOIN, INNER_JOIN, OUTER_JOIN = 0, 1, 2
-
 INSTANCEID = "Source position (index)"
 INDEX = "Position (index)"
+
+
+class ConditionBox(QWidget):
+    vars_changed = Signal(list)
+
+    RowItems = namedtuple(
+        "RowItems",
+        ("pre_label", "left_combo", "in_label", "right_combo",
+         "remove_button", "add_button"))
+
+    def __init__(self, parent, model_left, model_right, pre_label, in_label):
+        super().__init__(parent)
+        self.model_left = model_left
+        self.model_right = model_right
+        self.pre_label, self.in_label = pre_label, in_label
+        self.rows = []
+        self.setLayout(QVBoxLayout())
+        self.layout().setSpacing(0)
+        self.setMouseTracking(True)
+
+    def add_row(self, value_left=None, value_right=None):
+        def get_combo(model, value):
+            combo = QComboBox(self)
+            combo.setModel(model)
+            if value is not None:
+                combo.setCurrentIndex(model.indexOf(value))
+            return combo
+
+        def get_button(label, callback):
+            button = QPushButton(label, self)
+            button.setFlat(True)
+            button.setFixedWidth(12)
+            button.clicked.connect(callback)
+            return button
+
+        row = self.layout().count()
+        row_items = self.RowItems(
+            QLabel("and" if row else self.pre_label),
+            get_combo(self.model_left, value_left),
+            QLabel(self.in_label),
+            get_combo(self.model_right, value_right),
+            get_button("×", self.on_remove_row),
+            get_button("+", self.on_add_row)
+        )
+        layout = QHBoxLayout()
+        layout.setSpacing(10)
+        self.layout().addLayout(layout)
+        layout.addStretch(10)
+        for item in row_items:
+            layout.addWidget(item)
+        self.rows.append(row_items)
+        self._reset_buttons()
+
+    def remove_row(self, row):
+        self.layout().takeAt(self.rows.index(row))
+        self.rows.remove(row)
+        for item in row:
+            item.deleteLater()
+        self._reset_buttons()
+
+    def on_add_row(self, _):
+        self.add_row()
+        self.emit_list()
+
+    def on_remove_row(self):
+        if len(self.rows) == 1:
+            return
+        button = self.sender()
+        for row in self.rows:
+            if button is row.remove_button:
+                self.remove_row(row)
+                break
+        self.emit_list()
+
+    def _reset_buttons(self):
+        self.rows[0].pre_label.setText(self.pre_label)
+        self.rows[0].remove_button.setText("× "[len(self.rows) == 1])
+        self.rows[-1].add_button.setText("+")
+        if len(self.rows) > 1:
+            self.rows[-2].add_button.setText(" ")
+
+    def current_state(self):
+        def get_var(model, combo):
+            index = combo.currentIndex()
+            if 0 <= index < len(model):
+                return model[index]
+            else:
+                return None
+
+        return [(get_var(self.model_left, row.left_combo),
+                 get_var(self.model_right, row.right_combo))
+                for row in self.rows]
+
+    def set_state(self, values):
+        while len(self.rows) > len(values):
+            self.remove_row()
+        while len(self.rows) < len(values):
+            self.add_row()
+        for (val_left, val_right), row in zip(values, self.rows):
+            row.left_combo.setCurrentIndex(self.model_left.indexOf(val_left))
+            row.right_combo.setCurrentIndex(self.model_right.indexOf(val_right))
+
+    def emit_list(self):
+        self.vars_changed.emit(self.current_state())
 
 
 class OWMergeData(widget.OWWidget):
@@ -38,13 +141,11 @@ class OWMergeData(widget.OWWidget):
                       Orange.data.Table,
                       replaces=["Merged Data A+B", "Merged Data B+A", "Merged Data"])
 
-    attr_augment_data = settings.Setting('', schema_only=True)
-    attr_augment_extra = settings.Setting('', schema_only=True)
-    attr_merge_data = settings.Setting('', schema_only=True)
-    attr_merge_extra = settings.Setting('', schema_only=True)
-    attr_combine_data = settings.Setting('', schema_only=True)
-    attr_combine_extra = settings.Setting('', schema_only=True)
-    merging = settings.Setting(0)
+    LeftJoin, InnerJoin, OuterJoin = range(3)
+
+    # TODO: Context migration
+    attr_pairs = settings.Setting('', schema_only=True)
+    merging = settings.Setting(LeftJoin)
     auto_apply = settings.Setting(True)
 
     want_main_area = False
@@ -63,7 +164,6 @@ class OWMergeData(widget.OWWidget):
         super().__init__()
 
         self.data = None
-        self.extra_data = None
         self.extra_data = None
 
         self.model = itemmodels.VariableListModel()
@@ -85,42 +185,29 @@ class OWMergeData(widget.OWWidget):
         radio_width = \
             QApplication.style().pixelMetric(QStyle.PM_ExclusiveIndicatorWidth)
 
-        def add_option(label, pre_label, between_label,
-                       merge_type, model, extra_model):
+        def add_option(label, pre_label, in_label, model, extra_model):
             gui.appendRadioButton(grp, label)
             vbox = gui.vBox(grp)
-            box = gui.hBox(vbox)
-            box.layout().addSpacing(radio_width)
+            box = ConditionBox(vbox, model, extra_model, pre_label, in_label)
+            box.add_row()
+            vbox.layout().addWidget(box)
             self.attr_boxes.append(box)
-            gui.widgetLabel(box, pre_label)
-            model[:] = [getattr(self, 'attr_{}_data'.format(merge_type))]
-            extra_model[:] = [getattr(self, 'attr_{}_extra'.format(merge_type))]
-            cb = gui.comboBox(box, self, 'attr_{}_data'.format(merge_type),
-                              contentsLength=12, callback=self.commit,
-                              model=model)
-            cb.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
-            cb.setFixedWidth(190)
-            gui.widgetLabel(box, between_label)
-            cb = gui.comboBox(box, self, 'attr_{}_extra'.format(merge_type),
-                              contentsLength=12, callback=self.commit,
-                              model=extra_model)
-            cb.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
-            cb.setFixedWidth(190)
-            vbox.layout().addSpacing(6)
+            box.vars_changed.connect(self._invalidate)
 
-        add_option("Append columns from Extra Data",
-                   "by matching", "with", "augment",
+        add_option("Append columns from Extra Data", "by matching", "with",
                    self.model, self.extra_model_unique)
-        add_option("Find matching rows", "where",
-                   "equals", "merge",
+        add_option("Find matching rows", "where", "equals",
                    self.model_unique_with_id, self.extra_model_unique_with_id)
-        add_option("Concatenate tables, merge rows",
-                   "where", "equals", "combine",
+        add_option("Concatenate tables, merge rows", "where", "equals",
                    self.model_unique_with_id, self.extra_model_unique_with_id)
         self.set_merging()
-
         gui.auto_commit(self.controlArea, self, "auto_apply", "&Apply",
                         box=False)
+
+        self.settingsAboutToBePacked.connect(self.store_combo_state)
+
+    def store_combo_state(self):
+        self.attr_pairs = self.boxes[self.merging].current_state()
 
     def set_merging(self):
         # pylint: disable=invalid-sequence-index
@@ -174,11 +261,26 @@ class OWMergeData(widget.OWWidget):
             elif not needs_id and has_id:
                 model.remove(INSTANCEID)
 
-    def _init_combo_current_items(self, variables, models):
-        for var, model in zip(variables, models):
-            value = getattr(self, var)
-            if model.rowCount():
-                setattr(self, var, value if value in model else INDEX)
+    def _restore_combo_current_items(self, side, prev_settings):
+        for box, box_vars in zip(self.attr_boxes, prev_settings):
+            for row, vars in zip(box.rows, box_vars):
+                self._try_set_combo(
+                    [row.left_combo, row.right_combo][side], vars[side])
+
+    @staticmethod
+    def _try_set_combo(combo, var):
+        if var in combo.model():
+            combo.setCurrentIndex(combo.model().indexOf(var))
+        else:
+            combo.setCurrentIndex(0)
+
+    def _clean_repeated_combos(self):
+        # This remove rows with combos with default values after domain change
+        for box in self.attr_boxes:
+            state = box.current_state()
+            for i in range(len(box.rows) - 1, 0, -1):
+                if state[i] in state[:i]:
+                    box.remove_row(box.rows[i])
 
     def _find_best_match(self):
         def get_unique_str_metas_names(model_):
@@ -195,49 +297,46 @@ class OWMergeData(widget.OWWidget):
                     n_max_intersect, attr, extra_attr = n_inter, m_a, m_b
             return attr, extra_attr
 
-        def set_attrs(attr_name, attr_extra_name, attr, extra_attr):
-            if getattr(self, attr_name) == INDEX and \
-                    getattr(self, attr_extra_name) == INDEX:
-                setattr(self, attr_name, attr)
-                setattr(self, attr_extra_name, extra_attr)
-
         if self.data and self.extra_data:
-            attrs = best_match(self.model, self.extra_model_unique)
-            set_attrs("attr_augment_data", "attr_augment_extra", *attrs)
-            attrs = best_match(self.model_unique_with_id,
-                               self.extra_model_unique_with_id)
-            set_attrs("attr_merge_data", "attr_merge_extra", *attrs)
-            set_attrs("attr_combine_data", "attr_combine_extra", *attrs)
+            for box in self.attr_boxes:
+                state = box.current_state()
+                if len(state) == 1 \
+                        and not any(isinstance(v, Variable) for v in state[0]):
+                    l_var, r_var = best_match(box.model_left, box.model_right)
+                    self._try_set_combo(box.rows[0].left_combo, l_var)
+                    self._try_set_combo(box.rows[0].right_combo, r_var)
 
     @Inputs.data
     @check_sql_input
     def setData(self, data):
         self.data = data
+        prev_settings = [box.current_state() for box in self.attr_boxes]
         self._set_model(data, self.model)
         self._set_unique_model(data, self.model_unique_with_id)
         self._add_instanceid_to_models()
-        self._init_combo_current_items(
-            ("attr_augment_data", "attr_merge_data", "attr_combine_data"),
-            (self.model, self.model_unique_with_id, self.model_unique_with_id))
+        self._restore_combo_current_items(0, prev_settings)
         self.infoBoxData.setText(self.dataInfoText(data))
-        self._find_best_match()
 
     @Inputs.extra_data
     @check_sql_input
     def setExtraData(self, data):
         self.extra_data = data
+        prev_settings = [box.current_state() for box in self.attr_boxes]
         self._set_unique_model(data, self.extra_model_unique)
         self._set_unique_model(data, self.extra_model_unique_with_id)
         self._add_instanceid_to_models()
-        self._init_combo_current_items(
-            ("attr_augment_extra", "attr_merge_extra", "attr_combine_extra"),
-            (self.extra_model_unique, self.extra_model_unique_with_id,
-             self.extra_model_unique_with_id))
+        self._restore_combo_current_items(1, prev_settings)
         self.infoBoxExtraData.setText(self.dataInfoText(data))
-        self._find_best_match()
 
     def handleNewSignals(self):
-        self.unconditional_commit()
+        if self.attr_pairs:
+            self.boxes[self.merging].set_current_state(self.attr_pairs)
+            # This is schema-only setting, so it should be single-shot
+            # More complicated alternative: make it a context setting
+            self.attr_pairs = []
+        self._find_best_match()
+        self._clean_repeated_combos()
+        self._invalidate()
 
     @staticmethod
     def dataInfoText(data):
@@ -278,26 +377,28 @@ class OWMergeData(widget.OWWidget):
 
     def merge(self):
         # pylint: disable=invalid-sequence-index
-        operation = ["augment", "merge", "combine"][self.merging]
-        var_data = getattr(self, "attr_{}_data".format(operation))
-        var_extra_data = getattr(self, "attr_{}_extra".format(operation))
-        merge_method = getattr(self, "_{}_indices".format(operation))
+        pairs = self.attr_boxes[self.merging].current_state()
+        vars, extra_vars = zip(*pairs)
+        as_string = [not all(isinstance(v, ContinuousVariable) for v in pair)
+                     for pair in pairs]
+        merge_method = [
+            self._augment_indices, self._merge_indices, self._combine_indices][
+            self.merging]
 
-        as_string = not (isinstance(var_data, ContinuousVariable) and
-                         isinstance(var_extra_data, ContinuousVariable))
-        extra_map = self._get_keymap(self.extra_data, var_extra_data, as_string)
-        match_indices = merge_method(var_data, extra_map, as_string)
-        reduced_extra_data = self._compute_reduced_extra_data(var_extra_data)
+        extra_map = self._get_keymap(self.extra_data, extra_vars, as_string)
+        match_indices = merge_method(vars, extra_map, as_string)
+        reduced_extra_data = self._compute_reduced_extra_data(extra_vars)
         return self._join_table_by_indices(reduced_extra_data, match_indices)
 
-    def _compute_reduced_extra_data(self, var_extra_data):
+    def _compute_reduced_extra_data(self, extra_vars):
         """Prepare a table with extra columns that will appear in the merged
         table"""
         domain = self.data.domain
         extra_domain = self.extra_data.domain
         all_vars = set(chain(domain.variables, domain.metas))
-        if self.merging != MergeType.OUTER_JOIN:
-            all_vars.add(var_extra_data)
+
+        if self.merging != self.OuterJoin:
+            all_vars |= set(extra_vars)
         extra_vars = chain(extra_domain.variables, extra_domain.metas)
         return self.extra_data[:, [var for var in extra_vars
                                    if var not in all_vars]]
@@ -319,50 +420,52 @@ class OWMergeData(widget.OWWidget):
             return (str(val) if val else np.nan for val in col)
 
     @classmethod
-    def _get_keymap(cls, data, var, as_string):
+    def _get_keymap(cls, data, vars, as_strings):
         """Return a generator of pairs (key, index) by enumerating and
         switching the values for rows (method `_values`).
         """
-        return ((val, i)
-                for i, val in enumerate(cls._values(data, var, as_string)))
+        vals_combinations = zip(*(cls._values(data, var, as_string)
+                                  for var, as_string in zip(vars, as_strings)))
+        return ((val, i) for i, val in enumerate(vals_combinations))
 
-    def _augment_indices(self, var_data, extra_map, as_string):
+    @classmethod
+    def _get_values(cls, data, vars, as_strings):
+        return zip(*(cls._values(data, var, as_string)
+                     for var, as_string in zip(vars, as_strings)))
+
+    def _augment_indices(self, vars, extra_map, as_strings):
         """Compute a two-row array of indices:
         - the first row contains indices for the primary table,
         - the second row contains the matching rows in the extra table or -1"""
         data = self.data
-        extra_map = dict(extra_map)
         # Don't match nans. This is needed since numpy supports using nan as
         # keys. If numpy fixes this, the below conditions will always be false,
         # so we're OK again.
-        if np.nan in extra_map:
-            del extra_map[np.nan]
+        extra_map = {val: i for val, i in extra_map if all(x == x for x in val)}
         keys = (extra_map.get(val, -1)
-                for val in self._values(data, var_data, as_string))
+                for val in self._get_values(data, vars, as_strings))
         return np.vstack((np.arange(len(data), dtype=np.int64),
                           np.fromiter(keys, dtype=np.int64, count=len(data))))
 
-    def _merge_indices(self, var_data, extra_map, as_string):
+    def _merge_indices(self, vars, extra_map, as_strings):
         """Use _augment_indices to compute the array of indices,
         then remove those with no match in the second table"""
-        augmented = self._augment_indices(var_data, extra_map, as_string)
+        augmented = self._augment_indices(vars, extra_map, as_strings)
         return augmented[:, augmented[1] != -1]
 
-    def _combine_indices(self, var_data, extra_map, as_string):
+    def _combine_indices(self, vars, extra_map, as_strings):
         """Use _augment_indices to compute the array of indices,
         then add rows in the second table without a match in the first"""
-        to_add, extra_map = tee(extra_map)
+        extra_map = list(extra_map)  # we need it twice; tee would make a copy
         # dict instead of set because we have pairs; we'll need only keys
-        key_map = dict(self._get_keymap(self.data, var_data, as_string))
-        # _augment indices will skip rows where the key in the left table
-        # is nan. See comment in `_augment_indices` wrt numpy and nan in dicts
-        if np.nan in key_map:
-            del key_map[np.nan]
-        keys = np.fromiter((j for key, j in to_add if key not in key_map),
+        key_map = {val
+                   for val, _ in self._get_keymap(self.data, vars, as_strings)
+                   if all(x == x for x in val)}
+        keys = np.fromiter((j for key, j in extra_map if key not in key_map),
                            dtype=np.int64)
         right_indices = np.vstack((np.full(len(keys), -1, np.int64), keys))
         return np.hstack(
-            (self._augment_indices(var_data, extra_map, as_string),
+            (self._augment_indices(vars, extra_map, as_strings),
              right_indices))
 
     def _join_table_by_indices(self, reduced_extra, indices):

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -254,10 +254,14 @@ class OWMergeData(widget.OWWidget):
             str_metas = get_unique_str_metas_names(model)
             extra_str_metas = get_unique_str_metas_names(extra_model)
             for m_a, m_b in product(str_metas, extra_str_metas):
-                n_inter = len(np.intersect1d(self.data[:, m_a].metas,
-                                             self.extra_data[:, m_b].metas))
-                if n_inter > n_max_intersect:
-                    n_max_intersect, attr, extra_attr = n_inter, m_a, m_b
+                col = self.data[:, m_a].metas
+                extra_col = self.extra_data[:, m_b].metas
+                if col.size and extra_col.size \
+                        and isinstance(col[0][0], str) \
+                        and isinstance(extra_col[0][0], str):
+                    n_inter = len(np.intersect1d(col, extra_col))
+                    if n_inter > n_max_intersect:
+                        n_max_intersect, attr, extra_attr = n_inter, m_a, m_b
             return attr, extra_attr
 
         if self.data and self.extra_data:

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -45,11 +45,26 @@ class ConditionBox(QWidget):
             combo = self.sender()
             index = combo.currentIndex()
             model = combo.model()
-            if 0 <= index < len(combo.model()) \
-                    and isinstance(model[index], str):
-                other = ({row_items.left_combo, row_items.right_combo}
-                         - {combo}).pop()
-                other.setCurrentText(model[index])
+
+            other = ({row_items.left_combo, row_items.right_combo}
+                     - {combo}).pop()
+            other_index = other.currentIndex()
+            other_model = other.model()
+
+            if 0 <= index < len(combo.model()):
+                var = model[index]
+                if isinstance(var, str):
+                    other.setCurrentText(model[index])
+                elif isinstance(other_model[other_index], str):
+                    for other_var in other_model:
+                        if isinstance(other_var, Variable) \
+                                and var.name == other_var.name \
+                                and (type(other_var) is type(var)
+                                     or (not var.is_continuous
+                                         and not other_var.is_continuous)):
+                            other.setCurrentText(var.name)
+                            break
+
             self.emit_list()
 
         def get_combo(model):

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 import numpy as np
 import scipy.sparse as sp
 
-from Orange.data import Table, Domain, DiscreteVariable, StringVariable
+from Orange.data import Table, Domain, DiscreteVariable, StringVariable, \
+    ContinuousVariable
 from Orange.widgets.data.owmergedata import OWMergeData, INSTANCEID, INDEX
 from Orange.widgets.tests.base import WidgetTest
 from Orange.tests import test_filename
@@ -50,84 +51,30 @@ class TestOWMergeData(WidgetTest):
         self.send_signal(self.widget.Inputs.data, None)
         self.send_signal(self.widget.Inputs.extra_data, None)
 
-    def test_combobox_items_left(self):
-        """Check if combo box content is properly set for merging option
-        'Append columns from Extra Data'"""
-        domainA, domainB = self.dataA.domain, self.dataB.domain
-        data_combo = self.widget.controls.attr_augment_data
-        extra_combo = self.widget.controls.attr_augment_extra
-
-        self.send_signal(self.widget.Inputs.data, self.dataA)
-        self.send_signal(self.widget.Inputs.extra_data, self.dataA)
-        data_items = list(chain([INDEX], domainA.variables, domainA.metas))
-        extra_items = list(chain(
-            [INDEX], domainA.variables[::2], domainA.metas[1:]))
-        self.assertListEqual(data_combo.model()[:], data_items)
-        self.assertListEqual(extra_combo.model()[:], extra_items)
-
-        self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        extra_items = list(chain([INDEX], domainB.variables, domainB.metas))
-        self.assertListEqual(data_combo.model()[:], data_items)
-        self.assertListEqual(extra_combo.model()[:], extra_items)
-
-        self.send_signal(self.widget.Inputs.data, self.dataB)
-        data_items = list(chain([INDEX], domainB.variables, domainB.metas))
-        self.assertListEqual(data_combo.model()[:], data_items)
-        self.assertListEqual(extra_combo.model()[:], extra_items)
-
     def test_combobox_items_inner(self):
-        """Check if combo box content is properly set for merging option
-        'Find matching rows'"""
+        """Check if combo box content is properly set"""
         domainA, domainB = self.dataA.domain, self.dataB.domain
-        data_combo = self.widget.controls.attr_merge_data
-        extra_combo = self.widget.controls.attr_merge_extra
+        row = self.widget.attr_boxes.rows[0]
+        data_combo, extra_combo = row.left_combo, row.right_combo
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataA)
-        self.widget.controls.merging.buttons[1].click()
-        data_items = extra_items = list(chain(
-            [INSTANCEID, INDEX], domainA.variables[::2], domainA.metas[1:]))
+        data_items = extra_items = list(
+            chain([INDEX, INSTANCEID], domainA.variables, domainA.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        data_items = list(chain(
-            [INDEX], domainA.variables[::2], domainA.metas[1:]))
-        extra_items = list(chain([INDEX], domainB.variables, domainB.metas))
+        data_items = list(
+            chain([INDEX, INSTANCEID], domainA.variables, domainA.metas))
+        extra_items = list(
+            chain([INDEX, INSTANCEID], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
         self.send_signal(self.widget.Inputs.data, self.dataB)
-        data_items = extra_items = list(chain(
-            [INSTANCEID, INDEX], domainB.variables, domainB.metas))
-        self.assertListEqual(data_combo.model()[:], data_items)
-        self.assertListEqual(extra_combo.model()[:], extra_items)
-
-    def test_combobox_items_outer(self):
-        """Check if combo box content is properly set for merging option
-        'Concatenate tables, merge rows'"""
-        domainA, domainB = self.dataA.domain, self.dataB.domain
-        data_combo = self.widget.controls.attr_combine_data
-        extra_combo = self.widget.controls.attr_combine_extra
-
-        self.send_signal(self.widget.Inputs.data, self.dataA)
-        self.send_signal(self.widget.Inputs.extra_data, self.dataA)
-        self.widget.controls.merging.buttons[1].click()
-        data_items = extra_items = list(chain(
-            [INSTANCEID, INDEX], domainA.variables[::2], domainA.metas[1:]))
-        self.assertListEqual(data_combo.model()[:], data_items)
-        self.assertListEqual(extra_combo.model()[:], extra_items)
-
-        self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        data_items = list(chain(
-            [INDEX], domainA.variables[::2], domainA.metas[1:]))
-        extra_items = list(chain([INDEX], domainB.variables, domainB.metas))
-        self.assertListEqual(data_combo.model()[:], data_items)
-        self.assertListEqual(extra_combo.model()[:], extra_items)
-
-        self.send_signal(self.widget.Inputs.data, self.dataB)
-        data_items = extra_items = list(chain(
-            [INSTANCEID, INDEX], domainB.variables, domainB.metas))
+        data_items = extra_items = list(
+            chain([INDEX, INSTANCEID], domainB.variables, domainB.metas))
         self.assertListEqual(data_combo.model()[:], data_items)
         self.assertListEqual(extra_combo.model()[:], extra_items)
 
@@ -139,9 +86,8 @@ class TestOWMergeData(WidgetTest):
                        np.array([[1.0, "m2"], [np.nan, "m3"]]).astype(object))
         self.send_signal(self.widget.Inputs.data, self.dataA[:3, [0, "cls", -1]])
         self.send_signal(self.widget.Inputs.extra_data, self.dataA[1:, [1, "cls", -2]])
-        self.widget.attr_merge_data = "Source position (index)"
-        self.widget.attr_merge_extra = "Source position (index)"
-        self.widget.controls.merging.buttons[1].click()
+        self.widget.attr_boxes.set_state([(INSTANCEID, INSTANCEID)])
+        self.widget.controls.merging.buttons[self.widget.InnerJoin].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
     def test_output_merge_by_ids_outer(self):
@@ -155,9 +101,8 @@ class TestOWMergeData(WidgetTest):
                                  [np.nan, "m4"]]).astype(object))
         self.send_signal(self.widget.Inputs.data, self.dataA[:3, [0, "cls", -1]])
         self.send_signal(self.widget.Inputs.extra_data, self.dataA[1:, [1, "cls", -2]])
-        self.widget.attr_combine_data = "Source position (index)"
-        self.widget.attr_combine_extra = "Source position (index)"
-        self.widget.controls.merging.buttons[2].click()
+        self.widget.attr_boxes.set_state([(INSTANCEID, INSTANCEID)])
+        self.widget.controls.merging.buttons[self.widget.OuterJoin].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
     def test_output_merge_by_index_left(self):
@@ -234,8 +179,7 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_augment_data = domainA[0]
-        self.widget.attr_augment_extra = domainB[0]
+        self.widget.attr_boxes.set_state([(domainA[0], domainB[0])])
         self.widget.commit()
         output = self.get_output(self.widget.Outputs.data)
         self.assertTablesEqual(output, result)
@@ -257,9 +201,8 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_merge_data = domainA[0]
-        self.widget.attr_merge_extra = domainB[0]
-        self.widget.controls.merging.buttons[1].click()
+        self.widget.attr_boxes.set_state([(domainA[0], domainB[0])])
+        self.widget.controls.merging.buttons[self.widget.InnerJoin].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
     def test_output_merge_by_attribute_outer(self):
@@ -279,9 +222,8 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_combine_data = domainA[0]
-        self.widget.attr_combine_extra = domainB[0]
-        self.widget.controls.merging.buttons[2].click()
+        self.widget.attr_boxes.set_state([(domainA[0], domainB[0])])
+        self.widget.controls.merging.buttons[self.widget.OuterJoin].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
     def test_output_merge_by_class_left(self):
@@ -300,8 +242,7 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_augment_data = domainA[2]
-        self.widget.attr_augment_extra = domainB[2]
+        self.widget.attr_boxes.set_state([(domainA[2], domainB[2])])
         self.widget.commit()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
@@ -319,8 +260,8 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_merge_data = domainA.class_vars[0]
-        self.widget.attr_merge_extra = domainB.class_vars[0]
+        self.widget.attr_boxes.set_state(
+            [(domainA.class_vars[0], domainB.class_vars[0])])
         self.widget.controls.merging.buttons[1].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
@@ -343,8 +284,8 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_combine_data = domainA.class_vars[0]
-        self.widget.attr_combine_extra = domainB.class_vars[0]
+        self.widget.attr_boxes.set_state(
+            [(domainA.class_vars[0], domainB.class_vars[0])])
         self.widget.controls.merging.buttons[2].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
@@ -365,8 +306,7 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_augment_data = domainA[-2]
-        self.widget.attr_augment_extra = domainB[-1]
+        self.widget.attr_boxes.set_state([(domainA[-2], domainB[-1])])
         self.widget.commit()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
@@ -384,9 +324,8 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_merge_data = domainA[-2]
-        self.widget.attr_merge_extra = domainB[-1]
-        self.widget.controls.merging.buttons[1].click()
+        self.widget.attr_boxes.set_state([(domainA[-2], domainB[-1])])
+        self.widget.controls.merging.buttons[self.widget.InnerJoin].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
     def test_output_merge_by_meta_outer(self):
@@ -410,8 +349,7 @@ class TestOWMergeData(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.widget.attr_combine_data = domainA[-2]
-        self.widget.attr_combine_extra = domainB[-1]
+        self.widget.attr_boxes.set_state([(domainA[-2], domainB[-1])])
         self.widget.controls.merging.buttons[2].click()
         self.assertTablesEqual(self.get_output(self.widget.Outputs.data), result)
 
@@ -424,18 +362,17 @@ class TestOWMergeData(WidgetTest):
 
     def test_best_match(self):
         """Check default merging attributes setup"""
+        widget = self.widget
         indices = list(range(101))
         indices.pop(26)
         zoo = Table("zoo")[indices]
         zoo_images = Table(test_filename("datasets/zoo-with-images.tab"))
-        self.send_signal(self.widget.Inputs.data, zoo)
-        self.send_signal(self.widget.Inputs.extra_data, zoo_images)
-        self.assertEqual(self.widget.attr_augment_data, zoo.domain[-1])
-        self.assertEqual(self.widget.attr_augment_extra, zoo_images.domain[-1])
-        self.assertEqual(self.widget.attr_merge_data, zoo.domain[-1])
-        self.assertEqual(self.widget.attr_merge_extra, zoo_images.domain[-1])
-        self.assertEqual(self.widget.attr_combine_data, zoo.domain[-1])
-        self.assertEqual(self.widget.attr_combine_extra, zoo_images.domain[-1])
+        self.send_signal(widget.Inputs.data, zoo)
+        self.send_signal(widget.Inputs.extra_data, zoo_images)
+        for i in range(3):
+            self.assertEqual(widget.attr_boxes.current_state(),
+                             [(zoo.domain[-1], zoo_images.domain[-1])],
+                             f"wrong attributes chosen for merge_type={i}")
 
     def test_sparse(self):
         """
@@ -461,36 +398,165 @@ class TestOWMergeData(WidgetTest):
         output_sparse.X = output_sparse.X.toarray()
         self.assertTablesEqual(output_dense, output_sparse)
 
-    def test_auto_apply(self):
-        """Check auto apply"""
-        self.send_signal(self.widget.Inputs.data,
-                         self.dataA[:3, [0, "cls", -1]])
-        self.send_signal(self.widget.Inputs.extra_data,
-                         self.dataA[1:, [1, "cls", -2]])
-        self.widget.attr_merge_data = "Source position (index)"
-        self.widget.attr_merge_extra = "Source position (index)"
-        with patch.object(self.widget.Outputs.data, 'send') as send:
-            self.widget.auto_apply = False
-            self.widget.controls.merging.buttons[1].click()
-            send.assert_not_called()
-            self.widget.controls.merging.buttons[0].click()
-            self.widget.auto_apply = True
-            self.widget.controls.merging.buttons[1].click()
-            send.assert_called()
-
     def test_commit_on_new_data(self):
         """Check that disabling auto apply doesn't block on new data"""
         self.widget.auto_apply = False
+        self.widget.merging = 2
         self.send_signal(self.widget.Inputs.data, self.dataA)
         self.send_signal(self.widget.Inputs.extra_data, self.dataB)
         self.assertIsNotNone(self.get_output(self.widget.Outputs.data))
 
-    def test_non_unique_warning(self):
-        self.widget.auto_apply = True
-        self.send_signal(self.widget.Inputs.data, self.dataA)
-        self.send_signal(self.widget.Inputs.extra_data, self.dataB)
-        self.assertFalse(self.widget.Warning.non_unique_variables.is_shown())
-        self.send_signal(self.widget.Inputs.data, Table("iris"))
-        self.assertTrue(self.widget.Warning.non_unique_variables.is_shown())
-        self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Warning.non_unique_variables.is_shown())
+    def test_multiple_attributes_left(self):
+        domainA, domainB = self.dataA.domain, self.dataB.domain
+
+        X = np.array([[0, 1], [1, 1], [3, np.nan], [np.nan, 0]])
+        Y = np.array([1, 2, 0, 0])
+        metas = np.array([[0, "a"], [1, "b"], [0, "c"], [0, "d"]])
+        dataA = Table(domainA, X, Y, metas)
+        dataA.name = "dataA"
+
+        X = np.array(
+            [[0, 0], [1, 0], [0, 1], [1, 1], [2, 0], [3, np.nan]])
+        Y = np.array([0, 0, 1, 1, 0, 1])
+        metas = np.array([[0], [1], [0], [1], [1], [1]])
+        dataB = Table(domainB, X, Y, metas)
+        dataB.name = "dataB"
+
+        self.send_signal(self.widget.Inputs.data, dataA)
+        self.send_signal(self.widget.Inputs.extra_data, dataB)
+        self.widget.attr_boxes.set_state(
+            [(domainA[0], domainB[0]), (domainA[1], domainB[1])])
+        self.widget.commit()
+        output = self.get_output(self.widget.Outputs.data)
+
+        self.assertEqual(output.name, dataA.name)
+        np.testing.assert_array_equal(output.ids, dataA.ids)
+        self.assertEqual(output.attributes, dataA.attributes)
+        np.testing.assert_equal(output.X, dataA.X)
+
+    def test_nonunique(self):
+        widget = self.widget
+        x = ContinuousVariable("x")
+        d = DiscreteVariable("d", values=list("abc"))
+        domain = Domain([x, d], [])
+        dataA = Table.from_numpy(
+            domain, np.array([[1.0, 0], [1, 1], [2, 1]]))
+        dataB = Table.from_numpy(
+            domain, np.array([[1.0, 0], [2, 1], [3, 1]]))
+        dataB.ids = dataA.ids
+        self.send_signal(widget.Inputs.data, dataA)
+        self.send_signal(widget.Inputs.extra_data, dataB)
+        widget.merging = widget.InnerJoin
+
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+
+        widget.attr_boxes.set_state([(INSTANCEID, INSTANCEID)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+        self.assertIsNotNone(self.get_output(widget.Outputs.data))
+
+        widget.attr_boxes.set_state([(INDEX, INDEX)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+        self.assertIsNotNone(self.get_output(widget.Outputs.data))
+
+        widget.attr_boxes.set_state([(x, x)])
+        widget.unconditional_commit()
+        self.assertTrue(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+        self.assertIsNone(self.get_output(widget.Outputs.data))
+
+        widget.merging = widget.LeftJoin
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+        self.assertIsNotNone(self.get_output(widget.Outputs.data))
+
+        widget.merging = widget.InnerJoin
+        widget.attr_boxes.set_state([(x, x), (d, d)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+        self.assertIsNotNone(self.get_output(widget.Outputs.data))
+
+        widget.attr_boxes.set_state([(d, d)])
+        widget.unconditional_commit()
+        self.assertTrue(widget.Error.nonunique_left.is_shown())
+        self.assertTrue(widget.Error.nonunique_right.is_shown())
+        self.assertIsNone(self.get_output(widget.Outputs.data))
+
+        widget.merging = widget.LeftJoin
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertTrue(widget.Error.nonunique_right.is_shown())
+        self.assertIsNone(self.get_output(widget.Outputs.data))
+
+        widget.merging = widget.InnerJoin
+        widget.unconditional_commit()
+        self.assertTrue(widget.Error.nonunique_left.is_shown())
+        self.assertTrue(widget.Error.nonunique_right.is_shown())
+        self.assertIsNone(self.get_output(widget.Outputs.data))
+
+        self.send_signal(widget.Inputs.data, None)
+        self.send_signal(widget.Inputs.extra_data, None)
+        self.assertFalse(widget.Error.nonunique_left.is_shown())
+        self.assertFalse(widget.Error.nonunique_right.is_shown())
+        self.assertIsNone(self.get_output(widget.Outputs.data))
+
+    def test_invalide_pairs(self):
+        widget = self.widget
+        x = ContinuousVariable("x")
+        d = DiscreteVariable("d", values=list("abc"))
+        domain = Domain([x, d], [])
+        dataA = Table.from_numpy(
+            domain, np.array([[1.0, 0], [1, 1], [2, 1]]))
+        dataB = Table.from_numpy(
+            domain, np.array([[1.0, 0], [2, 1], [3, 1]]))
+        dataB.ids = dataA.ids
+        self.send_signal(widget.Inputs.data, dataA)
+        self.send_signal(widget.Inputs.extra_data, dataB)
+
+        widget.attr_boxes.set_state([(x, x), (d, d)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.matching_id_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_index_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_numeric_with_nonnum.is_shown())
+
+        widget.attr_boxes.set_state([(x, x), (INDEX, d)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.matching_id_with_sth.is_shown())
+        self.assertTrue(widget.Error.matching_index_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_numeric_with_nonnum.is_shown())
+
+        widget.attr_boxes.set_state([(x, x), (d, INDEX)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.matching_id_with_sth.is_shown())
+        self.assertTrue(widget.Error.matching_index_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_numeric_with_nonnum.is_shown())
+
+        widget.attr_boxes.set_state([(x, x), (INSTANCEID, d)])
+        widget.unconditional_commit()
+        self.assertTrue(widget.Error.matching_id_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_index_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_numeric_with_nonnum.is_shown())
+
+        widget.attr_boxes.set_state([(x, x), (d, INSTANCEID)])
+        widget.unconditional_commit()
+        self.assertTrue(widget.Error.matching_id_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_index_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_numeric_with_nonnum.is_shown())
+
+        widget.attr_boxes.set_state([(x, x), (INDEX, INSTANCEID)])
+        widget.unconditional_commit()
+        self.assertTrue(widget.Error.matching_id_with_sth.is_shown()
+                        or widget.Error.matching_index_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_numeric_with_nonnum.is_shown())
+
+        widget.attr_boxes.set_state([(x, x), (x, d)])
+        widget.unconditional_commit()
+        self.assertFalse(widget.Error.matching_id_with_sth.is_shown())
+        self.assertFalse(widget.Error.matching_index_with_sth.is_shown())
+        self.assertTrue(widget.Error.matching_numeric_with_nonnum.is_shown())

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -1,7 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 from itertools import chain
-from unittest.mock import patch
 
 import numpy as np
 import scipy.sparse as sp


### PR DESCRIPTION
##### Issue

Fixes #2121 by allowing multiple pairs of columns to be matched.

As a consequence, we require that the combination of values is unique, so combos list all available attributes. These lists are unfortunately longer, yet the upside is that the widget does not show a warning every time when it gets data with non-unique attributes (which is ... always). One may argue that it would be nice to show to the user which columns are useful for merging, but the user probably has a very good idea of what (s)he wants to match.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
