### PR TITLE
[FIX] run cleanup job on PR push

### DIFF
--- a/.github/workflows/cleanup_workflow.yml
+++ b/.github/workflows/cleanup_workflow.yml
@@ -1,6 +1,12 @@
 name: Cleanup workflow
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 # This is a temporary solution until Github actions provide an official support for this.
 # Workflow ids are located here: https://api.github.com/repos/biolab/orange3/actions/workflows


### PR DESCRIPTION
Run cleanup job when new commits are pushed to the pull request.