### PR TITLE
[FIX] Detect duplicate names of variables in projections.

### DIFF
--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from AnyQt.QtCore import QItemSelectionModel
 
-from Orange.data import Table, Domain, DiscreteVariable
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets.settings import Context
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, datasets,
@@ -184,6 +184,17 @@ class TestOWLinearProjection(WidgetTest, AnchorProjectionWidgetTestMixin,
         self.widget.radio_placement.buttons[1].click()
         self.send_signal(self.widget.Inputs.data, Table("heart_disease"))
         self.assertFalse(self.widget.radio_placement.buttons[1].isEnabled())
+
+    def test_unique_name(self):
+        data = Table("iris")
+        new = ContinuousVariable("C-y")
+        d = Table.from_numpy(Domain(list(data.domain.attributes[:3])+[new],
+                                    class_vars=data.domain.class_vars), data.X,
+                             data.Y)
+        self.send_signal(self.widget.Inputs.data, d)
+        output = self.get_output(self.widget.Outputs.annotated_data)
+        metas = ["C-x (1)", "C-y (1)", "Selected"]
+        self.assertEqual([meta.name for meta in output.domain.metas], metas)
 
 
 class LinProjVizRankTests(WidgetTest):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -707,10 +707,18 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget, openclass=True):
     def _get_projection_data(self):
         if self.data is None or self.projection is None:
             return None
+        proposed = [a.name for a in self.projection.domain.attributes]
+        names = get_unique_names(self.data.domain, proposed)
+
+        if proposed != names:
+            attributes = tuple([attr.copy(name=name) for name, attr in
+                                zip(names, self.projection.domain.attributes)])
+        else:
+            attributes = self.projection.domain.attributes
         return self.data.transform(
             Domain(self.data.domain.attributes,
                    self.data.domain.class_vars,
-                   self.data.domain.metas + self.projection.domain.attributes))
+                   self.data.domain.metas + attributes))
 
     def commit(self):
         super().commit()


### PR DESCRIPTION
##### Issue
Fixes #4497 


##### Description of changes
Check for duplicates in original domain, not only in the selected one.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
