### PR TITLE
Load crashed scratch workflows on start

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -632,10 +632,7 @@ def main(argv=None):
 
     app.fileOpenRequest.connect(canvas_window.open_scheme_file)
 
-    if want_welcome and not args and not open_requests:
-        canvas_window.welcome_dialog()
-
-    elif args:
+    if args:
         log.info("Loading a scheme from the command line argument %r",
                  args[0])
         canvas_window.load_scheme(args[0])
@@ -643,6 +640,10 @@ def main(argv=None):
         log.info("Loading a scheme from an `QFileOpenEvent` for %r",
                  open_requests[-1])
         canvas_window.load_scheme(open_requests[-1].toLocalFile())
+    else:
+        canvas_window.ask_load_swp_if_exists()
+        if want_welcome:
+            canvas_window.welcome_dialog()
 
     # local references prevent destruction
     update_check = check_for_updates()

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.1.9,<0.2a
+orange-canvas-core>=0.1.12,<0.2a
 orange-widget-base>=4.5.0
 
 # PyQt4/PyQt5 compatibility


### PR DESCRIPTION
Another crossover PR with canvas core!
This PR depends on https://github.com/biolab/orange-canvas-core/pull/79, hence raising the requirement, but is not necessary for merging the orange-canvas-core PR. Please check that the raised requirement is correct before merging.

I'll remove the NOMERGE tag when the canvas-core PR is released.

##### Description of changes
This applies to opening Orange without a file request (not specifying a file in args or double-clicking an `.ows` file).

Orange will check whether there were any crashed scratch (unsaved) workflows, asking the user if they wish to restore them.

I couldn't find any nice way to implement behavior on startup solely in canvas-core. Should we make a standard way for doing this? I could then also refactor some of the notifications code out of orange3.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
