### PR TITLE
[FIX] Rank: Fix error with Random forest

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -395,7 +395,7 @@ class OWRank(OWWidget):
     def get_scorer_scores(self, scorer):
         try:
             scores = scorer.scorer.score_data(self.data).T
-        except ValueError:
+        except (ValueError, TypeError):
             log.error("%s doesn't work on this data", scorer.name)
             scores = np.full((len(self.data.domain.attributes), 1), np.nan)
 

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -247,6 +247,24 @@ class TestOWRank(WidgetTest):
         self.assertEqual(self.get_output(self.widget.Outputs.scores).X.shape,
                          (len(self.iris.domain.variables), 8))
 
+    def test_no_class_data_learner_class_reg(self):
+        """
+        Check workflow with learners that can be both classifier
+        or regressor and data have no class variable. This test should not
+        fail.
+        """
+        data = Table.from_table(Domain(self.iris.domain.variables), self.iris)
+        random_forest = RandomForestLearner()
+        self.assertIsNone(data.domain.class_var)
+        self.send_signal(self.widget.Inputs.data, data)
+
+        with patch("Orange.widgets.data.owrank.log.error") as log:
+            self.send_signal(self.widget.Inputs.scorer, random_forest, 1)
+            log.assert_called()
+
+        self.assertEqual(self.get_output(self.widget.Outputs.scores).X.shape,
+                         (len(self.iris.domain.variables), 1))
+
     def test_scores_sorting(self):
         """Check clicking on header column orders scores in a different way"""
         self.send_signal(self.widget.Inputs.data, self.iris)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #4437

##### Description of changes
When no class variable random forest fails with TypeError since it cannot decides either on classifier or regressor. It is now caught in the widget. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
