### PR TITLE
Move select_rows function to utils

### DIFF
--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from AnyQt.QtWidgets import QListView, QApplication
 from AnyQt.QtGui import QBrush, QColor, QPainter
-from AnyQt.QtCore import QEvent, QItemSelectionModel, QItemSelection
+from AnyQt.QtCore import QEvent
 
 import pyqtgraph as pg
 from Orange.data import Table, Domain, ContinuousVariable, StringVariable
@@ -12,6 +12,7 @@ from Orange.statistics import contingency
 
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils import itemmodels, colorpalette
+from Orange.widgets.utils.itemmodels import select_rows
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 
 from Orange.widgets.visualize.owscatterplotgraph import ScatterPlotItem
@@ -24,23 +25,6 @@ class ScatterPlotItem(pg.ScatterPlotItem):
         painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
         painter.setRenderHint(QPainter.Antialiasing, True)
         super().paint(painter, option, widget)
-
-
-def select_rows(view, row_indices, command=QItemSelectionModel.ClearAndSelect):
-    """
-    Select rows in view.
-
-    :param QAbstractItemView view:
-    :param row_indices: Integer indices of rows to select.
-    :param command: QItemSelectionModel.SelectionFlags
-    """
-    selmodel = view.selectionModel()
-    model = view.model()
-    selection = QItemSelection()
-    for row in row_indices:
-        index = model.index(row, 0)
-        selection.select(index, index)
-    selmodel.select(selection, command | QItemSelectionModel.Rows)
 
 
 class OWCorrespondenceAnalysis(widget.OWWidget):

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -11,8 +11,7 @@ from xml.sax.saxutils import escape
 
 from AnyQt.QtCore import (
     Qt, QObject, QAbstractListModel, QModelIndex,
-    QItemSelectionModel
-)
+    QItemSelectionModel, QItemSelection)
 from AnyQt.QtCore import pyqtSignal as Signal
 from AnyQt.QtGui import QColor
 from AnyQt.QtWidgets import (
@@ -676,6 +675,23 @@ def select_row(view, row):
     selmodel.select(view.model().index(row, 0),
                     QItemSelectionModel.ClearAndSelect |
                     QItemSelectionModel.Rows)
+
+
+def select_rows(view, row_indices, command=QItemSelectionModel.ClearAndSelect):
+    """
+    Select several rows in view.
+
+    :param QAbstractItemView view:
+    :param row_indices: Integer indices of rows to select.
+    :param command: QItemSelectionModel.SelectionFlags
+    """
+    selmodel = view.selectionModel()
+    model = view.model()
+    selection = QItemSelection()
+    for row in row_indices:
+        index = model.index(row, 0)
+        selection.select(index, index)
+    selmodel.select(selection, command | QItemSelectionModel.Rows)
 
 
 class ModelActionsWidget(QWidget):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Sometimes, widgets require selecting multiple variables and saving them as a selection. Currently, we need this in Timeseries. I propose moving `select_rows()` function to utils.itemmodels, just under `select_row()`. This would make reusing the function in the add-ons much easier.

##### Description of changes
Move `select_rows()` from `OWCorrespondence` to `Orange.widgets.utils.itemmodels`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
