### PR TITLE
[WIP] Use biolab-helper access token in cleanup workflow 

### DIFF
--- a/.github/workflows/cleanup_workflow.yml
+++ b/.github/workflows/cleanup_workflow.yml
@@ -15,26 +15,8 @@ jobs:
     timeout-minutes: 3
 
     steps:
-      - name: Cleanup Linux workflow
-        uses: styfle/cancel-workflow-action@0.2.0
+      - name: Cleanup workflow
+        uses: styfle/cancel-workflow-action@0.3.1
         with:
-          workflow_id: 685155
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cleanup macOS workflow
-        uses: styfle/cancel-workflow-action@0.2.0
-        with:
-          workflow_id: 685156
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cleanup Windows workflow
-        uses: styfle/cancel-workflow-action@0.2.0
-        with:
-          workflow_id: 685157
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cleanup Documentation workflow
-        uses: styfle/cancel-workflow-action@0.2.0
-        with:
-          workflow_id: 685153
-          access_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow_id: 685155, 685156, 685157, 685153
+          access_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
##### Issue
The cleanup workflow in Github actions sometimes fail. Issue: https://github.com/styfle/cancel-workflow-action/issues/7#issuecomment-605057637

##### Description of changes
Use personal access token of our biolab-helper Github account. Hopefully, this will work more consistent now.