### PR TITLE
[FIX] Fix saving workflows that contain a Rank widget

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -464,8 +464,8 @@ class OWRank(OWWidget):
 
     def on_select(self):
         # Save indices of attributes in the original, unsorted domain
-        self.selected_rows = self.ranksModel.mapToSourceRows([
-            i.row() for i in self.ranksView.selectionModel().selectedRows(0)])
+        self.selected_rows = list(self.ranksModel.mapToSourceRows([
+            i.row() for i in self.ranksView.selectionModel().selectedRows(0)]))
         self.commit()
 
     def setSelectionMethod(self, method):


### PR DESCRIPTION
##### Issue

Fixes #4285.

##### Description of changes

`np.array` cannot be saved as setting. `selected_rows` is now a list.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
