### PR TITLE
[FIX] Feature Statistics: Do not crash on empty domain

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -827,7 +827,7 @@ class OWFeatureStatistics(widget.OWWidget):
     def __restore_sorting(self):
         """Restore the sort column and order from saved settings."""
         sort_column, sort_order = self.sorting
-        if self.data is not None and sort_column < self.model.columnCount():
+        if self.model.n_attributes and sort_column < self.model.columnCount():
             self.model.sort(sort_column, sort_order)
             self.table_view.horizontalHeader().setSortIndicator(sort_column, sort_order)
 

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -200,6 +200,10 @@ class TestVariousDataSets(WidgetTest):
         self.send_signal(self.widget.Inputs.data, make_table(discrete))
         self.send_signal(self.widget.Inputs.data, None)
 
+    def test_does_not_crash_on_empty_domain(self):
+        empty_data = Table('iris').transform(Domain([]))
+        self.send_signal(self.widget.Inputs.data, empty_data)
+
     # No missing values
     @table_dense_sparse
     def test_on_data_with_no_missing_values(self, prepare_table):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Feature Statistics crashes on data with an empty Domain.
To reproduce: File (iris) -> Select Columns (remove everything) -> Feature Statistics

##### Description of changes
Sort only if there is something to sort.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
