### PR TITLE
[FIX] DendrogramWidget: Remove event filters before removing items

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -311,6 +311,12 @@ class DendrogramWidget(QGraphicsWidget):
             self.setParentItem(parent)
 
     def clear(self):
+        # Remove event filter from all items before removal.
+        # Each removeItem is linear in number of installed filters in the whole
+        # scene -> so this would be quadratic for us (not accounting any other
+        # filters not part of DendrogramWidget).
+        for item in self._items.values():
+            item.removeSceneEventFilter(self)
         for item in self._items.values():
             item.setParentItem(None)
             if item.scene() is self.scene() and self.scene() is not None:

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -317,15 +317,20 @@ class DendrogramWidget(QGraphicsWidget):
         # filters not part of DendrogramWidget).
         for item in self._items.values():
             item.removeSceneEventFilter(self)
-        for item in self._items.values():
-            item.setParentItem(None)
-            if item.scene() is self.scene() and self.scene() is not None:
-                self.scene().removeItem(item)
+        scene = self.scene()
+        if scene is not None:
+            scene.removeItem(self._itemgroup)
+        else:
+            self._itemgroup.setParentItem(None)
+        self._itemgroup = QGraphicsWidget(self)
+        self._itemgroup.setGeometry(self.contentsRect())
+        self._items.clear()
 
         for item in self._selection.values():
-            item.setParentItem(None)
-            if item.scene():
-                item.scene().removeItem(item)
+            if scene is not None:
+                scene.removeItem(item)
+            else:
+                item.setParentItem(None)
 
         self._root = None
         self._items = {}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix what appears to be a quadratic time bottleneck in `DendrogramWidget.clear`

Alleviates gh-2663

##### Description of changes

* Remove event filters before removing items
Each `removeItem` seems to be linear in number of installed filters in the whole scene -> so this would be quadratic for us (not accounting any other filters not part of `DendrogramWidget`).


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
