### PR TITLE
owcsvimport: fix output summary test

### DIFF
--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -120,6 +120,8 @@ class TestOWCSVFileImport(WidgetTest):
             }
         )
         output_sum = widget.info.set_output_summary = mock.Mock()
+        widget.commit()
+        self.wait_until_finished(widget)
         output = self.get_output("Data", widget)
         output_sum.assert_called_with(len(output),
                                       format_summary_details(output))


### PR DESCRIPTION
##### Issue
Before, the widget sometimes processed data before a Mock was added, which caused the test to fail.

```
Traceback (most recent call last):
  File "/home/runner/work/orange3/orange3/.tox/coverage/lib/python3.6/site-packages/Orange/widgets/data/tests/test_owcsvimport.py", line 125, in test_summary
    format_summary_details(output))
  File "/opt/hostedtoolcache/Python/3.6.10/x64/lib/python3.6/unittest/mock.py", line 805, in assert_called_with
    raise AssertionError('Expected call: %s\nNot called' % (expected,))
AssertionError: Expected call: mock(3, '3 instances, 3 variables\nFeatures: 2 categorical\nTarget: —\nMetas: string')
Not called
```