### PR TITLE
Validation: Deprecated constructor calls removed

### DIFF
--- a/Orange/ensembles/stack.py
+++ b/Orange/ensembles/stack.py
@@ -69,7 +69,8 @@ class StackedLearner(Learner):
         self.params = vars()
 
     def fit_storage(self, data):
-        res = CrossValidation(data, self.learners, k=self.k)
+        cv = CrossValidation(k=self.k)
+        res = cv(data, self.learners)
         if data.domain.class_var.is_discrete:
             X = np.hstack(res.probabilities)
             use_prob = True

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -21,7 +21,8 @@ class TestSklAdaBoostLearner(unittest.TestCase):
 
     def test_adaboost(self):
         learn = SklAdaBoostClassificationLearner()
-        results = CrossValidation(self.iris, [learn], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, [learn])
         ca = CA(results)
         self.assertGreater(ca, 0.9)
         self.assertLess(ca, 0.99)
@@ -34,7 +35,8 @@ class TestSklAdaBoostLearner(unittest.TestCase):
             base_estimator=stump_estimator, n_estimators=5)
         tree = SklAdaBoostClassificationLearner(
             base_estimator=tree_estimator, n_estimators=5)
-        results = CrossValidation(self.iris, [stump, tree], k=4)
+        cv = CrossValidation(k=4)
+        results = cv(self.iris, [stump, tree])
         ca = CA(results)
         self.assertLessEqual(ca[0], ca[1])
 
@@ -62,7 +64,8 @@ class TestSklAdaBoostLearner(unittest.TestCase):
 
     def test_adaboost_reg(self):
         learn = SklAdaBoostRegressionLearner()
-        results = CrossValidation(self.housing, [learn], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.housing, [learn])
         _ = RMSE(results)
 
     def test_adaboost_reg_base_estimator(self):
@@ -71,7 +74,8 @@ class TestSklAdaBoostLearner(unittest.TestCase):
         tree_estimator = SklTreeRegressionLearner()
         stump = SklAdaBoostRegressionLearner(base_estimator=stump_estimator)
         tree = SklAdaBoostRegressionLearner(base_estimator=tree_estimator)
-        results = CrossValidation(self.housing, [stump, tree], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.housing, [stump, tree])
         rmse = RMSE(results)
         self.assertGreaterEqual(rmse[0], rmse[1])
 

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -238,7 +238,8 @@ class SklTest(unittest.TestCase):
         table = Table("titanic")
         lr = LogisticRegressionLearner()
         assert isinstance(lr, Orange.classification.SklLearner)
-        res = CrossValidation(table, [lr], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(table, [lr])
         self.assertGreater(Orange.evaluation.AUC(res)[0], 0.7)
         self.assertLess(Orange.evaluation.AUC(res)[0], 0.9)
 
@@ -246,7 +247,8 @@ class SklTest(unittest.TestCase):
         data = Orange.data.Table("iris")
         data.X[:, (1, 3)] = np.NaN
         lr = LogisticRegressionLearner()
-        res = CrossValidation(data, [lr], k=2, store_models=True)
+        cv = CrossValidation(k=2, store_models=True)
+        res = cv(data, [lr])
         self.assertEqual(len(res.models[0][0].domain.attributes), 2)
         self.assertGreater(Orange.evaluation.CA(res)[0], 0.8)
 

--- a/Orange/tests/test_knn.py
+++ b/Orange/tests/test_knn.py
@@ -18,7 +18,8 @@ class TestKNNLearner(unittest.TestCase):
         cls.housing = Table('housing')
 
     def test_KNN(self):
-        results = CrossValidation(self.iris, [KNNLearner()], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, [KNNLearner()])
         ca = CA(results)
         self.assertGreater(ca, 0.8)
         self.assertLess(ca, 0.99)
@@ -54,13 +55,15 @@ class TestKNNLearner(unittest.TestCase):
 
     def test_KNN_mahalanobis(self):
         learners = [KNNLearner(metric="mahalanobis")]
-        results = CrossValidation(self.iris, learners, k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, learners)
         ca = CA(results)
         self.assertGreater(ca, 0.8)
 
     def test_KNN_regression(self):
         learners = [KNNRegressionLearner(),
                     KNNRegressionLearner(metric="mahalanobis")]
-        results = CrossValidation(self.housing, learners, k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.housing, learners)
         mse = MSE(results)
         self.assertLess(mse[1], mse[0])

--- a/Orange/tests/test_linear_bfgs_regression.py
+++ b/Orange/tests/test_linear_bfgs_regression.py
@@ -13,6 +13,7 @@ class TestLinearRegressionLearner(unittest.TestCase):
         table = Table('housing')
         learners = [LinearRegressionLearner(preprocessors=[]),
                     LinearRegressionLearner()]
-        results = CrossValidation(table, learners, k=3)
+        cv = CrossValidation(k=3)
+        results = cv(table, learners)
         rmse = RMSE(results)
         self.assertLess(rmse[0], rmse[1])

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -44,7 +44,8 @@ class TestLinearRegressionLearner(unittest.TestCase):
         elasticCV = ElasticNetCVLearner()
         mean = MeanLearner()
         learners = [ridge, lasso, elastic, elasticCV, mean]
-        res = CrossValidation(self.housing, learners, k=2)
+        cv = CrossValidation(k=2)
+        res = cv(self.housing, learners)
         rmse = RMSE(res)
         for i in range(len(learners) - 1):
             self.assertLess(rmse[i], rmse[-1])

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -20,7 +20,8 @@ class TestLogisticRegressionLearner(unittest.TestCase):
 
     def test_LogisticRegression(self):
         learn = LogisticRegressionLearner()
-        results = CrossValidation(self.heart_disease, [learn], k=2)
+        cv = CrossValidation(k=2)
+        results = cv(self.heart_disease, [learn])
         ca = CA(results)
         self.assertGreater(ca, 0.8)
         self.assertLess(ca, 1.0)
@@ -40,7 +41,8 @@ class TestLogisticRegressionLearner(unittest.TestCase):
         lr_norm = LogisticRegressionLearner(normalize=True)
 
         # check that normalization produces better results
-        results = CrossValidation(table, [lr_norm, lr], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(table, [lr_norm, lr])
         ca = CA(results)
         self.assertGreater(ca[0], ca[1])
 

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -32,12 +32,14 @@ class TestNaiveBayesLearner(unittest.TestCase):
         self.model = self.learner(self.data)
 
     def test_NaiveBayes(self):
-        results = CrossValidation(self.table, [self.learner], k=10)
+        cv = CrossValidation(k=10)
+        results = cv(self.table, [self.learner])
         ca = CA(results)
         self.assertGreater(ca, 0.7)
         self.assertLess(ca, 0.9)
 
-        results = CrossValidation(Table("iris"), [self.learner], k=10)
+        cv = CrossValidation(k=10)
+        results = cv(Table("iris"), [self.learner])
         ca = CA(results)
         self.assertGreater(ca, 0.7)
 
@@ -56,7 +58,8 @@ class TestNaiveBayesLearner(unittest.TestCase):
     def test_allnan_cv(self):
         # GH 2740
         data = Table(test_filename('datasets/lenses.tab'))
-        results = CrossValidation(data, [self.learner])
+        cv = CrossValidation()
+        results = cv(data, [self.learner])
         self.assertFalse(any(results.failed))
 
     def test_prediction_routing(self):

--- a/Orange/tests/test_neural_network.py
+++ b/Orange/tests/test_neural_network.py
@@ -26,24 +26,27 @@ class TestNNLearner(unittest.TestCase):
         super().setUp()
 
     def test_NN_classification(self):
-        results = CrossValidation(self.iris, [NNClassificationLearner()], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, [NNClassificationLearner()])
         ca = CA(results)
         self.assertGreater(ca, 0.8)
         self.assertLess(ca, 0.99)
 
     def test_NN_regression(self):
         const = ConstantLearner()
-        results = CrossValidation(self.housing, [NNRegressionLearner(), const],
-                                  k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.housing, [NNRegressionLearner(), const])
         mse = MSE()
         res = mse(results)
         self.assertLess(res[0], 35)
         self.assertLess(res[0], res[1])
 
     def test_NN_model(self):
-        results = CrossValidation(self.iris, [self.learner], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, [self.learner])
         self.assertGreater(CA(results), 0.90)
-        results = CrossValidation(self.housing, [self.learner], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.housing, [self.learner])
         mse = MSE()
         res = mse(results)
         self.assertLess(res[0], 35)

--- a/Orange/tests/test_polynomial_learner.py
+++ b/Orange/tests/test_polynomial_learner.py
@@ -21,8 +21,8 @@ class TestPolynomialLearner(unittest.TestCase):
         polynomial2 = PolynomialLearner(linear, degree=2)
         polynomial3 = PolynomialLearner(linear, degree=3)
 
-        res = TestOnTrainingData(data,
-                                 [linear, polynomial2, polynomial3])
+        tt = TestOnTrainingData()
+        res = tt(data, [linear, polynomial2, polynomial3])
         rmse = RMSE(res)
 
         self.assertGreater(rmse[0], rmse[1])

--- a/Orange/tests/test_random_forest.py
+++ b/Orange/tests/test_random_forest.py
@@ -18,7 +18,8 @@ class RandomForestTest(unittest.TestCase):
 
     def test_RandomForest(self):
         forest = RandomForestLearner()
-        results = CrossValidation(self.iris, [forest], k=10)
+        cv = CrossValidation(k=10)
+        results = cv(self.iris, [forest])
         ca = CA(results)
         self.assertGreater(ca, 0.9)
         self.assertLess(ca, 0.99)
@@ -44,7 +45,8 @@ class RandomForestTest(unittest.TestCase):
 
     def test_RandomForestRegression(self):
         forest = RandomForestRegressionLearner()
-        results = CrossValidation(self.housing, [forest], k=10)
+        cv = CrossValidation(k=10)
+        results = cv(self.housing, [forest])
         _ = RMSE(results)
 
     def test_predict_single_instance_reg(self):

--- a/Orange/tests/test_sgd.py
+++ b/Orange/tests/test_sgd.py
@@ -25,7 +25,8 @@ class TestSGDRegressionLearner(unittest.TestCase):
         y = X.dot(np.random.rand(ncols))
         data = Table(X, y)
         sgd = SGDRegressionLearner()
-        res = CrossValidation(data, [sgd], k=3)
+        cv = CrossValidation(k=3)
+        res = cv(data, [sgd])
         self.assertLess(RMSE(res)[0], 0.1)
 
     def test_coefficients(self):
@@ -46,7 +47,8 @@ class TestSGDClassificationLearner(unittest.TestCase):
 
     def test_SGDClassification(self):
         sgd = SGDClassificationLearner()
-        res = CrossValidation(self.iris, [sgd], k=3)
+        cv = CrossValidation(k=3)
+        res = cv(self.iris, [sgd])
         self.assertGreater(AUC(res)[0], 0.8)
 
     def test_coefficients(self):

--- a/Orange/tests/test_softmax_regression.py
+++ b/Orange/tests/test_softmax_regression.py
@@ -15,7 +15,8 @@ class TestSoftmaxRegressionLearner(unittest.TestCase):
 
     def test_SoftmaxRegression(self):
         learner = SoftmaxRegressionLearner()
-        results = CrossValidation(self.iris, [learner], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, [learner])
         ca = CA(results)
         self.assertGreater(ca, 0.9)
         self.assertLess(ca, 1.0)
@@ -26,7 +27,8 @@ class TestSoftmaxRegressionLearner(unittest.TestCase):
         table.X[:, 3] = table.X[:, 3] * 0.001
         learners = [SoftmaxRegressionLearner(preprocessors=[]),
                     SoftmaxRegressionLearner()]
-        results = CrossValidation(table, learners, k=10)
+        cv = CrossValidation(k=10)
+        results = cv(table, learners)
         ca = CA(results)
 
         self.assertLess(ca[0], ca[1])

--- a/Orange/tests/test_stack.py
+++ b/Orange/tests/test_stack.py
@@ -14,15 +14,15 @@ class TestStackedFitter(unittest.TestCase):
 
     def test_classification(self):
         sf = StackedFitter([TreeLearner(), KNNLearner()])
-        results = CrossValidation(self.iris, [sf], k=3)
+        cv = CrossValidation(k=3)
+        results = cv(self.iris, [sf])
         ca = CA(results)
         self.assertGreater(ca, 0.9)
 
     def test_regression(self):
         sf = StackedFitter([TreeLearner(), KNNLearner()])
-        results = CrossValidation(self.housing[:50],
-                                  [sf, TreeLearner(), KNNLearner()], k=3,
-                                  random_state=0)
+        cv = CrossValidation(k=3, random_state=0)
+        results = cv(self.housing[:50], [sf, TreeLearner(), KNNLearner()])
         mse = MSE()(results)
         self.assertLess(mse[0], mse[1])
         self.assertLess(mse[0], mse[2])

--- a/Orange/tests/test_svm.py
+++ b/Orange/tests/test_svm.py
@@ -23,20 +23,23 @@ class TestSVMLearner(unittest.TestCase):
 
     def test_SVM(self):
         learn = SVMLearner()
-        res = CrossValidation(self.data, [learn], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(self.data, [learn])
         self.assertGreater(CA(res)[0], 0.9)
 
     def test_LinearSVM(self):
         # This warning is irrelevant here
         warnings.filterwarnings("ignore", ".*", ConvergenceWarning)
         learn = LinearSVMLearner()
-        res = CrossValidation(self.data, [learn], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(self.data, [learn])
         self.assertGreater(CA(res)[0], 0.8)
         self.assertLess(CA(res)[0], 0.9)
 
     def test_NuSVM(self):
         learn = NuSVMLearner(nu=0.01)
-        res = CrossValidation(self.data, [learn], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(self.data, [learn])
         self.assertGreater(CA(res)[0], 0.9)
 
     def test_SVR(self):
@@ -45,7 +48,8 @@ class TestSVMLearner(unittest.TestCase):
         y = X.dot(np.random.rand(ncols))
         data = Table(X, y)
         learn = SVRLearner(kernel='rbf', gamma=0.1)
-        res = CrossValidation(data, [learn], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(data, [learn])
         self.assertLess(RMSE(res)[0], 0.15)
 
     def test_LinearSVR(self):
@@ -54,7 +58,8 @@ class TestSVMLearner(unittest.TestCase):
         y = X.dot(np.random.rand(ncols))
         data = Table(X, y)
         learn = SVRLearner()
-        res = CrossValidation(data, [learn], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(data, [learn])
         self.assertLess(RMSE(res)[0], 0.15)
 
     def test_NuSVR(self):
@@ -63,7 +68,8 @@ class TestSVMLearner(unittest.TestCase):
         y = X.dot(np.random.rand(ncols))
         data = Table(X, y)
         learn = NuSVRLearner(kernel='rbf', gamma=0.1)
-        res = CrossValidation(data, [learn], k=2)
+        cv = CrossValidation(k=2)
+        res = cv(data, [learn])
         self.assertLess(RMSE(res)[0], 0.1)
 
     def test_OneClassSVM(self):


### PR DESCRIPTION
##### Issue
Fixes #4233 - Removed deprecated constructor calls in Validation.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
