### PR TITLE
[RFC][ENH] OWScatterPlot: axis displays time specific labels for time variable

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -119,6 +119,8 @@ class OWScatterPlotGraph(OWScatterPlotBase):
 
     def update_axes(self):
         for axis, title in self.master.get_axes().items():
+            use_time = title is not None and title.is_time
+            self.plot_widget.plotItem.getAxis(axis).use_time(use_time)
             self.plot_widget.setLabel(axis=axis, text=title or "")
             if title is None:
                 self.plot_widget.hideAxis(axis)


### PR DESCRIPTION
##### Issue
Fixes #4395 
##### Additional information
The labels can be changed according to [`strftime`](https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior) if anybody finds a better formating. It still doesn't look particularly nice when displaying days and hours. I also tried using binning `short_labels` but they didn't seem that nice.

The `timezone.utc` is used becous of a Python datetime [bug](https://bugs.python.org/issue31212).
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
