### PR TITLE
[ENH] Impose a sensible z-order to points in projections 

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -804,7 +804,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
 
     def _update_plot_coordinates(self, plot, x, y):
         """
-        Change the coordinates of points while keeping other properites
+        Change the coordinates of points while keeping other properites.
+
+        Asserts that the number of points stays the same.
 
         Note. Pyqtgraph does not offer a method for this: setting coordinates
         invalidates other data. We therefore retrieve the data to set it
@@ -814,6 +816,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         update for every property would essentially reset the graph, which
         can be time consuming.
         """
+        assert self.n_shown == len(x) == len(y)
         data = dict(x=x, y=y)
         for prop in ('pen', 'brush', 'size', 'symbol', 'data',
                      'sourceRect', 'targetRect'):

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -128,7 +128,8 @@ class LegendItem(PgLegendItem):
         anchor, parentanchor = anchors
         self.anchor(*bound_anchor_pos(anchor, parentanchor))
 
-    def paint(self, painter, option, widget=None):
+    # pylint: disable=arguments-differ
+    def paint(self, painter, _option, _widget=None):
         painter.setPen(self.__pen)
         painter.setBrush(self.__brush)
         rect = self.contentsRect()
@@ -619,7 +620,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
     def update_jittering(self):
         self.update_tooltip()
         x, y = self.get_coordinates()
-        if x is None or not len(x) or self.scatterplot_item is None:
+        if x is None or len(x) == 0 or self.scatterplot_item is None:
             return
         self._update_plot_coordinates(self.scatterplot_item, x, y)
         self._update_plot_coordinates(self.scatterplot_item_sel, x, y)
@@ -834,7 +835,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         the complete update by calling `reset_graph` instead of this method.
         """
         x, y = self.get_coordinates()
-        if x is None or not len(x):
+        if x is None or len(x) == 0:
             return
         if self.scatterplot_item is None:
             if self.sample_indices is None:
@@ -1053,9 +1054,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         # Reuse pens and brushes with the same colors because PyQtGraph then
         # builds smaller pixmap atlas, which makes the drawing faster
 
-        def reuse(cache, fn, *args):
+        def reuse(cache, fun, *args):
             if args not in cache:
-                cache[args] = fn(args)
+                cache[args] = fun(args)
             return cache[args]
 
         def create_pen(col):
@@ -1113,7 +1114,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
 
     def update_colors(self):
         """
-        Trigger an update of point sizes
+        Trigger an update of point colors
 
         The method calls `self.get_colors`, which in turn calls the widget's
         `get_color_data` to get the indices in the pallette. `get_colors`

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -58,6 +58,7 @@ class TestOWScatterPlotBase(WidgetTest):
     # pylint: disable=keyword-arg-before-vararg
     def setRange(self, rect=None, *_, **__):
         if isinstance(rect, QRectF):
+            # pylint: disable=attribute-defined-outside-init
             self.last_setRange = [[rect.left(), rect.right()],
                                   [rect.top(), rect.bottom()]]
 
@@ -308,12 +309,13 @@ class TestOWScatterPlotBase(WidgetTest):
 
     base = "Orange.widgets.visualize.owscatterplotgraph.OWScatterPlotBase."
 
+    @staticmethod
     @patch(base + "update_sizes")
     @patch(base + "update_colors")
     @patch(base + "update_selection_colors")
     @patch(base + "update_shapes")
     @patch(base + "update_labels")
-    def test_reset_calls_all_updates_and_update_doesnt(self, *mocks):
+    def test_reset_calls_all_updates_and_update_doesnt(*mocks):
         master = MockWidget()
         graph = OWScatterPlotBase(master)
         for mock in mocks:
@@ -443,6 +445,7 @@ class TestOWScatterPlotBase(WidgetTest):
 
         graph = self.graph
 
+        # pylint: disable=attribute-defined-outside-init
         self.master.get_size_data = lambda: d
         self.master.impute_sizes = impute_max
         d = np.arange(10, dtype=float)
@@ -1168,6 +1171,7 @@ class TestOWScatterPlotBase(WidgetTest):
         def impute0(data, _):
             data[np.isnan(data)] = 0
 
+        # pylint: disable=attribute-defined-outside-init
         self.master.impute_shapes = impute0
         d = np.arange(10, dtype=float) % 3
         d[2] = np.nan

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring,too-many-lines,too-many-public-methods
 # pylint: disable=protected-access
+from itertools import count
 from unittest.mock import patch, Mock
 import numpy as np
 
@@ -9,6 +10,7 @@ from AnyQt.QtTest import QSignalSpy
 
 from pyqtgraph import mkPen
 
+from orangewidget.tests.base import GuiTest
 from Orange.widgets.settings import SettingProvider
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils import colorpalettes
@@ -700,6 +702,127 @@ class TestOWScatterPlotBase(WidgetTest):
             else:
                 self.assertEqual(pen.style(), Qt.NoPen)
 
+    def test_z_values(self):
+        def check_ranks(exp_ranks):
+            z = set_z.call_args[0][0]
+            self.assertEqual(len(z), len(exp_ranks))
+            for i, exp1, z1 in zip(count(), exp_ranks, z):
+                for j, exp2, z2 in zip(range(i), exp_ranks, z):
+                    if exp1 != exp2:
+                        self.assertEqual(exp1 < exp2, z1 < z2,
+                                         f"error at pair ({j}, {i})")
+
+        colors = np.array([0, 1, 1, 0, np.nan, 2, 2, 2, 1, 1])
+        self.master.get_color_data = lambda: colors
+        self.master.is_continuous_color = lambda: False
+
+        graph = self.graph
+        with patch.object(ScatterPlotItem, "setZ") as set_z:
+            # Just colors
+            graph.reset_graph()
+            check_ranks([3, 1, 1, 3, 0, 2, 2, 2, 1, 1])
+
+            # Colors and selection
+            graph.selection_select([1, 5])
+            check_ranks([3, 11, 1, 3, 0, 12, 2, 2, 1, 1])
+
+            # Colors and selection, and nan is selected
+            graph.selection_append([4])
+            check_ranks([3, 11, 1, 3, 10, 12, 2, 2, 1, 1])
+
+            # Just colors again, no selection
+            graph.selection_select([])
+            check_ranks([3, 1, 1, 3, 0, 2, 2, 2, 1, 1])
+
+            # Colors and subset
+            self.master.get_subset_mask = \
+                lambda: np.array([True, True, False, False, True] * 2)
+            graph.update_colors()  # selecting subset triggers update_colors
+            check_ranks([23, 21, 1, 3, 20, 22, 22, 2, 1, 21])
+
+            # Colors, subset and selection
+            graph.selection_select([1, 5])
+            check_ranks([23, 31, 1, 3, 20, 32, 22, 2, 1, 21])
+
+            # Continuous colors
+            self.master.is_continuous_color = lambda: True
+            graph.update_colors()
+            check_ranks([20, 30, 0, 0, 20, 30, 20, 0, 0, 20])
+
+            # No colors => just subset and selection
+            # pylint: disable=attribute-defined-outside-init
+            self.master.get_colors = lambda: None
+            graph.update_colors()
+            check_ranks([20, 30, 0, 0, 20, 30, 20, 0, 0, 20])
+
+            # No selection or subset, but continuous colors with nan
+            graph.selection_select([1, 5])
+            self.master.get_subset_mask = lambda: None
+            self.master.get_color_data = lambda: colors
+            graph.update_colors()
+            check_ranks(np.isfinite(colors))
+
+    def test_z_values_with_sample(self):
+        def check_ranks(exp_ranks):
+            z = set_z.call_args[0][0]
+            self.assertEqual(len(z), len(exp_ranks))
+            for i, exp1, z1 in zip(count(), exp_ranks, z):
+                for j, exp2, z2 in zip(range(i), exp_ranks, z):
+                    if exp1 != exp2:
+                        self.assertEqual(exp1 < exp2, z1 < z2,
+                                         f"error at pair ({j}, {i})")
+
+        def create_sample():
+            graph.sample_indices = np.array([0, 1, 3, 4, 5, 6, 7, 8, 9])
+            graph.n_shown = 9
+
+        graph = self.graph
+        graph.sample_size = 9
+        graph._create_sample = create_sample
+
+        self.master.is_continuous_color = lambda: False
+        self.master.get_color_data = \
+            lambda: np.array([0, 1, 1, 0, np.nan, 2, 2, 2, 1, 1])
+
+        with patch.object(ScatterPlotItem, "setZ") as set_z:
+            # Just colors
+            graph.reset_graph()
+            check_ranks([3, 1, 3, 0, 2, 2, 2, 1, 1])
+
+            # Colors and selection
+            graph.selection_select([1, 5])
+            check_ranks([3, 11, 3, 0, 12, 2, 2, 1, 1])
+
+            # Colors and selection, and nan is selected
+            graph.selection_append([4])
+            check_ranks([3, 11, 3, 10, 12, 2, 2, 1, 1])
+
+            # Just colors again, no selection
+            graph.selection_select([])
+            check_ranks([3, 1, 3, 0, 2, 2, 2, 1, 1])
+
+            # Colors and subset
+            self.master.get_subset_mask = \
+                lambda: np.array([True, True, False, False, True] * 2)
+            graph.update_colors()  # selecting subset triggers update_colors
+            check_ranks([23, 21, 3, 20, 22, 22, 2, 1, 21])
+
+            # Colors, subset and selection
+            graph.selection_select([1, 5])
+            check_ranks([23, 31, 3, 20, 32, 22, 2, 1, 21])
+
+            # Continuous colors => just subset and selection
+            self.master.is_continuous_color = lambda: False
+            graph.update_colors()
+            check_ranks([20, 30, 0, 20, 30, 20, 0, 0, 20])
+
+            # No colors => just subset and selection
+            self.master.is_continuous_color = lambda: True
+            # pylint: disable=attribute-defined-outside-init
+            self.master.get_colors = lambda: None
+            graph.update_colors()
+            check_ranks([20, 30, 0, 20, 30, 20, 0, 0, 20])
+
     def test_density(self):
         graph = self.graph
         density = object()
@@ -1292,6 +1415,91 @@ class TestOWScatterPlotBase(WidgetTest):
         graph = self.graph
         graph.reset_graph()
         self.assertIsNone(graph.scatterplot_item.fragmentAtlas.atlas)
+
+
+class TestScatterPlotItem(GuiTest):
+    def test_setZ(self):
+        """setZ sets the appropriate mapping and inverse mapping"""
+        scp = ScatterPlotItem(x=np.arange(5), y=np.arange(5))
+        scp.setZ(np.array([3.12, 5.2, 1.2, 0, 2.15]))
+        np.testing.assert_equal(scp._z_mapping, [3, 2, 4, 0, 1])
+        np.testing.assert_equal(scp._inv_mapping, [3, 4, 1, 0, 2])
+
+        scp.setZ(None)
+        self.assertIsNone(scp._z_mapping)
+        self.assertIsNone(scp._inv_mapping)
+
+        self.assertRaises(AssertionError, scp.setZ, np.arange(4))
+
+    @staticmethod
+    def test_paint_mapping():
+        """paint permutes the points and reverses the permutation afterwards"""
+        def test_self_data(this, *_, **_1):
+            x, y = this.getData()
+            np.testing.assert_equal(x, exp_x)
+            np.testing.assert_equal(y, exp_y)
+
+        orig_x = np.arange(10, 15)
+        orig_y = np.arange(20, 25)
+        scp = ScatterPlotItem(x=orig_x[:], y=orig_y[:])
+        with patch("pyqtgraph.ScatterPlotItem.paint", new=test_self_data):
+            exp_x = orig_x
+            exp_y = orig_y
+            scp.paint(Mock(), Mock())
+
+            scp._z_mapping = np.array([3, 2, 4, 0, 1])
+            scp._inv_mapping = np.array([3, 4, 1, 0, 2])
+            exp_x = [13, 12, 14, 10, 11]
+            exp_y = [23, 22, 24, 20, 21]
+            scp.paint(Mock(), Mock())
+            x, y = scp.getData()
+            np.testing.assert_equal(x, np.arange(10, 15))
+            np.testing.assert_equal(y, np.arange(20, 25))
+
+    def test_paint_mapping_exception(self):
+        """exception in paint does not leave the points permuted"""
+        orig_x = np.arange(10, 15)
+        orig_y = np.arange(20, 25)
+        scp = ScatterPlotItem(x=orig_x[:], y=orig_y[:])
+        scp._z_mapping = np.array([3, 2, 4, 0, 1])
+        scp._inv_mapping = np.array([3, 4, 1, 0, 2])
+        with patch("pyqtgraph.ScatterPlotItem.paint", side_effect=ValueError):
+            self.assertRaises(ValueError, scp.paint, Mock(), Mock())
+            x, y = scp.getData()
+            np.testing.assert_equal(x, np.arange(10, 15))
+            np.testing.assert_equal(y, np.arange(20, 25))
+
+    @staticmethod
+    def test_paint_mapping_integration():
+        """setZ causes rendering in the appropriate order"""
+        def test_self_data(this, *_, **_1):
+            x, y = this.getData()
+            np.testing.assert_equal(x, exp_x)
+            np.testing.assert_equal(y, exp_y)
+
+        orig_x = np.arange(10, 15)
+        orig_y = np.arange(20, 25)
+        scp = ScatterPlotItem(x=orig_x[:], y=orig_y[:])
+        with patch("pyqtgraph.ScatterPlotItem.paint", new=test_self_data):
+            exp_x = orig_x
+            exp_y = orig_y
+            scp.paint(Mock(), Mock())
+
+            scp.setZ(np.array([3.12, 5.2, 1.2, 0, 2.15]))
+            exp_x = [13, 12, 14, 10, 11]
+            exp_y = [23, 22, 24, 20, 21]
+            scp.paint(Mock(), Mock())
+            x, y = scp.getData()
+            np.testing.assert_equal(x, np.arange(10, 15))
+            np.testing.assert_equal(y, np.arange(20, 25))
+
+            scp.setZ(None)
+            exp_x = orig_x
+            exp_y = orig_y
+            scp.paint(Mock(), Mock())
+            x, y = scp.getData()
+            np.testing.assert_equal(x, np.arange(10, 15))
+            np.testing.assert_equal(y, np.arange(20, 25))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Fixes #4487.

##### Description of changes

- Adds `setZ` to `owscatterplotgraph.ScatterPlotItem`
- Computes z-values in `OWScatterPlotBase`

Review by commits.

##### Includes
- [X] Code changes
- [X] Tests
