### PR TITLE
DiscreteVariable: Change `value` from list to tuple

### DIFF
--- a/Orange/classification/outlier_detection.py
+++ b/Orange/classification/outlier_detection.py
@@ -86,7 +86,7 @@ class _OutlierLearner(SklLearner):
         names = [v.name for v in domain.variables + domain.metas]
         variable = DiscreteVariable(
             get_unique_names(names, "Outlier"),
-            values=["Yes", "No"],
+            values=("Yes", "No"),
             compute_value=transformer
         )
 

--- a/Orange/classification/tests/test_base.py
+++ b/Orange/classification/tests/test_base.py
@@ -174,7 +174,7 @@ class TestModelMapping(unittest.TestCase):
             test_val_prob(val1, prob1)
 
     def test_no_common_values(self):
-        abc = DiscreteVariable("iris", values=list("abc"))
+        abc = DiscreteVariable("iris", values=tuple("abc"))
         iris_abc = Table.from_numpy(
             Domain(self.iris.domain.attributes, abc),
             self.iris.X, self.iris.Y)

--- a/Orange/data/tests/test_domain.py
+++ b/Orange/data/tests/test_domain.py
@@ -21,12 +21,12 @@ class DomainTest(unittest.TestCase):
         self.assertFalse(Domain([], [], [var]).empty())
 
     def test_conversion(self):
-        a1 = DiscreteVariable("a", values=list("abc"))
-        a2 = DiscreteVariable("a", values=list("cab"))
-        b1 = DiscreteVariable("b", values=list("def"))
-        b2 = DiscreteVariable("b", values=list("efg"))
+        a1 = DiscreteVariable("a", values=tuple("abc"))
+        a2 = DiscreteVariable("a", values=tuple("cab"))
+        b1 = DiscreteVariable("b", values=tuple("def"))
+        b2 = DiscreteVariable("b", values=tuple("efg"))
         c1 = ContinuousVariable("c")
-        c2 = DiscreteVariable("c", values=list("efg"))
+        c2 = DiscreteVariable("c", values=tuple("efg"))
         dom1 = Domain([a1, b1, c1])
         dom2 = Domain([a2, b2, c2])
 

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -41,7 +41,7 @@ class TestTableInit(unittest.TestCase):
         attributes = dict(a=5, b="foo")
 
         dom = Domain([ContinuousVariable(x) for x in "abcd"],
-                     DiscreteVariable("e", values=["no", "yes"]),
+                     DiscreteVariable("e", values=("no", "yes")),
                      [StringVariable("s")])
 
         for func in (Table.from_numpy, Table):
@@ -91,10 +91,10 @@ class TestTableFilters(unittest.TestCase):
         self.domain = Domain(
             [ContinuousVariable("c1"),
              ContinuousVariable("c2"),
-             DiscreteVariable("d1", values=["a", "b"])],
+             DiscreteVariable("d1", values=("a", "b"))],
             ContinuousVariable("y"),
             [ContinuousVariable("c3"),
-             DiscreteVariable("d2", values=["c", "d"]),
+             DiscreteVariable("d2", values=("c", "d")),
              StringVariable("s1"),
              StringVariable("s2")]
         )

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -167,18 +167,18 @@ class TestDiscreteVariable(VariableTest):
             var.to_val("G")
 
     def test_make(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         self.assertIsInstance(var, DiscreteVariable)
         self.assertEqual(var.name, "a")
         self.assertEqual(var.values, ("F", "M"))
 
     def test_val_from_str(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         self.assertTrue(math.isnan(var.to_val(None)))
         self.assertEqual(var.to_val(1), 1)
 
     def test_val_from_str_add(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         self.assertTrue(math.isnan(var.val_from_str_add(None)))
         self.assertEqual(var.val_from_str_add("M"), 1)
         self.assertEqual(var.val_from_str_add("F"), 0)
@@ -192,7 +192,7 @@ class TestDiscreteVariable(VariableTest):
 
 
     def test_repr(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         self.assertEqual(
             repr(var),
             "DiscreteVariable(name='a', values=('F', 'M'))")
@@ -207,8 +207,8 @@ class TestDiscreteVariable(VariableTest):
             "DiscreteVariable(name='a', values=('1', '2', '3', '4', '5', '6', '7'))")
 
     def test_no_nonstringvalues(self):
-        self.assertRaises(TypeError, DiscreteVariable, "foo", values=["a", 42])
-        a = DiscreteVariable("foo", values=["a", "b", "c"])
+        self.assertRaises(TypeError, DiscreteVariable, "foo", values=("a", 42))
+        a = DiscreteVariable("foo", values=("a", "b", "c"))
         self.assertRaises(TypeError, a.add_value, 42)
 
     def test_no_duplicated_values(self):
@@ -221,9 +221,9 @@ class TestDiscreteVariable(VariableTest):
         if LooseVersion(Orange.__version__) >= LooseVersion("3.27"):
             self.fail("Remove class TupleList; replace it with tuple.")
 
-        d1 = DiscreteVariable("A", values=["one", "two"])
+        d1 = DiscreteVariable("A", values=("one", "two"))
         with self.assertWarns(DeprecationWarning):
-            val = d1.values + ["three"]
+            val = d1.values + ("three", )
         self.assertEqual(val, ("one", "two", "three"))
         with self.assertWarns(DeprecationWarning):
             val = d1.values.copy()
@@ -231,9 +231,9 @@ class TestDiscreteVariable(VariableTest):
         self.assertIsNot(val, d1.values)
 
     def test_unpickle(self):
-        d1 = DiscreteVariable("A", values=["two", "one"])
+        d1 = DiscreteVariable("A", values=("two", "one"))
         s = pickle.dumps(d1)
-        d2 = DiscreteVariable.make("A", values=["one", "two", "three"])
+        d2 = DiscreteVariable.make("A", values=("one", "two", "three"))
         d2_values = tuple(d2.values)
         d1c = pickle.loads(s)
         # See: gh-3238
@@ -242,14 +242,14 @@ class TestDiscreteVariable(VariableTest):
         self.assertSequenceEqual(d2.values, d2_values)
         self.assertSequenceEqual(d1c.values, d1.values)
         s = pickle.dumps(d2)
-        d1 = DiscreteVariable("A", values=["one", "two"])
+        d1 = DiscreteVariable("A", values=("one", "two"))
         d2 = pickle.loads(s)
-        self.assertSequenceEqual(d2.values, ["one", "two", "three"])
-        self.assertSequenceEqual(d1.values, ["one", "two"])
+        self.assertSequenceEqual(d2.values, ("one", "two", "three"))
+        self.assertSequenceEqual(d1.values, ("one", "two"))
 
     def test_mapper_dense(self):
-        abc = DiscreteVariable("a", values=list("abc"))
-        dca = DiscreteVariable("a", values=list("dca"))
+        abc = DiscreteVariable("a", values=tuple("abc"))
+        dca = DiscreteVariable("a", values=tuple("dca"))
         mapper = dca.get_mapper_from(abc)
 
         self.assertEqual(mapper(0), 2)
@@ -296,8 +296,8 @@ class TestDiscreteVariable(VariableTest):
         self.assertRaises(ValueError, mapper, object())
 
     def test_mapper_sparse(self):
-        abc = DiscreteVariable("a", values=list("abc"))
-        dca = DiscreteVariable("a", values=list("dca"))
+        abc = DiscreteVariable("a", values=tuple("abc"))
+        dca = DiscreteVariable("a", values=tuple("dca"))
         mapper = dca.get_mapper_from(abc)
 
         arr = np.array([0, 0, 2, 1, 0, 1, np.nan])
@@ -316,7 +316,7 @@ class TestDiscreteVariable(VariableTest):
             np.array([2, 2, 1, np.nan, 2, np.nan, np.nan]))
 
         # 0 maps to 0 -> keep sparse
-        acd = DiscreteVariable("a", values=list("acd"))
+        acd = DiscreteVariable("a", values=tuple("acd"))
         mapper = acd.get_mapper_from(abc)
 
         arr_csr = sp.csr_matrix(arr)
@@ -337,8 +337,8 @@ class TestDiscreteVariable(VariableTest):
 
     def test_mapper_inplace(self):
         s = list(range(7))
-        abc = DiscreteVariable("a", values=list("abc"))
-        dca = DiscreteVariable("a", values=list("dca"))
+        abc = DiscreteVariable("a", values=tuple("abc"))
+        dca = DiscreteVariable("a", values=tuple("dca"))
         mapper = dca.get_mapper_from(abc)
 
         arr = np.array([[0, 0, 2, 1, 0, 1, np.nan], s]).T
@@ -350,7 +350,7 @@ class TestDiscreteVariable(VariableTest):
         self.assertRaises(ValueError, mapper, [1, 2, 3], 0)
         self.assertRaises(ValueError, mapper, 1, 0)
 
-        acd = DiscreteVariable("a", values=list("acd"))
+        acd = DiscreteVariable("a", values=tuple("acd"))
         mapper = acd.get_mapper_from(abc)
 
         arr = np.array([[0, 0, 2, 1, 0, 1, np.nan], s]).T
@@ -371,8 +371,8 @@ class TestDiscreteVariable(VariableTest):
             np.array([[0, 0, 1, np.nan, 0, np.nan, np.nan], s]).T)
 
     def test_mapper_dim_check(self):
-        abc = DiscreteVariable("a", values=list("abc"))
-        dca = DiscreteVariable("a", values=list("dca"))
+        abc = DiscreteVariable("a", values=tuple("abc"))
+        dca = DiscreteVariable("a", values=tuple("dca"))
         mapper = dca.get_mapper_from(abc)
 
         self.assertRaises(ValueError, mapper, np.zeros((7, 2)))
@@ -380,8 +380,8 @@ class TestDiscreteVariable(VariableTest):
         self.assertRaises(ValueError, mapper, sp.csc_matrix(np.zeros((7, 2))))
 
     def test_mapper_from_no_values(self):
-        abc = DiscreteVariable("a", values=[])
-        dca = DiscreteVariable("a", values=list("dca"))
+        abc = DiscreteVariable("a", values=())
+        dca = DiscreteVariable("a", values=tuple("dca"))
         mapper = dca.get_mapper_from(abc)
 
         arr = np.full(7, np.nan)
@@ -409,12 +409,12 @@ class TestDiscreteVariable(VariableTest):
         return var
 
     def test_copy_checks_len_values(self):
-        var = DiscreteVariable("gender", values=["F", "M"])
+        var = DiscreteVariable("gender", values=("F", "M"))
         self.assertEqual(var.values, ("F", "M"))
 
-        self.assertRaises(ValueError, var.copy, values=["F", "M", "N"])
-        self.assertRaises(ValueError, var.copy, values=["F"])
-        self.assertRaises(ValueError, var.copy, values=[])
+        self.assertRaises(ValueError, var.copy, values=("F", "M", "N"))
+        self.assertRaises(ValueError, var.copy, values=("F",))
+        self.assertRaises(ValueError, var.copy, values=())
 
         var2 = var.copy()
         self.assertEqual(var2.values, ("F", "M"))
@@ -422,7 +422,7 @@ class TestDiscreteVariable(VariableTest):
         var2 = var.copy(values=None)
         self.assertEqual(var2.values, ("F", "M"))
 
-        var2 = var.copy(values=["W", "M"])
+        var2 = var.copy(values=("W", "M"))
         self.assertEqual(var2.values, ("W", "M"))
 
 
@@ -595,9 +595,9 @@ PickleDiscreteVariable = create_pickling_tests(
     "PickleDiscreteVariable",
     ("with_name", lambda: DiscreteVariable(name="Feature 0")),
     ("with_str_value", lambda: DiscreteVariable(name="Feature 0",
-                                                values=["F", "M"])),
+                                                values=("F", "M"))),
     ("ordered", lambda: DiscreteVariable(name="Feature 0",
-                                         values=["F", "M"],
+                                         values=("F", "M"),
                                          ordered=True)),
 )
 

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -8,12 +8,14 @@ import unittest
 import pickle
 import pkgutil
 from datetime import datetime, timezone
+from distutils.version import LooseVersion
 
 from io import StringIO
 
 import numpy as np
 import scipy.sparse as sp
 
+import Orange
 from Orange.data import Variable, ContinuousVariable, DiscreteVariable, \
     StringVariable, TimeVariable, Unknown, Value
 from Orange.data.io import CSVReader
@@ -214,6 +216,19 @@ class TestDiscreteVariable(VariableTest):
         a.add_value("b")
         self.assertEqual(list(a.values), ["a", "b", "c"])
         self.assertEqual(list(a._value_index), ["a", "b", "c"])
+
+    def test_tuple_list_warning(self):
+        if LooseVersion(Orange.__version__) >= LooseVersion("3.27"):
+            self.fail("Remove class TupleList; replace it with tuple.")
+
+        d1 = DiscreteVariable("A", values=["one", "two"])
+        with self.assertWarns(DeprecationWarning):
+            val = d1.values + ["three"]
+        self.assertEqual(val, ("one", "two", "three"))
+        with self.assertWarns(DeprecationWarning):
+            val = d1.values.copy()
+        self.assertEqual(val, d1.values)
+        self.assertIsNot(val, d1.values)
 
     def test_unpickle(self):
         d1 = DiscreteVariable("A", values=["two", "one"])

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -218,17 +218,17 @@ class TestDiscreteVariable(VariableTest):
         self.assertEqual(list(a._value_index), ["a", "b", "c"])
 
     def test_tuple_list_warning(self):
-        if LooseVersion(Orange.__version__) >= LooseVersion("3.27"):
+        if LooseVersion(Orange.version.short_version) >= LooseVersion("3.27"):
             self.fail("Remove class TupleList; replace it with tuple.")
 
         d1 = DiscreteVariable("A", values=("one", "two"))
         with self.assertWarns(DeprecationWarning):
-            val = d1.values + ("three", )
-        self.assertEqual(val, ("one", "two", "three"))
+            val = d1.values + ["three", ]
+        self.assertEqual(val, ["one", "two", "three"])
         with self.assertWarns(DeprecationWarning):
             val = d1.values.copy()
-        self.assertEqual(val, d1.values)
-        self.assertIsNot(val, d1.values)
+        self.assertIsInstance(val, list)
+        self.assertSequenceEqual(val, d1.values)
 
     def test_unpickle(self):
         d1 = DiscreteVariable("A", values=("two", "one"))

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -168,7 +168,7 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertIsInstance(var, DiscreteVariable)
         self.assertEqual(var.name, "a")
-        self.assertEqual(var.values, ["F", "M"])
+        self.assertEqual(var.values, ("F", "M"))
 
     def test_val_from_str(self):
         var = DiscreteVariable.make("a", values=["F", "M"])
@@ -180,9 +180,9 @@ class TestDiscreteVariable(VariableTest):
         self.assertTrue(math.isnan(var.val_from_str_add(None)))
         self.assertEqual(var.val_from_str_add("M"), 1)
         self.assertEqual(var.val_from_str_add("F"), 0)
-        self.assertEqual(var.values, ["F", "M"])
+        self.assertEqual(var.values, ("F", "M"))
         self.assertEqual(var.val_from_str_add("N"), 2)
-        self.assertEqual(var.values, ["F", "M", "N"])
+        self.assertEqual(var.values, ("F", "M", "N"))
         self.assertEqual(var._value_index, {"F": 0, "M": 1, "N": 2})
         self.assertEqual(var.val_from_str_add("M"), 1)
         self.assertEqual(var.val_from_str_add("F"), 0)
@@ -193,16 +193,16 @@ class TestDiscreteVariable(VariableTest):
         var = DiscreteVariable.make("a", values=["F", "M"])
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'])")
+            "DiscreteVariable(name='a', values=('F', 'M'))")
         var.ordered = True
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['F', 'M'], ordered=True)")
+            "DiscreteVariable(name='a', values=('F', 'M'), ordered=True)")
 
         var = DiscreteVariable.make("a", values="1234567")
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=['1', '2', '3', '4', '5', '6', '7'])")
+            "DiscreteVariable(name='a', values=('1', '2', '3', '4', '5', '6', '7'))")
 
     def test_no_nonstringvalues(self):
         self.assertRaises(TypeError, DiscreteVariable, "foo", values=["a", 42])
@@ -395,20 +395,20 @@ class TestDiscreteVariable(VariableTest):
 
     def test_copy_checks_len_values(self):
         var = DiscreteVariable("gender", values=["F", "M"])
-        self.assertEqual(var.values, ["F", "M"])
+        self.assertEqual(var.values, ("F", "M"))
 
         self.assertRaises(ValueError, var.copy, values=["F", "M", "N"])
         self.assertRaises(ValueError, var.copy, values=["F"])
         self.assertRaises(ValueError, var.copy, values=[])
 
         var2 = var.copy()
-        self.assertEqual(var2.values, ["F", "M"])
+        self.assertEqual(var2.values, ("F", "M"))
 
         var2 = var.copy(values=None)
-        self.assertEqual(var2.values, ["F", "M"])
+        self.assertEqual(var2.values, ("F", "M"))
 
         var2 = var.copy(values=["W", "M"])
-        self.assertEqual(var2.values, ["W", "M"])
+        self.assertEqual(var2.values, ("W", "M"))
 
 
 @variabletest(ContinuousVariable)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -601,7 +601,7 @@ class DiscreteVariable(Variable):
     def __init__(self, name="", values=(), ordered=False, compute_value=None,
                  *, sparse=False):
         """ Construct a discrete variable descriptor with the given values. """
-        values = list(values)  # some people (including me) pass a generator
+        values = tuple(values)  # some people (including me) pass a generator
         if not all(isinstance(value, str) for value in values):
             raise TypeError("values of DiscreteVariables must be strings")
 
@@ -731,7 +731,7 @@ class DiscreteVariable(Variable):
         if s in self._value_index:
             return
         self._value_index[s] = len(self.values)
-        self.values.append(s)
+        self.values = self.values + (s, )
 
     def val_from_str_add(self, s):
         """

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -576,6 +576,24 @@ class ContinuousVariable(Variable):
         return var
 
 
+class TupleList(tuple):
+    def __add__(self, other):
+        if isinstance(other, list):
+            warnings.warn(
+                "DiscreteVariable.values is a tuple; "
+                "support for adding a list will be dropped in Orange 3.27",
+                DeprecationWarning)
+            other = tuple(other)
+        return super().__add__(other)
+
+    def copy(self):
+        warnings.warn(
+            "DiscreteVariable.values is a tuple;"
+            "method copy  will be dropped in Orange 3.27",
+            DeprecationWarning)
+        return tuple(self)
+
+
 class DiscreteVariable(Variable):
     """
     Descriptor for symbolic, discrete variables. Values of discrete variables
@@ -601,7 +619,7 @@ class DiscreteVariable(Variable):
     def __init__(self, name="", values=(), ordered=False, compute_value=None,
                  *, sparse=False):
         """ Construct a discrete variable descriptor with the given values. """
-        values = tuple(values)  # some people (including me) pass a generator
+        values = TupleList(values)  # some people (including me) pass a generator
         if not all(isinstance(value, str) for value in values):
             raise TypeError("values of DiscreteVariables must be strings")
 

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -583,15 +583,15 @@ class TupleList(tuple):
                 "DiscreteVariable.values is a tuple; "
                 "support for adding a list will be dropped in Orange 3.27",
                 DeprecationWarning)
-            other = tuple(other)
+            return list(self) + other
         return super().__add__(other)
 
     def copy(self):
         warnings.warn(
             "DiscreteVariable.values is a tuple;"
-            "method copy  will be dropped in Orange 3.27",
+            "method copy will be dropped in Orange 3.27",
             DeprecationWarning)
-        return tuple(self)
+        return list(self)
 
 
 class DiscreteVariable(Variable):
@@ -752,8 +752,8 @@ class DiscreteVariable(Variable):
             raise TypeError("values of DiscreteVariables must be strings")
         if s in self._value_index:
             return
-        self._value_index[s] = len(self._values)
-        self._values = self._values + (s, )
+        self._value_index[s] = len(self.values)
+        self._values += (s, )
 
     def val_from_str_add(self, s):
         """
@@ -770,7 +770,7 @@ class DiscreteVariable(Variable):
         val = self._value_index.get(s)
         if val is None:
             self.add_value(s)
-            val = len(self._values) - 1
+            val = len(self.values) - 1
         return val
 
     def repr_val(self, val):
@@ -784,7 +784,7 @@ class DiscreteVariable(Variable):
         """
         if isnan(val):
             return "?"
-        return '{}'.format(self._values[int(val)])
+        return '{}'.format(self.values[int(val)])
 
     str_val = repr_val
 
@@ -794,7 +794,7 @@ class DiscreteVariable(Variable):
         __dict__ = dict(self.__dict__)
         __dict__.pop("_values")
         return make_variable, (self.__class__, self._compute_value, self.name,
-                               self._values, self.ordered), \
+                               self.values, self.ordered), \
             __dict__
 
     def copy(self, compute_value=None, *, name=None, values=None, **_):
@@ -803,7 +803,7 @@ class DiscreteVariable(Variable):
             raise ValueError(
                 "number of values must match the number of original values")
         return super().copy(compute_value=compute_value, name=name,
-                            values=values or self._values, ordered=self.ordered)
+                            values=values or self.values, ordered=self.ordered)
 
 
 class StringVariable(Variable):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -606,9 +606,13 @@ class DiscreteVariable(Variable):
             raise TypeError("values of DiscreteVariables must be strings")
 
         super().__init__(name, compute_value, sparse=sparse)
-        self.values = values
+        self._values = values
         self._value_index = {value: i for i, value in enumerate(values)}
         self.ordered = ordered
+
+    @property
+    def values(self):
+        return self._values
 
     def get_mapping_from(self, other):
         return np.array(
@@ -730,8 +734,8 @@ class DiscreteVariable(Variable):
             raise TypeError("values of DiscreteVariables must be strings")
         if s in self._value_index:
             return
-        self._value_index[s] = len(self.values)
-        self.values = self.values + (s, )
+        self._value_index[s] = len(self._values)
+        self._values = self._values + (s, )
 
     def val_from_str_add(self, s):
         """
@@ -748,7 +752,7 @@ class DiscreteVariable(Variable):
         val = self._value_index.get(s)
         if val is None:
             self.add_value(s)
-            val = len(self.values) - 1
+            val = len(self._values) - 1
         return val
 
     def repr_val(self, val):
@@ -762,7 +766,7 @@ class DiscreteVariable(Variable):
         """
         if isnan(val):
             return "?"
-        return '{}'.format(self.values[int(val)])
+        return '{}'.format(self._values[int(val)])
 
     str_val = repr_val
 
@@ -770,9 +774,9 @@ class DiscreteVariable(Variable):
         if not self.name:
             raise PickleError("Variables without names cannot be pickled")
         __dict__ = dict(self.__dict__)
-        __dict__.pop("values")
+        __dict__.pop("_values")
         return make_variable, (self.__class__, self._compute_value, self.name,
-                               self.values, self.ordered), \
+                               self._values, self.ordered), \
             __dict__
 
     def copy(self, compute_value=None, *, name=None, values=None, **_):
@@ -781,7 +785,7 @@ class DiscreteVariable(Variable):
             raise ValueError(
                 "number of values must match the number of original values")
         return super().copy(compute_value=compute_value, name=name,
-                            values=values or self.values, ordered=self.ordered)
+                            values=values or self._values, ordered=self.ordered)
 
 
 class StringVariable(Variable):

--- a/Orange/distance/tests/test_distance.py
+++ b/Orange/distance/tests/test_distance.py
@@ -112,9 +112,9 @@ class FittedDistanceTest(unittest.TestCase):
             ContinuousVariable("c1"),
             ContinuousVariable("c2"),
             ContinuousVariable("c3"),
-            DiscreteVariable("d1", values=["a", "b"]),
-            DiscreteVariable("d2", values=["a", "b", "c", "d"]),
-            DiscreteVariable("d3", values=["a", "b", "c"]))
+            DiscreteVariable("d1", values=("a", "b")),
+            DiscreteVariable("d2", values=("a", "b", "c", "d")),
+            DiscreteVariable("d3", values=("a", "b", "c")))
         cls.domain = Domain(cls.attributes)
         cls.cont_domain = Domain(cls.attributes[:3])
         cls.disc_domain = Domain(cls.attributes[3:])

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -241,7 +241,7 @@ class AsValue(BaseImputeMethod):
             value = "N/A"
             var = Orange.data.DiscreteVariable(
                 fmt.format(var=variable),
-                values=variable.values + [value],
+                values=variable.values + (value, ),
                 compute_value=Lookup(
                     variable,
                     np.arange(len(variable.values), dtype=int),

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -109,7 +109,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         conn, table_name = self.create_sql_table(mat)
         sql_table = SqlTable(conn, table_name,
                              type_hints=Domain([], DiscreteVariable(
-                                 name='col2', values=['0', '1', '2'])))
+                                 name='col2', values=('0', '1', '2'))))
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
 
@@ -121,7 +121,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         conn, table_name = self.create_sql_table(mat)
         sql_table = SqlTable(conn, table_name,
                              type_hints=Domain([], DiscreteVariable(
-                                 name='col2', values=['0', '1', '2'])))
+                                 name='col2', values=('0', '1', '2'))))
         self.assertRaises(ValueError, lambda: sql_table.X)
         self.assertRaises(ValueError, lambda: sql_table.Y)
         with self.assertRaises(ValueError):
@@ -142,7 +142,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         for member in ('X', 'Y', 'metas', 'W', 'ids'):
             sql_table = SqlTable(conn, table_name,
                                  type_hints=Domain([], DiscreteVariable(
-                                     name='col2', values=['0', '1', '2'])))
+                                     name='col2', values=('0', '1', '2'))))
             self.assertFalse(getattr(sql_table, member) is None)
         # has all necessary class members to create a standard Table
         Table.from_table(sql_table.domain, sql_table)
@@ -232,7 +232,7 @@ class TestSqlTable(unittest.TestCase, dbt):
                  ORDER BY a."sepal length", b. "petal length" ASC""",
             type_hints=Domain([DiscreteVariable(
                 name="qualitative petal length",
-                values=['<', '>'])], []))
+                values=('<', '>'))], []))
 
         self.assertEqual(len(table), 498)
         self.assertAlmostEqual(list(table[497]), [5.8, 1.2, 0.])
@@ -281,7 +281,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         return self.create_sql_table(table)
 
     IRIS_VARIABLE = DiscreteVariable(
-        "iris", values=['Iris-setosa', 'Iris-virginica', 'Iris-versicolor'])
+        "iris", values=('Iris-setosa', 'Iris-virginica', 'Iris-versicolor'))
 
     @dbt.run_on(["postgres", "mssql"])
     def test_class_var_type_hints(self):

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -63,7 +63,7 @@ class TestSqlTable(unittest.TestCase, dbt):
             self.assertIsInstance(discrete_attr, DiscreteVariable)
             self.assertEqual(discrete_attr.name, "col1")
             self.assertTrue('"col1"' in discrete_attr.to_sql())
-            self.assertEqual(discrete_attr.values, ['f', 'm'])
+            self.assertEqual(discrete_attr.values, ('f', 'm'))
 
             self.assertIsInstance(string_attr, StringVariable)
             self.assertEqual(string_attr.name, "col2")

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -82,7 +82,7 @@ class ModelTest(unittest.TestCase):
         x = np.zeros((42, 5))
         y = np.zeros(42)
         domain = Domain([ContinuousVariable(n) for n in "abcde"],
-                        DiscreteVariable("y", values=["a", "b"]))
+                        DiscreteVariable("y", values=("a", "b")))
         data = Table.from_numpy(domain, x, y)
         a_list = [[0] * 5] * 42
         a_tuple = ((0, ) * 5,) * 42

--- a/Orange/tests/test_contingency.py
+++ b/Orange/tests/test_contingency.py
@@ -212,10 +212,10 @@ class TestDiscrete(unittest.TestCase):
     @staticmethod
     def _construct_sparse():
         domain = data.Domain(
-            [data.DiscreteVariable("d%i" % i, values=list("abc"))
+            [data.DiscreteVariable("d%i" % i, values=tuple("abc"))
              for i in range(10)] +
             [data.ContinuousVariable("c%i" % i) for i in range(10)],
-            data.DiscreteVariable("y", values=list("abc")))
+            data.DiscreteVariable("y", values=tuple("abc")))
 
         #  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19
         #------------------------------------------------------------

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -98,7 +98,7 @@ class TestEntropyMDL(TestCase):
     def test_entropy_constant(self):
         X = np.zeros((100, 1))
         domain = Domain([ContinuousVariable('v1')],
-                        [DiscreteVariable('c1', values=["1"])])
+                        [DiscreteVariable('c1', values=("1",))])
         table = data.Table(domain, X, X)
         disc = discretize.EntropyMDL()
         dvar = disc(table, table.domain[0])

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -132,21 +132,21 @@ class TestDiscretizer(TestCase):
     def test_create_discretized_var_formatting(self):
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [1, 2, 3])
-        self.assertEqual(dvar.values, ["< 1", "1 - 2", "2 - 3", "≥ 3"])
+        self.assertEqual(dvar.values, ("< 1", "1 - 2", "2 - 3", "≥ 3"))
 
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [10])
-        self.assertEqual(dvar.values, ["< 10", "≥ 10"])
+        self.assertEqual(dvar.values, ("< 10", "≥ 10"))
 
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [10.1234])
-        self.assertEqual(dvar.values, ["< 10.1", "≥ 10.1"])
+        self.assertEqual(dvar.values, ("< 10.1", "≥ 10.1"))
 
         self.var.number_of_decimals = 3
 
         dvar = discretize.Discretizer.create_discretized_var(
             self.var, [5, 10.1234])
-        self.assertEqual(dvar.values, ["< 5", "5 - 10.123", "≥ 10.123"])
+        self.assertEqual(dvar.values, ("< 5", "5 - 10.123", "≥ 10.123"))
 
     def test_discretizer_computation(self):
         dvar = discretize.Discretizer.create_discretized_var(

--- a/Orange/tests/test_distances.py
+++ b/Orange/tests/test_distances.py
@@ -990,8 +990,8 @@ class TestDistances(TestCase):
 
     def test_preprocess(self):
         domain = Domain([ContinuousVariable("c"),
-                         DiscreteVariable("d", values=['a', 'b'])],
-                        [DiscreteVariable("cls", values=['e', 'f'])],
+                         DiscreteVariable("d", values=('a', 'b'))],
+                        [DiscreteVariable("cls", values=('e', 'f'))],
                         [StringVariable("m")])
         table = Table.from_list(domain, [[1, 'a', 'e', 'm1'],
                                          [2, 'b', 'f', 'm2']])

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -31,8 +31,8 @@ class TestDiscreteDistribution(unittest.TestCase):
         self.data = data.Table.from_numpy(
             data.Domain(
                 attributes=[
-                    data.DiscreteVariable('rgb', values=['r', 'g', 'b', 'a']),
-                    data.DiscreteVariable('num', values=['1', '2', '3'], ordered=True),
+                    data.DiscreteVariable('rgb', values=('r', 'g', 'b', 'a')),
+                    data.DiscreteVariable('num', values=('1', '2', '3'), ordered=True),
                 ]
             ),
             X=np.array([
@@ -355,9 +355,9 @@ class TestClassDistribution(unittest.TestCase):
             data.Domain(
                 attributes=[data.ContinuousVariable('n1')],
                 class_vars=[
-                    data.DiscreteVariable('c1', values=['r', 'g', 'b', 'a']),
-                    data.DiscreteVariable('c2', values=['r', 'g', 'b', 'a']),
-                    data.DiscreteVariable('c3', values=['r', 'g', 'b', 'a']),
+                    data.DiscreteVariable('c1', values=('r', 'g', 'b', 'a')),
+                    data.DiscreteVariable('c2', values=('r', 'g', 'b', 'a')),
+                    data.DiscreteVariable('c3', values=('r', 'g', 'b', 'a')),
                 ]
             ),
             X=np.array([range(5)]).T,
@@ -429,7 +429,7 @@ class TestDomainDistribution(unittest.TestCase):
             self.assertEqual(computed.unknowns, n_all - sum_dist)
 
         domain = data.Domain(
-            [data.DiscreteVariable("d%i" % i, values=list("abc")) for i in range(10)] +
+            [data.DiscreteVariable("d%i" % i, values=tuple("abc")) for i in range(10)] +
             [data.ContinuousVariable("c%i" % i) for i in range(10)])
 
         # pylint: disable=bad-whitespace

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -22,13 +22,13 @@ from Orange.util import OrangeDeprecationWarning
 def create_domain(*ss):
     vars = dict(
         age=ContinuousVariable(name="AGE"),
-        gender=DiscreteVariable(name="Gender", values=["M", "F"]),
+        gender=DiscreteVariable(name="Gender", values=("M", "F")),
         incomeA=ContinuousVariable(name="incomeA"),
         income=ContinuousVariable(name="income"),
-        education=DiscreteVariable(name="education", values=["GS", "HS", "C"]),
+        education=DiscreteVariable(name="education", values=("GS", "HS", "C")),
         ssn=StringVariable(name="SSN"),
         race=DiscreteVariable(name="race",
-                              values=["White", "Hypsanic", "African", "Other"]),
+                              values=("White", "Hypsanic", "African", "Other")),
         arrival=TimeVariable("arrival"))
 
     def map_vars(s):
@@ -511,7 +511,7 @@ class TestDomainInit(unittest.TestCase):
                 ContinuousVariable(name='b'),
                 ContinuousVariable(name='c'),
             ],
-            class_vars=[DiscreteVariable('d', values=['e'])],
+            class_vars=[DiscreteVariable('d', values=('e', ))],
             metas=[StringVariable('f')]
         )
 

--- a/Orange/tests/test_impute.py
+++ b/Orange/tests/test_impute.py
@@ -132,7 +132,7 @@ class TestDefault(unittest.TestCase):
              [nan, nan]
         ]
         domain = data.Domain(
-            (data.DiscreteVariable("B", values=["a", "b", "c"]),
+            (data.DiscreteVariable("B", values=("a", "b", "c")),
              data.ContinuousVariable("C"))
         )
         table = data.Table.from_numpy(domain, np.array(X))
@@ -163,7 +163,7 @@ class TestAsValue(unittest.TestCase):
             [nan, nan, nan]
         ]
         domain = data.Domain(
-            (data.DiscreteVariable("A", values=["0", "1", "2"]),
+            (data.DiscreteVariable("A", values=("0", "1", "2")),
              data.ContinuousVariable("B"),
              data.ContinuousVariable("C"))
         )
@@ -227,7 +227,7 @@ class TestModel(unittest.TestCase):
         unknowns = np.isnan(X)
 
         domain = data.Domain(
-            (data.DiscreteVariable("A", values=["0", "1", "2"]),
+            (data.DiscreteVariable("A", values=("0", "1", "2")),
              data.ContinuousVariable("B"),
              data.ContinuousVariable("C"))
         )
@@ -301,7 +301,7 @@ class TestRandom(unittest.TestCase):
         unknowns = np.isnan(X)
 
         domain = data.Domain(
-            (data.DiscreteVariable("A", values=["0", "1", "2"]),
+            (data.DiscreteVariable("A", values=("0", "1", "2")),
              data.ContinuousVariable("B"),
              data.ContinuousVariable("C"))
         )

--- a/Orange/tests/test_knn.py
+++ b/Orange/tests/test_knn.py
@@ -42,7 +42,7 @@ class TestKNNLearner(unittest.TestCase):
                 ContinuousVariable('Feature 3'),
                 ContinuousVariable('Feature 4'),
                 ContinuousVariable('Feature 5'))
-        class_vars = (DiscreteVariable('Target 1', values=list("abcdefghij")),)
+        class_vars = (DiscreteVariable('Target 1', values=tuple("abcdefghij")),)
         domain = Domain(attr, class_vars)
         t = Table(domain, x1, y1)
         lrn = KNNLearner()

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -47,7 +47,7 @@ class TestNaiveBayesLearner(unittest.TestCase):
         d = Domain((ContinuousVariable(name="A"),
                     ContinuousVariable(name="B"),
                     ContinuousVariable(name="C")),
-                   DiscreteVariable(name="CLASS", values=["M", "F"]))
+                   DiscreteVariable(name="CLASS", values=("M", "F")))
         t = Table.from_list(d, [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 1]])
         nb = NaiveBayesLearner()
         model = nb(t)

--- a/Orange/tests/test_remove.py
+++ b/Orange/tests/test_remove.py
@@ -50,9 +50,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['4', '6']])
+                          if a.is_discrete], [('4', '6')])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3'], ['2']])
+                          if c.is_discrete], [('1', '2', '3'), ('2', )])
         self.assertDictEqual(attr_res,
                              {'removed': 2, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -72,9 +72,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4', '6']])
+                          if a.is_discrete], [('1', ), ('4', '6')])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3']])
+                          if c.is_discrete], [('1', '2', '3')])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -94,9 +94,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4']])
+                          if a.is_discrete], [('1', ), ('4', )])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3'], ['2']])
+                          if c.is_discrete], [('1', '2', '3'), ('2', )])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 1, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -118,9 +118,9 @@ class TestRemover(unittest.TestCase):
         self.assertEqual([c.name for c in new_data.domain.class_vars],
                          ["cl1", "cl0", "cl3", "cl4"])
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4', '6']])
+                          if a.is_discrete], [('1', ), ('4', '6')])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['2', '3'], ['2']])
+                          if c.is_discrete], [('2', '3'), ('2', )])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 0, 'sorted': 0})
         self.assertDictEqual(class_res,
@@ -133,8 +133,8 @@ class TestRemover(unittest.TestCase):
                      meta_flags=Remove.RemoveUnusedValues)(subset)
 
         self.assertEqual(res.domain["b"].values, res.domain["c"].values)
-        self.assertEqual(res.domain["d"].values, ["1", "2"])
-        self.assertEqual(res.domain["f"].values, ['1', 'hey'])
+        self.assertEqual(res.domain["d"].values, ("1", "2"))
+        self.assertEqual(res.domain["f"].values, ('1', 'hey'))
 
     def test_remove_unused_values_attr_sparse(self):
         data = self.test8
@@ -145,9 +145,9 @@ class TestRemover(unittest.TestCase):
 
         self.assertEqual((new_data.X != data.X).nnz, 0)
         self.assertEqual([a.values for a in new_data.domain.attributes
-                          if a.is_discrete], [['1'], ['4']])
+                          if a.is_discrete], [('1', ), ('4', )])
         self.assertEqual([c.values for c in new_data.domain.class_vars
-                          if c.is_discrete], [['1', '2', '3'], ['2']])
+                          if c.is_discrete], [('1', '2', '3'), ('2', )])
         self.assertDictEqual(attr_res,
                              {'removed': 0, 'reduced': 1, 'sorted': 0})
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1440,7 +1440,7 @@ class CreateTableWithData(TableTests):
         np.testing.assert_almost_equal(table.Y, Y)
         self.assertIsInstance(table.domain.class_vars[0],
                               data.DiscreteVariable)
-        self.assertEqual(table.domain.class_vars[0].values, ["v1", "v2"])
+        self.assertEqual(table.domain.class_vars[0].values, ("v1", "v2"))
 
     def test_creates_a_table_with_given_domain(self):
         domain = self.mock_domain()

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -669,7 +669,7 @@ class TableTestCase(unittest.TestCase):
         a = np.arange(20, dtype="d").reshape((4, 5))
         a[:, -1] = [0, 0, 0, 1]
         dom = data.Domain([data.ContinuousVariable(x) for x in "abcd"],
-                          data.DiscreteVariable("e", values=["no", "yes"]))
+                          data.DiscreteVariable("e", values=("no", "yes")))
         table = data.Table(dom, a)
         for i in range(4):
             self.assertEqual(table[i].get_class(), "no" if i < 3 else "yes")
@@ -883,7 +883,7 @@ class TableTestCase(unittest.TestCase):
         f = filter.FilterDiscrete(d.domain.class_var, values=[2, "martian"])
         self.assertRaises(ValueError, d._filter_values, f)
 
-        f = filter.FilterDiscrete(d.domain.class_var, values=[2, data.Table])
+        f = filter.FilterDiscrete(d.domain.class_var, values=(2, data.Table))
         self.assertRaises(TypeError, d._filter_values, f)
 
         v = d.columns
@@ -2010,14 +2010,14 @@ class InterfaceTest(unittest.TestCase):
     features = (
         data.ContinuousVariable(name="Continuous Feature 1"),
         data.ContinuousVariable(name="Continuous Feature 2"),
-        data.DiscreteVariable(name="Discrete Feature 1", values=["0", "1"]),
+        data.DiscreteVariable(name="Discrete Feature 1", values=("0", "1")),
         data.DiscreteVariable(name="Discrete Feature 2",
-                              values=["value1", "value2"]),
+                              values=("value1", "value2")),
     )
 
     class_vars = (
         data.ContinuousVariable(name="Continuous Class"),
-        data.DiscreteVariable(name="Discrete Class", values=["m", "f"])
+        data.DiscreteVariable(name="Discrete Class", values=("m", "f"))
     )
 
     feature_data = (
@@ -2196,7 +2196,7 @@ class TestTableTranspose(unittest.TestCase):
 
     def test_transpose_discrete_class(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
-        domain = Domain(attrs, [DiscreteVariable("cls", values=["a", "b"])])
+        domain = Domain(attrs, [DiscreteVariable("cls", values=("a", "b"))])
         data = Table(domain, np.arange(8).reshape((4, 2)),
                      np.array([1, 1, 0, 0]))
 
@@ -2327,7 +2327,7 @@ class TestTableTranspose(unittest.TestCase):
 
     def test_transpose_discrete_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
-        metas = [DiscreteVariable("m1", values=["aa", "bb"])]
+        metas = [DiscreteVariable("m1", values=("aa", "bb"))]
         domain = Domain(attrs, metas=metas)
         X = np.arange(8).reshape((4, 2))
         M = np.array([0, 1, 0, 1])[:, None]

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -45,7 +45,7 @@ class TestTransformation(unittest.TestCase):
 
     def test_identity(self):
         domain = Domain([ContinuousVariable("X")],
-                        [DiscreteVariable("C", values=["0", "1", "2"])],
+                        [DiscreteVariable("C", values=("0", "1", "2"))],
                         [StringVariable("S")])
         X = np.random.normal(size=(4, 1))
         Y = np.random.randint(3, size=(4, 1))

--- a/Orange/tests/test_value.py
+++ b/Orange/tests/test_value.py
@@ -37,7 +37,7 @@ class TestValue(unittest.TestCase):
         self.assertFalse(acc1 != acc1)
 
     def test_compare_discrete(self):
-        data = Table(Domain([DiscreteVariable(name="G", values=["M", "F"])]),
+        data = Table(Domain([DiscreteVariable(name="G", values=("M", "F"))]),
                      np.array([[0], [1]]))
         self.assertTrue(data[0]['G'] < data[1]['G'])
         self.assertTrue(data[0]['G'] >= data[0]['G'])

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -44,7 +44,7 @@ class TestExcelReader(unittest.TestCase):
         self.assertEqual(len(domain.attributes), 3)
         self.assertIsInstance(domain[0], ContinuousVariable)
         self.assertIsInstance(domain[1], ContinuousVariable)
-        self.assertListEqual(domain[2].values, ["1", "2"])
+        self.assertEqual(domain[2].values, ("1", "2"))
 
 
 class TestExcelHeader0(unittest.TestCase):
@@ -106,7 +106,7 @@ class TestExcelHeader1(unittest.TestCase):
         self.assertIsInstance(domain[3], ContinuousVariable)
         for i, var in enumerate(domain.variables):
             self.assertEqual(var.name, chr(97 + i))
-        self.assertEqual(domain[0].values, ["green", "red"])
+        self.assertEqual(domain[0].values, ("green", "red"))
         np.testing.assert_almost_equal(table.X,
                                        np.array([[1, 0.5, 0, 21],
                                                  [1, 0.1, 0, 123],
@@ -135,7 +135,7 @@ class TestExcelHeader1(unittest.TestCase):
         for n, var in zip("acf", domain.metas):
             self.assertEqual(var.name, n)
         self.assertIsInstance(domain.metas[0], DiscreteVariable)
-        self.assertEqual(domain.metas[0].values, ["green", "red"])
+        self.assertEqual(domain.metas[0].values, ("green", "red"))
         self.assertIsInstance(domain.metas[1], ContinuousVariable)
         np.testing.assert_almost_equal(
             table.metas[:, 0], np.array([1, 1, 0] * 7 + [1, 1]))
@@ -171,7 +171,7 @@ class TestExcelHeader3(unittest.TestCase):
         for n, var in zip("acf", domain.metas):
             self.assertEqual(var.name, n)
         self.assertIsInstance(domain.metas[0], DiscreteVariable)
-        self.assertEqual(domain.metas[0].values, ["green", "red"])
+        self.assertEqual(domain.metas[0].values, ("green", "red"))
         self.assertIsInstance(domain.metas[1], ContinuousVariable)
         np.testing.assert_almost_equal(
             table.metas[:, 0], np.array([1, 1, 0] * 7 + [1, 1]))

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -77,7 +77,7 @@ class DiscAttrDesc(AttrDesc):
 
     def set_value(self, i, value):
         if not self.new_values:
-            self.new_values = self.var.values.copy()
+            self.new_values = list(self.var.values)
         self.new_values[i] = value
 
     def create_variable(self):

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -513,7 +513,7 @@ class OWMergeData(widget.OWWidget):
             if var.is_discrete:
                 col = col.astype(int)
                 col[nans] = len(var.values)
-                col = np.array(var.values + [np.nan])[col]
+                col = np.array(var.values + (np.nan, ))[col]
         else:
             col = col.copy()
             defined = col.astype(bool)

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1274,7 +1274,7 @@ class OWPaintData(OWWidget):
             domain = Orange.data.Domain(
                 attrs,
                 Orange.data.DiscreteVariable(
-                    "Class", values=list(self.class_model))
+                    "Class", values=tuple(self.class_model))
             )
             data = Orange.data.Table.from_numpy(domain, X, Y)
         else:

--- a/Orange/widgets/data/owpivot.py
+++ b/Orange/widgets/data/owpivot.py
@@ -95,7 +95,7 @@ class Pivot:
         self._row_var_groups = nanunique(self._row_var_col)
         self._col_var_groups = nanunique(self._col_var_col)
 
-        self._total_var = DiscreteVariable("Total", values=["total"])
+        self._total_var = DiscreteVariable("Total", values=("total", ))
         self._current_agg_functions = sorted(agg_funs)
         self._indepen_agg_done = {}  # type: Dict[Functions, int]
         self._depen_agg_done = {}  # type: Dict[Functions, Dict[Variable, int]]
@@ -292,7 +292,7 @@ class Pivot:
                               for i, v in enumerate(vals, 2)])
             for x in (X_v, X_t):
                 attrs.append([DiscreteVariable("Total", map_values(0, x))])
-        row_var_h = DiscreteVariable(self._row_var.name, values=["Total"])
+        row_var_h = DiscreteVariable(self._row_var.name, values=("Total", ))
         aggr_attr = DiscreteVariable("Aggregate", [str(f) for f in agg_funs])
         return (Domain([self._row_var, aggr_attr] + attrs[0]),
                 Domain([row_var_h, aggr_attr] + attrs[1]),

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -431,7 +431,7 @@ class OWSelectRows(widget.OWWidget):
                 self.cond_list.setCellWidget(oper_combo.row, 2, button)
             else:
                 combo = QComboBox()
-                combo.addItems([""] + var.values)
+                combo.addItems(("", ) + var.values)
                 if lc[0]:
                     combo.setCurrentIndex(int(lc[0]))
                 else:

--- a/Orange/widgets/data/tests/test_owcolor.py
+++ b/Orange/widgets/data/tests/test_owcolor.py
@@ -55,7 +55,7 @@ class DiscAttrTest(unittest.TestCase):
         var = desc.create_variable()
         self.assertIsInstance(var, DiscreteVariable)
         self.assertEqual(var.name, "z")
-        self.assertEqual(var.values, ["a", "d", "c"])
+        self.assertEqual(var.values, ("a", "d", "c"))
         np.testing.assert_equal(var.colors, [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
 
         palette = desc.var.attributes["palette"] = object()

--- a/Orange/widgets/data/tests/test_owconcatenate.py
+++ b/Orange/widgets/data/tests/test_owconcatenate.py
@@ -167,7 +167,7 @@ class TestOWConcatenate(WidgetTest):
         widget.merge_type = OWConcatenate.MergeIntersection
 
         X1, X2, X3 = map(ContinuousVariable, ["X1", "X2", "X3"])
-        D1, D2, D3 = map(lambda n: DiscreteVariable(n, values=["a", "b"]),
+        D1, D2, D3 = map(lambda n: DiscreteVariable(n, values=("a", "b")),
                          ["D1", "D2", "D3"])
         S1, S2 = map(StringVariable, ["S1", "S2"])
         domain1 = Domain([X1, X2], [D1], [S1])
@@ -194,7 +194,7 @@ class TestOWConcatenate(WidgetTest):
         widget.merge_type = OWConcatenate.MergeUnion
 
         X1, X2, X3 = map(ContinuousVariable, ["X1", "X2", "X3"])
-        D1, D2, D3 = map(lambda n: DiscreteVariable(n, values=["a", "b"]),
+        D1, D2, D3 = map(lambda n: DiscreteVariable(n, values=("a", "b")),
                          ["D1", "D2", "D3"])
         S1, S2 = map(StringVariable, ["S1", "S2"])
         domain1 = Domain([X1, X2], [D1], [S1])
@@ -335,9 +335,9 @@ class TestOWConcatenate(WidgetTest):
         X1, X1a, X2, X2a = map(ContinuousVariable, ["X1", "X1", "X2", "X2"])
         X2.number_of_decimals = 3
         X2a.number_of_decimals = 4
-        D1 = DiscreteVariable("X1", values=["a", "b", "c"])
-        D1a = DiscreteVariable("X1", values=["e", "b", "d"])
-        D2 = DiscreteVariable("X2", values=["a", "b", "c"])
+        D1 = DiscreteVariable("X1", values=("a", "b", "c"))
+        D1a = DiscreteVariable("X1", values=("e", "b", "d"))
+        D2 = DiscreteVariable("X2", values=("a", "b", "c"))
         S1 = StringVariable("X1")
 
         # pylint: disable=unbalanced-tuple-unpacking,protected-access
@@ -352,11 +352,11 @@ class TestOWConcatenate(WidgetTest):
         self.assertEqual(X2a.number_of_decimals, 4)
         self.assertEqual(uX2.number_of_decimals, 4)
 
-        self.assertEqual(D1.values, list("abc"))
-        self.assertEqual(D1a.values, list("ebd"))
+        self.assertEqual(D1.values, tuple("abc"))
+        self.assertEqual(D1a.values, tuple("ebd"))
         self.assertEqual(uD1, D1)
         self.assertEqual(uD1, D1a)
-        self.assertEqual(uD1.values, list("abced"))
+        self.assertEqual(uD1.values, tuple("abced"))
 
         self.assertIs(uD2, D2)
 

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -152,7 +152,7 @@ class TestOWContinuize(WidgetTest):
 
 class TestOWContinuizeUtils(unittest.TestCase):
     def test_dummy_coding_zero_based(self):
-        var = DiscreteVariable("foo", values=list("abc"))
+        var = DiscreteVariable("foo", values=tuple("abc"))
 
         varb, varc = owcontinuize.dummy_coding(var)
 
@@ -179,7 +179,7 @@ class TestOWContinuizeUtils(unittest.TestCase):
         self.assertIs(varb.compute_value.variable, var)
 
     def test_dummy_coding_base_value(self):
-        var = DiscreteVariable("foo", values=list("abc"))
+        var = DiscreteVariable("foo", values=tuple("abc"))
 
         varb, varc = owcontinuize.dummy_coding(var, base_value=0)
 
@@ -200,7 +200,7 @@ class TestOWContinuizeUtils(unittest.TestCase):
         self.assertEqual(varc.compute_value.value, 2)
 
     def test_one_hot_coding(self):
-        var = DiscreteVariable("foo", values=list("abc"))
+        var = DiscreteVariable("foo", values=tuple("abc"))
 
         vars = owcontinuize.one_hot_coding(var)
         for i, (c, nvar) in enumerate(zip("abc", vars)):

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -214,7 +214,7 @@ class TestOWCreateClass(WidgetTest):
 
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
-        self.assertEqual(outdata.domain.class_var.values, ["Cls1", "Cls2"])
+        self.assertEqual(outdata.domain.class_var.values, ("Cls1", "Cls2"))
         classes = outdata.get_column_view("class")[0]
         attr = outdata.get_column_view("thal")[0]
         thal = self.heart.domain["thal"]
@@ -231,7 +231,7 @@ class TestOWCreateClass(WidgetTest):
 
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
-        self.assertEqual(outdata.domain.class_var.values, ["C1"])
+        self.assertEqual(outdata.domain.class_var.values, ("C1", ))
         classes = outdata.get_column_view("class")[0]
         np.testing.assert_equal(classes, 0)
 
@@ -255,7 +255,7 @@ class TestOWCreateClass(WidgetTest):
 
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
-        self.assertEqual(outdata.domain.class_var.values, ["C1", "C2"])
+        self.assertEqual(outdata.domain.class_var.values, ("C1", "C2"))
         classes = outdata.get_column_view("class")[0]
         attr = outdata.get_column_view("gender")[0]
         female = np.equal(attr, gender.values.index("female"))
@@ -308,7 +308,7 @@ class TestOWCreateClass(WidgetTest):
         self._check_counts([["117", ""], ["18", "+ 117"], ["166", "+ 117"],
                             ["", ""], ["", ""]])
         self.assertEqual(outdata.domain.class_var.values,
-                         ["Cls1", "Cls2", "Cls3"])
+                         ("Cls1", "Cls2", "Cls3"))
 
         widget.remove_buttons[1].click()
         self._check_counts([["117", ""], ["166", "+ 117"], ["18", "+ 117"],

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -706,13 +706,13 @@ class TestReinterpretTransforms(TestCase):
                 [1, 0, 0, 0],
             ], dtype=float)
         )
-        self.assertEqual(tdomain["A"].values, ["a", "b", "c"])
-        self.assertEqual(tdomain["B"].values, ["0", "1", "2"])
-        self.assertEqual(tdomain["C"].values, ["0.0", "0.2", "0.25", "1.25"])
+        self.assertEqual(tdomain["A"].values, ("a", "b", "c"))
+        self.assertEqual(tdomain["B"].values, ("0", "1", "2"))
+        self.assertEqual(tdomain["C"].values, ("0.0", "0.2", "0.25", "1.25"))
         self.assertEqual(
             tdomain["D"].values,
-            ["1970-01-01 00:00:00", "1970-01-01 00:03:00",
-             "1970-01-01 00:06:00", "1970-01-01 00:12:00"]
+            ("1970-01-01 00:00:00", "1970-01-01 00:03:00",
+             "1970-01-01 00:06:00", "1970-01-01 00:12:00")
         )
 
     def test_as_continuous(self):

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -212,7 +212,7 @@ class TestOWEditDomain(WidgetTest):
     def test_change_ordered(self):
         """Test categorical ordered flag change"""
         table = Table.from_domain(Domain(
-            [DiscreteVariable("A", values=["a", "b"], ordered=True)]))
+            [DiscreteVariable("A", values=("a", "b"), ordered=True)]))
         self.send_signal(self.widget.Inputs.data, table)
         output = self.get_output(self.widget.Outputs.data)
         self.assertTrue(output.domain[0].ordered)
@@ -641,8 +641,8 @@ class TestReinterpretTransforms(TestCase):
     def setUpClass(cls) -> None:
         super().setUpClass()
         domain = Domain([
-            DiscreteVariable("A", values=["a", "b", "c"]),
-            DiscreteVariable("B", values=["0", "1", "2"]),
+            DiscreteVariable("A", values=("a", "b", "c")),
+            DiscreteVariable("B", values=("0", "1", "2")),
             ContinuousVariable("C"),
             TimeVariable("D", have_time=True),
         ],

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -39,7 +39,7 @@ class FeatureConstructorTest(unittest.TestCase):
                                      data.domain.class_vars,
                                      data.domain.metas))
         self.assertTrue(isinstance(data.domain[name], DiscreteVariable))
-        self.assertEqual(data.domain[name].values, list(values))
+        self.assertEqual(data.domain[name].values, values)
         for i in range(3):
             self.assertEqual(data[i * 50, name], values[i])
 

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -45,23 +45,23 @@ continuous = [
 
 # Unordered discrete variable variations
 rgb_full = VarDataPair(
-    DiscreteVariable('rgb_full', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_full', values=('r', 'g', 'b')),
     np.array([0, 1, 1, 1, 2], dtype=float),
 )
 rgb_missing = VarDataPair(
-    DiscreteVariable('rgb_missing', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_missing', values=('r', 'g', 'b')),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
 )
 rgb_all_missing = VarDataPair(
-    DiscreteVariable('rgb_all_missing', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_all_missing', values=('r', 'g', 'b')),
     np.array([np.nan] * 5, dtype=float),
 )
 rgb_bins_missing = VarDataPair(
-    DiscreteVariable('rgb_bins_missing', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_bins_missing', values=('r', 'g', 'b')),
     np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
 )
 rgb_same = VarDataPair(
-    DiscreteVariable('rgb_same', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_same', values=('r', 'g', 'b')),
     np.array([2] * 5, dtype=float),
 )
 rgb = [
@@ -70,23 +70,23 @@ rgb = [
 
 # Ordered discrete variable variations
 ints_full = VarDataPair(
-    DiscreteVariable('ints_full', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_full', values=('2', '3', '4'), ordered=True),
     np.array([0, 1, 1, 1, 2], dtype=float),
 )
 ints_missing = VarDataPair(
-    DiscreteVariable('ints_missing', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_missing', values=('2', '3', '4'), ordered=True),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
 )
 ints_all_missing = VarDataPair(
-    DiscreteVariable('ints_all_missing', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_all_missing', values=('2', '3', '4'), ordered=True),
     np.array([np.nan] * 5, dtype=float),
 )
 ints_bins_missing = VarDataPair(
-    DiscreteVariable('ints_bins_missing', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_bins_missing', values=('2', '3', '4'), ordered=True),
     np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
 )
 ints_same = VarDataPair(
-    DiscreteVariable('ints_same', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_same', values=('2', '3', '4'), ordered=True),
     np.array([0] * 5, dtype=float),
 )
 ints = [

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -833,7 +833,7 @@ class TestOWMergeData(WidgetTest):
     def test_nonunique(self):
         widget = self.widget
         x = ContinuousVariable("x")
-        d = DiscreteVariable("d", values=list("abc"))
+        d = DiscreteVariable("d", values=tuple("abc"))
         domain = Domain([x, d], [])
         dataA = Table.from_numpy(
             domain, np.array([[1.0, 0], [1, 1], [2, 1]]))
@@ -905,7 +905,7 @@ class TestOWMergeData(WidgetTest):
     def test_invalide_pairs(self):
         widget = self.widget
         x = ContinuousVariable("x")
-        d = DiscreteVariable("d", values=list("abc"))
+        d = DiscreteVariable("d", values=tuple("abc"))
         domain = Domain([x, d], [])
         dataA = Table.from_numpy(
             domain, np.array([[1.0, 0], [1, 1], [2, 1]]))
@@ -959,7 +959,7 @@ class TestOWMergeData(WidgetTest):
 
     def test_duplicate_names(self):
         domain = Domain([ContinuousVariable("C1")],
-                        metas=[DiscreteVariable("Feature", values=["A", "B"])])
+                        metas=[DiscreteVariable("Feature", values=("A", "B"))])
         data = Table(domain, np.array([[1.], [0.]]),
                      metas=np.array([[1.], [0.]]))
         domain = Domain([ContinuousVariable("C1")],
@@ -984,7 +984,7 @@ class TestOWMergeData(WidgetTest):
                              ["A", "B (1)", "B (2)"])
 
     def test_keep_non_duplicate_variables_missing_rows(self):
-        c = DiscreteVariable("C", values=["a", "b", "c"])
+        c = DiscreteVariable("C", values=("a", "b", "c"))
         domain = Domain([ContinuousVariable("A"), ContinuousVariable("B"), c])
         data = Table(domain, np.array([[0., 0, 0], [1, 1, 1]]))
         extra_data = Table(domain, np.array([[0., 1, 1], [0, 1, 2]]))

--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -283,7 +283,7 @@ class OWConfusionMatrix(widget.OWWidget):
 
         nmodels = results.predicted.shape[0]
         self.headers = class_values + \
-                       [unicodedata.lookup("N-ARY SUMMATION")]
+                       (unicodedata.lookup("N-ARY SUMMATION"), )
 
         # NOTE: The 'learner_names' is set in 'Test Learners' widget.
         self.learners = getattr(

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -770,7 +770,7 @@ class OWTestLearners(OWWidget):
         if self.data.domain.has_discrete_class:
             self.cbox.setVisible(True)
             class_var = self.data.domain.class_var
-            items = [self.TARGET_AVERAGE] + class_var.values
+            items = (self.TARGET_AVERAGE, ) + class_var.values
             self.class_selection_combo.addItems(items)
 
             class_index = 0

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -1155,7 +1155,7 @@ def results_one_vs_rest(results, pos_index):
     value = results.domain.class_var.values[pos_index]
     class_var = Orange.data.DiscreteVariable(
         "I({}=={})".format(results.domain.class_var.name, value),
-        values=["False", "True"],
+        values=("False", "True"),
         compute_value=Indicator(results.domain.class_var, pos_index)
     )
     domain = Orange.data.Domain(

--- a/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
+++ b/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
@@ -78,7 +78,7 @@ class TestOWCalibrationPlot(WidgetTest, EvaluateTest):
         check_clsfr_names(["majority", "knn-3", "knn-1"])
         self.assertEqual(widget.selected_classifiers, [0, 1, 2])
         self.assertEqual(
-            [tcomb.itemText(i) for i in range(tcomb.count())],
+            tuple(tcomb.itemText(i) for i in range(tcomb.count())),
             self.lenses.domain.class_var.values)
         self.assertEqual(widget.target_index, 0)
 

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -60,10 +60,10 @@ class TestOWPredictions(WidgetTest):
         train = Table("titanic")
         model = ConstantLearner()(train)
         self.send_signal(self.widget.Inputs.predictors, model)
-        domain = Domain([DiscreteVariable("status", values=["first", "third"]),
-                         DiscreteVariable("age", values=["adult", "child"]),
-                         DiscreteVariable("sex", values=["female", "male"])],
-                        [DiscreteVariable("survived", values=[])])
+        domain = Domain([DiscreteVariable("status", values=("first", "third")),
+                         DiscreteVariable("age", values=("adult", "child")),
+                         DiscreteVariable("sex", values=("female", "male"))],
+                        [DiscreteVariable("survived", values=())])
         test = Table(domain, np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]]),
                      np.full((3, 1), np.nan))
         self.send_signal(self.widget.Inputs.data, test)

--- a/Orange/widgets/evaluate/tests/test_owtestlearners.py
+++ b/Orange/widgets/evaluate/tests/test_owtestlearners.py
@@ -40,7 +40,7 @@ class TestOWTestLearners(WidgetTest):
 
         self.scores_domain = Domain(
             [ContinuousVariable("a"), ContinuousVariable("b")],
-            [DiscreteVariable("c", values=["y", "n"])])
+            [DiscreteVariable("c", values=("y", "n"))])
 
         self.scores_table_values = [[1, 1, 1.23, 23.8], [1., 2., 3., 4.]]
 
@@ -159,7 +159,7 @@ class TestOWTestLearners(WidgetTest):
         table = Table.from_list(
             Domain(
                 [ContinuousVariable("a"), ContinuousVariable("b")],
-                [DiscreteVariable("c", values=["y"])]),
+                [DiscreteVariable("c", values=("y", ))]),
             list(zip(
                 [42.48, 16.84, 15.23, 23.8],
                 [1., 2., 3., 4.],

--- a/Orange/widgets/model/tests/test_owlogisticregression.py
+++ b/Orange/widgets/model/tests/test_owlogisticregression.py
@@ -86,7 +86,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
             Domain(
                 [ContinuousVariable("a"),
                  ContinuousVariable("b")],
-                [DiscreteVariable("c", values=["yes", "no"])]
+                [DiscreteVariable("c", values=("yes", "no"))]
             ),
             list(zip(
                 [1., 0.],

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -297,8 +297,12 @@ class ClassValuesContextHandler(ContextHandler):
             return (self.PERFECT_MATCH if context.classes is None
                     else self.NO_MATCH)
         else:
-            return (self.PERFECT_MATCH if context.classes == classes
-                    else self.NO_MATCH)
+            # variable.values used to be a list, and so were context.classes
+            # cast to tuple for compatibility with past contexts
+            if context.classes is not None and tuple(context.classes) == classes:
+                return self.PERFECT_MATCH
+            else:
+                return self.NO_MATCH
 
 
 class PerfectDomainContextHandler(DomainContextHandler):

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -739,7 +739,7 @@ class ProjectionWidgetTestMixin:
         hidden_var1.attributes["hidden"] = True
         hidden_var2 = ContinuousVariable("c2")
         hidden_var2.attributes["hidden"] = True
-        class_vars = [DiscreteVariable("cls", values=["a", "b"])]
+        class_vars = [DiscreteVariable("cls", values=("a", "b"))]
         table = Table(Domain([hidden_var1, hidden_var2], class_vars),
                       np.array([[0., 1.], [2., 3.]]),
                       np.array([[0.], [1.]]))
@@ -876,7 +876,7 @@ class datasets:
             Domain(
                 [ContinuousVariable("a"),
                  ContinuousVariable("b"),
-                 DiscreteVariable("c", values=["y", "n"])]
+                 DiscreteVariable("c", values=("y", "n"))]
             ),
             list(zip(
                 [42.48, 16.84, 15.23, 23.8],

--- a/Orange/widgets/tests/test_class_values_context_handler.py
+++ b/Orange/widgets/tests/test_class_values_context_handler.py
@@ -34,7 +34,7 @@ class TestClassValuesContextHandler(TestCase):
                 with_metas=[('d1', Discrete), ('d2', Discrete)]
             ))
         self.handler.global_contexts = \
-            [Mock(values={}), context, Mock(values={})]
+            [Mock(classes=[], values={}), context, Mock(classes=[], values={})]
 
         widget = SimpleWidget()
         self.handler.initialize(widget)
@@ -51,7 +51,7 @@ class TestClassValuesContextHandler(TestCase):
                 with_metas=[('d1', Discrete), ('d2', Discrete)]
             ))
         self.handler.global_contexts = \
-            [Mock(values={}), context, Mock(values={})]
+            [Mock(classes=[], values={}), context, Mock(classes=(), values={})]
         widget = SimpleWidget()
         self.handler.initialize(widget)
         widget.text = 'u'
@@ -59,7 +59,7 @@ class TestClassValuesContextHandler(TestCase):
         self.handler.open_context(widget, self.args[0][1])
 
         context = widget.current_context
-        self.assertEqual(context.classes, ['a', 'b', 'c'])
+        self.assertEqual(context.classes, ('a', 'b', 'c'))
         self.assertEqual(widget.text, 'u')
         self.assertEqual(widget.with_metas, [])
 

--- a/Orange/widgets/tests/test_domain_context_handler.py
+++ b/Orange/widgets/tests/test_domain_context_handler.py
@@ -52,7 +52,7 @@ class TestDomainContextHandler(TestCase):
         self.assertEqual(encoded_attributes,
                          {'c1': Continuous - 100, 'd1': Discrete - 100,
                           'd2': Discrete - 100,
-                          'd3': list('ghi')})
+                          'd3': tuple('ghi')})
         self.assertEqual(encoded_metas,
                          {'c2': Continuous - 100, 'd4': Discrete - 100})
 
@@ -63,10 +63,10 @@ class TestDomainContextHandler(TestCase):
         encoded_attributes, encoded_metas = handler.encode_domain(self.domain)
 
         self.assertEqual(encoded_attributes,
-                         {'c1': Continuous - 100, 'd1': list('abc'),
-                          'd2': list('def'), 'd3': list('ghi')})
+                         {'c1': Continuous - 100, 'd1': tuple('abc'),
+                          'd2': tuple('def'), 'd3': tuple('ghi')})
         self.assertEqual(encoded_metas,
-                         {'c2': Continuous - 100, 'd4': list('jkl')})
+                         {'c2': Continuous - 100, 'd4': tuple('jkl')})
 
     def test_match_returns_2_on_perfect_match(self):
         context = Mock(

--- a/Orange/widgets/unsupervised/owdbscan.py
+++ b/Orange/widgets/unsupervised/owdbscan.py
@@ -198,7 +198,7 @@ class OWDBSCAN(widget.OWWidget):
 
         clust_var = DiscreteVariable(
             "Cluster", values=["C%d" % (x + 1) for x in range(k)])
-        in_core_var = DiscreteVariable("DBSCAN Core", values=["0", "1"])
+        in_core_var = DiscreteVariable("DBSCAN Core", values=("0", "1"))
 
         domain = self.data.domain
         attributes, classes = domain.attributes, domain.class_vars

--- a/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
+++ b/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
@@ -28,9 +28,9 @@ class TestOWCorrespondence(WidgetTest):
         table = Table.from_list(
             Domain(
                 [ContinuousVariable("a"),
-                 DiscreteVariable("b", values=["t", "f"]),
-                 DiscreteVariable("c", values=["y", "n"]),
-                 DiscreteVariable("d", values=["k", "l", "z"])]
+                 DiscreteVariable("b", values=("t", "f")),
+                 DiscreteVariable("c", values=("y", "n")),
+                 DiscreteVariable("d", values=("k", "l", "z"))]
             ),
             list(zip(
                 [42.48, 16.84, 15.23, 23.8],
@@ -48,7 +48,7 @@ class TestOWCorrespondence(WidgetTest):
         """
         table = Table.from_list(
             Domain(
-                [DiscreteVariable("a", values=["0"])]
+                [DiscreteVariable("a", values=("0", ))]
             ),
             [(0,), (0,), (0,)]
         )

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -122,7 +122,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         table = Table.from_list(
             Domain(
                 [ContinuousVariable("a")],
-                [DiscreteVariable("b", values=["y"])]),
+                [DiscreteVariable("b", values=("y", ))]),
             list(zip([1.79e308, -1e120],
                      "yy"))
         )

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -118,7 +118,7 @@ class TestOWManifoldLearning(WidgetTest):
         table = Table(
             Domain(
                 [ContinuousVariable("a"), ContinuousVariable("b")],
-                class_vars=DiscreteVariable("c", values=["0", "1"])),
+                class_vars=DiscreteVariable("c", values=("0", "1"))),
             list(zip(
                 [1, 1, 1],
                 [0, 1, 2],

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -46,7 +46,7 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin, WidgetOutputsTestMixin):
 
         self.widget = self.create_widget(OWtSNE, stored_settings={"multiscale": False})
 
-        self.class_var = DiscreteVariable("Stage name", values=["STG1", "STG2"])
+        self.class_var = DiscreteVariable("Stage name", values=("STG1", "STG2"))
         self.attributes = [ContinuousVariable("GeneName" + str(i)) for i in range(5)]
         self.domain = Domain(self.attributes, class_vars=self.class_var)
         self.empty_domain = Domain([], class_vars=self.class_var)

--- a/Orange/widgets/utils/tests/test_annotated_data.py
+++ b/Orange/widgets/utils/tests/test_annotated_data.py
@@ -119,7 +119,7 @@ class TestAnnotatedData(unittest.TestCase):
             len(SameValue(selvar, "Unselected")(table)),
             len(self.zoo) - len(group_indices)
         )
-        self.assertEqual(selvar.values, ["G1", "G2", "Unselected"])
+        self.assertEqual(selvar.values, ("G1", "G2", "Unselected"))
 
     def test_create_groups_table_set_values(self):
         group_indices = random.sample(range(0, len(self.zoo)), 20)

--- a/Orange/widgets/utils/tests/test_colorpalettes.py
+++ b/Orange/widgets/utils/tests/test_colorpalettes.py
@@ -533,7 +533,7 @@ class PatchedVariableTest(unittest.TestCase):
 
 class PatchedDiscreteVariableTest(unittest.TestCase):
     def test_colors(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         self.assertIsNone(var._colors)
         self.assertEqual(var.colors.shape, (2, 3))
         self.assertFalse(var.colors.flags.writeable)
@@ -545,12 +545,12 @@ class PatchedDiscreteVariableTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             var.colors[0] = [42, 41, 40]
 
-        var = DiscreteVariable.make("x", values=["A", "B"])
+        var = DiscreteVariable.make("x", values=("A", "B"))
         var.attributes["colors"] = ['#0a0b0c', '#0d0e0f']
         np.testing.assert_almost_equal(var.colors, [[10, 11, 12], [13, 14, 15]])
 
         # Test ncolors adapts to nvalues
-        var = DiscreteVariable.make('foo', values=['d', 'r'])
+        var = DiscreteVariable.make('foo', values=('d', 'r'))
         self.assertEqual(len(var.colors), 2)
         var.add_value('e')
         self.assertEqual(len(var.colors), 3)
@@ -558,7 +558,7 @@ class PatchedDiscreteVariableTest(unittest.TestCase):
         self.assertEqual(len(var.colors), 4)
 
     def test_colors_fallback_to_palette(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         var.palette = Dark2Colors
         colors = var.colors
         self.assertEqual(len(colors), 2)
@@ -573,7 +573,7 @@ class PatchedDiscreteVariableTest(unittest.TestCase):
             np.testing.assert_equal(color, palcol.getRgb()[:3])
 
     def test_colors_default(self):
-        var = DiscreteVariable.make("a", values=["F", "M"])
+        var = DiscreteVariable.make("a", values=("F", "M"))
         colors = var.colors
         self.assertEqual(len(colors), 2)
         for color, palcol in zip(colors, DefaultRGBColors):
@@ -585,7 +585,7 @@ class PatchedDiscreteVariableTest(unittest.TestCase):
         for color, palcol in zip(colors, LimitedDiscretePalette(40)):
             np.testing.assert_equal(color, palcol.getRgb()[:3])
 
-        var = DiscreteVariable.make("a", values=["M", "F"])
+        var = DiscreteVariable.make("a", values=("M", "F"))
         var.attributes["colors"] = "foo"
         colors = var.colors
         self.assertEqual(len(colors), 2)
@@ -593,27 +593,27 @@ class PatchedDiscreteVariableTest(unittest.TestCase):
             np.testing.assert_equal(color, palcol.getRgb()[:3])
 
     def test_colors_no_values(self):
-        var = DiscreteVariable.make("a", values=[])
+        var = DiscreteVariable.make("a", values=())
         colors = var.colors
         self.assertEqual(len(colors), 0)
 
-        var = DiscreteVariable.make("a", values=[])
+        var = DiscreteVariable.make("a", values=())
         var.palette = DefaultRGBColors
         colors = var.colors
         self.assertEqual(len(colors), 0)
 
     def test_get_palette(self):
-        var = DiscreteVariable.make("a", values=["M", "F"])
+        var = DiscreteVariable.make("a", values=("M", "F"))
         palette = var.palette
         self.assertEqual(len(palette), 2)
         np.testing.assert_equal(palette.palette, DefaultRGBColors.palette[:2])
 
-        var = DiscreteVariable.make("a", values=["M", "F"])
+        var = DiscreteVariable.make("a", values=("M", "F"))
         var.attributes["palette"] = "dark"
         palette = var.palette
         self.assertIs(palette, Dark2Colors)
 
-        var = DiscreteVariable.make("a", values=["M", "F"])
+        var = DiscreteVariable.make("a", values=("M", "F"))
         var.attributes["colors"] = ['#0a0b0c', '#0d0e0f']
         palette = var.palette
         np.testing.assert_equal(palette.palette, [[10, 11, 12], [13, 14, 15]])

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -22,21 +22,21 @@ continuous_missing = VarDataPair(
 
 # Unordered discrete variable variations
 rgb_full = VarDataPair(
-    DiscreteVariable('rgb_full', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_full', values=('r', 'g', 'b')),
     np.array([0, 1, 1, 1, 2], dtype=float),
 )
 rgb_missing = VarDataPair(
-    DiscreteVariable('rgb_missing', values=['r', 'g', 'b']),
+    DiscreteVariable('rgb_missing', values=('r', 'g', 'b')),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
 )
 
 # Ordered discrete variable variations
 ints_full = VarDataPair(
-    DiscreteVariable('ints_full', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_full', values=('2', '3', '4'), ordered=True),
     np.array([0, 1, 1, 1, 2], dtype=float),
 )
 ints_missing = VarDataPair(
-    DiscreteVariable('ints_missing', values=['2', '3', '4'], ordered=True),
+    DiscreteVariable('ints_missing', values=('2', '3', '4'), ordered=True),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
 )
 

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -496,8 +496,8 @@ class OWBoxPlot(widget.OWWidget):
             self.dist = []
             self.conts = contingency.get_contingency(
                 dataset, attr, self.group_var)
-            group_var_labels = self.group_var.values + [
-                f"missing '{self.group_var.name}'"]
+            group_var_labels = self.group_var.values + (
+                f"missing '{self.group_var.name}'", )
             if self.is_continuous:
                 stats, label_texts = [], []
                 for i, cont in enumerate(self.conts.array_with_unknowns):
@@ -1074,7 +1074,7 @@ class OWBoxPlot(widget.OWWidget):
                 cond.append(FilterDiscrete(self.group_var, [group_val_index]))
             box.append(FilterGraphicsRectItem(cond, 0, -10, 1, 10))
         cum = 0
-        values = attr.values + [f"missing '{attr.name}'"]
+        values = attr.values + (f"missing '{attr.name}'", )
         colors = np.vstack((attr.colors, [128, 128, 128]))
         for i, v in enumerate(dist):
             if v < 1e-6:

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -81,7 +81,9 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         """Check widget with discrete data with missing values and group variable"""
         data = self.zoo
         data.X[:, 1] = np.nan
-        data.domain.attributes[1].values = []
+        # This is a test and does it at its own risk:
+        # pylint: disable=protected-access
+        data.domain.attributes[1]._values = []
         self.send_signal("Data", data)
         self.widget.controls.order_by_importance.setChecked(True)
         self._select_list_items(self.widget.controls.attribute)
@@ -92,7 +94,9 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         data = self.zoo
         data.domain.class_var = ContinuousVariable("cls")
         data.X[:, 1] = np.nan
-        data.domain.attributes[1].values = []
+        # This is a test and does it at its own risk:
+        # pylint: disable=protected-access
+        data.domain.attributes[1]._values = []
         self.send_signal("Data", data)
         self._select_list_items(self.widget.controls.attribute)
         self._select_list_items(self.widget.controls.group_var)

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -320,8 +320,8 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         handle this.
         """
         data = Table.from_list(
-            Domain([DiscreteVariable("a", values=["v1", "v2", "v3"]),
-                    DiscreteVariable("b", values=["v3", "v4"])]),
+            Domain([DiscreteVariable("a", values=("v1", "v2", "v3")),
+                    DiscreteVariable("b", values=("v3", "v4"))]),
             [[0., 0.],
              [0., 1.],
              [1., np.nan],

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -208,7 +208,7 @@ class TestOWDistributions(WidgetTest):
         widget = self.widget
 
         y = self.iris.domain.class_var
-        extra = DiscreteVariable("foo", values=["a", "b"])
+        extra = DiscreteVariable("foo", values=("a", "b"))
         domain = Domain(self.iris.domain.attributes + (extra, ), y)
         data = self.iris.transform(domain)
         data.X[:75, -1] = 0

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -183,7 +183,7 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
 
     def test_cls_with_single_instance(self):
         table = Table(Domain([ContinuousVariable("c1")],
-                             [DiscreteVariable("c2", values=["a", "b"])]),
+                             [DiscreteVariable("c2", values=("a", "b"))]),
                       np.array([[1], [2], [3]]), np.array([[0], [0], [1]]))
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.set_row_clustering(Clustering.Clustering)

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -73,7 +73,7 @@ class TestOWLinearProjection(WidgetTest, AnchorProjectionWidgetTestMixin,
         data = Table("iris")[:20]
         domain = data.domain
         domain = Domain(
-            attributes=domain.attributes[:4], class_vars=DiscreteVariable("class", values=["a"]))
+            attributes=domain.attributes[:4], class_vars=DiscreteVariable("class", values=("a", )))
         data = Table.from_numpy(domain=domain, X=data.X, Y=data.Y)
         self.assertTrue(w.radio_placement.buttons[1].isEnabled())
         self.send_signal(w.Inputs.data, data)

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -261,8 +261,8 @@ class TestOWNomogram(WidgetTest):
 
         ind = -1
         mocked_item().boundingRect().width.side_effect = mocked_width
-        attrs = [DiscreteVariable("var1", values=["foo1", "foo2"]),
-                 DiscreteVariable("var2", values=["foo3", "foo4"])]
+        attrs = [DiscreteVariable("var1", values=("foo1", "foo2")),
+                 DiscreteVariable("var2", values=("foo3", "foo4"))]
         points = [np.array([0, 1.8]), np.array([1.5, 2.0])]
         diff = np.max(points) - np.min(points)
         # foo3 eventually overcomes foo2, while the scale is getting smaller

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -198,7 +198,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         np.testing.assert_equal(selected_groups(), np.zeros(5))
         sel_column[:5] = 1
         np.testing.assert_equal(annotated(), sel_column)
-        self.assertEqual(annotations(), ["No", "Yes"])
+        self.assertEqual(annotations(), ("No", "Yes", ))
 
         # Shift-select 5:10; now we have groups 0:5 and 5:10
         with self.modifiers(Qt.ShiftModifier):
@@ -217,7 +217,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         sel_column[15:20] = 1
         np.testing.assert_equal(selectedx(), x[15:20])
         np.testing.assert_equal(selected_groups(), np.zeros(5))
-        self.assertEqual(annotations(), ["No", "Yes"])
+        self.assertEqual(annotations(), ("No", "Yes"))
 
         # Alt-select (remove) 10:17; we have 17:20
         with self.modifiers(Qt.AltModifier):
@@ -226,7 +226,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         np.testing.assert_equal(selected_groups(), np.zeros(3))
         sel_column[15:17] = 0
         np.testing.assert_equal(annotated(), sel_column)
-        self.assertEqual(annotations(), ["No", "Yes"])
+        self.assertEqual(annotations(), ("No", "Yes"))
 
         # Ctrl-Shift-select (add-to-last) 10:17; we have 17:25
         with self.modifiers(Qt.ShiftModifier | Qt.ControlModifier):
@@ -235,7 +235,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         np.testing.assert_equal(selected_groups(), np.zeros(8))
         sel_column[20:25] = 1
         np.testing.assert_equal(annotated(), sel_column)
-        self.assertEqual(annotations(), ["No", "Yes"])
+        self.assertEqual(annotations(), ("No", "Yes"))
 
         # Shift-select (add) 30:35; we have 17:25, 30:35
         with self.modifiers(Qt.ShiftModifier):

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -395,7 +395,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         data2 = Table("iris")[::30]
         data2.Y[:] = np.nan
         domain = Domain(
-            attributes=data2.domain.attributes[:4], class_vars=DiscreteVariable("iris", values=[]))
+            attributes=data2.domain.attributes[:4], class_vars=DiscreteVariable("iris", values=()))
         data2 = Table(domain, data2.X, Y=data2.Y)
         data3 = Table("iris")[::30]
         data3.Y[:] = np.nan
@@ -434,7 +434,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
                          ContinuousVariable("c2"),
                          ContinuousVariable("c3"),
                          ContinuousVariable("c4")],
-                        DiscreteVariable("cls", values=["a", "b"]))
+                        DiscreteVariable("cls", values=("a", "b")))
         X = np.zeros((10, 4))
         table = Table(domain, X, np.random.randint(2, size=10))
         self.send_signal(self.widget.Inputs.data, table)
@@ -460,7 +460,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
                          ContinuousVariable("c2"),
                          ContinuousVariable("c3"),
                          ContinuousVariable("c4")],
-                        DiscreteVariable("cls", values=["a", "b"]))
+                        DiscreteVariable("cls", values=("a", "b")))
         table = Table(domain, np.random.random((10, 4)), np.full(10, np.nan))
         self.send_signal(self.widget.Inputs.data, table)
         self.assertFalse(self.widget.vizrank_button.isEnabled())

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -104,8 +104,8 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         Check if it can calculate chi square when there are no attributes
         which suppose to be.
         """
-        a = DiscreteVariable("a", values=["y", "n"])
-        b = DiscreteVariable("b", values=["y", "n", "o"])
+        a = DiscreteVariable("a", values=("y", "n"))
+        b = DiscreteVariable("b", values=("y", "n", "o"))
         table = Table.from_list(Domain([a, b]), list(zip("yynny", "ynyyn")))
         chi = ChiSqStats(table, 0, 1)
         self.assertFalse(isnan(chi.chisq))
@@ -121,7 +121,7 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
                 [],
                 [],
                 [ContinuousVariable("a"),
-                 DiscreteVariable("b", values=["y", "n"])]
+                 DiscreteVariable("b", values=("y", "n"))]
             ),
             list(zip(
                 [42.48, 16.84, 15.23, 23.8],

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -149,7 +149,7 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         table = Table.from_list(
             Domain(
                 [ContinuousVariable("a"), ContinuousVariable("b"), ContinuousVariable("c")],
-                [DiscreteVariable("d", values=["y", "n"])]),
+                [DiscreteVariable("d", values=("y", "n"))]),
             list(zip([4, nan, nan],
                      [15, nan, nan],
                      [16, nan, nan],

--- a/benchmark/bench_domain.py
+++ b/benchmark/bench_domain.py
@@ -13,7 +13,7 @@ class BenchConversion(Benchmark):
         cols = 1000
         rows = 100
         cont = [ContinuousVariable(str(i)) for i in range(cols)]
-        disc = [DiscreteVariable("D" + str(i), values=["1", "2"]) for i in range(cols)]
+        disc = [DiscreteVariable("D" + str(i), values=("1", "2")) for i in range(cols)]
         self.domain = Domain(cont + disc)
         self.domain_x = Domain(list(self.domain.attributes) + [ContinuousVariable("x")])
         self.single = Domain([ContinuousVariable("0")])

--- a/doc/data-mining-library/source/tutorial/data.rst
+++ b/doc/data-mining-library/source/tutorial/data.rst
@@ -8,7 +8,7 @@ This section describes how to load the data in Orange. We also show how to explo
 Data Input
 ----------
 
-..  index:: 
+..  index::
     single: data; input
 
 Orange can read files in native tab-delimited format, or can load data from any of the major standard spreadsheet file types, like CSV and Excel. Native format starts with a header row with feature (column) names. The second header row gives the attribute type, which can be continuous, discrete, time, or string. The third header line contains meta information to identify dependent features (class), irrelevant features (ignore) or meta features (meta).
@@ -16,7 +16,7 @@ More detailed specification is available in :doc:`../reference/data.io`.
 Here are the first few lines from a dataset :download:`lenses.tab <code/lenses.tab>`::
 
     age       prescription  astigmatic    tear_rate     lenses
-    discrete  discrete      discrete      discrete      discrete 
+    discrete  discrete      discrete      discrete      discrete
                                                         class
     young     myope         no            reduced       none
     young     myope         no            normal        soft
@@ -28,7 +28,7 @@ Here are the first few lines from a dataset :download:`lenses.tab <code/lenses.t
 Values are tab-limited. This dataset has four attributes (age of the patient, spectacle prescription, notion on astigmatism, and information on tear production rate) and an associated three-valued dependent variable encoding lens prescription for the patient (hard contact lenses, soft contact lenses, no lenses). Feature descriptions could use one letter only, so the header of this dataset could also read::
 
     age       prescription  astigmatic    tear_rate     lenses
-    d         d             d             d             d 
+    d         d             d             d             d
                                                         c
 
 The rest of the table gives the data. Note that there are 5 instances in our table above. For the full dataset, check out or download :download:`lenses.tab <code/lenses.tab>`) to a target directory. You can also skip this step as Orange comes preloaded with several demo datasets, lenses being one of them. Now, open a python shell, import Orange and load the data:
@@ -40,12 +40,12 @@ The rest of the table gives the data. Note that there are 5 instances in our tab
 Note that for the file name no suffix is needed, as Orange checks if any files in the current directory are of a readable type. The call to ``Orange.data.Table`` creates an object called ``data`` that holds your dataset and information about the lenses domain:
 
     >>> data.domain.attributes
-    (DiscreteVariable('age', values=['pre-presbyopic', 'presbyopic', 'young']),
-     DiscreteVariable('prescription', values=['hypermetrope', 'myope']),
-     DiscreteVariable('astigmatic', values=['no', 'yes']),
-     DiscreteVariable('tear_rate', values=['normal', 'reduced']))
+    (DiscreteVariable('age', values=('pre-presbyopic', 'presbyopic', 'young')),
+     DiscreteVariable('prescription', values=('hypermetrope', 'myope')),
+     DiscreteVariable('astigmatic', values=('no', 'yes')),
+     DiscreteVariable('tear_rate', values=('normal', 'reduced')))
     >>> data.domain.class_var
-    DiscreteVariable('lenses', values=['hard', 'none', 'soft'])
+    DiscreteVariable('lenses', values=('hard', 'none', 'soft'))
     >>> for d in data[:3]:
        ...:     print(d)
        ...:
@@ -185,7 +185,7 @@ We can also construct a (classless) dataset from a numpy array::
 
 If we want to provide meaninful names to attributes, we need to construct an appropriate data domain::
 
-    >>> domain = Orange.data.Domain([Orange.data.ContinuousVariable("lenght"), 
+    >>> domain = Orange.data.Domain([Orange.data.ContinuousVariable("lenght"),
                                      Orange.data.ContinuousVariable("width")])
     >>> data = Orange.data.Table(domain, X)
     >>> data.domain
@@ -274,7 +274,7 @@ First three lines of the output of this script are::
 A single-liner that reports on number of data instances with at least one missing value is::
 
     >>> sum(any(np.isnan(d[x]) for x in data.domain.attributes) for d in data)
-    203 
+    203
 
 .. sum([np.any(np.isnan(x)) for x in data.X])
 


### PR DESCRIPTION
##### Issue

It is understood<sup>[by whom?]</sup> that `DiscreteVariable.values` shouldn't be modified.

##### Description of changes

It is enforced that `DiscreteVariable.values` can't be modified: it is made a read-only property, and changed from list to tuple.

##### Includes

- [X] Code changes
- [X] Tests
