### PR TITLE
[ENH] owheatmap: Add Split By combo box

### DIFF
--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -198,6 +198,17 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(w.Inputs.data, iris, widget=w)
         self.assertEqual(len(self.get_output(w.Outputs.selected_data)), 21)
 
+    def test_set_split_var(self):
+        data = Table("brown-selected")
+        w = self.widget
+        self.send_signal(self.widget.Inputs.data, data, widget=w)
+        self.assertIs(w.split_by_var, data.domain.class_var)
+        self.assertEqual(len(w.heatmapparts.rows),
+                         len(data.domain.class_var.values))
+        w.set_split_variable(None)
+        self.assertIs(w.split_by_var, None)
+        self.assertEqual(len(w.heatmapparts.rows), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Heat map splits vertically by discrete class variable. This is hardcoded in the widget but not always desired.

##### Description of changes

Allow (rows) split by other class or meta categorical var (not just the class var), or disable spliting at all.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
