### PR TITLE
[FIX] Select Rows: Fix crash on changed variable type

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -59,7 +59,7 @@ class SelectRowsContextHandler(DomainContextHandler):
     def decode_setting(self, setting, value, domain=None):
         value = super().decode_setting(setting, value, domain)
         if setting.name == 'conditions':
-            # Use this after 2021/1/1:
+            # Use this after 2022/2/2:
             # for i, (attr, _, op, values) in enumerate(value):
             for i, condition in enumerate(value):
                 attr = condition[0]
@@ -78,7 +78,7 @@ class SelectRowsContextHandler(DomainContextHandler):
         conditions = context.values["conditions"]
         all_vars = attrs
         all_vars.update(metas)
-        # Use this after 2021/1/1:
+        # Use this after 2022/2/2:
         # if all(all_vars.get(name) == tpe for name, tpe, *_ in conditions):
         if all(all_vars.get(name) == tpe if len(rest) == 2 else name in all_vars
                for name, tpe, *rest in conditions):
@@ -715,7 +715,7 @@ class OWSelectRows(widget.OWWidget):
                  ("Non-matching data",
                   nonmatch_inst > 0 and "{} instances".format(nonmatch_inst))))
 
-    # Uncomment this on 2021/1/1
+    # Uncomment this on 2022/2/2
     #
     # @classmethod
     # def migrate_context(cls, context, version):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -175,6 +175,19 @@ class TestOWSelectRows(WidgetTest):
         values = self.widget.conditions[0][2]
         self.assertTrue(values[0].startswith("5,2"))
 
+    @override_locale(QLocale.C)
+    def test_partial_matches(self):
+        iris = Table("iris")
+        domain = iris.domain
+        self.widget = self.widget_with_context(
+            domain, [[domain[0].name, 2, ("5.2",)]])
+        iris2 = iris.transform(Domain(domain.attributes[:2], None))
+        self.send_signal(self.widget.Inputs.data, iris2)
+        condition = self.widget.conditions[0]
+        self.assertEqual(condition[0], "sepal length")
+        self.assertEqual(condition[1], 2)
+        self.assertTrue(condition[2][0].startswith("5.2"))
+
     def test_load_settings(self):
         iris = Table("iris")[:5]
         self.send_signal(self.widget.Inputs.data, iris)
@@ -261,7 +274,7 @@ class TestOWSelectRows(WidgetTest):
         new_iris = iris.transform(new_domain)
         self.send_signal(self.widget.Inputs.data, new_iris)
 
-    # Uncomment this on 2021/1/1
+    # Uncomment this on 2022/2/2
     #
     # def test_migration_to_version_1(self):
     #     iris = Table("iris")
@@ -284,10 +297,10 @@ class TestOWSelectRows(WidgetTest):
         self.assertEqual(condition[1], 2)
         self.assertTrue(condition[2][0].startswith("5.2"))
 
-    def test_end_support_for_version_0(self):
-        if time.gmtime().tm_year == 2021:
+    def test_end_support_for_version_1(self):
+        if time.gmtime() >= (2022, 2, 2):
             self.fail("""
-Happy new year 2021!
+Happy 22/2/2!
 
 Now remove support for version==None settings in
 SelectRowsContextHandler.decode_setting and SelectRowsContextHandler.match,


### PR DESCRIPTION
##### Issue

Fixes #3952. Widget's settings stored variable names without type, and retrieved settings that did not really match.

##### Description of changes

Add variable types to settings.

~~Previous settings are not migrated because we cannot guess variable types in migration. A possible workaround would be to skip migration and instead add specific code for handling old settings in `decode_setting` and `match`.~~

Settings are not migrated; what crashed will still crash, but the only way to prevent this would be to clear settings entirely, which would harm more users than letting the widget crash for the few users who have existing settings and will change variables types.

##### Includes
- [X] Code changes
- [X] Tests
