### PR TITLE
README: Make links to orange2 more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the latest version of Orange (for Python 3). The deprecated version of O
 
 [Orange]: https://orange.biolab.si/
 [binaries]: https://orange.biolab.si/orange2/
-[sources]: https://github.com/biolab/orange
+[sources]: https://github.com/biolab/orange2
 
 
 Installing with Miniconda / Anaconda

--- a/README.pypi
+++ b/README.pypi
@@ -11,7 +11,7 @@ Orange 2.7 (for Python 2.7) is still available ([binaries] and [sources]).
 
 [Orange]: https://orange.biolab.si/
 [binaries]: https://orange.biolab.si/orange2/
-[sources]: https://github.com/biolab/orange
+[sources]: https://github.com/biolab/orange2
 
 Installing with pip
 -------------------


### PR DESCRIPTION
'https://github.com/biolab/orange' redirects to orange2 repo,
but the link should be explicit to aid readers and avoid
reliance on a uncontrollable github feature.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation