### PR TITLE
[FiX] Venn diagram crashes on tables with no X

### DIFF
--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -379,8 +379,12 @@ class OWVennDiagram(widget.OWWidget):
             X = np.hstack(values['attributes'])
         if 'metas' in values:
             metas = np.hstack(values['metas'])
+            n = len(metas)
         if 'class_vars' in values:
             class_vars = np.hstack(values['class_vars'])
+            n = len(class_vars)
+        if X is None:
+            X = np.empty((n,0))
         table = Table.from_numpy(Domain(**domain), X, class_vars, metas)
         if ids is not None:
             table.ids = ids
@@ -388,7 +392,7 @@ class OWVennDiagram(widget.OWWidget):
 
     def extract_columnwise(self, var_dict, columns=None):
         #for columns
-        domain = defaultdict(list)
+        domain = {type_ : [] for type_ in self.atr_types} 
         values = defaultdict(list)
         renamed = []
         for atr_type, vars_dict in var_dict.items():
@@ -514,7 +518,7 @@ class OWVennDiagram(widget.OWWidget):
         for table_key, dict_ in ids.items():
             permutations[table_key] = get_perm(list(dict_), all_ids)
 
-        domain = defaultdict(list)
+        domain = {type_ : [] for type_ in self.atr_types}
         values = defaultdict(list)
         renamed = []
         for atr_type, vars_dict in var_dict.items():
@@ -551,8 +555,8 @@ class OWVennDiagram(widget.OWWidget):
 
         if renamed:
             self.Warning.renamed_vars(', '.join(renamed))
-        idas = None if self.selected_feature else np.array(all_ids)
-        table = self.merge_data(domain, values, idas)
+        ids = None if self.selected_feature else np.array(all_ids)
+        table = self.merge_data(domain, values, ids)
         if selection:
             mask = [idx in self.selected_items for idx in all_ids]
             return create_annotated_table(table, mask)

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -384,15 +384,14 @@ class OWVennDiagram(widget.OWWidget):
             class_vars = np.hstack(values['class_vars'])
             n = len(class_vars)
         if X is None:
-            X = np.empty((n,0))
+            X = np.empty((n, 0))
         table = Table.from_numpy(Domain(**domain), X, class_vars, metas)
         if ids is not None:
             table.ids = ids
         return table
 
     def extract_columnwise(self, var_dict, columns=None):
-        #for columns
-        domain = {type_ : [] for type_ in self.atr_types} 
+        domain = {type_ : [] for type_ in self.atr_types}
         values = defaultdict(list)
         renamed = []
         for atr_type, vars_dict in var_dict.items():

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -12,10 +12,10 @@ from Orange.data import (Table, Domain, StringVariable,
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.utils.annotated_data import (ANNOTATED_DATA_FEATURE_NAME)
 from Orange.widgets.visualize.owvenndiagram import (
-                                                    OWVennDiagram,
-                                                    arrays_equal,
-                                                    pad_columns,
-                                                    get_perm)
+                        OWVennDiagram,
+                        arrays_equal,
+                        pad_columns,
+                        get_perm)
 
 
 class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
@@ -224,6 +224,15 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.signal_name, None, 6)
         self.assertFalse(self.widget.Error.too_many_inputs.is_shown())
 
+    def test_no_attributes(self):
+        domain = Domain([], class_vars=self.data.domain.attributes)
+        n = len(self.data)
+        table = Table.from_numpy(domain, np.empty((n, 0)), self.data.X)
+
+        self.widget.rowwise = True
+        self.send_signal(self.signal_name, table, 1)
+        out = self.get_output(self.widget.Outputs.annotated_data)
+        self.assertEqual(len(out), len(table))
 
 class TestVennUtilities(unittest.TestCase):
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Venn diagram didn't handle properly tables where there are only metas and/or class vars.:

##### Includes
- [X] Code changes
- [X] Tests
