### PR TITLE
[ENH] Preprocess: Max number of features

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -362,7 +362,7 @@ class UnivariateFeatureSelect(QWidget):
         fixedrb = QRadioButton("Fixed:", checked=True)
         group.addButton(fixedrb, UnivariateFeatureSelect.Fixed)
         kspin = QSpinBox(
-            minimum=1, value=self.__k,
+            minimum=1, maximum=1000000, value=self.__k,
             enabled=self.__strategy == UnivariateFeatureSelect.Fixed
         )
         kspin.valueChanged[int].connect(self.setK)
@@ -541,7 +541,7 @@ class RandomFeatureSelectEditor(BaseEditor):
         fixedrb = QRadioButton("Fixed", checked=True)
         group.addButton(fixedrb, RandomFeatureSelectEditor.Fixed)
         kspin = QSpinBox(
-            minimum=1, value=self.__k,
+            minimum=1, maximum=1000000, value=self.__k,
             enabled=self.__strategy == RandomFeatureSelectEditor.Fixed
         )
         kspin.valueChanged[int].connect(self.setK)
@@ -797,7 +797,7 @@ class CUR(BaseEditor):
         self.max_error = 1
 
         form = QFormLayout()
-        self.rspin = QSpinBox(minimum=2, value=self.rank)
+        self.rspin = QSpinBox(minimum=2, maximum=1000000, value=self.rank)
         self.rspin.valueChanged[int].connect(self.setR)
         self.rspin.editingFinished.connect(self.edited)
         self.espin = QDoubleSpinBox(

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -187,6 +187,11 @@ class TestFeatureSelectEditor(WidgetTest):
         self.assertIsInstance(p.method, score.InfoGain)
         self.assertEqual(p.k, 10)
 
+        widget.setParameters({"k": 9999})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, fss.SelectBestFeatures)
+        self.assertEqual(p.k, 9999)
+
 
 class TestRandomFeatureSelectEditor(WidgetTest):
     def test_editor(self):
@@ -194,6 +199,12 @@ class TestRandomFeatureSelectEditor(WidgetTest):
         p = widget.createinstance(widget.parameters())
         self.assertIsInstance(p, fss.SelectRandomFeatures)
         self.assertEqual(p.k, 10)
+
+        widget.setParameters({"strategy": owpreprocess.RandomFeatureSelectEditor.Fixed,
+                              "k": 9999})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, fss.SelectRandomFeatures)
+        self.assertEqual(p.k, 9999)
 
         widget.setParameters(
             {"strategy": owpreprocess.RandomFeatureSelectEditor.Percentage,
@@ -240,6 +251,11 @@ class TestCUREditor(WidgetTest):
         self.assertIsInstance(p, ProjectCUR)
         self.assertEqual(p.rank, 10)
         self.assertEqual(p.max_error, 1)
+
+        widget.setParameters({"rank": 9999})
+        p = widget.createinstance(widget.parameters())
+        self.assertIsInstance(p, ProjectCUR)
+        self.assertEqual(p.rank, 9999)
 
         widget.setParameters({"rank": 5, "max_error": 0.5})
         p = widget.createinstance(widget.parameters())


### PR DESCRIPTION
##### Issue
Fixes #4145 and #4103
Select Random Features, Select Relevant Features and CUR Matrix Decomposition preprocessors as implemented in the Preprocess widget allow the user to enter only a very limited number of attributes.


##### Description of changes
Set maximum possible value to be 1000000.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
