### PR TITLE
[ENH] OWColor: Data info displayed in the status bar

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -12,6 +12,7 @@ from Orange.widgets import widget, settings, gui
 from Orange.widgets.gui import HorizontalGridDelegate
 from Orange.widgets.utils import itemmodels, colorpalettes
 from Orange.widgets.utils.widgetpreview import WidgetPreview
+from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.widget import Input, Output
 from orangewidget.settings import IncompatibleContext
 
@@ -458,6 +459,9 @@ class OWColor(widget.OWWidget):
         box.button.setFixedWidth(180)
         box.layout().insertStretch(0)
 
+        self.info.set_input_summary(self.info.NoInput)
+        self.info.set_output_summary(self.info.NoOutput)
+
     @staticmethod
     def sizeHint():  # pragma: no cover
         return QSize(500, 570)
@@ -469,8 +473,10 @@ class OWColor(widget.OWWidget):
         self.cont_descs = []
         if data is None:
             self.data = self.domain = None
+            self.info.set_input_summary(self.info.NoInput)
         else:
             self.data = data
+            self.info.set_input_summary(len(data), format_summary_details(data))
             for var in chain(data.domain.variables, data.domain.metas):
                 if var.is_discrete:
                     self.disc_descs.append(DiscAttrDesc(var))
@@ -498,6 +504,7 @@ class OWColor(widget.OWWidget):
 
         if self.data is None:
             self.Outputs.data.send(None)
+            self.info.set_output_summary(self.info.NoOutput)
             return
 
         disc_dict = {desc.var.name: desc for desc in self.disc_descs}
@@ -507,6 +514,8 @@ class OWColor(widget.OWWidget):
         new_domain = Orange.data.Domain(
             make(dom.attributes), make(dom.class_vars), make(dom.metas))
         new_data = self.data.transform(new_domain)
+        self.info.set_output_summary(len(new_data),
+                                     format_summary_details(new_data))
         self.Outputs.data.send(new_data)
 
     def send_report(self):

--- a/Orange/widgets/data/tests/test_owcolor.py
+++ b/Orange/widgets/data/tests/test_owcolor.py
@@ -1,5 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring, protected-access
+# pylint: disable=missing-docstring, protected-access,unsubscriptable-object
 import unittest
 from unittest.mock import patch, Mock
 
@@ -10,6 +10,7 @@ from AnyQt.QtGui import QBrush
 from Orange.data import Table, ContinuousVariable, DiscreteVariable, Domain
 from Orange.util import color_to_hex
 from Orange.widgets.utils import colorpalettes
+from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.data import owcolor
 from Orange.widgets.data.owcolor import ColorRole
 from Orange.widgets.tests.base import WidgetTest
@@ -482,6 +483,25 @@ class TestOWColor(WidgetTest):
 
     def test_string_variables(self):
         self.send_signal(self.widget.Inputs.data, Table("zoo"))
+
+    def test_summary(self):
+        """Check if the status bar is updated when data is received"""
+        data = self.iris
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        self.send_signal(self.widget.Inputs.data, data)
+        input_sum.assert_called_with(len(data), format_summary_details(data))
+        output = self.get_output(self.widget.Outputs.data)
+        output_sum.assert_called_with(len(output),
+                                      format_summary_details(output))
+        input_sum.reset_mock()
+        output_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")
+        output_sum.assert_called_once()
+        self.assertEqual(output_sum.call_args[0][0].brief, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Description of changes
Input/output data info displayed in the status bar.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
