### PR TITLE
[MNT] CI: No pre-release deps in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
     # disable threaded builds on Python 3.5+ when using numpy's distutils
     # (https://github.com/numpy/numpy/issues/7607)
     BUILD_GLOBAL_OPTIONS: build -j1
-    BUILD_ENV: wheel==0.29.0 pip==9.0.1 numpy==1.13.* -r requirements-doc.txt
+    BUILD_ENV: wheel==0.29.0 pip~=19.0 numpy==1.13.* -r requirements-doc.txt
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
     TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy>=1.16.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
     ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'
@@ -43,7 +43,7 @@ install:
 
   - set "PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   - python -m ensurepip
-  - python -m pip install pip~=9.0.1 wheel~=0.29.0
+  - python -m pip install pip~=19.0 wheel~=0.29.0
   - python -m pip install %BUILD_ENV_INDEX% %BUILD_ENV%
 
 build_script:
@@ -58,10 +58,10 @@ test_script:
   - build\.test\Scripts\activate
   - cd build\.test
   # Pre-populate the test environment
-  - python -m pip install pip~=9.0.1 wheel~=0.29.0
+  - python -m pip install pip~=19.0 wheel~=0.29.0
 
   - python -m pip install %TEST_ENV_INDEX% %TEST_ENV%
-  - python -m pip install --pre -f ..\..\dist orange3==%VERSION%
+  - python -m pip install -f ..\..\dist orange3==%VERSION%
   - python -m pip list --format=freeze
 
   # Raise OrangeDeprecationWarnings as errors


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Appveyor CI step attempts and fails to build pre release of bottleneck 1.3.rc1

##### Description of changes

Remove '--pre' from the test install command and bump pip version to 19.*

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
