### PR TITLE
[FIX] File: Fix domain edit on no changes

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -484,6 +484,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
             if not (domain.variables or domain.metas):
                 table = None
+            elif domain is self.data.domain:
+                table = self.data
             else:
                 X, y, m = cols
                 table = Table.from_numpy(domain, X, y, m, self.data.W)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -321,6 +321,13 @@ a
             self.widget.load_data()
         self.assertTrue(self.widget.Error.missing_reader.is_shown())
 
+    def test_domain_edit_no_changes(self):
+        self.open_dataset("iris")
+        data = self.get_output(self.widget.Outputs.data)
+        # When no changes have been made in the domain editor,
+        # output data should be the same object (and not recreated)
+        self.assertTrue(data is self.widget.data)
+
     def test_domain_edit_on_sparse_data(self):
         iris = Table("iris").to_sparse()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When no changes have been made in domain editor, it nevertheless created a new instance of Table with the same domain.
In addition to needless work, this prevented loading pkl files with subclasses of Table.

##### Description of changes
If domain did not change, leave the data alone.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
