### PR TITLE
Update miniconda version in Windows installer to 4.7.12

### DIFF
--- a/scripts/windows/build-conda-installer.sh
+++ b/scripts/windows/build-conda-installer.sh
@@ -45,7 +45,7 @@ DISTDIR=
 CACHEDIR=
 
 # Python version in the Miniconda installer.
-MINICONDA_VERSION=4.5.11
+MINICONDA_VERSION=4.7.12
 PYTHON_VERSION=3.7.0
 
 PLATTAG=win_amd64


### PR DESCRIPTION
##### Issue
Fixes #4112

##### Description of changes
Updated installer fixes #4112 for users that do not have Miniconda installed. Those that already have the previous version need to uninstall it manually.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
