### PR TITLE
[CI] appveyor: Unpin scipy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
     PIP_DISABLE_PIP_VERSION_CHECK: 1
     BUILD_ENV: wheel==0.29.0 pip~=19.0
     # SIP 4.19.4+ with PyQt5==5.9.1+ segfault our tests (GH-2756)
-    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy>=1.16.0 scipy~=1.0.0 scikit-learn pandas==0.21.1 "pymssql<3.0"
+    TEST_ENV: sip==4.19.6 PyQt5==5.9.2 numpy>=1.16.0 scipy scikit-learn pandas==0.21.1 "pymssql<3.0"
     ORANGE_TEST_DB_URI: 'mssql://sa:Password12!@localhost:1433'
 
   matrix:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Appveyor CI pins scipy version that is incompatible with the latest release of numpy 1.18.0

##### Description of changes

Unpin scipy version.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
