### PR TITLE
Variable: Match two variables if they have the same compute_value=Identity

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -19,6 +19,7 @@ import Orange
 from Orange.data import Variable, ContinuousVariable, DiscreteVariable, \
     StringVariable, TimeVariable, Unknown, Value
 from Orange.data.io import CSVReader
+from Orange.preprocess.transformation import Identity
 from Orange.tests.base import create_pickling_tests
 from Orange.util import OrangeDeprecationWarning
 
@@ -142,6 +143,67 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(a, b)
         self.assertIsNot(a, b)
         self.assertNotEqual(a, "somestring")
+        self.assertEqual(hash(a), hash(b))
+
+    def test_eq_with_compute_value(self):
+        a = ContinuousVariable("a")
+        b = ContinuousVariable("a")
+        self.assertEqual(a, a)
+        self.assertEqual(a, b)
+        self.assertIsNot(a, b)
+
+        a._compute_value = lambda x: x
+        self.assertEqual(a, a)
+        self.assertNotEqual(a, b)
+
+        a1 = ContinuousVariable("a")
+        a2 = ContinuousVariable("a")
+        c = ContinuousVariable("c")
+
+        a._compute_value = Identity(a1)
+        self.assertEqual(a, a)
+        self.assertEqual(a, b)
+
+        b._compute_value = a.compute_value
+        self.assertEqual(a, b)
+
+        b._compute_value = Identity(a1)
+        self.assertEqual(a, b)
+
+        b._compute_value = Identity(a2)
+        self.assertEqual(a, b)
+
+        b._compute_value = Identity(c)
+        self.assertNotEqual(a, b)
+
+        b._compute_value = Identity(a2)
+        a1._compute_value = lambda x: x
+        self.assertNotEqual(a, b)
+
+        a1._compute_value = Identity(c)
+        self.assertNotEqual(a, b)
+
+        a2._compute_value = Identity(c)
+        self.assertEqual(a, b)
+
+    def test_hash(self):
+        a = ContinuousVariable("a")
+        b = ContinuousVariable("a")
+        self.assertEqual(hash(a), hash(b))
+
+        a._compute_value = lambda x: x
+        self.assertNotEqual(hash(a), hash(b))
+
+        b._compute_value = lambda x: x
+        self.assertNotEqual(hash(a), hash(b))
+
+        a1 = ContinuousVariable("a")
+        a2 = ContinuousVariable("a")
+
+        a._compute_value = Identity(a1)
+        self.assertNotEqual(hash(a), hash(b))
+
+        b._compute_value = Identity(a2)
         self.assertEqual(hash(a), hash(b))
 
 

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -347,12 +347,34 @@ class Variable(Reprable, metaclass=VariableMeta):
         return var
 
     def __eq__(self, other):
-        return type(self) is type(other) \
-               and self.name == other.name \
-               and self._compute_value == other._compute_value
+        # pylint: disable=protected-access,import-outside-toplevel
+
+        def to_match(var):
+            if var._compute_value is None:
+                return var
+            elif isinstance(var._compute_value, Identity):
+                return var._compute_value.variable
+            return None
+
+        from Orange.preprocess.transformation import Identity
+        return type(self) is type(other) and (
+            self.name == other.name
+            and self._compute_value == other._compute_value
+            or
+            (self.compute_value or other.compute_value)
+            and to_match(self) == to_match(other) != None)
 
     def __hash__(self):
-        return hash((self.name, type(self), self._compute_value))
+        # Two variables that are not equal can have the same hash.
+        # This happens if one has compute_value == Identity and the other
+        # doesn't have compute_value, or they have a different Identity.
+        # Having the same hash while not being equal is of course allowed.
+        # pylint: disable=import-outside-toplevel
+        from Orange.preprocess.transformation import Identity
+        compute_value = self._compute_value
+        if isinstance(self._compute_value, Identity):
+            compute_value = None
+        return hash((self.name, type(self), compute_value))
 
     @classmethod
     def make(cls, name, *args, **kwargs):

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -55,6 +55,12 @@ class Identity(Transformation):
     def transform(self, c):
         return c
 
+    def __eq__(self, other):
+        return type(other) is type(self) and self.variable == other.variable
+
+    def __hash__(self):
+        return hash((type(self), self.variable))
+
 
 class Indicator(Transformation):
     """

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -43,6 +43,8 @@ class TestTransformation(unittest.TestCase):
         trans = Transformation(self.data.domain[2])
         self.assertRaises(NotImplementedError, trans, self.data)
 
+
+class IdentityTest(unittest.TestCase):
     def test_identity(self):
         domain = Domain([ContinuousVariable("X")],
                         [DiscreteVariable("C", values=("0", "1", "2"))],
@@ -61,6 +63,20 @@ class TestTransformation(unittest.TestCase):
         np.testing.assert_equal(D1.X, D.X)
         np.testing.assert_equal(D1.Y, D.Y)
         np.testing.assert_equal(D1.metas, D.metas)
+
+    def test_eq_and_hash(self):
+        x = ContinuousVariable("x")
+        id_x1 = Identity(x)
+        id_x1b = Identity(x)
+        id_x2 = Identity(ContinuousVariable("x"))
+        self.assertEqual(id_x1, id_x1b)
+        self.assertEqual(hash(id_x1), hash(id_x1b))
+        self.assertEqual(id_x1, id_x2)
+        self.assertEqual(hash(id_x1), hash(id_x2))
+
+        id_y = Identity(ContinuousVariable("y"))
+        self.assertNotEqual(id_x1, id_y)
+        self.assertNotEqual(hash(id_x1), hash(id_y))
 
 
 class LookupTest(unittest.TestCase):


### PR DESCRIPTION
##### Issue

Renamed variables do not match their originals in widgets like Prediction.

##### Description of changes

Change `__eq__` and `__hash__` for `Variable` and `Identity`.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
