### PR TITLE
OW: auto_commit -> auto_send and auto_apply

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -326,9 +326,7 @@ class OWColor(widget.OWWidget):
         self.cont_model.dataChanged.connect(self._on_data_changed)
         box.layout().addWidget(cont_view)
 
-        box = gui.auto_commit(
-            self.controlArea, self, "auto_apply", "Apply",
-            orientation=Qt.Horizontal, checkbox_label="Apply automatically")
+        box = gui.auto_apply(self.controlArea, self, "auto_apply")
         box.button.setFixedWidth(180)
         box.layout().insertStretch(0)
 

--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -132,9 +132,7 @@ class OWConcatenate(widget.OWWidget):
         cb.disables.append(ibox)
         cb.makeConsistent()
 
-        box = gui.auto_commit(
-            self.controlArea, self, "auto_commit", "Apply", commit=self.apply,
-            orientation=Qt.Horizontal, checkbox_label="Apply automatically")
+        box = gui.auto_apply(self.controlArea, self, "auto_commit", commit=self.apply)
         box.button.setFixedWidth(180)
         box.layout().insertStretch(0)
 

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -94,7 +94,7 @@ class OWContinuize(widget.OWWidget):
             btnLabels=self.value_ranges,
             callback=self.settings_changed)
 
-        gui.auto_commit(self.buttonsArea, self, "autosend", "Apply", box=False)
+        gui.auto_apply(self.buttonsArea, self, "autosend", box=False)
 
         self.data = None
 

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -234,7 +234,7 @@ class OWDataSets(OWWidget):
         )
         self.mainArea.layout().addWidget(self.splitter)
         self.controlArea.layout().addStretch(10)
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Send Data")
+        gui.auto_send(self.controlArea, self, "auto_commit")
 
         proxy = QSortFilterProxyModel()
         proxy.setFilterKeyColumn(-1)

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -239,9 +239,7 @@ class OWDiscretize(widget.OWWidget):
 
         self.controlbox = controlbox
 
-        box = gui.auto_commit(self.controlArea, self, "autosend", "Apply",
-                              orientation=Qt.Horizontal,
-                              checkbox_label="Apply automatically")
+        box = gui.auto_apply(self.controlArea, self, "autosend")
         box.button.setFixedWidth(180)
         box.layout().insertStretch(0)
 

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -754,10 +754,7 @@ class OWFeatureStatistics(widget.OWWidget):
         self.cb_color_var.activated.connect(self.__color_var_changed)
 
         gui.rubber(self.controlArea)
-        gui.auto_commit(
-            self.buttonsArea, self, 'auto_commit', 'Send Selected Rows',
-            'Send Automatically',
-        )
+        gui.auto_send(self.buttonsArea, self, "auto_commit")
 
         # Main area
         self.model = FeatureStatisticsTableModel(parent=self)

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -245,10 +245,7 @@ class OWImpute(OWWidget):
 
         self.variable_button_group = button_group
 
-        box = gui.auto_commit(
-            self.controlArea, self, "autocommit", "Apply",
-            orientation=Qt.Horizontal,
-            checkbox_label="Apply automatically")
+        box = gui.auto_apply(self.controlArea, self, "autocommit")
         box.button.setFixedWidth(180)
         box.layout().insertStretch(0)
 

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -264,8 +264,7 @@ class OWMergeData(widget.OWWidget):
         box = gui.vBox(self.controlArea, box="Row matching")
         box.layout().addWidget(self.attr_boxes)
 
-        gui.auto_commit(self.controlArea, self, "auto_apply", "&Apply",
-                        box=False)
+        gui.auto_apply(self.controlArea, self, box=False)
         # connect after wrapping self.commit with gui.auto_commit!
         self.attr_boxes.vars_changed.connect(self.commit)
         self.settingsAboutToBePacked.connect(self.store_combo_state)

--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -86,8 +86,7 @@ class OWNeighbors(OWWidget):
             # call apply by gui.auto_commit, pylint: disable=unnecessary-lambda
             callback=lambda: self.apply())
 
-        self.apply_button = gui.auto_commit(
-            self.controlArea, self, "auto_apply", "&Apply", commit=self.apply)
+        self.apply_button = gui.auto_apply(self.controlArea, self, commit=self.apply)
 
     def _set_label_text(self, name):
         data = getattr(self, name)

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -934,8 +934,7 @@ class OWPaintData(OWWidget):
             tBox, self, "Reset to Input Data", self.reset_to_input)
         self.btResetToInput.setDisabled(True)
 
-        gui.auto_commit(self.controlArea, self, "autocommit",
-                        "Send")
+        gui.auto_send(self.controlArea, self, "autocommit")
 
         # main area GUI
         viewbox = PaintViewBox(enableMouse=False)

--- a/Orange/widgets/data/owpivot.py
+++ b/Orange/widgets/data/owpivot.py
@@ -709,7 +709,7 @@ class OWPivot(OWWidget):
                      callback=self.__val_feature_changed)
         self.__add_aggregation_controls()
         gui.rubber(self.controlArea)
-        gui.auto_commit(self.controlArea, self, "auto_commit", "&Apply")
+        gui.auto_apply(self.controlArea, self, "auto_commit")
 
     def __add_aggregation_controls(self):
         box = gui.vBox(self.controlArea, "Aggregations")

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1036,7 +1036,7 @@ class OWPreprocess(widget.OWWidget):
         self.flow_view.installEventFilter(self)
 
         box = gui.vBox(self.controlArea, "Output")
-        gui.auto_commit(box, self, "autocommit", "Send", box=False)
+        gui.auto_send(box, self, "autocommit", box=False)
 
         self._initialize()
 

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -97,8 +97,7 @@ class OWPurgeDomain(widget.OWWidget):
                 gui.separator(box3, 2)
             gui.label(box3, self, "{}: %({})s".format(label, value))
 
-        gui.auto_commit(self.buttonsArea, self, "autoSend", "Apply",
-                        orientation=Qt.Horizontal)
+        gui.auto_send(self.buttonsArea, self, "autoSend")
         gui.rubber(self.controlArea)
 
     @Inputs.data

--- a/Orange/widgets/data/owrandomize.py
+++ b/Orange/widgets/data/owrandomize.py
@@ -67,9 +67,7 @@ class OWRandomize(OWWidget):
             box, self, "random_seed", "Replicable shuffling",
             callback=self._shuffle_check_changed)
 
-        self.apply_button = gui.auto_commit(
-            self.controlArea, self, "auto_apply", "&Apply",
-            box=False, commit=self.apply)
+        self.apply_button = gui.auto_apply(self.controlArea, self, box=False, commit=self.apply)
 
     @property
     def parts(self):

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -291,7 +291,7 @@ class OWRank(OWWidget):
 
         selMethBox.layout().addLayout(grid)
 
-        gui.auto_commit(selMethBox, self, "auto_apply", "Send", box=False)
+        gui.auto_send(selMethBox, self, "auto_apply", box=False)
 
         self.resize(690, 500)
 

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -251,7 +251,7 @@ class OWSelectAttributes(widget.OWWidget):
         self.down_meta_button = gui.button(bbox, self, "Down",
                                            callback=partial(self.move_down, self.meta_attrs_view))
 
-        autobox = gui.auto_commit(None, self, "auto_commit", "Send")
+        autobox = gui.auto_send(None, self, "auto_commit")
         layout.addWidget(autobox, 3, 0, 1, 3)
         reset = gui.button(None, self, "Reset", callback=self.reset, width=120)
         autobox.layout().insertWidget(0, reset)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -215,9 +215,7 @@ class OWSelectRows(widget.OWWidget):
         gui.rubber(self.buttonsArea.layout())
         layout.addWidget(self.buttonsArea, 1, 0)
 
-        acbox = gui.auto_commit(
-            None, self, "auto_commit", label="Send", orientation=Qt.Horizontal,
-            checkbox_label="Send automatically")
+        acbox = gui.auto_send(None, self, "auto_commit")
         layout.addWidget(acbox, 1, 1)
 
         self.set_data(None)

--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -437,8 +437,7 @@ class OWDataTable(OWWidget):
             None, self, "Restore Original Order", callback=self.restore_order,
             tooltip="Show rows in the original order", autoDefault=False)
         self.buttonsArea.layout().insertWidget(0, reset)
-        gui.auto_commit(self.buttonsArea, self, "auto_commit",
-                        "Send Selected Rows", "Send Automatically")
+        gui.auto_send(self.buttonsArea, self, "auto_commit")
 
         # GUI with tabs
         self.tabs = gui.tabWidget(self.mainArea)

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -67,9 +67,7 @@ class OWTranspose(OWWidget):
             "feature_names_column", contentsLength=12,
             callback=self._feature_combo_changed, model=self.feature_model)
 
-        self.apply_button = gui.auto_commit(
-            self.controlArea, self, "auto_apply", "&Apply",
-            box=False, commit=self.apply)
+        self.apply_button = gui.auto_apply(self.controlArea, self, box=False, commit=self.apply)
         self.apply_button.button.setAutoDefault(False)
 
         self.set_controls()

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -154,8 +154,7 @@ class OWCalibrationPlot(widget.OWWidget):
         self.info_box = gui.widgetBox(self.controlArea, "Info")
         self.info_label = gui.widgetLabel(self.info_box)
 
-        gui.auto_commit(
-            self.controlArea, self, "auto_commit", "Apply", commit=self.apply)
+        gui.auto_apply(self.controlArea, self, "auto_commit", commit=self.apply)
 
         self.plotview = pg.GraphicsView(background="w")
         self.plot = pg.PlotItem(enableMenu=False)

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -140,8 +140,7 @@ class OWConfusionMatrix(widget.OWWidget):
                      "Probabilities",
                      callback=self._invalidate)
 
-        gui.auto_commit(self.outputbox, self, "autocommit",
-                        "Send Selected", "Send Automatically", box=False)
+        gui.auto_apply(self.outputbox, self, "autocommit", box=False)
 
         self.mainArea.layout().setContentsMargins(0, 0, 0, 0)
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -21,7 +21,7 @@ from orangewidget.gui import (
     miscellanea, setLayout, separator, rubber, widgetBox, hBox, vBox,
     indentedBox, widgetLabel, label, spin, doubleSpin, checkBox, lineEdit,
     button, toolButton, radioButtons, radioButtonsInBox, appendRadioButton,
-    hSlider, labeledSlider, valueSlider, auto_commit,
+    hSlider, labeledSlider, valueSlider, auto_commit, auto_send, auto_apply,
 
     # ItemDataRole's
     BarRatioRole, BarBrushRole, SortOrderRole, LinkRole,
@@ -68,7 +68,7 @@ __all__ = [
     "checkBox", "lineEdit", "button", "toolButton",
     "radioButtons", "radioButtonsInBox", "appendRadioButton",
     "hSlider", "labeledSlider", "valueSlider",
-    "auto_commit", "ProgressBar",
+    "auto_commit", "auto_send", "auto_apply", "ProgressBar",
     "VerticalLabel", "tabWidget", "createTabPage", "table", "tableItem",
     "VisibleHeaderSectionContextEventFilter", "checkButtonOffsetHint",
     "toolButtonSizeHint", "FloatSlider", "ControlGetter",  "VerticalScrollArea",

--- a/Orange/widgets/unsupervised/owdbscan.py
+++ b/Orange/widgets/unsupervised/owdbscan.py
@@ -103,8 +103,7 @@ class OWDBSCAN(widget.OWWidget):
                      items=list(zip(*self.METRICS))[0],
                      callback=self._metirc_changed)
 
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Apply",
-                        orientation=Qt.Horizontal)
+        gui.auto_apply(self.controlArea, self, "auto_commit")
         gui.rubber(self.controlArea)
 
         self.controlArea.layout().addStretch()

--- a/Orange/widgets/unsupervised/owdbscan.py
+++ b/Orange/widgets/unsupervised/owdbscan.py
@@ -1,9 +1,7 @@
 import sys
 
 import numpy as np
-from scipy import spatial
 from AnyQt.QtWidgets import QApplication
-from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QColor
 from sklearn.metrics import pairwise_distances
 

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -338,8 +338,7 @@ class OWDistanceMap(widget.OWWidget):
         self.annot_combo.model()[:] = ["None", "Enumeration"]
         self.controlArea.layout().addStretch()
 
-        gui.auto_commit(self.controlArea, self, "autocommit",
-                        "Send Selected")
+        gui.auto_send(self.controlArea, self, "autocommit")
 
         self.view = pg.GraphicsView(background="w")
         self.mainArea.layout().addWidget(self.view)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -250,8 +250,7 @@ class OWDistanceMatrix(widget.OWWidget):
         self.annot_combo.setModel(VariableListModel())
         self.annot_combo.model()[:] = ["None", "Enumeration"]
         gui.rubber(settings_box)
-        acb = gui.auto_commit(settings_box, self, "auto_commit",
-                              "Send Selected", "Send Automatically", box=None)
+        acb = gui.auto_send(settings_box, self, "auto_commit", box=None)
         acb.setFixedWidth(200)
         # Signal must be connected after self.commit is redirected
         selmodel.selectionChanged.connect(self.commit)

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -86,7 +86,7 @@ class OWDistances(OWWidget):
         _, metric = METRICS[self.metric_idx]
         self.normalization_check.setEnabled(metric.supports_normalization)
 
-        gui.auto_commit(self.controlArea, self, "autocommit", "Apply")
+        gui.auto_apply(self.controlArea, self, "autocommit")
         self.layout().setSizeConstraint(self.layout().SetFixedSize)
 
     @Inputs.data

--- a/Orange/widgets/unsupervised/owdistancetransformation.py
+++ b/Orange/widgets/unsupervised/owdistancetransformation.py
@@ -58,7 +58,7 @@ class OWDistanceTransformation(widget.OWWidget):
                          btnLabels=[x[0] for x in self.inversion_options],
                          callback=self._invalidate)
 
-        gui.auto_commit(self.controlArea, self, "autocommit", "Apply")
+        gui.auto_apply(self.controlArea, self, "autocommit")
 
     @Inputs.distances
     def set_data(self, data):

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1011,8 +1011,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         ibox.layout().addLayout(form)
         ibox.layout().addSpacing(5)
 
-        gui.auto_commit(box, self, "autocommit", "Send Selected", "Send Automatically",
-                        box=False)
+        gui.auto_send(box, self, "autocommit", box=False)
 
         self.scene = QGraphicsScene()
         self.view = StickyGraphicsView(

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -215,9 +215,8 @@ class OWKMeans(widget.OWWidget):
             sb, self, "max_iterations", controlWidth=60, valueType=int,
             validator=QIntValidator(), callback=self.invalidate)
 
-        self.apply_button = gui.auto_commit(
-            self.buttonsArea, self, "auto_commit", "Apply", box=None,
-            commit=self.commit)
+        self.apply_button = gui.auto_apply(self.buttonsArea, self, "auto_commit", box=None,
+                                           commit=self.commit)
         gui.rubber(self.controlArea)
 
         box = gui.vBox(self.mainArea, box="Silhouette Scores")

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -139,10 +139,9 @@ class OWLouvainClustering(widget.OWWidget):
             "Smaller values tend to produce more clusters and larger values "
             "retrieve less clusters."
         )
-        self.apply_button = gui.auto_commit(
-            self.controlArea, self, "auto_commit", "Apply", box=None,
-            commit=lambda: self.commit(),
-            callback=lambda: self._on_auto_commit_changed(),
+        self.apply_button = gui.auto_apply(
+            self.controlArea, self, "auto_commit", box=None,
+            commit=lambda: self.commit(), callback=lambda: self._on_auto_commit_changed()
         )  # type: QWidget
 
     def _preprocess_data(self):

--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -269,9 +269,7 @@ class OWManifoldLearning(OWWidget):
             output_box, self, "n_components", 1, 10, label="Components:",
             alignment=Qt.AlignRight, callbackOnReturn=True,
             callback=self.settings_changed)
-        self.apply_button = gui.auto_commit(
-            self.controlArea, self, "auto_apply", "&Apply",
-            box=False, commit=self.apply)
+        self.apply_button = gui.auto_apply(self.controlArea, self, box=False, commit=self.apply)
 
     def manifold_method_changed(self):
         self.params_widget.hide()

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -100,8 +100,7 @@ class OWPCA(widget.OWWidget):
 
         self.controlArea.layout().addStretch()
 
-        gui.auto_commit(self.controlArea, self, "auto_commit", "Apply",
-                        checkbox_label="Apply automatically")
+        gui.auto_apply(self.controlArea, self, "auto_commit")
 
         self.plot = SliderGraph(
             "Principal Components", "Proportion of variance",

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -267,9 +267,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
             orientation=Qt.Horizontal, callback=self.learner_name_changed)
 
     def add_bottom_buttons(self):
-        self.apply_button = gui.auto_commit(
-            self.controlArea, self, 'auto_apply', '&Apply',
-            box=True, commit=self.apply)
+        self.apply_button = gui.auto_apply(self.controlArea, self, commit=self.apply)
 
     def send(self, signalName, value, id=None):
         # A subclass might still use the old syntax to send outputs

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -323,8 +323,7 @@ class OWDistributions(OWWidget):
             box, self, "show_probs", "Show probabilities",
             callback=self._on_show_probabilities_changed)
 
-        gui.auto_commit(
-            self.controlArea, self, "auto_apply", "&Apply", commit=self.apply)
+        gui.auto_apply(self.controlArea, self, commit=self.apply)
 
         self._set_smoothing_visibility()
         self._setup_plots()

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -567,12 +567,7 @@ class OWHeatMap(widget.OWWidget):
                      callback=self.__aspect_mode_changed)
 
         gui.rubber(self.controlArea)
-        gui.auto_commit(self.controlArea,
-                        self,
-                        "auto_commit",
-                        "Send Selection",
-                        "Send Automatically"
-                       )
+        gui.auto_send(self.controlArea, self, "auto_commit")
 
         # Scene with heatmap
         self.heatmap_scene = self.scene = HeatmapScene(parent=self)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -147,7 +147,7 @@ def leaf_indices(tree):
     return [leaf.value.index for leaf in hierarchical.leaves(tree)]
 
 
-def palette_gradient(colors, discrete=False):
+def palette_gradient(colors):
     n = len(colors)
     stops = np.linspace(0.0, 1.0, n, endpoint=True)
     gradstops = [(float(stop), color) for stop, color in zip(stops, colors)]

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -503,8 +503,7 @@ class OWLinePlot(OWWidget):
         plot_gui.box_zoom_select(self.controlArea)
 
         gui.rubber(self.controlArea)
-        gui.auto_commit(self.controlArea, self, "auto_commit",
-                        "Send Selection", "Send Automatically")
+        gui.auto_send(self.controlArea, self, "auto_commit")
 
     def __show_profiles_changed(self):
         self.check_display_options()

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -153,9 +153,7 @@ class OWSilhouettePlot(widget.OWWidget):
         # Thunk the call to commit to call conditional commit
         gui.checkBox(box, self, "add_scores", "Add silhouette scores",
                      callback=lambda: self.commit())
-        gui.auto_commit(
-            box, self, "auto_commit", "Commit",
-            auto_label="Auto commit", box=False)
+        gui.auto_send(box, self, "auto_commit", box=False)
         # Ensure that the controlArea is not narrower than buttonsArea
         self.controlArea.layout().addWidget(self.buttonsArea)
 

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -126,7 +126,7 @@ class OWVennDiagram(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Output")
         gui.checkBox(box, self, "output_duplicates", "Output duplicates",
                      callback=lambda: self.commit())
-        gui.auto_commit(box, self, "autocommit", "Send Selection", "Send Automatically", box=False)
+        gui.auto_send(box, self, "autocommit", box=False)
 
         # Main area view
         self.scene = QGraphicsScene()

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -417,8 +417,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         self.control_area_stretch = gui.widgetBox(area)
         self.control_area_stretch.layout().addStretch(100)
         self.gui.box_zoom_select(area)
-        gui.auto_commit(
-            area, self, "auto_commit", "Send Selection", "Send Automatically")
+        gui.auto_send(area, self, "auto_commit")
 
     @property
     def effective_variables(self):


### PR DESCRIPTION
##### Issue
#3910 

##### Description of changes
Import `auto_send` and `auto_apply` from orange widget base, and refactor calls to `auto_commit` in widgets. After this PR is merged, `auto_commit` will be deprecated in orange widget base.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation