### PR TITLE
[ENH] Searchable combo boxes in all data widgets

### DIFF
--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -180,7 +180,8 @@ class OWCreateClass(widget.OWWidget):
 
         combo = gui.comboBox(
             self.controlArea, self, "attribute", label="From column: ",
-            box=True, orientation=Qt.Horizontal, callback=self.update_rules,
+            box=True, orientation=Qt.Horizontal, searchable=True,
+            callback=self.update_rules,
             model=DomainModel(valid_types=(StringVariable, DiscreteVariable)))
         # Don't use setSizePolicy keyword argument here: it applies to box,
         # not the combo

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -28,6 +28,7 @@ from AnyQt.QtWidgets import (
     QPushButton, QMenu, QListView, QFrame, QLabel)
 from AnyQt.QtGui import QKeySequence
 from AnyQt.QtCore import Qt, pyqtSignal as Signal, pyqtProperty as Property
+from orangewidget.utils.combobox import ComboBoxSearch
 
 import Orange
 from Orange.widgets import gui
@@ -127,7 +128,7 @@ class FeatureEditor(QFrame):
 
         self.attrs_model = itemmodels.VariableListModel(
             ["Select Feature"], parent=self)
-        self.attributescb = gui.OrangeComboBox(
+        self.attributescb = ComboBoxSearch(
             minimumContentsLength=16,
             sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon,
             sizePolicy=QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
@@ -143,7 +144,7 @@ class FeatureEditor(QFrame):
             [''],
             [self.FUNCTIONS[func].__doc__ for func in sorted_funcs])
 
-        self.functionscb = gui.OrangeComboBox(
+        self.functionscb = ComboBoxSearch(
             minimumContentsLength=16,
             sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon,
             sizePolicy=QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum))

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -741,6 +741,7 @@ class OWFeatureStatistics(widget.OWWidget):
         self.cb_color_var = gui.comboBox(
             box, master=self, value='color_var', model=self.color_var_model,
             label='Color:', orientation=Qt.Horizontal, contentsLength=13,
+            searchable=True
         )
         self.cb_color_var.activated.connect(self.__color_var_changed)
 

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -4,8 +4,10 @@ from itertools import chain, product
 import numpy as np
 
 from AnyQt.QtCore import Qt, QModelIndex, pyqtSignal as Signal
-from AnyQt.QtWidgets import QWidget, QLabel, QComboBox, QPushButton, \
-    QVBoxLayout, QHBoxLayout
+from AnyQt.QtWidgets import (
+    QWidget, QLabel, QPushButton, QVBoxLayout, QHBoxLayout
+)
+from orangewidget.utils.combobox import ComboBoxSearch
 
 import Orange
 from Orange.data import StringVariable, ContinuousVariable, Variable
@@ -69,7 +71,7 @@ class ConditionBox(QWidget):
             self.emit_list()
 
         def get_combo(model):
-            combo = QComboBox(self)
+            combo = ComboBoxSearch(self)
             combo.setModel(model)
             # We use signal activated because it is triggered only on user
             # interaction, not programmatically.

--- a/Orange/widgets/data/owpivot.py
+++ b/Orange/widgets/data/owpivot.py
@@ -696,17 +696,20 @@ class OWPivot(OWWidget):
     def _add_control_area_controls(self):
         box = gui.vBox(self.controlArea, "Rows")
         gui.comboBox(box, self, "row_feature", contentsLength=12,
+                     searchable=True,
                      model=DomainModel(valid_types=DomainModel.PRIMITIVE),
                      callback=self.__feature_changed)
         box = gui.vBox(self.controlArea, "Columns")
         gui.comboBox(box, self, "col_feature", contentsLength=12,
+                     searchable=True,
                      model=DomainModel(placeholder="(Same as rows)",
                                        valid_types=DiscreteVariable),
-                     callback=self.__feature_changed)
+                     callback=self.__feature_changed,)
         box = gui.vBox(self.controlArea, "Values")
         gui.comboBox(box, self, "val_feature", contentsLength=12,
-                     model=DomainModel(placeholder="(None)"),
+                     searchable=True,
                      orientation=Qt.Horizontal,
+                     model=DomainModel(placeholder="(None)"),
                      callback=self.__val_feature_changed)
         self.__add_aggregation_controls()
         gui.rubber(self.controlArea)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -13,6 +13,7 @@ from AnyQt.QtGui import (
     QFontMetrics, QPalette
 )
 from AnyQt.QtCore import Qt, QPoint, QRegExp, QPersistentModelIndex, QLocale
+from orangewidget.utils.combobox import ComboBoxSearch
 
 from Orange.data import (
     Variable, ContinuousVariable, DiscreteVariable, StringVariable,
@@ -247,7 +248,7 @@ class OWSelectRows(widget.OWWidget):
         row = model.rowCount()
         model.insertRow(row)
 
-        attr_combo = gui.OrangeComboBox(
+        attr_combo = ComboBoxSearch(
             minimumContentsLength=12,
             sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon)
         attr_combo.row = row
@@ -428,7 +429,7 @@ class OWSelectRows(widget.OWWidget):
                 button.var_type = vtype
                 self.cond_list.setCellWidget(oper_combo.row, 2, button)
             else:
-                combo = QComboBox()
+                combo = ComboBoxSearch()
                 combo.addItems(("", ) + var.values)
                 if lc[0]:
                     combo.setCurrentIndex(int(lc[0]))

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -66,7 +66,7 @@ class OWTranspose(OWWidget):
             alphabetical=False)
         self.feature_combo = gui.comboBox(
             gui.indentedBox(box, gui.checkButtonOffsetHint(button)), self,
-            "feature_names_column", contentsLength=12,
+            "feature_names_column", contentsLength=12, searchable=True,
             callback=self._feature_combo_changed, model=self.feature_model)
 
         self.apply_button = gui.auto_apply(self.controlArea, self, box=False, commit=self.apply)

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -415,3 +415,7 @@ class FeatureConstructorHandlerTests(unittest.TestCase):
                 {}
             )
         )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Description of changes
Now when we have ComboBoxSearch available, it can be used where suitable. With this PR I am adding it to all widgets from the data section where a lot of options can be in the combo box - mostly where variables appear in combo boxes:

- Pivot table
- Select rows
- Merge data
- Transpose
- Create class
- Feature constructor
- Feature statistics

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
