### PR TITLE
[FIX] Explicitly define the protocol version for pickling

### DIFF
--- a/Orange/data/__init__.py
+++ b/Orange/data/__init__.py
@@ -6,7 +6,6 @@ from .instance import *
 from .domain import *
 from .storage import *
 from .table import *
-from .io_base import *
 from .io_util import *
 from .io import *
 from .filter import *

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -23,9 +23,9 @@ import xlsxwriter
 import openpyxl
 
 from Orange.data import _io, Table, Domain, ContinuousVariable
-from Orange.data import Flags, FileFormatBase, DataTableMixin
 from Orange.data import Compression, open_compressed, detect_encoding, \
     isnastr, guess_data_type, sanitize_variable
+from Orange.data.io_base import FileFormatBase, Flags, DataTableMixin, PICKLE_PROTOCOL
 
 from Orange.util import flatten
 
@@ -218,7 +218,7 @@ class PickleReader(FileFormat):
     @classmethod
     def write_file(cls, filename, data):
         with cls.open(filename, 'wb') as f:
-            pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
+            pickle.dump(data, f, protocol=PICKLE_PROTOCOL)
 
 
 class BasketReader(FileFormat):

--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -23,7 +23,10 @@ from Orange.data.io_util import Compression, open_compressed, \
 from Orange.data.variable import VariableMeta
 from Orange.util import Registry, flatten, namegen
 
-__all__ = ["FileFormatBase", "Flags", "DataTableMixin"]
+__all__ = ["FileFormatBase", "Flags", "DataTableMixin", "PICKLE_PROTOCOL"]
+
+
+PICKLE_PROTOCOL = 4
 
 
 class Flags:
@@ -605,7 +608,7 @@ class _FileWriter:
                                       for kv in data.attributes.items()))
             else:
                 with open(fn, 'wb') as f:
-                    pickle.dump(data.attributes, f, pickle.HIGHEST_PROTOCOL)
+                    pickle.dump(data.attributes, f, protocol=PICKLE_PROTOCOL)
 
         if isinstance(filename, str):
             metafile = filename + '.metadata'

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -1,16 +1,18 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
+import io
+import os
+import pickle
+import shutil
+import tempfile
 import unittest
 from unittest.mock import Mock, patch
-import os
-import tempfile
-import shutil
-import io
 
 from Orange import data
 
 from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader
+from Orange.data.io_base import PICKLE_PROTOCOL
 from Orange.data.table import get_sample_datasets_dir
 from Orange.data import Table, Variable
 from Orange.tests import test_dirname
@@ -180,3 +182,17 @@ class TestReader(unittest.TestCase):
         self.assertEqual(attributes_count, len(data2.domain.attributes))
         self.assertEqual(attributes_count, len(data3.domain.attributes))
         self.assertEqual(attributes_count, len(data4.domain.attributes))
+
+    def test_pickle_version(self):
+        """
+        Orange uses a fixed PICKLE_PROTOCOL (currently set to 4)
+        for pickling data files and possibly elsewhere for consistent
+        behaviour across different python versions (e.g. 3.6 - 3.8).
+        When the default protocol is increased in a future version of python
+        we should consider increasing this constant to match it as well.
+        """
+        # we should use a version that is at least as high as the default.
+        # it could be higher for older (but supported) python versions
+        self.assertGreaterEqual(PICKLE_PROTOCOL, pickle.DEFAULT_PROTOCOL)
+        # we should not use a version that is not supported
+        self.assertLessEqual(PICKLE_PROTOCOL, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
##### Issue
Data saved in pickle format in python 3.8 was not readable on older versions of python.


##### Description of changes
Define a new constant `PICKLE_PROTOCOL` and fix it to a specific version (4, as was used now on py3.6 & py3.7). Use it instead of pickle.HIGHEST_PROTOCOL, which became 5 in py3.8.

Disclaimer: I also removed `from .io_base import *` in `data/__init__.py` as we don't need to make the base classes publicly visible in a top level module. `Orange.data` even had `Flags` imported twice into its namespace, since it was provided by `io_base` and later overwritten by `from .io import *`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
