### PR TITLE
[FIX] Fix crash in Preprocess' Select Relevant Features when there are no features

### DIFF
--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -91,8 +91,9 @@ class SelectBestFeatures(Reprable):
         return data.transform(domain)
 
     def score_only_nice_features(self, data, method):
+        # dtype must be defined because array can be empty
         mask = np.array([isinstance(a, method.feature_type)
-                         for a in data.domain.attributes])
+                         for a in data.domain.attributes], dtype=np.bool)
         features = [f for f in data.domain.attributes
                     if isinstance(f, method.feature_type)]
         scores = [method(data, f) for f in features]

--- a/Orange/preprocess/tests/test_fss.py
+++ b/Orange/preprocess/tests/test_fss.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import Mock
+
+import numpy as np
+
+from Orange.data import Domain, Table, DiscreteVariable, ContinuousVariable
+from Orange.preprocess import fss
+
+
+class SelectBestFeaturesTest(unittest.TestCase):
+    def test_no_nice_features(self):
+        method = Mock()
+        method.feature_type = DiscreteVariable
+        selector = fss.SelectBestFeatures(method, 5)
+
+        domain = Domain([])
+        data = Table.from_numpy(domain, np.zeros((100, 0)))
+        selection = selector.score_only_nice_features(data, method)
+        self.assertEqual(selection.size, 0)
+        method.assert_not_called()
+
+        domain = Domain([ContinuousVariable("x")])
+        data = Table.from_numpy(domain, np.zeros((100, 1)))
+        selector.decreasing = True
+        selection = selector.score_only_nice_features(data, method)
+        np.testing.assert_equal(selection, [float('-inf')])
+        method.assert_not_called()
+
+        selector.decreasing = False
+        selection = selector.score_only_nice_features(data, method)
+        np.testing.assert_equal(selection, [float('inf')])
+        method.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #4202 

##### Description of changes

When mask was empty, numpy assumed `dtype` is `float` instead of `bool`.

##### Includes
- [X] Code changes
- [X] Tests
