### PR TITLE
Outliers: Move fix from widget to learners

### DIFF
--- a/Orange/classification/elliptic_envelope.py
+++ b/Orange/classification/elliptic_envelope.py
@@ -1,7 +1,7 @@
 import sklearn.covariance as skl_covariance
 
 from Orange.base import SklLearner, SklModel
-from Orange.data import Table
+from Orange.data import Table, Domain
 from Orange.preprocess import Continuize, RemoveNaNColumns, SklImpute
 
 __all__ = ["EllipticEnvelopeLearner"]
@@ -35,3 +35,7 @@ class EllipticEnvelopeLearner(SklLearner):
                  random_state=None, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
+
+    def __call__(self, data):
+        classless_data = data.transform(Domain(data.domain.attributes))
+        return super().__call__(classless_data)

--- a/Orange/classification/svm.py
+++ b/Orange/classification/svm.py
@@ -1,7 +1,8 @@
 import sklearn.svm as skl_svm
 
-from Orange.classification import SklLearner, SklModel
 from Orange.base import SklLearner as SklLearnerBase
+from Orange.classification import SklLearner, SklModel
+from Orange.data import Domain
 from Orange.preprocess import AdaptiveNormalize
 
 __all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner",
@@ -76,6 +77,10 @@ class OneClassSVMLearner(SklLearnerBase):
                  max_iter=-1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
+
+    def __call__(self, data):
+        classless_data = data.transform(Domain(data.domain.attributes))
+        return super().__call__(classless_data)
 
     def fit(self, X, Y=None, W=None):
         clf = self.__wraps__(**self.params)

--- a/Orange/tests/test_elliptic_envelope.py
+++ b/Orange/tests/test_elliptic_envelope.py
@@ -41,3 +41,22 @@ class TestEllipticEnvelopeLearner(unittest.TestCase):
         y_mahal, y_pred = zip(*sorted(zip(y_mahal, y_pred), reverse=True))
         self.assertTrue(all(i == -1 for i in y_pred[:int(self.cont * n)]))
         self.assertTrue(all(i == 1 for i in y_pred[int(self.cont * n):]))
+
+    def test_EllipticEnvelope_ignores_y(self):
+        domain = Domain((ContinuousVariable("x1"), ContinuousVariable("x2")),
+                        class_vars=(ContinuousVariable("y1"), ContinuousVariable("y2")))
+        X = np.random.random((40, 2))
+        Y = np.random.random((40, 2))
+        table = Table(domain, X, Y)
+        classless_table = table.transform(Domain(table.domain.attributes))
+        learner = EllipticEnvelopeLearner()
+        classless_model = learner(classless_table)
+        model = learner(table)
+        pred1 = classless_model(classless_table)
+        pred2 = classless_model(table)
+        pred3 = model(classless_table)
+        pred4 = model(table)
+
+        np.testing.assert_array_equal(pred1, pred2)
+        np.testing.assert_array_equal(pred2, pred3)
+        np.testing.assert_array_equal(pred3, pred4)

--- a/Orange/tests/test_svm.py
+++ b/Orange/tests/test_svm.py
@@ -88,3 +88,22 @@ class TestSVMLearner(unittest.TestCase):
         self.assertLess(np.absolute(n_pred_out_all - n_true_out), 2)
         self.assertLess(np.absolute(n_pred_in_true_in - n_true_in), 4)
         self.assertLess(np.absolute(n_pred_out_true_out - n_true_out), 3)
+
+    def test_OneClassSVM_ignores_y(self):
+        domain = Domain((ContinuousVariable("x1"), ContinuousVariable("x2")),
+                        class_vars=(ContinuousVariable("y1"), ContinuousVariable("y2")))
+        X = np.random.random((40, 2))
+        Y = np.random.random((40, 2))
+        table = Table(domain, X, Y)
+        classless_table = table.transform(Domain(table.domain.attributes))
+        learner = OneClassSVMLearner()
+        classless_model = learner(classless_table)
+        model = learner(table)
+        pred1 = classless_model(classless_table)
+        pred2 = classless_model(table)
+        pred3 = model(classless_table)
+        pred4 = model(table)
+
+        np.testing.assert_array_equal(pred1, pred2)
+        np.testing.assert_array_equal(pred2, pred3)
+        np.testing.assert_array_equal(pred3, pred4)

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -183,9 +183,8 @@ class OWOutliers(widget.OWWidget):
                 support_fraction=self.support_fraction
                 if self.empirical_covariance else None,
                 contamination=self.cont / 100.)
-        data = self.data.transform(Domain(self.data.domain.attributes))
-        model = learner(data)
-        y_pred = model(data)
+        model = learner(self.data)
+        y_pred = model(self.data)
         amended_data = self.amended_data(model)
         return np.array(y_pred), amended_data
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #1906

##### Description of changes
#1906 was fixed temporarily in #1907 and then more properly in #2677, but the fix was only in the `Outliers` widget and not in the underlying learner classes (`OneClassSVMLearner`, `EllipticEnvelopeLearner`).
This does the same transformation (remove classes), but in learners instead of the widget.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
