### PR TITLE
[ENH] Notarization Workflow

### DIFF
--- a/scripts/macos/sign-dmg.sh
+++ b/scripts/macos/sign-dmg.sh
@@ -81,7 +81,11 @@ mkdir "${MOUNT}"
 hdiutil attach "${IMGRW}".sparsebundle -readwrite -noverify -noautoopen \
         -mountpoint "${MOUNT}"
 
-codesign --sign "${IDENTITY}" --deep --verbose "${MOUNT}"/*.app
+# sign app bundle
+codesign --verbose --deep --options=runtime --sign "${IDENTITY}" "${MOUNT}"/*.app
+
+# sanity check
+codesign --verify -vvv --deep --strict "${MOUNT}"/*.app/
 
 # detach/unmount to sync
 hdiutil detach "${MOUNT}" -force
@@ -90,7 +94,9 @@ hdiutil resize -sectors min "${IMGRW}".sparsebundle
 # convert back to compressed read only image
 hdiutil convert -format UDZO -imagekey zlib-level=9 \
         -o "${IMG}" "${IMGRW}.sparsebundle"
-codesign -s "${IDENTITY}" "${IMG}"
+
+codesign --force -s "${IDENTITY}" "${IMG}"
+codesign --verify -vvv --deep --strict "${IMG}"
 
 if [ ! "${OUTPUT}" ]; then
     OUTPUT=${DMG}.signed


### PR DESCRIPTION
##### Issue
The software that you sign it with must be notarized by Apple in order to run on macOS 10.14.5 or later. [More info.](https://developer.apple.com/developer-id/)

##### Description of changes

Use **--options=runtime** when signing app bundle. If you don’t enable the hardened runtime, notarization fails!

Add "sanity check" step to ensure a valid code signature. The **strict** flag increases the restrictiveness of the validation to match that required by notarization.

##### Notarization steps

Requirements:

- Have Developer ID cerfiticate in you keychain
- Have xcode installed
- Find *Orange apple ID* and *APP-SPECIFIC-PASSWORD* in our 1Password manager. 

Run:
```
xcrun altool -t osx -f </Path/to/orange.dmg> --primary-bundle-id "si.biolab.orange" --notarize-app --username <Orange apple ID> --password <APP-SPECIFIC-PASSWORD>
```

Output example
```
No errors uploading '<Path to dmg>'.
RequestUUID = <RequestUUID>
```

This will upload .dmg and return RequestUUID which you can use to request the status of notarization process.
```
xcrun altool --notarization-info <RequestUUID> -u <Orange apple ID> --password <APP-SPECIFIC-PASSWORD>
```
 
Output example
```
Date: 2020-01-03 12:22:28 +0000
Hash: *********
RequestUUID: <RequestUUID>
Status: in progress
```

This can take a couple of minutes. When the process is finished and everything is OK you will see a status change.

```
Status: success
Status Code: 0
Status Message: Package Approved
```

Also, if notarization steps were successful we should get a mail from Apple:
```
Dear Orange,

Your Mac software has been notarized. You can now export this software and distribute it directly to users.

Bundle Identifier: si.biolab.orange
Request Identifier: <RequestUUID>

For details on exporting a notarized app, visit Xcode Help or the notarization guide. 
Best Regards,

Apple Developer Relations

```

Finally, we have to staple the .dmg at the end of the log produced by this, you should see a **The staple and validate action worked!** at the end.

```
xcrun stapler staple -v  </Path/to/orange.dmg>
```

And thats it. 


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
