### PR TITLE
[ENH] Preprocess: Add filtering by missing values

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -572,44 +572,42 @@ class PreprocessorList(Preprocess):
 
 class RemoveSparse(Preprocess):
     """
-    Filter out the features with too many nan's or 0. Threshold is user defined.
+    Filter out the features with too many (>threshold) zeros or missing values. Threshold is user defined.
 
     Parameters
     ----------
-    filter_0: bool
-        filter out by zeros or nan's
-    fixed_threshold: bool
-        threshold is either a fixed number of elements or percentage
-    threshold: int
-        kept as is if fixed threshold or the percent is used to calculate
-        the appropriate number of elements
+    threshold: int or float
+        if >= 1, the argument represents the allowed number of 0s or NaNs;
+        if below 1, it represents the allowed proportion of 0s or NaNs
+    filter0: bool
+        if True (default), preprocessor counts 0s, otherwise NaNs
     """
-
-    def __init__(self, filter_0=True, fixed_threshold=False, threshold=5):
-        self.filter_0 = filter_0
-        self.fixed_threshold = fixed_threshold
+    def __init__(self, threshold=0.05, filter0=True):
+        self.filter0 = filter0
         self.threshold = threshold
 
     def __call__(self, data):
-        if self.fixed_threshold:
-            tailored_threshold = self.threshold
-        else:
-            tailored_threshold = np.ceil(self.threshold/100 * data.X.shape[0])
+        threshold = self.threshold
+        if self.threshold < 1:
+            threshold *= data.X.shape[0]
 
-        if self.filter_0:
+        if self.filter0:
             if sp.issparse(data.X):
                 data_csc = sp.csc_matrix(data.X)
                 h, w = data_csc.shape
-                sparsness = [(h - data_csc[:, i].count_nonzero()) for i in range(w)]
+                sparseness = [h - data_csc[:, i].count_nonzero()
+                              for i in range(w)]
             else:
-                sparsness = data.X.shape[0] - np.count_nonzero(data.X, axis=0)
-        else: # filter by nans
+                sparseness = data.X.shape[0] - np.count_nonzero(data.X, axis=0)
+        else:  # filter by nans
             if sp.issparse(data.X):
                 data_csc = sp.csc_matrix(data.X)
-                sparsness = [np.sum(np.isnan(data.X[:, i].data)) for i in range(data_csc.shape[1])]
+                sparseness = [np.sum(np.isnan(data.X[:, i].data))
+                              for i in range(data_csc.shape[1])]
             else:
-                sparsness = np.sum(np.isnan(data.X), axis=0)
-        att = [a for a, s in zip(data.domain.attributes, sparsness) if s <= tailored_threshold]
+                sparseness = np.sum(np.isnan(data.X), axis=0)
+        att = [a for a, s in zip(data.domain.attributes, sparseness)
+               if s <= threshold]
         domain = Orange.data.Domain(att, data.domain.class_vars,
                                     data.domain.metas)
         return data.transform(domain)

--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -605,7 +605,8 @@ class RemoveSparse(Preprocess):
                 sparsness = data.X.shape[0] - np.count_nonzero(data.X, axis=0)
         else: # filter by nans
             if sp.issparse(data.X):
-                sparsness = np.sum(np.isnan(data.X.data), axis=0)
+                data_csc = sp.csc_matrix(data.X)
+                sparsness = [np.sum(np.isnan(data.X[:, i].data)) for i in range(data_csc.shape[1])]
             else:
                 sparsness = np.sum(np.isnan(data.X), axis=0)
         att = [a for a, s in zip(data.domain.attributes, sparsness) if s <= tailored_threshold]

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -183,21 +183,49 @@ class TestRemoveSparse(unittest.TestCase):
     def setUp(self):
         domain = Domain([ContinuousVariable('a'), ContinuousVariable('b')])
         self.data = Table.from_numpy(domain, np.zeros((3, 2)))
-        self.data[1:, 1] = 7
 
-    def test_dense(self):
+    def test_0_dense(self):
+        self.data[1:, 1] = 7
         true_out = self.data[:, 1]
         true_out.X = true_out.X.reshape(-1, 1)
-        out = RemoveSparse(0.5)(self.data)
+        out = RemoveSparse(True, False, 0.5)(self.data)
         np.testing.assert_array_equal(out, true_out)
 
-    def test_sparse(self):
+        out = RemoveSparse(True, True, 2)(self.data)
+        np.testing.assert_array_equal(out, true_out)
+
+    def test_0_sparse(self):
+        self.data[1:, 1] = 7
         true_out = self.data[:, 1]
         self.data.X = csr_matrix(self.data.X)
         true_out.X = csr_matrix(true_out.X)
-        out = RemoveSparse(0.5)(self.data).X
+        out = RemoveSparse(True, False, 0.5)(self.data).X
         np.testing.assert_array_equal(out, true_out)
 
+        out = RemoveSparse(True, True, 1)(self.data).X
+        np.testing.assert_array_equal(out, true_out)
+
+    def test_nan_dense(self):
+        self.data[1:, 1] = np.nan
+        self.data.X[:, 0] = 7
+        true_out = self.data[:, 0]
+        true_out.X = true_out.X.reshape(-1, 1)
+        out = RemoveSparse(False, False, 0.5)(self.data)
+        np.testing.assert_array_equal(out, true_out)
+
+        out = RemoveSparse(False, True, 1)(self.data)
+        np.testing.assert_array_equal(out, true_out)
+
+    def test_nan_sparse(self):
+        self.data[1:, 1] = np.nan
+        self.data.X[:, 0] = 7
+        true_out = self.data[:, 0]
+        true_out.X = true_out.X.reshape(-1, 1)
+        out = RemoveSparse(False, False, 0.5)(self.data)
+        np.testing.assert_array_equal(out, true_out)
+
+        out = RemoveSparse(False, True, 1)(self.data)
+        np.testing.assert_array_equal(out, true_out)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -221,6 +221,8 @@ class TestRemoveSparse(unittest.TestCase):
         self.data.X[:, 0] = 7
         true_out = self.data[:, 0]
         true_out.X = true_out.X.reshape(-1, 1)
+        self.data.X = csr_matrix(self.data.X)
+        true_out.X = csr_matrix(true_out.X)
         out = RemoveSparse(False, False, 0.5)(self.data)
         np.testing.assert_array_equal(out, true_out)
 

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -1,7 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
-import os
 import pickle
 import unittest
 from unittest.mock import Mock
@@ -15,7 +14,6 @@ from Orange.preprocess import EntropyMDL, DoNotImpute, Default, Average, \
     EqualWidth, SelectBestFeatures, RemoveNaNRows, Preprocess, Scale, \
     Randomize, Continuize, Discretize, Impute, SklImpute, Normalize, \
     ProjectCUR, ProjectPCA, RemoveConstant, AdaptiveNormalize, RemoveSparse
-from Orange.util import OrangeDeprecationWarning
 
 
 class TestPreprocess(unittest.TestCase):
@@ -54,7 +52,7 @@ class TestRemoveConstant(unittest.TestCase):
         X[3, 1] = np.nan
         X[1, 1] = np.nan
         X[:, 4] = np.nan
-        data = Table(X)
+        data = Table.from_numpy(None, X)
         d = RemoveConstant()(data)
         self.assertEqual(len(d.domain.attributes), 2)
 
@@ -103,10 +101,10 @@ class TestRemoveNaNColumns(unittest.TestCase):
 class TestScaling(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.table = Table([[1, 2, 3],
-                           [2, 3, 4],
-                           [3, 4, 5],
-                           [4, 5, 6]])
+        cls.table = Table.from_numpy(None, [[1, 2, 3],
+                                            [2, 3, 4],
+                                            [3, 4, 5],
+                                            [4, 5, 6]])
 
     def test_scaling_mean_span(self):
         table = Scale(center=Scale.Mean, scale=Scale.Span)(self.table)
@@ -188,10 +186,10 @@ class TestRemoveSparse(unittest.TestCase):
         self.data[1:, 1] = 7
         true_out = self.data[:, 1]
         true_out.X = true_out.X.reshape(-1, 1)
-        out = RemoveSparse(True, False, 0.5)(self.data)
+        out = RemoveSparse(0.5, True)(self.data)
         np.testing.assert_array_equal(out, true_out)
 
-        out = RemoveSparse(True, True, 2)(self.data)
+        out = RemoveSparse(2, True)(self.data)
         np.testing.assert_array_equal(out, true_out)
 
     def test_0_sparse(self):
@@ -199,10 +197,10 @@ class TestRemoveSparse(unittest.TestCase):
         true_out = self.data[:, 1]
         self.data.X = csr_matrix(self.data.X)
         true_out.X = csr_matrix(true_out.X)
-        out = RemoveSparse(True, False, 0.5)(self.data).X
+        out = RemoveSparse(0.5, True)(self.data).X
         np.testing.assert_array_equal(out, true_out)
 
-        out = RemoveSparse(True, True, 1)(self.data).X
+        out = RemoveSparse(1, True)(self.data).X
         np.testing.assert_array_equal(out, true_out)
 
     def test_nan_dense(self):
@@ -210,10 +208,10 @@ class TestRemoveSparse(unittest.TestCase):
         self.data.X[:, 0] = 7
         true_out = self.data[:, 0]
         true_out.X = true_out.X.reshape(-1, 1)
-        out = RemoveSparse(False, False, 0.5)(self.data)
+        out = RemoveSparse(0.5, False)(self.data)
         np.testing.assert_array_equal(out, true_out)
 
-        out = RemoveSparse(False, True, 1)(self.data)
+        out = RemoveSparse(1, False)(self.data)
         np.testing.assert_array_equal(out, true_out)
 
     def test_nan_sparse(self):
@@ -223,11 +221,12 @@ class TestRemoveSparse(unittest.TestCase):
         true_out.X = true_out.X.reshape(-1, 1)
         self.data.X = csr_matrix(self.data.X)
         true_out.X = csr_matrix(true_out.X)
-        out = RemoveSparse(False, False, 0.5)(self.data)
+        out = RemoveSparse(0.5, False)(self.data)
         np.testing.assert_array_equal(out, true_out)
 
-        out = RemoveSparse(False, True, 1)(self.data)
+        out = RemoveSparse(1, False)(self.data)
         np.testing.assert_array_equal(out, true_out)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -252,7 +252,7 @@ class ContinuizeEditor(BaseEditor):
 
 class RemoveSparseEditor(BaseEditor):
 
-    options = ["Nan's", "0's"]
+    options = ["missing", "zeros"]
 
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
@@ -263,7 +263,7 @@ class RemoveSparseEditor(BaseEditor):
         self.setLayout(QVBoxLayout())
 
         choose_filts = QGroupBox(title='Filter out features with too many:')
-        choose_filts.setLayout(QHBoxLayout())
+        choose_filts.setLayout(QVBoxLayout())
         self.filter_buttons = QButtonGroup(exclusive=True)
         self.filter_buttons.buttonClicked.connect(self.filterByClicked)
         for option, idx in zip(self.options, range(len(self.options))):
@@ -278,21 +278,21 @@ class RemoveSparseEditor(BaseEditor):
         self.settings_buttons = QButtonGroup(exclusive=True)
         self.settings_buttons.buttonClicked.connect(self.filterSettingsClicked)
 
-        btn_perc = QRadioButton(self, text='Max %: ', checked=not self.useFixedThreshold)
+        btn_perc = QRadioButton(self, text='Percentage', checked=not self.useFixedThreshold)
         self.settings_buttons.addButton(btn_perc, id=0)
         self.percSpin = QSpinBox(minimum=0, maximum=100, value=self.percThresh,
                                  enabled=not self.useFixedThreshold)
         self.percSpin.valueChanged[int].connect(self.setPercThresh)
         self.percSpin.editingFinished.connect(self.edited)
-        filter_settings.layout().addRow(btn_perc, self.percSpin)
 
-        btn_fix = QRadioButton(self, text='Max #: ', checked=self.useFixedThreshold)
+        btn_fix = QRadioButton(self, text='Fixed', checked=self.useFixedThreshold)
         self.settings_buttons.addButton(btn_fix, id=1)
         self.fixedSpin = QSpinBox(minimum=0, maximum=1000000, value=self.fixedThresh,
                                   enabled=self.useFixedThreshold)
         self.fixedSpin.valueChanged[int].connect(self.setFixedThresh)
         self.fixedSpin.editingFinished.connect(self.edited)
         filter_settings.layout().addRow(btn_fix, self.fixedSpin)
+        filter_settings.layout().addRow(btn_perc, self.percSpin)
 
         self.layout().addWidget(filter_settings)
 

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -262,18 +262,19 @@ class RemoveSparseEditor(BaseEditor):
         self.filter0 = True
         self.setLayout(QVBoxLayout())
 
-        choose_filts = QGroupBox(title='Filter out features with too many:')
-        choose_filts.setLayout(QVBoxLayout())
+        self.layout().addWidget(QLabel("Remove features with too many"))
+        options = ["missing values",
+                   "zeros"]
         self.filter_buttons = QButtonGroup(exclusive=True)
         self.filter_buttons.buttonClicked.connect(self.filterByClicked)
-        for option, idx in zip(self.options, range(len(self.options))):
+        for idx, option, in enumerate(options):
             btn = QRadioButton(self, text=option, checked=idx == 0)
             self.filter_buttons.addButton(btn, id=idx)
-            choose_filts.layout().addWidget(btn)
-        self.layout().addWidget(choose_filts)
+            self.layout().addWidget(btn)
 
+        self.layout().addSpacing(20)
 
-        filter_settings = QGroupBox(title='Threshold settings:', flat=True)
+        filter_settings = QGroupBox(title='Threshold:', flat=True)
         filter_settings.setLayout(QFormLayout())
         self.settings_buttons = QButtonGroup(exclusive=True)
         self.settings_buttons.buttonClicked.connect(self.filterSettingsClicked)
@@ -347,8 +348,8 @@ class RemoveSparseEditor(BaseEditor):
         if useFixedThreshold:
             threshold = params.pop('fixedThresh', 50)
         else:
-            threshold = params.pop('percThresh', 5)
-        return RemoveSparse(filter0, useFixedThreshold, threshold=threshold)
+            threshold = params.pop('percThresh', 5) / 100
+        return RemoveSparse(threshold, filter0)
 
 class ImputeEditor(BaseEditor):
     (NoImputation, Constant, Average,

--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -252,35 +252,103 @@ class ContinuizeEditor(BaseEditor):
 
 class RemoveSparseEditor(BaseEditor):
 
+    options = ["Nan's", "0's"]
+
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent, **kwargs)
+        self.fixedThresh = 50
+        self.percThresh = 5
+        self.useFixedThreshold = False
+        self.filter0 = True
         self.setLayout(QVBoxLayout())
-        self.sparse_thresh = 5
-        form = QFormLayout()
-        self.cspin = QSpinBox(minimum=1, maximum=100, value=self.sparse_thresh)
-        self.cspin.valueChanged[int].connect(self.setThresh)
-        self.cspin.editingFinished.connect(self.edited)
 
-        form.addRow("Min % of nonzero values:", self.cspin)
-        self.layout().addLayout(form)
+        choose_filts = QGroupBox(title='Filter out features with too many:')
+        choose_filts.setLayout(QHBoxLayout())
+        self.filter_buttons = QButtonGroup(exclusive=True)
+        self.filter_buttons.buttonClicked.connect(self.filterByClicked)
+        for option, idx in zip(self.options, range(len(self.options))):
+            btn = QRadioButton(self, text=option, checked=idx == 0)
+            self.filter_buttons.addButton(btn, id=idx)
+            choose_filts.layout().addWidget(btn)
+        self.layout().addWidget(choose_filts)
 
-    def setThresh(self, thresh):
-        if self.sparse_thresh != thresh:
-            self.sparse_thresh = thresh
-            self.cspin.setValue(thresh)
-            self.changed.emit()
+
+        filter_settings = QGroupBox(title='Threshold settings:', flat=True)
+        filter_settings.setLayout(QFormLayout())
+        self.settings_buttons = QButtonGroup(exclusive=True)
+        self.settings_buttons.buttonClicked.connect(self.filterSettingsClicked)
+
+        btn_perc = QRadioButton(self, text='Max %: ', checked=not self.useFixedThreshold)
+        self.settings_buttons.addButton(btn_perc, id=0)
+        self.percSpin = QSpinBox(minimum=0, maximum=100, value=self.percThresh,
+                                 enabled=not self.useFixedThreshold)
+        self.percSpin.valueChanged[int].connect(self.setPercThresh)
+        self.percSpin.editingFinished.connect(self.edited)
+        filter_settings.layout().addRow(btn_perc, self.percSpin)
+
+        btn_fix = QRadioButton(self, text='Max #: ', checked=self.useFixedThreshold)
+        self.settings_buttons.addButton(btn_fix, id=1)
+        self.fixedSpin = QSpinBox(minimum=0, maximum=1000000, value=self.fixedThresh,
+                                  enabled=self.useFixedThreshold)
+        self.fixedSpin.valueChanged[int].connect(self.setFixedThresh)
+        self.fixedSpin.editingFinished.connect(self.edited)
+        filter_settings.layout().addRow(btn_fix, self.fixedSpin)
+
+        self.layout().addWidget(filter_settings)
+
+    def filterSettingsClicked(self):
+        self.setUseFixedThreshold(self.settings_buttons.checkedId())
+        self.percSpin.setEnabled(not self.useFixedThreshold)
+        self.fixedSpin.setEnabled(self.useFixedThreshold)
+        self.edited.emit()
+
+    def filterByClicked(self):
+        self.setFilter0(self.filter_buttons.checkedId())
+
+    def setFilter0(self, id_):
+        if self.filter0 != id_:
+            self.filter0 = id_
+            self.edited.emit()
+
+    def setFixedThresh(self, thresh):
+        if self.fixedThresh != thresh:
+            self.fixedThresh = thresh
+            self.fixedSpin.setValue(thresh)
+            self.edited.emit()
+
+    def setPercThresh(self, thresh):
+        if self.percThresh != thresh:
+            self.percThresh = thresh
+            self.percSpin.setValue(thresh)
+            self.edited.emit()
+
+    def setUseFixedThreshold(self, val):
+        if self.useFixedThreshold != val:
+            self.useFixedThreshold = val
+            self.edited.emit()
 
     def parameters(self):
-        return {'sparse_thresh': self.sparse_thresh}
+        return {'fixedThresh': self.fixedThresh,
+                'percThresh' : self.percThresh,
+                'useFixedThreshold' : self.useFixedThreshold,
+                'filter0' : self.filter0}
 
     def setParameters(self, params):
-        self.setThresh(params.get('sparse_thresh', 5))
+        self.setPercThresh(params.get('percThresh', 5))
+        self.setFixedThresh(params.get('fixedThresh', 50))
+        self.setUseFixedThreshold(params.get('useFixedThreshold', False))
+        self.setFilter0(params.get('filter0', True))
 
     @staticmethod
     def createinstance(params):
         params = dict(params)
-        threshold = params.pop('sparse_thresh', 5)
-        return RemoveSparse(threshold=threshold / 100)
+        filter0 = params.pop('filter0', True)
+        useFixedThreshold = params.pop('useFixedThreshold', True)
+        if useFixedThreshold:
+            threshold = params.pop('fixedThresh', 50)
+        else:
+            threshold = params.pop('percThresh', 5)
+        return RemoveSparse(filter0, useFixedThreshold, threshold=threshold)
 
 class ImputeEditor(BaseEditor):
     (NoImputation, Constant, Average,

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -42,7 +42,9 @@ class TestOWPreprocess(WidgetTest):
         data = Table("iris")
         idx = int(data.X.shape[0]/10)
         data.X[:idx+1, 0] = np.zeros((idx+1,))
-        saved = {"preprocessors": [("orange.preprocess.remove_sparse", {'sparse_thresh':90})]}
+        saved = {"preprocessors": [("orange.preprocess.remove_sparse",
+                                    {'filter0': True, 'useFixedThreshold': False,
+                                     'percThresh':10, 'fixedThresh': 50})]}
         model = self.widget.load(saved)
 
         self.widget.set_model(model)
@@ -282,13 +284,18 @@ class TestRemoveSparseEditor(WidgetTest):
 
     def test_editor(self):
         widget = owpreprocess.RemoveSparseEditor()
-        self.assertEqual(widget.parameters(), {"sparse_thresh": 5})
+        self.assertEqual(widget.parameters(), {"fixedThresh" : 50,
+                                               "percThresh": 5,
+                                               "filter0" : True,
+                                               "useFixedThreshold": False})
 
         p = widget.createinstance(widget.parameters())
         self.assertIsInstance(p, RemoveSparse)
-        self.assertEqual(p.threshold, 0.05)
+        self.assertEqual(p.fixed_threshold, False)
+        self.assertEqual(p.filter_0, True)
+        self.assertEqual(p.threshold, 5)
 
-        widget.setParameters({"sparse_thresh": 90})
+        widget.setParameters({"useFixedThreshold" : True})
         p = widget.createinstance(widget.parameters())
         self.assertIsInstance(p, RemoveSparse)
-        self.assertEqual(p.threshold, 0.9)
+        self.assertEqual(p.fixed_threshold, True)

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -284,25 +284,22 @@ class TestRemoveSparseEditor(WidgetTest):
 
     def test_editor(self):
         widget = owpreprocess.RemoveSparseEditor()
-        self.assertEqual(widget.parameters(), {"fixedThresh" : 50,
-                                               "percThresh": 5,
-                                               "filter0" : True,
-                                               "useFixedThreshold": False})
+        self.assertEqual(
+            widget.parameters(),
+            dict(fixedThresh=50, percThresh=5, filter0=True,
+                 useFixedThreshold=False))
 
         p = widget.createinstance(widget.parameters())
         widget.filterSettingsClicked()
         self.assertTrue(widget.percSpin.isEnabled())
         self.assertFalse(widget.fixedSpin.isEnabled())
         self.assertIsInstance(p, RemoveSparse)
-        self.assertEqual(p.fixed_threshold, False)
-        self.assertEqual(p.filter_0, True)
-        self.assertEqual(p.threshold, 5)
+        self.assertEqual(p.filter0, True)
+        self.assertEqual(p.threshold, 0.05)
 
-        widget.setParameters({"useFixedThreshold" : True,
-                              "fixedThresh" : 30,
-                              "filter0" : False})
+        widget.setParameters(
+            dict(useFixedThreshold=True, fixedThresh=30, filter0=False))
         p = widget.createinstance(widget.parameters())
         self.assertIsInstance(p, RemoveSparse)
-        self.assertEqual(p.fixed_threshold, True)
         self.assertEqual(p.threshold, 30)
-        self.assertFalse(p.filter_0)
+        self.assertFalse(p.filter0)

--- a/Orange/widgets/data/tests/test_owpreprocess.py
+++ b/Orange/widgets/data/tests/test_owpreprocess.py
@@ -290,12 +290,19 @@ class TestRemoveSparseEditor(WidgetTest):
                                                "useFixedThreshold": False})
 
         p = widget.createinstance(widget.parameters())
+        widget.filterSettingsClicked()
+        self.assertTrue(widget.percSpin.isEnabled())
+        self.assertFalse(widget.fixedSpin.isEnabled())
         self.assertIsInstance(p, RemoveSparse)
         self.assertEqual(p.fixed_threshold, False)
         self.assertEqual(p.filter_0, True)
         self.assertEqual(p.threshold, 5)
 
-        widget.setParameters({"useFixedThreshold" : True})
+        widget.setParameters({"useFixedThreshold" : True,
+                              "fixedThresh" : 30,
+                              "filter0" : False})
         p = widget.createinstance(widget.parameters())
         self.assertIsInstance(p, RemoveSparse)
         self.assertEqual(p.fixed_threshold, True)
+        self.assertEqual(p.threshold, 30)
+        self.assertFalse(p.filter_0)


### PR DESCRIPTION
##### Description of changes
I extended Filter sparse features preprocessor with filtering columns by Nan's. We spoke about having 3 options, filter by 0, Nan's or both. I chose not to implement the third option, since the order of operation matters here and the user just use this preprocessor two times and have complete control that way.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
