### PR TITLE
[FIX] Normalize: Fix crash with nan column

### DIFF
--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from Orange.data import ContinuousVariable, Domain
 from Orange.statistics import distribution
 from Orange.util import Reprable
@@ -57,7 +59,7 @@ class Normalizer(Reprable):
         )
 
     def normalize_by_span(self, dist, var):
-        dma, dmi = dist.max(), dist.min()
+        dma, dmi = (dist.max(), dist.min()) if dist.shape[1] else (np.nan, np.nan)
         diff = dma - dmi
         if diff < 1e-15:
             diff = 1

--- a/Orange/tests/datasets/test10.tab
+++ b/Orange/tests/datasets/test10.tab
@@ -1,6 +1,6 @@
-c1	c2	d1	d2	n1	n2	c3	d3	cl1	cl2
-c	t	d	d	c	d	c	d	d	c
-								class	class
-1	1995-01-21	a	a	?	a	2	a	a	2
-1	2003-07-23	a	b	1	?	0	b	b	0
-1	1967-03-12	a	b	2	b	-2	c	c	1
+c1	c2	d1	d2	n1	n2	c3	d3	c4	cl1	cl2
+c	t	d	d	c	d	c	d	c	d	c
+									class	class
+1	1995-01-21	a	a	?	a	2	a		a	2
+1	2003-07-23	a	b	1	?	0	b		b	0
+1	1967-03-12	a	b	2	b	-2	c		c	1

--- a/Orange/tests/datasets/test5.tab
+++ b/Orange/tests/datasets/test5.tab
@@ -1,6 +1,6 @@
-c1	c2	d1	d2	n1	n2	c3	d3	cl1	cl2
-c	c	d	d	c	d	c	d	d	c
-								class	class
-1	2	a	a	?	a	2	a	a	2
-1	0	a	b	1	?	0	b	b	0
-1	1	a	b	2	b	-2	c	c	1
+c1	c2	d1	d2	n1	n2	c3	d3	c4	cl1	cl2
+c	c	d	d	c	d	c	d	c	d	c
+									class	class
+1	2	a	a	?	a	2	a		a	2
+1	0	a	b	1	?	0	b		b	0
+1	1	a	b	2	b	-2	c		c	1

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -970,8 +970,8 @@ class TestDistances(TestCase):
         new_table = _preprocess(table)
         np.testing.assert_equal(new_table.Y, table.Y)
         self.assertEqual([a.name for a in new_table.domain.attributes],
-                         [a.name for a in table.domain.attributes
-                          if a.is_continuous])
+                         [a.name for a in table.domain.attributes if
+                          a.is_continuous and not all(np.isnan(table[:, a].X))])
         self.assertEqual(new_table.domain.class_vars, table.domain.class_vars)
 
     def test_preprocess_impute(self):

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -20,7 +20,7 @@ class TestNormalizer(unittest.TestCase):
                 else:
                     self.assertEqual(dataNorm[i, j], solution[i][j])
         self.assertEqual([attr.name for attr in dataNorm.domain.attributes],
-                         ["c1", "c2", "d1", "d2", "n1", "n2", "c3", "d3"])
+                         ["c1", "c2", "d1", "d2", "n1", "n2", "c3", "d3", "c4"])
         self.assertEqual([attr.name for attr in dataNorm.domain.class_vars],
                          ["cl1", "cl2"])
     @classmethod
@@ -30,9 +30,9 @@ class TestNormalizer(unittest.TestCase):
     def test_normalize_default(self):
         normalizer = Normalize()
         data_norm = normalizer(self.data)
-        solution = [[0., 1.225, 'a', 'a', '?', 'a', 1.225, 'a', 'a', 2],
-                    [0., -1.225, 'a', 'b', -1., '?', 0., 'b', 'b', 0],
-                    [0., 0., 'a', 'b', 1., 'b', -1.225, 'c', 'c', 1]]
+        solution = [[0., 1.225, 'a', 'a', '?', 'a', 1.225, 'a', '?', 'a', 2],
+                    [0., -1.225, 'a', 'b', -1., '?', 0., 'b', '?', 'b', 0],
+                    [0., 0., 'a', 'b', 1., 'b', -1.225, 'c', '?', 'c', 1]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_transform_by_sd(self):
@@ -40,9 +40,9 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySD,
                                transform_class=False)
         data_norm = normalizer(self.data)
-        solution = [[0., 1.225, 'a', 'a', '?', 'a', 1.225, 'a', 'a', 2],
-                    [0., -1.225, 'a', 'b', -1., '?', 0., 'b', 'b', 0],
-                    [0., 0., 'a', 'b', 1., 'b', -1.225, 'c', 'c', 1]]
+        solution = [[0., 1.225, 'a', 'a', '?', 'a', 1.225, 'a', '?', 'a', 2],
+                    [0., -1.225, 'a', 'b', -1., '?', 0., 'b', '?', 'b', 0],
+                    [0., 0., 'a', 'b', 1., 'b', -1.225, 'c', '?', 'c', 1]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_transform_class(self):
@@ -50,9 +50,9 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySD,
                                transform_class=True)
         data_norm = normalizer(self.data)
-        solution = [[0., 1.225, 'a', 'a', '?', 'a', 1.225, 'a', 'a', 1.225],
-                    [0., -1.225, 'a', 'b', -1., '?', 0., 'b', 'b', -1.225],
-                    [0., 0., 'a', 'b', 1., 'b', -1.225, 'c', 'c', 0.]]
+        solution = [[0., 1.225, 'a', 'a', '?', 'a', 1.225, 'a', '?', 'a', 1.225],
+                    [0., -1.225, 'a', 'b', -1., '?', 0., 'b', '?', 'b', -1.225],
+                    [0., 0., 'a', 'b', 1., 'b', -1.225, 'c', '?', 'c', 0.]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_transform_by_span(self):
@@ -60,9 +60,9 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySpan,
                                transform_class=False)
         data_norm = normalizer(self.data)
-        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', 'a', 2.],
-                    [0., -1., 'a', 'b', -1., '?', 0., 'b', 'b', 0.],
-                    [0., 0., 'a', 'b', 1., 'b', -1., 'c', 'c', 1.]]
+        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', '?', 'a', 2.],
+                    [0., -1., 'a', 'b', -1., '?', 0., 'b', '?', 'b', 0.],
+                    [0., 0., 'a', 'b', 1., 'b', -1., 'c', '?', 'c', 1.]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_transform_by_span_zero(self):
@@ -70,9 +70,9 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySpan,
                                transform_class=False)
         data_norm = normalizer(self.data)
-        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', 'a', 2.],
-                    [0., 0., 'a', 'b', 0., '?', 0.5, 'b', 'b', 0.],
-                    [0., 0.5, 'a', 'b', 1., 'b', 0., 'c', 'c', 1.]]
+        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', '?', 'a', 2.],
+                    [0., 0., 'a', 'b', 0., '?', 0.5, 'b', '?', 'b', 0.],
+                    [0., 0.5, 'a', 'b', 1., 'b', 0., 'c', '?', 'c', 1.]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_transform_by_span_class(self):
@@ -80,9 +80,9 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySpan,
                                transform_class=True)
         data_norm = normalizer(self.data)
-        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', 'a', 1.],
-                    [0., -1., 'a', 'b', -1., '?', 0., 'b', 'b', -1.],
-                    [0., 0., 'a', 'b', 1., 'b', -1., 'c', 'c', 0.]]
+        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', '?', 'a', 1.],
+                    [0., -1., 'a', 'b', -1., '?', 0., 'b', '?', 'b', -1.],
+                    [0., 0., 'a', 'b', 1., 'b', -1., 'c', '?', 'c', 0.]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_transform_by_span_zero_class(self):
@@ -90,9 +90,9 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySpan,
                                transform_class=True)
         data_norm = normalizer(self.data)
-        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', 'a', 1.],
-                    [0., 0., 'a', 'b', 0., '?', 0.5, 'b', 'b', 0.],
-                    [0., 0.5, 'a', 'b', 1., 'b', 0., 'c', 'c', 0.5]]
+        solution = [[0., 1., 'a', 'a', '?', 'a', 1., 'a', '?', 'a', 1.],
+                    [0., 0., 'a', 'b', 0., '?', 0.5, 'b', '?', 'b', 0.],
+                    [0., 0.5, 'a', 'b', 1., 'b', 0., 'c', '?', 'c', 0.5]]
         self.compare_tables(data_norm, solution)
 
     def test_normalize_sparse(self):
@@ -138,7 +138,7 @@ class TestNormalizer(unittest.TestCase):
                                norm_type=Normalize.NormalizeBySD,
                                transform_class=False)
         data_norm = normalizer(data)
-        solution = [[0., '1995-01-21', 'a', 'a', '?', 'a', 1.225, 'a', 'a', 2],
-                    [0., '2003-07-23', 'a', 'b', -1., '?', 0., 'b', 'b', 0],
-                    [0., '1967-03-12', 'a', 'b', 1., 'b', -1.225, 'c', 'c', 1]]
+        solution = [[0., '1995-01-21', 'a', 'a', '?', 'a', 1.225, 'a', '?', 'a', 2],
+                    [0., '2003-07-23', 'a', 'b', -1., '?', 0., 'b', '?', 'b', 0],
+                    [0., '1967-03-12', 'a', 'b', 1., 'b', -1.225, 'c', '?', 'c', 1]]
         self.compare_tables(data_norm, solution)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Normalization crashes when data contains a feature without a value.
To reproduce: File (Iris) -> Feature Constructor (new `numeric` variable with expression: `nan`) -> Preprocess (Normalize Features (normalize to interval))

##### Description of changes
Feature with missing values retains missing values after normalization.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
