### PR TITLE
[DOC] Python Script: minor fixes

### DIFF
--- a/doc/visual-programming/source/widgets/data/file.md
+++ b/doc/visual-programming/source/widgets/data/file.md
@@ -10,7 +10,7 @@ Reads attribute-value data from an input file.
 
 The **File** widget [reads the input data file](../../loading-your-data/index.md) (data table with data instances) and sends the dataset to its output channel. The history of most recently opened files is maintained in the widget. The widget also includes a directory with sample datasets that come pre-installed with Orange.
 
-The widget reads data from Excel (**.xlsx**), simple tab-delimited (**.txt**), comma-separated files (**.csv**) or URLs. For other formats see [Other Formats](#other-formats) section.
+The widget reads data from Excel (**.xlsx**), simple tab-delimited (**.txt**), comma-separated files (**.csv**) or URLs. For other formats see Other Formats section below.
 
 ![](images/File-stamped.png)
 

--- a/doc/visual-programming/source/widgets/data/pythonscript.md
+++ b/doc/visual-programming/source/widgets/data/pythonscript.md
@@ -42,7 +42,7 @@ Note: You should not modify the input objects in place.
 Examples
 --------
 
-Python Script widget is intended to extend functionalities for advanced users. Classes used in Orange are described in the [documentation](../../../../data-mining-library/source/reference). To find further information about orange Table class see [Table](../../../../data-mining-library/source/reference/data.table.rst), [Domain](../../../../data-mining-library/source/reference/data.domain.rst), and [Variable](../../../../data-mining-library/source/reference/data.variable.rst) documentation.
+Python Script widget is intended to extend functionalities for advanced users. Classes from Orange library are described in the [documentation](https://docs.biolab.si//3/data-mining-library/#reference). To find further information about orange Table class see [Table](https://docs.biolab.si//3/data-mining-library/reference/data.table.html), [Domain](https://docs.biolab.si//3/data-mining-library/reference/data.domain.html), and [Variable](https://docs.biolab.si//3/data-mining-library/reference/data.variable.html) documentation.
 
 One can, for example, do batch filtering by attributes. We used zoo.tab for the example and we filtered out all the attributes that have more than 5 discrete values. This in our case removed only 'leg' attribute, but imagine an example where one would have many such attributes.
 

--- a/doc/visual-programming/source/widgets/data/pythonscript.md
+++ b/doc/visual-programming/source/widgets/data/pythonscript.md
@@ -42,7 +42,7 @@ Note: You should not modify the input objects in place.
 Examples
 --------
 
-Python Script widget is intended to extend functionalities for advanced users.
+Python Script widget is intended to extend functionalities for advanced users. Classes used in Orange are described in the [documentation](../../../../data-mining-library/source/reference). To find further information about orange Table class see [Table](../../../../data-mining-library/source/reference/data.table.rst), [Domain](../../../../data-mining-library/source/reference/data.domain.rst), and [Variable](../../../../data-mining-library/source/reference/data.variable.rst) documentation.
 
 One can, for example, do batch filtering by attributes. We used zoo.tab for the example and we filtered out all the attributes that have more than 5 discrete values. This in our case removed only 'leg' attribute, but imagine an example where one would have many such attributes.
 


### PR DESCRIPTION
##### Issue
1.) In documentation of File widget the link to the Other Formats title within the document was not working.
2.) In documentation of Python Script widget there was no reference to Orange library documentation, which is required to work with Table class etc. 

##### Description of changes
1.) Removed the link to the section, retaining only the title. 
2.) Added link to Orange library documentation. 

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
