### PR TITLE
state_summary: Add multiple inputs function and missing values info

### DIFF
--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -55,10 +55,49 @@ def format_summary_details(data):
         targets = format_variables_string(data.domain.class_vars)
         metas = format_variables_string(data.domain.metas)
 
+        features_missing = missing_values(data.has_missing_attribute()
+                                          and data.get_nan_frequency_attribute())
         n_features = len(data.domain.variables) + len(data.domain.metas)
         details = \
             f'{len(data)} instance{_plural(len(data))}, ' \
             f'{n_features} variable{_plural(n_features)}\n' \
-            f'Features: {features}\nTarget: {targets}\nMetas: {metas}'
-
+            f'Features: {features} {features_missing}\n' \
+            f'Target: {targets}\nMetas: {metas}'
     return details
+
+
+def missing_values(value):
+    if value:
+        return f'({value*100:.1f}% missing values)'
+    else:
+        return '(No missing values)'
+
+
+def format_multiple_summaries(data_list, type_io='input'):
+    """
+    A function that forms the entire descriptive part of the input/output
+    summary for widgets that have more than one input/output.
+
+    :param data_list: A list of tuples for each input/output dataset where the
+    first element of the tuple is the name of the dataset (can be omitted)
+    and the second is the dataset
+    :type data_list: list(tuple(str, Orange.data.Table))
+    :param type_io: A string that indicates weather the input or output data
+    is being formatted
+    :type type_io: str
+
+    :return A formatted summary
+    :rtype str
+    """
+
+    def new_line(text):
+        return text.replace('\n', '<br>')
+
+    full_details = []
+    for (name, data) in data_list:
+        if data:
+            details = new_line(format_summary_details(data))
+        else:
+            details = f'No data on {type_io}.'
+        full_details.append(details if not name else f'{name}:<br>{details}')
+    return '<hr>'.join(full_details)

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from Orange.data import Table, Domain, StringVariable, ContinuousVariable, \
     DiscreteVariable, TimeVariable
-from Orange.widgets.utils.state_summary import format_summary_details
+from Orange.widgets.utils.state_summary import format_summary_details, \
+    format_multiple_summaries
 
 VarDataPair = namedtuple('VarDataPair', ['variable', 'data'])
 
@@ -106,7 +107,8 @@ class TestUtils(unittest.TestCase):
         n_features = len(data.domain.variables) + len(data.domain.metas)
         details = f'{len(data)} instances, ' \
                   f'{n_features} variables\n' \
-                  f'Features: {len(data.domain.attributes)} categorical\n' \
+                  f'Features: {len(data.domain.attributes)} categorical ' \
+                  f'(No missing values)\n' \
                   f'Target: categorical\n' \
                   f'Metas: string'
         self.assertEqual(details, format_summary_details(data))
@@ -115,7 +117,8 @@ class TestUtils(unittest.TestCase):
         n_features = len(data.domain.variables) + len(data.domain.metas)
         details = f'{len(data)} instances, ' \
                   f'{n_features} variables\n' \
-                  f'Features: {len(data.domain.attributes)} numeric\n' \
+                  f'Features: {len(data.domain.attributes)} numeric ' \
+                  f'(No missing values)\n' \
                   f'Target: numeric\n' \
                   f'Metas: —'
         self.assertEqual(details, format_summary_details(data))
@@ -125,7 +128,7 @@ class TestUtils(unittest.TestCase):
         details = f'{len(data)} instances, ' \
                   f'{n_features} variables\n' \
                   f'Features: {len(data.domain.attributes)} ' \
-                  f'(7 categorical, 6 numeric)\n' \
+                  f'(7 categorical, 6 numeric) (0.2% missing values)\n' \
                   f'Target: categorical\n' \
                   f'Metas: —'
         self.assertEqual(details, format_summary_details(data))
@@ -137,7 +140,8 @@ class TestUtils(unittest.TestCase):
         n_features = len(data.domain.variables) + len(data.domain.metas)
         details = f'{len(data)} instances, ' \
                   f'{n_features} variables\n' \
-                  f'Features: {len(data.domain.attributes)} numeric\n' \
+                  f'Features: {len(data.domain.attributes)} numeric ' \
+                  f'(10.0% missing values)\n' \
                   f'Target: {len(data.domain.class_vars)} categorical\n' \
                   f'Metas: {len(data.domain.metas)} categorical'
         self.assertEqual(details, format_summary_details(data))
@@ -151,7 +155,7 @@ class TestUtils(unittest.TestCase):
         details = f'{len(data)} instances, ' \
                   f'{n_features} variables\n' \
                   f'Features: {len(data.domain.attributes)} ' \
-                  f'(2 categorical, 1 numeric, 1 time)\n' \
+                  f'(2 categorical, 1 numeric, 1 time) (5.0% missing values)\n' \
                   f'Target: {len(data.domain.class_vars)} ' \
                   f'(1 categorical, 1 numeric)\n' \
                   f'Metas: {len(data.domain.metas)} string'
@@ -161,7 +165,8 @@ class TestUtils(unittest.TestCase):
                           metas=None)
         details = f'{len(data)} instances, ' \
                   f'{len(data.domain.variables)} variables\n' \
-                  f'Features: {len(data.domain.attributes)} time\n' \
+                  f'Features: {len(data.domain.attributes)} time ' \
+                  f'(10.0% missing values)\n' \
                   f'Target: categorical\n' \
                   f'Metas: —'
         self.assertEqual(details, format_summary_details(data))
@@ -169,7 +174,8 @@ class TestUtils(unittest.TestCase):
         data = make_table([rgb_full, ints_full], target=None, metas=None)
         details = f'{len(data)} instances, ' \
                   f'{len(data.domain.variables)} variables\n' \
-                  f'Features: {len(data.domain.variables)} categorical\n' \
+                  f'Features: {len(data.domain.variables)} categorical ' \
+                  f'(No missing values)\n' \
                   f'Target: —\n' \
                   f'Metas: —'
         self.assertEqual(details, format_summary_details(data))
@@ -177,13 +183,61 @@ class TestUtils(unittest.TestCase):
         data = make_table([rgb_full], target=None, metas=None)
         details = f'{len(data)} instances, ' \
                   f'{len(data.domain.variables)} variable\n' \
-                  f'Features: categorical\n' \
+                  f'Features: categorical (No missing values)\n' \
                   f'Target: —\n' \
                   f'Metas: —'
         self.assertEqual(details, format_summary_details(data))
 
         data = None
         self.assertEqual('', format_summary_details(data))
+
+    def test_multiple_summaries(self):
+        data = Table('zoo')
+        extra_data = Table('zoo')[20:]
+        n_features_data = len(data.domain.variables) + len(data.domain.metas)
+        n_features_extra_data = len(extra_data.domain.variables) + \
+                                len(extra_data.domain.metas)
+        details = f'Data:<br>{len(data)} instances, ' \
+                  f'{n_features_data} variables<br>' \
+                  f'Features: {len(data.domain.attributes)} categorical ' \
+                  f'(No missing values)<br>' \
+                  f'Target: categorical<br>' \
+                  f'Metas: string<hr>'\
+                  f'Extra Data:<br>{len(extra_data)} instances, ' \
+                  f'{n_features_extra_data} variables<br>' \
+                  f'Features: {len(extra_data.domain.attributes)} ' \
+                  f'categorical (No missing values)<br>' \
+                  f'Target: categorical<br>' \
+                  f'Metas: string'
+        inputs = [('Data', data), ('Extra Data', extra_data)]
+        self.assertEqual(details, format_multiple_summaries(inputs))
+
+        details = f'{len(data)} instances, ' \
+                  f'{n_features_data} variables<br>' \
+                  f'Features: {len(data.domain.attributes)} categorical ' \
+                  f'(No missing values)<br>' \
+                  f'Target: categorical<br>' \
+                  f'Metas: string<hr>'\
+                  f'{len(extra_data)} instances, ' \
+                  f'{n_features_extra_data} variables<br>' \
+                  f'Features: {len(extra_data.domain.attributes)} ' \
+                  f'categorical (No missing values)<br>' \
+                  f'Target: categorical<br>' \
+                  f'Metas: string'
+        inputs = [('', data), ('', extra_data)]
+        self.assertEqual(details, format_multiple_summaries(inputs))
+
+        details = f'No data on output.<hr>' \
+                  f'Extra data:<br>{len(extra_data)} instances, ' \
+                  f'{n_features_extra_data} variables<br>' \
+                  f'Features: {len(extra_data.domain.attributes)} ' \
+                  f'categorical (No missing values)<br>' \
+                  f'Target: categorical<br>' \
+                  f'Metas: string<hr>'\
+                  f'No data on output.'
+        outputs = [('', None), ('Extra data', extra_data), ('', None)]
+        self.assertEqual(details,
+                         format_multiple_summaries(outputs, type_io='output'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
Existing state_summary could not be used for widgets that have multiple inputs and has no information about missing values of input/output.


##### Description of changes
Information about missing values added.

`format_multiple_inputs` function added for formatting details string for widgets with multiple inputs.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
