### PR TITLE
[FIX] Fix slow clear/delete in 'Heat Map' 'Hier. Clustering', 'Distance Map'

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -288,6 +288,8 @@ class DendrogramWidget(QGraphicsWidget):
                  **kwargs):
 
         super().__init__(None, **kwargs)
+        # Filter all events from children (`ClusterGraphicsItem`s)
+        self.setFiltersChildEvents(True)
         self.orientation = orientation
         self._root = None
         #: A tree with dendrogram geometry
@@ -312,12 +314,6 @@ class DendrogramWidget(QGraphicsWidget):
             self.setParentItem(parent)
 
     def clear(self):
-        # Remove event filter from all items before removal.
-        # Each removeItem is linear in number of installed filters in the whole
-        # scene -> so this would be quadratic for us (not accounting any other
-        # filters not part of DendrogramWidget).
-        for item in self._items.values():
-            item.removeSceneEventFilter(self)
         scene = self.scene()
         if scene is not None:
             scene.removeItem(self._itemgroup)
@@ -355,7 +351,6 @@ class DendrogramWidget(QGraphicsWidget):
                 item.setAcceptHoverEvents(True)
                 item.setPen(pen)
                 item.node = node
-                item.installSceneEventFilter(self)
                 for branch in node.branches:
                     assert branch in self._items
                     self._cluster_parent[branch] = node

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1156,8 +1156,8 @@ class OWHierarchicalClustering(widget.OWWidget):
                 else self.annotation_if_enumerate
 
     def _clear_plot(self):
-        self.labels.setItems([])
         self.dendrogram.set_root(None)
+        self.labels.setItems([])
 
     def _set_displayed_root(self, root):
         self._clear_plot()

--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -98,6 +98,7 @@ class TextListWidget(QGraphicsWidget):
         if self.__orientation != orientation:
             self.__orientation = orientation
             self.__layout()
+            self.updateGeometry()
 
     def orientation(self) -> Qt.Orientation:
         return self.__orientation

--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -1,21 +1,46 @@
-from AnyQt.QtCore import Qt, QSizeF, QEvent
+from typing import Optional, Union, Any, Iterable, List
+
+from AnyQt.QtCore import Qt, QSizeF, QEvent, QMarginsF
 from AnyQt.QtGui import QFontMetrics
 from AnyQt.QtWidgets import (
     QGraphicsWidget, QSizePolicy, QGraphicsItemGroup, QGraphicsSimpleTextItem,
-    QWIDGETSIZE_MAX,
+    QGraphicsItem, QGraphicsScene, QWIDGETSIZE_MAX,
 )
 
 __all__ = ["TextListWidget"]
 
 
 class TextListWidget(QGraphicsWidget):
-    def __init__(self, parent=None, items=None, **kwargs):
-        super().__init__(parent, **kwargs)
+    """
+    A linear text list widget.
+
+    Displays a list of uniformly spaced text lines.
+
+    Parameters
+    ----------
+    parent: Optional[QGraphicsItem]
+    items: Iterable[str]
+    alignment: Qt.Alignment
+    orientation: Qt.Orientation
+    """
+    def __init__(
+            self,
+            parent: Optional[QGraphicsItem] = None,
+            items: Iterable[str] = (),
+            alignment: Union[Qt.AlignmentFlag, Qt.Alignment] = Qt.AlignLeading,
+            orientation: Qt.Orientation = Qt.Vertical,
+            **kwargs: Any
+    ) -> None:
+        sizePolicy = kwargs.pop(
+            "sizePolicy", None)  # type: Optional[QSizePolicy]
+        super().__init__(None, **kwargs)
         self.setFlag(QGraphicsWidget.ItemClipsChildrenToShape, True)
-        self.__items = []
-        self.__textitems = []
-        self.__group = None
+        self.__items: List[str] = []
+        self.__textitems: List[QGraphicsSimpleTextItem] = []
+        self.__group: Optional[QGraphicsItemGroup] = None
         self.__spacing = 0
+        self.__alignment = Qt.AlignmentFlag(alignment)
+        self.__orientation = orientation
 
         sp = QSizePolicy(QSizePolicy.Preferred,
                          QSizePolicy.Preferred)
@@ -25,42 +50,104 @@ class TextListWidget(QGraphicsWidget):
         if items is not None:
             self.setItems(items)
 
-    def setItems(self, items):
+        if sizePolicy is not None:
+            self.setSizePolicy(sizePolicy)
+
+        if parent is not None:
+            self.setParentItem(parent)
+
+    def setItems(self, items: Iterable[str]) -> None:
+        """
+        Set items for display
+
+        Parameters
+        ----------
+        items: Iterable[str]
+        """
         self.__clear()
         self.__items = list(items)
         self.__setup()
         self.__layout()
         self.updateGeometry()
 
-    def clear(self):
+    def setAlignment(self, alignment: Qt.AlignmentFlag) -> None:
+        """
+        Set the text item's alignment.
+        """
+        if self.__alignment != alignment:
+            self.__alignment = alignment
+            self.__layout()
+
+    def alignment(self) -> Qt.AlignmentFlag:
+        """Return the text item's alignment."""
+        return self.__alignment
+
+    def setOrientation(self, orientation: Qt.Orientation) -> None:
+        """
+        Set text orientation.
+
+        If Qt.Vertical items are put in a vertical layout
+        if Qt.Horizontal the n items are drawn rotated 90 degrees and laid out
+        horizontally with first text items's top corner in the bottom left
+        of `self.geometry()`.
+
+        Parameters
+        ----------
+        orientation: Qt.Orientation
+        """
+        if self.__orientation != orientation:
+            self.__orientation = orientation
+            self.__layout()
+
+    def orientation(self) -> Qt.Orientation:
+        return self.__orientation
+
+    def clear(self) -> None:
+        """
+        Remove all items.
+        """
         self.__clear()
         self.__items = []
         self.updateGeometry()
 
-    def sizeHint(self, which, constraint=QSizeF()):
+    def count(self) -> int:
+        """
+        Return the number of items
+        """
+        return len(self.__items)
+
+    def sizeHint(self, which: Qt.SizeHint, constraint=QSizeF()) -> QSizeF:
+        """Reimplemented."""
         if which == Qt.PreferredSize:
             sh = self.__naturalsh()
-            if 0 < constraint.height() < sh.height():
-                sh = scaled(sh, constraint, Qt.KeepAspectRatioByExpanding)
-            return sh
+            if self.__orientation == Qt.Vertical:
+                if 0 < constraint.height() < sh.height():
+                    sh = scaled(sh, constraint, Qt.KeepAspectRatioByExpanding)
+            else:
+                sh = sh.transposed()
+                if 0 < constraint.width() < sh.width():
+                    sh = scaled(sh, constraint, Qt.KeepAspectRatioByExpanding)
+        else:
+            sh = super().sizeHint(which, constraint)
+        return sh
 
-        return super().sizeHint(which, constraint)
-
-    def __naturalsh(self):
+    def __naturalsh(self) -> QSizeF:
+        """Return the natural size hint (preferred sh with no constraints)."""
         fm = QFontMetrics(self.font())
         spacing = self.__spacing
         N = len(self.__items)
         width = max((fm.width(text) for text in self.__items),
                     default=0)
-        height = N * fm.height() + (N - 1) * spacing
+        height = N * fm.height() + max(N - 1, 0) * spacing
         return QSizeF(width, height)
 
-    def event(self, event):
+    def event(self, event: QEvent) -> bool:
         if event.type() == QEvent.LayoutRequest:
             self.__layout()
         elif event.type() == QEvent.GraphicsSceneResize:
             self.__layout()
-
+        elif event.type() == QEvent.ContentsRectChange:
+            self.__layout()
         return super().event(event)
 
     def changeEvent(self, event):
@@ -69,56 +156,113 @@ class TextListWidget(QGraphicsWidget):
             font = self.font()
             for item in self.__textitems:
                 item.setFont(font)
+        super().changeEvent(event)
 
-    def __setup(self):
+    def __setup(self) -> None:
         self.__clear()
         font = self.font()
-        group = QGraphicsItemGroup(self)
-
+        assert self.__group is None
+        group = QGraphicsItemGroup()
         for text in self.__items:
-            t = QGraphicsSimpleTextItem(text, group)
-            t.setData(0, text)
+            t = QGraphicsSimpleTextItem(group)
             t.setFont(font)
+            t.setText(text)
             t.setToolTip(text)
+            t.setData(0, text)
             self.__textitems.append(t)
+        group.setParentItem(self)
+        self.__group = group
 
-    def __layout(self):
-        crect = self.contentsRect()
+    def __layout(self) -> None:
+        margins = QMarginsF(*self.getContentsMargins())
+        if self.__orientation == Qt.Horizontal:
+            # transposed margins
+            margins = QMarginsF(
+                margins.bottom(), margins.left(), margins.top(), margins.right()
+            )
+            crect = self.rect().transposed().marginsRemoved(margins)
+        else:
+            crect = self.rect().marginsRemoved(margins)
+
         spacing = self.__spacing
+
+        align_horizontal = self.__alignment & Qt.AlignHorizontal_Mask
+        align_vertical = self.__alignment & Qt.AlignVertical_Mask
+        if align_vertical == 0:
+            align_vertical = Qt.AlignTop
+        if align_horizontal == 0:
+            align_horizontal = Qt.AlignLeft
+
         N = len(self.__items)
 
         if not N:
             return
 
+        assert self.__group is not None
+
         fm = QFontMetrics(self.font())
         naturalheight = fm.height()
-        th = (crect.height() - (N - 1) * spacing) / N
-        if th > naturalheight and N > 1:
-            th = naturalheight
-            spacing = (crect.height() - N * th) / (N - 1)
+        cell_height = (crect.height() - (N - 1) * spacing) / N
 
-        for i, item in enumerate(self.__textitems):
-            item.setPos(crect.left(), crect.top() + i * (th + spacing))
+        if cell_height > naturalheight and N > 1:
+            cell_height = naturalheight
+            spacing = (crect.height() - N * cell_height) / N
 
-    def __clear(self):
-        def remove(items, scene):
+        advance = cell_height + spacing
+        if align_vertical == Qt.AlignTop:
+            align_dy = 0.
+        elif align_vertical == Qt.AlignVCenter:
+            align_dy = advance / 2.0 - naturalheight / 2.0
+        else:
+            align_dy = advance - naturalheight
+
+        if align_horizontal == Qt.AlignLeft:
+            for i, item in enumerate(self.__textitems):
+                item.setPos(crect.left(), crect.top() + i * advance + align_dy)
+        elif align_horizontal == Qt.AlignHCenter:
+            for i, item in enumerate(self.__textitems):
+                item.setPos(
+                    crect.center().x() - item.boundingRect().width() / 2,
+                    crect.top() + i * advance + align_dy
+                )
+        else:
+            for i, item in enumerate(self.__textitems):
+                item.setPos(
+                    crect.right() - item.boundingRect().width(),
+                    crect.top() + i * advance + align_dy
+                )
+
+        if self.__orientation == Qt.Vertical:
+            self.__group.setRotation(0)
+            self.__group.setPos(0, 0)
+        else:
+            self.__group.setRotation(-90)
+            self.__group.setPos(self.rect().bottomLeft())
+
+    def __clear(self) -> None:
+        def remove(items: Iterable[QGraphicsItem],
+                   scene: Optional[QGraphicsScene]):
             for item in items:
-                item.setParentItem(None)
                 if scene is not None:
                     scene.removeItem(item)
-
-        remove(self.__textitems, self.scene())
+                else:
+                    item.setParentItem(None)
+        self.__textitems = []
         if self.__group is not None:
             remove([self.__group], self.scene())
+            self.__group = None
 
-        self.__textitems = []
 
+def scaled(size: QSizeF, constraint: QSizeF, mode=Qt.KeepAspectRatio) -> QSizeF:
+    """
+    Return size scaled to fit in the constrains using the aspect mode `mode`.
 
-def scaled(size, constraint, mode=Qt.KeepAspectRatio):
+    If  width or height of constraint are negative they are ignored,
+    ie. the result is not constrained in that dimension.
+    """
+    size, constraint = QSizeF(size), QSizeF(constraint)
     if constraint.width() < 0 and constraint.height() < 0:
         return size
-
-    size, constraint = QSizeF(size), QSizeF(constraint)
     if mode == Qt.IgnoreAspectRatio:
         if constraint.width() >= 0:
             size.setWidth(constraint.width())

--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -1,0 +1,139 @@
+from AnyQt.QtCore import Qt, QSizeF, QEvent
+from AnyQt.QtGui import QFontMetrics
+from AnyQt.QtWidgets import (
+    QGraphicsWidget, QSizePolicy, QGraphicsItemGroup, QGraphicsSimpleTextItem,
+    QWIDGETSIZE_MAX,
+)
+
+__all__ = ["TextListWidget"]
+
+
+class TextListWidget(QGraphicsWidget):
+    def __init__(self, parent=None, items=None, **kwargs):
+        super().__init__(parent, **kwargs)
+        self.setFlag(QGraphicsWidget.ItemClipsChildrenToShape, True)
+        self.__items = []
+        self.__textitems = []
+        self.__group = None
+        self.__spacing = 0
+
+        sp = QSizePolicy(QSizePolicy.Preferred,
+                         QSizePolicy.Preferred)
+        sp.setWidthForHeight(True)
+        self.setSizePolicy(sp)
+
+        if items is not None:
+            self.setItems(items)
+
+    def setItems(self, items):
+        self.__clear()
+        self.__items = list(items)
+        self.__setup()
+        self.__layout()
+        self.updateGeometry()
+
+    def clear(self):
+        self.__clear()
+        self.__items = []
+        self.updateGeometry()
+
+    def sizeHint(self, which, constraint=QSizeF()):
+        if which == Qt.PreferredSize:
+            sh = self.__naturalsh()
+            if 0 < constraint.height() < sh.height():
+                sh = scaled(sh, constraint, Qt.KeepAspectRatioByExpanding)
+            return sh
+
+        return super().sizeHint(which, constraint)
+
+    def __naturalsh(self):
+        fm = QFontMetrics(self.font())
+        spacing = self.__spacing
+        N = len(self.__items)
+        width = max((fm.width(text) for text in self.__items),
+                    default=0)
+        height = N * fm.height() + (N - 1) * spacing
+        return QSizeF(width, height)
+
+    def event(self, event):
+        if event.type() == QEvent.LayoutRequest:
+            self.__layout()
+        elif event.type() == QEvent.GraphicsSceneResize:
+            self.__layout()
+
+        return super().event(event)
+
+    def changeEvent(self, event):
+        if event.type() == QEvent.FontChange:
+            self.updateGeometry()
+            font = self.font()
+            for item in self.__textitems:
+                item.setFont(font)
+
+    def __setup(self):
+        self.__clear()
+        font = self.font()
+        group = QGraphicsItemGroup(self)
+
+        for text in self.__items:
+            t = QGraphicsSimpleTextItem(text, group)
+            t.setData(0, text)
+            t.setFont(font)
+            t.setToolTip(text)
+            self.__textitems.append(t)
+
+    def __layout(self):
+        crect = self.contentsRect()
+        spacing = self.__spacing
+        N = len(self.__items)
+
+        if not N:
+            return
+
+        fm = QFontMetrics(self.font())
+        naturalheight = fm.height()
+        th = (crect.height() - (N - 1) * spacing) / N
+        if th > naturalheight and N > 1:
+            th = naturalheight
+            spacing = (crect.height() - N * th) / (N - 1)
+
+        for i, item in enumerate(self.__textitems):
+            item.setPos(crect.left(), crect.top() + i * (th + spacing))
+
+    def __clear(self):
+        def remove(items, scene):
+            for item in items:
+                item.setParentItem(None)
+                if scene is not None:
+                    scene.removeItem(item)
+
+        remove(self.__textitems, self.scene())
+        if self.__group is not None:
+            remove([self.__group], self.scene())
+
+        self.__textitems = []
+
+
+def scaled(size, constraint, mode=Qt.KeepAspectRatio):
+    if constraint.width() < 0 and constraint.height() < 0:
+        return size
+
+    size, constraint = QSizeF(size), QSizeF(constraint)
+    if mode == Qt.IgnoreAspectRatio:
+        if constraint.width() >= 0:
+            size.setWidth(constraint.width())
+        if constraint.height() >= 0:
+            size.setHeight(constraint.height())
+    elif mode == Qt.KeepAspectRatio:
+        if constraint.width() < 0:
+            constraint.setWidth(QWIDGETSIZE_MAX)
+        if constraint.height() < 0:
+            constraint.setHeight(QWIDGETSIZE_MAX)
+        size.scale(constraint, mode)
+    elif mode == Qt.KeepAspectRatioByExpanding:
+        if constraint.width() < 0:
+            constraint.setWidth(0)
+        if constraint.height() < 0:
+            constraint.setHeight(0)
+        size.scale(constraint, mode)
+    return size

--- a/Orange/widgets/utils/tests/test_graphicstextlist.py
+++ b/Orange/widgets/utils/tests/test_graphicstextlist.py
@@ -1,0 +1,87 @@
+import unittest
+
+from AnyQt.QtCore import Qt, QSizeF
+
+from orangewidget.tests.base import GuiTest
+from Orange.widgets.utils.graphicstextlist import TextListWidget, scaled
+
+
+class TestTextListWidget(GuiTest):
+    def test_setItems(self):
+        w = TextListWidget()
+        w.setItems([])
+        self.assertEqual(w.count(), 0)
+        w.setItems(["Aa"])
+        self.assertEqual(w.count(), 1)
+        w.setItems(["Aa", "Bb"])
+        self.assertEqual(w.count(), 2)
+        w.clear()
+        self.assertEqual(w.count(), 0)
+        w.clear()
+
+    def test_orientation(self):
+        w = TextListWidget()
+        w.setItems(['x' * 20] * 2)
+        w.setOrientation(Qt.Vertical)
+        self.assertEqual(w.orientation(), Qt.Vertical)
+        sh = w.effectiveSizeHint(Qt.PreferredSize)
+        self.assertGreater(sh.width(), sh.height())
+        w.setOrientation(Qt.Horizontal)
+        sh = w.effectiveSizeHint(Qt.PreferredSize)
+        self.assertLess(sh.width(), sh.height())
+
+    def test_alignment(self):
+        w = TextListWidget()
+        w.setItems(["a"])
+        w.resize(200, 100)
+        w.setAlignment(Qt.AlignRight)
+        self.assertEqual(w.alignment(), Qt.AlignRight)
+        item = w.childItems()[0].childItems()[0]
+
+        def brect(item):
+            return item.mapRectToItem(w, item.boundingRect())
+
+        self.assertEqual(brect(item).right(), 200)
+        w.setAlignment(Qt.AlignLeft)
+        self.assertEqual(brect(item).left(), 0)
+
+        w.setAlignment(Qt.AlignHCenter)
+        self.assertTrue(90 <= brect(item).center().x() < 110)
+
+        w.setAlignment(Qt.AlignTop)
+        self.assertEqual(brect(item).top(), 0)
+
+        w.setAlignment(Qt.AlignBottom)
+        self.assertEqual(brect(item).bottom(), 100)
+
+        w.setAlignment(Qt.AlignVCenter)
+        self.assertTrue(45 <= brect(item).center().y() < 55)
+
+
+class TestUtils(unittest.TestCase):
+    def test_scaled(self):
+        cases_keep_aspect = [
+            (QSizeF(100, 100), QSizeF(200, 300), QSizeF(200, 200)),
+            (QSizeF(100, 100), QSizeF(300, 200), QSizeF(200, 200)),
+            (QSizeF(100, 100), QSizeF(300, -1), QSizeF(300, 300)),
+            (QSizeF(100, 100), QSizeF(-1, 300), QSizeF(300, 300)),
+            (QSizeF(100, 100), QSizeF(-1, -1), QSizeF(100, 100)),
+        ]
+        for size, const, expected in cases_keep_aspect:
+            s = scaled(size, const)
+            self.assertEqual(s, expected, f"scaled({size}, {const})")
+
+        cases_keep_aspect_by_expaindig = [
+            (QSizeF(100, 100), QSizeF(200, 300), QSizeF(300, 300)),
+            (QSizeF(100, 100), QSizeF(300, 200), QSizeF(300, 300)),
+            (QSizeF(100, 100), QSizeF(300, -1), QSizeF(300, 300)),
+            (QSizeF(100, 100), QSizeF(-1, 300), QSizeF(300, 300)),
+            (QSizeF(100, 100), QSizeF(-1, -1), QSizeF(100, 100)),
+        ]
+
+        for size, const, expected in cases_keep_aspect_by_expaindig:
+            s = scaled(size, const, Qt.KeepAspectRatioByExpanding)
+            self.assertEqual(
+                s, expected,
+                f"scaled({size}, {const}, Qt.KeepAspectRatioByExpanding)"
+            )

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -37,6 +37,7 @@ from Orange.clustering import hierarchical, kmeans
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.stickygraphicsview import StickyGraphicsView
 from Orange.widgets.utils import colorbrewer
+from Orange.widgets.utils.graphicstextlist import scaled
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
 from Orange.widgets import widget, gui, settings
@@ -1614,31 +1615,6 @@ class GraphicsWidget(QGraphicsWidget):
         if event.type() == QEvent.LayoutRequest and self.layout() is not None:
             self.layoutDidActivate.emit()
         return rval
-
-
-def scaled(size, constraint, mode=Qt.KeepAspectRatio):
-    if constraint.width() < 0 and constraint.height() < 0:
-        return size
-
-    size, constraint = QSizeF(size), QSizeF(constraint)
-    if mode == Qt.IgnoreAspectRatio:
-        if constraint.width() >= 0:
-            size.setWidth(constraint.width())
-        if constraint.height() >= 0:
-            size.setHeight(constraint.height())
-    elif mode == Qt.KeepAspectRatio:
-        if constraint.width() < 0:
-            constraint.setWidth(QWIDGETSIZE_MAX)
-        if constraint.height() < 0:
-            constraint.setHeight(QWIDGETSIZE_MAX)
-        size.scale(constraint, mode)
-    elif mode == Qt.KeepAspectRatioByExpanding:
-        if constraint.width() < 0:
-            constraint.setWidth(0)
-        if constraint.height() < 0:
-            constraint.setHeight(0)
-        size.scale(constraint, mode)
-    return size
 
 
 class GraphicsPixmapWidget(QGraphicsWidget):

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -10,9 +10,8 @@ import sklearn.metrics
 
 from AnyQt.QtWidgets import (
     QGraphicsScene, QGraphicsWidget, QGraphicsGridLayout,
-    QGraphicsItemGroup, QGraphicsSimpleTextItem, QGraphicsRectItem,
-    QSizePolicy, QStyleOptionGraphicsItem, QWidget, QWIDGETSIZE_MAX,
-    QVBoxLayout
+    QGraphicsSimpleTextItem, QGraphicsRectItem, QStyleOptionGraphicsItem,
+    QSizePolicy, QWidget, QWIDGETSIZE_MAX, QVBoxLayout
 )
 from AnyQt.QtGui import QColor, QPen, QBrush, QPainter, QFontMetrics, QPalette
 from AnyQt.QtCore import Qt, QEvent, QRectF, QSizeF, QSize, QPointF
@@ -31,12 +30,12 @@ from Orange.widgets.utils.stickygraphicsview import StickyGraphicsView
 from Orange.widgets.utils import itemmodels
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
+from Orange.widgets.utils.graphicstextlist import TextListWidget
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
     WrapperLayoutItem
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Msg, Input, Output
-from Orange.widgets.visualize.owheatmap import scaled
 
 
 ROW_NAMES_WIDTH = 200
@@ -1206,112 +1205,6 @@ class BarPlotItem(QGraphicsWidget):
         for i, (v, item) in enumerate(zip(datascaled, self.__items)):
             item.setRect(QRectF(base, rect.top() + i * (h + spacing),
                                 v - base, h).normalized())
-
-
-class TextListWidget(QGraphicsWidget):
-    def __init__(self, parent=None, items=None, **kwargs):
-        super().__init__(parent, **kwargs)
-        self.setFlag(QGraphicsWidget.ItemClipsChildrenToShape, True)
-        self.__items = []
-        self.__textitems = []
-        self.__group = None
-        self.__spacing = 0
-
-        sp = QSizePolicy(QSizePolicy.Preferred,
-                         QSizePolicy.Preferred)
-        sp.setWidthForHeight(True)
-        self.setSizePolicy(sp)
-
-        if items is not None:
-            self.setItems(items)
-
-    def setItems(self, items):
-        self.__clear()
-        self.__items = list(items)
-        self.__setup()
-        self.__layout()
-        self.updateGeometry()
-
-    def clear(self):
-        self.__clear()
-        self.__items = []
-        self.updateGeometry()
-
-    def sizeHint(self, which, constraint=QSizeF()):
-        if which == Qt.PreferredSize:
-            sh = self.__naturalsh()
-            if 0 < constraint.height() < sh.height():
-                sh = scaled(sh, constraint, Qt.KeepAspectRatioByExpanding)
-            return sh
-
-        return super().sizeHint(which, constraint)
-
-    def __naturalsh(self):
-        fm = QFontMetrics(self.font())
-        spacing = self.__spacing
-        N = len(self.__items)
-        width = max((fm.width(text) for text in self.__items),
-                    default=0)
-        height = N * fm.height() + (N - 1) * spacing
-        return QSizeF(width, height)
-
-    def event(self, event):
-        if event.type() == QEvent.LayoutRequest:
-            self.__layout()
-        elif event.type() == QEvent.GraphicsSceneResize:
-            self.__layout()
-
-        return super().event(event)
-
-    def changeEvent(self, event):
-        if event.type() == QEvent.FontChange:
-            self.updateGeometry()
-            font = self.font()
-            for item in self.__textitems:
-                item.setFont(font)
-
-    def __setup(self):
-        self.__clear()
-        font = self.font()
-        group = QGraphicsItemGroup(self)
-
-        for text in self.__items:
-            t = QGraphicsSimpleTextItem(text, group)
-            t.setData(0, text)
-            t.setFont(font)
-            t.setToolTip(text)
-            self.__textitems.append(t)
-
-    def __layout(self):
-        crect = self.contentsRect()
-        spacing = self.__spacing
-        N = len(self.__items)
-
-        if not N:
-            return
-
-        fm = QFontMetrics(self.font())
-        naturalheight = fm.height()
-        th = (crect.height() - (N - 1) * spacing) / N
-        if th > naturalheight and N > 1:
-            th = naturalheight
-            spacing = (crect.height() - N * th) / (N - 1)
-
-        for i, item in enumerate(self.__textitems):
-            item.setPos(crect.left(), crect.top() + i * (th + spacing))
-
-    def __clear(self):
-        def remove(items, scene):
-            for item in items:
-                item.setParentItem(None)
-                if scene is not None:
-                    scene.removeItem(item)
-
-        remove(self.__textitems, self.scene())
-        if self.__group is not None:
-            remove([self.__group], self.scene())
-
-        self.__textitems = []
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

owheatmap, owdistancemap and owhierarchicalclustering use QGraphicsLinearLayout to position text labels in a list. Clearing the QGraphicsLinearLayout however is slow (seems to be another quadratic time complexity).

Extract a more limited (but sufficient) TextListWidget from owsilhouetteplot and replace the use of QGraphicsLinearLayout.

Fixes gh-2663
Fixes gh-4349

##### Description of changes

* extract and extend the TextListWidget from owsilhouetteplot
* use the TextListWidget in owheatmap, owhierarchiclustering, owdistancemap

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
