### PR TITLE
[ENH] Save widgets: Store paths relative to workflow directory

### DIFF
--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -79,7 +79,6 @@ class TestOWSave(OWSaveTestBase):
 
     def test_initial_start_dir(self):
         widget = self.widget
-        widget.filename = _w("/usr/foo/bar.csv")
         self.assertEqual(widget.initial_start_dir(),
                          _w(os.path.expanduser("~/")))
 

--- a/doc/visual-programming/source/widgets/data/save.md
+++ b/doc/visual-programming/source/widgets/data/save.md
@@ -11,6 +11,8 @@ The **Save Data** widget considers a dataset provided in the input channel and s
 
 The widget does not save the data every time it receives a new signal in the input as this would constantly (and, mostly, inadvertently) overwrite the file. Instead, the data is saved only after a new file name is set or the user pushes the *Save* button.
 
+If the file is saved to the same directory as the workflow or in the subtree of that directory, the widget remembers the relative path. Otherwise it will store an absolute path, but disable auto save for security reasons.
+
 ![](images/Save-stamped.png)
 
 1. Save by overwriting the existing file.

--- a/doc/visual-programming/source/widgets/model/savemodel.md
+++ b/doc/visual-programming/source/widgets/model/savemodel.md
@@ -3,6 +3,8 @@ Save Model
 
 Save a trained model to an output file.
 
+If the file is saved to the same directory as the workflow or in the subtree of that directory, the widget remembers the relative path. Otherwise it will store an absolute path, but disable auto save for security reasons.
+
 **Inputs**
 
 - Model: trained model

--- a/doc/visual-programming/source/widgets/unsupervised/savedistancematrix.md
+++ b/doc/visual-programming/source/widgets/unsupervised/savedistancematrix.md
@@ -3,6 +3,8 @@ Save Distance Matrix
 
 Saves a distance matrix.
 
+If the file is saved to the same directory as the workflow or in the subtree of that directory, the widget remembers the relative path. Otherwise it will store an absolute path, but disable auto save for security reasons.
+
 **Inputs**
 
 - Distances: distance matrix


### PR DESCRIPTION
##### Issue

Fixes part of #4464 by storing paths relative to the workflow directory. 

##### Description of changes

Path is always relative to the workflow directory, and the saved file must be either in the same director or in its subtree. On loading the widget, auto-save is disabled unless a relative path is used to prevent auto saving to arbitrary locations when the workflow is loaded.

Implementation does not use `RecentPath` because it does not fit.

All core widgets for saving (Save, Save Distances, Save Model) are derived from this base class, so the patch should work for them, as well as for all properly written widgets in add-ons (Save Network).

I took care to keep the backward compatibility, though ... please check all potentially affected add-ons.

Unlike codecov, I believe that coverage is 100 %. At least judging by codecov's diff.

##### Includes
- [X] Code changes
- [X] Tests
- [x] Documentation
