### PR TITLE
[FIX] Table: Send correct output when switching between tabs

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -718,6 +718,7 @@ class OWDataTable(OWWidget):
         view = self.tabs.widget(index)
         if view is not None and view.model() is not None:
             self.set_info(view.input_slot.summary)
+            self.update_selection()
         else:
             self.set_info(None)
 


### PR DESCRIPTION
##### Issue
Fix #4618 
##### Description of changes
`update_selection` added in `on_current_tab_changed` in order to change output each time the user changes tab.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
