### PR TITLE
Consider YAML Notification start and end dates inclusively

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -262,8 +262,8 @@ def pull_notifications():
 
         # check time validity
         today = date.today()
-        if (YAMLnotif.start and YAMLnotif.start >= today) or \
-                (YAMLnotif.end and YAMLnotif.end <= today):
+        if (YAMLnotif.start and YAMLnotif.start > today) or \
+                (YAMLnotif.end and YAMLnotif.end < today):
             return
 
         # check requirements


### PR DESCRIPTION
Previously, start and end dates were mistakenly implemented exclusively.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
