### PR TITLE
Validation: Deprecated constructor calls removed

### DIFF
--- a/Orange/evaluation/testing.py
+++ b/Orange/evaluation/testing.py
@@ -385,10 +385,6 @@ class Validation:
                                  "and train_data are omitted")
             return self
 
-        warn("calling Validation's constructor with data and learners "
-             "is deprecated;\nconstruct an instance and call it",
-             DeprecationWarning, stacklevel=2)
-
         # Explicitly call __init__ because Python won't
         self.__init__(store_data=store_data, store_models=store_models,
                       **kwargs)
@@ -403,11 +399,6 @@ class Validation:
     def __init__(self, *, store_data=False, store_models=False):
         self.store_data = store_data
         self.store_models = store_models
-
-    def fit(self, *args, **kwargs):
-        warn("Validation.fit is deprecated; use the call operator",
-             DeprecationWarning)
-        return self(*args, **kwargs)
 
     def __call__(self, data, learners, preprocessor=None, *, callback=None):
         """

--- a/Orange/tests/test_evaluation_testing.py
+++ b/Orange/tests/test_evaluation_testing.py
@@ -116,46 +116,6 @@ class TestValidation(unittest.TestCase):
         self.assertRaises(ValueError, Validation, preprocessor=lambda x: x)
         self.assertRaises(ValueError, Validation, callback=lambda x: x)
 
-    @patch("Orange.evaluation.testing.Validation.__call__")
-    def test_warn_deprecations(self, _):
-        self.assertWarns(
-            DeprecationWarning,
-            Validation, self.data, [MajorityLearner()])
-
-        self.assertWarns(DeprecationWarning, Validation().fit)
-
-    @patch("Orange.evaluation.testing.Validation.__call__")
-    def test_obsolete_call_constructor(self, validation_call):
-
-        class MockValidation(Validation):
-            args = kwargs = None
-
-            def __init__(self, *args, **kwargs):
-                super().__init__()
-                MockValidation.args = args
-                MockValidation.kwargs = kwargs
-
-            def get_indices(self, data):
-                pass
-
-        data = self.data
-        learners = [MajorityLearner(), MajorityLearner()]
-        kwargs = dict(foo=42, store_data=43, store_models=44, callback=45, n_jobs=46)
-        self.assertWarns(
-            DeprecationWarning,
-            MockValidation, data, learners=learners,
-            **kwargs)
-        self.assertEqual(MockValidation.args, ())
-        kwargs.pop("n_jobs")  # do not pass n_jobs and callback from __new__ to __init__
-        kwargs.pop("callback")
-        self.assertEqual(MockValidation.kwargs, kwargs)
-
-        cargs, ckwargs = validation_call.call_args
-        self.assertEqual(len(cargs), 1)
-        self.assertIs(cargs[0], data)
-        self.assertIs(ckwargs["learners"], learners)
-        self.assertEqual(ckwargs["callback"], 45)
-
 
 class TestCrossValidation(TestSampling):
     @classmethod


### PR DESCRIPTION
##### Description of changes
Fixes #4233 - Removed deprecated constructor calls in Validation.
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
