### PR TITLE
[ENH] Searchable combo boxes in all evaluate widgets

### DIFF
--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -119,7 +119,7 @@ class OWCalibrationPlot(widget.OWWidget):
         self.target_cb = gui.comboBox(
             box, self, "target_index", label="Target:",
             orientation=Qt.Horizontal, callback=self.target_index_changed,
-            contentsLength=8)
+            contentsLength=8, searchable=True)
         gui.checkBox(
             box, self, "display_rug", "Show rug",
             callback=self._on_display_rug_changed)

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -93,7 +93,7 @@ class OWLiftCurve(widget.OWWidget):
 
         self.target_cb = gui.comboBox(
             tbox, self, "target_index", callback=self._on_target_changed,
-            contentsLength=8)
+            contentsLength=8, searchable=True)
 
         cbox = gui.vBox(box, "Classifiers")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -344,7 +344,7 @@ class OWROCAnalysis(widget.OWWidget):
 
         self.target_cb = gui.comboBox(
             tbox, self, "target_index", callback=self._on_target_changed,
-            contentsLength=8)
+            contentsLength=8, searchable=True)
 
         cbox = gui.vBox(box, "Classifiers")
         cbox.setFlat(True)

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -255,7 +255,8 @@ class OWTestAndScore(OWWidget):
             order=DomainModel.METAS, valid_types=DiscreteVariable)
         self.features_combo = gui.comboBox(
             ibox, self, "fold_feature", model=self.feature_model,
-            orientation=Qt.Horizontal, callback=self.fold_feature_changed)
+            orientation=Qt.Horizontal, searchable=True,
+            callback=self.fold_feature_changed)
 
         gui.appendRadioButton(rbox, "Random sampling")
         ibox = gui.indentedBox(rbox)
@@ -281,8 +282,9 @@ class OWTestAndScore(OWWidget):
         self.cbox = gui.vBox(self.controlArea, "Target Class")
         self.class_selection_combo = gui.comboBox(
             self.cbox, self, "class_selection", items=[],
-            sendSelectedValue=True, callback=self._on_target_class_changed,
-            contentsLength=8)
+            sendSelectedValue=True, contentsLength=8, searchable=True,
+            callback=self._on_target_class_changed
+        )
 
         self.modcompbox = box = gui.vBox(self.controlArea, "Model Comparison")
         gui.comboBox(


### PR DESCRIPTION
##### Description of changes

Now when we have ComboBoxSearch available, it can be used where suitable. With this PR I am adding it to all widgets from the evaluate section where a lot of options can be in the combo box - mostly where variables appear in combo boxes:

- Test and Score
- Roc analysis
- Lift curve
- Calibration plot

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
