### PR TITLE
Update deprecated methods

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -663,7 +663,7 @@ def main(argv=None):
         stdout.flushed.connect(sys.stdout.flush)
 
     stderr = TextStream()
-    error_writer = log_view.formated(color=Qt.red)
+    error_writer = log_view.formatted(color=Qt.red)
     stderr.stream.connect(error_writer.write)
     if sys.stderr:
         stderr.stream.connect(sys.stderr.write)

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -52,6 +52,7 @@ from Orange.util import literal_eval, requirementsSatisfied, resource_filename
 from Orange.version import version as current, release as is_release
 from Orange.canvas import config
 from Orange.canvas.mainwindow import MainWindow
+from Orange.widgets.settings import widget_settings_dir
 
 
 log = logging.getLogger(__name__)
@@ -469,15 +470,12 @@ def main(argv=None):
     sql_level = min(levels[options.log_level], logging.INFO)
     make_sql_logger(sql_level)
 
-    clear_settings_flag = os.path.join(
-        config.widget_settings_dir(), "DELETE_ON_START")
+    clear_settings_flag = os.path.join(widget_settings_dir(), "DELETE_ON_START")
 
     if options.clear_widget_settings or \
             os.path.isfile(clear_settings_flag):
         log.info("Clearing widget settings")
-        shutil.rmtree(
-            config.widget_settings_dir(),
-            ignore_errors=True)
+        shutil.rmtree(widget_settings_dir(), ignore_errors=True)
 
     # Set http_proxy environment variables, after (potentially) clearing settings
     fix_set_proxy_env()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Deprecation warnings when running Orange.

##### Description of changes
- Change `formated` -> `formatted`
(https://github.com/biolab/orange-canvas-core/commit/36142fb48d46e9ca178501ca2668cdcdb30f1c13)
- Change `Orange.canvas.config.widget_settings_dir` -> `Orange.widgets.settings.widget_settings_dir`
(#3932) 

@ales-erjavec Can you double check that the second one is the correct new way of getting widgets settings dir?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
