### PR TITLE
[WIP][ENH] Removed limit for number of features for Preprocess: Select Random Features

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -541,7 +541,7 @@ class RandomFeatureSelectEditor(BaseEditor):
         fixedrb = QRadioButton("Fixed", checked=True)
         group.addButton(fixedrb, RandomFeatureSelectEditor.Fixed)
         kspin = QSpinBox(
-            minimum=1, maximum= 10000000, value=self.__k,
+            minimum=1, maximum=10000000, value=self.__k,
             enabled=self.__strategy == RandomFeatureSelectEditor.Fixed
         )
         kspin.valueChanged[int].connect(self.setK)

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -541,7 +541,7 @@ class RandomFeatureSelectEditor(BaseEditor):
         fixedrb = QRadioButton("Fixed", checked=True)
         group.addButton(fixedrb, RandomFeatureSelectEditor.Fixed)
         kspin = QSpinBox(
-            minimum=1, value=self.__k,
+            minimum=1, maximum= 10000000, value=self.__k,
             enabled=self.__strategy == RandomFeatureSelectEditor.Fixed
         )
         kspin.valueChanged[int].connect(self.setK)


### PR DESCRIPTION
##### Issue
Fixes #4103 - Select Random Features preprocessor as implemented in the Preprocess widget allows the user to enter only a very limited number of attributes.

##### Description of changes
`QLineEdit` implemented with a `QIntValidator` instead of `QSpinBox`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
