### PR TITLE
[FIX] Conda Installer: Restore compatibility with latest anaconda python

### DIFF
--- a/scripts/windows/build-conda-installer.sh
+++ b/scripts/windows/build-conda-installer.sh
@@ -373,4 +373,5 @@ cp "${CACHEDIR:?}/miniconda/Miniconda3-${MINICONDA_VERSION}-Windows-${CONDAPLATT
 
 mkdir -p "${BASEDIR:?}/icons"
 cp scripts/windows/{Orange.ico,OrangeOWS.ico} "${BASEDIR:?}/icons"
+cp "$(dirname "$0")"/sitecustomize.py "${BASEDIR:?}"/conda-pkgs
 make-installer

--- a/scripts/windows/condainstall.bat
+++ b/scripts/windows/condainstall.bat
@@ -59,3 +59,6 @@ if not exist "%ACTIVATE_BAT%" (
     echo @echo off >  "%ACTIVATE_BAT%"
     echo call "%CONDA_BASE_PREFIX%\Scripts\activate.bat" "%PREFIX%" >> "%ACTIVATE_BAT%"
 )
+
+rem # install custom sitecustomize module
+copy sitecustomize.py "%PREFIX%\Lib\

--- a/scripts/windows/sitecustomize.py
+++ b/scripts/windows/sitecustomize.py
@@ -1,0 +1,27 @@
+#
+# sitecustomize added by orange3 installer.
+#
+# (Ana)conda python distribution expects it is 'activated', it does not really
+# support unactivated invocations (although a similar facility to this was
+# included in anaconda python 3.6 and earlier).
+
+import sys
+import os
+
+
+def normalize(path):
+    return os.path.normcase(os.path.normpath(path))
+
+
+extra_paths = [
+    r"Library\bin",
+]
+
+paths = os.environ.get("PATH", "").split(os.path.pathsep)
+paths = [normalize(path) for path in paths]
+
+for path in extra_paths:
+    path = os.path.join(sys.prefix, path)
+
+    if os.path.isdir(path) and normalize(path) not in paths:
+        os.environ["PATH"] = os.pathsep.join((path, os.environ.get("PATH", "")))


### PR DESCRIPTION
### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

(Ana)conda python distribution expects to be 'activated', but we use it without in shortcuts and open commands etc.

##### Description of changes

Add the ${PREFIX}\Library\bin to PATH if not already there.

Transplated From: biolab/orange3-single-cell@5934d6d06783238c6fffceb3a611495d6708f397

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
