### PR TITLE
Omit all test folders from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,7 @@ source =
     Orange
 omit =
     Orange/canvas/*
-    Orange/tests/*
+    */tests/*
     */setup.py
     */*/setup.py
 


### PR DESCRIPTION
Some test folders are inflating code coverage. Should we consider dropping them from coverage report?