### PR TITLE
Compatibility with pyqtgraph 0.11

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -228,8 +228,8 @@ class ElidedAxisNoUnits(ElidedLabelsAxis):
                  maxTickLength=-5, showValues=True):
         self.show_unit = False
         self.tick_dict = {}
-        super().__init__(orientation, pen, linkView, parent, maxTickLength,
-                         showValues)
+        super().__init__(orientation, pen=pen, linkView=linkView, parent=parent,
+                         maxTickLength=maxTickLength, showValues=showValues)
 
     def setShowUnit(self, show_unit):
         self.show_unit = show_unit

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -851,7 +851,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         line1 = graph.reg_line_items[1]
         self.assertEqual(line1.pos().x(), 0)
         self.assertAlmostEqual(line1.pos().y(), -0.6180339887498949)
-        self.assertEqual(line1.angle, 58.28252558853899)
+        self.assertAlmostEqual(line1.angle, 58.28252558853899)
         self.assertEqual(line1.pen.color().getRgb(), graph.palette[0].getRgb())
 
         line2 = graph.reg_line_items[2]
@@ -868,7 +868,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
             np.array([0, 1, 1, 2]), np.array([0, 0, 2, 2]), color, width)
         self.assertEqual(line.pos().x(), 0)
         self.assertAlmostEqual(line.pos().y(), -0.6180339887498949)
-        self.assertEqual(line.angle, 58.28252558853899)
+        self.assertAlmostEqual(line.angle, 58.28252558853899)
         self.assertEqual(line.pen.color(), color)
         self.assertEqual(line.pen.width(), width)
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - keyring
     - keyrings.alt  # for alternative keyring implementations
     - pyqt
-    - pyqtgraph     =0.10.0
+    - pyqtgraph     ~=0.10.0|~=0.11.0
     - anyqt         >=0.0.8
     - joblib
     - python.app    # [osx]

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -4,7 +4,7 @@ orange-widget-base>=4.4.0
 # PyQt4/PyQt5 compatibility
 AnyQt>=0.0.8
 
-pyqtgraph==0.10.0
+pyqtgraph>=0.10.0
 matplotlib>=2.0.0
 
 # For add-ons' descriptions


### PR DESCRIPTION
##### Issue
Fixes #4336. This PR contains some minor fixes which make Orange compatible with pyqtgraphs develop branch.

##### Description of changes
Conda requirements are set to `~=0.10.0|~=0.11.0` to avoid pre-releases. Pip avoids them by default, therefore I set pip requirements to `>=0.10.0.

##### Includes
- [X] Code changes
- [X] Test changes
