### PR TITLE
[FIX] main: Fix widget settings directory path to clear

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -158,10 +158,9 @@ def init():
 
 def data_dir():
     """
-    Return the application data directory. If the directory path
+    Return the Orange application data directory. If the directory path
     does not yet exists then create it.
     """
-
     from Orange.misc import environ
     path = os.path.join(environ.data_dir(), "canvas")
     try:
@@ -172,9 +171,9 @@ def data_dir():
 
 
 def cache_dir():
-    """Return the application cache directory. If the directory path
+    """
+    Return the Orange application cache directory. If the directory path
     does not yet exists then create it.
-
     """
     from Orange.misc import environ
     path = os.path.join(environ.cache_dir(), "canvas")

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -30,7 +30,7 @@ class Config(config.Config):
     Orange application configuration
     """
     OrganizationDomain = "biolab.si"
-    ApplicationName = "Orange Canvas"
+    ApplicationName = "Orange"
     ApplicationVersion = Orange.__version__
 
     @staticmethod
@@ -203,12 +203,11 @@ def log_dir():
     return logdir
 
 
-def widget_settings_dir():
+def widget_settings_dir(versioned=True):
     """
     Return the widget settings directory.
     """
-    from Orange.misc import environ
-    return environ.widget_settings_dir()
+    return config.widget_settings_dir(versioned)
 
 
 def widgets_entry_points():

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -2,6 +2,8 @@
 Orange Canvas Configuration
 
 """
+import warnings
+
 import os
 import sys
 import itertools
@@ -203,11 +205,18 @@ def log_dir():
     return logdir
 
 
-def widget_settings_dir(versioned=True):
+def widget_settings_dir():
     """
     Return the widget settings directory.
+
+    .. deprecated:: 3.23
     """
-    return config.widget_settings_dir(versioned)
+    warnings.warn(
+        f"'{__name__}.widget_settings_dir' is deprecated.",
+        DeprecationWarning, stacklevel=2
+    )
+    import orangewidget.settings
+    return orangewidget.settings.widget_settings_dir()
 
 
 def widgets_entry_points():

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -17,7 +17,7 @@ import requests
 from AnyQt.QtGui import QPainter, QFont, QFontMetrics, QColor, QPixmap, QIcon
 from AnyQt.QtCore import Qt, QPoint, QRect
 
-from orangewidget.workflow import widgetsscheme, discovery, config
+from orangewidget.workflow import config
 
 import Orange
 
@@ -133,9 +133,6 @@ class Config(config.Config):
             (default_ep,),
             pkg_resources.iter_entry_points("orange.widgets.tutorials")
         )
-
-    widget_discovery = discovery.WidgetDiscovery
-    workflow_constructor = widgetsscheme.WidgetsScheme
 
     APPLICATION_URLS = {
         #: Submit a bug report action in the Help menu

--- a/Orange/misc/environ.py
+++ b/Orange/misc/environ.py
@@ -57,15 +57,14 @@ def widget_settings_dir(versioned=True):
     """
     Return the platform dependent directory where widgets save their settings.
 
-    This a subdirectory of ``data_dir(versioned)`` named "widgets"
+    .. deprecated:: 3.23
     """
     warnings.warn(
-        f"'{__name__}.widget_settings_dir' is deprecated. "
-        "Use 'Orange.widgets.settings.widget_settings_dir'",
+        f"'{__name__}.widget_settings_dir' is deprecated.",
         DeprecationWarning, stacklevel=2
     )
-    from Orange.canvas import config
-    return config.widget_settings_dir(versioned)
+    import orangewidget.settings
+    return orangewidget.settings.widget_settings_dir(versioned)
 
 
 def cache_dir(*args):

--- a/Orange/misc/environ.py
+++ b/Orange/misc/environ.py
@@ -9,16 +9,10 @@ $DATA_HOME/Orange/$VERSION/
 
 where DATA_HOME is a platform dependent application directory
 (:ref:`data_dir_base`) and VERSION is Orange.__version__ string.
-
-``canvas`` subdirectory is reserved for settings/preferences stored
-by Orange Canvas
-``widget`` subdirectory is reserved for settings/preferences stored
-by OWWidget
-
 """
-
 import os
 import sys
+import warnings
 
 import Orange
 
@@ -65,7 +59,13 @@ def widget_settings_dir(versioned=True):
 
     This a subdirectory of ``data_dir(versioned)`` named "widgets"
     """
-    return os.path.join(data_dir(versioned=versioned), "widgets")
+    warnings.warn(
+        f"'{__name__}.widget_settings_dir' is deprecated. "
+        "Use 'Orange.widgets.settings.widget_settings_dir'",
+        DeprecationWarning, stacklevel=2
+    )
+    from Orange.canvas import config
+    return config.widget_settings_dir(versioned)
 
 
 def cache_dir(*args):


### PR DESCRIPTION
### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-3931

Since gh-3772 the `environ.widget_settings_dir` is no longer the authoritative directory path.

##### Description of changes

* Deprecate `Orange.misc.environ.widget_settings_dir`, (but make it return the correct path).
* Change the application name to 'Orange' to preserve historical directory layout (the application name is used as the path component in the settings path).
##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
