### PR TITLE
[ENH] Sticky graphics header/footer views

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1444,12 +1444,8 @@ class OWHierarchicalClustering(widget.OWWidget):
             return rect
 
         self.view.setSceneRect(geom)
-        self.view.setHeaderSceneRect(
-            adjustLeft(self.top_axis.geometry()).adjusted(0, 0, 0, 1)
-        )
-        self.view.setFooterSceneRect(
-            adjustLeft(self.bottom_axis.geometry()).adjusted(0, 0, 0, -1)
-        )
+        self.view.setHeaderSceneRect(adjustLeft(self.top_axis.geometry()))
+        self.view.setFooterSceneRect(adjustLeft(self.bottom_axis.geometry()))
 
     def _dendrogram_slider_changed(self, value):
         p = QPointF(value, 0)

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -323,6 +323,7 @@ class DendrogramWidget(QGraphicsWidget):
         self._selection = OrderedDict()
         self._highlighted_item = None
         self._cluster_parent = {}
+        self.updateGeometry()
 
     def set_root(self, root):
         """Set the root cluster.
@@ -347,7 +348,7 @@ class DendrogramWidget(QGraphicsWidget):
 
             self._relayout()
             self._rescale()
-            self.updateGeometry()
+        self.updateGeometry()
 
     def item(self, node):
         """Return the DendrogramNode instance representing the cluster.

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1029,6 +1029,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             ax.mousePressed.connect(self._activate_cut_line)
             ax.mouseMoved.connect(self._activate_cut_line)
             ax.mouseReleased.connect(self._activate_cut_line)
+            ax.setRange(1.0, 0.0)
             return ax
 
         self.top_axis = axis_view("top")

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1442,10 +1442,14 @@ class OWHierarchicalClustering(widget.OWWidget):
             rect = QRectF(rect)
             rect.setLeft(geom.left())
             return rect
-
+        margin = 3
         self.view.setSceneRect(geom)
-        self.view.setHeaderSceneRect(adjustLeft(self.top_axis.geometry()))
-        self.view.setFooterSceneRect(adjustLeft(self.bottom_axis.geometry()))
+        self.view.setHeaderSceneRect(
+            adjustLeft(self.top_axis.geometry()).adjusted(0, 0, 0, margin)
+        )
+        self.view.setFooterSceneRect(
+            adjustLeft(self.bottom_axis.geometry()).adjusted(0, -margin, 0, 0)
+        )
 
     def _dendrogram_slider_changed(self, value):
         p = QPointF(value, 0)

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -4,8 +4,8 @@ import warnings
 
 import numpy as np
 
-from AnyQt.QtCore import QPoint, Qt, QEvent
-from AnyQt.QtGui import QMouseEvent
+from AnyQt.QtCore import QPoint, Qt
+from AnyQt.QtTest import QTest
 
 import Orange.misc
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
@@ -141,16 +141,15 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         self.assertIsNotNone(annotated)
 
         # selecting clusters with cutoff should select all data
-        self.widget.eventFilter(self.widget.top_axis_view.viewport(),
-                                self._mouse_button_press_event())
+        QTest.mousePress(
+            self.widget.view.headerView().viewport(),
+            Qt.LeftButton, Qt.NoModifier,
+            QPoint(100, 10)
+        )
         selected = self.get_output(self.widget.Outputs.selected_data)
         annotated = self.get_output(self.widget.Outputs.annotated_data)
         self.assertEqual(len(selected), len(self.data))
         self.assertIsNotNone(annotated)
-
-    def _mouse_button_press_event(self):
-        return QMouseEvent(QEvent.MouseButtonPress, QPoint(100, 10),
-                           Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
 
     def test_retain_selection(self):
         """Hierarchical Clustering didn't retain selection. GH-1563"""

--- a/Orange/widgets/utils/stickygraphicsview.py
+++ b/Orange/widgets/utils/stickygraphicsview.py
@@ -1,11 +1,11 @@
 import sys
 import math
 
-from PyQt5.QtCore import Qt, QRectF, QEvent, QCoreApplication, QObject
-from PyQt5.QtGui import QBrush
+from PyQt5.QtCore import Qt, QRectF, QEvent, QCoreApplication, QObject, QPointF
+from PyQt5.QtGui import QBrush, QPalette
 from PyQt5.QtWidgets import (
     QGraphicsView, QGraphicsScene, QWidget, QVBoxLayout, QSizePolicy,
-    QScrollBar,
+    QScrollBar, QGraphicsDropShadowEffect
 )
 
 from orangewidget.utils.overlay import OverlayWidget
@@ -16,6 +16,28 @@ __all__ = [
 
 
 class _OverlayWidget(OverlayWidget):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        palette = self.palette()
+        ds = QGraphicsDropShadowEffect(
+            parent=self,
+            objectName="sticky-view-shadow",
+            color=palette.color(QPalette.Foreground),
+            blurRadius=15,
+            offset=QPointF(0, 0),
+            enabled=True
+        )
+        self.setGraphicsEffect(ds)
+
+    def changeEvent(self, event: QEvent) -> None:
+        super().changeEvent(event)
+        if event.type() == QEvent.PaletteChange:
+            effect = self.findChild(
+                QGraphicsDropShadowEffect, "sticky-view-shadow")
+            if effect is not None:
+                palette = self.palette()
+                effect.setColor(palette.color(QPalette.Foreground))
+
     def eventFilter(self, recv: QObject, event: QEvent) -> bool:
         if event.type() in (QEvent.Show, QEvent.Hide) and recv is self.widget():
             return False

--- a/Orange/widgets/utils/stickygraphicsview.py
+++ b/Orange/widgets/utils/stickygraphicsview.py
@@ -1,0 +1,242 @@
+import sys
+import math
+
+from PyQt5.QtCore import Qt, QRectF, QEvent, QCoreApplication, QObject
+from PyQt5.QtGui import QBrush
+from PyQt5.QtWidgets import (
+    QGraphicsView, QGraphicsScene, QWidget, QVBoxLayout, QSizePolicy,
+    QScrollBar,
+)
+
+from orangewidget.utils.overlay import OverlayWidget
+
+__all__ = [
+    "StickyGraphicsView"
+]
+
+
+class _OverlayWidget(OverlayWidget):
+    def eventFilter(self, recv: QObject, event: QEvent) -> bool:
+        if event.type() in (QEvent.Show, QEvent.Hide) and recv is self.widget():
+            return False
+        else:
+            return super().eventFilter(recv, event)
+
+
+class _HeaderGraphicsView(QGraphicsView):
+    def viewportEvent(self, event: QEvent) -> bool:
+        if event.type() == QEvent.Wheel:
+            # delegate wheel events to parent StickyGraphicsView
+            parent = self.parent().parent().parent()
+            if isinstance(parent, StickyGraphicsView):
+                QCoreApplication.sendEvent(parent.viewport(), event)
+                if event.isAccepted():
+                    return True
+        return super().viewportEvent(event)
+
+
+class StickyGraphicsView(QGraphicsView):
+    """
+    A graphics view with sticky header/footer views.
+
+    Set the scene rect of the header/footer geometry with
+    setHeaderRect/setFooterRect. When scrolling they will be displayed
+    top/bottom of the viewport.
+    """
+    def __init__(self, *args, **kwargs) -> None:
+        if args and isinstance(args[0], QGraphicsScene):
+            scene, args = args[0], args[1:]
+        else:
+            scene = None
+        super().__init__(*args, **kwargs)
+        self.__headerRect = QRectF()
+        self.__footerRect = QRectF()
+        self.__headerView: QGraphicsView = ...
+        self.__footerView: QGraphicsView = ...
+        self.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.setupViewport(self.viewport())
+
+        if scene is not None:
+            self.setScene(scene)
+
+    def setHeaderSceneRect(self, rect: QRectF) -> None:
+        """
+        Set the header scene rect.
+
+        Parameters
+        ----------
+        rect : QRectF
+        """
+        if self.__headerRect != rect:
+            self.__headerRect = QRectF(rect)
+            self.__updateHeader()
+
+    def headerSceneRect(self) -> QRectF:
+        return QRectF(self.__headerRect)
+
+    def setFooterSceneRect(self, rect: QRectF) -> None:
+        """
+        Set the footer scene rect.
+
+        Parameters
+        ----------
+        rect : QRectF
+        """
+        if self.__footerRect != rect:
+            self.__footerRect = QRectF(rect)
+            self.__updateFooter()
+
+    def footerSceneRect(self) -> QRectF:
+        return QRectF(self.__headerRect)
+
+    def setScene(self, scene: QGraphicsScene) -> None:
+        """Reimplemented"""
+        super().setScene(scene)
+        self.headerView().setScene(scene)
+        self.footerView().setScene(scene)
+        self.__headerRect = QRectF()
+        self.__footerRect = QRectF()
+
+    def setupViewport(self, widget: QWidget) -> None:
+        """Reimplemented"""
+        super().setupViewport(widget)
+        sp = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        header = _HeaderGraphicsView(
+            objectName="sticky-header-view", sizePolicy=sp,
+            verticalScrollBarPolicy=Qt.ScrollBarAlwaysOff,
+            horizontalScrollBarPolicy=Qt.ScrollBarAlwaysOff,
+            alignment=self.alignment()
+        )
+        header.setFocusProxy(self)
+        header.viewport().installEventFilter(self)
+        header.setFrameStyle(QGraphicsView.NoFrame)
+
+        footer = _HeaderGraphicsView(
+            objectName="sticky-footer-view", sizePolicy=sp,
+            verticalScrollBarPolicy=Qt.ScrollBarAlwaysOff,
+            horizontalScrollBarPolicy=Qt.ScrollBarAlwaysOff,
+            alignment=self.alignment()
+        )
+        footer.setFocusProxy(self)
+        footer.viewport().installEventFilter(self)
+        footer.setFrameStyle(QGraphicsView.NoFrame)
+
+        over = _OverlayWidget(
+            widget, objectName="sticky-header-overlay-container",
+            alignment=Qt.AlignTop,
+            sizePolicy=sp,
+            visible=False,
+        )
+        over.setLayout(QVBoxLayout(margin=0))
+        over.layout().addWidget(header)
+        over.setWidget(widget)
+
+        over = _OverlayWidget(
+            widget, objectName="sticky-footer-overlay-container",
+            alignment=Qt.AlignBottom,
+            sizePolicy=sp,
+            visible=False
+        )
+        over.setLayout(QVBoxLayout(margin=0))
+        over.layout().addWidget(footer)
+        over.setWidget(widget)
+
+        def bind(source: QScrollBar, target: QScrollBar) -> None:
+            # bind target scroll bar to `source` (range and value).
+            target.setRange(source.minimum(), source.maximum())
+            target.setValue(source.value())
+            source.rangeChanged.connect(target.setRange)
+            source.valueChanged.connect(target.setValue)
+
+        hbar = self.horizontalScrollBar()
+        footer_hbar = footer.horizontalScrollBar()
+        header_hbar = header.horizontalScrollBar()
+
+        bind(hbar, footer_hbar)
+        bind(hbar, header_hbar)
+
+        self.__headerView = header
+        self.__footerView = footer
+        self.__updateView(header, self.__footerRect)
+        self.__updateView(footer, self.__footerRect)
+
+    def headerView(self) -> QGraphicsView:
+        """
+        Return the header view.
+
+        Returns
+        -------
+        view: QGraphicsView
+        """
+        return self.__headerView
+
+    def footerView(self) -> QGraphicsView:
+        """
+        Return the footer view.
+
+        Returns
+        -------
+        view: QGraphicsView
+        """
+        return self.__footerView
+
+    def __updateView(self, view: QGraphicsView, rect: QRectF) -> None:
+        view.setSceneRect(rect)
+        view.setFixedHeight(int(math.ceil(rect.height())))
+        container = view.parent()
+        if rect.isEmpty():
+            container.setVisible(False)
+            return
+        # map the rect to (main) viewport coordinates
+        viewrect = self.mapFromScene(rect).boundingRect()
+        viewportrect = self.viewport().rect()
+        visible = not (viewrect.top() >= viewportrect.top()
+                       and viewrect.bottom() <= viewportrect.bottom())
+        container.setVisible(visible)
+        # force immediate layout of the container overlay
+        QCoreApplication.sendEvent(container, QEvent(QEvent.LayoutRequest))
+
+    def __updateHeader(self) -> None:
+        view = self.headerView()
+        self.__updateView(view, self.__headerRect)
+
+    def __updateFooter(self) -> None:
+        view = self.footerView()
+        self.__updateView(view, self.__footerRect)
+
+    def scrollContentsBy(self, dx: int, dy: int) -> None:
+        """Reimplemented."""
+        super().scrollContentsBy(dx, dy)
+        self.__updateFooter()
+        self.__updateHeader()
+
+    def viewportEvent(self, event: QEvent) -> bool:
+        """Reimplemented."""
+        if event.type() == QEvent.Resize:
+            self.__updateHeader()
+            self.__updateFooter()
+        return super().viewportEvent(event)
+
+
+def main(args):  # pragma: no cover
+    from PyQt5.QtWidgets import QApplication
+    app = QApplication(args)
+    view = StickyGraphicsView()
+    scene = QGraphicsScene(view)
+    scene.setBackgroundBrush(QBrush(Qt.lightGray, Qt.CrossPattern))
+    view.setScene(scene)
+    scene.addRect(
+        QRectF(0, 0, 300, 20), Qt.red, QBrush(Qt.red, Qt.BDiagPattern))
+    scene.addRect(QRectF(0, 25, 300, 100))
+    scene.addRect(
+        QRectF(0, 130, 300, 20),
+        Qt.darkGray, QBrush(Qt.darkGray, Qt.BDiagPattern)
+    )
+    view.setHeaderSceneRect(QRectF(0, 0, 300, 20))
+    view.setFooterSceneRect(QRectF(0, 130, 300, 20))
+    view.show()
+    return app.exec()
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/Orange/widgets/utils/tests/test_stickygraphicsview.py
+++ b/Orange/widgets/utils/tests/test_stickygraphicsview.py
@@ -1,0 +1,71 @@
+from PyQt5.QtCore import Qt, QRectF, QPoint, QPointF
+from PyQt5.QtGui import QBrush, QWheelEvent
+from PyQt5.QtWidgets import QGraphicsScene, QWidget, QApplication
+
+from Orange.widgets.tests.base import GuiTest
+
+from Orange.widgets.utils.stickygraphicsview import StickyGraphicsView
+
+
+class TestStickyGraphicsView(GuiTest):
+    def test(self):
+        view = StickyGraphicsView()
+        scene = QGraphicsScene(view)
+        scene.setBackgroundBrush(QBrush(Qt.lightGray, Qt.CrossPattern))
+        view.setScene(scene)
+        scene.addRect(
+            QRectF(0, 0, 300, 20), Qt.red, QBrush(Qt.red, Qt.BDiagPattern))
+        scene.addRect(QRectF(0, 25, 300, 100))
+        scene.addRect(
+            QRectF(0, 130, 300, 20),
+            Qt.darkGray, QBrush(Qt.darkGray, Qt.BDiagPattern)
+        )
+        view.setHeaderSceneRect(QRectF(0, 0, 300, 20))
+        view.setFooterSceneRect(QRectF(0, 130, 300, 20))
+
+        header = view.headerView()
+        footer = view.footerView()
+
+        view.resize(310, 310)
+        view.grab()
+
+        self.assertFalse(header.isVisibleTo(view))
+        self.assertFalse(footer.isVisibleTo(view))
+
+        view.resize(310, 100)
+        view.verticalScrollBar().setValue(0)  # scroll to top
+        view.grab()
+
+        self.assertFalse(header.isVisibleTo(view))
+        self.assertTrue(footer.isVisibleTo(view))
+
+        view.verticalScrollBar().setValue(
+            view.verticalScrollBar().maximum())  # scroll to bottom
+        view.grab()
+
+        self.assertTrue(header.isVisibleTo(view))
+        self.assertFalse(footer.isVisibleTo(view))
+
+        qWheelScroll(header.viewport(), angleDelta=QPoint(0, -720 * 8))
+
+
+def qWheelScroll(
+        widget: QWidget, buttons=Qt.NoButton, modifiers=Qt.NoModifier,
+        pos=QPoint(), angleDelta=QPoint(0, 1),
+):
+    if pos.isNull():
+        pos = widget.rect().center()
+    globalPos = widget.mapToGlobal(pos)
+
+    if angleDelta.y() >= angleDelta.x():
+        qt4orient = Qt.Vertical
+        qt4delta = angleDelta.y()
+    else:
+        qt4orient = Qt.Horizontal
+        qt4delta = angleDelta.x()
+
+    event = QWheelEvent(
+        QPointF(pos), QPointF(globalPos), QPoint(), angleDelta,
+        qt4delta, qt4orient, buttons, modifiers
+    )
+    QApplication.sendEvent(widget, event)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -647,6 +647,9 @@ class OWHeatMap(widget.OWWidget):
         self.col_dendrograms = []
         self.row_dendrograms = []
         self.selection_rects = []
+        self.sceneView.setSceneRect(QRectF())
+        self.sceneView.setHeaderSceneRect(QRectF())
+        self.sceneView.setFooterSceneRect(QRectF())
 
     @Inputs.data
     def set_dataset(self, data=None):

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -30,6 +30,7 @@ from Orange.data.sql.table import SqlTable
 import Orange.distance
 
 from Orange.clustering import hierarchical, kmeans
+from Orange.widgets.utils.stickygraphicsview import StickyGraphicsView
 from Orange.widgets.utils import colorbrewer
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
@@ -587,7 +588,7 @@ class OWHeatMap(widget.OWWidget):
         self.heatmap_scene.itemsBoundingRect()
         self.heatmap_scene.removeItem(item)
 
-        self.sceneView = QGraphicsView(
+        self.sceneView = StickyGraphicsView(
             self.scene,
             verticalScrollBarPolicy=Qt.ScrollBarAlwaysOn,
             horizontalScrollBarPolicy=Qt.ScrollBarAlwaysOn,
@@ -942,7 +943,7 @@ class OWHeatMap(widget.OWWidget):
         self.heatmap_scene.clear()
         # The top level container widget
         widget = GraphicsWidget()
-        widget.layoutDidActivate.connect(self.__update_selection_geometry)
+        widget.layoutDidActivate.connect(self.__on_layout_activate)
 
         grid = QGraphicsGridLayout()
         grid.setSpacing(self.space_x)
@@ -1210,8 +1211,41 @@ class OWHeatMap(widget.OWWidget):
 
     def __fixup_grid_layout(self):
         self.__update_margins()
+        self.__update_scene_rects()
+        self.__update_selection_geometry()
+
+    def __update_scene_rects(self):
         rect = self.scene.widget.geometry()
         self.heatmap_scene.setSceneRect(rect)
+
+        spacing = self.scene.widget.layout().rowSpacing(2)
+        headerrect = QRectF(rect)
+        headerrect.setBottom(
+            max((w.geometry().bottom()
+                 for w in (self.col_annotation_widgets_top +
+                           self.col_dendrograms)
+                 if w is not None and w.isVisible()),
+                default=rect.top())
+        )
+
+        if not headerrect.isEmpty():
+            headerrect = headerrect.adjusted(0, 0, 0, spacing / 2)
+
+        footerrect = QRectF(rect)
+        footerrect.setTop(
+            min((w.geometry().top() for w in self.col_annotation_widgets_bottom
+                 if w is not None and w.isVisible()),
+                default=rect.bottom())
+        )
+        if not footerrect.isEmpty():
+            footerrect = footerrect.adjusted(0, - spacing / 2, 0, 0)
+
+        self.sceneView.setSceneRect(rect)
+        self.sceneView.setHeaderSceneRect(headerrect)
+        self.sceneView.setFooterSceneRect(footerrect)
+
+    def __on_layout_activate(self):
+        self.__update_scene_rects()
         self.__update_selection_geometry()
 
     def __aspect_mode_changed(self):

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -388,10 +388,14 @@ class OWSilhouettePlot(widget.OWWidget):
             rect.setLeft(geom.left())
             rect.setRight(geom.right())
             return rect
+
+        margin = 3
         if header is not None:
-            self.view.setHeaderSceneRect(extend_horizontal(header.geometry()))
+            self.view.setHeaderSceneRect(
+                extend_horizontal(header.geometry().adjusted(0, 0, 0, margin)))
         if footer is not None:
-            self.view.setFooterSceneRect(extend_horizontal(footer.geometry()))
+            self.view.setFooterSceneRect(
+                extend_horizontal(footer.geometry().adjusted(0, -margin, 0, 0)))
 
     def commit(self):
         """

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -389,11 +389,9 @@ class OWSilhouettePlot(widget.OWWidget):
             rect.setRight(geom.right())
             return rect
         if header is not None:
-            self.view.setHeaderSceneRect(
-                extend_horizontal(header.geometry().adjusted(0, 0, 0, 1)))
+            self.view.setHeaderSceneRect(extend_horizontal(header.geometry()))
         if footer is not None:
-            self.view.setFooterSceneRect(
-                extend_horizontal(footer.geometry().adjusted(0, -1, 0, 0)))
+            self.view.setFooterSceneRect(extend_horizontal(footer.geometry()))
 
     def commit(self):
         """

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -231,6 +231,9 @@ class OWSilhouettePlot(widget.OWWidget):
         # Clear the graphics scene and associated objects
         self.scene.clear()
         self.scene.setSceneRect(QRectF())
+        self.view.setSceneRect(QRectF())
+        self.view.setHeaderSceneRect(QRectF())
+        self.view.setFooterSceneRect(QRectF())
         self._silplot = None
 
     def _invalidate_distances(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-3918
Fixes gh-1745

##### Description of changes

Add s StickyGraphicsView utility class implementing a sticky header/footer views to anchor scene header/footer in the view.

Hierarchical Clustering: Move the top and bottom scales into the same scene as the dendrogram (and are therefore exported to image along with it - gh-3918).

Silhouette Plot: Anchor top and bottom scales in the view.

Heatmap: Anchor top dendrogram/labels and bottom labels in view when applicable (gh-1745).

![sticky-header](https://user-images.githubusercontent.com/4716745/61124619-981c5c80-a4a7-11e9-965f-5e37ac804bf2.gif)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
