### PR TITLE
[FIX] utils/textimport: Remove 'exclusive' kwarg from QActionGroup call

### DIFF
--- a/Orange/widgets/utils/textimport.py
+++ b/Orange/widgets/utils/textimport.py
@@ -1108,7 +1108,7 @@ class CSVImportWidget(QWidget):
         else:
             current = None
         cb = self.column_type_edit_cb
-        g = QActionGroup(menu, exclusive=True)
+        g = QActionGroup(menu)
         current_action = None
         # 'Copy' the column types model into a menu
         for i in range(cb.count()):


### PR DESCRIPTION
#### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

In Qt 5.14 'exclusive' is no longer a Q_PROPERTY of QActionGroup and hence the call raises a type error.

##### Description of changes

Remove 'exclusive' kwarg from QActionGroup call

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
