### PR TITLE
README: Better shields, Orange img next to title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Orange
+<kbd height=36><img src=https://raw.githubusercontent.com/irgolic/orange3/master/distribute/icon-48.png alt=img height=36/></kbd> Orange
 ======
 
 [![Discord Chat](https://img.shields.io/discord/633376992607076354?style=for-the-badge&logo=discord&color=orange&labelColor=black)](https://discord.gg/FWrfeXV)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Orange
 ======
 
-[![Discord Chat](https://img.shields.io/discord/633376992607076354?style=plastic)](https://discord.gg/FWrfeXV)
-[![build: passing](https://img.shields.io/travis/biolab/orange3?style=plastic)](https://travis-ci.org/biolab/orange3)
-[![codecov](https://img.shields.io/codecov/c/github/biolab/orange3?style=plastic)](https://codecov.io/gh/biolab/orange3)
+[![Discord Chat](https://img.shields.io/discord/633376992607076354?style=for-the-badge&logo=discord&color=orange)](https://discord.gg/FWrfeXV)
+[![build: passing](https://img.shields.io/travis/biolab/orange3?style=for-the-badge)](https://travis-ci.org/biolab/orange3)
+[![codecov](https://img.shields.io/codecov/c/github/biolab/orange3?style=for-the-badge)](https://codecov.io/gh/biolab/orange3)
 
 [Orange] is a component-based data mining software. It includes a range of data
 visualization, exploration, preprocessing and modeling techniques. It can be

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Orange
 ======
 
-[![Discord Chat](https://img.shields.io/discord/633376992607076354?style=for-the-badge&logo=discord&color=orange)](https://discord.gg/FWrfeXV)
-[![build: passing](https://img.shields.io/travis/biolab/orange3?style=for-the-badge)](https://travis-ci.org/biolab/orange3)
-[![codecov](https://img.shields.io/codecov/c/github/biolab/orange3?style=for-the-badge)](https://codecov.io/gh/biolab/orange3)
+[![Discord Chat](https://img.shields.io/discord/633376992607076354?style=for-the-badge&logo=discord&color=orange&labelColor=black)](https://discord.gg/FWrfeXV)
+[![build: passing](https://img.shields.io/travis/biolab/orange3?style=for-the-badge&labelColor=black)](https://travis-ci.org/biolab/orange3)
+[![codecov](https://img.shields.io/codecov/c/github/biolab/orange3?style=for-the-badge&labelColor=black)](https://codecov.io/gh/biolab/orange3)
 
 [Orange] is a component-based data mining software. It includes a range of data
 visualization, exploration, preprocessing and modeling techniques. It can be


### PR DESCRIPTION
##### Description of changes
The Discord, build and codecov shields are given a new look. They're larger, higher-contrast, and the chat shield shows a Discord icon and is orange.

Additionally, an Orange image is placed next to the title. I couldn't get it to align nicely, so I used a `kbd` tag and fiddled with the image height.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
