### PR TITLE
[WIP] Hierarchical clustering: Fix visualisations for small values

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -92,7 +92,7 @@ def path_toQtPath(geom):
         r.moveCenter(*points[0])
         p.addRect(r)
     elif len(points) == 0:
-        r = QRectF(0, 0, 1e-16, 1e-16)
+        r = QRectF(0, 0, 0, 0)
         r.moveCenter(QPointF(*anchor))
         p.addRect(r)
     return p


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes (partially) https://github.com/biolab/orange3/issues/2650

The problem here is that distances in a case when we are using cosine distance are very small since values are not normalized and dates are huge numbers (seconds from January 1, 1970) comparing to other values. Why we do not normalize values for the cosine distance? @lanzagar In this case, it would solve the problem.

##### Description of changes
This PR currently removes lines at the right of the visualization. 

Lining lines still persist. They are caused since qt somehow randomly drops elements in QPainterPath when numbers are really small. Here is the example:
```
>>> from AnyQt.QtGui import QPainterPath
>>> p = QPainterPath()
>>> p.moveTo(4.996003610813204e-16, 0.5)
>>> p.elementCount()
1
>>> p.lineTo(0.0, 0.5)
>>> p.elementCount()
1
>>> p.lineTo(0.0, 2.375)
>>> p.elementCount()
2
>>> p.lineTo(3.885780586188048e-16, 2.375)
>>> p.elementCount()
2
```
Four elements should be in QPainterPath but only 2 persists.

This can be solved with scaling values for example in the range from 0 to 1. @ales-erjavec is there any better and easier solution for that? Sine if we do scaling the widget would need to be partially redesigned.

And there is another potential issue. After finding out that I cannot compute the cosine distance with normalization I was trying to normalize with the Preprocess widget. It also does not normalize the time variable since by default `normalize_datetime=False`. In my opinion, when one has a time variable among attributes and does the preprocessing he also wants to preprocess/normalize it together with other variables. Is there a specific reason that it is disabled? @lanzagar @janezd 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
