### PR TITLE
Table: Enable warning about deprecation of table changes, add it to doc

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -12,6 +12,7 @@ import bottleneck as bn
 import numpy as np
 from scipy import sparse as sp
 
+from Orange.util import OrangeDeprecationWarning
 import Orange.data  # import for io.py
 from Orange.data import (
     _contingency, _valuecount,
@@ -47,7 +48,7 @@ _conversion_cache_lock = RLock()
 
 def pending_deprecation_resize(name):
     warnings.warn(f"Method Table.{name} will be removed in Orange 3.24",
-                  PendingDeprecationWarning)
+                  OrangeDeprecationWarning)
 
 
 class DomainTransformationError(Exception):
@@ -865,7 +866,11 @@ class Table(MutableSequence, Storage):
         return s
 
     def clear(self):
-        """Remove all rows from the table."""
+        """
+        Remove all rows from the table.
+
+        This method is deprecated and will be removed in Orange 3.24.
+        """
         pending_deprecation_resize("clear()")
         if not self._check_all_dense():
             raise ValueError("Tables with sparse data cannot be cleared")
@@ -874,6 +879,8 @@ class Table(MutableSequence, Storage):
     def append(self, instance):
         """
         Append a data instance to the table.
+
+        This method is deprecated and will be removed in Orange 3.24.
 
         :param instance: a data instance
         :type instance: Orange.data.Instance or a sequence of values
@@ -884,6 +891,8 @@ class Table(MutableSequence, Storage):
     def insert(self, row, instance):
         """
         Insert a data instance into the table.
+
+        This method is deprecated and will be removed in Orange 3.24.
 
         :param row: row index
         :type row: int
@@ -923,6 +932,8 @@ class Table(MutableSequence, Storage):
         latter case, each instances can be given as
         :obj:`~Orange.data.Instance` or a sequence of values (e.g. list,
         tuple, numpy.array).
+
+        This method is deprecated and will be removed in Orange 3.24.
 
         :param instances: additional instances
         :type instances: Orange.data.Table or a sequence of instances

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -680,20 +680,6 @@ class TableTestCase(unittest.TestCase):
         self.assertRaises(ValueError,
                           lambda: data.Table.concatenate((t1, t2), axis=5))
 
-        t3 = data.Table.concatenate((t1, t2))
-        self.assertEqual(t3.domain.attributes,
-                         t1.domain.attributes + t2.domain.attributes)
-        self.assertEqual(len(t3.domain.metas), 1)
-        self.assertEqual(t3.X.shape, (2, 2))
-        self.assertRaises(ValueError, lambda: data.Table.concatenate((t3, t1)))
-        self.assertRaises(ValueError, lambda: data.Table.concatenate((t3, t1), axis=0))
-
-        t4 = data.Table.concatenate((t3, t3), axis=0)
-        np.testing.assert_equal(t4.X, [[1, 3],
-                                       [2, 4],
-                                       [1, 3],
-                                       [2, 4]])
-
     def test_sparse_concatenate_rows(self):
         iris = Table("iris")
         iris.X = sp.csc_matrix(iris.X)

--- a/doc/data-mining-library/source/reference/data.table.rst
+++ b/doc/data-mining-library/source/reference/data.table.rst
@@ -96,6 +96,10 @@ Inspection
 Row manipulation
 ----------------
 
+.. note::
+   Methods that change the table length, that is, all methods in this section
+   except for `Table.shuffle` are deprecated and will be removed in Orange 3.24.
+
 .. automethod:: Table.append
 .. automethod:: Table.extend
 .. automethod:: Table.insert


### PR DESCRIPTION
##### Issue

Fixes #3908 by making the warning visible (`DeprecationWarning` and `PendingDeprecationWarning` are ignored by default) and by adding a note into documentation.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
