### PR TITLE
[FIX] owhierclustering: Update the scene's sceneRect

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -1430,6 +1430,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             rect.setLeft(geom.left())
             return rect
         margin = 3
+        self.scene.setSceneRect(geom)
         self.view.setSceneRect(geom)
         self.view.setHeaderSceneRect(
             adjustLeft(self.top_axis.geometry()).adjusted(0, 0, 0, margin)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-4449

##### Description of changes

Set the scene's sceneRect, not just the view's. The scene's sceneRect is used when exporting the image.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
