### PR TITLE
[FIX] Feature Constructor: Catch exceptions

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -1069,9 +1069,12 @@ class FeatureFunc:
         if isinstance(instance, Orange.data.Table):
             return [self(inst) for inst in instance]
         else:
-            args = [str(instance[var])
-                    if instance.domain[var].is_string else instance[var]
-                    for _, var in self.args]
+            try:
+                args = [str(instance[var])
+                        if instance.domain[var].is_string else instance[var]
+                        for _, var in self.args]
+            except KeyError:
+                return np.nan
             y = self.func(*args)
             if self.cast:
                 y = self.cast(y)

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -659,12 +659,18 @@ class OWFeatureConstructor(OWWidget):
         )
 
         try:
+            for variable in new_variables:
+                variable.compute_value.mask_exceptions = False
             data = self.data.transform(new_domain)
         # user's expression can contain arbitrary errors
         # pylint: disable=broad-except
         except Exception as err:
             report_error(err)
             return
+        finally:
+            for variable in new_variables:
+                variable.compute_value.mask_exceptions = True
+
         disc_attrs_not_ok = self.check_attrs_values(
             [var for var in attrs if var.is_discrete], data)
         if disc_attrs_not_ok:
@@ -1064,6 +1070,7 @@ class FeatureFunc:
         self.func = make_lambda(ast.parse(expression, mode="eval"),
                                 [name for name, _ in args], self.extra_env)
         self.cast = cast
+        self.mask_exceptions = True
 
     def __call__(self, instance, *_):
         if isinstance(instance, Orange.data.Table):
@@ -1073,9 +1080,13 @@ class FeatureFunc:
                 args = [str(instance[var])
                         if instance.domain[var].is_string else instance[var]
                         for _, var in self.args]
-            except KeyError:
+                y = self.func(*args)
+            # user's expression can contain arbitrary errors
+            # this also covers missing attributes
+            except:  # pylint: disable=bare-except
+                if not self.mask_exceptions:
+                    raise
                 return np.nan
-            y = self.func(*args)
             if self.cast:
                 y = self.cast(y)
             return y

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -285,6 +285,24 @@ class FeatureFuncTest(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(r)))
         self.assertTrue(np.isnan(f(data2[0])))
 
+    def test_invalid_expression_variable(self):
+        iris = Table("iris")
+        f = FeatureFunc("1 / petal_length",
+                        [("petal_length", iris.domain["petal length"])])
+        iris[0]["petal length"] = 0
+
+        f.mask_exceptions = False
+        self.assertRaises(Exception, f, iris)
+        self.assertRaises(Exception, f, iris[0])
+        _ = f(iris[1])
+
+        f.mask_exceptions = True
+        r = f(iris)
+        self.assertTrue(np.isnan(r[0]))
+        self.assertFalse(np.isnan(r[1]))
+        self.assertTrue(np.isnan(f(iris[0])))
+        self.assertFalse(np.isnan(f(iris[1])))
+
 
 class OWFeatureConstructorTests(WidgetTest):
     def setUp(self):

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -274,6 +274,17 @@ class FeatureFuncTest(unittest.TestCase):
         self.assertEqual(r, [x[0] for x in zoo.metas[:, 0]])
         self.assertEqual(f(zoo[0]), str(zoo[0, "name"])[0])
 
+    def test_missing_variable(self):
+        zoo = Table("zoo")
+        assert zoo.domain.class_var.name == "type"
+        f = FeatureFunc("type[0]",
+                        [("type", zoo.domain["type"])])
+        no_class = Domain(zoo.domain.attributes, None, zoo.domain.metas)
+        data2 = zoo.transform(no_class)
+        r = f(data2)
+        self.assertTrue(np.all(np.isnan(r)))
+        self.assertTrue(np.isnan(f(data2[0])))
+
 
 class OWFeatureConstructorTests(WidgetTest):
     def setUp(self):


### PR DESCRIPTION
##### Issue

Fixes #4373.

This PR contains two different solutions: one is limited to missing variables (the problem in #4373), the other also catches other exceptions. I think we should do the latter.

### First commit

Feature constructor assumes that all variables exist. If they don't, it shows an error -- but only for transformations that occur inside the widget, that is, on the input data. If the transformation is applied in another widget on some other data, it may crash.

#4373 can be reproduced with the following workflow, where Feature constructor transfroms the target variable, e.g. computes `log(MEDV)` for housing data:

<img width="553" alt="Screenshot 2020-02-07 at 15 12 32" src="https://user-images.githubusercontent.com/2387315/74036305-49db2780-49bc-11ea-85dd-b013845373e2.png">

Prediction constructs a class-less domain. The model transforms the data into it's training domain. The target in that domain tries to compute `log(MEDV)`, but Predictions removed MEDV, so transformation fails with KeyError in the formula from Feature Constructor.

##### Description of changes

The code that extracts variable values is not wrapped into `try` - `except KeyError`, and returns `np.nan` in case of exception.

An alternative would be to do this per-value:

```python
            args = [np.nan if var not in instance.domain
                    else str(instance[var]) if instance.domain[var].is_string
                    else instance[var]
                    for _, var in self.args]
```

but this doesn't work because `var` can refer to a string variable -- which we don't know because `var` is not in `domain` (see the unit test in this PR -- it would fail with the above snipper). While this code would work in some cases in which the current doesn't (e.g. with formula `var1 if var2 == "X" else var3` would survive a missing `var1` is `var2` is not `"X"`), I don't think it's worth the effort.

### Second commit

User's expression can raise exceptions (e.g. division by zero) that don't occur on the data input to Feature Constructor but only on some other data that is transformed to this domain. We need to catch these expections; even though the user is typing Python expressions and may hence be able to read the exception message, it would seem to be coming from another widget (e.g. predictions), so it wouldn't be helpful and would give an impression that Orange crashed. Though it's better, IMHO, to replace them with nans.

The second commit implements this. Note that exceptions must not be raised if the transformation is called from Feature Constructor because there we can catch it and show an error message to the user. Since computation is done through `Table.transform`, I haven't found a better solution than a flag that tells `FeatureFunc` whether to raise exceptions or not.

##### Includes
- [X] Code changes
- [X] Tests