### PR TITLE
Fix numpy version on 1.16.*

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
     BUILD_GLOBAL_OPTIONS: build -j1
     BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.13.* -r requirements-doc.txt
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy~=1.14.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy==1.16.* scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
     ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'
 
   matrix:

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,5 +1,5 @@
 pip>=9.0
-numpy>=1.13.0
+numpy==1.16.*  # because of numba-numpy issue, remove restriction after it is fixed
 scipy>=0.16.1
 scikit-learn>=0.20.0
 bottleneck>=1.0.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
AppVeyor fails on openTSNE import - reason numba issue.

##### Description of changes

With this PR we fixed the numpy version on 1.1.6.* It can be undone when numba resolves an issue.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
