### PR TITLE
OWScatterPlotGraph: Don't combine color and shape legend for different data

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1208,7 +1208,15 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         cont_color = self.master.is_continuous_color()
         shape_labels = self.master.get_shape_labels()
         color_labels = self.master.get_color_labels()
-        if shape_labels == color_labels and shape_labels is not None:
+        if not cont_color and shape_labels is not None \
+                and shape_labels == color_labels:
+            colors = self.master.get_color_data()
+            shapes = self.master.get_shape_data()
+            mask = np.isfinite(colors) * np.isfinite(shapes)
+            combined = (colors == shapes)[mask].all()
+        else:
+            combined = False
+        if combined:
             self._update_combined_legend(shape_labels)
         else:
             self._update_shape_legend(shape_labels)

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1105,6 +1105,10 @@ class TestOWScatterPlotBase(WidgetTest):
     def test_legend_combine(self):
         master = self.master
         graph = self.graph
+
+        master.get_shape_data = lambda: np.arange(10, dtype=float) % 3
+        master.get_color_data = lambda: 2 * np.arange(10, dtype=float) % 3
+
         graph.reset_graph()
 
         shape_legend = self.graph.shape_legend.setVisible = Mock()
@@ -1117,6 +1121,12 @@ class TestOWScatterPlotBase(WidgetTest):
         self.assertTrue(color_legend.call_args[0][0])
 
         master.get_color_labels = lambda: ["a", "b"]
+        graph.update_legends()
+        self.assertTrue(shape_legend.call_args[0][0])
+        self.assertTrue(color_legend.call_args[0][0])
+        self.assertEqual(len(graph.shape_legend.items), 2)
+
+        master.get_color_data = lambda: np.arange(10, dtype=float) % 3
         graph.update_legends()
         self.assertTrue(shape_legend.call_args[0][0])
         self.assertFalse(color_legend.call_args[0][0])


### PR DESCRIPTION
Fixes #4065.

This approach could be costly if getting the colors and sizes from master is slow -- which, I think, we said shouldn't be the case: the graph requests this data multiple times and the widget should have it cached if necessary.

The advantage of this approach is that it doesn't require a new function provided by widget.

@VesnaT's opinion would be appreciated.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
