### PR TITLE
Add anonymous machine ID to useragent string

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -65,11 +65,12 @@ statistics_server_url = os.getenv(
 
 def ua_string():
     is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
-    return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}'.format(
+    return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}:{uuid}'.format(
         orange_version=current,
-        py_version='.'.join(sys.version[:3]),
+        py_version='.'.join(str(a) for a in sys.version_info[:3]),
         platform=sys.platform,
         conda='Anaconda' if is_anaconda else '',
+        uuid=QSettings().value("error-reporting/machine-id", "", str),
     )
 
 

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -2,6 +2,7 @@
 Orange Canvas Configuration
 
 """
+import uuid
 import warnings
 
 import os
@@ -33,7 +34,7 @@ spec = [
 
     ("startup/launch-count", int, 0, ""),
 
-    ("error-reporting/machine-id", str, "", ""),
+    ("error-reporting/machine-id", str, str(uuid.uuid4()), ""),
 
     ("error-reporting/send-statistics", bool, False, ""),
 


### PR DESCRIPTION
##### Description of changes
Instead of setting `machine-id` to empty string by default, initialize it to a randomly generated value with `uuid.uuid4()`.

As the next release of Orange changes the name of the `.ini` config file due to the separation of orange3 and orange-canvas-core, all machines will initialize their machine ID this way, regardless of its value in previous installation of Orange.

##### Corresponding pull request
A user should still be able to change their machine ID to an empty string, and this should be used in the useragent string and in error reporting. 
https://github.com/biolab/orange-widget-base/pull/11

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
