### PR TITLE
Logistic regression regularization slider acts when dragging stopped

### DIFF
--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -56,7 +56,7 @@ class OWLogisticRegression(OWBaseLearner):
         gui.widgetLabel(box2, "Weak").setStyleSheet("margin-top:6px")
         self.c_slider = gui.hSlider(
             box2, self, "C_index", minValue=0, maxValue=len(self.C_s) - 1,
-            callback=lambda: (self.set_c(), self.settings_changed()),
+            callback=self.set_c, callback_finished=self.settings_changed,
             createLabel=False)
         gui.widgetLabel(box2, "Strong").setStyleSheet("margin-top:6px")
         box2 = gui.hBox(box)

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -438,7 +438,9 @@ class WidgetLearnerTestMixin:
                 new_value = [x for x in parameter.values
                              if x != parameter.get_value()][0]
                 parameter.set_value(new_value)
-                self.widget.apply.assert_called_once_with()
+                # wait for asynchronous calls
+                self.process_events(lambda: self.widget.apply.call_args is not None)
+                self.widget.apply.assert_called_once()
 
     @staticmethod
     def _should_check_parameter(parameter, data):


### PR DESCRIPTION
If slider was moved, the model was built multiple times, which was a problem for bigger data sets.

Needs biolab/orange-widget-base#7

##### Includes
- [X] Code changes
- [X] Test changes :)
- [ ] Documentation
