### PR TITLE
[FIX] Correlations: Add progress bar, retain responsiveness

### DIFF
--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -199,8 +199,7 @@ class CorrelationRank(VizRankDialogAttrPair):
     def start(self, task, *args, **kwargs):
         self.__set_state_ready()
         super().start(task, *args, **kwargs)
-        self.master.progressBarInit()
-        self.master.setBlocking(True)
+        self.__set_state_busy()
 
     def cancel(self):
         super().cancel()
@@ -209,10 +208,12 @@ class CorrelationRank(VizRankDialogAttrPair):
     def _connect_signals(self, state):
         super()._connect_signals(state)
         state.progress_changed.connect(self.master.progressBarSet)
+        state.status_changed.connect(self.master.setStatusMessage)
 
     def _disconnect_signals(self, state):
         super()._disconnect_signals(state)
         state.progress_changed.disconnect(self.master.progressBarSet)
+        state.status_changed.disconnect(self.master.setStatusMessage)
 
     def _on_task_done(self, future):
         super()._on_task_done(future)
@@ -221,6 +222,11 @@ class CorrelationRank(VizRankDialogAttrPair):
     def __set_state_ready(self):
         self.master.progressBarFinished()
         self.master.setBlocking(False)
+        self.master.setStatusMessage("")
+
+    def __set_state_busy(self):
+        self.master.progressBarInit()
+        self.master.setBlocking(True)
 
 
 class OWCorrelations(OWWidget):
@@ -276,7 +282,6 @@ class OWCorrelations(OWWidget):
 
         self.vizrank, _ = CorrelationRank.add_vizrank(
             None, self, None, self._vizrank_selection_changed)
-        self.vizrank.progressBar = self.progressBar
         self.vizrank.button.setEnabled(False)
         self.vizrank.threadStopped.connect(self._vizrank_stopped)
 

--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -196,6 +196,32 @@ class CorrelationRank(VizRankDialogAttrPair):
         header = self.rank_table.horizontalHeader()
         header.setSectionResizeMode(1, QHeaderView.Stretch)
 
+    def start(self, task, *args, **kwargs):
+        self.__set_state_ready()
+        super().start(task, *args, **kwargs)
+        self.master.progressBarInit()
+        self.master.setBlocking(True)
+
+    def cancel(self):
+        super().cancel()
+        self.__set_state_ready()
+
+    def _connect_signals(self, state):
+        super()._connect_signals(state)
+        state.progress_changed.connect(self.master.progressBarSet)
+
+    def _disconnect_signals(self, state):
+        super()._disconnect_signals(state)
+        state.progress_changed.disconnect(self.master.progressBarSet)
+
+    def _on_task_done(self, future):
+        super()._on_task_done(future)
+        self.__set_state_ready()
+
+    def __set_state_ready(self):
+        self.master.progressBarFinished()
+        self.master.setBlocking(False)
+
 
 class OWCorrelations(OWWidget):
     name = "Correlations"

--- a/Orange/widgets/data/tests/test_owcorrelations.py
+++ b/Orange/widgets/data/tests/test_owcorrelations.py
@@ -229,6 +229,7 @@ class TestOWCorrelations(WidgetTest):
                            if attr.is_continuous]
         self.assertEqual(len(feature_combo.model()), len(cont_attributes) + 1)
 
+        self.wait_until_stop_blocking()
         self.send_signal(self.widget.Inputs.data, Table("housing"))
         self.assertEqual(len(feature_combo.model()), 14)
 
@@ -281,6 +282,7 @@ class TestOWCorrelations(WidgetTest):
         """Test report """
         self.send_signal(self.widget.Inputs.data, self.data_cont)
         self.widget.report_button.click()
+        self.wait_until_stop_blocking()
         self.send_signal(self.widget.Inputs.data, None)
         self.widget.report_button.click()
 

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -59,6 +59,7 @@ class LinearProjectionVizRank(VizRankDialog, OWComponent):
         gui.rubber(box)
         self.last_run_n_attrs = None
         self.attr_color = master.attr_color
+        self.attrs = []
 
     def initialize(self):
         super().initialize()
@@ -95,6 +96,8 @@ class LinearProjectionVizRank(VizRankDialog, OWComponent):
 
     def state_count(self):
         n_all_attrs = len(self.attrs)
+        if not n_all_attrs:
+            return 0
         n_attrs = self.n_attrs
         return factorial(n_all_attrs) // (2 * factorial(n_all_attrs - n_attrs) * n_attrs)
 

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -203,14 +203,14 @@ class LinProjVizRankTests(WidgetTest):
     def test_discrete_class(self):
         self.send_signal(self.widget.Inputs.data, self.data)
         run_vizrank(self.vizrank.compute_score,
-                    self.vizrank.iterate_states(None),
+                    self.vizrank.iterate_states, None,
                     [], 0, self.vizrank.state_count(), Mock())
 
     def test_continuous_class(self):
         data = Table("housing")[::100]
         self.send_signal(self.widget.Inputs.data, data)
         run_vizrank(self.vizrank.compute_score,
-                    self.vizrank.iterate_states(None),
+                    self.vizrank.iterate_states, None,
                     [], 0, self.vizrank.state_count(), Mock())
 
     def test_set_attrs(self):

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -203,13 +203,15 @@ class LinProjVizRankTests(WidgetTest):
     def test_discrete_class(self):
         self.send_signal(self.widget.Inputs.data, self.data)
         run_vizrank(self.vizrank.compute_score,
-                    self.vizrank.iterate_states(None), [], Mock())
+                    self.vizrank.iterate_states(None),
+                    [], 0, self.vizrank.state_count(), Mock())
 
     def test_continuous_class(self):
         data = Table("housing")[::100]
         self.send_signal(self.widget.Inputs.data, data)
         run_vizrank(self.vizrank.compute_score,
-                    self.vizrank.iterate_states(None), [], Mock())
+                    self.vizrank.iterate_states(None),
+                    [], 0, self.vizrank.state_count(), Mock())
 
     def test_set_attrs(self):
         self.send_signal(self.widget.Inputs.data, self.data)

--- a/Orange/widgets/visualize/tests/test_vizrankdialog.py
+++ b/Orange/widgets/visualize/tests/test_vizrankdialog.py
@@ -41,7 +41,7 @@ class TestRunner(unittest.TestCase):
         res_scores = sorted([compute_score(x) for x in states])
         self.assertListEqual(res.scores, res_scores)
         self.assertIsNot(scores, res.scores)
-        self.assertEqual(task.set_partial_result.call_count, 6)
+        self.assertEqual(task.set_partial_result.call_count, 2)
         self.assertEqual(task.set_progress_value.call_count, 7)
 
     def test_run_vizrank_interrupt(self):
@@ -59,7 +59,7 @@ class TestRunner(unittest.TestCase):
         res_scores = sorted([compute_score(x) for x in states[:2]])
         self.assertListEqual(res.scores, res_scores)
         self.assertIsNot(scores, res.scores)
-        self.assertEqual(task.set_partial_result.call_count, 2)
+        self.assertEqual(task.set_partial_result.call_count, 1)
         self.assertEqual(task.set_progress_value.call_count, 3)
         task.set_progress_value.assert_called_with(int(1 / 6 * 100))
 
@@ -76,7 +76,7 @@ class TestRunner(unittest.TestCase):
         res_scores = sorted([compute_score(x) for x in states])
         self.assertListEqual(res.scores, res_scores)
         self.assertIsNot(scores, res.scores)
-        self.assertEqual(task.set_partial_result.call_count, 6)
+        self.assertEqual(task.set_partial_result.call_count, 3)
         self.assertEqual(task.set_progress_value.call_count, 8)
         task.set_progress_value.assert_called_with(int(5 / 6 * 100))
 

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -6,7 +6,7 @@ from bisect import bisect_left
 from operator import attrgetter
 from queue import Queue, Empty
 from types import SimpleNamespace as namespace
-from typing import Optional, Iterable, List, Callable, Iterator
+from typing import Optional, Iterable, List, Callable
 
 from AnyQt.QtCore import Qt, QSize, pyqtSignal as Signal, QSortFilterProxyModel
 from AnyQt.QtGui import QStandardItemModel, QStandardItem, QColor, QBrush, QPen
@@ -366,7 +366,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
             self.progressBarInit()
             self.before_running()
             self.start(run_vizrank, self.compute_score,
-                       self.iterate_states(self.saved_state), self.scores,
+                       self.iterate_states, self.saved_state, self.scores,
                        self.saved_progress, self.state_count())
         else:
             self.button.setText("Continue")
@@ -383,8 +383,14 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         pass
 
 
-def run_vizrank(compute_score: Callable, states: Iterator, scores: List,
+def run_vizrank(compute_score: Callable, iterate_states: Callable,
+                saved_state: Optional[Iterable], scores: List,
                 progress: int, state_count: int, task: TaskState):
+    task.set_status("Getting combinations...")
+    task.set_progress_value(0.1)
+    states = iterate_states(saved_state)
+
+    task.set_status("Getting scores...")
     res = Result(queue=Queue(), scores=None)
     scores = scores.copy()
 

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -366,7 +366,8 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
             self.progressBarInit()
             self.before_running()
             self.start(run_vizrank, self.compute_score,
-                       self.iterate_states(self.saved_state), self.scores)
+                       self.iterate_states(self.saved_state), self.scores,
+                       self.saved_progress, self.state_count())
         else:
             self.button.setText("Continue")
             self.button.repaint()
@@ -382,8 +383,8 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         pass
 
 
-def run_vizrank(compute_score: Callable, states: Iterator,
-                scores: List, task: TaskState):
+def run_vizrank(compute_score: Callable, states: Iterator, scores: List,
+                progress: int, state_count: int, task: TaskState):
     res = Result(queue=Queue(), scores=None)
     scores = scores.copy()
 
@@ -406,6 +407,8 @@ def run_vizrank(compute_score: Callable, states: Iterator,
         while True:
             if task.is_interruption_requested():
                 return res
+            task.set_progress_value(int(progress * 100 / max(1, state_count)))
+            progress += 1
             state = copy.copy(next_state)
             next_state = copy.copy(next(states))
             do_work(state, next_state)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #4008

Since adding the progress bar was somehow trivial, making the widget responsive was not and I'm still not sure about the solution.

The widget was getting unresponsive for datasets with small number of instances and many features. In those cases correlation between a pair of features was calculated 'too fast' which caused a signal, for setting partial results, being emitted too frequently. Consequently the widget was getting unresponsive.

##### Description of changes
To prevent the congestion, the signal is only emitted every 0.01 second.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
