### PR TITLE
[ENH] Load Model: Use paths relative to workflow file

### DIFF
--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -572,7 +572,8 @@
     "background": "#FAC1D9",
     "keywords": [
      "file",
-     "open"
+     "open",
+     "model"
     ]
    }
   ]


### PR DESCRIPTION
##### Issue

The second part of fix for #4464.

##### Description of changes

- Refactor the widget to use `RecentPathsWComboMixin`. The code is adapted from the Distance File widget.
- Add tests for the hitherto unchallenged widget.

##### Includes
- [X] Code changes
- [X] Tests
