### PR TITLE
[ENH] Outliers: Offload work onto separate thread

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -10,11 +10,12 @@ import scipy
 from Orange.data import Table, Storage, Instance, Value
 from Orange.data.filter import HasClass
 from Orange.data.table import DomainTransformationError
-from Orange.data.util import one_hot, progress_callback, dummy_callback
+from Orange.data.util import one_hot
 from Orange.misc.wrapper_meta import WrapperMeta
 from Orange.preprocess import Continuize, RemoveNaNColumns, SklImpute, Normalize
 from Orange.statistics.util import all_nan
-from Orange.util import Reprable, OrangeDeprecationWarning
+from Orange.util import Reprable, OrangeDeprecationWarning, wrap_callback, \
+    dummy_callback
 
 __all__ = ["Learner", "Model", "SklLearner", "SklModel",
            "ReprableWithPreprocessors"]
@@ -102,7 +103,7 @@ class Learner(ReprableWithPreprocessors):
         X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
         return self.fit(X, Y, W)
 
-    def __call__(self, data, callback=None):
+    def __call__(self, data, progress_callback=None):
         if not self.check_learner_adequacy(data.domain):
             raise ValueError(self.learner_adequacy_err_msg)
 
@@ -112,25 +113,25 @@ class Learner(ReprableWithPreprocessors):
             data = Table(data.domain, [data])
         origdata = data
 
-        if callback is None:
-            callback = dummy_callback
-        callback(0, "Preprocessing...")
+        if progress_callback is None:
+            progress_callback = dummy_callback
+        progress_callback(0, "Preprocessing...")
         try:
-            cb = progress_callback(callback, end=0.1)
-            data = self.preprocess(data, callback=cb)
+            cb = wrap_callback(progress_callback, end=0.1)
+            data = self.preprocess(data, progress_callback=cb)
         except TypeError:
             data = self.preprocess(data)
-            warnings.warn("A keyword argument 'callback' has been added to the"
-                          " preprocess() signature. Implementing the method "
-                          "without the argument is deprecated and will result "
-                          "in an error in the future.",
+            warnings.warn("A keyword argument 'progress_callback' has been "
+                          "added to the preprocess() signature. Implementing "
+                          "the method without the argument is deprecated and "
+                          "will result in an error in the future.",
                           OrangeDeprecationWarning)
 
         if len(data.domain.class_vars) > 1 and not self.supports_multiclass:
             raise TypeError("%s doesn't support multiple class variables" %
                             self.__class__.__name__)
 
-        callback(0.1, "Fitting...")
+        progress_callback(0.1, "Fitting...")
         model = self._fit_model(data)
         model.used_vals = [np.unique(y).astype(int) for y in data.Y[:, None].T]
         model.domain = data.domain
@@ -138,7 +139,7 @@ class Learner(ReprableWithPreprocessors):
         model.name = self.name
         model.original_domain = origdomain
         model.original_data = origdata
-        callback(1)
+        progress_callback(1)
         return model
 
     def _fit_model(self, data):
@@ -148,15 +149,15 @@ class Learner(ReprableWithPreprocessors):
             X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
             return self.fit(X, Y, W)
 
-    def preprocess(self, data, callback=None):
+    def preprocess(self, data, progress_callback=None):
         """Apply the `preprocessors` to the data"""
-        if callback is None:
-            callback = dummy_callback
+        if progress_callback is None:
+            progress_callback = dummy_callback
         n_pps = len(list(self.active_preprocessors))
         for i, pp in enumerate(self.active_preprocessors):
-            callback(i / n_pps)
+            progress_callback(i / n_pps)
             data = pp(data)
-        callback(1)
+        progress_callback(1)
         return data
 
     @property
@@ -489,8 +490,8 @@ class SklLearner(Learner, metaclass=WrapperMeta):
             raise TypeError("Wrapper does not define '__wraps__'")
         return params
 
-    def preprocess(self, data, callback=None):
-        data = super().preprocess(data, callback)
+    def preprocess(self, data, progress_callback=None):
+        data = super().preprocess(data, progress_callback)
 
         if any(v.is_discrete and len(v.values) > 2
                for v in data.domain.attributes):
@@ -499,8 +500,8 @@ class SklLearner(Learner, metaclass=WrapperMeta):
 
         return data
 
-    def __call__(self, data, callback=None):
-        m = super().__call__(data, callback)
+    def __call__(self, data, progress_callback=None):
+        m = super().__call__(data, progress_callback)
         m.params = self.params
         return m
 

--- a/Orange/data/tests/test_util.py
+++ b/Orange/data/tests/test_util.py
@@ -2,7 +2,7 @@ import unittest
 
 from Orange.data import Domain, ContinuousVariable
 from Orange.data.util import get_unique_names, get_unique_names_duplicates, \
-    get_unique_names_domain, progress_callback
+    get_unique_names_domain
 
 
 class TestGetUniqueNames(unittest.TestCase):
@@ -113,22 +113,6 @@ class TestGetUniqueNames(unittest.TestCase):
         self.assertEqual(classes, [])
         self.assertEqual(metas, [])
         self.assertEqual(renamed, [])
-
-
-class TestProgressCallback(unittest.TestCase):
-    def test_wrap(self):
-        def func(i):
-            return i
-
-        f = progress_callback(func, start=0, end=0.8)
-        self.assertEqual(f(0), 0)
-        self.assertEqual(round(f(0.1), 2), 0.08)
-        self.assertEqual(f(1), 0.8)
-
-        f = progress_callback(func, start=0.1, end=0.8)
-        self.assertEqual(f(0), 0.1)
-        self.assertEqual(f(0.1), 0.17)
-        self.assertEqual(f(1), 0.8)
 
 
 if __name__ == "__main__":

--- a/Orange/data/tests/test_util.py
+++ b/Orange/data/tests/test_util.py
@@ -1,8 +1,8 @@
 import unittest
 
 from Orange.data import Domain, ContinuousVariable
-from Orange.data.util import \
-    get_unique_names, get_unique_names_duplicates, get_unique_names_domain
+from Orange.data.util import get_unique_names, get_unique_names_duplicates, \
+    get_unique_names_domain, progress_callback
 
 
 class TestGetUniqueNames(unittest.TestCase):
@@ -113,6 +113,22 @@ class TestGetUniqueNames(unittest.TestCase):
         self.assertEqual(classes, [])
         self.assertEqual(metas, [])
         self.assertEqual(renamed, [])
+
+
+class TestProgressCallback(unittest.TestCase):
+    def test_wrap(self):
+        def func(i):
+            return i
+
+        f = progress_callback(func, start=0, end=0.8)
+        self.assertEqual(f(0), 0)
+        self.assertEqual(round(f(0.1), 2), 0.08)
+        self.assertEqual(f(1), 0.8)
+
+        f = progress_callback(func, start=0.1, end=0.8)
+        self.assertEqual(f(0), 0.1)
+        self.assertEqual(f(0.1), 0.17)
+        self.assertEqual(f(1), 0.8)
 
 
 if __name__ == "__main__":

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -4,7 +4,6 @@ Data-manipulation utilities.
 import re
 from collections import Counter, defaultdict
 from itertools import chain
-from functools import wraps
 
 import numpy as np
 import bottleneck as bn
@@ -251,26 +250,3 @@ def get_unique_names_domain(attributes, class_vars=(), metas=()):
                                  for old, new in zip(all_names, unique_names)
                                  if new != old))
     return (attributes, class_vars, metas), renamed
-
-
-def progress_callback(callback, start=0, end=1):
-    """
-    Wraps a callback function to allocate it end-start proportion of
-    the progress.
-
-    :param callback: callable
-    :param start: float
-    :param end: float
-    :return: callable
-    """
-    @wraps(callback)
-    def func(i, *args, **kwargs):
-        x = start + i * (end - start)
-        return callback(x, *args, **kwargs)
-    return func
-
-
-def dummy_callback(*_, **__):
-    """ A dummy callable. """
-    return 1
-

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -4,6 +4,7 @@ Data-manipulation utilities.
 import re
 from collections import Counter, defaultdict
 from itertools import chain
+from functools import wraps
 
 import numpy as np
 import bottleneck as bn
@@ -250,3 +251,26 @@ def get_unique_names_domain(attributes, class_vars=(), metas=()):
                                  for old, new in zip(all_names, unique_names)
                                  if new != old))
     return (attributes, class_vars, metas), renamed
+
+
+def progress_callback(callback, start=0, end=1):
+    """
+    Wraps a callback function to allocate it end-start proportion of
+    the progress.
+
+    :param callback: callable
+    :param start: float
+    :param end: float
+    :return: callable
+    """
+    @wraps(callback)
+    def func(i, *args, **kwargs):
+        x = start + i * (end - start)
+        return callback(x, *args, **kwargs)
+    return func
+
+
+def dummy_callback(*_, **__):
+    """ A dummy callable. """
+    return 1
+

--- a/Orange/modelling/base.py
+++ b/Orange/modelling/base.py
@@ -41,8 +41,8 @@ class Fitter(Learner):
             X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
             return learner.fit(X, Y, W)
 
-    def preprocess(self, data, callback=None):
-        return self.get_learner(data).preprocess(data, callback)
+    def preprocess(self, data, progress_callback=None):
+        return self.get_learner(data).preprocess(data, progress_callback)
 
     def get_learner(self, problem_type):
         """Get the learner for a given problem type.

--- a/Orange/modelling/base.py
+++ b/Orange/modelling/base.py
@@ -41,8 +41,8 @@ class Fitter(Learner):
             X, Y, W = data.X, data.Y, data.W if data.has_weights() else None
             return learner.fit(X, Y, W)
 
-    def preprocess(self, data):
-        return self.get_learner(data).preprocess(data)
+    def preprocess(self, data, callback=None):
+        return self.get_learner(data).preprocess(data, callback)
 
     def get_learner(self, problem_type):
         """Get the learner for a given problem type.

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -4,13 +4,19 @@ import pickle
 import unittest
 
 from Orange.base import SklLearner, Learner, Model
-from Orange.data import Domain
-from Orange.preprocess import Discretize, Randomize
+from Orange.data import Domain, Table
+from Orange.preprocess import Discretize, Randomize, Continuize
 from Orange.regression import LinearRegressionLearner
 
 
 class DummyLearner(Learner):
-    pass
+    def fit(self, *_, **__):
+        return unittest.mock.Mock()
+
+
+class DummySklLearner(SklLearner):
+    def fit(self, *_, **__):
+        return unittest.mock.Mock()
 
 
 class DummyLearnerPP(Learner):
@@ -71,6 +77,15 @@ class TestLearner(unittest.TestCase):
             'Preprocessors should be able to be passed in as single object '
             'as well as an iterable object')
 
+    def test_callback(self):
+        callback = unittest.mock.Mock()
+        learner = DummyLearner(preprocessors=[Discretize(), Randomize()])
+        learner(Table("iris"), callback)
+        args = [x[0][0] for x in callback.call_args_list]
+        self.assertEqual(min(args), 0)
+        self.assertEqual(max(args), 1)
+        self.assertListEqual(args, sorted(args))
+
 
 class TestSklLearner(unittest.TestCase):
     def test_sklearn_supports_weights(self):
@@ -101,6 +116,15 @@ class TestSklLearner(unittest.TestCase):
             "Either LinearRegression no longer supports weighted tables or "
             "SklLearner.supports_weights is out-of-date.")
 
+    def test_callback(self):
+        callback = unittest.mock.Mock()
+        learner = DummySklLearner(preprocessors=[Continuize(), Randomize()])
+        learner(Table("iris"), callback)
+        args = [x[0][0] for x in callback.call_args_list]
+        self.assertEqual(min(args), 0)
+        self.assertEqual(max(args), 1)
+        self.assertListEqual(args, sorted(args))
+
 
 class TestModel(unittest.TestCase):
     def test_pickle(self):
@@ -111,3 +135,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(model.domain, model2.domain)
         self.assertEqual(model.original_data, [1, 2, 3])
         self.assertEqual(model2.original_data, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -11,6 +11,7 @@ from Orange.data import Table
 from Orange.data.util import vstack, hstack, array_equal
 from Orange.statistics.util import stats
 from Orange.tests.test_statistics import dense_sparse
+from Orange.util import wrap_callback
 
 SOMETHING = 0xf00babe
 
@@ -158,3 +159,21 @@ class TestUtil(unittest.TestCase):
         a1 = sp.csc_matrix(([1, 4, 5], [0, 0, 1], [0, 1, 1, 3]), shape=(2, 3))
         a2 = sp.csc_matrix(([1, 5, 4], [0, 1, 0], [0, 1, 1, 3]), shape=(2, 3))
         self.assertTrue(array_equal(a1, a2))
+
+    def test_wrap_callback(self):
+        def func(i):
+            return i
+
+        f = wrap_callback(func, start=0, end=0.8)
+        self.assertEqual(f(0), 0)
+        self.assertEqual(round(f(0.1), 2), 0.08)
+        self.assertEqual(f(1), 0.8)
+
+        f = wrap_callback(func, start=0.1, end=0.8)
+        self.assertEqual(f(0), 0.1)
+        self.assertEqual(f(0.1), 0.17)
+        self.assertEqual(f(1), 0.8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/util.py
+++ b/Orange/util.py
@@ -416,6 +416,29 @@ class Reprable:
             name, ", ".join("{}={!r}".format(f, v) for f, _, v in self._reprable_items())
         )
 
+
+def wrap_callback(progress_callback, start=0, end=1):
+    """
+    Wraps a progress callback function to allocate it end-start proportion
+    of an execution time.
+
+    :param progress_callback: callable
+    :param start: float
+    :param end: float
+    :return: callable
+    """
+    @wraps(progress_callback)
+    def func(progress, *args, **kwargs):
+        adjusted_progress = start + progress * (end - start)
+        return progress_callback(adjusted_progress, *args, **kwargs)
+    return func
+
+
+def dummy_callback(*_, **__):
+    """ A dummy callable. """
+    return 1
+
+
 # For best result, keep this at the bottom
 __all__ = export_globals(globals(), __name__)
 

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -12,7 +12,7 @@ from Orange.base import Learner
 from Orange.classification import OneClassSVMLearner, EllipticEnvelopeLearner,\
     LocalOutlierFactorLearner, IsolationForestLearner
 from Orange.data import Table
-from Orange.data.util import progress_callback
+from Orange.util import wrap_callback
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.concurrent import TaskState, ConcurrentWidgetMixin
@@ -40,8 +40,8 @@ def run(data: Table, learner: Learner, state: TaskState) -> Results:
             raise Exception
 
     callback(0, "Initializing...")
-    model = learner(data, progress_callback(callback, end=0.6))
-    pred = model(data, progress_callback(callback, start=0.6, end=0.99))
+    model = learner(data, wrap_callback(callback, end=0.6))
+    pred = model(data, wrap_callback(callback, start=0.6, end=0.99))
 
     col = pred.get_column_view(model.outlier_var)[0]
     inliers_ind = np.where(col == 1)[0]

--- a/Orange/widgets/data/tests/test_owoutliers.py
+++ b/Orange/widgets/data/tests/test_owoutliers.py
@@ -108,6 +108,7 @@ class TestOWOutliers(WidgetTest):
         self.assertFalse(self.widget.Error.memory_error.is_shown())
         mocked_predict.side_effect = MemoryError
         self.send_signal(self.widget.Inputs.data, self.iris)
+        self.wait_until_finished()
         self.assertTrue(self.widget.Error.memory_error.is_shown())
 
     @patch("Orange.classification.outlier_detection._OutlierModel.predict")
@@ -115,6 +116,7 @@ class TestOWOutliers(WidgetTest):
         self.assertFalse(self.widget.Error.singular_cov.is_shown())
         mocked_predict.side_effect = ValueError
         self.send_signal(self.widget.Inputs.data, self.iris)
+        self.wait_until_finished()
         self.assertTrue(self.widget.Error.singular_cov.is_shown())
 
     def test_nans(self):
@@ -132,10 +134,12 @@ class TestOWOutliers(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.brief, "")
 
         self.send_signal(self.widget.Inputs.data, self.iris)
+        self.wait_until_finished()
         self.assertEqual(info._StateInfo__input_summary.brief, "150")
         self.assertEqual(info._StateInfo__output_summary.brief, "135")
 
         self.send_signal(self.widget.Inputs.data, None)
+        self.wait_until_finished()
         self.assertEqual(info._StateInfo__input_summary.brief, "")
         self.assertEqual(info._StateInfo__output_summary.brief, "")
 
@@ -162,6 +166,7 @@ class TestOWOutliers(WidgetTest):
     @patch("Orange.widgets.data.owoutliers.OWOutliers.report_items")
     def test_report(self, mocked_report: Mock):
         self.send_signal(self.widget.Inputs.data, self.iris)
+        self.wait_until_finished()
         self.widget.send_report()
         mocked_report.assert_called()
         mocked_report.reset_mock()

--- a/Orange/widgets/data/tests/test_owoutliers.py
+++ b/Orange/widgets/data/tests/test_owoutliers.py
@@ -13,9 +13,9 @@ from Orange.widgets.tests.base import WidgetTest, simulate
 class TestRun(unittest.TestCase):
     def test_results(self):
         iris = Table("iris")
-        learner = LocalOutlierFactorLearner()
-
-        res = run(iris, learner, Mock())
+        state = Mock()
+        state.is_interruption_requested = Mock(return_value=False)
+        res = run(iris, LocalOutlierFactorLearner(), state)
         self.assertIsInstance(res.inliers, Table)
         self.assertIsInstance(res.outliers, Table)
         self.assertIsInstance(res.annotated_data, Table)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Responsive Outliers widget: the widget could make calculations in a separate thread to make Orange responsive.

##### Description of changes
- Create a `progress_callback` function that serves as a wrapper function for callbacks. It allocates the corresponding proportion of the progress to the callback.
- Add callback to `Learner` to enable preprocessing interruption.
- Add callback to `_OutlierModel`.
- Do work in a separate thread.
- Still impossible to terminate the fit/predict operations.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
