### PR TITLE
[WIP] OWFeatureStatistics: data info displayed in the status bar

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -749,7 +749,7 @@ class OWFeatureStatistics(widget.OWWidget):
         box = gui.vBox(self.controlArea, 'Histogram')
         self.cb_color_var = gui.comboBox(
             box, master=self, value='color_var', model=self.color_var_model,
-            label='Color:', orientation=Qt.Horizontal,
+            label='Color:', orientation=Qt.Horizontal, contentsLength=13,
         )
         self.cb_color_var.activated.connect(self.__color_var_changed)
 

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -1,12 +1,15 @@
+# pylint: disable=unsubscriptable-object
 import datetime
 from collections import namedtuple
 from functools import partial
 from itertools import chain
 from typing import List
+from unittest.mock import Mock
 
 import numpy as np
 from AnyQt.QtCore import QItemSelection, QItemSelectionRange, \
     QItemSelectionModel, Qt
+from orangewidget.widget import StateInfo
 
 from Orange.data import Table, Domain, StringVariable, ContinuousVariable, \
     DiscreteVariable, TimeVariable
@@ -461,3 +464,50 @@ class TestFeatureStatisticsUI(WidgetTest):
         # Sending back the old data restores the selection
         self.send_signal(self.widget.Inputs.data, self.data1)
         self.assertEqual(len(self.widget.selected_rows), 2)
+
+class TestSummary(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWFeatureStatistics)
+        self.data = make_table(
+            [continuous_full, continuous_missing],
+            target=[rgb_full, rgb_missing], metas=[ints_full, ints_missing]
+        )
+        self.select_rows = partial(select_rows, widget=self.widget)
+
+    def test_summary(self):
+        data = self.data
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        self.send_signal(self.widget.Inputs.data, data)
+        details = f'{len(data)} instances, ' \
+                  f'{len(data.domain.attributes)} features \n' \
+                  f'Features: {len(data.domain.attributes)} ' \
+                  f'numeric variables \n' \
+                  f'Target: {len(data.domain.class_vars)} ' \
+                  f'categorical variables \n' \
+                  f'Metas: {len(data.domain.metas)} ' \
+                  f'categorical variables'
+        input_sum.assert_called_with(StateInfo.format_number(len(data)),
+                                     details)
+
+        self.select_rows([0, 2])
+        self.widget.unconditional_commit()
+        output = self.get_output(self.widget.Outputs.reduced_data)
+        details = f'{len(output)} instances, ' \
+                  f'{len(output.domain.attributes)} feature \n' \
+                  f'Features: {len(output.domain.attributes)} ' \
+                  f'numeric variable \n' \
+                  f'Target: {len(output.domain.class_vars)} ' \
+                  f'categorical variable \n' \
+                  f'Metas: No variables'
+        output_sum.assert_called_with(StateInfo.format_number(len(output)),
+                                      details)
+
+        input_sum.reset_mock()
+        output_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")
+        output_sum.assert_called_once()
+        self.assertEqual(output_sum.call_args[0][0].brief, "")


### PR DESCRIPTION
##### Issue
The drop-down list for choosing color of histograms was very narrow so feature names were not seen properly.

##### Description of changes
Display input and output data info in the status bar.
Made Color drop-down list wider.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
