### PR TITLE
[FIX] Color widget failed after removing Variable.make

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -195,8 +195,6 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertIsNone(var._colors)
         self.assertEqual(var.colors.shape, (2, 3))
-        self.assertIs(var._colors, var.colors)
-        self.assertEqual(var.colors.shape, (2, 3))
         self.assertFalse(var.colors.flags.writeable)
 
         var.colors = np.arange(6).reshape((2, 3))
@@ -204,8 +202,6 @@ class TestDiscreteVariable(VariableTest):
         self.assertFalse(var.colors.flags.writeable)
         with self.assertRaises(ValueError):
             var.colors[0] = [42, 41, 40]
-        var.set_color(0, [42, 41, 40])
-        np.testing.assert_almost_equal(var.colors, [[42, 41, 40], [3, 4, 5]])
 
         var = DiscreteVariable.make("x", values=["A", "B"])
         var.attributes["colors"] = ['#0a0b0c', '#0d0e0f']
@@ -216,11 +212,8 @@ class TestDiscreteVariable(VariableTest):
         self.assertEqual(len(var.colors), 2)
         var.add_value('e')
         self.assertEqual(len(var.colors), 3)
-        user_defined = (0, 0, 0)
-        var.set_color(2, user_defined)
         var.add_value('k')
         self.assertEqual(len(var.colors), 4)
-        np.testing.assert_array_equal(var.colors[2], user_defined)
 
     def test_no_nonstringvalues(self):
         self.assertRaises(TypeError, DiscreteVariable, "foo", values=["a", 42])
@@ -433,7 +426,6 @@ class TestContinuousVariable(VariableTest):
     def test_colors(self):
         a = ContinuousVariable("a")
         self.assertEqual(a.colors, ((0, 0, 255), (255, 255, 0), False))
-        self.assertIs(a.colors, a._colors)
 
         a = ContinuousVariable("a")
         a.attributes["colors"] = ['#010203', '#040506', True]

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -696,13 +696,15 @@ class DiscreteVariable(Variable):
     def colors(self):
         if self._colors is not None:
             colors = np.array(self._colors)
+        elif not self.values:
+            colors = np.zeros((0, 3))  # to match additional colors in vstacks
         else:
             from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
             default = tuple(ColorPaletteGenerator.palette(self))
             colors = self.attributes.get('colors', ())
             colors = tuple(hex_to_color(color) for color in colors) \
                     + default[len(colors):]
-        colors = np.array(colors)
+            colors = np.array(colors)
         colors.flags.writeable = False
         return colors
 

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -11,7 +11,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from Orange.data import _variable
-from Orange.util import Registry, color_to_hex, hex_to_color, Reprable, \
+from Orange.util import Registry, hex_to_color, Reprable,\
     OrangeDeprecationWarning
 
 __all__ = ["Unknown", "MISSING_VALUES", "make_variable", "is_discrete_values",
@@ -326,6 +326,14 @@ class Variable(Reprable, metaclass=VariableMeta):
     def name(self):
         return self._name
 
+    @property
+    def colors(self):  # unreachable; pragma: no cover
+        return self._colors
+
+    @colors.setter
+    def colors(self, value):
+        self._colors = value
+
     def make_proxy(self):
         """
         Copy the variable and set the master to `self.master` or to `self`.
@@ -513,22 +521,16 @@ class ContinuousVariable(Variable):
     def format_str(self, value):
         self._format_str = value
 
-    @property
+    @Variable.colors.getter
     def colors(self):
-        if self._colors is None:
-            try:
-                col1, col2, black = self.attributes["colors"]
-                self._colors = (hex_to_color(col1), hex_to_color(col2), black)
-            except (KeyError, ValueError):
-                # Stored colors were not available or invalid, use defaults
-                self._colors = ((0, 0, 255), (255, 255, 0), False)
-        return self._colors
-
-    @colors.setter
-    def colors(self, value):
-        col1, col2, black = self._colors = value
-        self.attributes["colors"] = \
-            [color_to_hex(col1), color_to_hex(col2), black]
+        if self._colors is not None:
+            return self._colors
+        try:
+            col1, col2, black = self.attributes["colors"]
+            return (hex_to_color(col1), hex_to_color(col2), black)
+        except (KeyError, ValueError):
+            # User-provided colors were not available or invalid
+            return ((0, 0, 255), (255, 255, 0), False)
 
     # noinspection PyAttributeOutsideInit
     @number_of_decimals.setter
@@ -690,29 +692,19 @@ class DiscreteVariable(Variable):
 
         return mapper
 
-    @property
+    @Variable.colors.getter
     def colors(self):
-        if self._colors is None:
+        if self._colors is not None:
+            colors = np.array(self._colors)
+        else:
             from Orange.widgets.utils.colorpalette import ColorPaletteGenerator
-            self._colors = ColorPaletteGenerator.palette(self)
-            colors = self.attributes.get('colors')
-            if colors:
-                self._colors[:len(colors)] = [hex_to_color(color) for color in colors]
-            self._colors.flags.writeable = False
-        return self._colors
-
-    @colors.setter
-    def colors(self, value):
-        self._colors = value
-        self._colors.flags.writeable = False
-        self.attributes["colors"] = [color_to_hex(col) for col in value]
-
-    def set_color(self, i, color):
-        self.colors = self.colors
-        self._colors.flags.writeable = True
-        self._colors[i, :] = color
-        self._colors.flags.writeable = False
-        self.attributes["colors"][i] = color_to_hex(color)
+            default = tuple(ColorPaletteGenerator.palette(self))
+            colors = self.attributes.get('colors', ())
+            colors = tuple(hex_to_color(color) for color in colors) \
+                    + default[len(colors):]
+        colors = np.array(colors)
+        colors.flags.writeable = False
+        return colors
 
     def to_val(self, s):
         """

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -451,7 +451,7 @@ class Variable(Reprable, metaclass=VariableMeta):
         # Use make to unpickle variables.
         return make_variable, (self.__class__, self._compute_value, self.name), self.__dict__
 
-    def copy(self, compute_value=None, name=None, **kwargs):
+    def copy(self, compute_value=None, *, name=None, **kwargs):
         var = type(self)(name=name or self.name,
                          compute_value=compute_value or self.compute_value,
                          sparse=self.sparse, **kwargs)
@@ -565,7 +565,7 @@ class ContinuousVariable(Variable):
 
     str_val = repr_val
 
-    def copy(self, compute_value=None, name=None, **kwargs):
+    def copy(self, compute_value=None, *, name=None, **kwargs):
         var = super().copy(compute_value=compute_value, name=name,
                            number_of_decimals=self.number_of_decimals,
                            **kwargs)
@@ -789,22 +789,7 @@ class DiscreteVariable(Variable):
                                self.values, self.ordered), \
             __dict__
 
-    @staticmethod
-    def ordered_values(values):
-        """
-        Return a sorted list of values. If there exists a prescribed order for
-        such set of values, it is returned. Otherwise, values are sorted
-        alphabetically.
-        """
-        for presorted in DiscreteVariable.presorted_values:
-            if values == set(presorted):
-                return presorted
-        try:
-            return sorted(values, key=float)
-        except ValueError:
-            return sorted(values)
-
-    def copy(self, compute_value=None, name=None, **_):
+    def copy(self, compute_value=None, *, name=None, **_):
         return super().copy(compute_value=compute_value, name=name,
                             values=self.values, ordered=self.ordered)
 
@@ -920,7 +905,7 @@ class TimeVariable(ContinuousVariable):
         self.have_date = have_date
         self.have_time = have_time
 
-    def copy(self, compute_value=None, name=None, **_):
+    def copy(self, compute_value=None, *, name=None, **_):
         return super().copy(compute_value=compute_value, name=name,
                             have_date=self.have_date, have_time=self.have_time)
 

--- a/Orange/widgets/data/tests/test_owcolor.py
+++ b/Orange/widgets/data/tests/test_owcolor.py
@@ -1,16 +1,20 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
-from unittest.mock import patch
+# pylint: disable=missing-docstring, protected-access
+import unittest
+from unittest.mock import patch, Mock
+
+import numpy as np
+from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QColor
 
 from Orange.data import Table, ContinuousVariable, Domain
-from Orange.widgets.data.owcolor import OWColor
+from Orange.widgets.data.owcolor import OWColor, ColorRole, DiscColorTableModel
 from Orange.widgets.tests.base import WidgetTest
 
 
 class TestOWColor(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWColor)
-
         self.iris = Table("iris")
 
     def test_reuse_old_settings(self):
@@ -36,3 +40,97 @@ class TestOWColor(WidgetTest):
             commit.reset_mock()
             self.send_signal(self.widget.Inputs.data, self.iris)
             commit.assert_called()
+
+    def test_lose_data(self):
+        widget = self.widget
+        send = widget.Outputs.data.send = Mock()
+
+        self.send_signal(widget.Inputs.data, self.iris)
+        send.assert_called_once()
+        self.assertEqual(widget.disc_model.rowCount(), 1)
+        self.assertEqual(widget.cont_model.rowCount(), 4)
+
+        send.reset_mock()
+        self.send_signal(widget.Inputs.data, None)
+        send.assert_called_with(None)
+        self.assertEqual(widget.disc_model.rowCount(), 0)
+        self.assertEqual(widget.cont_model.rowCount(), 0)
+
+    def test_base_model(self):
+        widget = self.widget
+        dm = widget.disc_model
+        cm = widget.disc_model
+
+        data = Table("heart_disease")
+        self.send_signal(widget.Inputs.data, data)
+        self.assertEqual(
+            [dm.data(dm.index(i, 0)) for i in range(dm.rowCount())],
+            [var.name for var in data.domain.variables if var.is_discrete]
+        )
+        self.assertEqual(
+            [dm.data(cm.index(i, 0)) for i in range(cm.rowCount())],
+            [var.name for var in data.domain.variables if var.is_discrete]
+        )
+
+        dm.setData(dm.index(1, 0), "foo", Qt.EditRole)
+        self.assertEqual(dm.data(dm.index(1, 0)), "foo")
+        self.assertEqual(widget.disc_colors[1].name, "foo")
+
+        widget.disc_colors[1].name = "bar"
+        self.assertEqual(dm.data(dm.index(1, 0)), "bar")
+
+    def test_disc_model(self):
+        widget = self.widget
+        dm = widget.disc_model
+
+        data = Table("heart_disease")
+        self.send_signal(widget.Inputs.data, data)
+
+        # Consider these two as sanity checks
+        self.assertEqual(dm.data(dm.index(0, 0)), "gender")
+        self.assertEqual(dm.data(dm.index(1, 0)), "chest pain")
+
+        self.assertEqual(dm.columnCount(), 5)  # 1 + four types of chest pain
+        self.assertEqual(dm.data(dm.index(0, 1)), "female")
+        self.assertEqual(dm.data(dm.index(0, 2)), "male")
+        self.assertIsNone(dm.data(dm.index(0, 3)))
+        self.assertIsNone(dm.data(dm.index(0, 4)))
+        self.assertIsNone(dm.data(dm.index(0, 3), ColorRole))
+        self.assertIsNone(dm.data(dm.index(0, 3), Qt.DecorationRole))
+        self.assertIsNone(dm.data(dm.index(0, 3), Qt.ToolTipRole))
+
+        chest_pain = data.domain["chest pain"]
+        self.assertEqual(
+            [dm.data(dm.index(1, i)) for i in range(1, 5)],
+            list(chest_pain.values))
+        np.testing.assert_equal(
+            [dm.data(dm.index(1, i), ColorRole) for i in range(1, 5)],
+            list(chest_pain.colors))
+        self.assertEqual(
+            [dm.data(dm.index(1, i), Qt.DecorationRole) for i in range(1, 5)],
+            [QColor(*color) for color in chest_pain.colors])
+        self.assertEqual(
+            [dm.data(dm.index(1, i), Qt.ToolTipRole) for i in range(1, 5)],
+            list(map(DiscColorTableModel._encode_color, chest_pain.colors)))
+
+        dm.setData(dm.index(0, 1), "F", Qt.EditRole)
+        self.assertEqual(dm.data(dm.index(0, 1)), "F")
+        self.assertEqual(widget.disc_colors[0].values, ["F", "male"])
+
+        widget.disc_colors[0].values[1] = "M"
+        self.assertEqual(dm.data(dm.index(0, 2)), "M")
+
+        dm.setData(dm.index(0, 1), (1, 2, 3, 4), ColorRole)
+        self.assertEqual(list(dm.data(dm.index(0, 1), ColorRole)), [1, 2, 3])
+        self.assertEqual(list(widget.disc_colors[0].colors[0]), [1, 2, 3])
+
+        widget.disc_colors[0].colors[1] = (4, 5, 6)
+        self.assertEqual(list(dm.data(dm.index(0, 2), ColorRole)), [4, 5, 6])
+
+    def test_report(self):
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.widget.send_report()  # don't crash
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

After removing `Variable.make`, `OWColor` fails when loading settings because it tries to set `Variable.name` when loading settings.

The widget was misbehaving badly. `set_data` constructed the output table(!) and modified its attributes (not only colors but also names!). This most probably also broke `Domain`'s dictionary `_indices`.

##### Description of changes

Fixing this required reimplementing the way in which the widget stores the data. Instead of storing variables, it stores the data (names, colors) and constructs variables before sending output.

#3822 could have also been the result of the questionable behaviour of the widget and may be fixed with this PR.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
