### PR TITLE
Widgets: unify with resizing_enabled

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -489,6 +489,7 @@ class OWCSVFileImport(widget.OWWidget):
 
     want_main_area = False
     buttons_area_orientation = None
+    resizing_enabled = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -2,8 +2,6 @@ from collections import OrderedDict
 import threading
 import textwrap
 
-from AnyQt.QtWidgets import QLayout
-
 from Orange.widgets import widget, gui
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input
@@ -30,6 +28,7 @@ class OWDataInfo(widget.OWWidget):
         data = Input("Data", Table)
 
     want_main_area = False
+    resizing_enabled = False
 
     def __init__(self):
         super().__init__()
@@ -52,8 +51,6 @@ class OWDataInfo(widget.OWWidget):
         # override any minimum/fixed size set on `self`).
         self.targets = ""
         self.controlArea.setMinimumWidth(self.controlArea.sizeHint().width())
-        self.layout().setSizeConstraint(QLayout.SetFixedSize)
-
 
     @Inputs.data
     def data(self, data):

--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -55,6 +55,7 @@ class OWNeighbors(OWWidget):
     auto_apply = Setting(True)
 
     want_main_area = False
+    resizing_enabled = False
     buttons_area_orientation = Qt.Vertical
 
     def __init__(self):

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -169,7 +169,7 @@ class OWPurgeDomain(widget.OWWidget):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    data = Table("car.tab")
+    data = Table.from_url("https://datasets.biolab.si/core/car.tab")
     subset = [inst for inst in data if inst["buying"] == "v-high"]
     subset = Table(data.domain, subset)
     # The "buying" should be removed and the class "y" reduced

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -41,8 +41,6 @@ class OWLinearRegression(OWBaseLearner):
     l2_ratio = settings.Setting(0.5)
     autosend = settings.Setting(True)
 
-    want_main_area = False
-
     alphas = list(chain([x / 10000 for x in range(1, 10)],
                         [x / 1000 for x in range(1, 20)],
                         [x / 100 for x in range(2, 20)],

--- a/Orange/widgets/model/owrules.py
+++ b/Orange/widgets/model/owrules.py
@@ -217,10 +217,6 @@ class OWRuleLearner(OWBaseLearner):
     priority = 19
     keywords = []
 
-    want_main_area = False
-    resizing_enabled = False
-    auto_apply = Setting(True)
-
     LEARNER = CustomRuleLearner
     supports_sparse = False
 

--- a/Orange/widgets/model/owsgd.py
+++ b/Orange/widgets/model/owsgd.py
@@ -30,7 +30,6 @@ class OWSGD(OWBaseLearner):
 
     LEARNER = SGDLearner
 
-    resizing_enabled = False
     left_side_scrolling = True
 
     class Outputs(OWBaseLearner.Outputs):

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -75,6 +75,7 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
     autocommit = Setting(True)       # type: bool
 
     want_main_area = False
+    resizing_enabled = False
     buttons_area_orientation = Qt.Vertical
 
     class Error(OWWidget.Error):
@@ -118,7 +119,6 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
         self.normalization_check.setEnabled(metric.supports_normalization)
 
         gui.auto_apply(self.controlArea, self, "autocommit")
-        self.layout().setSizeConstraint(self.layout().SetFixedSize)
 
     @Inputs.data
     @check_sql_input

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -52,6 +52,7 @@ class OWLouvainClustering(widget.OWWidget):
     priority = 2110
 
     want_main_area = False
+    resizing_enabled = False
 
     settingsHandler = DomainContextHandler()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #4410.

##### Description of changes
Remove explicit `SetFixedSize` calls, replace them with `resizing_enabled`.
Add `resizing_enabled=False` where appropriate.
Remove redundant parameters where they are already inherited from BaseLearner.
Small fix to run __main__ in PurgeDomain.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
