### PR TITLE
PymssqlBackend: Skip tests if pymssql not installed

### DIFF
--- a/Orange/data/tests/test_sql_mssql.py
+++ b/Orange/data/tests/test_sql_mssql.py
@@ -1,14 +1,21 @@
 import unittest
 
 from Orange.data.sql.backend.base import BackendError
-from Orange.data.sql.backend.mssql import PymssqlBackend, parse_ex
+try:
+    from Orange.data.sql.backend.mssql import PymssqlBackend, parse_ex
+    err = ""
+except ModuleNotFoundError as ex:
+    PymssqlBackend = None
+    err = str(ex)
 
 
 class TestPymssqlBackend(unittest.TestCase):
+    @unittest.skipIf(PymssqlBackend is None, err)
     def test_connection_error(self):
         connection_params = {"host": "host", "port": "", "database": "DB"}
         self.assertRaises(BackendError, PymssqlBackend, connection_params)
 
+    @unittest.skipIf(PymssqlBackend is None, err)
     def test_parse_ex(self):
         err_msg = "Foo"
         self.assertEqual(parse_ex(ValueError(err_msg)), err_msg)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #4129

##### Description of changes
Skip unittess if pymssql is not installed.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
