### PR TITLE
[FIX] Fix storing and retrieving selection, and unconditional auto commit

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -536,7 +536,7 @@ class OWDataTable(OWWidget):
             self.selected_cols = []
 
         self.set_selection()
-        self.commit()
+        self.unconditional_commit()
 
     def _setup_table_view(self, view, data):
         """Setup the `view` (QTableView) with `data` (Orange.data.Table)

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock
+import unittest
+from unittest.mock import Mock, patch
 
 from Orange.widgets.data.owtable import OWDataTable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -57,3 +58,14 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
         # false positive, pylint: disable=unsubscriptable-object
         self.assertEqual(
             self.widget.set_corner_text.call_args[0][1], "\na\nb\nc")
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_commit') as commit:
+            self.widget.auto_commit = False
+            commit.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.data)
+            commit.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -620,7 +620,7 @@ class ProjectionWidgetTestMixin:
         """Test if data is plotted only once but committed on every input change"""
         table = Table("heart_disease")
         self.widget.setup_plot = Mock()
-        self.widget.commit = Mock()
+        self.widget.commit = self.widget.unconditional_commit = Mock()
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.setup_plot.assert_called_once()
         self.widget.commit.assert_called_once()

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -225,6 +225,16 @@ class DistanceMapItem(pg.ImageItem):
                  range(r.left(), r.right() + 1))
                 for r in selections]
 
+    def set_selections(self, ranges):
+        self.__clearSelections()
+        for y, x in ranges:
+            area = QRectF(x.start, y.start,
+                          x.stop - x.start - 1, y.stop - y.start - 1)
+            item = DistanceMapItem.SelectionRect(area, self)
+            item.setPen(QPen(Qt.red, 0))
+            self.__selections.append((item, area))
+        self.selectionChanged.emit()
+
     def hoverMoveEvent(self, event):
         super().hoverMoveEvent(event)
         i, j = self._cellAt(event.pos())
@@ -268,6 +278,7 @@ class OWDistanceMap(widget.OWWidget):
     color_high = settings.Setting(1.0)
 
     annotation_idx = settings.ContextSetting(0)
+    pending_selection = settings.Setting(None, schema_only=True)
 
     autocommit = settings.Setting(True)
 
@@ -393,6 +404,14 @@ class OWDistanceMap(widget.OWWidget):
 
         self.grid_widget.scene().installEventFilter(self)
 
+        self.settingsAboutToBePacked.connect(self.pack_settings)
+
+    def pack_settings(self):
+        if self.matrix_item is not None:
+            self.pending_selection = self.matrix_item.selections()
+        else:
+            self.pending_selection = None
+
     @Inputs.distances
     def set_distances(self, matrix):
         self.closeContext()
@@ -473,6 +492,9 @@ class OWDistanceMap(widget.OWWidget):
             self._update_ordering()
             self._setup_scene()
             self._update_labels()
+            if self.pending_selection is not None:
+                self.matrix_item.set_selections(self.pending_selection)
+                self.pending_selection = None
         self.unconditional_commit()
 
     def _clear_plot(self):

--- a/Orange/widgets/unsupervised/tests/test_owdistancemap.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancemap.py
@@ -1,6 +1,8 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 import random
+import unittest
+
 from Orange.distance import Euclidean
 from Orange.widgets.unsupervised.owdistancemap import OWDistanceMap
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -24,3 +26,20 @@ class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
         self.widget._selection = selected_indices
         self.widget.commit()
         return selected_indices
+
+    def test_saved_selection(self):
+        self.widget.settingsHandler.pack_data(self.widget)
+        # no assert here, just test is doesn't crash on empty
+
+        self.send_signal(self.signal_name, self.signal_data)
+        random.seed(42)
+        self.widget.matrix_item.set_selections([(range(5, 10), range(8, 15))])
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+
+        w = self.create_widget(OWDistanceMap, stored_settings=settings)
+        self.send_signal(self.signal_name, self.signal_data)
+        self.assertEqual(len(self.get_output(w.Outputs.selected_data)), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/unsupervised/tests/test_owmds.py
+++ b/Orange/widgets/unsupervised/tests/test_owmds.py
@@ -53,7 +53,7 @@ class TestOWMDS(WidgetTest, ProjectionWidgetTestMixin,
         """Test if data is plotted only once but committed on every input change"""
         table = Table("heart_disease")
         self.widget.setup_plot = Mock()
-        self.widget.commit = Mock()
+        self.widget.commit = self.widget.unconditional_commit = Mock()
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.commit.reset_mock()
         self.wait_until_stop_blocking()

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -211,7 +211,7 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin, WidgetOutputsTestMixin):
     def test_plot_once(self):
         """Test if data is plotted only once but committed on every input change"""
         self.widget.setup_plot = Mock()
-        self.widget.commit = Mock()
+        self.widget.commit = self.widget.unconditional_commit = Mock()
 
         self.send_signal(self.widget.Inputs.data, self.data)
         # TODO: The base widget immediately calls `setup_plot` and `commit`

--- a/Orange/widgets/utils/tests/test_concurrent_example.py
+++ b/Orange/widgets/utils/tests/test_concurrent_example.py
@@ -44,7 +44,7 @@ class TestOWConcurrentWidget(WidgetTest, ProjectionWidgetTestMixin,
     def test_plot_once(self):
         table = Table("heart_disease")
         self.widget.setup_plot = Mock()
-        self.widget.commit = Mock()
+        self.widget.commit = self.widget.unconditional_commit = Mock()
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.setup_plot.assert_called_once()
         self.widget.commit.assert_called_once()

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -427,6 +427,7 @@ class OWHeatMap(widget.OWWidget):
 
     palette_index = settings.Setting(_default_palette_index)
     column_label_pos = settings.Setting(PositionTop)
+    selected_rows = settings.Setting(None, schema_only=True)
 
     auto_commit = settings.Setting(True)
 
@@ -454,6 +455,7 @@ class OWHeatMap(widget.OWWidget):
 
     def __init__(self):
         super().__init__()
+        self.__pending_selection = self.selected_rows
 
         # set default settings
         self.space_x = 10
@@ -719,7 +721,13 @@ class OWHeatMap(widget.OWWidget):
             self.openContext(self.data)
             if self.annotation_index >= len(self.annotation_vars):
                 self.annotation_index = 0
+
         self.update_heatmaps()
+        if data is not None and self.__pending_selection is not None:
+            self.selection_manager.select_rows(self.__pending_selection)
+            self.selected_rows = self.__pending_selection
+            self.__pending_selection = None
+
         self.unconditional_commit()
 
     def update_heatmaps(self):

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -720,6 +720,7 @@ class OWHeatMap(widget.OWWidget):
             if self.annotation_index >= len(self.annotation_vars):
                 self.annotation_index = 0
         self.update_heatmaps()
+        self.unconditional_commit()
 
     def update_heatmaps(self):
         if self.data is not None:
@@ -739,13 +740,13 @@ class OWHeatMap(widget.OWWidget):
                 self.selected_rows = []
         else:
             self.clear()
-        self.commit()
 
     def update_merge(self):
         self.kmeans_model = None
         self.merge_indices = None
         if self.data is not None and self.merge_kmeans:
             self.update_heatmaps()
+            self.commit()
 
     def _make_parts(self, data, group_var=None, group_key=None):
         """
@@ -1393,9 +1394,11 @@ class OWHeatMap(widget.OWWidget):
 
     def update_sorting_examples(self):
         self.update_heatmaps()
+        self.commit()
 
     def update_clustering_examples(self):
         self.update_heatmaps()
+        self.commit()
 
     def update_legend(self):
         for item in self.heatmap_scene.items():

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -547,7 +547,7 @@ class OWLinePlot(OWWidget):
 
         self.openContext(data)
         self.setup_plot()
-        self.commit()
+        self.unconditional_commit()
 
     def check_data(self):
         def error(err):

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -317,6 +317,7 @@ class OWMosaicDisplay(OWWidget):
         self.discrete_data = None
         self.subset_data = None
         self.subset_indices = None
+        self.__pending_selection = None
 
         self.color_data = None
 
@@ -442,6 +443,7 @@ class OWMosaicDisplay(OWWidget):
 
         self.init_combos(self.data)
         self.openContext(self.data)
+        self.__pending_selection = self.selection
 
     @Inputs.data_subset
     def set_subset_data(self, data):
@@ -475,6 +477,11 @@ class OWMosaicDisplay(OWWidget):
     def reset_graph(self):
         self.clear_selection()
         self.update_graph()
+        if self.__pending_selection is not None:
+            self.selection = self.__pending_selection
+            self.__pending_selection = None
+            self.update_selection_rects()
+            self.send_selection()
 
     def set_color_data(self):
         if self.data is None:

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -290,7 +290,7 @@ class OWMosaicDisplay(OWWidget):
     variable3 = ContextSetting(None)
     variable4 = ContextSetting(None)
     variable_color = ContextSetting(None)
-    selection = ContextSetting(set())
+    selection = Setting(set(), schema_only=True)
 
     BAR_WIDTH = 5
     SPACING = 4
@@ -317,7 +317,8 @@ class OWMosaicDisplay(OWWidget):
         self.discrete_data = None
         self.subset_data = None
         self.subset_indices = None
-        self.__pending_selection = None
+        self.__pending_selection = self.selection
+        self.selection = set()
 
         self.color_data = None
 
@@ -443,7 +444,6 @@ class OWMosaicDisplay(OWWidget):
 
         self.init_combos(self.data)
         self.openContext(self.data)
-        self.__pending_selection = self.selection
 
     @Inputs.data_subset
     def set_subset_data(self, data):
@@ -462,8 +462,14 @@ class OWMosaicDisplay(OWWidget):
             else:
                 indices = {e.id for e in transformed}
                 self.subset_indices = [ex.id in indices for ex in self.data]
+        if self.data is not None and self.__pending_selection is not None:
+            self.selection = self.__pending_selection
+            self.__pending_selection = None
+        else:
+            self.selection = set()
         self.set_color_data()
-        self.reset_graph()
+        self.update_graph()
+        self.send_selection()
 
     def clear_selection(self):
         self.selection = set()
@@ -477,11 +483,6 @@ class OWMosaicDisplay(OWWidget):
     def reset_graph(self):
         self.clear_selection()
         self.update_graph()
-        if self.__pending_selection is not None:
-            self.selection = self.__pending_selection
-            self.__pending_selection = None
-            self.update_selection_rects()
-            self.send_selection()
 
     def set_color_data(self):
         if self.data is None:

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -76,6 +76,8 @@ class OWSilhouettePlot(widget.OWWidget):
     add_scores = settings.Setting(False)
     auto_commit = settings.Setting(True)
 
+    pending_selection = settings.ContextSetting(None, schema_only=True)
+
     Distances = [("Euclidean", Orange.distance.Euclidean),
                  ("Manhattan", Orange.distance.Manhattan),
                  ("Cosine", Orange.distance.Cosine)]
@@ -165,9 +167,17 @@ class OWSilhouettePlot(widget.OWWidget):
         self.view.setAlignment(Qt.AlignTop | Qt.AlignLeft)
         self.mainArea.layout().addWidget(self.view)
 
+        self.settingsAboutToBePacked.connect(self.pack_settings)
+
     def sizeHint(self):
         sh = self.controlArea.sizeHint()
         return sh.expandedTo(QSize(600, 720))
+
+    def pack_settings(self):
+        if self.data and self._silplot is not None:
+            self.pending_selection = self._silplot.selection()
+        else:
+            self.pending_selection = None
 
     @Inputs.data
     @check_sql_input
@@ -209,6 +219,9 @@ class OWSilhouettePlot(widget.OWWidget):
         if self.data is not None:
             self._update()
             self._replot()
+            if self.pending_selection is not None and self._silplot is not None:
+                self._silplot.setSelection(self.pending_selection)
+                self.pending_selection = None
 
         self.unconditional_commit()
 

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -76,7 +76,7 @@ class OWSilhouettePlot(widget.OWWidget):
     add_scores = settings.Setting(False)
     auto_commit = settings.Setting(True)
 
-    pending_selection = settings.ContextSetting(None, schema_only=True)
+    pending_selection = settings.Setting(None, schema_only=True)
 
     Distances = [("Euclidean", Orange.distance.Euclidean),
                  ("Manhattan", Orange.distance.Manhattan),
@@ -175,7 +175,7 @@ class OWSilhouettePlot(widget.OWWidget):
 
     def pack_settings(self):
         if self.data and self._silplot is not None:
-            self.pending_selection = self._silplot.selection()
+            self.pending_selection = list(self._silplot.selection())
         else:
             self.pending_selection = None
 
@@ -220,7 +220,10 @@ class OWSilhouettePlot(widget.OWWidget):
             self._update()
             self._replot()
             if self.pending_selection is not None and self._silplot is not None:
-                self._silplot.setSelection(self.pending_selection)
+                # If selection contains indices that are too large, the data
+                # file must had been modified, so we ignore selection
+                if max(self.pending_selection) < len(self.data):
+                    self._silplot.setSelection(np.array(self.pending_selection))
                 self.pending_selection = None
 
         self.unconditional_commit()

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -210,6 +210,10 @@ class OWVennDiagram(widget.OWWidget):
         del self._queue[:]
 
         self._createDiagram()
+        # If autocommit is enabled, _createDiagram already outputs data
+        # If not, call unconditional_commit from here
+        if not self.autocommit:
+            self.unconditional_commit()
         if self.data:
             self.infolabel.setText(f"{len(self.data)} datasets on input.\n")
         else:

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -57,7 +57,7 @@ class OWVennDiagram(widget.OWWidget):
     selection: list
 
     # Selected disjoint subset indices
-    selection = settings.Setting([])
+    selection = settings.Setting([], schema_only=True)
     #: Stored input set hints
     #: {(index, inputname, attributes): (selectedattrname, itemsettitle)}
     #: The 'selectedattrname' can be None

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -264,6 +264,13 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, None)
         self.widget.report_button.click()
 
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_commit') as commit:
+            self.widget.auto_commit = False
+            commit.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.titanic)
+            commit.assert_called()
+
 
 class TestSegmentsIntersection(unittest.TestCase):
     def test_ccw(self):

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -144,6 +144,24 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(call_args[0].name, data.domain[0].name)
         self.assertEqual(call_args[1].name, data.domain[2].name)
 
+    def test_selection_setting(self):
+        widget = self.widget
+        data = Table("iris.tab")
+        self.send_signal(widget.Inputs.data, data)
+
+        widget.select_area(
+            1,
+            QMouseEvent(QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,
+                        Qt.LeftButton, Qt.KeyboardModifiers()))
+
+        self.send_signal(widget.Inputs.data, None)
+        self.assertFalse(bool(widget.selection))
+        self.assertIsNone(self.get_output(widget.Outputs.selected_data))
+
+        self.send_signal(widget.Inputs.data, data)
+        self.assertEqual(widget.selection, {1})
+        self.assertIsNotNone(self.get_output(widget.Outputs.selected_data))
+
 
 # Derive from WidgetTest to simplify creation of the Mosaic widget, although
 # we are actually testing the MosaicVizRank dialog and not the widget

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -154,13 +154,35 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
             QMouseEvent(QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,
                         Qt.LeftButton, Qt.KeyboardModifiers()))
 
+        # Changing the data must reset the selection
+        self.send_signal(widget.Inputs.data, Table("titanic"))
+        self.assertFalse(bool(widget.selection))
+        self.assertIsNone(self.get_output(widget.Outputs.selected_data))
+
+        self.send_signal(widget.Inputs.data, data)
+        self.assertFalse(bool(widget.selection))
+        self.assertIsNone(self.get_output(widget.Outputs.selected_data))
+
+        widget.select_area(
+            1,
+            QMouseEvent(QEvent.MouseButtonPress, QPoint(), Qt.LeftButton,
+                        Qt.LeftButton, Qt.KeyboardModifiers()))
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+
+        # Setting data to None must reset the selection
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(bool(widget.selection))
         self.assertIsNone(self.get_output(widget.Outputs.selected_data))
 
         self.send_signal(widget.Inputs.data, data)
-        self.assertEqual(widget.selection, {1})
-        self.assertIsNotNone(self.get_output(widget.Outputs.selected_data))
+        self.assertFalse(bool(widget.selection))
+        self.assertIsNone(self.get_output(widget.Outputs.selected_data))
+
+        w = self.create_widget(OWMosaicDisplay, stored_settings=settings)
+        self.assertFalse(bool(widget.selection))
+        self.send_signal(w.Inputs.data, data, widget=w)
+        self.assertEqual(w.selection, {1})
+        self.assertIsNotNone(self.get_output(w.Outputs.selected_data, widget=w))
 
 
 # Derive from WidgetTest to simplify creation of the Mosaic widget, although

--- a/Orange/widgets/visualize/tests/test_owprojectionwidget.py
+++ b/Orange/widgets/visualize/tests/test_owprojectionwidget.py
@@ -1,7 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 
@@ -213,6 +213,13 @@ class TestOWDataProjectionWidget(WidgetTest, ProjectionWidgetTestMixin,
         self.send_signal(self.widget.Inputs.data, table)
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.setup_plot.assert_called_once()
+
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_commit') as commit:
+            self.widget.auto_commit = False
+            commit.reset_mock()
+            self.send_signal(self.widget.Inputs.data, self.data)
+            commit.assert_called()
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -157,3 +157,23 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         )
         self.widget.controls.add_scores.setChecked(1)
         self.send_signal(self.widget.Inputs.data, table)
+
+    def test_saved_selection(self):
+        self.widget.settingsHandler.pack_data(self.widget)
+        # no assert here, just test is doesn't crash on empty
+
+        iris = Table("iris")
+
+        self.send_signal(self.widget.Inputs.data, iris)
+        random.seed(42)
+        points = random.sample(range(0, len(self.data)), 20)
+        self.widget._silplot.setSelection(points)
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+
+        w = self.create_widget(OWSilhouettePlot, stored_settings=settings)
+        self.send_signal(w.Inputs.data, iris, widget=w)
+        self.assertEqual(len(self.get_output(w.Outputs.selected_data)), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 
 import unittest
+from unittest.mock import patch
 from collections import defaultdict
 
 import numpy as np
@@ -180,6 +181,13 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.signal_name, self.data[50:], 2)
         self.send_signal(self.signal_name, self.data[:0], 3)
 
+    def test_unconditional_commit_on_new_signal(self):
+        with patch.object(self.widget, 'unconditional_commit') as commit:
+            self.widget.autocommit = False
+            commit.reset_mock()
+            self.send_signal(self.signal_name, self.data[:100], 1)
+            commit.assert_called()
+
 
 class GroupTableIndicesTest(unittest.TestCase):
 
@@ -269,3 +277,7 @@ class TestVennUtilities(unittest.TestCase):
 
         copied = copy_descriptor(var, "cux")
         self.assertEqual(copied.name, "cux")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -474,7 +474,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
             self.setup_plot()
         else:
             self.graph.update_point_props()
-        self.commit()
+        self.unconditional_commit()
 
     def _handle_subset_data(self):
         self.Warning.subset_independent.clear()


### PR DESCRIPTION
Fixes #3762. Fixes #3763.

Following @markotoplak suggestion, instance selections are schema-only because data is not a part of the context.