### PR TITLE
Add config option to enable/disable notification feed

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -218,9 +218,13 @@ yaml.add_constructor(u'!Notification', YAMLNotification.yamlConstructor, Loader=
 
 
 def pull_notifications():
+    settings = QSettings()
+    check_notifs = settings.value("notifications/check-notifications", True, bool)
+    if not check_notifs:
+        return None
+
     Version = pkg_resources.parse_version
 
-    settings = QSettings()
     # create settings_dict for notif requirements purposes (read-only)
     spec = canvasconfig.spec + config.spec
     settings_dict = canvasconfig.Settings(defaults=spec, store=settings)

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -40,6 +40,8 @@ spec = [
 
     ("error-reporting/permission-requested", bool, False, ""),
 
+    ("notifications/check-notifications", bool, True, "Check for notifications"),
+
     ("notifications/announcements", bool, True,
      "Show notifications about Biolab announcements"),
 

--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -54,6 +54,19 @@ class OUserSettingsDialog(UserSettingsDialog):
 
         form = QFormLayout()
 
+        box = QWidget()
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        cb = QCheckBox(
+            self.tr("Enable notifications"), self,
+            toolTip="Pull and display a notification feed."
+        )
+        self.bind(cb, "checked", "notifications/check-notifications")
+
+        layout.addWidget(cb)
+        box.setLayout(layout)
+        form.addRow(self.tr("On startup"), box)
+
         notifs = QWidget(self, objectName="notifications-group")
         notifs.setLayout(QVBoxLayout())
         notifs.layout().setContentsMargins(0, 0, 0, 0)
@@ -68,8 +81,8 @@ class OUserSettingsDialog(UserSettingsDialog):
                                 "We'll only send you the highlights.")
         cb3 = QCheckBox(self.tr("New features"), self,
                         toolTip="Show notifications about new features in Orange when a new "
-                                "version is downloaded and installed, should the new version "
-                                "entail notable updates.")
+                                "version is downloaded and installed,\n"
+                                "should the new version entail notable updates.")
 
         self.bind(cb1, "checked", "notifications/announcements")
         self.bind(cb2, "checked", "notifications/blog")


### PR DESCRIPTION
##### Description of changes
Adds a toggleable option to enable/disable pulling the notification feed (default enabled). Note, this does not affect the update check notification.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
