### PR TITLE
Add white background to Pivot Table icon

### DIFF
--- a/Orange/widgets/data/icons/Pivot.svg
+++ b/Orange/widgets/data/icons/Pivot.svg
@@ -16,7 +16,7 @@
 	.st10{fill:none;stroke:#333333;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:10;}
 </style>
 <g>
-	<rect x="6.9" y="11.1" class="st2" width="34.3" height="25.7"/>
+	<rect x="6.9" y="11.1" class="st2" width="34.3" height="25.7" fill="white"/>
 	<line class="st2" x1="6.9" y1="19.7" x2="41.1" y2="19.7"/>
 	<line class="st2" x1="6.9" y1="28.3" x2="41.1" y2="28.3"/>
 	<line class="st2" x1="15.4" y1="11.1" x2="15.4" y2="36.9"/>


### PR DESCRIPTION
##### Description of changes
Adds a white background to pivot table's icon. I believe that with this change, all data widgets are correctly transparent/have a white background.

Other widgets should be inspected too (some that come to mind: Box Plot, Save Distances).
