### PR TITLE
[FIX] build-conda-installer.sh: Do not use python version from Miniconda

### DIFF
--- a/scripts/windows/build-conda-installer.sh
+++ b/scripts/windows/build-conda-installer.sh
@@ -4,11 +4,11 @@
 set -e
 
 function usage() {
-    echo 'build-conda-installer.sh
+    echo "build-conda-installer.sh
 
 Build a conda based based windows application installer.
 
-Note: This script needs makensis and curl on $PATH
+Note: This script needs makensis and curl on \$PATH
 Note: Needs basic bash env on Windows (git-bash is sufficient/tested, but
       cygwin should work too)
 
@@ -16,12 +16,15 @@ Options:
     -b --build-base <path>  Build directory (default ./build)
     -d --dist-dir <path>    Distribution dir (default ./dist)
     --cache-dir <path>      Cache downloaded packages in DIR (the default
-                            is "build/download-cache")
+                            is \"build/download-cache\")
+    -M, --miniconda-version <version>
+                            The miniconda distribution to include in the
+                            installer (default ${MINICONDA_VERSION_DEFAULT}).
     --platform <plattag>    win32 or win_amd64
     --env-spec              An environment specification file as exported by
-                            `conda list --export --explicit --md5`
+                            \`conda list --export --explicit --md5\`
                             (the default is specs/conda-spec.txt)
-    --online (yes|no)       Build an "online" or "offline" installer.
+    --online (yes|no)       Build an \"online\" or \"offline\" installer.
                             In an online installer only the Miniconda installer
                             is included. All other packages are otherwise
                             fetched at installation time
@@ -32,21 +35,21 @@ Options:
 Examples
 
     $ ./scripts/windows/build-conda-installer.sh --online=yes
-'
+"
 }
 
 NAME=Orange3
 # version is determined from the ENV_SPEC_FILE
 VERSION=
 
-PYTHON=
 BUILDBASE=
 DISTDIR=
 CACHEDIR=
 
-# Python version in the Miniconda installer.
-MINICONDA_VERSION=4.7.12
-PYTHON_VERSION=3.7.0
+# Miniconda installer version; included and installed if there is no existing
+# Anaconda/Miniconda installation found on the target system.
+MINICONDA_VERSION_DEFAULT=4.7.12
+MINICONDA_VERSION=${MINICONDA_VERSION_DEFAULT}
 
 PLATTAG=win_amd64
 
@@ -71,6 +74,10 @@ while [[ "${1:0:1}" = "-" ]]; do
             CACHEDIR=${2:?}; shift 2;;
         --cache-dir=*)
             CACHEDIR=${1#*=}; shift 1;;
+        -M|--miniconda-version)
+            MINICONDA_VERSION=${2:?}; shift 2;;
+        --miniconda-version=*)
+            MINICONDA_VERSION=${1*=}; shift 1;;
         --platform)
             PLATTAG=${2:?}; shift 2;;
         --platform=*)
@@ -90,10 +97,6 @@ while [[ "${1:0:1}" = "-" ]]; do
      esac
 done
 
-if [[ ! ${PYTHON_VERSION} =~ ^([0-9]+\.){2,}[0-9]+$ ]]; then
-    echo "Invalid python version: $PYTHON_VERSION (need major.minor.micro)" >&2
-    exit 1
-fi
 
 if [[ ! ${PLATTAG:?} =~ (win32|win_amd64) ]]; then
     echo "Invalid platform tag: ${PLATTAG} (expected win32 or win_amd64)" >&2
@@ -106,10 +109,6 @@ if [[ ! "${ONLINE}" =~ ^(yes|no)$ ]]; then
     exit 1
 fi
 
-# Major.Minor
-PYTHON_VER=${PYTHON_VERSION%.*}
-# MajorMinor
-PYTAG=${PYTHON_VER/./}
 
 if [[ ${PLATTAG} == win32 ]]; then
     CONDAPLATTAG=x86
@@ -119,7 +118,7 @@ fi
 
 
 BUILDBASE=${BUILDBASE:-./build}
-BASEDIR="${BUILDBASE:?}"/temp.${PLATTAG}-${PYTHON_VER}.conda-installer
+BASEDIR="${BUILDBASE:?}"/temp.${PLATTAG}.conda-installer
 
 CACHEDIR=${CACHEDIR:-./build/download-cache}
 DISTDIR=${DISTDIR:-./dist}
@@ -184,6 +183,14 @@ fetch-miniconda() {
         fi
     fi
 }
+
+
+# extract Mayor.Minor.Micro python version string from a conda env spec file
+# contents read from stdin
+conda-env-spec-python-version() {
+    grep -E "(^|.+/)python-(\d+.\d+.\d+)" | sed -n 's@.*python-\([^-]*\)-.*$@\1@p'
+}
+
 
 # $ conda-fetch-packages DESTDIR SPECFILE
 #
@@ -311,9 +318,9 @@ make-installer() {
     local major=$(version-component 1 "${versionstr}")
     local minor=$(version-component 2 "${versionstr}")
     local micro=$(version-component 3 "${versionstr}")
-    local pymajor=$(version-component 1 "${PYTHON_VERSION}")
-    local pyminor=$(version-component 2 "${PYTHON_VERSION}")
-    local pymicro=$(version-component 3 "${PYTHON_VERSION}")
+    local pymajor=$(version-component 1 "${PYTHON_VERSION:?}")
+    local pyminor=$(version-component 2 "${PYTHON_VERSION:?}")
+    local pymicro=$(version-component 3 "${PYTHON_VERSION:?}")
 
     cat <<EOF > "${BASEDIR}"/license.txt
 Acknowledgments and License Agreement
@@ -355,12 +362,16 @@ if [[ "${ONLINE}" == yes ]]; then
     VERSION=$(cat < "${BASEDIR}"/conda-spec.txt |
               grep -E 'orange3-.*tar.bz2' |
               sed -e 's@^.*orange3-\([^-]*\)-.*tar.bz2.*@\1@')
+    PYTHON_VERSION=$(conda-env-spec-python-version \
+                     < "${BASEDIR:?}"/conda-spec.txt)
 else
     conda-fetch-packages "${BASEDIR:?}"/conda-pkgs "${ENV_SPEC_FILE}"
     # extract the orange version from env spec
     VERSION=$(cat < "${BASEDIR:?}"/conda-pkgs/conda-spec.txt |
               grep -E 'orange3-.*tar.bz2' |
               cut -d "-" -f 2)
+    PYTHON_VERSION=$(conda-env-spec-python-version \
+                     < "${BASEDIR:?}"/conda-pkgs/conda-spec.txt)
 fi
 
 if [[ ! "${VERSION}" ]]; then

--- a/scripts/windows/orange-conda.nsi
+++ b/scripts/windows/orange-conda.nsi
@@ -5,7 +5,7 @@
 # Required definitions need to be passed to the makensis call
 #  - BASEDIR base location of all required files, ... (see below)
 #  - PYARCH python architecture identifier (win32 or amd64)
-#  - PY{MAJOR,MINOR,MICRO} Python version of the included installer
+#  - PY{MAJOR,MINOR,MICRO} Python version to be installed in the new env
 #  - APPNAME Application (short) name
 #  - VER{MAJOR,MINOR,MICRO} Application version
 #  - PYINSTALLER basename of the Miniconda python installer
@@ -362,7 +362,7 @@ Function DirectoryLeave
         ${Else}
             ${LogWrite} "$InstDir is not empty, aborting"
             MessageBox MB_OK '"$InstDir" exists and is not empty.$\r$\n \
-                              Please choose annother destination folder.'
+                              Please choose another destination folder.'
             Abort '"$InstDir" exists an is not empty'
         ${EndIf}
     ${EndIf}
@@ -384,7 +384,7 @@ FunctionEnd
 # Section Miniconda
 # -----------------
 # A Miniconda Python distributions
-Section "Miniconda ${MINICONDA_VERSION} (Python ${PYTHON_VERSION} ${BITS}-bit)" \
+Section "Miniconda ${MINICONDA_VERSION}" \
         SectionMiniconda
     ${GetAnyAnacondaInstall} $BasePythonPrefix $PythonInstallMode
     ${If} $BasePythonPrefix != ""
@@ -407,10 +407,7 @@ Section "Miniconda ${MINICONDA_VERSION} (Python ${PYTHON_VERSION} ${BITS}-bit)" 
         ${If} $0 != 0
             Abort "Miniconda installation failed (error value: $0)"
         ${EndIf}
-
-        ${GetAnacondaInstall} ${PYMAJOR}${PYMINOR} ${BITS} \
-                          $BasePythonPrefix $PythonInstallMode
-
+        ${GetAnyAnacondaInstall} $BasePythonPrefix $PythonInstallMode
         ${IfNot} ${FileExists} "$BasePythonPrefix\python.exe"
             Abort "No python.exe found in $BasePythonPrefix$\r$\n \
                    Cannot continue."


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-3830

##### Description of changes

Use the version from python package that will be installed and not miniconda python version for the compatibility check.

Also make Miniconda installer version configurable from the command line.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
