### PR TITLE
[ENH] Outliers: Save model into compute_value

### DIFF
--- a/Orange/classification/outlier_detection.py
+++ b/Orange/classification/outlier_detection.py
@@ -1,21 +1,74 @@
 # pylint: disable=unused-argument
+import numpy as np
+
+from Orange.data.table import DomainTransformationError
+from Orange.data.util import get_unique_names
 from sklearn.covariance import EllipticEnvelope
 from sklearn.ensemble import IsolationForest
 from sklearn.neighbors import LocalOutlierFactor
 from sklearn.svm import OneClassSVM
 
 from Orange.base import SklLearner, SklModel
-from Orange.data import Table, Domain
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.preprocess import AdaptiveNormalize
+from Orange.statistics.util import all_nan
 
 __all__ = ["LocalOutlierFactorLearner", "IsolationForestLearner",
            "EllipticEnvelopeLearner", "OneClassSVMLearner"]
 
 
+class _OutlierModel(SklModel):
+    def __init__(self, skl_model):
+        super().__init__(skl_model)
+        self._cached_data = None
+        self.outlier_var = None
+
+    def predict(self, X: np.ndarray) -> np.ndarray:
+        pred = self.skl_model.predict(X)
+        pred[pred == -1] = 0
+        return pred[:, None]
+
+    def __call__(self, data: Table) -> Table:
+        assert isinstance(data, Table)
+        assert self.outlier_var is not None
+
+        domain = Domain(data.domain.attributes, data.domain.class_vars,
+                        data.domain.metas + (self.outlier_var,))
+        self._cached_data = self.data_to_model_domain(data)
+        metas = np.hstack((data.metas, self.predict(self._cached_data.X)))
+        return Table.from_numpy(domain, data.X, data.Y, metas)
+
+    def data_to_model_domain(self, data: Table) -> Table:
+        if data.domain == self.domain:
+            return data
+
+        if self.original_domain.attributes != data.domain.attributes \
+                and data.X.size \
+                and not all_nan(data.X):
+            new_data = data.transform(self.original_domain)
+            if all_nan(new_data.X):
+                raise DomainTransformationError(
+                    "domain transformation produced no defined values")
+            return new_data.transform(self.domain)
+        return data.transform(self.domain)
+
+
 class _OutlierLearner(SklLearner):
-    def __call__(self, data: Table):
+    __returns__ = _OutlierModel
+    supports_multiclass = True
+
+    def _fit_model(self, data: Table) -> _OutlierModel:
+        names = [v.name for v in data.domain.variables + data.domain.metas]
         data = data.transform(Domain(data.domain.attributes))
-        return super().__call__(data)
+        self.__model = super()._fit_model(data)
+        self.__model.outlier_var = DiscreteVariable(
+            get_unique_names(names, "Outlier"), values=["Yes", "No"],
+            compute_value=self.compute_value
+        )
+        return self.__model
+
+    def compute_value(self, table: Table) -> np.ndarray:
+        return self.__model(table)[:, self.__model.outlier_var].metas
 
 
 class OneClassSVMLearner(_OutlierLearner):
@@ -28,12 +81,6 @@ class OneClassSVMLearner(_OutlierLearner):
                  max_iter=-1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-
-    def fit(self, X, Y=None, W=None):
-        clf = self.__wraps__(**self.params)
-        if W is not None:
-            return self.__returns__(clf.fit(X, W.reshape(-1)))
-        return self.__returns__(clf.fit(X))
 
 
 class LocalOutlierFactorLearner(_OutlierLearner):
@@ -60,22 +107,31 @@ class IsolationForestLearner(_OutlierLearner):
         self.params = vars()
 
 
-class EllipticEnvelopeClassifier(SklModel):
-    def mahalanobis(self, observations):
+class EllipticEnvelopeClassifier(_OutlierModel):
+    def __init__(self, skl_model):
+        super().__init__(skl_model)
+        self.mahal_var = None
+
+    def mahalanobis(self, observations: np.ndarray) -> np.ndarray:
         """Computes squared Mahalanobis distances of given observations.
 
         Parameters
         ----------
-        observations : ndarray (n_samples, n_features) or Orange Table
+        observations : ndarray (n_samples, n_features)
 
         Returns
         -------
-        distances : ndarray (n_samples,)
+        distances : ndarray (n_samples, 1)
             Squared Mahalanobis distances given observations.
         """
-        if isinstance(observations, Table):
-            observations = observations.X
-        return self.skl_model.mahalanobis(observations)
+        return self.skl_model.mahalanobis(observations)[:, None]
+
+    def __call__(self, data: Table) -> Table:
+        pred = super().__call__(data)
+        domain = Domain(pred.domain.attributes, pred.domain.class_vars,
+                        pred.domain.metas + (self.mahal_var,))
+        metas = np.hstack((pred.metas, self.mahalanobis(self._cached_data.X)))
+        return Table.from_numpy(domain, pred.X, pred.Y, metas)
 
 
 class EllipticEnvelopeLearner(_OutlierLearner):
@@ -89,6 +145,15 @@ class EllipticEnvelopeLearner(_OutlierLearner):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
 
-    def __call__(self, data: Table):
-        data = data.transform(Domain(data.domain.attributes))
-        return super().__call__(data)
+    def _fit_model(self, data: Table) -> EllipticEnvelopeClassifier:
+        names = [v.name for v in data.domain.variables + data.domain.metas]
+        self.__model = super()._fit_model(data)
+        self.__model.mahal_var = ContinuousVariable(
+            get_unique_names(names, "Mahalanobis"),
+            compute_value=self.compute_mahal
+        )
+        return self.__model
+
+    def compute_mahal(self, table: Table) -> np.ndarray:
+        return self.__model(table)[:, self.__model.mahal_var].metas
+

--- a/Orange/classification/svm.py
+++ b/Orange/classification/svm.py
@@ -1,12 +1,9 @@
 import sklearn.svm as skl_svm
 
-from Orange.base import SklLearner as SklLearnerBase
 from Orange.classification import SklLearner, SklModel
-from Orange.data import Domain
 from Orange.preprocess import AdaptiveNormalize
 
-__all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner",
-           "OneClassSVMLearner"]
+__all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner"]
 
 svm_pps = SklLearner.preprocessors + [AdaptiveNormalize()]
 
@@ -60,28 +57,6 @@ class NuSVMLearner(SklLearner):
                  max_iter=-1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-
-
-class OneClassSVMLearner(SklLearnerBase):
-    name = "One class SVM"
-    __wraps__ = skl_svm.OneClassSVM
-    preprocessors = svm_pps
-
-    def __init__(self, kernel='rbf', degree=3, gamma="auto", coef0=0.0,
-                 tol=0.001, nu=0.5, shrinking=True, cache_size=200,
-                 max_iter=-1, preprocessors=None):
-        super().__init__(preprocessors=preprocessors)
-        self.params = vars()
-
-    def __call__(self, data):
-        classless_data = data.transform(Domain(data.domain.attributes))
-        return super().__call__(classless_data)
-
-    def fit(self, X, Y=None, W=None):
-        clf = self.__wraps__(**self.params)
-        if W is not None:
-            return self.__returns__(clf.fit(X, W.reshape(-1)))
-        return self.__returns__(clf.fit(X))
 
 
 if __name__ == '__main__':

--- a/Orange/classification/tests/test_outlier_detection.py
+++ b/Orange/classification/tests/test_outlier_detection.py
@@ -5,9 +5,10 @@ import tempfile
 import unittest
 
 import numpy as np
-from Orange.data import Table, Domain, ContinuousVariable
+
 from Orange.classification import EllipticEnvelopeLearner, \
     IsolationForestLearner, LocalOutlierFactorLearner, OneClassSVMLearner
+from Orange.data import Table, Domain, ContinuousVariable
 
 
 class _TestDetector(unittest.TestCase):
@@ -212,6 +213,14 @@ class TestOutlierModel(_TestDetector):
         self.assert_table_appended_outlier(self.iris, pred)
         pred2 = self.iris.transform(pred.domain)
         self.assert_table_equal(pred, pred2)
+
+    def test_transformer(self):
+        detect = self.detector(self.iris)
+        pred = detect(self.iris)
+        var = pred.domain.metas[0]
+        self.assertIs(var, var.compute_value.variable)
+        np.testing.assert_array_equal(pred[:, "Outlier"].metas.ravel(),
+                                      var.compute_value(self.iris))
 
     def test_pickle_model(self):
         detect = self.detector(self.iris)

--- a/Orange/classification/tests/test_outlier_detection.py
+++ b/Orange/classification/tests/test_outlier_detection.py
@@ -6,7 +6,51 @@ import unittest
 import numpy as np
 from Orange.data import Table, Domain, ContinuousVariable
 from Orange.classification import EllipticEnvelopeLearner, \
-    IsolationForestLearner, LocalOutlierFactorLearner
+    IsolationForestLearner, LocalOutlierFactorLearner, OneClassSVMLearner
+
+
+class TestOneClassSVMLearner(unittest.TestCase):
+    def test_OneClassSVM(self):
+        np.random.seed(42)
+        domain = Domain((ContinuousVariable("c1"), ContinuousVariable("c2")))
+        X_in = 0.3 * np.random.randn(40, 2)
+        X_out = np.random.uniform(low=-4, high=4, size=(20, 2))
+        X_all = Table(domain, np.r_[X_in + 2, X_in - 2, X_out])
+        n_true_in = len(X_in) * 2
+        n_true_out = len(X_out)
+
+        nu = 0.2
+        learner = OneClassSVMLearner(nu=nu)
+        cls = learner(X_all)
+        y_pred = cls(X_all)
+        n_pred_out_all = np.sum(y_pred == -1)
+        n_pred_in_true_in = np.sum(y_pred[:n_true_in] == 1)
+        n_pred_out_true_out = np.sum(y_pred[- n_true_out:] == -1)
+
+        self.assertEqual(np.absolute(y_pred).all(), 1)
+        self.assertLessEqual(n_pred_out_all, len(X_all) * nu)
+        self.assertLess(np.absolute(n_pred_out_all - n_true_out), 2)
+        self.assertLess(np.absolute(n_pred_in_true_in - n_true_in), 4)
+        self.assertLess(np.absolute(n_pred_out_true_out - n_true_out), 3)
+
+    def test_OneClassSVM_ignores_y(self):
+        domain = Domain((ContinuousVariable("x1"), ContinuousVariable("x2")),
+                        class_vars=(ContinuousVariable("y1"), ContinuousVariable("y2")))
+        X = np.random.random((40, 2))
+        Y = np.random.random((40, 2))
+        table = Table(domain, X, Y)
+        classless_table = table.transform(Domain(table.domain.attributes))
+        learner = OneClassSVMLearner()
+        classless_model = learner(classless_table)
+        model = learner(table)
+        pred1 = classless_model(classless_table)
+        pred2 = classless_model(table)
+        pred3 = model(classless_table)
+        pred4 = model(table)
+
+        np.testing.assert_array_equal(pred1, pred2)
+        np.testing.assert_array_equal(pred2, pred3)
+        np.testing.assert_array_equal(pred3, pred4)
 
 
 class TestEllipticEnvelopeLearner(unittest.TestCase):
@@ -63,18 +107,24 @@ class TestEllipticEnvelopeLearner(unittest.TestCase):
         np.testing.assert_array_equal(pred3, pred4)
 
 
-class TestOutlierDetection(unittest.TestCase):
+class TestLocalOutlierFactorLearner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.iris = Table("iris")
 
-    def test_LocalOutlierFactorDetector(self):
+    def test_LocalOutlierFactor(self):
         detector = LocalOutlierFactorLearner(contamination=0.1)
         detect = detector(self.iris)
         is_inlier = detect(self.iris)
         self.assertEqual(len(np.where(is_inlier == -1)[0]), 14)
 
-    def test_IsolationForestDetector(self):
+
+class TestIsolationForestLearner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.iris = Table("iris")
+
+    def test_IsolationForest(self):
         detector = IsolationForestLearner(contamination=0.1)
         detect = detector(self.iris)
         is_inlier = detect(self.iris)

--- a/Orange/tests/test_svm.py
+++ b/Orange/tests/test_svm.py
@@ -7,11 +7,10 @@ import warnings
 import numpy as np
 from sklearn.exceptions import ConvergenceWarning
 
-from Orange.classification import (SVMLearner, LinearSVMLearner,
-                                   NuSVMLearner, OneClassSVMLearner)
-from Orange.regression import (SVRLearner, NuSVRLearner)
-from Orange.data import Table, Domain, ContinuousVariable
+from Orange.classification import SVMLearner, LinearSVMLearner, NuSVMLearner
+from Orange.data import Table
 from Orange.evaluation import CrossValidation, CA, RMSE
+from Orange.regression import SVRLearner, NuSVRLearner
 from Orange.tests import test_filename
 
 
@@ -72,44 +71,6 @@ class TestSVMLearner(unittest.TestCase):
         res = cv(data, [learn])
         self.assertLess(RMSE(res)[0], 0.1)
 
-    def test_OneClassSVM(self):
-        np.random.seed(42)
-        domain = Domain((ContinuousVariable("c1"), ContinuousVariable("c2")))
-        X_in = 0.3 * np.random.randn(40, 2)
-        X_out = np.random.uniform(low=-4, high=4, size=(20, 2))
-        X_all = Table(domain, np.r_[X_in + 2, X_in - 2, X_out])
-        n_true_in = len(X_in) * 2
-        n_true_out = len(X_out)
 
-        nu = 0.2
-        learner = OneClassSVMLearner(nu=nu)
-        cls = learner(X_all)
-        y_pred = cls(X_all)
-        n_pred_out_all = np.sum(y_pred == -1)
-        n_pred_in_true_in = np.sum(y_pred[:n_true_in] == 1)
-        n_pred_out_true_out = np.sum(y_pred[- n_true_out:] == -1)
-
-        self.assertEqual(np.absolute(y_pred).all(), 1)
-        self.assertLessEqual(n_pred_out_all, len(X_all) * nu)
-        self.assertLess(np.absolute(n_pred_out_all - n_true_out), 2)
-        self.assertLess(np.absolute(n_pred_in_true_in - n_true_in), 4)
-        self.assertLess(np.absolute(n_pred_out_true_out - n_true_out), 3)
-
-    def test_OneClassSVM_ignores_y(self):
-        domain = Domain((ContinuousVariable("x1"), ContinuousVariable("x2")),
-                        class_vars=(ContinuousVariable("y1"), ContinuousVariable("y2")))
-        X = np.random.random((40, 2))
-        Y = np.random.random((40, 2))
-        table = Table(domain, X, Y)
-        classless_table = table.transform(Domain(table.domain.attributes))
-        learner = OneClassSVMLearner()
-        classless_model = learner(classless_table)
-        model = learner(table)
-        pred1 = classless_model(classless_table)
-        pred2 = classless_model(table)
-        pred3 = model(classless_table)
-        pred4 = model(table)
-
-        np.testing.assert_array_equal(pred1, pred2)
-        np.testing.assert_array_equal(pred2, pred3)
-        np.testing.assert_array_equal(pred3, pred4)
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -7,11 +7,9 @@ from AnyQt.QtWidgets import QWidget, QVBoxLayout
 
 from orangewidget.settings import SettingProvider
 
-from Orange.base import Model
 from Orange.classification import OneClassSVMLearner, EllipticEnvelopeLearner,\
     LocalOutlierFactorLearner, IsolationForestLearner
-from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
-from Orange.data.util import get_unique_names
+from Orange.data import Table, DiscreteVariable
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.sql import check_sql_input
@@ -244,7 +242,7 @@ class OWOutliers(OWWidget):
         self.Error.singular_cov.clear()
         self.Error.memory_error.clear()
         try:
-            y_pred, amended_data = self.detect_outliers()
+            pred, outlier_var = self.detect_outliers()
         except ValueError:
             self.Error.singular_cov()
             return None, None, None
@@ -252,13 +250,12 @@ class OWOutliers(OWWidget):
             self.Error.memory_error()
             return None, None, None
         else:
-            inliers_ind = np.where(y_pred == 1)[0]
-            outliers_ind = np.where(y_pred == -1)[0]
-            inliers = amended_data[inliers_ind]
-            outliers = amended_data[outliers_ind]
-            self.n_inliers = len(inliers)
-            self.n_outliers = len(outliers)
-            return inliers, outliers, self.annotated_data(amended_data, y_pred)
+            col = pred[:, outlier_var].metas
+            inliers_ind = np.where(col == 1)[0]
+            outliers_ind = np.where(col == 0)[0]
+            self.n_inliers = len(inliers_ind)
+            self.n_outliers = len(outliers_ind)
+            return self.data[inliers_ind], self.data[outliers_ind], pred
 
     def commit(self):
         inliers = outliers = data = None
@@ -272,43 +269,12 @@ class OWOutliers(OWWidget):
         self.Outputs.outliers.send(outliers)
         self.Outputs.data.send(data)
 
-    def detect_outliers(self) -> Tuple[np.ndarray, Table]:
+    def detect_outliers(self) -> Tuple[Table, DiscreteVariable]:
         learner_class = self.METHODS[self.outlier_method]
         kwargs = self.current_editor.get_parameters()
         learner = learner_class(**kwargs)
         model = learner(self.data)
-        y_pred = model(self.data)
-        amended_data = self.amended_data(model)
-        return np.array(y_pred), amended_data
-
-    def amended_data(self, model: Model) -> Table:
-        if self.outlier_method != self.Covariance:
-            return self.data
-        mahal = model.mahalanobis(self.data.X)
-        mahal = mahal.reshape(len(self.data), 1)
-        attrs = self.data.domain.attributes
-        classes = self.data.domain.class_vars
-        new_metas = list(self.data.domain.metas) + \
-                    [ContinuousVariable(name="Mahalanobis")]
-        new_domain = Domain(attrs, classes, new_metas)
-        amended_data = self.data.transform(new_domain)
-        amended_data.metas = np.hstack((self.data.metas, mahal))
-        return amended_data
-
-    @staticmethod
-    def annotated_data(data: Table, labels: np.ndarray) -> Table:
-        domain = data.domain
-        names = [v.name for v in domain.variables + domain.metas]
-        name = get_unique_names(names, "Outlier")
-
-        outlier_var = DiscreteVariable(name, values=["Yes", "No"])
-        metas = domain.metas + (outlier_var,)
-        domain = Domain(domain.attributes, domain.class_vars, metas)
-        data = data.transform(domain)
-
-        labels[labels == -1] = 0
-        data.metas[:, -1] = labels
-        return data
+        return model(self.data), model.outlier_var
 
     def send_report(self):
         if self.n_outliers is None or self.n_inliers is None:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Outlier widget could be used for novelty detection using the Apply Domain widget.

##### Description of changes
- invoking model's call operator now returns original dataset, appended an Outlier meta variable
- save fitted model into the Outlier variable compute_value
- the data output of Outliers widget can be used as a template data for Apply Domain widget
- fix EllipticEnvelopeClassifier for dataset with missing values


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
