### PR TITLE
[ENH] Test against widget-base, orange-canvas and pyqtgraph development versions

### DIFF
--- a/.github/workflows/cleanup_workflow.yml
+++ b/.github/workflows/cleanup_workflow.yml
@@ -1,9 +1,6 @@
 name: Cleanup workflow
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/linux_workflow.yml
+++ b/.github/workflows/linux_workflow.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: False
       matrix:

--- a/.github/workflows/miscellaneous_workflow.yml
+++ b/.github/workflows/miscellaneous_workflow.yml
@@ -1,4 +1,4 @@
-name: macOS workflow
+name: Miscellaneous workflow
 
 on:
   # Trigger the workflow on push or pull request, but only for the master branch
@@ -10,15 +10,14 @@ on:
       - master
 
 jobs:
-  build:
+  test_future_compatibility:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: False
       matrix:
-        python: [3.6, 3.7]
-        os: [macos-10.15]
-
+        python: [3.7]
+        os: [ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -26,8 +25,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Install linux system dependencies
+        run: sudo apt-get install -y libxkbcommon-x11-0
+
       - name: Install Tox
         run: pip install tox
 
       - name: Run Tox
-        run: tox -e py
+        run: xvfb-run -a -s "-screen 0 1280x1024x24" tox -e future_compatibility

--- a/.github/workflows/windows_workflow.yml
+++ b/.github/workflows/windows_workflow.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: False
       matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{36,37,38}
+    future_compatibility
     pylint
     build_doc
     coverage
@@ -33,6 +34,13 @@ commands_pre =
 commands =
     # --buffer
     python -m unittest --verbose Orange.tests Orange.widgets.tests
+
+[testenv:future_compatibility]
+deps =
+    {[testenv]deps}
+    git+git://github.com/pyqtgraph/pyqtgraph.git#egg=pyqtgraph
+    git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
+    git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
 
 [testenv:coverage]
 setenv =


### PR DESCRIPTION
##### Description of changes
New workflow where we run Orange test suite against development versions of orange-canvas-core, orange-widget-base and pyqtgraph.

Build jobs now have a timeout limit (30 min).
