### PR TITLE
[FIX] Edit Domain: Improve Text/Categorical to Time conversion

### DIFF
--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import pandas as pd
 
 from AnyQt.QtCore import QItemSelectionModel, Qt, QItemSelection
 from AnyQt.QtWidgets import QAction, QComboBox, QLineEdit, \
@@ -33,7 +34,7 @@ from Orange.widgets.data.oweditdomain import (
     table_column_data, ReinterpretVariableEditor, CategoricalVector,
     VariableEditDelegate, TransformRole,
     RealVector, TimeVector, StringVector, make_dict_mapper, DictMissingConst,
-    LookupMappingTransform, as_float_or_nan, column_str_repr,
+    LookupMappingTransform, as_float_or_nan, column_str_repr, time_parse,
     GroupItemsDialog)
 from Orange.widgets.data.owcolor import OWColor, ColorRole
 from Orange.widgets.tests.base import WidgetTest, GuiTest
@@ -916,6 +917,19 @@ class TestUtils(TestCase):
         v = TimeVariable("T", have_date=False, have_time=True)
         d = column_str_repr(v, np.array([0., np.nan, 1.0]))
         assert_array_equal(d, ["00:00:00", "?", "00:00:01"])
+
+    def test_time_parse(self):
+        """parsing additional datetimes by pandas"""
+        date = ["1/22/20", "1/23/20", "1/24/20"]
+        # we use privet method, check if still exists
+        assert hasattr(pd.DatetimeIndex, '_is_dates_only')
+
+        tval, values = time_parse(date)
+
+        self.assertTrue(tval.have_date)
+        self.assertFalse(tval.have_time)
+        self.assertListEqual(list(values),
+                             [1579651200.0, 1579737600.0, 1579824000.0])
 
 
 class TestLookupMappingTransform(TestCase):


### PR DESCRIPTION
##### Issue
New TimeVariable is initialized considering its parsing of string but actual data is converted by pandas.
This results in two issues:
 * Edit Domain can convert more formats (like m/d/y) but the TimeVariable is not correctly initialized (have_date and have_time)
 * pandas conversion is applied only when converting from Text but not when converting from Categorical.

##### Description of changes
Move pandas transformation into a separate function and apply it accordingly.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
