### PR TITLE
Box Plot: Correct mean label rounding

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -15,6 +15,7 @@ from scipy.stats import f_oneway, chi2_contingency
 
 import Orange.data
 from Orange.data.filter import FilterDiscrete, FilterContinuous, Values
+from Orange.data.variable import MAX_NUM_OF_DECIMALS
 from Orange.statistics import contingency, distribution
 
 from Orange.widgets import widget, gui
@@ -824,7 +825,9 @@ class OWBoxPlot(widget.OWWidget):
 
     def mean_label(self, stat, attr, val_name):
         label = QGraphicsItemGroup()
-        t = QGraphicsSimpleTextItem(attr.str_val(stat.mean), label)
+        t = QGraphicsSimpleTextItem(
+            str(round(stat.mean, MAX_NUM_OF_DECIMALS)), label
+        )
         t.setFont(self._label_font)
         bbox = t.boundingRect()
         w2, h = bbox.width() / 2, bbox.height()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Mean label not rounded correctly when only whole numbers in data (read from file). In this case, the domain sets the formatting string to 0 decimal numbers. Box plot should not use `attr.str_val` for mean since in the described case mean of whole numbers can be a decimal number.

![Screenshot 2020-03-04 09 11 22](https://user-images.githubusercontent.com/6421558/75985762-26d56200-5eed-11ea-9f67-b38027c019fa.png)

##### Description of changes

Mean rounded to MAX_NUM_OF_DECIMALS (defined by a variable).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
