### PR TITLE
[RFC] Short names for widgets whose name elides in toolbox

### DIFF
--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -16,6 +16,7 @@ from Orange.widgets.widget import Output
 
 class OWLinearRegression(OWBaseLearner):
     name = "Linear Regression"
+    short_name = "Lin Reg"
     description = "A linear regression algorithm with optional L1 (LASSO), " \
                   "L2 (ridge) or L1L2 (elastic net) regularization."
     icon = "icons/LinearRegression.svg"

--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -12,6 +12,7 @@ from Orange.widgets.utils.widgetpreview import WidgetPreview
 
 class OWLogisticRegression(OWBaseLearner):
     name = "Logistic Regression"
+    short_name = "Log Reg"
     description = "The logistic regression classification algorithm with " \
                   "LASSO (L1) or ridge (L2) regularization."
     icon = "icons/LogisticRegression.svg"

--- a/Orange/widgets/model/owsgd.py
+++ b/Orange/widgets/model/owsgd.py
@@ -17,6 +17,7 @@ MAXINT = 2 ** 31 - 1
 
 class OWSGD(OWBaseLearner):
     name = 'Stochastic Gradient Descent'
+    short_name = 'SGD'
     description = 'Minimize an objective function using a stochastic ' \
                   'approximation of gradient descent.'
     icon = "icons/SGD.svg"

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -172,6 +172,7 @@ N_ITERATIONS = 200
 
 class OWSOM(OWWidget):
     name = "Self-Organizing Map"
+    short_name = "SOM"
     description = "Computation of self-organizing map."
     icon = "icons/SOM.svg"
     keywords = ["SOM"]

--- a/doc/development/source/code/widgetTemplate.py
+++ b/doc/development/source/code/widgetTemplate.py
@@ -4,6 +4,7 @@ from Orange.widgets.settings import Setting
 
 class OWWidgetName(widget.OWWidget):
     name = "Widget Name"
+    short_name = "Name"
     id = "orange.widgets.widget_category.widget_name"
     description = ""
     icon = "icons/Unknown.svg"


### PR DESCRIPTION
RFC regarding the chosen widget short names (e.g. Randomize -> Random).

##### Relevant PRs
https://github.com/biolab/orange-canvas-core/pull/31
https://github.com/biolab/orange-widget-base/pull/16

##### Description of changes
In an effort to avoid eliding text in the toolbox, a `short_name` property was added to widgets and `WidgetDescription`, which overrides the text in the toolbox.

<img width="832" alt="Screenshot 2019-09-25 at 19 49 10" src="https://user-images.githubusercontent.com/24586651/65626504-d23ccb00-dfcd-11e9-90d6-0317f34270d2.png">


##### Includes
- [X] Code changes