### PR TITLE
[ENH] Bhatthacharayya distance

### DIFF
--- a/Orange/distance/__init__.py
+++ b/Orange/distance/__init__.py
@@ -1,7 +1,7 @@
 from .distance import (Distance, DistanceModel,
                        Euclidean, Manhattan, Cosine, Jaccard,
                        SpearmanR, SpearmanRAbsolute, PearsonR, PearsonRAbsolute,
-                       Mahalanobis, MahalanobisDistance, Hamming)
+                       Mahalanobis, MahalanobisDistance, Hamming, Bhattacharyya)
 
 from .base import (
     _preprocess, remove_discrete_features, remove_nonbinary_features, impute)

--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import numpy as np
 from scipy import stats
+from scipy.spatial.distance import cdist
 from scipy import sparse as sp
 import sklearn.metrics as skl_metrics
 from sklearn.utils.extmath import row_norms, safe_sparse_dot
@@ -643,6 +644,21 @@ class PearsonR(CorrelationDistance):
 class PearsonRAbsolute(CorrelationDistance):
     def fit(self, _):
         return PearsonModel(True, self.axis, self.impute)
+
+def _bhattacharyya(a, b):
+    # not a real metric, does not obey triangle inequality
+    return -np.log(np.sum(np.sqrt(a*b)))
+
+class Bhattacharyya(Distance):
+    def fit(self, data):
+        return BhattacharyyaModel(self.axis, self.impute)
+
+class BhattacharyyaModel(DistanceModel):
+
+    def compute_distances(self, x1, x2):
+        if x2 is None:
+            x2 = x1
+        return cdist(x1, x2, _bhattacharyya)
 
 
 class Mahalanobis(Distance):

--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -645,32 +645,30 @@ class PearsonRAbsolute(CorrelationDistance):
     def fit(self, _):
         return PearsonModel(True, self.axis, self.impute)
 
+
 def _prob_dist(a):
     # Makes the vector sum to one, as to mimic probability distribution.
     return a / np.sum(a)
 
-def non_negative(a):
-    #Raise an exception for infinities, nans and negative values
-    try:
-        check_array(a, accept_sparse=True, accept_large_sparse=True, ensure_2d=False)
-    except:
+
+def check_non_negative(a):
+    # Raise an exception for infinities, nans and negative values
+    check_array(a,
+                accept_sparse=True, accept_large_sparse=True, ensure_2d=False)
+    if a.min() < 0:
         raise ValueError("Bhattcharyya distance requires non-negative values")
-    if sp.issparse(a):
-        if a.min() < 0:
-            raise ValueError("Bhattcharyya distance requires non-negative values")
-        return
-    if min(a) < 0:
-        raise ValueError("Bhattcharyya distance requires non-negative values")
+
 
 def _bhattacharyya(a, b):
     # not a real metric, does not obey triangle inequality
-    non_negative(a)
-    non_negative(b)
+    check_non_negative(a)
+    check_non_negative(b)
     a = _prob_dist(a)
     b = _prob_dist(b)
     if sp.issparse(a):
         return -np.log(np.sum(np.sqrt(a.multiply(b))))
     return -np.log(np.sum(np.sqrt(a * b)))
+
 
 class Bhattacharyya(Distance):
     supports_discrete = False

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -962,12 +962,22 @@ class TestBhattacharyya(TestCase):
     def test_sparse_array(self):
         data = csr_matrix([[0.5, 0.5], [0, 0.5]])
         self.assertAlmostEqual(self.dist(data[0], data[1]), 0.3465735902799726, delta=1e-5)
-    
+
     def test_columns(self):
         data = np.array([[0.5, 0.2], [0.5, 0.8]])
         true_out = np.array([[0, 0.05268025782891318],
                              [0.05268025782891318, 0]])
         np.testing.assert_array_almost_equal(self.dist(data, axis=0), true_out)
+
+    def test_negative_input(self):
+        a = np.array([0, np.nan])
+        b = np.array([1, 1])
+        self.assertRaises(ValueError, self.dist, a, b)
+        a[1] = -1
+        self.assertRaises(ValueError, self.dist, a, b)
+        a = csr_matrix(a)
+        b = csr_matrix(b)
+        self.assertRaises(ValueError, self.dist, a, b)
 
 
 class TestDistances(TestCase):

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -1,6 +1,5 @@
 from AnyQt.QtCore import Qt
 from scipy.sparse import issparse
-from numpy import min as _min
 import bottleneck as bn
 
 import Orange.data
@@ -59,7 +58,6 @@ class OWDistances(OWWidget):
         dense_metric_sparse_data = Msg("{} requires dense data.")
         distances_memory_error = Msg("Not enough memory")
         distances_value_error = Msg("Problem in calculation:\n{}")
-        negative_value_error = Msg("Only non-negative values alowed for Bhattcharyya.")
 
     class Warning(OWWidget.Warning):
         ignoring_discrete = Msg("Ignoring categorical features")
@@ -160,9 +158,6 @@ class OWDistances(OWWidget):
                       _fix_discrete, _fix_missing, _fix_nonbinary):
             if not check():
                 return None
-        if (METRICS[self.metric_idx][0] == 'Bhattacharyya') and _min(data.X) < 0:
-            self.Error.negative_value_error()
-            return None
         try:
             if metric.supports_normalization and self.normalized_dist:
                 return metric(data, axis=1 - self.axis, impute=True,

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -21,7 +21,8 @@ METRICS = [
     ("Absolute Spearman", distance.SpearmanRAbsolute),
     ("Pearson", distance.PearsonR),
     ("Absolute Pearson", distance.PearsonRAbsolute),
-    ("Hamming", distance.Hamming)
+    ("Hamming2", distance.Hamming),
+    ('Bhattacharyya', distance.Bhattacharyya)
 ]
 
 

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -1,5 +1,6 @@
 from AnyQt.QtCore import Qt
 from scipy.sparse import issparse
+from numpy import min as _min
 import bottleneck as bn
 
 import Orange.data
@@ -21,7 +22,7 @@ METRICS = [
     ("Absolute Spearman", distance.SpearmanRAbsolute),
     ("Pearson", distance.PearsonR),
     ("Absolute Pearson", distance.PearsonRAbsolute),
-    ("Hamming2", distance.Hamming),
+    ("Hamming", distance.Hamming),
     ('Bhattacharyya', distance.Bhattacharyya)
 ]
 
@@ -58,6 +59,7 @@ class OWDistances(OWWidget):
         dense_metric_sparse_data = Msg("{} requires dense data.")
         distances_memory_error = Msg("Not enough memory")
         distances_value_error = Msg("Problem in calculation:\n{}")
+        negative_value_error = Msg("Only non-negative values alowed for Bhattcharyya.")
 
     class Warning(OWWidget.Warning):
         ignoring_discrete = Msg("Ignoring categorical features")
@@ -158,6 +160,9 @@ class OWDistances(OWWidget):
                       _fix_discrete, _fix_missing, _fix_nonbinary):
             if not check():
                 return None
+        if (METRICS[self.metric_idx][0] == 'Bhattacharyya') and _min(data.X) < 0:
+            self.Error.negative_value_error()
+            return None
         try:
             if metric.supports_normalization and self.normalized_dist:
                 return metric(data, axis=1 - self.axis, impute=True,

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -106,9 +106,9 @@ class TestOWDistances(WidgetTest):
 
     def test_negative_values_bhattacharyya(self):
         self.iris.X[0, 0] *= -1
-        for self.widget.metric_idx, (name, _) in enumerate(METRICS):
-            if name == "Bhattacharyya":
+        for self.widget.metric_idx, (_, metric) in enumerate(METRICS):
+            if metric == distance.Bhattacharyya:
                 break
         self.send_signal(self.widget.Inputs.data, self.iris)
-        self.assertTrue(self.widget.Error.negative_value_error.is_shown())
+        self.assertTrue(self.widget.Error.distances_value_error.is_shown())
         self.iris.X[0, 0] *= -1

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -103,3 +103,12 @@ class TestOWDistances(WidgetTest):
     def test_migrates_normalized_dist(self):
         w = self.create_widget(OWDistances, stored_settings={"metric_idx": 0})
         self.assertFalse(w.normalized_dist)
+
+    def test_negative_values_bhattacharyya(self):
+        self.iris.X[0, 0] *= -1
+        for self.widget.metric_idx, (name, _) in enumerate(METRICS):
+            if name == "Bhattacharyya":
+                break
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.assertTrue(self.widget.Error.negative_value_error.is_shown())
+        self.iris.X[0, 0] *= -1

--- a/doc/visual-programming/source/widgets/unsupervised/distances.md
+++ b/doc/visual-programming/source/widgets/unsupervised/distances.md
@@ -32,8 +32,9 @@ Distances work well with Orange add-ons, too. The distance matrix can be fed to 
    - [Pearson](https://en.wikipedia.org/wiki/Pearson_product-moment_correlation_coefficient) (linear correlation between the values, remapped as a distance in a [0, 1] interval)
    - [Pearson absolute](https://en.wikipedia.org/wiki/Pearson_product-moment_correlation_coefficient) (linear correlation between the absolute values, remapped as a distance in a [0, 1] interval)
    - [Hamming](https://en.wikipedia.org/wiki/Hamming_distance) (the number of features at which the corresponding values are different)
+   - [Bhattacharyya distance](https://en.wikipedia.org/wiki/Bhattacharyya_distance) (Similarity between two probability distributions, not a real distance as it doesn't obey triangle inequality.)
 
-   Normalize the features. Normalization is always done column-wise.
+   Normalize the features. Normalization is always done column-wise. Values are zero centered and scaled.
    In case of missing values, the widget automatically imputes the average value of the row or the column.
    The widget works for both numeric and categorical data. In case of categorical data, the distance is 0 if the two values are the same ('green' and 'green') and 1 if they are not ('green' and 'blue').
 3. Tick *Apply Automatically* to automatically commit changes to other widgets. Alternatively, press '*Apply*'.


### PR DESCRIPTION

##### Description of changes
A new metric is introduced in distances widget. Bhatthacharayya is used to measure the distance between distributions. Currently, the user has to already have the data that they see as a distribution. In the future, pivot could be extended to have aggregation of all features, filtered by column values, so distributions could be generated in Orange itself. 

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
