### PR TITLE
[ENH] OWDiscretize: data info displayed in status bar

### DIFF
--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -245,6 +245,9 @@ class OWDiscretize(widget.OWWidget):
 
         self._update_spin_positions()
 
+        self.info.set_input_summary(self.info.NoInput)
+        self.info.set_output_summary(self.info.NoOutput)
+
 
     @Inputs.data
     def set_data(self, data):
@@ -257,7 +260,9 @@ class OWDiscretize(widget.OWWidget):
             self._restore(self.saved_var_states)
             # Complete the induction of cut points
             self._update_points()
+            self.info.set_input_summary(len(data))
         else:
+            self.info.set_input_summary(self.info.NoInput)
             self._clear()
         self.unconditional_commit()
 
@@ -478,6 +483,9 @@ class OWDiscretize(widget.OWWidget):
         if self.data is not None and len(self.data):
             domain = self.discretized_domain()
             output = self.data.transform(domain)
+            self.info.set_output_summary(len(output))
+        else:
+            self.info.set_output_summary(self.info.NoOutput)
         self.Outputs.data.send(output)
 
     def storeSpecificSettings(self):

--- a/Orange/widgets/data/tests/test_owdiscretize.py
+++ b/Orange/widgets/data/tests/test_owdiscretize.py
@@ -1,8 +1,11 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,unsubscriptable-object
+from unittest.mock import Mock
+
 from Orange.data import Table
 from Orange.widgets.data.owdiscretize import OWDiscretize
 from Orange.widgets.tests.base import WidgetTest
+from orangewidget.widget import StateInfo
 
 
 class TestOWDiscretize(WidgetTest):
@@ -17,3 +20,22 @@ class TestOWDiscretize(WidgetTest):
         self.send_signal(self.widget.Inputs.data,
                          Table.from_domain(data.domain))
         widget.unconditional_commit()
+
+    def test_summary(self):
+        """Check if status bar is updated when data is received"""
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, data)
+        input_sum.assert_called_with(int(StateInfo.format_number(len(data))))
+        output = self.get_output(self.widget.Outputs.data)
+        output_sum.assert_called_with(int(StateInfo.format_number(len(output))))
+
+        input_sum.reset_mock()
+        output_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")
+        output_sum.assert_called_once()
+        self.assertEqual(output_sum.call_args[0][0].brief, "")


### PR DESCRIPTION
##### Description of changes
Display input and output data info in the status bar.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
