### PR TITLE
[FIX] Backcompatibility stubs

### DIFF
--- a/Orange/canvas/report.py
+++ b/Orange/canvas/report.py
@@ -1,0 +1,11 @@
+import sys
+import warnings
+import Orange.widgets.report
+
+warnings.warn(
+    f"'{__name__}' is deprecated and will be removed in the future.\n"
+    "The contents of this package were moved to 'Orange.widgets.report'. "
+    "Please update the imports accordingly.",
+    FutureWarning, stacklevel=2
+)
+sys.modules[__name__] = Orange.widgets.report

--- a/Orange/canvas/utils/environ.py
+++ b/Orange/canvas/utils/environ.py
@@ -1,0 +1,11 @@
+import warnings
+
+from Orange.misc import environ
+
+warnings.warn(
+    f"'{__name__}' is deprecated and will be removed on the future. "
+    "Use 'Orange.misc.environ' instead",
+    FutureWarning, stacklevel=2
+)
+buffer_dir = environ.cache_dir()
+widget_settings_dir = environ.widget_settings_dir()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Orange.canvas.utils.environ and Orange.canvas.report were at one point part of API intended for external use. They were both already deprecated before gh-3772, but never emitted visible deprecation warnings.

##### Description of changes

Restore Orange.canvas.utils.environ and Orange.canvas.report and raise visible FutureWarnings.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
