### PR TITLE
#4103 - Updating maximum number of features for Preprocess: Select Random Fea…

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -541,7 +541,7 @@ class RandomFeatureSelectEditor(BaseEditor):
         fixedrb = QRadioButton("Fixed", checked=True)
         group.addButton(fixedrb, RandomFeatureSelectEditor.Fixed)
         kspin = QSpinBox(
-            minimum=1, value=self.__k,
+            minimum=1, maximum= 10000000, value=self.__k,
             enabled=self.__strategy == RandomFeatureSelectEditor.Fixed
         )
         kspin.valueChanged[int].connect(self.setK)


### PR DESCRIPTION
…tures

##### Issue 
#4103 - Select Random Features preprocessor as implemented in the Preprocess widget allows the user to enter only a very limited number of attributes.


##### Description of changes
Added a maximum attribute to QSpinBox function in RandomFeatureSelectEditor to allow up to 10000000 features to be selected.
