### PR TITLE
DiscreteVariable: Ignore existing values in add_value

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -209,6 +209,12 @@ class TestDiscreteVariable(VariableTest):
         a = DiscreteVariable("foo", values=["a", "b", "c"])
         self.assertRaises(TypeError, a.add_value, 42)
 
+    def test_no_duplicated_values(self):
+        a = DiscreteVariable("foo", values=["a", "b", "c"])
+        a.add_value("b")
+        self.assertEqual(list(a.values), ["a", "b", "c"])
+        self.assertEqual(list(a._value_index), ["a", "b", "c"])
+
     def test_unpickle(self):
         d1 = DiscreteVariable("A", values=["two", "one"])
         s = pickle.dumps(d1)

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -34,11 +34,10 @@ def is_on_path(name):
     -------
     found : bool
     """
-    for loader, name_, ispkg in pkgutil.iter_modules(sys.path):
+    for _, name_, _ in pkgutil.iter_modules(sys.path):
         if name == name_:
             return True
-    else:
-        return False
+    return False
 
 
 # noinspection PyPep8Naming,PyUnresolvedReferences
@@ -263,12 +262,15 @@ class TestDiscreteVariable(VariableTest):
 
         arr_list = list(arr)
         self.assertIsNot(mapper(arr_list), arr_list)
-        self.assertTrue(all(x == y or (x != x and y != y) for x, y in zip(
-            mapper(arr_list), [2, 2, 1, np.nan, 2, np.nan, np.nan])))
+        self.assertTrue(
+            all(x == y or (np.isnan(x) and np.isnan(y))
+                for x, y in zip(mapper(arr_list),
+                                [2, 2, 1, np.nan, 2, np.nan, np.nan])))
 
-        self.assertTrue(x == y or (x != x and y != y) for x, y in zip(
-            mapper(tuple(arr)),
-            (2, 2, 1, np.nan, 2, np.nan, np.nan)))
+        self.assertTrue(
+            x == y or (np.isnan(x) and np.isnan(y))
+            for x, y in zip(mapper(tuple(arr)),
+                            (2, 2, 1, np.nan, 2, np.nan, np.nan)))
 
         self.assertRaises(ValueError, mapper, object())
 

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -719,6 +719,8 @@ class DiscreteVariable(Variable):
         """
         if not isinstance(s, str):
             raise TypeError("values of DiscreteVariables must be strings")
+        if s in self._value_index:
+            return
         self._value_index[s] = len(self.values)
         self.values.append(s)
 

--- a/pylintrc
+++ b/pylintrc
@@ -28,7 +28,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=Orange.distance._distance,numpy.random.mtrand
+extension-pkg-whitelist=Orange.distance._distance,Orange.data._variable,numpy.random.mtrand
 
 # Allow optimization of some AST trees. This will activate a peephole AST
 # optimizer, which will apply various small optimizations. For instance, it can


### PR DESCRIPTION
##### Issue

https://github.com/biolab/orange3/pull/4425#discussion_r383130485

##### Description of changes

Prevent adding existing values through `add_value`.

Diff coverage is only 90 % due to uncovered code in tests. It's a won't fix, obviously.

##### Includes
- [X] Code changes
- [X] Tests
