### PR TITLE
[BLD] setup.py: numpy 1.18.0 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,14 @@ try:
 except ImportError:
     have_sphinx = False
 
-from distutils.command.build_ext import build_ext
-from distutils.command import install_data, sdist, config, build
+from distutils.command import install_data, sdist
+try:
 
+    from numpy.distutils.command.build_ext import build_ext
+    from numpy.distutils.command import config, build
+except ImportError:
+    from distutils.command.build_ext import build_ext
+    from distutils.command import config, build
 
 NAME = 'Orange3'
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Building with numpy.distutils 1.18.0 fails with an error:
```
running build
running build_py
Traceback (most recent call last):
  File "./setup.py", line 480, in <module>
    setup_package()
  File "./setup.py", line 475, in setup_package
    **extra_args
  File "/Users/aleserjavec/virtual/py36/lib/python3.6/site-packages/numpy/distutils/core.py", line 171, in setup
    return old_setup(**new_attr)
  File "/Users/aleserjavec/virtual/py36/lib/python3.6/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/Users/aleserjavec/virtual/py36/lib/python3.6/site-packages/numpy/distutils/command/build_py.py", line 9, in run
    build_src = self.get_finalized_command('build_src')
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 299, in get_finalized_command
    cmd_obj.ensure_finalized()
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 107, in ensure_finalized
    self.finalize_options()
  File "/Users/aleserjavec/virtual/py36/lib/python3.6/site-packages/numpy/distutils/command/build_src.py", line 127, in finalize_options
    build_ext = self.get_finalized_command('build_ext')
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 299, in get_finalized_command
    cmd_obj.ensure_finalized()
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 107, in ensure_finalized
    self.finalize_options()
  File "/Users/aleserjavec/virtual/py36/lib/python3.6/site-packages/numpy/distutils/command/build_ext.py", line 79, in finalize_options
    ('warn_error', 'warn_error'),
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 290, in set_undefined_options
    setattr(self, dst_option, getattr(src_cmd_obj, src_option))
  File "/Users/aleserjavec/.local/opt/python3.6/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 103, in __getattr__
    raise AttributeError(attr)
AttributeError: warn_error
```

##### Description of changes

* Use `build` and `config` from numpy.distutils

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
