### PR TITLE
[FIX] ContinuousPalettesModel: Disable 'category' items via `flags`

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -617,7 +617,7 @@ class ContinuousPalettesModel(QAbstractListModel):
         if isinstance(item, ContinuousPalette):
             return Qt.ItemIsEnabled | Qt.ItemIsSelectable
         else:
-            return Qt.ItemIsEnabled
+            return Qt.NoItemFlags
 
     def indexOf(self, x):
         if isinstance(x, str):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

In Heatmap tab to the palette selection combo, change selection via up/down arrow keys.

```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/Documents/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 917, in update_color_schema
    self.palette_name = self.color_cb.currentData().name
AttributeError: 'NoneType' object has no attribute 'name'
-------------------------------------------------------------------------------
```

##### Description of changes

Disable 'category' items via model `flags`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
