### PR TITLE
Hamming distance:  Distances calculation between input and secondary data

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -714,21 +714,16 @@ class Hamming(Distance):
     supports_discrete = True
 
     def fit(self, data):
-        x = _orange_to_numpy(data)
         if self.axis == 0:
-            return HammingColumnsModel(self.axis, self.impute, x)
+            return HammingColumnsModel(self.axis, self.impute)
         else:
-            return HammingRowsModel(self.axis, self.impute, x)
+            return HammingRowsModel(self.axis, self.impute)
 
 
 class HammingColumnsModel(DistanceModel):
     """
     Model for computation of Hamming distances between columns.
     """
-    def __init__(self, axis, impute, x):
-        super().__init__(axis, impute)
-        self.x = x
-
     def __call__(self, e1, e2=None, impute=None):
         if impute is not None:
             self.impute = impute
@@ -742,10 +737,6 @@ class HammingRowsModel(DistanceModel):
     """
     Model for computation of Hamming distances between rows.
     """
-    def __init__(self, axis, impute, x):
-        super().__init__(axis, impute)
-        self.x = x
-
     def __call__(self, e1, e2=None, impute=None):
         if impute is not None:
             self.impute = impute

--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -706,6 +706,7 @@ class MahalanobisDistance:
             return cls
         return Mahalanobis(axis=axis).fit(data)
 
+
 class Hamming(Distance):
     supports_sparse = False
     supports_missing = False
@@ -718,6 +719,7 @@ class Hamming(Distance):
             return HammingColumnsModel(self.axis, self.impute, x)
         else:
             return HammingRowsModel(self.axis, self.impute, x)
+
 
 class HammingColumnsModel(DistanceModel):
     """
@@ -735,6 +737,7 @@ class HammingColumnsModel(DistanceModel):
     def compute_distances(self, x1, x2=None):
         return pairwise_distances(x1.T, metric='hamming')
 
+
 class HammingRowsModel(DistanceModel):
     """
     Model for computation of Hamming distances between rows.
@@ -749,4 +752,4 @@ class HammingRowsModel(DistanceModel):
         return super().__call__(e1, e2)
 
     def compute_distances(self, x1, x2=None):
-        return pairwise_distances(x1, metric='hamming')
+        return pairwise_distances(x1, x2, metric='hamming')

--- a/Orange/distance/tests/test_distance.py
+++ b/Orange/distance/tests/test_distance.py
@@ -906,31 +906,32 @@ class JaccardDistanceTest(unittest.TestCase, CommonFittedTests):
         self.assertEqual(dist_dense[0][2], 1)
         self.assertEqual(dist_sparse[0][2], 1)
 
+
 class HammingDistanceTest(FittedDistanceTest):
     Distance = distance.Hamming
 
     def test_hamming_col(self):
-        assert_almost_equal = np.testing.assert_almost_equal
-        data = self.disc_data
-        dist = distance.Hamming(data, axis=0)
-
-        assert_almost_equal(
-            dist,
-            [[0, 2/3, 1/3],
-             [2/3, 0, 1/3],
-             [1/3, 1/3, 0]])
+        np.testing.assert_almost_equal(
+            self.Distance(self.disc_data, axis=0),
+            [[0, 2 / 3, 1 / 3],
+             [2 / 3, 0, 1 / 3],
+             [1 / 3, 1 / 3, 0]])
 
     def test_hamming_row(self):
-        assert_almost_equal = np.testing.assert_almost_equal
-        data = self.disc_data
-        dist = distance.Hamming(data)
-
-        assert_almost_equal(
-            dist,
-            [[0, 2/3, 1],
-             [2/3, 0, 2/3],
-             [1, 2/3, 0]]
+        np.testing.assert_almost_equal(
+            self.Distance(self.disc_data),
+            [[0, 2 / 3, 1],
+             [2 / 3, 0, 2 / 3],
+             [1, 2 / 3, 0]]
         )
+
+    def test_hamming_row_secondary_data(self):
+        np.testing.assert_almost_equal(
+            self.Distance(self.disc_data, self.disc_data[:2]),
+            [[0, 2 / 3],
+             [2 / 3, 0],
+             [1, 2 / 3]])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Hamming distances between input data and secondary data can not be computed.

##### Description of changes
Enable computation of Hamming distances between input and secondary data.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
