### PR TITLE
[FIX] Distances: Fix restoring the cosine distance

### DIFF
--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -63,7 +63,7 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
     class Outputs:
         distances = Output("Distances", Orange.misc.DistMatrix, dynamic=False)
 
-    settings_version = 2
+    settings_version = 3
 
     axis = Setting(0)        # type: int
     metric_idx = Setting(0)  # type: int


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When saving a Distance widget with cosine distance it was restored as Mahalonobis. In https://github.com/biolab/orange3/pull/4280/files settings_version was not increased. 

##### Description of changes
Increasing the settings version.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
