### PR TITLE
test_owtestlearners: Ensure a header section is clicked

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -278,10 +278,15 @@ class TestOWTestAndScore(WidgetTest):
 
         self.send_signal(self.widget.Inputs.test_data, setosa, wait=5000)
 
-        self.widget.show()
+        self.widget.adjustSize()
         view = self.widget.score_table.view
         header = view.horizontalHeader()
-        QTest.mouseClick(header.viewport(), Qt.LeftButton)
+        p = header.rect().center()
+        # second visible header section (after 'Model')
+        _, idx, *_ = (i for i in range(header.count())
+                      if not header.isSectionHidden(i))
+        p.setX(header.sectionPosition(idx) + 5)
+        QTest.mouseClick(header.viewport(), Qt.LeftButton, pos=p)
 
         # Ensure that the click on header caused an ascending sort
         # Ascending sort means that wrong model should be listed first
@@ -290,8 +295,6 @@ class TestOWTestAndScore(WidgetTest):
 
         self.send_signal(self.widget.Inputs.test_data, versicolor, wait=5000)
         self.assertEqual(view.model().index(0, 0).data(), "SetosaLearner")
-
-        self.widget.hide()
 
     def _retrieve_scores(self):
         w = self.widget


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
From https://ci.appveyor.com/project/ales-erjavec/orange3-installers/builds/31860638/job/4gt7oa3p12c8eydj

```
======================================================================
FAIL: test_resort_on_data_change (Orange.widgets.evaluate.tests.test_owtestlearners.TestOWTestLearners)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\test-install\lib\site-packages\Orange\widgets\evaluate\tests\test_owtestlearners.py", line 288, in test_resort_on_data_change
    self.assertEqual(header.sortIndicatorOrder(), Qt.AscendingOrder)
AssertionError: 1 != 0
----------------------------------------------------------------------
```


##### Description of changes

Ensure the click is actually on a header section and not on an empty area.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
