### PR TITLE
[FIX] Louvain Clustering: fix setting to restore correctly

### DIFF
--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -431,10 +431,8 @@ class OWLouvainClustering(widget.OWWidget):
         # Can't have more PCA components than the number of attributes
         n_attrs = len(data.domain.attributes)
         self.pca_components_slider.setMaximum(min(_MAX_PCA_COMPONENTS, n_attrs))
-        self.pca_components_slider.setValue(min(_DEFAULT_PCA_COMPONENTS, n_attrs))
         # Can't have more k neighbors than there are data points
         self.k_neighbors_spin.setMaximum(min(_MAX_K_NEIGBOURS, len(data) - 1))
-        self.k_neighbors_spin.setValue(min(_DEFAULT_K_NEIGHBORS, len(data) - 1))
 
         self.info_label.setText("Clustering not yet run.")
 

--- a/Orange/widgets/unsupervised/tests/test_owlouvain.py
+++ b/Orange/widgets/unsupervised/tests/test_owlouvain.py
@@ -5,7 +5,7 @@ import numpy as np
 from Orange.data import Table, Domain, ContinuousVariable
 from Orange.preprocess import Normalize
 from Orange.widgets.tests.base import WidgetTest
-from Orange.widgets.tests.utils import table_dense_sparse
+from Orange.widgets.tests.utils import table_dense_sparse, simulate
 from Orange.widgets.unsupervised.owlouvainclustering import OWLouvainClustering
 from sklearn.utils import check_random_state
 
@@ -234,3 +234,34 @@ class TestOWLouvain(WidgetTest):
         dense_result = _compute_clustering(dense_data)
         sparse_result = _compute_clustering(sparse_data)
         np.testing.assert_equal(dense_result.metas, sparse_result.metas)
+
+    def test_settings_correctly_restored(self):
+        """
+        This test checks if contextsettings are correctly restored after
+        dataset changed.
+        """
+        w = self.widget
+
+        self.send_signal(w.Inputs.data, self.iris)
+        w.controls.apply_pca.setChecked(False)
+        w.controls.pca_components.setValue(2)
+        simulate.combobox_activate_item(w.controls.metric_idx, "Manhattan")
+        w.controls.normalize.setChecked(False)
+        w.controls.k_neighbors.setValue(4)
+        w.controls.resolution.setValue(0.5)
+
+        self.send_signal(w.Inputs.data, Table("zoo"))
+        w.controls.apply_pca.setChecked(True)
+        w.controls.pca_components.setValue(3)
+        simulate.combobox_activate_item(w.controls.metric_idx, "Euclidean")
+        w.controls.normalize.setChecked(True)
+        w.controls.k_neighbors.setValue(5)
+        w.controls.resolution.setValue(1)
+
+        self.send_signal(w.Inputs.data, self.iris)
+        self.assertFalse(w.apply_pca)
+        self.assertEqual(2, w.pca_components)
+        self.assertEqual(1, w.metric_idx)
+        self.assertFalse(w.normalize)
+        self.assertEqual(4, w.k_neighbors)
+        self.assertEqual(0.5, w.resolution)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #4182, also when just chaning the dataset and changing it back settings did not restored. 

##### Description of changes
Removed two lines that caused that settings did not restore to the old value. In my opinion, those two lines are not required since spin has the same functionality itself.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
