### PR TITLE
[ENH] OWPurgeDomain: Data info displayed in the status bar

### DIFF
--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -5,6 +5,7 @@ from Orange.widgets import gui, widget
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.utils.widgetpreview import WidgetPreview
+from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.widget import Input, Output
 
 
@@ -100,11 +101,16 @@ class OWPurgeDomain(widget.OWWidget):
         gui.auto_send(self.buttonsArea, self, "autoSend")
         gui.rubber(self.controlArea)
 
+        self.info.set_input_summary(self.info.NoInput)
+        self.info.set_output_summary(self.info.NoOutput)
+
     @Inputs.data
     @check_sql_input
     def setData(self, dataset):
         if dataset is not None:
             self.data = dataset
+            self.info.set_input_summary(len(dataset),
+                                        format_summary_details(dataset))
             self.unconditional_commit()
         else:
             self.removedAttrs = "-"
@@ -117,6 +123,8 @@ class OWPurgeDomain(widget.OWWidget):
             self.reducedMetas = "-"
             self.Outputs.data.send(None)
             self.data = None
+            self.info.set_input_summary(self.info.NoInput)
+            self.info.set_output_summary(self.info.NoOutput)
 
     def optionsChanged(self):
         self.commit()
@@ -149,6 +157,8 @@ class OWPurgeDomain(widget.OWWidget):
         self.removedMetas = meta_res['removed']
         self.reducedMetas = meta_res['reduced']
 
+        self.info.set_output_summary(len(cleaned),
+                                     format_summary_details(cleaned))
         self.Outputs.data.send(cleaned)
 
     def send_report(self):

--- a/Orange/widgets/data/tests/test_owpurgedomain.py
+++ b/Orange/widgets/data/tests/test_owpurgedomain.py
@@ -1,0 +1,32 @@
+# pylint: disable=unsubscriptable-object
+from unittest.mock import Mock
+
+from Orange.data import Table
+from Orange.widgets.data.owpurgedomain import OWPurgeDomain
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.utils.state_summary import format_summary_details
+
+
+class TestOWPurgeDomain(WidgetTest):
+    def setUp(self):
+        self.widget = self.create_widget(OWPurgeDomain)
+        self.iris = Table("iris")
+
+    def test_summary(self):
+        """Check if the status bar is updated when data is received"""
+        data = self.iris
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        self.send_signal(self.widget.Inputs.data, data)
+        input_sum.assert_called_with(len(data), format_summary_details(data))
+        output = self.get_output(self.widget.Outputs.data)
+        output_sum.assert_called_with(len(output),
+                                      format_summary_details(output))
+        input_sum.reset_mock()
+        output_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")
+        output_sum.assert_called_once()
+        self.assertEqual(output_sum.call_args[0][0].brief, "")


### PR DESCRIPTION
##### Description of changes
Input/output data info displayed in the status bar.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
