### PR TITLE
from_table: speedup for sparse and dense data

### DIFF
--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -4,6 +4,7 @@ Data-manipulation utilities.
 import re
 from collections import Counter
 from itertools import chain
+from typing import Callable
 
 import numpy as np
 import bottleneck as bn
@@ -117,32 +118,33 @@ def array_equal(a1, a2):
 def assure_array_dense(a):
     if sp.issparse(a):
         a = a.toarray()
-    return a
+    return np.asarray(a)
 
 
-def assure_array_sparse(a):
+def assure_array_sparse(a, sparse_class: Callable = sp.csc_matrix):
     if not sp.issparse(a):
         # since x can be a list, cast to np.array
         # since x can come from metas with string, cast to float
         a = np.asarray(a).astype(np.float)
-        return sp.csc_matrix(a)
-    return a
+    return sparse_class(a)
 
 
 def assure_column_sparse(a):
-    a = assure_array_sparse(a)
-    # if x of shape (n, ) is passed to csc_matrix constructor,
+    # if x of shape (n, ) is passed to csc_matrix constructor or
+    # sparse matrix with shape (1, n) is passed,
     # the resulting matrix is of shape (1, n) and hence we
     # need to transpose it to make it a column
-    if a.shape[0] == 1:
-        a = a.T
-    return a
+    if a.ndim == 1 or a.shape[0] == 1:
+        # csr matrix becomes csc when transposed
+        return assure_array_sparse(a, sparse_class=sp.csr_matrix).T
+    else:
+        return assure_array_sparse(a, sparse_class=sp.csc_matrix)
 
 
 def assure_column_dense(a):
     a = assure_array_dense(a)
-    # column assignments must be of shape (n,) and not (n, 1)
-    return np.ravel(a)
+    # column assignments must be (n, )
+    return a.reshape(-1)
 
 
 def get_indices(names, name):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1767,6 +1767,36 @@ class CreateTableWithDomainAndTable(TableTests):
         self.assertEqual(back_brown.X.shape, brown.X.shape)
         self.assertEqual(back_brown.metas.shape, brown.metas.shape)
 
+    def test_from_table_shared_compute_value(self):
+        iris = data.Table("iris").to_sparse()
+        d1 = Domain(
+            [
+                ContinuousVariable(
+                    name=at.name,
+                    compute_value=PreprocessSharedComputeValue(
+                        None, PreprocessShared(iris.domain, None)
+                    )
+                )
+                for at in iris.domain.attributes
+            ]
+        )
+
+        new_table = Table.from_table(d1, iris)
+        np.testing.assert_array_equal(
+            new_table.X[:3],
+            [[5.1, 5.1, 5.1, 5.1],
+             [4.9, 4.9, 4.9, 4.9],
+             [4.7, 4.7, 4.7, 4.7]]
+        )
+
+        new_table = Table.from_table(d1, iris, row_indices=[0, 1, 2])
+        np.testing.assert_array_equal(
+            new_table.X[:3],
+            [[5.1, 5.1, 5.1, 5.1],
+             [4.9, 4.9, 4.9, 4.9],
+             [4.7, 4.7, 4.7, 4.7]]
+        )
+
     def assert_table_with_filter_matches(
             self, new_table, old_table,
             rows=..., xcols=..., ycols=..., mcols=...):
@@ -2624,6 +2654,16 @@ class TestTableSparseDense(unittest.TestCase):
         d = self.iris.transform(domain)
         self.assertFalse(sp.issparse(d.X))
 
+        # try with indices that are not Ellipsis
+        d = Table.from_table(domain, self.iris, row_indices=[0, 1, 2])
+        np.testing.assert_array_equal(
+            d.X,
+            [[5.1, 3.5, 1.4, 0.2, 0],
+             [4.9, 3.0, 1.4, 0.2, 0],
+             [4.7, 3.2, 1.3, 0.2, 0]]
+        )
+        self.assertFalse(sp.issparse(d.X))
+
     def test_from_table_add_lots_of_sparse_columns(self):
         n_attrs = len(self.iris.domain.attributes)
 
@@ -2713,7 +2753,8 @@ class PreprocessShared:
         self.callback = callback
 
     def __call__(self, data_):
-        self.callback(data_)
+        if self.callback:
+            self.callback(data_)
         data_.transform(self.domain)
         return True
 
@@ -2726,7 +2767,8 @@ class PreprocessSharedComputeValue(SharedComputeValue):
 
     # pylint: disable=arguments-differ
     def compute(self, data_, shared_data):
-        self.callback(data_)
+        if self.callback:
+            self.callback(data_)
         return data_.X[:, 0]
 
 

--- a/benchmark/bench_transform.py
+++ b/benchmark/bench_transform.py
@@ -1,0 +1,53 @@
+from functools import partial
+
+import numpy as np
+import scipy.sparse
+
+from Orange.data import Table, ContinuousVariable, Domain
+from .base import Benchmark, benchmark
+
+
+def add_unknown_attribute(table):
+    new_domain = Domain(list(table.domain.attributes) + [ContinuousVariable("x")])
+    return table.transform(new_domain)
+
+
+class BenchTransform(Benchmark):
+
+    def setup_dense(self, rows, cols):
+        self.table = Table.from_numpy(  # pylint: disable=W0201
+            Domain([ContinuousVariable(str(i)) for i in range(cols)]),
+            np.random.RandomState(0).rand(rows, cols))
+
+    def setup_sparse(self, rows, cols):
+        sparse = scipy.sparse.rand(rows, cols, density=0.01, format='csr', random_state=0)
+        self.table = Table.from_numpy(  # pylint: disable=W0201
+            Domain([ContinuousVariable(str(i), sparse=True) for i in range(cols)]),
+            sparse)
+
+    @benchmark(setup=partial(setup_dense, rows=10000, cols=100), number=5)
+    def bench_copy_dense_long(self):
+        add_unknown_attribute(self.table)
+
+    @benchmark(setup=partial(setup_dense, rows=1000, cols=1000), number=5)
+    def bench_copy_dense_square(self):
+        add_unknown_attribute(self.table)
+
+    @benchmark(setup=partial(setup_dense, rows=100, cols=10000), number=2)
+    def bench_copy_dense_wide(self):
+        add_unknown_attribute(self.table)
+
+    @benchmark(setup=partial(setup_sparse, rows=10000, cols=100), number=5)
+    def bench_copy_sparse_long(self):
+        t = add_unknown_attribute(self.table)
+        self.assertIsInstance(t.X, scipy.sparse.csr_matrix)
+
+    @benchmark(setup=partial(setup_sparse, rows=1000, cols=1000), number=5)
+    def bench_copy_sparse_square(self):
+        t = add_unknown_attribute(self.table)
+        self.assertIsInstance(t.X, scipy.sparse.csr_matrix)
+
+    @benchmark(setup=partial(setup_sparse, rows=100, cols=10000), number=2)
+    def bench_copy_sparse_wide(self):
+        t = add_unknown_attribute(self.table)
+        self.assertIsInstance(t.X, scipy.sparse.csr_matrix)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/3923

##### Description of changes
Speedup from_table - tested on random data (10000, 3000):
- on dense data: 6s -> 4s
- on sparse data: 350s -> 1.3s

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
