### PR TITLE
[FIX] Warning for discrete variable with >100 values in OWFile

### DIFF
--- a/Orange/data/tests/test_io.py
+++ b/Orange/data/tests/test_io.py
@@ -1,0 +1,70 @@
+import unittest
+import numpy as np
+
+from Orange.data import ContinuousVariable, DiscreteVariable, StringVariable
+from Orange.data.io import guess_data_type
+
+
+class TestTableFilters(unittest.TestCase):
+
+    def test_guess_data_type_continuous(self):
+        # should be ContinuousVariable
+        valuemap, values, coltype = guess_data_type(list(range(1, 100)))
+        self.assertEqual(ContinuousVariable, coltype)
+        self.assertIsNone(valuemap)
+        np.testing.assert_array_equal(np.array(list(range(1, 100))), values)
+
+        valuemap, values, coltype = guess_data_type([1, 2, 3, 1, 2, 3])
+        self.assertEqual(ContinuousVariable, coltype)
+        self.assertIsNone(valuemap)
+        np.testing.assert_array_equal([1, 2, 3, 1, 2, 3], values)
+
+        valuemap, values, coltype = guess_data_type(
+            ["1", "2", "3", "1", "2", "3"])
+        self.assertEqual(ContinuousVariable, coltype)
+        self.assertIsNone(valuemap)
+        np.testing.assert_array_equal([1, 2, 3, 1, 2, 3], values)
+
+    def test_guess_data_type_discrete(self):
+        # should be DiscreteVariable
+        valuemap, values, coltype = guess_data_type([1, 2, 1, 2])
+        self.assertEqual(DiscreteVariable, coltype)
+        self.assertEqual([1, 2], valuemap)
+        np.testing.assert_array_equal([1, 2, 1, 2], values)
+
+        valuemap, values, coltype = guess_data_type(["1", "2", "1", "2", "a"])
+        self.assertEqual(DiscreteVariable, coltype)
+        self.assertEqual(["1", "2", "a"], valuemap)
+        np.testing.assert_array_equal(['1', '2', '1', '2', 'a'], values)
+
+        # just below the threshold for string variable
+        in_values = list(map(lambda x: str(x) + "a", range(24))) + ["a"] * 76
+        valuemap, values, coltype = guess_data_type(in_values)
+        self.assertEqual(DiscreteVariable, coltype)
+        self.assertEqual(sorted(set(in_values)), valuemap)
+        np.testing.assert_array_equal(in_values, values)
+
+    def test_guess_data_type_string(self):
+        # should be StringVariable
+        # too many different values for discrete
+        in_values = list(map(lambda x: str(x) + "a", range(90)))
+        valuemap, values, coltype = guess_data_type(in_values)
+        self.assertEqual(StringVariable, coltype)
+        self.assertIsNone(valuemap)
+        np.testing.assert_array_equal(in_values, values)
+
+        # more than len(values)**0.7
+        in_values = list(map(lambda x: str(x) + "a", range(25))) + ["a"] * 75
+        valuemap, values, coltype = guess_data_type(in_values)
+        self.assertEqual(StringVariable, coltype)
+        self.assertIsNone(valuemap)
+        np.testing.assert_array_equal(in_values, values)
+
+        # more than 100 different values - exactly 101
+        # this is the case when len(values)**0.7 rule would vote for the
+        # DiscreteVariable
+        in_values = list(map(lambda x: str(x) + "a", range(100))) + ["a"] * 999
+        valuemap, values, coltype = guess_data_type(in_values)
+        self.assertEqual(StringVariable, coltype)
+        self.assertIsNone(valuemap)
+        np.testing.assert_array_equal(in_values, values)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -26,6 +26,8 @@ MISSING_VALUES = {np.nan, "?", "nan", ".", "", "NA", "~", None}
 
 DISCRETE_MAX_VALUES = 3  # == 2 + nan
 MAX_NUM_OF_DECIMALS = 5
+# the variable with more than 100 different values should not be StringVariable
+DISCRETE_MAX_ALLOWED_VALUES = 100
 
 
 def make_variable(cls, compute_value, *args):
@@ -63,7 +65,8 @@ def is_discrete_values(values):
     unique = set()
     for i in values:
         unique.add(i)
-        if len(unique) > max_values:
+        if (len(unique) > max_values or
+                len(unique) > DISCRETE_MAX_ALLOWED_VALUES):
             return False
 
     # Strip NaN from unique


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/4094

##### Description of changes
As @janezd suggested the variable with more than 100 different values should not be DiscreteVariable. This PR:

- changes guessing mechanism such that the variable with more than 100 different values is not a StringVariable
- add tests for `guess_data_type` function
- `OWFile` warns the user who set the variable with more than 100 different values as a DiscreteVariable

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
