### PR TITLE
gui: Remove comboBox, use the one from orange-widget-base

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -39,7 +39,6 @@ from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.utils.concurrent import ThreadExecutor, TaskState
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
-from orangewidget.utils.itemmodels import PyListModel
 
 log = logging.getLogger(__name__)
 
@@ -285,7 +284,7 @@ class OWTestLearners(OWWidget):
 
         self.modcompbox = box = gui.vBox(self.controlArea, "Model Comparison")
         gui.comboBox(
-            box, self, "comparison_criterion", model=PyListModel(),
+            box, self, "comparison_criterion",
             callback=self.update_comparison_table)
 
         hbox = gui.hBox(box)
@@ -490,12 +489,14 @@ class OWTestLearners(OWWidget):
             new_scorers = usable_scorers(self.data.domain.class_var)
         else:
             new_scorers = []
-        # Don't unnecessarily reset the model because this would always reset
-        # comparison_criterion; we alse set it explicitly, though, for clarity
+        # Don't unnecessarily reset the combo because this would always reset
+        # comparison_criterion; we also set it explicitly, though, for clarity
         if new_scorers != self.scorers:
             self.scorers = new_scorers
-            self.controls.comparison_criterion.model()[:] = \
-                [scorer.long_name or scorer.name for scorer in self.scorers]
+            combo = self.controls.comparison_criterion
+            combo.clear()
+            combo.addItems([scorer.long_name or scorer.name
+                            for scorer in self.scorers])
             self.comparison_criterion = 0
         if self.__pending_comparison_criterion is not None:
             # Check for the unlikely case that some scorers have been removed

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -280,8 +280,7 @@ class OWTestLearners(OWWidget):
         self.cbox = gui.vBox(self.controlArea, "Target Class")
         self.class_selection_combo = gui.comboBox(
             self.cbox, self, "class_selection", items=[],
-            sendSelectedValue=True, valueType=str,
-            callback=self._on_target_class_changed,
+            sendSelectedValue=True, callback=self._on_target_class_changed,
             contentsLength=8)
 
         self.modcompbox = box = gui.vBox(self.controlArea, "Model Comparison")

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -403,7 +403,7 @@ class TestOWTestLearners(WidgetTest):
         w = self.widget
         control = w.controls.comparison_criterion
         control.setCurrentText(score)
-        w.comparison_criterion = control.model().indexOf(score)
+        w.comparison_criterion = control.findText(score)
 
     def _set_three_majorities(self):
         w = self.widget

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -36,9 +36,7 @@ from orangewidget.gui import (
 # exposed for backcompat. Should not be imported from here, or not
 # imported at all
 from orangewidget.gui import (
-    SpinBoxWFocusOut, DoubleSpinBoxWFocusOut, LineEditWFocusOut,
-    LAMBDA_NAME, disable_opposite,
-    _addSpace  # was included in docs
+    SpinBoxWFocusOut, DoubleSpinBoxWFocusOut, LineEditWFocusOut, OrangeComboBox
 )  # pylint: disable=unused-import
 from Orange.widgets.utils.buttons import (
     VariableTextPushButton

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -4,21 +4,20 @@ Wrappers for controls used in widgets
 import math
 
 import logging
+import warnings
 import weakref
 from collections.abc import Sequence
 
 from AnyQt import QtWidgets, QtCore, QtGui
-from AnyQt.QtCore import (
-    Qt, QSize, QItemSelection,
-)
+from AnyQt.QtCore import Qt, QSize, QItemSelection
 from AnyQt.QtGui import QColor
 from AnyQt.QtWidgets import QWidget, QItemDelegate, QListView, QComboBox
 
 # re-export relevant objects
-from orangewidget.utils.combobox import ComboBox as OrangeComboBox
 from orangewidget.gui import (
     OWComponent, OrangeUserRole, TableView, resource_filename,
     miscellanea, setLayout, separator, rubber, widgetBox, hBox, vBox,
+    comboBox as gui_comboBox,
     indentedBox, widgetLabel, label, spin, doubleSpin, checkBox, lineEdit,
     button, toolButton, radioButtons, radioButtonsInBox, appendRadioButton,
     hSlider, labeledSlider, valueSlider, auto_commit, auto_send, auto_apply,
@@ -32,7 +31,7 @@ from orangewidget.gui import (
     VisibleHeaderSectionContextEventFilter,
     checkButtonOffsetHint, toolButtonSizeHint, FloatSlider,
     ControlGetter, VerticalScrollArea, ProgressBar,
-    ControlledCallback, ControlledCallFront, ValueCallback, connectControl,
+    ControlledCallback, ControlledCallFront, connectControl,
 )
 # exposed for backcompat. Should not be imported from here, or not
 # imported at all
@@ -65,7 +64,7 @@ __all__ = [
     "miscellanea", "setLayout", "separator", "rubber",
     "widgetBox", "hBox", "vBox", "indentedBox",
     "widgetLabel", "label", "spin", "doubleSpin",
-    "checkBox", "lineEdit", "button", "toolButton",
+    "checkBox", "lineEdit", "button", "toolButton", "comboBox",
     "radioButtons", "radioButtonsInBox", "appendRadioButton",
     "hSlider", "labeledSlider", "valueSlider",
     "auto_commit", "auto_send", "auto_apply", "ProgressBar",
@@ -470,172 +469,12 @@ class ControlledList(list):
         super().remove(item)
 
 
-# TODO comboBox looks overly complicated:
-# - can valueType be anything else than str?
-# - sendSelectedValue is not a great name
-def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
-             orientation=Qt.Vertical, items=(), callback=None,
-             sendSelectedValue=False, valueType=str,
-             emptyString=None, editable=False,
-             contentsLength=None, maximumContentsLength=25,
-             **misc):
-    """
-    Construct a combo box.
-
-    The `value` attribute of the `master` contains either the index of the
-    selected row (if `sendSelected` is left at default, `False`) or a value
-    converted to `valueType` (`str` by default).
-
-    :param widget: the widget into which the box is inserted
-    :type widget: QWidget or None
-    :param master: master widget
-    :type master: OWWidget or OWComponent
-    :param value: the master's attribute with which the value is synchronized
-    :type value:  str
-    :param box: tells whether the widget has a border, and its label
-    :type box: int or str or None
-    :param orientation: tells whether to put the label above or to the left
-    :type orientation: `Qt.Horizontal` (default), `Qt.Vertical` or
-        instance of `QLayout`
-    :param label: a label that is inserted into the box
-    :type label: str
-    :param labelWidth: the width of the label
-    :type labelWidth: int
-    :param callback: a function that is called when the value is changed
-    :type callback: function
-    :param items: items (optionally with data) that are put into the box
-    :type items: tuple of str or tuples
-    :param sendSelectedValue: flag telling whether to store/retrieve indices
-        or string values from `value`
-    :type sendSelectedValue: bool
-    :param valueType: the type into which the selected value is converted
-        if sentSelectedValue is `False`
-    :type valueType: type
-    :param emptyString: the string value in the combo box that gets stored as
-        an empty string in `value`
-    :type emptyString: str
-    :param editable: a flag telling whether the combo is editable
-    :type editable: bool
-    :param int contentsLength: Contents character length to use as a
-        fixed size hint. When not None, equivalent to::
-
-            combo.setSizeAdjustPolicy(
-                QComboBox.AdjustToMinimumContentsLengthWithIcon)
-            combo.setMinimumContentsLength(contentsLength)
-    :param int maximumContentsLength: Specifies the upper bound on the
-        `sizeHint` and `minimumSizeHint` width specified in character
-        length (default: 25, use 0 to disable)
-    :rtype: QComboBox
-    """
-
-    # Local import to avoid circular imports
-    from Orange.widgets.utils.itemmodels import VariableListModel
-
-    if box or label:
-        hb = widgetBox(widget, box, orientation, addToLayout=False)
-        if label is not None:
-            label = widgetLabel(hb, label, labelWidth)
-    else:
-        hb = widget
-
-    combo = OrangeComboBox(
-        hb, maximumContentsLength=maximumContentsLength,
-        editable=editable)
-
-    if contentsLength is not None:
-        combo.setSizeAdjustPolicy(
-            QtWidgets.QComboBox.AdjustToMinimumContentsLengthWithIcon)
-        combo.setMinimumContentsLength(contentsLength)
-
-    combo.box = hb
-    combo.label = label
-    for item in items:
-        if isinstance(item, (tuple, list)):
-            combo.addItem(*item)
-        else:
-            combo.addItem(str(item))
-
-    if value:
-        cindex = getdeepattr(master, value)
-        model = misc.pop("model", None)
-        if model is not None:
-            combo.setModel(model)
-        if isinstance(model, VariableListModel):
-            callfront = CallFrontComboBoxModel(combo, model)
-            callfront.action(cindex)
-        else:
-            if isinstance(cindex, str):
-                if items and cindex in items:
-                    cindex = items.index(cindex)
-                else:
-                    cindex = 0
-            if cindex > combo.count() - 1:
-                cindex = 0
-            combo.setCurrentIndex(cindex)
-
-        if isinstance(model, VariableListModel):
-            connectControl(
-                master, value, callback, combo.activated[int],
-                callfront,
-                ValueCallbackComboModel(master, value, model)
-            )
-        elif sendSelectedValue:
-            connectControl(
-                master, value, callback, combo.activated[str],
-                CallFrontComboBox(combo, valueType, emptyString),
-                ValueCallbackCombo(master, value, valueType, emptyString))
-        else:
-            connectControl(
-                master, value, callback, combo.activated[int],
-                CallFrontComboBox(combo, None, emptyString))
-    miscellanea(combo, hb, widget, **misc)
-    combo.emptyString = emptyString
-    return combo
-
-
-class ValueCallbackCombo(ValueCallback):
-    def __init__(self, widget, attribute, f=None, emptyString=""):
-        super().__init__(widget, attribute, f)
-        self.emptyString = emptyString
-
-    def __call__(self, value):
-        value = str(value)
-        return super().__call__("" if value == self.emptyString else value)
-
-
-class ValueCallbackComboModel(ValueCallback):
-    def __init__(self, widget, attribute, model):
-        super().__init__(widget, attribute)
-        self.model = model
-
-    def __call__(self, index):
-        # Can't use super here since, it doesn't set `None`'s?!
-        return self.acyclic_setattr(self.model[index])
-
-
-class FunctionCallback:
-    def __init__(self, master, f, widget=None, id=None, getwidget=False):
-        self.master = master
-        self.widget = widget
-        self.func = f
-        self.id = id
-        self.getwidget = getwidget
-        if hasattr(master, "callbackDeposit"):
-            master.callbackDeposit.append(self)
-        self.disabled = 0
-
-    def __call__(self, *value):
-        if not self.disabled and value is not None:
-            kwds = {}
-            if self.id is not None:
-                kwds['id'] = self.id
-            if self.getwidget:
-                kwds['widget'] = self.widget
-            if isinstance(self.func, list):
-                for func in self.func:
-                    func(**kwds)
-            else:
-                self.func(**kwds)
+def comboBox(*args, **kwargs):
+    if "valueType" in kwargs:
+        del kwargs["valueType"]
+        warnings.warn("Argument 'valueType' is deprecated and ignored",
+                      DeprecationWarning)
+    return gui_comboBox(*args, **kwargs)
 
 
 class CallBackListView(ControlledCallback):
@@ -682,51 +521,6 @@ class CallBackListBox:
 
 ##############################################################################
 # call fronts (change of the attribute value changes the related control)
-
-
-class CallFrontComboBox(ControlledCallFront):
-    def __init__(self, control, valType=None, emptyString=""):
-        super().__init__(control)
-        self.valType = valType
-        self.emptyString = emptyString
-
-    def action(self, value):
-        if value in ('', None):
-            value = self.emptyString
-        if self.valType:
-            for i in range(self.control.count()):
-                if self.valType(self.control.itemText(i)) == value:
-                    self.control.setCurrentIndex(i)
-                    return
-            if value:
-                log.warning("Unable to set %s to '%s'. Possible values are: %s",
-                            self.control, value,
-                            ', '.join(self.control.itemText(i)
-                                      for i in range(self.control.count())))
-        else:
-            if value < self.control.count():
-                self.control.setCurrentIndex(value)
-
-
-class CallFrontComboBoxModel(ControlledCallFront):
-    def __init__(self, control, model):
-        super().__init__(control)
-        self.model = model
-
-    def action(self, value):
-        if value == "":  # the latter accomodates PyListModel
-            value = None
-        if value is None and None not in self.model:
-            return  # e.g. attribute x in uninitialized scatter plot
-        if value in self.model:
-            self.control.setCurrentIndex(self.model.indexOf(value))
-            return
-        elif isinstance(value, str):
-            for i, val in enumerate(self.model):
-                if value == str(val):
-                    self.control.setCurrentIndex(i)
-                    return
-        raise ValueError("Combo box does not contain item " + repr(value))
 
 
 class CallFrontListView(ControlledCallFront):

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from AnyQt.QtCore import Qt
 
 from Orange.data import ContinuousVariable
@@ -96,3 +98,9 @@ class ComboBoxTest(GuiTest):
         widget.foo = variables[1]
         combo = gui.comboBox(widget.controlArea, widget, "foo", model=model)
         self.assertEqual(combo.currentIndex(), 1)
+
+    @patch("Orange.widgets.gui.gui_comboBox")
+    def test_warn_value_type(self, gui_combobox):
+        with self.assertWarns(DeprecationWarning):
+            gui.comboBox(None, None, "foo", valueType=int, editable=True)
+        self.assertEqual(gui_combobox.call_args[1], {"editable": True})

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -693,7 +693,7 @@ class OWPlotGUI:
             widget, gui.comboBox, label,
             master=self._master, value=value, items=items, model=model,
             callback=self._get_callback(cb_name, self._master),
-            orientation=Qt.Horizontal, valueType=str,
+            orientation=Qt.Horizontal,
             sendSelectedValue=True, contentsLength=12,
             labelWidth=50)
 
@@ -903,7 +903,7 @@ class OWPlotGUI:
 
     def theme_combo_box(self, widget):
         c = gui.comboBox(widget, self._plot, "theme_name", "Theme",
-                         callback=self._plot.update_theme, sendSelectedValue=1, valueType=str)
+                         callback=self._plot.update_theme, sendSelectedValue=1)
         c.addItem('Default')
         c.addItem('Light')
         c.addItem('Dark')

--- a/Orange/widgets/utils/plot/owplotgui_obsolete.py
+++ b/Orange/widgets/utils/plot/owplotgui_obsolete.py
@@ -663,7 +663,7 @@ class OWPlotGUI:
     def _combo(self, widget, value, label, cb_name, items=(), model=None):
         gui.comboBox(widget, self._plot, value, label=label, items=items,
                      model=model, callback=self._get_callback(cb_name),
-                     labelWidth=50, orientation=Qt.Horizontal, valueType=str,
+                     labelWidth=50, orientation=Qt.Horizontal,
                      sendSelectedValue=True, contentsLength=12)
 
     def color_value_combo(self, widget):
@@ -857,7 +857,7 @@ class OWPlotGUI:
 
     def theme_combo_box(self, widget):
         c = gui.comboBox(widget, self._plot, "theme_name", "Theme",
-                         callback=self._plot.update_theme, sendSelectedValue=1, valueType=str)
+                         callback=self._plot.update_theme, sendSelectedValue=1)
         c.addItem('Default')
         c.addItem('Light')
         c.addItem('Dark')

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -272,7 +272,7 @@ class OWScatterPlot(OWDataProjectionWidget):
     def _add_controls_axis(self):
         common_options = dict(
             labelWidth=50, orientation=Qt.Horizontal, sendSelectedValue=True,
-            valueType=str, contentsLength=14
+            contentsLength=14
         )
         self.attr_box = gui.vBox(self.controlArea, True)
         dmod = DomainModel

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -111,7 +111,7 @@ class OWSieveDiagram(OWWidget):
         self.domain_model = DomainModel(valid_types=DomainModel.PRIMITIVE)
         combo_args = dict(
             widget=self.attr_box, master=self, contentsLength=12,
-            callback=self.attr_changed, sendSelectedValue=True, valueType=str,
+            callback=self.attr_changed, sendSelectedValue=True,
             model=self.domain_model)
         fixed_size = (QSizePolicy.Fixed, QSizePolicy.Fixed)
         gui.comboBox(value="attr_x", **combo_args)

--- a/doc/development/source/gui.rst
+++ b/doc/development/source/gui.rst
@@ -192,5 +192,4 @@ Other functions
 
 .. autofunction:: miscellanea
 .. autofunction:: setLayout
-.. autofunction:: _addSpace
 .. autofunction:: createAttributePixmap


### PR DESCRIPTION
##### Issue

https://github.com/biolab/orange-widget-base/pull/21 eliminates `valueType` argument from `comboBox`. This PR removes the argument from calls.

https://github.com/biolab/orange-widget-base/pull/21 also implements full comboBox function in orange-widget-base, so the function no longer needs to be reimplemented in this repo.

This slightly modifies behaviour of combo boxes: previously, a box could have assigned a model, but use ints as settings. This was invalid and no longer works. Only one core widget did this, and the error should be easily detected by tests, probably already at widget's initialization.
