### PR TITLE
Concurrent: Prevent running new task from on_done, on_exception

### DIFF
--- a/Orange/widgets/utils/concurrent.py
+++ b/Orange/widgets/utils/concurrent.py
@@ -552,6 +552,12 @@ class ConcurrentMixin:
             self.on_exception(ex)
         else:
             self.on_done(future.result())
+        # This assert prevents user to start new task (call start) from either
+        # on_done or on_exception
+        assert self.__task is None, (
+            "Starting new task from "
+            f"{'on_done' if ex is None else 'on_exception'} is forbidden"
+        )
 
 
 class ConcurrentWidgetMixin(ConcurrentMixin):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In the new implementation of the ImageEmbedding widget, I have a case when I call `start` from `on_exception`. The case is I call `start` for the first time, then exception happens. in `on_exception` function I change something in the widget and call `start` with new configuration again. It works well.

The problem is that then wait_until_finished does not work correctly since after `on_exception` is called state invalidated is set to `False` (it happens after the start is called again). 

##### Description of changes
With @VesnaT we decided that it is not good practice to call start while fetching the results or exception. So I changed my implementation in ImageAnalytics to use partial results instead. With this PR I am just adding the assert that prevents user to call `start` from `on_done` or `on_exception`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
