### PR TITLE
[FIX] TestOWRank: Setting type should not be np.ndarray

### DIFF
--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -1,4 +1,5 @@
 import warnings
+import unittest
 from unittest.mock import patch
 
 import numpy as np
@@ -381,7 +382,11 @@ class TestOWRank(WidgetTest):
         self.send_signal(w.Inputs.data, self.iris)
 
         # select first and second row
-        w.selected_rows = np.array([1, 2])
+        w.selected_rows = [1, 2]
         output = self.get_output(w.Outputs.reduced_data)
 
         self.assertEqual(len(output), len(self.iris))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Setting type should not be` np.ndarray.`

##### Description of changes
Assign a list to `selected_rows`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
