### PR TITLE
[FIX] colorpalettes: fix BinnedContinuousPalette color assignments

### DIFF
--- a/Orange/widgets/utils/colorpalettes.py
+++ b/Orange/widgets/utils/colorpalettes.py
@@ -394,7 +394,7 @@ class BinnedContinuousPalette(IndexedPalette):
 
     def _bin_indices(self, x):
         nans = np.isnan(x)
-        binx = np.digitize(x, self.bins[1:-1], right=True)
+        binx = np.digitize(x, self.bins[1:-1])
         binx.clip(0, len(self.bins) - 1)
         binx[nans] = -1
         return binx, nans

--- a/Orange/widgets/utils/tests/test_colorpalettes.py
+++ b/Orange/widgets/utils/tests/test_colorpalettes.py
@@ -9,6 +9,7 @@ from AnyQt.QtGui import QImage, QColor, QIcon
 from orangewidget.tests.base import GuiTest
 from Orange.util import color_to_hex
 from Orange.data import DiscreteVariable, ContinuousVariable, Variable
+from Orange.preprocess.discretize import decimal_binnings
 # pylint: disable=wildcard-import,unused-wildcard-import
 from Orange.widgets.utils.colorpalettes import *
 
@@ -463,6 +464,14 @@ class BinnedPaletteTest(unittest.TestCase):
         self.assertNotEqual(self.binned.palette[0, 0], copy.palette[0, 0])
         copy.bins[0] += 1
         self.assertNotEqual(self.bins[0], copy.bins[0])
+
+    def test_decimal_binnings(self):
+        """test for consistency with binning from discretize"""
+        data = np.array([1, 2])
+        bins = decimal_binnings(data)[0].thresholds
+        binned = BinnedContinuousPalette.from_palette(self.palette, bins)
+        colors = binned.values_to_colors(data)
+        assert not np.array_equal(colors[0], colors[1])
 
 
 class UtilsTest(GuiTest):


### PR DESCRIPTION
##### Issue
There is an inconsistency between `decimal_binnings` and `BinnedContinuousPalette` on whether the equal sign is on the upper or lower border of bins.
The result is that we get the wrong colors for data points that lie on the border between bins.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
