### PR TITLE
Require orange-widget-base==4.4.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - pandas
     - pyyaml
     - orange-canvas-core  >=0.1.9
-    - orange-widget-base  >=4.2.0
+    - orange-widget-base  >=4.4.0
     - openpyxl
     - python-louvain      >=0.13
     - xlsxwriter

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.9,<0.2a
-orange-widget-base>=4.2.0a
+orange-widget-base>=4.4.0
 
 # PyQt4/PyQt5 compatibility
 AnyQt>=0.0.8


### PR DESCRIPTION
##### Issue
At least #4158 requires it.