### PR TITLE
[FIX] K-means slowness

### DIFF
--- a/Orange/clustering/clustering.py
+++ b/Orange/clustering/clustering.py
@@ -72,7 +72,7 @@ class Clustering(metaclass=WrapperMeta):
     preprocessors = [Continuize(), SklImpute()]
 
     def __init__(self, preprocessors, parameters):
-        self.preprocessors = tuple(preprocessors or self.preprocessors)
+        self.preprocessors = preprocessors if preprocessors is not None else self.preprocessors
         self.params = {k: v for k, v in parameters.items()
                        if k not in ["self", "preprocessors", "__class__"]}
 

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -533,10 +533,11 @@ class OWKMeans(widget.OWWidget):
         new_table.get_column_view(cluster_var)[0][:] = clust_ids
         new_table.get_column_view(silhouette_var)[0][:] = scores
 
+        domain_attributes = set(domain.attributes)
         centroid_attributes = [
             attr.compute_value.variable
             if isinstance(attr.compute_value, ReplaceUnknowns)
-            and attr.compute_value.variable in domain.attributes
+            and attr.compute_value.variable in domain_attributes
             else attr
             for attr in km.domain.attributes]
         centroid_domain = add_columns(

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -161,7 +161,6 @@ class OWKMeans(widget.OWWidget):
         super().__init__()
 
         self.data = None  # type: Optional[Table]
-        self.__preprocessed_data = None  # type: Optional[Table]
         self.__pending_selection = self.selection  # type: Optional[int]
         self.clusterings = {}
 
@@ -351,10 +350,10 @@ class OWKMeans(widget.OWWidget):
     def __launch_tasks(self, ks):
         # type: (List[int]) -> None
         """Execute clustering in separate threads for all given ks."""
-        self.__preprocessed_data = self.preproces(self.data)
+        preprocessed_data = self.preproces(self.data)
         futures = [self.__executor.submit(
             self._compute_clustering,
-            data=self.__preprocessed_data,
+            data=preprocessed_data,
             k=k,
             init=self.INIT_METHODS[self.smart_init][1],
             n_init=self.n_init,
@@ -447,7 +446,6 @@ class OWKMeans(widget.OWWidget):
     def invalidate(self, unconditional=False):
         self.cancel()
         self.Error.clear()
-        self.__preprocessed_data = None
         self.Warning.clear()
         self.clusterings = {}
         self.table_model.clear_scores()

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -323,7 +323,7 @@ class TestOWKMeans(WidgetTest):
         # the best selection is 3 clusters, so row no. 1
         self.assertEqual(widget.selected_row(), 1)
 
-        widget.normalize = True
+        self.widget.controls.normalize.toggle()
         self.send_signal(self.widget.Inputs.data, Table("housing"), wait=5000)
         self.commit_and_wait()
         widget.update_results()

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -205,9 +205,7 @@ class TestOWKMeans(WidgetTest):
         self.send_signal(widget.Inputs.data, self.data)
         self.commit_and_wait()
         widget.clusterings[widget.k].labels = np.array([0] * 100 + [1] * 203).flatten()
-
-        widget.samples_scores = lambda x: np.arctan(
-            np.arange(303) / 303) / np.pi + 0.5
+        widget.clusterings[widget.k].silhouette_samples = np.arange(303) / 303
         widget.send_data()
         out = self.get_output(widget.Outputs.centroids)
         np.testing.assert_array_almost_equal(

--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -7,6 +7,14 @@ import numpy as np
 
 from Orange.data import Table
 
+
+try:  # try to disable App Nap on OS X
+    import appnope
+    appnope.nope()
+except ImportError:
+    pass
+
+
 # override method prefix for niceness
 BENCH_METHOD_PREFIX = 'bench'
 unittest.TestLoader.testMethodPrefix = BENCH_METHOD_PREFIX

--- a/benchmark/bench_owkmeans.py
+++ b/benchmark/bench_owkmeans.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from Orange.data import Domain, Table, ContinuousVariable
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.unsupervised.owkmeans import OWKMeans
+
+from .base import benchmark
+
+
+def table(rows, cols):
+    return Table.from_numpy(  # pylint: disable=W0201
+        Domain([ContinuousVariable(str(i)) for i in range(cols)]),
+        np.random.RandomState(0).rand(rows, cols))
+
+
+class BenchOWKmeans(WidgetTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.d_100_100 = table(100, 100)
+        cls.d_sampled_silhouette = table(10000, 1)
+        cls.d_10_500 = table(10, 500)
+
+    def setUp(self):
+        self.widget = None  # to avoid lint errors
+
+    def widget_from_to(self):
+        self.widget = self.create_widget(
+            OWKMeans, stored_settings={"auto_commit": False})
+        self.widget.controls.k_from.setValue(2)
+        self.widget.controls.k_to.setValue(6)
+
+    @benchmark(number=3, warmup=1, repeat=3)
+    def bench_from_to_100_100(self):
+        self.widget_from_to()
+        self.send_signal(self.widget.Inputs.data, self.d_100_100)
+        self.commit_and_wait(wait=100*1000)
+
+    @benchmark(number=3, warmup=1, repeat=3)
+    def bench_from_to_100_100_no_normalize(self):
+        self.widget_from_to()
+        self.widget.normalize = False
+        self.send_signal(self.widget.Inputs.data, self.d_100_100)
+        self.commit_and_wait(wait=100*1000)
+
+    @benchmark(number=3, warmup=1, repeat=3)
+    def bench_from_to_sampled_silhouette(self):
+        self.widget_from_to()
+        self.send_signal(self.widget.Inputs.data, self.d_sampled_silhouette)
+        self.commit_and_wait(wait=100*1000)
+
+    @benchmark(number=3, warmup=1, repeat=3)
+    def bench_wide(self):
+        self.widget = self.create_widget(
+            OWKMeans, stored_settings={"auto_commit": False})
+        self.send_signal(self.widget.Inputs.data, self.d_10_500)
+        self.commit_and_wait(wait=100*1000)


### PR DESCRIPTION
##### Issue
After Orange 3.21 we introduced quite a few performance-regressions to K-means, which became very slow for large data set. 

##### Description of changes

1. Preprocess data once. In master, data set is preprocessed separately for each number of clusters and then also when computing silhouettes. If used with from-to this caused too many in-memory copies of data. Which means crashes on big data due to memory usage. Note that sklearn's k-means makes another copy of the data.

2. Only compute approximate (sampled) silhouettes for big data. Fixes bug introduced in Orange 3.22. Compute them in worker threads.

3. Fix O(|features|^2) when creating centroids.

There is a further obvious improvement that I did not tackle in this PR: preprocessing in a worker thread. Now (=this branch, master, current release) the preprocessing for big data blocks UI for about a minute for a data set with 98304 rows and 806 columns. It is mainly normalization. If it is disabled, it only blocks for a few seconds. 

Benchmarks
=========

Orange  3.21

```
[from_to_100_100] with 3 loops, best of 3:
	min 372 msec per loop
	avg 374 msec per loop
[from_to_100_100_no_normalize] with 3 loops, best of 3:
	min 379 msec per loop
	avg 414 msec per loop
[from_to_sampled_silhouette] with 3 loops, best of 3:
	min 2.1 sec per loop
	avg 2.18 sec per loop
[wide] with 3 loops, best of 3:
	min 306 msec per loop
	avg 315 msec per loop
```

Master

```
[from_to_100_100] with 3 loops, best of 3:
	min 1.98 sec per loop
	avg 1.99 sec per loop
[from_to_100_100_no_normalize] with 3 loops, best of 3:
	min 824 msec per loop
	avg 828 msec per loop
[from_to_sampled_silhouette] with 3 loops, best of 3:
	min 10.6 sec per loop
	avg 10.7 sec per loop
[wide] with 3 loops, best of 3:
	min 2.43 sec per loop
	avg 2.44 sec per loop
```

This branch

```
[from_to_100_100] with 3 loops, best of 3:
	min 636 msec per loop
	avg 663 msec per loop
[from_to_100_100_no_normalize] with 3 loops, best of 3:
	min 462 msec per loop
	avg 486 msec per loop
[from_to_sampled_silhouette] with 3 loops, best of 3:
	min 2.62 sec per loop
	avg 2.99 sec per loop
[wide] with 3 loops, best of 3:
	min 640 msec per loop
	avg 649 msec per loop
```

Still not quite Orange 3.21 performance, but will do. The different in [wide] is due to normalization.


##### Includes
- [X] Code changes
- [X] Benchmarks
- [ ] Documentation
