### PR TITLE
[FIX] Deprecated processEvents argument in Test&Score

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -677,7 +677,7 @@ class OWTestLearners(OWWidget):
 
     @Slot(float)
     def setProgressValue(self, value):
-        self.progressBarSet(value, processEvents=False)
+        self.progressBarSet(value)
 
     def __update(self):
         self.__needupdate = False
@@ -821,7 +821,7 @@ class OWTestLearners(OWWidget):
         task.future = self.__executor.submit(testfunc)
         task.future.add_done_callback(ondone)
 
-        self.progressBarInit(processEvents=None)
+        self.progressBarInit()
         self.setBlocking(True)
         self.setStatusMessage("Running")
 
@@ -838,7 +838,7 @@ class OWTestLearners(OWWidget):
             return
 
         self.setBlocking(False)
-        self.progressBarFinished(processEvents=None)
+        self.progressBarFinished()
         self.setStatusMessage("")
         result = task.future
         assert result.done()

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 # pylint: disable=protected-access
 import unittest
+import warnings
 
 import numpy as np
 from AnyQt.QtCore import Qt
@@ -381,6 +382,14 @@ class TestOWTestLearners(WidgetTest):
                     Table("iris")[::15], None, LogisticRegressionLearner(),
                     OWTestLearners.KFold, 0),
                 (0.8, 0.5, 0.5, 0.5, 0.5))))
+
+    def test_no_pregressbar_warning(self):
+        data = Table("iris")[::15]
+
+        with warnings.catch_warnings(record=True) as w:
+            self.send_signal(self.widget.Inputs.train_data, data)
+            self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0)
+            assert not w
 
 
 class TestHelpers(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Fix ```FutureWarning: 'processEvents' argument is deprecated.``` by removing the argument
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
