### PR TITLE
Machine ID initialization, inclusion in useragent string and statistics sessions

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -322,6 +322,12 @@ def send_usage_statistics():
             log.info("Not sending usage statistics (disabled).")
             return
 
+        if settings.contains('error-reporting/machine-id'):
+            machine_id = settings.value('error-reporting/machine-id')
+        else:
+            machine_id = uuid.uuid4()
+            settings.setValue('error-reporting/machine-id', machine_id)
+
         is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
 
         usage = UsageStatistics()
@@ -329,6 +335,7 @@ def send_usage_statistics():
         for d in data:
             d["Orange Version"] = d.pop("Application Version", "")
             d["Anaconda"] = is_anaconda
+            d["UUID"] = machine_id
         try:
             r = requests.post(url, files={'file': json.dumps(data)})
             if r.status_code != 200:

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -14,8 +14,8 @@ import gc
 import re
 import time
 import logging
-import signal
 from logging.handlers import RotatingFileHandler
+import signal
 import optparse
 import pickle
 import shlex
@@ -33,28 +33,25 @@ from AnyQt.QtCore import (
 import pyqtgraph
 
 import orangecanvas
-from Orange import canvas
-from orangecanvas.registry import qt
-from orangecanvas.registry import WidgetRegistry, set_global_registry
-from orangecanvas.registry import cache
+from orangecanvas import config as canvasconfig
+from orangecanvas.registry import qt, WidgetRegistry, set_global_registry, cache
 from orangecanvas.application.application import CanvasApplication
 from orangecanvas.application.outputview import TextStream, ExceptHook
 from orangecanvas.document.usagestatistics import UsageStatistics
 from orangecanvas.gui.splashscreen import SplashScreen
 from orangecanvas.utils.overlay import Notification, NotificationServer
-from orangecanvas import config as canvasconfig
 from orangecanvas.main import (
     fix_win_pythonw_std_stream, fix_set_proxy_env, fix_macos_nswindow_tabbing,
     breeze_dark,
 )
 
 from orangewidget.workflow.errorreporting import handle_exception
-from Orange.util import literal_eval, requirementsSatisfied
 
+from Orange import canvas
+from Orange.util import literal_eval, requirementsSatisfied, resource_filename
+from Orange.version import version as current, release as is_release
 from Orange.canvas import config
 from Orange.canvas.mainwindow import MainWindow
-from Orange.util import resource_filename
-from Orange.version import version as current, release as is_release
 
 
 log = logging.getLogger(__name__)

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -2,6 +2,7 @@
 Orange Canvas main entry point
 
 """
+import uuid
 from collections import defaultdict
 from contextlib import closing
 
@@ -64,13 +65,16 @@ statistics_server_url = os.getenv(
 
 
 def ua_string():
+    settings = QSettings()
+
     is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
+    machine_id = settings.value("error-reporting/machine-id", "", str)
     return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}:{uuid}'.format(
         orange_version=current,
         py_version='.'.join(str(a) for a in sys.version_info[:3]),
         platform=sys.platform,
         conda='Anaconda' if is_anaconda else '',
-        uuid=QSettings().value("error-reporting/machine-id", "", str),
+        uuid=machine_id if settings.value("error-reporting/send-statistics", False, bool) else ''
     )
 
 


### PR DESCRIPTION
##### Description of changes
- [X] Add machine ID to useragent string only if statistics sending is enabled
- [X] Refactor statistics request notification into a YAML notification https://github.com/biolab/orange-notification-feed/pull/1
- [X] Upon responding to notification, generate machine ID
- [X] Add machine ID to statistics sessions as a UUID

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
