### PR TITLE
[ENH] Use Github actions as a new CI system.

### DIFF
--- a/.github/workflows/cleanup_workflow.yml
+++ b/.github/workflows/cleanup_workflow.yml
@@ -1,0 +1,37 @@
+name: Cleanup workflow
+
+on: [push]
+
+# This is a temporary solution until Github actions provide an official support for this.
+# Workflow ids are located here: https://api.github.com/repos/biolab/orange3/actions/workflows
+
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - name: Cleanup Linux workflow
+        uses: styfle/cancel-workflow-action@0.2.0
+        with:
+          workflow_id: 685155
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup macOS workflow
+        uses: styfle/cancel-workflow-action@0.2.0
+        with:
+          workflow_id: 685156
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup Windows workflow
+        uses: styfle/cancel-workflow-action@0.2.0
+        with:
+          workflow_id: 685157
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup Documentation workflow
+        uses: styfle/cancel-workflow-action@0.2.0
+        with:
+          workflow_id: 685153
+          access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/doc_workflow.yml
+++ b/.github/workflows/doc_workflow.yml
@@ -1,0 +1,34 @@
+name: Documentation workflow
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        python: [3.7]
+        os: [ubuntu-18.04]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install linux system dependencies
+        run: sudo apt-get install -y libxkbcommon-x11-0
+
+      - name: Install Tox
+        run: pip install tox
+
+      - name: Build documentation
+        run:  xvfb-run -a -s "-screen 0 1280x1024x24" tox -e build_doc

--- a/.github/workflows/lint_workflow.yml
+++ b/.github/workflows/lint_workflow.yml
@@ -1,0 +1,34 @@
+name: Lint workflow
+
+on:
+  # Trigger the workflow on push or pull request, but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        python: [3.7]
+        os: [ubuntu-18.04]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '2'
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Tox
+        run: pip install tox
+
+      - name: Run Pylint
+        run:  tox -e pylint-ci

--- a/.github/workflows/linux_workflow.yml
+++ b/.github/workflows/linux_workflow.yml
@@ -1,0 +1,64 @@
+name: Linux workflow
+
+on:
+  # Trigger the workflow on push or pull request, but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        python: [3.6, 3.7]
+        os: [ubuntu-18.04]
+
+    services:
+      postgres:
+        image: orangedm/postgres:11
+        env:
+          POSTGRES_USER: postgres_user
+          POSTGRES_PASSWORD: postgres_password
+          POSTGRES_DB: postgres_db
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      SQLServer:
+        image: mcr.microsoft.com/mssql/server:2017-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: sqlServerPassw0rd
+        ports:
+          - 1433:1433
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install linux system dependencies
+        run: sudo apt-get install -y libxkbcommon-x11-0
+
+      - name: Install Tox
+        run: pip install tox
+
+      - name: Run Tox
+        run: xvfb-run -a -s "-screen 0 1280x1024x24" tox -e coverage
+        env:
+          ORANGE_TEST_DB_URI: postgres://postgres_user:postgres_password@localhost:5432/postgres_db|mssql://SA:sqlServerPassw0rd@localhost:1433
+
+      - name: Upload code coverage
+        if: matrix.python == '3.7'
+        run: |
+          pip install codecov
+          codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/macos_workflow.yml
+++ b/.github/workflows/macos_workflow.yml
@@ -1,0 +1,32 @@
+name: macOS workflow
+
+on:
+  # Trigger the workflow on push or pull request, but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        python: [3.6, 3.7]
+        os: [macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Tox
+        run: pip install tox
+
+      - name: Run Tox
+        run: tox -e py

--- a/.github/workflows/windows_workflow.yml
+++ b/.github/workflows/windows_workflow.yml
@@ -1,0 +1,31 @@
+name: Windows workflow
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        python: [3.6, 3.7]
+        os: [windows-2016]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Tox
+        run: pip install tox
+
+      - name: Run Tox
+        run: tox -e py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 requires = [
     "setuptools>=40.8.0",
     "wheel",
-    "numpy==1.14.5; python_version=='3.6'",
-    "numpy==1.14.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version=='3.8'",
+    "oldest-supported-numpy"
 ]
 
 build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -23,14 +23,15 @@ setenv =
     # our desire to have OrangeDeprecationWarnings raised
     PYTHONWARNINGS=module
 deps =
-    pyqt5!=5.10,<5.14
-    pyqtwebengine<5.14
+    pyqt5==5.13.*
+    pyqtwebengine==5.12.*
 commands_pre =
     # Verify installed packages have compatible dependencies
     pip check
     # freeze environment
     pip freeze
 commands =
+    # --buffer
     python -m unittest --verbose Orange.tests Orange.widgets.tests
 
 [testenv:coverage]
@@ -68,7 +69,8 @@ skip_install = true
 whitelist_externals = bash
 deps = pylint
 commands =
-    bash {toxinidir}/.travis/check_pylint_diff
+    bash .travis/check_pylint_diff
+;    bash .github/workflows/check_pylint_diff.sh
 
 [testenv:build_doc]
 changedir = {toxinidir}


### PR DESCRIPTION
**Issue**
Experimentally use Github actions as a new CI system. 

**Description of changes**
Run new CI alongside Travis and Appveyor to test how it behaves.

**Known downsides:**

##### Update: Previous running jobs are cancelled if a new commit is pushed to the same PR 👍 

Github action is not as feature reach as other systems because it was released not long ago. So I noticed that currently there is no officially supported way to cancel "stale" commits in a certain branch. Potentially this could be a problem. I hope there will soon be support for this. For now, we could use some third-party solutions that use Github public APIs (did not test those yet).
https://github.community/t5/GitHub-Actions/Github-actions-Cancel-redundant-builds/td-p/29549




To see running job go here: https://github.com/biolab/orange3/actions

**Linux job (ubuntu 18.04):**
- runs coverage for python 3.6 and 3.7. 
- spawns two contianers (Postgres and mssql)
- Postgres container comes with needed extensions. Dockerfile is defined in this PR: https://github.com/biolab/orange-tools/pull/15 and repository with docker image is here: https://hub.docker.com/repository/docker/orangedm/postgres
- Token for codecov upload is here: https://github.com/biolab/orange3/settings/secrets

**To-do:**
- [X] Complete tests with codecoverage (linux)
- [x] Run tests on Windows and MacOS (tests that need database support will be skipped.)
- [x] Pylint
- [x] Documentation build check
