### PR TITLE
[RFC] Nomogram: Prevent connecting incompatible models

### DIFF
--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -17,6 +17,15 @@ class ModelClassification(Model):
     pass
 
 
+class LinearModel:
+    """
+    A mix-in that serves as a flag for linear models, like naive Bayesian
+    classifier and logistic regression (but not SVM which can also be
+    non-linear -- in terms of original variables). The nomogram widget
+    accepts only models with this mix-in.
+    """
+
+
 class SklModelClassification(SklModel, ModelClassification):
     def predict(self, X):
         prediction = super().predict(X)

--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -6,6 +6,7 @@ import sklearn.linear_model as skl_linear_model
 
 import Orange
 from Orange.classification import SklLearner, SklModel
+from Orange.classification.base_classification import LinearModel
 from Orange.preprocess import Normalize
 from Orange.preprocess.score import LearnerScorer
 from Orange.data import Variable, DiscreteVariable
@@ -23,7 +24,7 @@ class _FeatureScorerMixin(LearnerScorer):
         return np.abs(model.coefficients), model.domain.attributes
 
 
-class LogisticRegressionClassifier(SklModel):
+class LogisticRegressionClassifier(SklModel, LinearModel):
     @property
     def intercept(self):
         return self.skl_model.intercept_

--- a/Orange/classification/naive_bayes.py
+++ b/Orange/classification/naive_bayes.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from Orange.classification import Learner, Model
+from Orange.classification.base_classification import LinearModel
 from Orange.data import Instance, Storage, Table
 from Orange.statistics import contingency
 from Orange.preprocess import Discretize, RemoveNaNColumns
@@ -53,7 +54,7 @@ class NaiveBayesLearner(Learner):
         return NaiveBayesModel(log_cont_prob, class_prob, table.domain)
 
 
-class NaiveBayesModel(Model):
+class NaiveBayesModel(Model, LinearModel):
     def __init__(self, log_cont_prob, class_prob, domain):
         super().__init__(domain)
         self.log_cont_prob = log_cont_prob

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -13,6 +13,7 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import QColor, QPainter, QFont, QPen, QBrush
 from AnyQt.QtCore import Qt, QRectF, QSize
 
+from Orange.classification.base_classification import LinearModel
 from Orange.data import Table, Domain
 from Orange.statistics.util import nanmin, nanmax, nanmean, unique
 from Orange.classification import Model
@@ -570,7 +571,7 @@ class OWNomogram(OWWidget):
     keywords = []
 
     class Inputs:
-        classifier = Input("Classifier", Model)
+        classifier = Input("Classifier", LinearModel)
         data = Input("Data", Table)
 
     class Outputs:
@@ -580,7 +581,6 @@ class OWNomogram(OWWidget):
     POINT_SCALE = 0
     ALIGN_LEFT = 0
     ALIGN_ZERO = 1
-    ACCEPTABLE = (NaiveBayesModel, LogisticRegressionClassifier)
     settingsHandler = ClassValuesContextHandler()
     target_class_index = ContextSetting(0)
     normalize_probabilities = Setting(False)
@@ -591,10 +591,6 @@ class OWNomogram(OWWidget):
     cont_feature_dim_index = Setting(0)
 
     graph_name = "scene"
-
-    class Error(OWWidget.Error):
-        invalid_classifier = Msg("Nomogram accepts only Naive Bayes and "
-                                 "Logistic Regression classifiers.")
 
     def __init__(self):
         super().__init__()
@@ -772,9 +768,6 @@ class OWNomogram(OWWidget):
         self.closeContext()
         self.classifier = classifier
         self.Error.clear()
-        if self.classifier and not isinstance(self.classifier, self.ACCEPTABLE):
-            self.Error.invalid_classifier()
-            self.classifier = None
         self.domain = self.classifier.domain if self.classifier else None
         self.data = None
         self.calculate_log_odds_ratios()

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -7,9 +7,7 @@ import numpy as np
 from AnyQt.QtCore import QPoint
 
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
-from Orange.classification import (
-    NaiveBayesLearner, LogisticRegressionLearner, MajorityLearner
-)
+from Orange.classification import NaiveBayesLearner, LogisticRegressionLearner
 from Orange.tests import test_filename
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.visualize.ownomogram import (
@@ -51,14 +49,6 @@ class TestOWNomogram(WidgetTest):
             len([item for item in self.widget.scene.items() if
                  isinstance(item, ContinuousFeatureItem)]),
             len([a for a in self.data.domain.attributes if a.is_continuous]))
-
-    def test_input_invalid_cls(self):
-        """Check any classifier on input"""
-        majority_cls = MajorityLearner()(self.data)
-        self.send_signal(self.widget.Inputs.classifier, majority_cls)
-        self.assertTrue(self.widget.Error.invalid_classifier.is_shown())
-        self.send_signal(self.widget.Inputs.classifier, None)
-        self.assertFalse(self.widget.Error.invalid_classifier.is_shown())
 
     def test_input_instance(self):
         """ Check data instance on input"""


### PR DESCRIPTION
##### Issue

Users can connect arbitrary classifiers to nomogram; if the classifier is not naive Bayes or logistic regression, the widget informs the user that this type of classifier is invalid. It would be nicer if classifiers of wrong types couldn't be connected at all.

**Caveat:** are there (or could there be) widgets that output models and this model can be naive Bayes or logistic regression -- but not necessarily? E.g. what if ROC would output the optimal model for some operating condition? In this case, the current code supports connecting and checking later, while this PR prohibits it.

##### Description of changes

Implement a mixin that serves as a flag and mark the acceptable models.
