### PR TITLE
format_summary_details: Remove '(not shown)' from metas

### DIFF
--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -24,9 +24,7 @@ def format_variables_string(variables):
         # `isinstance`, which would fail in the above case
         var_type_list = [v for v in variables if type(v) is var_type]  # pylint: disable=unidiomatic-typecheck
         if var_type_list:
-            not_shown = ' (not shown)' if issubclass(var_type, StringVariable)\
-                else ''
-            agg.append((f'{var_type_name}{not_shown}', len(var_type_list)))
+            agg.append((var_type_name, len(var_type_list)))
 
     attrs, counts = list(zip(*agg))
     if len(attrs) > 1:

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -108,7 +108,7 @@ class TestUtils(unittest.TestCase):
                   f'{n_features} variables\n' \
                   f'Features: {len(data.domain.attributes)} categorical\n' \
                   f'Target: categorical\n' \
-                  f'Metas: string (not shown)'
+                  f'Metas: string'
         self.assertEqual(details, format_summary_details(data))
 
         data = Table('housing')
@@ -154,7 +154,7 @@ class TestUtils(unittest.TestCase):
                   f'(2 categorical, 1 numeric, 1 time)\n' \
                   f'Target: {len(data.domain.class_vars)} ' \
                   f'(1 categorical, 1 numeric)\n' \
-                  f'Metas: {len(data.domain.metas)} string (not shown)'
+                  f'Metas: {len(data.domain.metas)} string'
         self.assertEqual(details, format_summary_details(data))
 
         data = make_table([time_full, time_missing], target=[ints_missing],


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When info summary detail is show, the string ' (not shown)' appears in metas detail.

##### Description of changes
Remove the ' (not shown)'.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
