### PR TITLE
Do not mask import errors of the Orange.data._variable

### DIFF
--- a/Orange/__init__.py
+++ b/Orange/__init__.py
@@ -1,13 +1,6 @@
 # This module is a mixture of imports and code, so we allow import anywhere
 # pylint: disable=wrong-import-position,wrong-import-order
 
-try:
-    from Orange.data import _variable
-except ImportError:
-    raise ImportError("Compiled libraries cannot be found.\n"
-                      "Try reinstalling the package with:\n"
-                      "pip install --no-binary Orange3") from None
-
 from Orange import data
 
 from .misc.lazy_module import _LazyModule

--- a/Orange/util.py
+++ b/Orange/util.py
@@ -10,11 +10,6 @@ from itertools import chain, count, repeat
 from collections import OrderedDict, namedtuple
 import warnings
 
-try:
-    from AnyQt.QtCore import pyqtWrapperType
-except ImportError:
-    from sip import wrappertype as pyqtWrapperType
-
 # Exposed here for convenience. Prefer patching to try-finally blocks
 from unittest.mock import patch  # pylint: disable=unused-import
 


### PR DESCRIPTION
### Issue
Orange was trying to kind, but it was actually misleading.

Case: in a new virtualenv I did:

```
pip install sip pyqt5==5.9.2
pip install orange3
```

Then orange-canvas returned
```
Traceback (most recent call last):
  File "/home/marko/venvt/bin/orange-canvas", line 6, in <module>
    from Orange.canvas.__main__ import main
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/__init__.py", line 9, in <module>
    "pip install --no-binary Orange3") from None
ImportError: Compiled libraries cannot be found.
Try reinstalling the package with:
pip install --no-binary Orange3
```

When I changed the exception to catch something else I got:
```
Traceback (most recent call last):
  File "/home/marko/venvt/bin/orange-canvas", line 6, in <module>
    from Orange.canvas.__main__ import main
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/__init__.py", line 9, in <module>
    "pip install --no-binary Orange3") from None
ImportError: Compiled libraries cannot be found.
Try reinstalling the package with:
pip install --no-binary Orange3
(venvt) marko@niga2:~$ vim /home/marko/venvt/lib/python3.6/site-packages/Orange/__init__.py
(venvt) marko@niga2:~$ orange-canvas
Traceback (most recent call last):
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/util.py", line 14, in <module>
    from AnyQt.QtCore import pyqtWrapperType
  File "/home/marko/venvt/lib/python3.6/site-packages/AnyQt/QtCore.py", line 247, in <module>
    from PyQt5.QtCore import *
ModuleNotFoundError: No module named 'sip'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/marko/venvt/bin/orange-canvas", line 6, in <module>
    from Orange.canvas.__main__ import main
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/__init__.py", line 5, in <module>
    from Orange.data import _variable
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/data/__init__.py", line 4, in <module>
    from .variable import *
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/data/variable.py", line 12, in <module>
    from Orange.util import Registry, color_to_hex, hex_to_color, Reprable
  File "/home/marko/venvt/lib/python3.6/site-packages/Orange/util.py", line 16, in <module>
    from sip import wrappertype as pyqtWrapperType
ModuleNotFoundError: No module named 'sip'
```

Which clearly shows that Orange is  trying to be too smart. I also remember one user showing the first error and we did not know where it came from. Of course, if I fix my PyQt installation Orange starts working, but in the current state these kind of errors are impossible to debug.

And then, why do we need PyQt to import Orange.data.variable? I know that we do not advertise Orange as a library anymore, but still, Orange.util probably contains some things it should not. @irgolic?

##### Description of changes
Reverted #3614

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
