### PR TITLE
Adapt usage statistics for orange-canvas-core 0.1.9

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -160,7 +160,6 @@ def open_link(url: QUrl):
 
             if not settings.contains('reporting/machine-id'):
                 settings.setValue('reporting/machine-id', str(uuid.uuid4()))
-        pass
     else:
         QDesktopServices.openUrl(url)
 

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -332,8 +332,7 @@ def send_usage_statistics():
 
         is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
 
-        usage = UsageStatistics()
-        data = usage.load()
+        data = UsageStatistics.load()
         for d in data:
             d["Orange Version"] = d.pop("Application Version", "")
             d["Anaconda"] = is_anaconda
@@ -342,11 +341,11 @@ def send_usage_statistics():
             r = requests.post(url, files={'file': json.dumps(data)})
             if r.status_code != 200:
                 log.warning("Error communicating with server while attempting to send "
-                            "usage statistics.")
+                            "usage statistics. Status code " + str(r.status_code))
                 return
             # success - wipe statistics file
             log.info("Usage statistics sent.")
-            with open(usage.filename(), 'w', encoding="utf-8") as f:
+            with open(UsageStatistics.filename(), 'w', encoding="utf-8") as f:
                 json.dump([], f)
         except (ConnectionError, requests.exceptions.RequestException):
             log.warning("Connection error while attempting to send usage statistics.")

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - opentsne      >=0.3.11
     - pandas
     - pyyaml
-    - orange-canvas-core  >=0.1.7
+    - orange-canvas-core  >=0.1.9
     - orange-widget-base
 
 test:

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.1.7,<0.2a
+orange-canvas-core>=0.1.9,<0.2a
 orange-widget-base>=4.1.0
 
 # PyQt4/PyQt5 compatibility


### PR DESCRIPTION
To be merged after https://github.com/biolab/orange-canvas-core/pull/49.

##### Description of changes
Call the `UsageStatistics.load()` static function instead of instantiating the class and calling the method.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
