### PR TITLE
[ENH] OWTreeViewer: Bold predicted values in tree nodes

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -358,7 +358,7 @@ class OWTreeGraph(OWTreeViewer2D):
         else:
             modus = np.argmax(distr)
             tabs = distr[modus]
-            text = f"{self.domain.class_vars[0].values[int(modus)]}<br/>"
+            text = f"<b>{self.domain.class_vars[0].values[int(modus)]}</b><br/>"
         if tabs > 0.999:
             text += f"100%, {total}/{total}"
         else:
@@ -373,7 +373,7 @@ class OWTreeGraph(OWTreeViewer2D):
         node_inst = node.node_inst
         mean, var = self.tree_adapter.get_distribution(node_inst)[0]
         insts = self.tree_adapter.num_samples(node_inst)
-        text = f"{mean:.1f} ± {var:.1f}<br/>"
+        text = f"<b>{mean:.1f}</b> ± {var:.1f}<br/>"
         text += f"{insts} instances"
         text = self._update_node_info_attr_name(node, text)
         node.setHtml(


### PR DESCRIPTION
##### Description of changes

I think this better visually differentiates a node's prediction from its next branching feature.

<img width="447" alt="Screenshot 2019-12-15 at 23 15 37" src="https://user-images.githubusercontent.com/24586651/70870951-a9572100-1f91-11ea-8f82-874299e975a3.png">
<img width="402" alt="Screenshot 2019-12-15 at 23 21 31" src="https://user-images.githubusercontent.com/24586651/70870952-ab20e480-1f91-11ea-95c3-9d62e9673497.png">

On a tangent, is the background color of a regression tree's nodes always this color by default? Either the background's or the separator line's color should be changed.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
