### PR TITLE
Reset statistics collection permission, add more info link

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -66,13 +66,13 @@ def ua_string():
     settings = QSettings()
 
     is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
-    machine_id = settings.value("error-reporting/machine-id", "", str)
+    machine_id = settings.value("reporting/machine-id", "", str)
     return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}:{uuid}'.format(
         orange_version=current,
         py_version='.'.join(str(a) for a in sys.version_info[:3]),
         platform=sys.platform,
         conda='Anaconda' if is_anaconda else '',
-        uuid=machine_id if settings.value("error-reporting/send-statistics", False, bool) else ''
+        uuid=machine_id if settings.value("reporting/send-statistics", False, bool) else ''
     )
 
 
@@ -155,11 +155,11 @@ def open_link(url: QUrl):
         if url.host() == "enable-statistics":
             settings = QSettings()
 
-            settings.setValue("error-reporting/send-statistics", True)
+            settings.setValue("reporting/send-statistics", True)
             UsageStatistics.set_enabled(True)
 
-            if not settings.contains('error-reporting/machine-id'):
-                settings.setValue('error-reporting/machine-id', str(uuid.uuid4()))
+            if not settings.contains('reporting/machine-id'):
+                settings.setValue('reporting/machine-id', str(uuid.uuid4()))
         pass
     else:
         QDesktopServices.openUrl(url)
@@ -316,7 +316,7 @@ def send_usage_statistics():
         import json
         import requests
         settings = QSettings()
-        if not settings.value("error-reporting/send-statistics", False,
+        if not settings.value("reporting/send-statistics", False,
                               type=bool):
             log.info("Not sending usage statistics (preferences setting).")
             return
@@ -324,11 +324,11 @@ def send_usage_statistics():
             log.info("Not sending usage statistics (disabled).")
             return
 
-        if settings.contains('error-reporting/machine-id'):
-            machine_id = settings.value('error-reporting/machine-id')
+        if settings.contains('reporting/machine-id'):
+            machine_id = settings.value('reporting/machine-id')
         else:
             machine_id = str(uuid.uuid4())
-            settings.setValue('error-reporting/machine-id', machine_id)
+            settings.setValue('reporting/machine-id', machine_id)
 
         is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
 
@@ -515,7 +515,7 @@ def main(argv=None):
     settings = QSettings()
     settings.setValue('startup/launch-count', settings.value('startup/launch-count', 0, int) + 1)
 
-    if settings.value("error-reporting/send-statistics", False, type=bool) \
+    if settings.value("reporting/send-statistics", False, type=bool) \
             and is_release:
         UsageStatistics.set_enabled(True)
 

--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -34,11 +34,11 @@ spec = [
 
     ("startup/launch-count", int, 0, ""),
 
-    ("error-reporting/machine-id", str, str(uuid.uuid4()), ""),
+    ("reporting/machine-id", str, str(uuid.uuid4()), ""),
 
-    ("error-reporting/send-statistics", bool, False, ""),
+    ("reporting/send-statistics", bool, False, ""),
 
-    ("error-reporting/permission-requested", bool, False, ""),
+    ("reporting/permission-requested", bool, False, ""),
 
     ("notifications/check-notifications", bool, True, "Check for notifications"),
 

--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -1,6 +1,6 @@
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import (
-    QFormLayout, QCheckBox, QLineEdit, QWidget, QVBoxLayout,
+    QFormLayout, QCheckBox, QLineEdit, QWidget, QVBoxLayout, QLabel
 )
 from orangecanvas.application.settings import UserSettingsDialog
 from orangecanvas.document.usagestatistics import UsageStatistics
@@ -35,7 +35,7 @@ class OUserSettingsDialog(UserSettingsDialog):
         layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         cb1 = QCheckBox(
-            self.tr(""),
+            self.tr("Share"),
             toolTip=self.tr(
                 "Share anonymous usage statistics to improve Orange")
         )
@@ -43,7 +43,13 @@ class OUserSettingsDialog(UserSettingsDialog):
         cb1.clicked.connect(UsageStatistics.set_enabled)
         layout.addWidget(cb1)
         box.setLayout(layout)
-        form.addRow(self.tr("Share Anonymous Statistics"), box)
+        form.addRow(self.tr("Anonymous Statistics"), box)
+        label = QLabel("<a "
+                       "href=\"https://orange.biolab.si/statistics-more-info\">"
+                       "More info..."
+                       "</a>")
+        label.setOpenExternalLinks(True)
+        form.addRow(self.tr(""), label)
 
         tab.setLayout(form)
 

--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -4,9 +4,9 @@ from AnyQt.QtWidgets import (
 )
 from orangecanvas.application.settings import UserSettingsDialog
 from orangecanvas.document.usagestatistics import UsageStatistics
-from orangewidget.workflow.mainwindow import OWCanvasMainWindow
-
 from orangecanvas.utils.overlay import NotificationOverlay
+
+from orangewidget.workflow.mainwindow import OWCanvasMainWindow
 
 
 class OUserSettingsDialog(UserSettingsDialog):

--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -21,14 +21,14 @@ class OUserSettingsDialog(UserSettingsDialog):
         layout.addRow("Updates", cb)
         self.bind(cb, "checked", "startup/check-updates")
 
-        # Error Reporting Tab
+        # Reporting Tab
         tab = QWidget()
-        self.addTab(tab, self.tr("Error Reporting"),
-                    toolTip="Settings related to error reporting")
+        self.addTab(tab, self.tr("Reporting"),
+                    toolTip="Settings related to reporting")
 
         form = QFormLayout()
         line_edit_mid = QLineEdit()
-        self.bind(line_edit_mid, "text", "error-reporting/machine-id")
+        self.bind(line_edit_mid, "text", "reporting/machine-id")
         form.addRow("Machine ID:", line_edit_mid)
 
         box = QWidget()
@@ -39,7 +39,7 @@ class OUserSettingsDialog(UserSettingsDialog):
             toolTip=self.tr(
                 "Share anonymous usage statistics to improve Orange")
         )
-        self.bind(cb1, "checked", "error-reporting/send-statistics")
+        self.bind(cb1, "checked", "reporting/send-statistics")
         cb1.clicked.connect(UsageStatistics.set_enabled)
         layout.addWidget(cb1)
         box.setLayout(layout)


### PR DESCRIPTION
In light of https://github.com/biolab/orange-canvas-core/pull/49, it's right to inform the user of updates to usage statistics collection and to request permission anew.

##### Description of changes
- [X] Rename `error-reporting` to `reporting`
- [X] Add `More info...` hyperlink label to `reporting` preferences pane, below statistics toggle ([leads to a wiki page](https://github.com/biolab/orange3/wiki/Anonymous-Usage-Statistics-Tracking), this page will be updated before the next release)

By renaming the `error-reporting` config category to `reporting`, the following config values are reset:
- `error-reporting/machine-id` [`uuid.uuid4()`]
- `error-reporting/send-statistics` [`False`]
- `error-reporting/add-scheme` [`True`] (default value for sending scheme along with error report)

Additionally, the preferences pane is narrower due to a smaller tab name.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
