### PR TITLE
[BUG] Predictions: Fix misaligned columns

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -305,7 +305,7 @@ class OWPredictions(OWWidget):
             name = learner_name(pred.predictor)
             head = QStandardItem(name)
             #            head.setData(key, Qt.UserRole)
-            row = [head]
+            row = [head, QStandardItem("N/A"), QStandardItem("N/A")]
             results = self.predictors[inputid].results
             if isinstance(results, str):
                 head.setToolTip(results)


### PR DESCRIPTION
##### Issue

Fixes #4029.

#3943 added two new columns that do not come from scorers. All widgets that use `Orange.widgets.evaluate.ScoreTable` need to adapt the models. Fortunately, there is only one, Predictions (besides Test and Score). Unfortunately, it was not adapted. :)

##### Description of changes

The first two columns are now initialized to N/A.

##### Includes
- [X] Code changes