### PR TITLE
[FIX] Nomogram: Fix crash on Python 3.8

### DIFF
--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -860,7 +860,7 @@ class OWNomogram(OWWidget):
                 coef = self.log_reg_coeffs[i]
                 self.log_reg_coeffs[i] = np.hstack((coef * min_t, coef * max_t))
                 self.log_reg_cont_data_extremes.append(
-                    [sorted([min_t, max_t], reverse=(c < 0)) for c in coef])
+                    [sorted([min_t, max_t], reverse=(c < 0)) for c in coef.flat])
             else:
                 self.log_reg_cont_data_extremes.append([None])
 

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -848,7 +848,7 @@ class OWNomogram(OWWidget):
         if len(self.domain.class_var.values) == 2:
             self.b0 = np.hstack((self.b0 * (-1), self.b0))
             coeffs = np.vstack((coeffs * (-1), coeffs))
-        self.log_reg_coeffs = [coeffs[:, ranges[i]] for i in range(len(attrs))]
+        self.log_reg_coeffs = [coeffs[:, r] for r in ranges]
         self.log_reg_coeffs_orig = self.log_reg_coeffs.copy()
 
         min_values = nanmin(self.data.X, axis=0)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
On py3.8 nomogram crashed for logistic regression models with:
`TypeError: only integer scalar arrays can be converted to a scalar index`

##### Description of changes
Iterate over actual coefficient values (numbers) instead of rows of a ndarray (which are still ndarrays) to get a proper boolean value for `reverse`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
