### PR TITLE
[FIX] Give created QGraphicsScenes a parent

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -266,7 +266,7 @@ class OWHierarchicalClustering(widget.OWWidget):
 
         gui.auto_send(box, self, "autocommit", box=False)
 
-        self.scene = QGraphicsScene()
+        self.scene = QGraphicsScene(self)
         self.view = StickyGraphicsView(
             self.scene,
             horizontalScrollBarPolicy=Qt.ScrollBarAlwaysOff,

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -263,7 +263,7 @@ class OWBoxPlot(widget.OWWidget):
             stateWhenDisabled=False)
 
         gui.vBox(self.mainArea, addSpace=True)
-        self.box_scene = QGraphicsScene()
+        self.box_scene = QGraphicsScene(self)
         self.box_scene.selectionChanged.connect(self.commit)
         self.box_view = QGraphicsView(self.box_scene)
         self.box_view.setRenderHints(QPainter.Antialiasing |

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -324,7 +324,7 @@ class OWMosaicDisplay(OWWidget):
 
         self.areas = []
 
-        self.canvas = QGraphicsScene()
+        self.canvas = QGraphicsScene(self)
         self.canvas_view = ViewWithPress(
             self.canvas, handler=self.clear_selection)
         self.mainArea.layout().addWidget(self.canvas_view)

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -121,7 +121,7 @@ class OWSieveDiagram(OWWidget):
             self.attr_box, self, "Score Combinations", self.set_attr)
         self.vizrank_button.setSizePolicy(*fixed_size)
 
-        self.canvas = QGraphicsScene()
+        self.canvas = QGraphicsScene(self)
         self.canvasView = ViewWithPress(
             self.canvas, self.mainArea, handler=self.reset_selection)
         self.mainArea.layout().addWidget(self.canvasView)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -179,7 +179,7 @@ class OWSilhouettePlot(widget.OWWidget):
         # Ensure that the controlArea is not narrower than buttonsArea
         self.controlArea.layout().addWidget(self.buttonsArea)
 
-        self.scene = QGraphicsScene()
+        self.scene = QGraphicsScene(self)
         self.view = StickyGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing, True)
         self.view.setAlignment(Qt.AlignTop | Qt.AlignLeft)

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -100,7 +100,7 @@ class OWVennDiagram(widget.OWWidget):
         self.area_keys = []
 
         # Main area view
-        self.scene = QGraphicsScene()
+        self.scene = QGraphicsScene(self)
         self.view = QGraphicsView(self.scene)
         self.view.setRenderHint(QPainter.Antialiasing)
         self.view.setBackgroundRole(QPalette.Window)


### PR DESCRIPTION
#### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref gh-4284

Fix an runtime error at process exit

Will require https://github.com/biolab/orange-widget-base/pull/37 to be merged and released

##### Description of changes

* Give QGraphicsScenes in VennDiagram and BoxPlot a parent the (OWWidget instance). Otherwise the scenes survive until process exit on PyQt 5.14.* 
* <s>Enable testing on PyQt5 5.14</s> (test still segfault with PyQt5 5.14 at process exit)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
