### PR TITLE
SOM tests: Call inherited tearDown

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -42,6 +42,7 @@ class TestOWSOM(WidgetTest):
 
     def tearDown(self):
         self.widget.onDeleteWidget()
+        super().tearDown()
 
     def test_requires_continuous(self):
         widget = self.widget


### PR DESCRIPTION
##### Issue

I am stupid.

##### Description of changes in Orange

When I wrote tests for SOM, I apparently noticed that `tearDown` doesn't call `self.widget.onDeleteWidget`. Instead of adding it to the inherited method, I added my own `tearDown` ... and haven't called the inherited.

`onDeleteWidget` still probably needs to be called in `WidgetTest.tearDown`.
