### PR TITLE
[FIX] Self-Organizing Map: Fix restoring width

### DIFF
--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -245,7 +245,7 @@ class OWSOM(OWWidget):
         spin_x.setValue(self.size_x)
         gui.widgetLabel(box3, "×")
         spin_y = gui.spin(**spinargs)
-        spin_x.setValue(self.size_y)
+        spin_y.setValue(self.size_y)
         gui.rubber(box3)
         self.manual_box.setEnabled(not self.auto_dimension)
 


### PR DESCRIPTION
SOM restores height into width due to a trivial copy/paste mistake.