### PR TITLE
Feature Statistics: Fix coloring of the last bin

### DIFF
--- a/Orange/widgets/data/utils/histogram.py
+++ b/Orange/widgets/data/utils/histogram.py
@@ -359,9 +359,7 @@ class Histogram(QGraphicsWidget):
 
             bins = np.arange(self.n_bins)[:, np.newaxis]
             edges = self.edges if self.attribute.is_discrete else self.edges[1:-1]
-            # Need to digitize on `right` here so the samples will be assigned
-            # to the correct bin for coloring
-            bin_indices = ut.digitize(self.x, bins=edges, right=True)
+            bin_indices = ut.digitize(self.x, bins=edges)
             mask = bin_indices == bins
 
             colors = []


### PR DESCRIPTION
##### Issue

Fixes #4195.

##### Description of changes

The code that computed bins for coloring produced just 9 bins because data instances with values equal to the last edge were put in the previous bin because of `right=True`. Removing the argument solves the issue.

##### Includes
- [X] Code changes
