### PR TITLE
heatmap: Fix aspect preserving scaling when a part of a 'split' is empty

### DIFF
--- a/Orange/widgets/utils/graphicslayoutitem.py
+++ b/Orange/widgets/utils/graphicslayoutitem.py
@@ -142,6 +142,8 @@ def scaled(size: QSizeF, constraint: QSizeF, mode=Qt.KeepAspectRatio) -> QSizeF:
     ie. the result is not constrained in that dimension.
     """
     size, constraint = QSizeF(size), QSizeF(constraint)
+    if size.isEmpty():
+        return size
     if constraint.width() < 0 and constraint.height() < 0:
         return size
     if mode == Qt.IgnoreAspectRatio:

--- a/Orange/widgets/utils/tests/test_graphicstextlist.py
+++ b/Orange/widgets/utils/tests/test_graphicstextlist.py
@@ -85,3 +85,7 @@ class TestUtils(unittest.TestCase):
                 s, expected,
                 f"scaled({size}, {const}, Qt.KeepAspectRatioByExpanding)"
             )
+
+        self.assertEqual(
+            scaled(QSizeF(0, 0), QSizeF(100, 100)), QSizeF(0, 0)
+        )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Workflow:

    File -> Select Rows -> Heatmap

* *File*: Load brown-selected 
* *Select rows*: choose *function*, *is on of*, *Proteas, Ribo*
* *Heatmap* Select *Split By: function* and check *Keep aspect ratio*

There is a extremely large empty space after Proteas section in the heatmap.

![Screen Shot 2020-03-16 at 10 03 58](https://user-images.githubusercontent.com/4716745/76740310-fa7fd800-676d-11ea-9f7e-278b6a7e4be6.png)


Fixes gh-4527

##### Description of changes

Do not attempt to scale empty widgets.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
