### PR TITLE
OWPCA: Fix invalid callback on treshold drag

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -199,18 +199,19 @@ class OWPCA(widget.OWWidget):
         self._update_axis()
 
     def _on_cut_changed(self, components):
+        if components == self.ncomponents \
+                or self.ncomponents == 0 \
+                or self._pca is not None \
+                and components == len(self._variance_ratio):
+            return
 
-        if not (self.ncomponents == 0 and
-                components == len(self._variance_ratio)):
-            self.ncomponents = components
-
+        self.ncomponents = components
         if self._pca is not None:
             var = self._cumulative[components - 1]
             if numpy.isfinite(var):
                 self.variance_covered = int(var * 100)
 
-        if components != self._nselected_components():
-            self._invalidate_selection()
+        self._invalidate_selection()
 
     def _update_selection_component_spin(self):
         # cut changed by "ncomponents" spin.

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
-from unittest.mock import patch
+# pylint: disable=missing-docstring, protected-access
+import unittest
+from unittest.mock import patch, Mock
 
 import numpy as np
 
@@ -203,3 +204,22 @@ class TestOWPCA(WidgetTest):
         self.widget.set_data(data)
         ndata = Table("iris.tab")
         self.assertEqual(data.domain[0], ndata.domain[0])
+
+    def test_on_cut_changed(self):
+        widget = self.widget
+        widget.ncomponents = 2
+        invalidate = widget._invalidate_selection = Mock()
+        widget._on_cut_changed(2)
+        invalidate.assert_not_called()
+        widget._on_cut_changed(3)
+        invalidate.assert_called()
+
+        widget.ncomponents = 0  # Take all components
+        invalidate.reset_mock()
+        widget._on_cut_changed(1)
+        invalidate.assert_not_called()
+        self.assertEqual(widget.ncomponents, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #4037.

##### Description of changes

Don't check whether new number of components equals the original after already updating the original.

If `_nselected_components` was called for side effects, it shouldn't had been: `self.ncomponents` cannot be out of range, and the only effect or computing `self.ncomponents` from `self.variance_covered` (which has itself been just computed from `self.ncomponets`) can be problems due to rounding.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
