### PR TITLE
[ENH] Heatmap: Restore ability to cluster larger datasets

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1975,9 +1975,10 @@ class GraphicsSimpleTextList(QGraphicsWidget):
         self.clear()
         orientation = Qt.Horizontal if self.orientation == Qt.Vertical else Qt.Vertical
         for text in labels:
-            item = QGraphicsSimpleTextItem(text, self)
+            item = QGraphicsSimpleTextItem(self)
             item.setFont(self.font())
             item.setToolTip(text)
+            item.setText(text)
             item = GraphicsSimpleTextLayoutItem(item, orientation, parent=self)
             self.layout().addItem(item)
             self.layout().setAlignment(item, self.alignment)

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -239,6 +239,17 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
             colors = image_row_colors(image)
             np.testing.assert_almost_equal(colors, desired)
 
+    def test_migrate_settings_v3(self):
+        w = self.create_widget(
+            OWHeatMap, stored_settings={
+                "row_clustering": False,
+                "col_clustering": True,
+            }
+        )
+        self.assertEqual(w.row_clustering, Clustering.None_)
+        self.assertEqual(w.col_clustering, Clustering.OrderedClustering)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

In gh-2000 'Heatmap' widget lost the ability to cluster larger datasets (>1000).

##### Description of changes

Restore the ability to cluster without opt. ordering to allow clustering on larger datasets.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
