### PR TITLE
[ENH] OWContinuize: data info displayed in status bar

### DIFF
--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -97,6 +97,8 @@ class OWContinuize(widget.OWWidget):
         gui.auto_apply(self.buttonsArea, self, "autosend", box=False)
 
         self.data = None
+        self.info.set_input_summary(self.info.NoInput)
+        self.info.set_output_summary(self.info.NoOutput)
 
     def settings_changed(self):
         self.commit()
@@ -106,8 +108,11 @@ class OWContinuize(widget.OWWidget):
     def setData(self, data):
         self.data = data
         if data is None:
+            self.info.set_input_summary(self.info.NoInput)
+            self.info.set_output_summary(self.info.NoOutput)
             self.Outputs.data.send(None)
         else:
+            self.info.set_input_summary(len(data))
             self.unconditional_commit()
 
     def constructContinuizer(self):
@@ -133,8 +138,10 @@ class OWContinuize(widget.OWWidget):
             domain = continuizer(self.data)
             data = self.data.transform(domain)
             self.Outputs.data.send(data)
+            self.info.set_output_summary(len(data))
         else:
             self.Outputs.data.send(self.data)  # None or empty data
+
 
     def send_report(self):
         self.report_items(
@@ -391,4 +398,4 @@ class DomainContinuizer(Reprable):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    WidgetPreview(OWContinuize).run(Table("lenses"))
+    WidgetPreview(OWContinuize).run(Table("iris"))

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,unsubscriptable-object
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
 
@@ -9,6 +10,7 @@ from Orange.preprocess import transformation
 from Orange.widgets.data import owcontinuize
 from Orange.widgets.data.owcontinuize import OWContinuize
 from Orange.widgets.tests.base import WidgetTest
+from orangewidget.widget import StateInfo
 
 
 class TestOWContinuize(WidgetTest):
@@ -38,6 +40,25 @@ class TestOWContinuize(WidgetTest):
         widget.unconditional_commit()
         imp_data = self.get_output(self.widget.Outputs.data)
         self.assertIsNone(imp_data)
+
+    def test_summary(self):
+        """Check if status bar is updated when data is received"""
+        data = Table("iris")
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        self.send_signal(self.widget.Inputs.data, data)
+        input_sum.assert_called_with(int(StateInfo.format_number(len(data))))
+        output = self.get_output(self.widget.Outputs.data)
+        output_sum.assert_called_with(int(StateInfo.format_number(len(output))))
+
+        input_sum.reset_mock()
+        output_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")
+        output_sum.assert_called_once()
+        self.assertEqual(output_sum.call_args[0][0].brief, "")
 
     def test_one_column_equal_values(self):
         """


### PR DESCRIPTION
##### Description of changes
Display input and output data info in the status bar.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
