### PR TITLE
[FIX] owhierarchicalclustering: Prescale dendrogram geometry

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -5,14 +5,17 @@ import warnings
 import numpy as np
 
 from AnyQt.QtCore import QPoint, Qt
+from AnyQt.QtWidgets import QGraphicsScene, QGraphicsView
 from AnyQt.QtTest import QTest
 
+from orangewidget.tests.base import GuiTest
 import Orange.misc
+from Orange.clustering import hierarchical
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
-    OWHierarchicalClustering
+    OWHierarchicalClustering, DendrogramWidget
 
 
 class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
@@ -170,3 +173,54 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(w.Inputs.distances, self.distances, widget=w)
         ids_2 = self.get_output(w.Outputs.selected_data, widget=w).ids
         self.assertSequenceEqual(list(ids_1), list(ids_2))
+
+
+class TestDendrogramWidget(GuiTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.scene = QGraphicsScene()
+        self.view = QGraphicsView(self.scene)
+        self.widget = DendrogramWidget()
+        self.scene.addItem(self.widget)
+
+    def tearDown(self) -> None:
+        self.scene.clear()
+        del self.widget
+        del self.view
+        super().tearDown()
+
+    def test_widget(self):
+        w = self.widget
+
+        T = hierarchical.Tree
+        C = hierarchical.ClusterData
+        S = hierarchical.SingletonData
+
+        def t(h: float, left: T, right: T):
+            return T(C((left.value.first, right.value.last), h), (left, right))
+
+        def leaf(r, index):
+            return T(S((r, r + 1), 0.0, index))
+
+        T = hierarchical.Tree
+
+        w.set_root(t(0.0, leaf(0, 0), leaf(1, 1)))
+        w.resize(w.effectiveSizeHint(Qt.PreferredSize))
+        h = w.height_at(QPoint())
+        self.assertEqual(h, 0)
+        h = w.height_at(QPoint(10, 0))
+        self.assertEqual(h, 0)
+
+        self.assertEqual(w.pos_at_height(0).x(), w.rect().x())
+        self.assertEqual(w.pos_at_height(1).x(), w.rect().x())
+
+        height = np.finfo(float).eps
+        w.set_root(t(height, leaf(0, 0), leaf(1, 1)))
+
+        h = w.height_at(QPoint())
+        self.assertEqual(h, height)
+        h = w.height_at(QPoint(w.size().width(), 0))
+        self.assertEqual(h, 0)
+
+        self.assertEqual(w.pos_at_height(0).x(), w.rect().right())
+        self.assertEqual(w.pos_at_height(height).x(), w.rect().left())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-2650

##### Description of changes

* Prescale the dendrogram geometry to a fixed range to avoid fuzzy comparisons in QPainterPath, ...

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
