### PR TITLE
[FIX] Restore usage tracking

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -212,10 +212,8 @@ def send_usage_statistics():
 
         usage = UsageStatistics()
         data = usage.load()
-        data = [
-            dict({"Orange Version": d.get("Application Version", "")}, **d)
-            for d in data
-        ]
+        for d in data:
+            d["Orange Version"] = d.pop("Application Version", "")
         try:
             r = requests.post(url, files={'file': json.dumps(data)})
             if r.status_code != 200:
@@ -399,7 +397,6 @@ def main(argv=None):
     if settings.value("error-reporting/send-statistics", False, type=bool) \
             and is_release:
         UsageStatistics.set_enabled(True)
-        log.info("Enabling usage statistics tracking")
 
     stylesheet = options.stylesheet or defaultstylesheet
     stylesheet_string = None

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -17,6 +17,7 @@ import requests
 from AnyQt.QtGui import QPainter, QFont, QFontMetrics, QColor, QPixmap, QIcon
 from AnyQt.QtCore import Qt, QPoint, QRect
 
+from orangecanvas import config as occonfig
 from orangewidget.workflow import config
 
 import Orange
@@ -26,6 +27,13 @@ OFFICIAL_ADDON_LIST = "https://orange.biolab.si/addons/list"
 
 WIDGETS_ENTRY = "orange.widgets"
 
+spec = [
+    ("startup/check-updates", bool, False, "Check for updates"),
+    ("error-reporting/machine-id", str, "", ""),
+    ("error-reporting/send-statistics", bool, False, ""),
+    ("error-reporting/permission-requested", bool, False, ""),
+]
+
 
 class Config(config.Config):
     """
@@ -34,6 +42,11 @@ class Config(config.Config):
     OrganizationDomain = "biolab.si"
     ApplicationName = "Orange"
     ApplicationVersion = Orange.__version__
+
+    def init(self):
+        super().init()
+        for t in spec:
+            occonfig.register_setting(*t)
 
     @staticmethod
     def application_icon():

--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -3,6 +3,7 @@ from AnyQt.QtWidgets import (
     QFormLayout, QCheckBox, QLineEdit, QWidget, QVBoxLayout,
 )
 from orangecanvas.application.settings import UserSettingsDialog
+from orangecanvas.document.usagestatistics import UsageStatistics
 from orangewidget.workflow.mainwindow import OWCanvasMainWindow
 
 from Orange.canvas.utils.overlay import NotificationOverlay
@@ -39,6 +40,7 @@ class OUserSettingsDialog(UserSettingsDialog):
                 "Share anonymous usage statistics to improve Orange")
         )
         self.bind(cb1, "checked", "error-reporting/send-statistics")
+        cb1.clicked.connect(UsageStatistics.set_enabled)
         layout.addWidget(cb1)
         box.setLayout(layout)
         form.addRow(self.tr("Share Anonymous Statistics"), box)

--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -1,5 +1,49 @@
+from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import (
+    QFormLayout, QCheckBox, QLineEdit, QWidget, QVBoxLayout,
+)
+from orangecanvas.application.settings import UserSettingsDialog
 from orangewidget.workflow.mainwindow import OWCanvasMainWindow
+
 from Orange.canvas.utils.overlay import NotificationOverlay
+
+
+class OUserSettingsDialog(UserSettingsDialog):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        w = self.widget(0)  # 'General' tab
+        layout = w.layout()
+        assert isinstance(layout, QFormLayout)
+        cb = QCheckBox(self.tr("Automatically check for updates"))
+        cb.setAttribute(Qt.WA_LayoutUsesWidgetRect)
+
+        layout.addRow("Updates", cb)
+        self.bind(cb, "checked", "startup/check-updates")
+
+        # Error Reporting Tab
+        tab = QWidget()
+        self.addTab(tab, self.tr("Error Reporting"),
+                    toolTip="Settings related to error reporting")
+
+        form = QFormLayout()
+        line_edit_mid = QLineEdit()
+        self.bind(line_edit_mid, "text", "error-reporting/machine-id")
+        form.addRow("Machine ID:", line_edit_mid)
+
+        box = QWidget()
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        cb1 = QCheckBox(
+            self.tr(""),
+            toolTip=self.tr(
+                "Share anonymous usage statistics to improve Orange")
+        )
+        self.bind(cb1, "checked", "error-reporting/send-statistics")
+        layout.addWidget(cb1)
+        box.setLayout(layout)
+        form.addRow(self.tr("Share Anonymous Statistics"), box)
+
+        tab.setLayout(form)
 
 
 class MainWindow(OWCanvasMainWindow):
@@ -11,3 +55,12 @@ class MainWindow(OWCanvasMainWindow):
         super().closeEvent(event)
         if event.isAccepted():
             self.notification_overlay.close()
+
+    def open_canvas_settings(self):
+        # type: () -> None
+        """Reimplemented."""
+        dlg = OUserSettingsDialog(self, windowTitle=self.tr("Preferences"))
+        dlg.show()
+        status = dlg.exec_()
+        if status == 0:
+            self.user_preferences_changed_notify_all()

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.1a,<0.2a
+orange-canvas-core>=0.1.3,<0.2a
 orange-widget-base>=4.0a,<4.1a
 
 # PyQt4/PyQt5 compatibility


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Usage tracking an related user preferences settings were lost in gh-3772 

##### Description of changes

* Extend preferences dialog and add back setting controls lost in the refactoring
* Re-enable usage tracking

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
