### PR TITLE
[ENH] Datasets: Remove control area

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -457,7 +457,7 @@ class OWDataSets(OWWidget):
                 # TODO: There are possible pending __progress_advance queued
                 self.__awaiting_state.pb.advance.disconnect(
                     self.__progress_advance)
-                self.progressBarFinished(processEvents=None)
+                self.progressBarFinished()
                 self.__awaiting_state = None
 
             if not di.islocal:
@@ -465,7 +465,7 @@ class OWDataSets(OWWidget):
                 callback = lambda pr=pr: pr.advance.emit()
                 pr.advance.connect(self.__progress_advance, Qt.QueuedConnection)
 
-                self.progressBarInit(processEvents=None)
+                self.progressBarInit()
                 self.setStatusMessage("Fetching...")
                 self.setBlocking(True)
 
@@ -492,7 +492,7 @@ class OWDataSets(OWWidget):
         assert self.__awaiting_state.future is f
 
         if self.isBlocking():
-            self.progressBarFinished(processEvents=None)
+            self.progressBarFinished()
             self.setBlocking(False)
             self.setStatusMessage("")
 
@@ -514,7 +514,7 @@ class OWDataSets(OWWidget):
     @Slot()
     def __progress_advance(self):
         assert QThread.currentThread() is self.thread()
-        self.progressBarAdvance(1, processEvents=None)
+        self.progressBarAdvance(1)
 
     def onDeleteWidget(self):
         super().onDeleteWidget()

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest.mock import patch, Mock
 
 import requests
@@ -59,7 +60,7 @@ class TestOWDataSets(WidgetTest):
         # select the only dataset
         sel_type = QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows
         w.view.selectionModel().select(w.view.model().index(0, 0), sel_type)
-        w.unconditional_commit()
+        w.commit()
         iris = self.get_output(w.Outputs.data, w)
         self.assertEqual(len(iris), 150)
 
@@ -73,3 +74,7 @@ class TestOWDataSets(WidgetTest):
         w = self.create_widget(OWDataSets)  # type: OWDataSets
         self.wait_until_stop_blocking(w)
         self.assertEqual(w.view.model().rowCount(), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sapientem sat?

<img width="965" alt="Screenshot 2019-10-03 at 14 54 35" src="https://user-images.githubusercontent.com/2387315/66124700-c2387300-e5ed-11e9-8007-df2941339390.png">

(Fixes #4069.)

To show indicators with different colors, it needs https://github.com/biolab/orange-widget-base/pull/17. Before https://github.com/biolab/orange-widget-base/pull/17 is merged, indicators will remain black, as they are now, but the widget will still work.

##### Includes
- [X] Code changes
