### PR TITLE
Remove domain transformation cache

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -397,27 +397,6 @@ class Domain:
     def has_time_class(self):
         return bool(self.class_var and self.class_var.is_time)
 
-    def get_conversion(self, source):
-        """
-        Return an instance of :class:`DomainConversion` for conversion from the
-        given source domain to this domain. Domain conversions are cached to
-        speed-up the conversion in the common case in which the domain
-        is based on another domain, for instance, when the domain contains
-        discretized variables from another domain.
-
-        :param source: the source domain
-        :type source: Orange.data.Domain
-        """
-        # the method is thread-safe
-        c = self._last_conversion
-        if c and c.source is source:
-            return c
-        c = self._known_domains.get(source, None)
-        if not c:
-            c = DomainConversion(source, self)
-            self._known_domains[source] = self._last_conversion = c
-        return c
-
     # noinspection PyProtectedMember
     def convert(self, inst):
         """
@@ -431,7 +410,7 @@ class Domain:
         if isinstance(inst, Instance):
             if inst.domain == self:
                 return inst._x, inst._y, inst._metas
-            c = self.get_conversion(inst.domain)
+            c = DomainConversion(inst.domain, self)
             l = len(inst.domain.attributes)
             values = [(inst._x[i] if 0 <= i < l
                        else inst._y[i - l] if i >= l

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -21,8 +21,8 @@ import Orange.data  # import for io.py
 from Orange.data import (
     _contingency, _valuecount,
     Domain, Variable, Storage, StringVariable, Unknown, Value, Instance,
-    ContinuousVariable, DiscreteVariable, MISSING_VALUES
-)
+    ContinuousVariable, DiscreteVariable, MISSING_VALUES,
+    DomainConversion)
 from Orange.data.util import SharedComputeValue, \
     assure_array_dense, assure_array_sparse, \
     assure_column_dense, assure_column_sparse, get_unique_names_duplicates
@@ -424,7 +424,7 @@ class Table(Sequence, Storage):
 
             self = cls()
             self.domain = domain
-            conversion = domain.get_conversion(source.domain)
+            conversion = DomainConversion(source.domain, domain)
             self.X = get_columns(row_indices, conversion.attributes, n_rows,
                                  is_sparse=conversion.sparse_X,
                                  variables=domain.attributes)
@@ -1829,7 +1829,7 @@ def assure_domain_conversion_sparsity(target, source):
         Table: with fixed sparsity. The sparsity is set as it is recommended by domain conversion
             for transformation from source to the target domain.
     """
-    conversion = target.domain.get_conversion(source.domain)
+    conversion = DomainConversion(source.domain, target.domain)
     match_density = [assure_array_dense, assure_array_sparse]
     target.X = match_density[conversion.sparse_X](target.X)
     target.Y = match_density[conversion.sparse_Y](target.Y)

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+# pylint: disable=protected-access
 
 import sys
 import math
@@ -174,6 +175,20 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertTrue(math.isnan(var.to_val(None)))
         self.assertEqual(var.to_val(1), 1)
+
+    def test_val_from_str_add(self):
+        var = DiscreteVariable.make("a", values=["F", "M"])
+        self.assertTrue(math.isnan(var.val_from_str_add(None)))
+        self.assertEqual(var.val_from_str_add("M"), 1)
+        self.assertEqual(var.val_from_str_add("F"), 0)
+        self.assertEqual(var.values, ["F", "M"])
+        self.assertEqual(var.val_from_str_add("N"), 2)
+        self.assertEqual(var.values, ["F", "M", "N"])
+        self.assertEqual(var._value_index, {"F": 0, "M": 1, "N": 2})
+        self.assertEqual(var.val_from_str_add("M"), 1)
+        self.assertEqual(var.val_from_str_add("F"), 0)
+        self.assertEqual(var.val_from_str_add("N"), 2)
+
 
     def test_repr(self):
         var = DiscreteVariable.make("a", values=["F", "M"])
@@ -365,7 +380,8 @@ class TestDiscreteVariable(VariableTest):
 
     def varcls_modified(self, name):
         var = super().varcls_modified(name)
-        var.values = ["A", "B"]
+        var.add_value("A")
+        var.add_value("B")
         var.ordered = True
         return var
 

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -99,7 +99,7 @@ class TestSqlTable(unittest.TestCase, dbt):
             filtered_table = filter.SameValue(table.domain[0], 'm')(table)
             self.assertEqual(len(filtered_table), 13)
 
-            table.domain[0].values.append('x')
+            table.domain[0].add_value('x')
             filtered_table = filter.SameValue(table.domain[0], 'x')(table)
             self.assertEqual(len(filtered_table), 0)
 

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -390,7 +390,7 @@ class TestDomainInit(unittest.TestCase):
                 (d, f, [1], [-2, 2], [0, 2, -1]),
                 (f, g, [], [], [-1, 0, -3]),
                 (g, h, [-2], [None, compute_value], [-1, compute_value, -3])):
-            to_domain = domain.get_conversion(conver)
+            to_domain = DomainConversion(conver, domain)
             self.assertIs(to_domain.source, conver)
             self.assertEqual(to_domain.attributes, attr)
             self.assertEqual(to_domain.class_vars, class_vars)

--- a/benchmark/bench_domain.py
+++ b/benchmark/bench_domain.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from Orange.data import DomainConversion, Domain, Table, \
+    ContinuousVariable, DiscreteVariable
+from Orange.preprocess import Discretize, EqualFreq, Normalize
+
+from .base import Benchmark, benchmark
+
+
+class BenchConversion(Benchmark):
+
+    def setUp(self):
+        cols = 1000
+        rows = 100
+        cont = [ContinuousVariable(str(i)) for i in range(cols)]
+        disc = [DiscreteVariable("D" + str(i), values=["1", "2"]) for i in range(cols)]
+        self.domain = Domain(cont + disc)
+        self.domain_x = Domain(list(self.domain.attributes) + [ContinuousVariable("x")])
+        self.single = Domain([ContinuousVariable("0")])
+        self.table = Table.from_numpy(
+            self.domain,
+            np.random.RandomState(0).randint(0, 2, (rows, len(self.domain))))
+        self.discretized_domain = Discretize(EqualFreq(n=3))(self.table).domain
+        self.normalized_domain = Normalize()(self.table).domain
+
+    @benchmark(number=5)
+    def bench_full(self):
+        DomainConversion(self.domain, self.domain_x)
+
+    @benchmark(number=5)
+    def bench_selection(self):
+        DomainConversion(self.domain, self.single)
+
+    @benchmark(number=5)
+    def bench_transform_copy(self):
+        self.table.transform(self.domain_x)
+
+    @benchmark(number=5)
+    def bench_transform_discretize(self):
+        self.table.transform(self.discretized_domain)
+
+    @benchmark(number=5)
+    def bench_transform_normalize(self):
+        self.table.transform(self.normalized_domain)


### PR DESCRIPTION
##### Issue

The first part of fix for #4406.

Two domains are considered equal if variables are equal. However, equality of discrete variables does not check for `values`.

##### Description of changes

Eliminate caching of domain conversions.

##### Includes
- [X] Code changes
