### PR TITLE
[NOMERGE] OWSelectRows: data info displayed in status bar

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -7,7 +7,7 @@ import numpy as np
 from AnyQt.QtWidgets import (
     QWidget, QTableWidget, QHeaderView, QComboBox, QLineEdit, QToolButton,
     QMessageBox, QMenu, QListView, QGridLayout, QPushButton, QSizePolicy,
-    QLabel)
+    QLabel, QHBoxLayout)
 from AnyQt.QtGui import (
     QDoubleValidator, QRegExpValidator, QStandardItemModel, QStandardItem,
     QFontMetrics, QPalette
@@ -191,15 +191,13 @@ class OWSelectRows(widget.OWWidget):
             box2, self, "Remove All", callback=self.remove_all)
         gui.rubber(box2)
 
-        boxes = gui.widgetBox(self.controlArea, orientation=QGridLayout())
+        boxes = gui.widgetBox(self.controlArea, orientation=QHBoxLayout())
         layout = boxes.layout()
-        layout.setColumnStretch(0, 1)
-        layout.setColumnStretch(1, 1)
 
         self.update_input_summary(None)
         self.update_output_summary(None)
 
-        box_setting = gui.vBox(boxes, 'Purging', addToLayout=False)
+        box_setting = gui.vBox(boxes, addToLayout=False, box=True)
         self.cb_pa = gui.checkBox(
             box_setting, self, "purge_attributes", "Remove unused features",
             callback=self.conditions_changed)
@@ -207,14 +205,15 @@ class OWSelectRows(widget.OWWidget):
         self.cb_pc = gui.checkBox(
             box_setting, self, "purge_classes", "Remove unused classes",
             callback=self.conditions_changed)
-        layout.addWidget(box_setting, 0, 0)
+        layout.addWidget(box_setting, 1)
 
         self.report_button.setFixedWidth(120)
         gui.rubber(self.buttonsArea.layout())
-        layout.addWidget(self.buttonsArea, 1, 0)
+        layout.addWidget(self.buttonsArea)
 
         acbox = gui.auto_send(None, self, "auto_commit")
-        layout.addWidget(acbox, 1, 0)
+        layout.addWidget(acbox, 1)
+        layout.setAlignment(acbox, Qt.AlignBottom)
 
         self.set_data(None)
         self.resize(600, 400)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -196,10 +196,8 @@ class OWSelectRows(widget.OWWidget):
         layout.setColumnStretch(0, 1)
         layout.setColumnStretch(1, 1)
 
-        box_data = gui.vBox(boxes, 'Data', addToLayout=False)
-        self.data_in_variables = gui.widgetLabel(box_data, " ")
-        self.data_out_rows = gui.widgetLabel(box_data, " ")
-        layout.addWidget(box_data, 0, 0)
+        self.update_input_summary(None)
+        self.update_output_summary(None)
 
         box_setting = gui.vBox(boxes, 'Purging', addToLayout=False)
         self.cb_pa = gui.checkBox(
@@ -209,14 +207,14 @@ class OWSelectRows(widget.OWWidget):
         self.cb_pc = gui.checkBox(
             box_setting, self, "purge_classes", "Remove unused classes",
             callback=self.conditions_changed)
-        layout.addWidget(box_setting, 0, 1)
+        layout.addWidget(box_setting, 0, 0)
 
         self.report_button.setFixedWidth(120)
         gui.rubber(self.buttonsArea.layout())
         layout.addWidget(self.buttonsArea, 1, 0)
 
         acbox = gui.auto_send(None, self, "auto_commit")
-        layout.addWidget(acbox, 1, 1)
+        layout.addWidget(acbox, 1, 0)
 
         self.set_data(None)
         self.resize(600, 400)
@@ -449,6 +447,7 @@ class OWSelectRows(widget.OWWidget):
             len(data.domain.variables) + len(data.domain.metas) > 100)
         if not data:
             self.data_desc = None
+            self.update_input_summary(None)
             self.commit()
             return
         self.data_desc = report.describe_data_brief(data)
@@ -469,7 +468,7 @@ class OWSelectRows(widget.OWWidget):
         else:
             self.add_row()
 
-        self.update_info(data, self.data_in_variables, "In: ")
+        self.update_input_summary(data)
         self.unconditional_commit()
 
     def conditions_changed(self):
@@ -605,20 +604,33 @@ class OWSelectRows(widget.OWWidget):
         self.match_desc = report.describe_data_brief(matching_output)
         self.nonmatch_desc = report.describe_data_brief(non_matching_output)
 
-        self.update_info(matching_output, self.data_out_rows, "Out: ")
+        self.update_output_summary(matching_output)
 
-    def update_info(self, data, lab1, label):
+    def update_input_summary(self, data):
         def sp(s, capitalize=True):
             return s and s or ("No" if capitalize else "no"), "s" * (s != 1)
 
-        if data is None:
-            lab1.setText("")
+        if data:
+            n = data.approx_len()
+            details = "~%s row%s, %s variable%s" % \
+                      (sp(n) + sp(len(data.domain.variables) + len(data.domain.metas)))
+            n = self.info.format_number(n)
+            self.info.set_input_summary(n, details)
         else:
-            lab1.setText(label + "~%s row%s, %s variable%s" %
-                         (sp(data.approx_len()) +
-                          sp(len(data.domain.variables) +
-                             len(data.domain.metas)))
-                        )
+            self.info.set_input_summary(self.info.NoInput)
+
+    def update_output_summary(self, data):
+        def sp(s, capitalize=True):
+            return s and s or ("No" if capitalize else "no"), "s" * (s != 1)
+
+        if data:
+            n = data.approx_len()
+            details = "~%s row%s, %s variable%s" % \
+                      (sp(n) + sp(len(data.domain.variables) + len(data.domain.metas)))
+            n = self.info.format_number(n)
+            self.info.set_output_summary(n, details)
+        else:
+            self.info.set_output_summary(self.info.NoInput)
 
     def send_report(self):
         if not self.data:

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,unsubscriptable-object
+from unittest.mock import Mock
+
 from AnyQt.QtCore import QLocale, Qt
 from AnyQt.QtTest import QTest
 from AnyQt.QtWidgets import QLineEdit, QComboBox
@@ -241,6 +243,30 @@ class TestOWSelectRows(WidgetTest):
         annotations = annotated.get_column_view(ANNOTATED_DATA_FEATURE_NAME)[0]
         np.testing.assert_equal(annotations[:50], True)
         np.testing.assert_equal(annotations[50:], False)
+
+    def test_summary(self):
+        """Check if status bar displays correct input/output summary"""
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, data)
+        input_sum.assert_called_with(str(len(data)), f"~{len(data)} rows, "
+                                     f"{len(data.domain.variables)} variables")
+        output = self.get_output("Matching Data")
+        output_sum.assert_called_with(str(len(output)), f"~{len(output)} rows, "
+                                      f"{len(output.domain.variables)} variables")
+        self.enterFilter(data.domain["iris"], "is", "Iris-setosa")
+        output = self.get_output("Matching Data")
+        output_sum.assert_called_with(str(len(output)), f"~{len(output)} rows, "
+                                      f"{len(output.domain.variables)} variables")
+        input_sum.reset_mock()
+        output_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")
+        output_sum.assert_called_once()
+        self.assertEqual(output_sum.call_args[0][0].brief, "")
 
     def widget_with_context(self, domain, conditions):
         ch = SelectRowsContextHandler()


### PR DESCRIPTION
##### Description of changes
Display input and output data info in status bar. 

Within this pull request I am using code that only exists in the development version of orange-base-widget. **Requires orange-widget-base > 4.2.0.**

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
