### PR TITLE
installers: Activate the root conda env in the condainstall.bat

### DIFF
--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -7,6 +7,13 @@ set PREFIX=%~1
 rem Path to conda executable
 set CONDA=%~2
 
+rem activate the root conda environment (miniconda3 4.7.0 installs
+rem libarchive that requires this - conda cannot be used as a executable
+rem without activation first)
+if exist "%CONDA%\..\activate" (
+    call "%CONDA%\..\activate"
+)
+
 if not exist "%PREFIX%\python.exe" (
     echo Creating a conda env in "%PREFIX%"
     rem # Create an empty initial skeleton to layout the conda, activate.bat
@@ -15,7 +22,7 @@ if not exist "%PREFIX%\python.exe" (
 
     rem # Also install python (msvc runtime and python might be required
     rem # for any post-link scripts).
-    for %%f in ( python-*.tar.bz2 ) do (
+    for %%f in ( vs*runtime*.tar.bz2 vc-*.tar.bz2 python-*.tar.bz2 ) do (
         "%CONDA%" install --yes --copy --quiet --prefix "%PREFIX%" "%CD%\%%f" ^
             || exit /b !ERRORLEVEL!
     )


### PR DESCRIPTION
### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The stock miniconda 4.7.0 installer (current latest) installs libarchive package that fails to import if env is not activated (and it is imported by the conda command).

##### Description of changes

Activate the root env in the condainstall.bat utility script.

Also install the vc runtime packages before the rest (again).

##### Includeswip
- [X] Code changes
- [ ] Tests
- [ ] Documentation
