### PR TITLE
PyTableModel.__setitem__: properly emit signals

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -102,6 +102,7 @@ class PyTableModel(AbstractSortTableModel):
     # pylint: disable=missing-docstring
     def __init__(self, sequence=None, parent=None, editable=False):
         super().__init__(parent)
+        self._rows = self._cols = 0
         self._headers = {}
         self._editable = editable
         self._table = None
@@ -109,10 +110,10 @@ class PyTableModel(AbstractSortTableModel):
         self.wrap(sequence or [])
 
     def rowCount(self, parent=QModelIndex()):
-        return 0 if parent.isValid() else len(self)
+        return 0 if parent.isValid() else self._rows
 
     def columnCount(self, parent=QModelIndex()):
-        return 0 if parent.isValid() else max(map(len, self._table), default=0)
+        return 0 if parent.isValid() else self._cols
 
     def flags(self, index):
         flags = super().flags(index)
@@ -214,6 +215,7 @@ class PyTableModel(AbstractSortTableModel):
             del self[row:row + count]
             for rowidx in range(row, row + count):
                 self._roleData.pop(rowidx, None)
+            self._rows = self._table_dim()[0]
             return True
         return False
 
@@ -225,12 +227,17 @@ class PyTableModel(AbstractSortTableModel):
             for col in range(column, column + count):
                 cols.pop(col, None)
         del self._headers.get(Qt.Horizontal, [])[column:column + count]
+        self._cols = self._table_dim()[1]
         self.endRemoveColumns()
         return True
+
+    def _table_dim(self):
+        return len(self._table), max(map(len, self), default=0)
 
     def insertRows(self, row, count, parent=QModelIndex()):
         self.beginInsertRows(parent, row, row + count - 1)
         self._table[row:row] = [[''] * self.columnCount() for _ in range(count)]
+        self._rows = self._table_dim()[0]
         self.endInsertRows()
         return True
 
@@ -238,6 +245,7 @@ class PyTableModel(AbstractSortTableModel):
         self.beginInsertColumns(parent, column, column + count - 1)
         for row in self._table:
             row[column:column] = [''] * count
+        self._rows = self._table_dim()[0]
         self.endInsertColumns()
         return True
 
@@ -262,24 +270,37 @@ class PyTableModel(AbstractSortTableModel):
         self._check_sort_order()
         self.beginRemoveRows(QModelIndex(), start, stop)
         del self._table[i]
+        rows = self._table_dim()[0]
+        self._rows = rows
         self.endRemoveRows()
+        self._update_column_count()
 
     def __setitem__(self, i, value):
         self._check_sort_order()
         if isinstance(i, slice):
-            self.beginResetModel()
             start, stop, _ = _as_contiguous_range(i, len(self))
             self.removeRows(start, stop - start)
-            self.insertRows(start, len(value))
+            self.beginInsertRows(QModelIndex(), start, start + len(value) - 1)
             self._table[start:start + len(value)] = value
-            self.dataChanged.emit(
-                self.index(start, 0),
-                self.index(start + len(value) - 1, self.columnCount() - 1))
-            self.endResetModel()
+            self._rows = self._table_dim()[0]
+            self.endInsertRows()
+            self._update_column_count()
         else:
             self._table[i] = value
             self.dataChanged.emit(self.index(i, 0),
                                   self.index(i, self.columnCount() - 1))
+
+    def _update_column_count(self):
+        cols_before = self._cols
+        cols_after = self._table_dim()[1]
+        if cols_before < cols_after:
+            self.beginInsertColumns(QModelIndex(), cols_before, cols_after - 1)
+            self._cols = cols_after
+            self.endInsertColumns()
+        elif cols_before > cols_after:
+            self.beginRemoveColumns(QModelIndex(), cols_after, cols_before - 1)
+            self._cols = cols_after
+            self.endRemoveColumns()
 
     def _check_sort_order(self):
         if self.mapToSourceRows(Ellipsis) is not Ellipsis:
@@ -291,6 +312,7 @@ class PyTableModel(AbstractSortTableModel):
         self.beginResetModel()
         self._table = table
         self._roleData = self._RoleData()
+        self._rows, self._cols = self._table_dim()
         self.resetSorting()
         self.endResetModel()
 
@@ -302,6 +324,7 @@ class PyTableModel(AbstractSortTableModel):
         self._table.clear()
         self.resetSorting()
         self._roleData.clear()
+        self._rows, self._cols = self._table_dim()
         self.endResetModel()
 
     def append(self, row):

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -281,7 +281,7 @@ class PyTableModel(AbstractSortTableModel):
             start, stop, _ = _as_contiguous_range(i, len(self))
             self.removeRows(start, stop - start)
             self.beginInsertRows(QModelIndex(), start, start + len(value) - 1)
-            self._table[start:start + len(value)] = value
+            self._table[start:start] = value
             self._rows = self._table_dim()[0]
             self.endInsertRows()
             self._update_column_count()

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 
 from AnyQt.QtCore import Qt, QModelIndex
+from AnyQt.QtTest import QSignalSpy
 
 from Orange.data import \
     Domain, \
@@ -122,6 +123,27 @@ class TestPyTableModel(unittest.TestCase):
         self.assertTrue(Qt.AlignCenter &
                         self.model.data(self.model.index(1, 0),
                                         Qt.TextAlignmentRole))
+
+    def test_emits_column_changes_on_row_insert(self):
+        inserted = []
+        removed = []
+        model = PyTableModel()
+        model.columnsInserted.connect(inserted.append)
+        model.columnsRemoved.connect(removed.append)
+        inserted = QSignalSpy(model.columnsInserted)
+        removed = QSignalSpy(model.columnsRemoved)
+        model.append([2])
+        self.assertEqual(list(inserted)[-1][1:], [0, 0])
+        model.append([2, 3])
+        self.assertEqual(list(inserted)[-1][1:], [1, 1])
+        del model[:]
+        self.assertEqual(list(removed)[0][1:], [0, 1])
+        model.extend([[0, 1], [0, 2]])
+        self.assertEqual(list(inserted)[-1][1:], [0, 1])
+        model.clear()
+        self.assertEqual(list(removed)[0][1:], [0, 1])
+        model[:] = [[1], [2]]
+        self.assertEqual(list(inserted)[-1][1:], [0, 0])
 
 
 class TestVariableListModel(unittest.TestCase):

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -124,6 +124,19 @@ class TestPyTableModel(unittest.TestCase):
                         self.model.data(self.model.index(1, 0),
                                         Qt.TextAlignmentRole))
 
+    def test_set_iten_slice(self):
+        self.model[:1] = [[10, 11], [12, 13], [14, 15]]
+        self.assertEqual(list(self.model), [[10, 11], [12, 13], [14, 15], [2, 3]])
+
+        self.model[1:3] = []
+        self.assertEqual(list(self.model), [[10, 11], [2, 3]])
+
+        self.model[:] = [[20, 21]]
+        self.assertEqual(list(self.model), [[20, 21]])
+
+        self.model[1:] = [[10, 11], [2, 3]]
+        self.assertEqual(list(self.model), [[20, 21], [10, 11], [2, 3]])
+
     def test_emits_column_changes_on_row_insert(self):
         inserted = []
         removed = []


### PR DESCRIPTION
##### Issue

`PyTableModel.__setitem__` didn't properly signal the change: it emitted `dataChanged` for indices in the existing slice, which was empty for empty models.

0. In Time Series, pull https://github.com/biolab/orange3-timeseries/pull/80.
1. Take Datasets, load Philadelphia. 
2. Connect to Aggregate, change Aggregation function for one of the attributes.
3. Disconnect Aggregate
4. Connect again. Previous changes are gone (because they were not saved because the model didn't emit the signal properly).

##### Description of changes

Add proper signals.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
