### PR TITLE
[WIP] OWPaintData: Fix Reset to Input; Data info displayed in the status bar

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1029,7 +1029,6 @@ class OWPaintData(OWWidget):
         else:
             self.input_data = np.column_stack((X, y))
         self.reset_to_input()
-        self.unconditional_commit()
 
     def reset_to_input(self):
         """Reset the painting to input data if present."""
@@ -1058,6 +1057,8 @@ class OWPaintData(OWWidget):
             self.set_dimensions()
         else:  # set_dimensions already calls _replot, no need to call it again
             self._replot()
+
+        self.commit()
 
     def add_new_class_label(self, undoable=True):
 

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -29,6 +29,7 @@ from Orange.widgets.utils import itemmodels, colorpalettes
 
 from Orange.util import scale, namegen
 from Orange.widgets.utils.widgetpreview import WidgetPreview
+from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 
 
@@ -862,6 +863,9 @@ class OWPaintData(OWWidget):
         buttonBox = gui.hBox(tBox)
         toolsBox = gui.widgetBox(buttonBox, orientation=QGridLayout())
 
+        self.info.set_input_summary(self.info.NoInput)
+        self.info.set_output_summary(self.info.NoOutput)
+
         self.toolActions = QActionGroup(self)
         self.toolActions.setExclusive(True)
         self.toolButtons = []
@@ -996,11 +1000,15 @@ class OWPaintData(OWWidget):
                 self.Warning.sparse_not_supported()
                 return False
             if data:
+                self.info.set_input_summary(len(data),
+                                            format_summary_details(data))
                 if not data.domain.attributes:
                     self.Warning.no_input_variables()
                     data = None
                 elif len(data.domain.attributes) > 2:
                     self.Information.use_first_two()
+            else:
+                self.info.set_input_summary(self.info.NoInput)
             self.input_data = data
             self.btResetToInput.setDisabled(data is None)
             return bool(data)
@@ -1262,6 +1270,7 @@ class OWPaintData(OWWidget):
     def commit(self):
         if not self.data:
             self.Outputs.data.send(None)
+            self.info.set_output_summary(self.info.NoOutput)
             return
         data = np.array(self.data)
         if self.hasAttr2:
@@ -1283,6 +1292,8 @@ class OWPaintData(OWWidget):
             data = Orange.data.Table.from_numpy(domain, X)
         data.name = self.table_name
         self.Outputs.data.send(data)
+        self.info.set_output_summary(len(data),
+                                     format_summary_details(data))
 
     def sizeHint(self):
         sh = super().sizeHint()

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring, protected-access
+# pylint: disable=missing-docstring, protected-access, unsubscriptable-object
+from unittest.mock import Mock
 
 import numpy as np
 import scipy.sparse as sp
@@ -10,6 +11,7 @@ from Orange.data import Table, DiscreteVariable, ContinuousVariable, Domain
 from Orange.widgets.data import owpaintdata
 from Orange.widgets.data.owpaintdata import OWPaintData
 from Orange.widgets.tests.base import WidgetTest, datasets
+from Orange.widgets.utils.state_summary import format_summary_details
 
 
 class TestOWPaintData(WidgetTest):
@@ -79,3 +81,20 @@ class TestOWPaintData(WidgetTest):
         GH-2399
         """
         self.create_widget(OWPaintData, stored_settings={"data": []})
+
+    def test_summary(self):
+        """Check if status bar is updated when data is received"""
+        input_sum = self.widget.info.set_input_summary = Mock()
+        output_sum = self.widget.info.set_output_summary = Mock()
+
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, data)
+        input_sum.assert_called_with(len(data), format_summary_details(data))
+        output = self.get_output(self.widget.Outputs.data)
+        output_sum.assert_called_with(len(output),
+                                      format_summary_details(output))
+
+        input_sum.reset_mock()
+        self.send_signal(self.widget.Inputs.data, None)
+        input_sum.assert_called_once()
+        self.assertEqual(input_sum.call_args[0][0].brief, "")


### PR DESCRIPTION
##### Description of changes
Fixes #4514 .
Input / Output data info displayed in the status bar.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
