### PR TITLE
table: Avoid deprecated hstack use in concatenate

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -859,7 +859,7 @@ class Table(Sequence, Storage):
             vstack(collect("metas")),
             merge1d(collect("W"))
         )
-        conc.ids = np.hstack(map(operator.attrgetter("ids"), tables))
+        conc.ids = np.hstack([t.ids for t in tables])
         names = [table.name for table in tables if table.name != "untitled"]
         if names:
             conc.name = names[0]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.

##### Description of changes
Change a non-sequence iterable (map object) to a sequence type (list).

