### PR TITLE
OWCalibrationPlot: Specificity definition fixed

### DIFF
--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -35,7 +35,7 @@ Metrics = [MetricDefinition(*args) for args in (
      "<p><b>Sensitivity</b> (falling) is the proportion of correctly "
      "detected positive instances (TP&nbsp;/&nbsp;P).</p>"
      "<p><b>Specificity</b> (rising) is the proportion of detected "
-     "negative instances (TP&nbsp;/&nbsp;N).</p>"),
+     "negative instances (TN&nbsp;/&nbsp;N).</p>"),
     ("Precision and recall",
      (Curves.precision, Curves.recall),
      ("prec", "recall"),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/3973

##### Description of changes

The formula for specificity in description fixed to TN / N. I also checked the correctness of the method and found out that correct formula is used in the calculation of specificity.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
