### PR TITLE
Fix requirement pyqtgraph==0.10.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - keyring
     - keyrings.alt  # for alternative keyring implementations
     - pyqt
-    - pyqtgraph     >=0.10.0
+    - pyqtgraph     =0.10.0
     - anyqt         >=0.0.8
     - joblib
     - python.app    # [osx]

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -4,7 +4,7 @@ orange-widget-base>=4.2.0a
 # PyQt4/PyQt5 compatibility
 AnyQt>=0.0.8
 
-pyqtgraph>=0.10.0
+pyqtgraph==0.10.0
 matplotlib>=2.0.0
 
 # For add-ons' descriptions


### PR DESCRIPTION
Orange does not work with pyqtgraph 0.11 release candidate.

##### Issue
See #4336