### PR TITLE
Data Table: change output when selecting is finished

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -601,7 +601,12 @@ class OWDataTable(OWWidget):
         selmodel = BlockSelectionModel(
             view.model(), parent=view, selectBlocks=not self.select_rows)
         view.setSelectionModel(selmodel)
-        view.selectionModel().selectionChanged.connect(self.update_selection)
+
+        def click_release_event_handler(_):
+            self.update_selection()
+
+        view.mouseReleaseEvent = click_release_event_handler
+        view.keyReleaseEvent = click_release_event_handler
 
     #noinspection PyBroadException
     def set_corner_text(self, table, text):
@@ -799,6 +804,9 @@ class OWDataTable(OWWidget):
                     )
             view.selectionModel().select(
                 selection, QItemSelectionModel.ClearAndSelect)
+            # widget do not catch selectionChanged anymore it is implemented
+            # through mouseReleaseEvent
+            view.mouseReleaseEvent(None)
 
     @staticmethod
     def get_selection(view):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Table widget output the selection on every change (when the user still making his/her selection). It is annoying since the widget that is connected to the table is constantly performing its calculation or plotting. Some widgets even block the main thread for part of the second or more and it blocks the selection process.

##### Description of changes
After this change, the widget is outputting selection when selection is finished - when the user stop selecting.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
