### PR TITLE
[FIX] Heatmap: Sticky footer

### DIFF
--- a/Orange/widgets/utils/stickygraphicsview.py
+++ b/Orange/widgets/utils/stickygraphicsview.py
@@ -221,7 +221,7 @@ class StickyGraphicsView(QGraphicsView):
         viewrect = self.mapFromScene(rect).boundingRect()
         viewportrect = self.viewport().rect()
         visible = not (viewrect.top() >= viewportrect.top()
-                       and viewrect.bottom() <= viewportrect.bottom())
+                       and viewrect.bottom() <= viewportrect.y() + viewportrect.height())
         container.setVisible(visible)
         # force immediate layout of the container overlay
         QCoreApplication.sendEvent(container, QEvent(QEvent.LayoutRequest))

--- a/Orange/widgets/utils/stickygraphicsview.py
+++ b/Orange/widgets/utils/stickygraphicsview.py
@@ -109,7 +109,7 @@ class StickyGraphicsView(QGraphicsView):
             self.__updateFooter()
 
     def footerSceneRect(self) -> QRectF:
-        return QRectF(self.__headerRect)
+        return QRectF(self.__footerRect)
 
     def setScene(self, scene: QGraphicsScene) -> None:
         """Reimplemented"""

--- a/Orange/widgets/utils/stickygraphicsview.py
+++ b/Orange/widgets/utils/stickygraphicsview.py
@@ -1,7 +1,9 @@
 import sys
 import math
 
-from PyQt5.QtCore import Qt, QRectF, QEvent, QCoreApplication, QObject, QPointF
+from PyQt5.QtCore import (
+    Qt, QRectF, QEvent, QCoreApplication, QObject, QPointF, QRect
+)
 from PyQt5.QtGui import QBrush, QPalette, QTransform, QPolygonF
 from PyQt5.QtWidgets import (
     QGraphicsView, QGraphicsScene, QWidget, QVBoxLayout, QSizePolicy,
@@ -219,10 +221,10 @@ class StickyGraphicsView(QGraphicsView):
             return
         # map the rect to (main) viewport coordinates
         viewrect = qgraphicsview_map_rect_from_scene(self, rect).boundingRect()
-        viewrect = viewrect.toAlignedRect()
+        viewrect = qrectf_to_inscribed_rect(viewrect)
         viewportrect = self.viewport().rect()
-        visible = not (viewrect.top() >= viewportrect.top()
-                       and viewrect.bottom() <= viewportrect.y() + viewportrect.height())
+        visible = (viewrect.top() < viewportrect.top() or
+                   viewrect.y() + viewrect.height() > viewportrect.y() + viewportrect.height())
         container.setVisible(visible)
         # force immediate layout of the container overlay
         QCoreApplication.sendEvent(container, QEvent(QEvent.LayoutRequest))
@@ -261,6 +263,18 @@ def qgraphicsview_map_rect_from_scene(
     p3 = tr.map(rect.bottomRight())
     p4 = tr.map(rect.bottomLeft())
     return QPolygonF([p1, p2, p3, p4])
+
+
+def qrectf_to_inscribed_rect(rect: QRectF) -> QRect:
+    """
+    Return the largest integer QRect such that it is completely contained in
+    `rect`.
+    """
+    xmin = int(math.ceil(rect.x()))
+    xmax = int(math.floor(rect.right()))
+    ymin = int(math.ceil(rect.top()))
+    ymax = int(math.floor(rect.bottom()))
+    return QRect(xmin, ymin, max(xmax - xmin, 0), max(ymax - ymin, 0))
 
 
 def main(args):  # pragma: no cover

--- a/Orange/widgets/utils/tests/test_stickygraphicsview.py
+++ b/Orange/widgets/utils/tests/test_stickygraphicsview.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import Qt, QRectF, QPoint, QPointF
 from PyQt5.QtGui import QBrush, QWheelEvent
-from PyQt5.QtWidgets import QGraphicsScene, QWidget, QApplication
+from PyQt5.QtWidgets import QGraphicsScene, QWidget, QApplication, QStyle
 
 from Orange.widgets.tests.base import GuiTest
 
@@ -8,11 +8,16 @@ from Orange.widgets.utils.stickygraphicsview import StickyGraphicsView
 
 
 class TestStickyGraphicsView(GuiTest):
-    def test(self):
+    def create_view(self):
         view = StickyGraphicsView()
         scene = QGraphicsScene(view)
-        scene.setBackgroundBrush(QBrush(Qt.lightGray, Qt.CrossPattern))
         view.setScene(scene)
+        return view
+
+    def test(self):
+        view = self.create_view()
+        scene = view.scene()
+        scene.setBackgroundBrush(QBrush(Qt.lightGray, Qt.CrossPattern))
         scene.addRect(
             QRectF(0, 0, 300, 20), Qt.red, QBrush(Qt.red, Qt.BDiagPattern))
         scene.addRect(QRectF(0, 25, 300, 100))
@@ -47,6 +52,66 @@ class TestStickyGraphicsView(GuiTest):
         self.assertFalse(footer.isVisibleTo(view))
 
         qWheelScroll(header.viewport(), angleDelta=QPoint(0, -720 * 8))
+
+    @staticmethod
+    def _ensure_laid_out(view: QWidget) -> None:
+        """Ensure view has had pending resize events flushed."""
+        # when a widget is not visible it does not get resizeEvents dispatched
+        # immediately, only before it is actually shown or its rendering is
+        # requested.
+        view.grab()
+
+    def _test_visibility(self, view: StickyGraphicsView) -> None:
+        header = view.headerView()
+        footer = view.footerView()
+        vsbar = view.verticalScrollBar()
+        vsbar.triggerAction(vsbar.SliderToMinimum)
+        self._ensure_laid_out(view)
+
+        self.assertFalse(header.isVisibleTo(view))
+        self.assertTrue(footer.isVisibleTo(view))
+
+        vsbar.triggerAction(vsbar.SliderSingleStepAdd)
+        self._ensure_laid_out(view)
+
+        self.assertTrue(header.isVisibleTo(view))
+        self.assertTrue(footer.isVisibleTo(view))
+
+        vsbar.triggerAction(vsbar.SliderToMaximum)
+        self._ensure_laid_out(view)
+
+        self.assertTrue(header.isVisibleTo(view))
+        self.assertFalse(footer.isVisibleTo(view))
+
+        vsbar.triggerAction(vsbar.SliderSingleStepSub)
+        self._ensure_laid_out(view)
+        if not view.style().styleHint(QStyle.SH_ScrollBar_Transient, None, vsbar):
+            # cannot reliably test due to QTBUG-65074
+            self.assertTrue(header.isVisibleTo(view))
+            self.assertTrue(footer.isVisibleTo(view))
+
+    def test_fractional_1(self):
+        view = self.create_view()
+        view.resize(300, 100)
+        scenerect = QRectF(-0.1, -0.1, 300.2, 300.2)
+        headerrect = QRectF(-0.1, -0.1, 300.2, 20.2)
+        footerrect = QRectF(-0.1, 279.9, 300.2, 20.2)
+        view.setSceneRect(scenerect)
+        view.setHeaderSceneRect(headerrect)
+        view.setFooterSceneRect(footerrect)
+        self._test_visibility(view)
+
+    def test_fractional_2(self):
+        view = self.create_view()
+        view.resize(300, 100)
+        view.grab()
+        scenerect = QRectF(0.1, 0.1, 300, 299.8)
+        headerrect = QRectF(0.1, 0.1, 300, 20)
+        footerrect = QRectF(0.1, 299.9 - 20, 300, 20)
+        view.setSceneRect(scenerect)
+        view.setHeaderSceneRect(headerrect)
+        view.setFooterSceneRect(footerrect)
+        self._test_visibility(view)
 
 
 def qWheelScroll(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

'Heatmap' does not always hide the 'footer' shadow when it should. This seems to be style related. Observable with Fusion and Windows styles, on MacOS only if 'Show scroll bars' is 'Always' in System Preferences.

##### Description of changes

* Map the footer/header scene rect to viewport coords using float precision to avoid premature rounding.
* Accout for QRect.bottom() being one off.

Before

![Screen Shot 2020-04-02 at 13 32 20](https://user-images.githubusercontent.com/4716745/78249567-dacb0c80-74ee-11ea-8dca-98bec43b93cb.png)

After

![Screen Shot 2020-04-02 at 13 33 15](https://user-images.githubusercontent.com/4716745/78249596-e28ab100-74ee-11ea-8938-82af57877b3f.png)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
