### PR TITLE
Update version constraint for orange-widget-base

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owdistancemap.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancemap.py
@@ -37,8 +37,8 @@ class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
         settings = self.widget.settingsHandler.pack_data(self.widget)
 
         w = self.create_widget(OWDistanceMap, stored_settings=settings)
-        self.send_signal(self.signal_name, self.signal_data)
-        self.assertEqual(len(self.get_output(w.Outputs.selected_data)), 10)
+        self.send_signal(self.signal_name, self.signal_data, widget=w)
+        self.assertEqual(len(self.get_output(w.Outputs.selected_data, widget=w)), 10)
 
 
 if __name__ == "__main__":

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.7,<0.2a
-orange-widget-base>=4.0a,<4.1a
+orange-widget-base>=4.1.0
 
 # PyQt4/PyQt5 compatibility
 AnyQt>=0.0.8


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Remove upper version constraint for orange-widget-base requirement.

##### Description of changes

Update required version of orange-widget-base
Fix a test for owdistancemap's selection restore. It was always wrong, but would now fail since https://github.com/biolab/orange-widget-base/pull/13

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
