### PR TITLE
OWDataSets: Rename to Data Sets

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -130,7 +130,7 @@ class TreeViewWithReturn(QTreeView):
 
 
 class OWDataSets(OWWidget):
-    name = "Datasets"
+    name = "Data Sets"
     description = "Load a dataset from an online repository"
     icon = "icons/DataSets.svg"
     priority = 20

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -135,7 +135,7 @@ class OWDataSets(OWWidget):
     icon = "icons/DataSets.svg"
     priority = 20
     replaces = ["orangecontrib.prototypes.widgets.owdatasets.OWDataSets"]
-    keywords = ["online"]
+    keywords = ["datasets", "online"]
 
     want_control_area = False
 

--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -33,6 +33,7 @@
     "icon": "../Orange/widgets/data/icons/DataSets.svg",
     "background": "#FFD39F",
     "keywords": [
+     "datasets",
      "online"
     ]
    },

--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -28,7 +28,7 @@
     ]
    },
    {
-    "text": "Datasets",
+    "text": "Data Sets",
     "doc": "visual-programming/source/widgets/data/datasets.md",
     "icon": "../Orange/widgets/data/icons/DataSets.svg",
     "background": "#FFD39F",


### PR DESCRIPTION
(I seem to not know how to properly rename a widget, is there something else to do besides editing `owdatasets.py` and `widget.json`?)

I can't find a good source right now, but if I remember correctly, Data Sets is more widely agreed upon as the correct spelling of the phrase.

It'd be nice to get this in for the release, a soon-to-be-posted blog references the widget as 'Data Sets'.