### PR TITLE
[FIX] Scatterplot: Disable vizrank when features on input

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -274,18 +274,18 @@ class OWScatterPlot(OWDataProjectionWidget):
             labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True,
             valueType=str, contentsLength=14
         )
-        box = gui.vBox(self.controlArea, True)
+        self.attr_box = gui.vBox(self.controlArea, True)
         dmod = DomainModel
         self.xy_model = DomainModel(dmod.MIXED, valid_types=ContinuousVariable)
         self.cb_attr_x = gui.comboBox(
-            box, self, "attr_x", label="Axis x:",
+            self.attr_box, self, "attr_x", label="Axis x:",
             callback=self.set_attr_from_combo,
             model=self.xy_model, **common_options)
         self.cb_attr_y = gui.comboBox(
-            box, self, "attr_y", label="Axis y:",
+            self.attr_box, self, "attr_y", label="Axis y:",
             callback=self.set_attr_from_combo,
             model=self.xy_model, **common_options)
-        vizrank_box = gui.hBox(box)
+        vizrank_box = gui.hBox(self.attr_box)
         self.vizrank, self.vizrank_button = ScatterPlotVizRank.add_vizrank(
             vizrank_box, self, "Find Informative Projections", self.set_attr)
 
@@ -318,6 +318,7 @@ class OWScatterPlot(OWDataProjectionWidget):
 
     def set_data(self, data):
         super().set_data(data)
+        self._vizrank_color_change()
 
         def findvar(name, iterable):
             """Find a Orange.data.Variable in `iterable` by name"""
@@ -437,17 +438,19 @@ class OWScatterPlot(OWDataProjectionWidget):
 
     # called when all signals are received, so the graph is updated only once
     def handleNewSignals(self):
+        self.attr_box.setEnabled(True)
+        self.vizrank.setEnabled(True)
         if self.attribute_selection_list and self.data is not None and \
                 self.data.domain is not None and \
                 all(attr in self.data.domain for attr
                         in self.attribute_selection_list):
             self.attr_x, self.attr_y = self.attribute_selection_list[:2]
-            self.attribute_selection_list = None
+            self.attr_box.setEnabled(False)
+            self.vizrank.setEnabled(False)
         super().handleNewSignals()
         if self._domain_invalidated:
             self.graph.update_axes()
             self._domain_invalidated = False
-        self._vizrank_color_change()
 
     @Inputs.features
     def set_shown_attributes(self, attributes):

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -519,5 +519,6 @@ class OWScatterPlot(OWDataProjectionWidget):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    data = Table("iris")
-    WidgetPreview(OWScatterPlot).run(set_data=data, set_subset_data=data[:30])
+    table = Table("iris")
+    WidgetPreview(OWScatterPlot).run(set_data=table,
+                                     set_subset_data=table[:30])

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -318,18 +318,31 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         self.send_signal(self.widget.Inputs.features, None)
 
     def test_features_and_data(self):
-        data = Table("iris")
-        self.send_signal(self.widget.Inputs.data, data)
+        self.assertTrue(self.widget.attr_box.isEnabled())
+        self.send_signal(self.widget.Inputs.data, self.data)
         x, y = self.widget.graph.scatterplot_item.getData()
-        np.testing.assert_array_equal(x, data.X[:, 0])
-        np.testing.assert_array_equal(y, data.X[:, 1])
+        np.testing.assert_array_equal(x, self.data.X[:, 0])
+        np.testing.assert_array_equal(y, self.data.X[:, 1])
         self.send_signal(self.widget.Inputs.features,
-                         AttributeList(data.domain[2:]))
-        self.assertIs(self.widget.attr_x, data.domain[2])
-        self.assertIs(self.widget.attr_y, data.domain[3])
+                         AttributeList(self.data.domain[2:]))
+        self.assertIs(self.widget.attr_x, self.data.domain[2])
+        self.assertIs(self.widget.attr_y, self.data.domain[3])
+        self.assertFalse(self.widget.attr_box.isEnabled())
+        self.assertFalse(self.widget.vizrank.isEnabled())
         x, y = self.widget.graph.scatterplot_item.getData()
-        np.testing.assert_array_equal(x, data.X[:, 2])
-        np.testing.assert_array_equal(y, data.X[:, 3])
+        np.testing.assert_array_equal(x, self.data.X[:, 2])
+        np.testing.assert_array_equal(y, self.data.X[:, 3])
+
+        self.send_signal(self.widget.Inputs.data, None)
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.assertIs(self.widget.attr_x, self.data.domain[2])
+        self.assertIs(self.widget.attr_y, self.data.domain[3])
+        self.assertFalse(self.widget.attr_box.isEnabled())
+        self.assertFalse(self.widget.vizrank.isEnabled())
+
+        self.send_signal(self.widget.Inputs.features, None)
+        self.assertTrue(self.widget.attr_box.isEnabled())
+        self.assertTrue(self.widget.vizrank.isEnabled())
 
     def test_output_features(self):
         data = Table("iris")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Feature selection is enabled, even though features are passed to the input of Scatterplot.
To reproduce: File (Iris) -> Scatterplot
                                        -> Correlations -> Scatterplot -> Axis x, Axis y and Find Informative Projections are enabled

Similar to #4101.

##### Description of changes
- disable table and button on vizrank popup when features are not the input of the widget
- disable attr_x and attr_y selection when features are not the input of the widget
- initialize vizrank only when data (input) changes, not features

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
