### PR TITLE
[FIX] SOM: Fix crash when clicking on empty canvas

### DIFF
--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -423,6 +423,8 @@ class OWSOM(OWWidget):
         self.redraw_selection()
 
     def on_selection_change(self, selection, action=SomView.SelectionSet):
+        if self.data is None:  # clicks on empty canvas
+            return
         if self.selection is None:
             self.selection = np.zeros(self.grid_cells.T.shape, dtype=np.int16)
         if action == SomView.SelectionSet:

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -501,6 +501,12 @@ class TestOWSOM(WidgetTest):
         np.testing.assert_equal(widget.selection, m)
 
     @_patch_recompute_som
+    def test_on_selection_change_on_empty(self):
+        """Test clicks on empty scene, when no data"""
+        widget = self.widget
+        widget.on_selection_change([])
+
+    @_patch_recompute_som
     def test_output(self):
         widget = self.widget
         self.send_signal(self.widget.Inputs.data, self.iris)

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -42,6 +42,7 @@ class TestOWSOM(WidgetTest):
 
     def tearDown(self):
         self.widget.onDeleteWidget()
+        super().tearDown()
 
     def test_requires_continuous(self):
         widget = self.widget


### PR DESCRIPTION
##### Issue

Fixes #4168.

##### Description of changes

Don't "reset" selection when clicking on empty canvas.

##### Includes
- [X] Code changes
- [X] Tests

