### PR TITLE
[FIX] Ensure unique var names in file

### DIFF
--- a/Orange/data/tests/test_util.py
+++ b/Orange/data/tests/test_util.py
@@ -59,10 +59,39 @@ class TestGetUniqueNames(unittest.TestCase):
             ["x (2)", "x (3)", "x (1)"])
         self.assertEqual(
             get_unique_names_duplicates(["x (2)", "x", "x", "x (2)", "x (3)"]),
-            ["x (2) (1)", "x (1)", "x (4)", "x (2) (2)", "x (3)"])
+            ["x (2) (1)", "x (4)", "x (5)", "x (2) (2)", "x (3)"])
+        self.assertEqual(
+                        get_unique_names_duplicates(["iris", "iris", "iris (1)"]),
+                        ["iris (2)", "iris (3)", "iris (1)"])
+
+        self.assertEqual(
+            get_unique_names_duplicates(["foo", "bar", "baz"], return_duplicated=True),
+            (["foo", "bar", "baz"], []))
+        self.assertEqual(
+            get_unique_names_duplicates(["foo", "bar", "baz", "bar"], return_duplicated=True),
+            (["foo", "bar (1)", "baz", "bar (2)"], ["bar"]))
+        self.assertEqual(
+            get_unique_names_duplicates(["x", "x", "x (1)"], return_duplicated=True),
+            (["x (2)", "x (3)", "x (1)"], ["x"]))
+        self.assertEqual(
+            get_unique_names_duplicates(["x (2)", "x", "x", "x (2)", "x (3)"], return_duplicated=True),
+            (["x (2) (1)", "x (4)", "x (5)", "x (2) (2)", "x (3)"], ["x (2)", "x"]))
         self.assertEqual(
             get_unique_names_duplicates(["x", "", "", None, None, "x"]),
             ["x (1)", "", "", None, None, "x (2)"])
+        self.assertEqual(
+            get_unique_names_duplicates(["iris", "iris", "iris (1)", "iris (2)"], return_duplicated=True),
+            (["iris (3)", "iris (4)", "iris (1)", "iris (2)"], ["iris"]))
+
+        self.assertEqual(
+            get_unique_names_duplicates(["iris (1) (1)", "iris (1)", "iris (1)"]),
+            ["iris (1) (1)", "iris (1) (2)", "iris (1) (3)"]
+        )
+
+        self.assertEqual(
+            get_unique_names_duplicates(["iris (1) (1)", "iris (1)", "iris (1)", "iris", "iris"]),
+            ["iris (1) (1)", "iris (1) (2)", "iris (1) (3)", "iris (2)", "iris (3)"]
+        )
 
     def test_get_unique_names_domain(self):
         (attrs, classes, metas), renamed = \

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -124,16 +124,16 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         file_too_big = Msg("The file is too large to load automatically."
                            " Press Reload to load.")
         load_warning = Msg("Read warning:\n{}")
-        performance_warning = widget.Msg(
+        performance_warning = Msg(
             "Categorical variables with >100 values may decrease performance.")
         renamed_vars = Msg("Some variables have been renamed "
                            "to avoid duplicates.\n{}")
 
     class Error(widget.OWWidget.Error):
-        file_not_found = widget.Msg("File not found.")
-        missing_reader = widget.Msg("Missing reader.")
-        sheet_error = widget.Msg("Error listing available sheets.")
-        unknown = widget.Msg("Read error:\n{}")
+        file_not_found = Msg("File not found.")
+        missing_reader = Msg("Missing reader.")
+        sheet_error = Msg("Error listing available sheets.")
+        unknown = Msg("Read error:\n{}")
 
     class NoFileSelected:
         pass
@@ -484,7 +484,9 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         if self.data is None:
             table = None
         else:
-            domain, cols = self.domain_editor.get_domain(self.data.domain, self.data)
+            domain, cols, renamed = \
+                self.domain_editor.get_domain(self.data.domain, self.data,
+                                              deduplicate=True)
             if not (domain.variables or domain.metas):
                 table = None
             elif domain is self.data.domain:
@@ -496,8 +498,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
                 table.ids = np.array(self.data.ids)
                 table.attributes = getattr(self.data, 'attributes', {})
                 self._inspect_discrete_variables(domain)
-        if self.domain_editor.renamed_variables:
-            self.Warning.renamed_vars(', '.join(self.domain_editor.renamed_variables))
+            if renamed:
+                self.Warning.renamed_vars(f"Renamed: {', '.join(renamed)}")
 
         self.Outputs.data.send(table)
         self.apply_button.setEnabled(False)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -171,6 +171,12 @@ class TestOWFile(WidgetTest):
         data = self.get_output(self.widget.Outputs.data)
         self.assertIn("a", data.domain)
 
+        idx = self.widget.domain_editor.model().createIndex(3, 0)
+        self.widget.domain_editor.model().setData(idx, "d", Qt.EditRole)
+        self.widget.apply_button.click()
+        data = self.get_output(self.widget.Outputs.data)
+        self.assertIn("d", data.domain)
+
         # rename and change to text
         idx = self.widget.domain_editor.model().createIndex(4, 0)
         self.widget.domain_editor.model().setData(idx, "b", Qt.EditRole)
@@ -265,6 +271,13 @@ class TestOWFile(WidgetTest):
         self.assertEqual(self.widget.domain_editor.model().data(idx, Qt.DisplayRole), temp)
         self.widget.domain_editor.model().setData(idx, "", Qt.EditRole)
         self.assertEqual(self.widget.domain_editor.model().data(idx, Qt.DisplayRole), temp)
+
+    def test_invalid_role_mode(self):
+        self.open_dataset("iris")
+        model = self.widget.domain_editor.model()
+        idx = model.createIndex(1, 0)
+        self.assertFalse(model.setData(idx, Qt.StatusTipRole, ""))
+        self.assertIsNone(model.data(idx, Qt.StatusTipRole))
 
     def test_context_match_includes_variable_values(self):
         file1 = """\

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -141,6 +141,22 @@ class TestOWFile(WidgetTest):
         data = self.get_output(self.widget.Outputs.data)
         self.assertIsInstance(data.domain["iris"], StringVariable)
 
+    def test_rename_duplicates(self):
+        self.open_dataset("iris")
+
+        idx = self.widget.domain_editor.model().createIndex(3, 0)
+        self.assertFalse(self.widget.Warning.renamed_vars.is_shown())
+        self.widget.domain_editor.model().setData(idx, "iris", Qt.EditRole)
+        self.widget.apply_button.click()
+        data = self.get_output(self.widget.Outputs.data)
+        self.assertIn("iris (1)", data.domain)
+        self.assertIn("iris (2)", data.domain)
+        self.assertTrue(self.widget.Warning.renamed_vars.is_shown())
+
+        self.widget.domain_editor.model().setData(idx, "different iris", Qt.EditRole)
+        self.widget.apply_button.click()
+        self.assertFalse(self.widget.Warning.renamed_vars.is_shown())
+
     def test_variable_name_change(self):
         """
         Test whether the name of the variable is changed correctly by

--- a/Orange/widgets/utils/tests/test_domaineditor.py
+++ b/Orange/widgets/utils/tests/test_domaineditor.py
@@ -1,0 +1,116 @@
+import unittest
+from unittest.mock import Mock
+
+import numpy as np
+
+from orangewidget.settings import SettingProvider
+from orangewidget.widget import OWBaseWidget
+from Orange.data import DiscreteVariable, ContinuousVariable, StringVariable, \
+    TimeVariable, Domain, Table
+from Orange.widgets.tests.base import GuiTest
+from Orange.widgets.utils.domaineditor import DomainEditor, Column, Place
+
+
+class MockWidget(OWBaseWidget):
+    name = "mock"
+    domain_editor = SettingProvider(DomainEditor)
+
+    def __init__(self):
+        self.domain_editor = DomainEditor(self)
+
+
+class DomainEditorTest(GuiTest):
+    def setUp(self):
+        self.widget = MockWidget()
+        self.editor = self.widget.domain_editor
+
+        self.orig_variables = [
+            ["d1", DiscreteVariable, 0, "x, y, z, ...", False],
+            ["d2", DiscreteVariable, 0, "1, 2, 3, ...", True],
+            ["c1", ContinuousVariable, 0, "", True],
+            ["d3", DiscreteVariable, 1, "4, 3, 6, ...", True],
+            ["s", StringVariable, 2, "", False],
+            ["t", TimeVariable, 2, "", True]
+        ]
+        self.domain = Domain(
+            [DiscreteVariable("d1", values=list("xyzw")),
+             DiscreteVariable("d2", values=list("12345")),
+             ContinuousVariable("c1")],
+            DiscreteVariable("d3", values=list("4368")),
+            [StringVariable("s"),
+             TimeVariable("t")])
+
+    def test_deduplication(self):
+        editor = self.editor
+        model = editor.model()
+        model.set_orig_variables(self.orig_variables)
+        model.reset_variables()
+
+        data = Table.from_numpy(
+            self.domain,
+            np.zeros((1, 3)), np.zeros((1, 1)), np.array([["foo", 42]]))
+
+        # No duplicates
+
+        domain, _ = \
+            editor.get_domain(self.domain, data)
+        self.assertEqual([var.name for var in domain.attributes],
+                         ["d1", "d2", "c1"])
+        self.assertEqual([var.name for var in domain.class_vars],
+                         ["d3"])
+        self.assertEqual([var.name for var in domain.metas],
+                         ["s", "t"])
+
+        domain, _, renamed = \
+            editor.get_domain(self.domain, data, deduplicate=True)
+        self.assertEqual([var.name for var in domain.attributes],
+                         ["d1", "d2", "c1"])
+        self.assertEqual([var.name for var in domain.class_vars],
+                         ["d3"])
+        self.assertEqual([var.name for var in domain.metas],
+                         ["s", "t"])
+        self.assertEqual(renamed, [])
+
+
+        # Duplicates
+
+        model.setData(model.index(3, Column.name), "d2")
+        model.setData(model.index(5, Column.name), "s")
+
+        domain, _ = \
+            editor.get_domain(self.domain, data)
+        self.assertEqual([var.name for var in domain.attributes],
+                         ["d1", "d2", "c1"])
+        self.assertEqual([var.name for var in domain.class_vars],
+                         ["d2"])
+        self.assertEqual([var.name for var in domain.metas],
+                         ["s", "s"])
+
+        domain, _, renamed = \
+            editor.get_domain(self.domain, data, deduplicate=True)
+        self.assertEqual([var.name for var in domain.attributes],
+                         ["d1", "d2 (1)", "c1"])
+        self.assertEqual([var.name for var in domain.class_vars],
+                         ["d2 (2)"])
+        self.assertEqual([var.name for var in domain.metas],
+                         ["s (1)", "s (2)"])
+        self.assertEqual(renamed, ["d2", "s"])
+
+
+        # Duplicates, some skipped
+
+        model.setData(model.index(5, Column.place), "skip")
+
+        domain, _, renamed = \
+            editor.get_domain(self.domain, data, deduplicate=True)
+        self.assertEqual([var.name for var in domain.attributes],
+                         ["d1", "d2 (1)", "c1"])
+        self.assertEqual([var.name for var in domain.class_vars],
+                         ["d2 (2)"])
+        self.assertEqual([var.name for var in domain.metas],
+                         ["s"])
+        self.assertEqual(renamed, ["d2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/utils/tests/test_domaineditor.py
+++ b/Orange/widgets/utils/tests/test_domaineditor.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import Mock
 
 import numpy as np
 
@@ -8,7 +7,7 @@ from orangewidget.widget import OWBaseWidget
 from Orange.data import DiscreteVariable, ContinuousVariable, StringVariable, \
     TimeVariable, Domain, Table
 from Orange.widgets.tests.base import GuiTest
-from Orange.widgets.utils.domaineditor import DomainEditor, Column, Place
+from Orange.widgets.utils.domaineditor import DomainEditor, Column
 
 
 class MockWidget(OWBaseWidget):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes part of  #4382
File widget allowed renaming vars with no regards for possible duplicates it may create.

##### Description of changes
As in other widgets, duplicates are checked by get_unique_name_duplicates and a warning is shown.

##### Includes
- [X] Code changes
- [X] Tests
