### PR TITLE
[FIX] Normalize: Integer variable representation

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -505,12 +505,7 @@ class ContinuousVariable(Variable):
         three, but adjusted at the first call of :obj:`to_val`.
         """
         super().__init__(name, compute_value, sparse=sparse)
-        if number_of_decimals is None:
-            self._number_of_decimals = 3
-            self.adjust_decimals = 2
-            self._format_str = "%g"
-        else:
-            self.number_of_decimals = number_of_decimals
+        self.number_of_decimals = number_of_decimals
 
     @property
     def number_of_decimals(self):
@@ -538,6 +533,12 @@ class ContinuousVariable(Variable):
     # noinspection PyAttributeOutsideInit
     @number_of_decimals.setter
     def number_of_decimals(self, x):
+        if x is None:
+            self._number_of_decimals = 3
+            self.adjust_decimals = 2
+            self._format_str = "%g"
+            return
+
         self._number_of_decimals = x
         self.adjust_decimals = 0
         if self._number_of_decimals <= MAX_NUM_OF_DECIMALS:

--- a/Orange/preprocess/normalize.py
+++ b/Orange/preprocess/normalize.py
@@ -39,9 +39,11 @@ class Normalizer(Reprable):
         if not var.is_continuous or (var.is_time and not self.normalize_datetime):
             return var
         elif self.norm_type == Normalize.NormalizeBySD:
-            return self.normalize_by_sd(dist, var)
+            var = self.normalize_by_sd(dist, var)
         elif self.norm_type == Normalize.NormalizeBySpan:
-            return self.normalize_by_span(dist, var)
+            var = self.normalize_by_span(dist, var)
+        var.number_of_decimals = None
+        return var
 
     def normalize_by_sd(self, dist, var):
         avg, sd = (dist.mean(), dist.standard_deviation()) if dist.size else (0, 1)

--- a/Orange/tests/test_normalize.py
+++ b/Orange/tests/test_normalize.py
@@ -154,6 +154,21 @@ class TestNormalizer(unittest.TestCase):
             Normalize(norm_type=Normalize.NormalizeBySpan)(
                 data).domain.attributes[0].attributes, attributes)
 
+    def test_number_of_decimals(self):
+        foo = ContinuousVariable("Foo", number_of_decimals=0)
+        data = Table.from_list(Domain((foo,)), [[1], [2], [3]])
+
+        normalized = Normalize()(data)
+        norm_foo = normalized.domain.attributes[0]
+
+        self.assertEqual(norm_foo.number_of_decimals, 3)
+        self.assertEqual(norm_foo.format_str, "%g")
+        self.assertEqual(norm_foo.adjust_decimals, 2)
+
+        for val1, val2 in zip(normalized[:, "Foo"],
+                              ["-1.22474", "0", "1.22474"]):
+            self.assertEqual(str(val1[0]), val2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When copying a variable, number_of_decimals is copied along with other variable properties, causing the normalized integer variable being represented as an integer.

##### Description of changes
Override `number_of_decimals`, when copying a variable.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
