### PR TITLE
[ENH] Searchable combo boxes in all visualize widgets

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -345,6 +345,7 @@ class OWDistributions(OWWidget):
         box = gui.vBox(self.controlArea, "Columns")
         gui.comboBox(
             box, self, "cvar", label="Split by", orientation=Qt.Horizontal,
+            searchable=True,
             model=DomainModel(placeholder="(None)",
                               valid_types=(DiscreteVariable), ),
             callback=self._on_cvar_changed, contentsLength=18)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -306,7 +306,7 @@ class OWHeatMap(widget.OWWidget):
             valid_types=(Orange.data.DiscreteVariable,),
             parent=self,
         )
-        self.row_split_cb = cb = ComboBox(
+        self.row_split_cb = cb = ComboBoxSearch(
             enabled=not self.merge_kmeans,
             sizeAdjustPolicy=ComboBox.AdjustToMinimumContentsLengthWithIcon,
             minimumContentsLength=14,

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -342,6 +342,7 @@ class OWMosaicDisplay(OWWidget):
             gui.comboBox(
                 box, self, value="variable{}".format(i),
                 orientation=Qt.Horizontal, contentsLength=12,
+                searchable=True,
                 callback=self.attr_changed,
                 model=self.model_1 if i == 1 else self.model_234)
             for i in range(1, 5)]
@@ -355,6 +356,7 @@ class OWMosaicDisplay(OWWidget):
         self.cb_attr_color = gui.comboBox(
             box2, self, value="variable_color",
             orientation=Qt.Horizontal, contentsLength=12, labelWidth=50,
+            searchable=True,
             callback=self.set_color_data, model=self.color_model)
         self.bar_button = gui.checkBox(
             box2, self, 'use_boxes', label='Compare with total',

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -644,7 +644,7 @@ class OWNomogram(OWWidget):
         box = gui.vBox(self.controlArea, "Target class")
         self.class_combo = gui.comboBox(
             box, self, "target_class_index", callback=self._class_combo_changed,
-            contentsLength=12)
+            contentsLength=12, searchable=True)
         self.norm_check = gui.checkBox(
             box, self, "normalize_probabilities", "Normalize probabilities",
             hidden=True, callback=self.update_scene,

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -102,6 +102,7 @@ class OWPythagorasTree(OWWidget):
         self.target_class_combo = gui.comboBox(
             box_display, self, 'target_class_index', label='Target class',
             orientation=Qt.Horizontal, items=[], contentsLength=8,
+            searchable=True,
             callback=self.update_colors)
         self.size_calc_combo = gui.comboBox(
             box_display, self, 'size_calc_idx', label='Size',

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -219,6 +219,7 @@ class OWPythagoreanForest(OWWidget):
         self.ui_target_class_combo = gui.comboBox(
             box_display, self, 'target_class_index', label='Target class',
             orientation=Qt.Horizontal, items=[], contentsLength=8,
+            searchable=True
         )  # type: gui.OrangeComboBox
         self.ui_size_calc_combo = gui.comboBox(
             box_display, self, 'size_calc_idx', label='Size',

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -111,8 +111,8 @@ class OWSieveDiagram(OWWidget):
         self.domain_model = DomainModel(valid_types=DomainModel.PRIMITIVE)
         combo_args = dict(
             widget=self.attr_box, master=self, contentsLength=12,
-            callback=self.attr_changed, sendSelectedValue=True,
-            model=self.domain_model)
+            searchable=True, sendSelectedValue=True,
+            callback=self.attr_changed, model=self.domain_model)
         fixed_size = (QSizePolicy.Fixed, QSizePolicy.Fixed)
         gui.comboBox(value="attr_x", **combo_args)
         gui.widgetLabel(self.attr_box, "\u2715", sizePolicy=fixed_size)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -146,7 +146,7 @@ class OWSilhouettePlot(widget.OWWidget):
         box = gui.vBox(self.controlArea, "Cluster Label")
         self.cluster_var_cb = gui.comboBox(
             box, self, "cluster_var_idx", contentsLength=14, addSpace=4,
-            callback=self._invalidate_scores
+            searchable=True, callback=self._invalidate_scores
         )
         gui.checkBox(
             box, self, "group_by_cluster", "Group by cluster",

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -7,6 +7,7 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtGui import QColor, QBrush, QPen, QFontMetrics
 from AnyQt.QtCore import Qt, QPointF, QSizeF, QRectF
+from orangewidget.utils.combobox import ComboBoxSearch
 
 from Orange.base import TreeModel, SklModel
 from Orange.widgets.utils.signals import Input, Output
@@ -18,7 +19,6 @@ from Orange.data import Table
 
 from Orange.widgets.settings import ContextSetting, ClassValuesContextHandler, \
     Setting
-from Orange.widgets import gui
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
 from Orange.widgets.visualize.utils.tree.skltreeadapter import SklTreeAdapter
@@ -190,7 +190,7 @@ class OWTreeGraph(OWTreeViewer2D):
         self.tree_adapter = None
 
         self.color_label = QLabel("Target class: ")
-        combo = self.color_combo = gui.OrangeComboBox()
+        combo = self.color_combo = ComboBoxSearch()
         combo.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)
         combo.setSizeAdjustPolicy(
             QComboBox.AdjustToMinimumContentsLengthWithIcon)

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -395,3 +395,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         # The domain is still the same, so restore the depth limit from before
         self.send_signal(self.widget.Inputs.tree, forest.trees[1])
         self.assertEqual(self.widget.ptree._depth_limit, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Description of changes
Now when we have ComboBoxSearch available, it can be used where suitable. With this PR I am adding it to all widgets from the visualize section where a lot of options can be in the combo box - mostly where variables (and values) appear in combo boxes:

- Tree viewer
- Distributions
- Mosaic
- Sieve diagram
- Heat Map
- Pythagorean Forest
- Pythagorean Tree
- Silhouette Plot
- Nomogram

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
