### PR TITLE
Excel Reader: Read values, not formulae

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -1053,7 +1053,8 @@ class ExcelReader(_BaseExcelReader):
     @property
     def workbook(self) -> openpyxl.Workbook:
         if not self._workbook:
-            self._workbook = openpyxl.load_workbook(self.filename)
+            self._workbook = openpyxl.load_workbook(self.filename,
+                                                    data_only=True)
         return self._workbook
 
     @property


### PR DESCRIPTION
##### Issue

Solves #2974, the remaining issue noted by @PrimozGodec: if an Excel file contains formulae, after #4279 they are loaded as formulae, not values.

##### Description of changes

Add a `data_only` argument when opening the workbook (https://openpyxl.readthedocs.io/en/stable/api/openpyxl.reader.excel.html#openpyxl.reader.excel.load_workbook).

##### Includes
- [X] Code changes