### PR TITLE
[FIX] File widget: fix name change

### DIFF
--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -141,6 +141,52 @@ class TestOWFile(WidgetTest):
         data = self.get_output(self.widget.Outputs.data)
         self.assertIsInstance(data.domain["iris"], StringVariable)
 
+    def test_variable_name_change(self):
+        """
+        Test whether the name of the variable is changed correctly by
+        the domaineditor.
+        """
+        self.open_dataset("iris")
+
+        # just rename
+        idx = self.widget.domain_editor.model().createIndex(4, 0)
+        self.widget.domain_editor.model().setData(idx, "a", Qt.EditRole)
+        self.widget.apply_button.click()
+        data = self.get_output(self.widget.Outputs.data)
+        self.assertIn("a", data.domain)
+
+        # rename and change to text
+        idx = self.widget.domain_editor.model().createIndex(4, 0)
+        self.widget.domain_editor.model().setData(idx, "b", Qt.EditRole)
+        idx = self.widget.domain_editor.model().createIndex(4, 1)
+        self.widget.domain_editor.model().setData(idx, "text", Qt.EditRole)
+        self.widget.apply_button.click()
+        data = self.get_output(self.widget.Outputs.data)
+        self.assertIn("b", data.domain)
+        self.assertIsInstance(data.domain["b"], StringVariable)
+
+        # rename and change to discrete
+        idx = self.widget.domain_editor.model().createIndex(4, 0)
+        self.widget.domain_editor.model().setData(idx, "c", Qt.EditRole)
+        idx = self.widget.domain_editor.model().createIndex(4, 1)
+        self.widget.domain_editor.model().setData(
+            idx, "categorical", Qt.EditRole)
+        self.widget.apply_button.click()
+        data = self.get_output(self.widget.Outputs.data)
+        self.assertIn("c", data.domain)
+        self.assertIsInstance(data.domain["c"], DiscreteVariable)
+
+        # rename and change to continuous
+        self.open_dataset("zoo")
+        idx = self.widget.domain_editor.model().createIndex(0, 0)
+        self.widget.domain_editor.model().setData(idx, "c", Qt.EditRole)
+        idx = self.widget.domain_editor.model().createIndex(0, 1)
+        self.widget.domain_editor.model().setData(idx, "numeric", Qt.EditRole)
+        self.widget.apply_button.click()
+        data = self.get_output(self.widget.Outputs.data)
+        self.assertIn("c", data.domain)
+        self.assertIsInstance(data.domain["c"], ContinuousVariable)
+
     def open_dataset(self, name):
         filename = FileFormat.locate(name, dataset_dirs)
         self.widget.add_path(filename)

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -299,9 +299,7 @@ class DomainEditor(QTableView):
             if name == orig_var.name and tpe == type(orig_var):
                 var = orig_var
             elif tpe == type(orig_var):
-                # change the name so that all_vars will get the correct name
-                orig_var.name = name
-                var = orig_var
+                var = orig_var.copy(name=name)
             elif tpe == DiscreteVariable:
                 values = list(str(i) for i in unique(col_data) if not self._is_missing(i))
                 round_numbers = numbers_are_round(orig_var, col_data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
File widget fails on an attribute name change. It happens just in cases when only the name is changed and the type of variable stays the same.

##### Description of changes
Fixed name change using the copy function. It seems that the variable name is protected (no setter function).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
