### PR TITLE
[ENH] clustering/hierarchical: Use optimal_leaf_ordering from scipy

### DIFF
--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -285,11 +285,7 @@ class OWDistanceMap(widget.OWWidget):
     graph_name = "grid_widget"
 
     # Disable clustering for inputs bigger than this
-    if hierarchical._HAS_NN_CHAIN:
-        _MaxClustering = 25000
-    else:
-        _MaxClustering = 3000
-
+    _MaxClustering = 25000
     # Disable cluster leaf ordering for inputs bigger than this
     _MaxOrderedClustering = 1000
 

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -287,7 +287,7 @@ class OWDistanceMap(widget.OWWidget):
     # Disable clustering for inputs bigger than this
     _MaxClustering = 25000
     # Disable cluster leaf ordering for inputs bigger than this
-    _MaxOrderedClustering = 1000
+    _MaxOrderedClustering = 2000
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -327,7 +327,7 @@ class OWHeatMap(widget.OWWidget):
     NoPosition, PositionTop, PositionBottom = 0, 1, 2
 
     # Disable cluster leaf ordering for inputs bigger than this
-    _MaxOrderedClustering = 1000
+    _MaxOrderedClustering = 2000
 
     gamma = settings.Setting(0)
     threshold_low = settings.Setting(0.0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Scipy >= 1.0.0 has a compiled optimal_leaf_ordering implementation that can be used instead of the implementation here.

##### Description of changes

* Use `scipy.cluster.hierarchical.optimal_leaf_ordering` instead of the implementation contained here.
* Remove some scipy <= 0.18 compatibility code.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
