### PR TITLE
[FIX] Table: Keep pending selection if data is None

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -519,20 +519,17 @@ class OWDataTable(OWWidget):
             if current is not None:
                 # pylint: disable=protected-access
                 self.set_info(current._input_slot.summary)
-        else:
-            self.__pending_selected_rows = None
-            self.__pending_selected_cols = None
 
         self.tabs.tabBar().setVisible(self.tabs.count() > 1)
         self.openContext(data)
 
-        if self.__pending_selected_rows is not None:
+        if data and self.__pending_selected_rows is not None:
             self.selected_rows = self.__pending_selected_rows
             self.__pending_selected_rows = None
         else:
             self.selected_rows = []
 
-        if self.__pending_selected_cols is not None:
+        if data and self.__pending_selected_cols is not None:
             self.selected_cols = self.__pending_selected_cols
             self.__pending_selected_cols = None
         else:

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -66,6 +66,15 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
             self.send_signal(self.widget.Inputs.data, self.data)
             commit.assert_called()
 
+    def test_pending_selection(self):
+        widget = self.create_widget(OWDataTable, stored_settings=dict(
+            selected_rows=[5, 6, 7, 8, 9],
+            selected_cols=list(range(len(self.data.domain)))))
+        self.send_signal(widget.Inputs.data, None, 1)
+        self.send_signal(widget.Inputs.data, self.data, 1)
+        output = self.get_output(widget.Outputs.selected_data)
+        self.assertEqual(5, len(output))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #4184.

##### Description of changes

The problem was that the widget removed pending selection even if the preceeding widget sent None before actual data (which PCA did).

##### Includes
- [X] Code changes
- [x] Tests
