### PR TITLE
[FIX] Continuize: Disable normalizing sparse data

### DIFF
--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -34,9 +34,12 @@ class OWContinuize(widget.OWWidget):
     buttons_area_orientation = Qt.Vertical
     resizing_enabled = False
 
+    # continuous treats
+    Leave, NormalizeBySpan, NormalizeBySD = range(3)
+
     multinomial_treatment = Setting(0)
     zero_based = Setting(1)
-    continuous_treatment = Setting(0)
+    continuous_treatment = Setting(Leave)
     class_treatment = Setting(0)
 
     transform_class = Setting(False)
@@ -107,6 +110,7 @@ class OWContinuize(widget.OWWidget):
     @check_sql_input
     def setData(self, data):
         self.data = data
+        self.enable_normalization()
         if data is None:
             self.info.set_input_summary(self.info.NoInput)
             self.info.set_output_summary(self.info.NoOutput)
@@ -114,6 +118,15 @@ class OWContinuize(widget.OWWidget):
         else:
             self.info.set_input_summary(len(data))
             self.unconditional_commit()
+
+    def enable_normalization(self):
+        enable = not (self.data and self.data.is_sparse())
+        if not enable and self.continuous_treatment in (self.NormalizeBySpan,
+                                                        self.NormalizeBySD):
+            self.continuous_treatment = self.Leave
+        buttons = self.controls.continuous_treatment.buttons
+        buttons[self.NormalizeBySpan].setEnabled(enable)
+        buttons[self.NormalizeBySD].setEnabled(enable)
 
     def constructContinuizer(self):
         conzer = DomainContinuizer(

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -110,6 +110,45 @@ class TestOWContinuize(WidgetTest):
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.unconditional_commit()
 
+    def test_disable_normalize_sparse(self):
+        def assert_enabled(enabled):
+            buttons[BySpan].click()
+            buttons[BySD].click()
+            self.assertTrue(buttons[Leave].isEnabled())
+            self.assertEqual(buttons[BySpan].isEnabled(), enabled)
+            self.assertEqual(buttons[BySD].isEnabled(), enabled)
+
+        w = self.widget
+        Leave, BySpan, BySD = w.Leave, w.NormalizeBySpan, w.NormalizeBySD
+        buttons = w.controls.continuous_treatment.buttons
+        iris = Table("iris")
+        sparse_iris = iris.to_sparse()
+
+        # input dense
+        self.send_signal(w.Inputs.data, iris)
+        assert_enabled(True)
+        self.assertEqual(w.continuous_treatment, BySD)
+
+        # input sparse
+        self.send_signal(w.Inputs.data, sparse_iris)
+        assert_enabled(False)
+        self.assertEqual(w.continuous_treatment, Leave)
+
+        self.widget.continuous_treatment = BySpan
+        self.assertRaises(ValueError, w.commit)
+
+        # remove data
+        self.send_signal(w.Inputs.data, None)
+        assert_enabled(True)
+
+        # input sparse
+        self.send_signal(w.Inputs.data, sparse_iris)
+        assert_enabled(False)
+
+        # input dense
+        self.send_signal(w.Inputs.data, iris)
+        assert_enabled(True)
+
 
 class TestOWContinuizeUtils(unittest.TestCase):
     def test_dummy_coding_zero_based(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #4378

##### Description of changes
Disable `Normalize by span` and `Normalize by standard deviation` radio buttons for sparse datasets.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
