### PR TITLE
Remove maximumContentsLength

### DIFF
--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -243,7 +243,7 @@ class OWTestLearners(OWWidget):
         ibox = gui.indentedBox(rbox)
         gui.comboBox(
             ibox, self, "n_folds", label="Number of folds: ",
-            items=[str(x) for x in self.NFolds], maximumContentsLength=3,
+            items=[str(x) for x in self.NFolds],
             orientation=Qt.Horizontal, callback=self.kfold_changed)
         gui.checkBox(
             ibox, self, "cv_stratified", "Stratified",
@@ -260,13 +260,14 @@ class OWTestLearners(OWWidget):
         ibox = gui.indentedBox(rbox)
         gui.comboBox(
             ibox, self, "n_repeats", label="Repeat train/test: ",
-            items=[str(x) for x in self.NRepeats], maximumContentsLength=3,
-            orientation=Qt.Horizontal, callback=self.shuffle_split_changed)
+            items=[str(x) for x in self.NRepeats], orientation=Qt.Horizontal,
+            callback=self.shuffle_split_changed
+        )
         gui.comboBox(
             ibox, self, "sample_size", label="Training set size: ",
             items=["{} %".format(x) for x in self.SampleSizes],
-            maximumContentsLength=5, orientation=Qt.Horizontal,
-            callback=self.shuffle_split_changed)
+            orientation=Qt.Horizontal, callback=self.shuffle_split_changed
+        )
         gui.checkBox(
             ibox, self, "shuffle_stratified", "Stratified",
             callback=self.shuffle_split_changed)

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -264,7 +264,7 @@ class OWSOM(OWWidget):
 
         box = gui.vBox(self.controlArea, "Color")
         gui.comboBox(
-            box, self, "attr_color", maximumContentsLength=15,
+            box, self, "attr_color",
             callback=self.on_attr_color_change,
             model=DomainModel(placeholder="(Same color)",
                               valid_types=DomainModel.PRIMITIVE))

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -269,7 +269,7 @@ class OWHeatMap(widget.OWWidget):
 
         cluster_box = gui.vBox(self.controlArea, "Clustering")
         # Row clustering
-        self.row_cluster_cb = cb = ComboBox(maximumContentsLength=14)
+        self.row_cluster_cb = cb = ComboBox()
         cb.setModel(create_list_model(ClusteringModelData, self))
         cbselect(cb, self.row_clustering, ClusteringRole)
         self.connect_control(
@@ -281,7 +281,7 @@ class OWHeatMap(widget.OWWidget):
             self.set_row_clustering(cb.itemData(idx, ClusteringRole))
 
         # Column clustering
-        self.col_cluster_cb = cb = ComboBox(maximumContentsLength=14)
+        self.col_cluster_cb = cb = ComboBox()
         cb.setModel(create_list_model(ClusteringModelData, self))
         cbselect(cb, self.col_clustering, ClusteringRole)
         self.connect_control(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`maximumContentsLength` parameter on ComboBox is deprecated and does not have an effect.

##### Description of changes
Removing all appearances of `maximumContentsLength` in Orange.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
