### PR TITLE
[FIX] owcsvimport: Fix last/recent item serialization

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -569,11 +569,12 @@ class OWCSVFileImport(widget.OWWidget):
             "button-layout: {:d};".format(QDialogButtonBox.MacLayout)
         )
         self.controlArea.layout().addWidget(button_box)
+        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Maximum)
 
         self._restoreState()
-        if self.current_item() is not None:
-            self._invalidate()
-        self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Maximum)
+        item = self.current_item()
+        if item is not None:
+            self.set_selected_file(item.path(), item.options())
 
     @Slot(int)
     def activate_recent(self, index):

--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -1,33 +1,106 @@
-from numpy.testing import assert_array_equal
 import unittest
+from unittest import mock
 
 import os
 import io
 import csv
+import json
 
 import numpy as np
+from numpy.testing import assert_array_equal
+
+from AnyQt.QtCore import QSettings
 
 from Orange.widgets.tests.base import WidgetTest, GuiTest
-
 from Orange.widgets.data import owcsvimport
 from Orange.widgets.data.owcsvimport import (
     pandas_to_table, ColumnType, RowSpec
 )
+from Orange.widgets.utils.settings import QSettings_writeArray
 
 
 class TestOWCSVFileImport(WidgetTest):
     def setUp(self):
+        # patch `_local_settings` to avoid side effects
+        s = QSettings(os.devnull, QSettings.IniFormat)
+        self._patch = mock.patch.object(
+            owcsvimport.OWCSVFileImport, "_local_settings", lambda *a: s)
+        self._patch.__enter__()
         self.widget = self.create_widget(owcsvimport.OWCSVFileImport)
 
     def tearDown(self):
         self.widgets.remove(self.widget)
         self.widget.onDeleteWidget()
         self.widget = None
+        self._patch.__exit__()
 
     def test_basic(self):
         w = self.widget
         w.activate_recent(0)
         w.cancel()
+
+    data_regions_options = owcsvimport.Options(
+        encoding="ascii", dialect=csv.excel_tab(),
+        columntypes=[
+            (range(0, 1), ColumnType.Categorical),
+            (range(1, 2), ColumnType.Text),
+            (range(2, 3), ColumnType.Categorical),
+        ], rowspec=[
+            (range(0, 1), RowSpec.Header),
+            (range(1, 3), RowSpec.Skipped),
+        ],
+    )
+
+    def _check_data_regions(self, table):
+        self.assertEqual(len(table), 3)
+        self.assertEqual(len(table), 3)
+        self.assertTrue(table.domain["id"].is_discrete)
+        self.assertTrue(table.domain["continent"].is_discrete)
+        self.assertTrue(table.domain["state"].is_string)
+        assert_array_equal(table.X, [[0, 1], [1, 1], [2, 0]])
+        assert_array_equal(table.metas,
+                           np.array([["UK"], ["Russia"], ["Mexico"]], object))
+
+    def test_restore(self):
+        dirname = os.path.dirname(__file__)
+        path = os.path.join(dirname, "data-regions.tab")
+
+        w = self.create_widget(
+            owcsvimport.OWCSVFileImport,
+            stored_settings={
+                "_session_items": [
+                    (path, self.data_regions_options.as_dict())
+                ]
+            }
+        )
+        item = w.current_item()
+        self.assertEqual(item.path(), path)
+        self.assertEqual(item.options(), self.data_regions_options)
+        out = self.get_output("Data", w)
+        self._check_data_regions(out)
+
+    def test_restore_from_local(self):
+        dirname = os.path.dirname(__file__)
+        path = os.path.join(dirname, "data-regions.tab")
+        s = owcsvimport.OWCSVFileImport._local_settings()
+        s.clear()
+        QSettings_writeArray(
+            s, "recent", [
+                {"path": path,
+                 "options": json.dumps(self.data_regions_options.as_dict())}]
+        )
+        w = self.create_widget(
+            owcsvimport.OWCSVFileImport,
+        )
+        item = w.current_item()
+        self.assertEqual(item.path(), path)
+        self.assertEqual(item.options(), self.data_regions_options)
+        self.assertEqual(
+            w._session_items, [(path, self.data_regions_options.as_dict())],
+            "local settings item must be recorded in _session_items when "
+            "activated in __init__",
+        )
+        self._check_data_regions(self.get_output("Data", w))
 
 
 class TestImportDialog(GuiTest):

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ PACKAGE_DATA = {
                             "icons/paintdata/*.svg"],
     "Orange.widgets.data.tests": ["origin1/*.tab",
                                   "origin2/*.tab",
-                                  "*.txt"],
+                                  "*.txt", "*.tab"],
     "Orange.widgets.evaluate": ["icons/*.svg"],
     "Orange.widgets.model": ["icons/*.svg"],
     "Orange.widgets.visualize": ["icons/*.svg"],


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

'CSV Import' does not store the current file/options in a workflow scheme if the current file is not explicitly selected after the widget is placed in the workflow.

##### Steps to reproduce

1) Place the widget on the workflow and let it load the last loaded file (do not change anything), save the workflow.
2) Create a new workflow and add the 'CSV Import' widget, select a different file to load.
3) Reload the workflow from step 1. The widget will load the file from the second step.

Selecting a different file in step 1 would correctly store the item.

##### Description of changes

 Call `set_current_file` in `__init__` to record the initial loaded file in the `scheme_only` recorded  `_session_items`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
