### PR TITLE
Update requirements

### DIFF
--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -158,7 +158,7 @@ class TestDiscretizer(TestCase):
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [1, 2, 3])
         X = sp.csr_matrix(np.array([0, 0.9, 1, 1.1, 1.9, 2, 2.5, 3, 3.5]))
-        self.assertEqual((dvar.compute_value.transform(X) != np.floor(X)).nnz, 0)
+        self.assertEqual((dvar.compute_value.transform(X) != X.floor()).nnz, 0)
 
     def test_discretizer_computation_sparse_no_points(self):
         dvar = discretize.Discretizer.create_discretized_var(

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
     BUILD_GLOBAL_OPTIONS: build -j1
     BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.13.* -r requirements-doc.txt
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy==1.16.* scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy>=1.16.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
     ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'
 
   matrix:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
   run:
     - python
     - setuptools
-    - numpy         >=1.9.0
+    - numpy         >=1.16.0
     - scipy
     - scikit-learn  >=0.20
     - bottleneck    >=1.0.0
@@ -51,7 +51,7 @@ requirements:
     - commonmark
     - serverfiles
     - matplotlib    >=2.0.0
-    - opentsne      >=0.3.0
+    - opentsne      >=0.3.11
     - pandas
     - pyyaml
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,5 +1,5 @@
 pip>=9.0
-numpy==1.16.*  # because of numba-numpy issue, remove restriction after it is fixed
+numpy>=1.16.0
 scipy>=0.16.1
 scikit-learn>=0.20.0
 bottleneck>=1.0.0
@@ -18,6 +18,6 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain>=0.13
 requests
-openTSNE>=0.3.0
+openTSNE>=0.3.11
 pandas
 pyyaml


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In #3979 we fixed numpy requirement to 1.16.* because of conflicts with openTSNE (numba). Keeping requirements so hardly defined is not nice practice and package with those requirements cannot be released.

##### Description of changes

- We are changing those requirements back to old values.
- We limit the openTSNE version to >=3.11.0, older versions were built with newer numpy(1.16) and those not compatible with older numpy versions.
- We fix a test which does not work in numpy 1.17

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
