### PR TITLE
Pin Qt version below 5.14

### DIFF
--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -7,9 +7,6 @@ if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install pandas==0.20.3; fi
 
 pip install numba==0.41.0 llvmlite==0.26.0
 
-# PyQt >= 5.12 distributes WebEngine separately
-pip install pyqtwebengine
-
 # Install dependencies sequentially
 cat requirements-core.txt \
     requirements-gui.txt \

--- a/.travis/install_pyqt.sh
+++ b/.travis/install_pyqt.sh
@@ -1,7 +1,10 @@
 if [ ! "$PYQT4" ]; then
-    foldable pip install sip 'pyqt5!=5.10'  # 5.10 exhibits QTBUG-65235
+    foldable pip install sip 'pyqt5!=5.10,<5.14'  # 5.10 exhibits QTBUG-65235
+    # PyQt >= 5.12 distributes WebEngine separately
+    foldable pip install 'pyqtwebengine<5.14'
     return $?;
 fi
+
 
 PYQT=$TRAVIS_BUILD_DIR/pyqt
 


### PR DESCRIPTION
##### Issue

Orange crashes on travis with Qt 5.14.

##### Description of changes

Temporarily pin Qt to version below 5.14 to avoid crashes on Travis.

This should be reverted after a permanent fix.
