### PR TITLE
[ENH] Heatmap: Tighter layout

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -2071,6 +2071,7 @@ class GradientLegendWidget(QGraphicsWidget):
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.__pixitem = GraphicsPixmapWidget(parent=self, scaleContents=True,
                                               aspectMode=Qt.IgnoreAspectRatio)
+        self.__pixitem.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Preferred)
         self.__pixitem.setMinimumHeight(12)
         layout.addItem(self.__pixitem)
         self.__update()

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1505,20 +1505,8 @@ class OWHeatMap(widget.OWWidget):
 
             for labelslist in self.col_annotation_widgets_top:
                 labelslist.setVisible(show_top)
-
-            TopLabelsRow = 2
-            Row0 = 3
-            BottomLabelsRow = Row0 + len(self.heatmapparts.rows)
-
-            layout = self.heatmap_scene.widget.layout()
-            layout.setRowMaximumHeight(TopLabelsRow, FLT_MAX if show_top else 0)
-            layout.setRowSpacing(TopLabelsRow, -1 if show_top else 0)
-
             for labelslist in self.col_annotation_widgets_bottom:
                 labelslist.setVisible(show_bottom)
-
-            layout.setRowMaximumHeight(BottomLabelsRow, FLT_MAX if show_top else 0)
-
             self.__fixup_grid_layout()
 
     def __select_by_cluster(self, item, dendrogramindex):

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1836,8 +1836,9 @@ class GraphicsHeatmapWidget(QGraphicsWidget):
 
         self.heatmap_item.setMinimumSize(hmsize)
         self.averages_item.setMinimumSize(avsize)
-        self.heatmap_item.setPreferredSize(hmsize * 10)
-        self.averages_item.setPreferredSize(avsize * 10)
+        size = QFontMetrics(self.font()).lineSpacing()
+        self.heatmap_item.setPreferredSize(hmsize * size)
+        self.averages_item.setPreferredSize(avsize * size)
         self.layout().invalidate()
 
     def cell_at(self, pos):

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -340,6 +340,9 @@ def enum_get(etype: Type[E], name: str, default: E) -> E:
         return default
 
 
+FLT_MAX = np.finfo(np.float32).max
+
+
 class OWHeatMap(widget.OWWidget):
     name = "Heat Map"
     description = "Plot a data matrix heatmap."
@@ -1204,7 +1207,7 @@ class OWHeatMap(widget.OWWidget):
             if mode == Qt.IgnoreAspectRatio:
                 # Reset the row height constraints ...
                 for i, hm_row in enumerate(self.heatmap_widget_grid):
-                    layout.setRowMaximumHeight(3 + i, np.finfo(np.float32).max)
+                    layout.setRowMaximumHeight(3 + i, FLT_MAX)
                 # ... and resize to match the viewport, taking the minimum size
                 # into account
                 minsize = widget.minimumSize()
@@ -1508,13 +1511,13 @@ class OWHeatMap(widget.OWWidget):
             BottomLabelsRow = Row0 + len(self.heatmapparts.rows)
 
             layout = self.heatmap_scene.widget.layout()
-            layout.setRowMaximumHeight(TopLabelsRow, -1 if show_top else 0)
+            layout.setRowMaximumHeight(TopLabelsRow, FLT_MAX if show_top else 0)
             layout.setRowSpacing(TopLabelsRow, -1 if show_top else 0)
 
             for labelslist in self.col_annotation_widgets_bottom:
                 labelslist.setVisible(show_bottom)
 
-            layout.setRowMaximumHeight(BottomLabelsRow, -1 if show_top else 0)
+            layout.setRowMaximumHeight(BottomLabelsRow, FLT_MAX if show_top else 0)
 
             self.__fixup_grid_layout()
 

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -999,12 +999,13 @@ class OWHeatMap(widget.OWWidget):
         Col0 = 3
         LegendRow = 0
         # The column for the vertical dendrogram
-        DendrogramColumn = 0
+        DendrogramColumn = 1
         # The row for the horizontal dendrograms
         DendrogramRow = 1
         RightLabelColumn = Col0 + M
         TopLabelsRow = 2
-        BottomLabelsRow = Row0 + 2 * N
+        BottomLabelsRow = Row0 + N
+        GroupTitleColumn = 0
 
         widget.setLayout(grid)
 
@@ -1019,9 +1020,9 @@ class OWHeatMap(widget.OWWidget):
         for i, rowitem in enumerate(parts.rows):
             if rowitem.title:
                 title = QGraphicsSimpleTextItem(rowitem.title, widget)
-                item = GraphicsSimpleTextLayoutItem(title, parent=grid)
-                item.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
-                grid.addItem(item, Row0 + i * 2, Col0)
+                item = GraphicsSimpleTextLayoutItem(title, orientation=Qt.Vertical, parent=grid)
+                item.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Maximum)
+                grid.addItem(item, Row0 + i, GroupTitleColumn, alignment=Qt.AlignCenter)
 
             if rowitem.cluster:
                 dendrogram = DendrogramWidget(
@@ -1040,7 +1041,7 @@ class OWHeatMap(widget.OWWidget):
                     self.__select_by_cluster(item, partindex)
                 )
 
-                grid.addItem(dendrogram, Row0 + i * 2 + 1, DendrogramColumn)
+                grid.addItem(dendrogram, Row0 + i, DendrogramColumn)
                 sort_i.append(np.array(leaf_indices(rowitem.cluster)))
                 row_dendrograms[i] = dendrogram
             else:
@@ -1092,8 +1093,8 @@ class OWHeatMap(widget.OWWidget):
                 hw.set_show_averages(self.averages)
                 hw.set_heatmap_data(X_part)
 
-                grid.addItem(hw, Row0 + i * 2 + 1, Col0 + j)
-                grid.setRowStretchFactor(Row0 + i * 2 + 1, X_part.shape[0] * 100)
+                grid.addItem(hw, Row0 + i, Col0 + j)
+                grid.setRowStretchFactor(Row0 + i, X_part.shape[0] * 100)
                 heatmap_row.append(hw)
             heatmap_widgets.append(heatmap_row)
 
@@ -1121,7 +1122,7 @@ class OWHeatMap(widget.OWWidget):
             labelslist.setContentsMargins(0.0, 0.0, 0.0, 0.0)
             labelslist.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
 
-            grid.addItem(labelslist, Row0 + i * 2 + 1, RightLabelColumn)
+            grid.addItem(labelslist, Row0 + i, RightLabelColumn)
             grid.setAlignment(labelslist, Qt.AlignLeft)
             row_annotation_widgets.append(labelslist)
 
@@ -1203,8 +1204,7 @@ class OWHeatMap(widget.OWWidget):
             if mode == Qt.IgnoreAspectRatio:
                 # Reset the row height constraints ...
                 for i, hm_row in enumerate(self.heatmap_widget_grid):
-                    layout.setRowMaximumHeight(3 + i * 2 + 1, np.finfo(np.float32).max)
-                    layout.setRowPreferredHeight(3 + i * 2 + 1, 0)
+                    layout.setRowMaximumHeight(3 + i, np.finfo(np.float32).max)
                 # ... and resize to match the viewport, taking the minimum size
                 # into account
                 minsize = widget.minimumSize()
@@ -1234,8 +1234,8 @@ class OWHeatMap(widget.OWWidget):
                             Qt.KeepAspectRatioByExpanding)
 
                         heights.append(hm_size.height())
-                    layout.setRowMaximumHeight(3 + i * 2 + 1, max(heights))
-                    layout.setRowPreferredHeight(3 + i * 2 + 1, max(heights))
+                    layout.setRowMaximumHeight(3 + i, max(heights))
+                    layout.setRowPreferredHeight(3 + i, max(heights))
 
                 # set/update the widget's height
                 constraint = QSizeF(size.width(), -1)
@@ -1505,7 +1505,7 @@ class OWHeatMap(widget.OWWidget):
 
             TopLabelsRow = 2
             Row0 = 3
-            BottomLabelsRow = Row0 + 2 * len(self.heatmapparts.rows)
+            BottomLabelsRow = Row0 + len(self.heatmapparts.rows)
 
             layout = self.heatmap_scene.widget.layout()
             layout.setRowMaximumHeight(TopLabelsRow, -1 if show_top else 0)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -433,7 +433,7 @@ class OWHeatMap(widget.OWWidget):
             self.row_clustering_method = self.row_clustering.name
 
         # set default settings
-        self.space_x = 10
+        self.space_x = 3
 
         self.colorSettings = None
         self.selectedSchemaIndex = 0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref gh-4380

##### Description of changes

* Improve size hinting
* Move 'Split by' labels/titles (when in effect) to the left of the heatmaps/dendrogram.
* Decrease spacing between consecutive heatmap parts when split
* Fix an error in 'resetting' fixed row size constraints which could cause QGraphicsGridLayout to enter an endless loop.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
