### PR TITLE
Appveryor: Build numpy version raised to 1.13.*

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     # disable threaded builds on Python 3.5+ when using numpy's distutils
     # (https://github.com/numpy/numpy/issues/7607)
     BUILD_GLOBAL_OPTIONS: build -j1
-    BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.9.3 -r requirements-doc.txt
+    BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.13.* -r requirements-doc.txt
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
     TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
     ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests starts to fail with

    Could not find a version that satisfies the requirement numpy==1.9.3

##### Description of changes

Numpy version raised to 1.13.*

##### Includes
- [ ] Code changes
- [ ] Tests
- [x] Documentation
