### PR TITLE
[ENH] Projections keep colors after merging values

### DIFF
--- a/Orange/widgets/visualize/tests/test_owprojectionwidget.py
+++ b/Orange/widgets/visualize/tests/test_owprojectionwidget.py
@@ -11,7 +11,9 @@ from Orange.data import (
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, ProjectionWidgetTestMixin
 )
-from Orange.widgets.utils.colorpalettes import ContinuousPalettes
+from Orange.widgets.utils.colorpalettes import (
+    ContinuousPalettes, DiscretePalette
+)
 from Orange.widgets.visualize.utils.widget import (
     OWDataProjectionWidget, OWProjectionWidgetBase
 )
@@ -112,6 +114,33 @@ class TestOWProjectionWidget(WidgetTest):
         self.assertTrue("1" in widget.get_tooltip([0, 1])
                         and "3" in widget.get_tooltip([0, 1]))
         self.assertEqual(widget.get_tooltip([]), "")
+
+    def test_get_palette(self):
+        widget = self.widget
+
+        widget.attr_color = None
+        self.assertIsNone(widget.get_palette())
+
+        var = ContinuousVariable("v")
+        var.palette = Mock()
+        widget.attr_color = var
+        self.assertIs(widget.get_palette(), var.palette)
+
+        var = DiscreteVariable("v", values=tuple("abc"))
+        var.palette = Mock()
+        widget.attr_color = var
+        self.assertIs(widget.get_palette(), var.palette)
+
+        values = tuple("abcdefghijklmn")
+        merged = ["a", "c", "d", "h", "n", "Others"]
+        var = DiscreteVariable("v", values=values)
+        var.palette = DiscretePalette(
+            "foo", "bar", [[i] * 3 for i, _ in enumerate(values)])
+        widget.get_color_labels = lambda: merged
+        widget.attr_color = var
+        np.testing.assert_equal(
+            widget.get_palette().palette[:-1],
+            [[var.values.index(label)] * 3 for label in merged[:-1]])
 
 
 class TestableDataProjectionWidget(OWDataProjectionWidget):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -16,6 +16,7 @@ from Orange.widgets import gui, report
 from Orange.widgets.settings import (
     Setting, ContextSetting, DomainContextHandler, SettingProvider
 )
+from Orange.widgets.utils import colorpalettes
 from Orange.widgets.utils.annotated_data import (
     create_annotated_table, ANNOTATED_DATA_SIGNAL_NAME, create_groups_table
 )
@@ -222,7 +223,17 @@ class OWProjectionWidgetBase(OWWidget, openclass=True):
         This method must be overridden if the widget offers coloring that is
         not based on attribute values.
         """
-        return self.attr_color and self.attr_color.palette
+        attr = self.attr_color
+        if not attr:
+            return None
+        palette = attr.palette
+        if attr.is_discrete and len(attr.values) >= MAX_COLORS:
+            values = self.get_color_labels()
+            colors = [palette.palette[attr.to_val(value)]
+                      for value in values[:-1]] + [[192, 192, 192]]
+
+            palette = colorpalettes.DiscretePalette.from_colors(colors)
+        return palette
 
     def can_draw_density(self):
         """


### PR DESCRIPTION
##### Issue

Fixes #4515.

~~I don't like it because if a variable has 100 values, which are merged into 15, they will not use a better palette for 15 colors, but instead have a HSL-based palette with 15 hues out of 100. This rather defeats the purpose of merging.~~ No longer important after we implement #4581.

**To do:**

- [ ] ~~Improve implementation if possible. Rethink `get_column` which was called twice for colors and shapes, and would now be called thrice for colors.~~ We decided, upon @VesnaT's encouragement, that the code may not be optimal, but it is more maintainable the way it is. Calling `get_column_view` multiple times shouldn't affect the performance because it is linear w.r.t. the number of rows.

##### Description of changes

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
