### PR TITLE
Feature Constructor: Allow decreasing the height

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -485,7 +485,7 @@ class OWFeatureConstructor(OWWidget):
         self.featuremodel = DescriptorModel(parent=self)
 
         self.featureview = QListView(
-            minimumWidth=200,
+            minimumWidth=200, minimumHeight=50,
             sizePolicy=QSizePolicy(QSizePolicy.Minimum,
                                    QSizePolicy.MinimumExpanding)
         )


### PR DESCRIPTION
##### Issue

Feature Constructor's height should be allowed to be decreased. It would make for nicer screenshots.

##### Description of changes

The problem was the height of the list view. Minimum height is now set to 50.

##### Includes
- [X] Code changes
