### PR TITLE
Fix 404ing widget documentation URL

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -142,7 +142,7 @@ class Config(config.Config):
         "Quick Start": "https://orange.biolab.si/getting-started/",
         #: The 'full' documentation, should be something like current /docs/
         #: but specific for 'Visual Programing' only
-        "Documentation": "https://orange.biolab.si/toolbox/",
+        "Documentation": "https://orange.biolab.si/widget-catalog/",
         #: YouTube tutorials
         "Screencasts":
             "https://www.youtube.com/watch"


### PR DESCRIPTION
After the website change, the widget catalog URL changed. This PR updates it to the correct URL.