### PR TITLE
[FIX] Test and Score: Sort numerically, not alphabetically

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -533,7 +533,7 @@ class OWTestLearners(OWWidget):
                 for stat, scorer in zip(stats, self.scorers):
                     item = QStandardItem()
                     if stat.success:
-                        item.setText("{:.3f}".format(stat.value[0]))
+                        item.setData(float(stat.value[0]), Qt.DisplayRole)
                     else:
                         item.setToolTip(str(stat.exception))
                         if scorer.name in self.score_table.shown_scores:

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -277,10 +277,10 @@ class TestOWTestLearners(WidgetTest):
         # Ensure that the click on header caused an ascending sort
         # Ascending sort means that wrong model should be listed first
         self.assertEqual(header.sortIndicatorOrder(), Qt.AscendingOrder)
-        self.assertEqual(view.model().item(0, 0).text(), "VersicolorLearner")
+        self.assertEqual(view.model().index(0, 0).data(), "VersicolorLearner")
 
         self.send_signal(self.widget.Inputs.test_data, versicolor, wait=5000)
-        self.assertEqual(view.model().item(0, 0).text(), "SetosaLearner")
+        self.assertEqual(view.model().index(0, 0).data(), "SetosaLearner")
 
         self.widget.hide()
 
@@ -365,10 +365,11 @@ class TestOWTestLearners(WidgetTest):
                 [1, 1, 1.23, 23.8, 5.], [1., 2., 3., 4., 3.], "yynnn"))
         )
 
-        self.assertTupleEqual(self._test_scores(
-            table_train, table_test, LogisticRegressionLearner(),
-            OWTestLearners.TestOnTest, None),
-                              (0.667, 0.8, 0.8, 0.867, 0.8))
+        np.testing.assert_almost_equal(
+            self._test_scores(table_train, table_test,
+                              LogisticRegressionLearner(),
+                              OWTestLearners.TestOnTest, None),
+            (2 / 3, 0.8, 0.8, 13 / 15, 0.8))
 
     def test_scores_cross_validation(self):
         """

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -3,8 +3,11 @@
 import unittest
 import collections
 
+import numpy as np
+
 from AnyQt.QtWidgets import QMenu
-from AnyQt.QtCore import QPoint
+from AnyQt.QtGui import QStandardItem
+from AnyQt.QtCore import QPoint, Qt
 
 from Orange.widgets.evaluate.utils import ScoreTable
 from Orange.widgets.tests.base import GuiTest
@@ -69,6 +72,49 @@ class TestScoreTable(GuiTest):
             self.assertEqual(i == 0,
                              not header.isSectionHidden(i),
                              msg="error in section {}({})".format(i, name))
+
+    def test_sorting(self):
+        def order(n=5):
+            return "".join(model.index(i, 0).data() for i in range(n))
+
+        score_table = ScoreTable(None)
+
+        data = [
+            ["D", 11.0, 15.3],
+            ["C", 5.0, -15.4],
+            ["b", 20.0, np.nan],
+            ["A", None, None],
+            ["E", "", 0.0]
+        ]
+        for data_row in data:
+            row = []
+            for x in data_row:
+                item = QStandardItem()
+                if x is not None:
+                    item.setData(x, Qt.DisplayRole)
+                row.append(item)
+            score_table.model.appendRow(row)
+
+        model = score_table.view.model()
+
+        model.sort(0, Qt.AscendingOrder)
+        self.assertEqual(order(), "AbCDE")
+
+        model.sort(0, Qt.DescendingOrder)
+        self.assertEqual(order(), "EDCbA")
+
+        model.sort(1, Qt.AscendingOrder)
+        self.assertEqual(order(3), "CDb")
+
+        model.sort(1, Qt.DescendingOrder)
+        self.assertEqual(order(3), "bDC")
+
+        model.sort(2, Qt.AscendingOrder)
+        self.assertEqual(order(3), "CED")
+
+        model.sort(2, Qt.DescendingOrder)
+        self.assertEqual(order(3), "DEC")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #3947 by using a QSortFilterProxy that sorts numerically, if column values can be converted to numbers, or case-insensitive, if they can't.

##### Includes
- [X] Code changes
- [ ] Tests
