### PR TITLE
[FIX] ROC and LiftCurve: Store context settings

### DIFF
--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -16,6 +16,8 @@ import pyqtgraph as pg
 
 import Orange
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.evaluate.contexthandlers import \
+    EvaluationResultsContextHandler
 from Orange.widgets.evaluate.utils import check_results_adequacy
 from Orange.widgets.utils import colorpalette, colorbrewer
 from Orange.widgets.evaluate.owrocanalysis import convex_hull
@@ -64,8 +66,9 @@ class OWLiftCurve(widget.OWWidget):
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)
 
-    target_index = settings.Setting(0)
-    selected_classifiers = settings.Setting([])
+    settingsHandler = EvaluationResultsContextHandler()
+    target_index = settings.ContextSetting(0)
+    selected_classifiers = settings.ContextSetting([])
 
     display_convex_hull = settings.Setting(False)
     display_cost_func = settings.Setting(True)
@@ -133,10 +136,13 @@ class OWLiftCurve(widget.OWWidget):
     @Inputs.evaluation_results
     def set_results(self, results):
         """Set the input evaluation results."""
+        self.closeContext()
         self.clear()
         self.results = check_results_adequacy(results, self.Error)
         if self.results is not None:
             self._initialize(results)
+            self.openContext(self.results.domain.class_var,
+                             self.classifier_names)
             self._setup_plot()
 
     def clear(self):

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -17,6 +17,8 @@ import pyqtgraph as pg
 
 import Orange
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.evaluate.contexthandlers import \
+    EvaluationResultsContextHandler
 from Orange.widgets.evaluate.utils import \
     check_results_adequacy, results_for_preview
 from Orange.widgets.utils import colorpalette, colorbrewer
@@ -303,8 +305,9 @@ class OWROCAnalysis(widget.OWWidget):
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)
 
-    target_index = settings.Setting(0)
-    selected_classifiers = []
+    settingsHandler = EvaluationResultsContextHandler()
+    target_index = settings.ContextSetting(0)
+    selected_classifiers = settings.ContextSetting([])
 
     display_perf_line = settings.Setting(True)
     display_def_threshold = settings.Setting(True)
@@ -423,10 +426,13 @@ class OWROCAnalysis(widget.OWWidget):
     @Inputs.evaluation_results
     def set_results(self, results):
         """Set the input evaluation results."""
+        self.closeContext()
         self.clear()
         self.results = check_results_adequacy(results, self.Error)
         if self.results is not None:
             self._initialize(self.results)
+            self.openContext(self.results.domain.class_var,
+                             self.classifier_names)
             self._setup_plot()
         else:
             self.warning()


### PR DESCRIPTION
##### Issue

Fixes #4115: Lift curve and ROC Analysis did not have context settings. (Also because there was no suitable handler before #3881; #3881 implemented such a handler for the new calibration plot widget and even [noticed that Lift Curve and ROC Analysis can now use it](https://github.com/biolab/orange3/pull/3881/files#r295931586) :).

##### Description of changes

Use `EvaluationResultsContextHandler` in the two widgets.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
