### PR TITLE
[FIX] Fix missing values after purging unused values

### DIFF
--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import numpy as np
 
-from Orange.data import Domain, DiscreteVariable, Table
+from Orange.data import Domain, DiscreteVariable
 from Orange.preprocess.transformation import Lookup
 from Orange.statistics.util import nanunique
 from .preprocess import Preprocess
@@ -238,7 +238,10 @@ def remove_unused_values(var, data):
     if len(unique) == len(var.values):
         return var
     used_values = [var.values[i] for i in unique]
-    return DiscreteVariable(var.name, values=used_values, sparse=var.sparse)
+    translation_table = np.array([np.NaN] * len(var.values))
+    translation_table[unique] = range(len(used_values))
+    return DiscreteVariable(var.name, values=used_values, sparse=var.sparse,
+                            compute_value=Lookup(var, translation_table))
 
 
 def sort_var_values(var):

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 
 from Orange.data import Table
-from Orange.preprocess import Remove
+from Orange.preprocess import Remove, discretize
 from Orange.tests import test_filename
 
 
@@ -160,3 +160,16 @@ class TestRemover(unittest.TestCase):
         cleaned = remover(data)
         np.testing.assert_array_equal(cleaned.Y[:50], 0)
         np.testing.assert_array_equal(cleaned.Y[50:], 1)
+
+    def test_remove_mapping_after_compute_value(self):
+        housing = Table("housing")
+        method = discretize.EqualFreq(n=3)
+        discretizer = discretize.DomainDiscretizer(
+            discretize_class=True, method=method)
+        domain = discretizer(housing)
+        data = housing.transform(domain)
+        val12 = np.nonzero(data.Y > 0)[0]
+        data = data[val12]
+        remover = Remove(class_flags=Remove.RemoveUnusedValues)
+        cleaned = remover(data)
+        np.testing.assert_equal(cleaned.Y, data.Y - 1)


### PR DESCRIPTION
##### Issue

Fixes #4416.

When removing `Variable.make`, I assumed that we no longer needed `Lookup` in `remove_unused_values` because values are mapped anyway. This doesn't work when the variable that is being purged has `compute_value` defined, for instance if the variable is a discretized version of some numeric variable.

##### Description of changes

Re-add lookup.

Although the bug was in remover, I also kept the test in `test_owselectrows`, where we detected the problem.

##### Includes
- [X] Code changes
- [X] Tests
