### PR TITLE
pymssql: Freeze to version <3.0

### DIFF
--- a/.travis/install_mssql.sh
+++ b/.travis/install_mssql.sh
@@ -2,6 +2,6 @@ sudo docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=YourStrong!Passw0rd' \
    -p 1433:1433 -d microsoft/mssql-server-linux:2017-latest
 
 export PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1
-pip install pymssql
+pip install "pymssql<3.0"
 
 export ORANGE_TEST_DB_URI="${ORANGE_TEST_DB_URI}|mssql://SA:YourStrong!Passw0rd@0.0.0.0:1433"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
     PIP_DISABLE_PIP_VERSION_CHECK: 1
     BUILD_ENV: wheel==0.29.0 pip~=19.0
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy>=1.16.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 pymssql
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy>=1.16.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 "pymssql<3.0"
     ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'
 
   matrix:

--- a/requirements-sql.txt
+++ b/requirements-sql.txt
@@ -1,2 +1,2 @@
 psycopg2
-pymssql
+pymssql<3.0


### PR DESCRIPTION
##### Issue

Orange no longer builds because pymssql is discontinued and version 3.0 deliberately blocks building. 

##### Description of changes

The temporary solution proposed in pymssql is to freeze version. The longterm solution is to migrate to ODBC.
