### PR TITLE
[FIX] Fix dimensionality of probabilities from values

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -358,7 +358,11 @@ class Model(Reprable):
 
         def one_hot_probs(value):
             if not multitarget:
-                return one_hot(value)
+                return one_hot(
+                    value,
+                    dim=len(self.domain.class_var.values)
+                    if self.domain is not None else None
+                )
 
             max_card = max(len(c.values) for c in self.domain.class_vars)
             probs = np.zeros(value.shape + (max_card,), float)

--- a/Orange/data/tests/test_util.py
+++ b/Orange/data/tests/test_util.py
@@ -1,8 +1,9 @@
 import unittest
+import numpy as np
 
 from Orange.data import Domain, ContinuousVariable
 from Orange.data.util import get_unique_names, get_unique_names_duplicates, \
-    get_unique_names_domain
+    get_unique_names_domain, one_hot
 
 
 class TestGetUniqueNames(unittest.TestCase):
@@ -142,6 +143,49 @@ class TestGetUniqueNames(unittest.TestCase):
         self.assertEqual(classes, [])
         self.assertEqual(metas, [])
         self.assertEqual(renamed, [])
+
+
+class TestOneHot(unittest.TestCase):
+
+    def setUp(self):
+        self.values = np.array([0, 1, 2, 1])
+
+    @staticmethod
+    def test_empty():
+        np.testing.assert_array_equal(
+            one_hot([]), np.zeros((0, 0))
+        )
+        np.testing.assert_array_equal(
+            one_hot([], dim=2), np.zeros((0, 2))
+        )
+
+    def test_one_hot(self):
+        np.testing.assert_array_equal(
+            one_hot(self.values),
+            [[1, 0, 0],
+             [0, 1, 0],
+             [0, 0, 1],
+             [0, 1, 0]]
+        )
+
+    def test_dtype(self):
+        res = one_hot(self.values)
+        self.assertEqual(res.dtype, float)
+        res = one_hot(self.values, dtype=int)
+        self.assertEqual(res.dtype, int)
+
+    def test_dim(self):
+        np.testing.assert_array_equal(
+            one_hot(self.values, dim=4),
+            [[1, 0, 0, 0],
+             [0, 1, 0, 0],
+             [0, 0, 1, 0],
+             [0, 1, 0, 0]]
+        )
+
+    def test_dim_too_low(self):
+        with self.assertRaises(ValueError):
+            one_hot(self.values, dim=2)
 
 
 if __name__ == "__main__":

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -4,7 +4,7 @@ Data-manipulation utilities.
 import re
 from collections import Counter
 from itertools import chain, count
-from typing import Callable
+from typing import Callable, Union, List, Type
 
 import numpy as np
 import bottleneck as bn
@@ -13,22 +13,34 @@ from scipy import sparse as sp
 RE_FIND_INDEX = r"(^{} \()(\d{{1,}})(\)$)"
 
 
-def one_hot(values, dtype=float):
+def one_hot(
+        values: Union[np.ndarray, List], dtype: Type = float, dim: int = None
+) -> np.ndarray:
     """Return a one-hot transform of values
 
     Parameters
     ----------
     values : 1d array
         Integer values (hopefully 0-max).
+    dtype
+        dtype of result array
+    dim
+        Number of columns (attributes) in the one hot encoding. This parameter
+        is used when we need fixed number of columns and values does not
+        reflect that number correctly, e.g. not all values from the discrete
+        variable are present in values parameter.
 
     Returns
     -------
     result
         2d array with ones in respective indicator columns.
     """
-    if len(values) == 0:
-        return np.zeros((0, 0), dtype=dtype)
-    return np.eye(int(np.max(values) + 1), dtype=dtype)[np.asanyarray(values, dtype=int)]
+    dim_values = int(np.max(values) + 1 if len(values) > 0 else 0)
+    if dim is None:
+        dim = dim_values
+    elif dim < dim_values:
+        raise ValueError("dim must be greater than max(values)")
+    return np.eye(dim, dtype=dtype)[np.asanyarray(values, dtype=int)]
 
 
 # pylint: disable=redefined-builtin

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -134,16 +134,6 @@ class LinearModel(SklModel):
     def coefficients(self):
         return self.skl_model.coef_
 
-    def predict(self, X):
-        vals = self.skl_model.predict(X)
-        if len(vals.shape) == 1:
-            # Prevent IndexError for 1D array
-            return vals
-        elif vals.shape[1] == 1:
-            return vals.ravel()
-        else:
-            return vals
-
     def __str__(self):
         return 'LinearModel {}'.format(self.skl_model)
 

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -18,10 +18,12 @@ from Orange.base import SklLearner
 import Orange.classification
 from Orange.classification import (
     Learner, Model,
-    NaiveBayesLearner, LogisticRegressionLearner, NuSVMLearner, MajorityLearner,
+    NaiveBayesLearner, LogisticRegressionLearner, NuSVMLearner,
+    MajorityLearner,
     RandomForestLearner, SimpleTreeLearner, SoftmaxRegressionLearner,
     SVMLearner, LinearSVMLearner, OneClassSVMLearner, TreeLearner, KNNLearner,
-    SimpleRandomForestLearner, EllipticEnvelopeLearner)
+    SimpleRandomForestLearner, EllipticEnvelopeLearner,
+    SGDClassificationLearner)
 from Orange.classification.rules import _RuleLearner
 from Orange.data import (ContinuousVariable, DiscreteVariable,
                          Domain, Table)
@@ -189,6 +191,24 @@ class ModelTest(unittest.TestCase):
         clf = DummyLearner()(iris)
         with self.assertRaises(DomainTransformationError):
             clf(titanic)
+
+    def test_result_shape(self):
+        """
+        This test function will be extended for all models in on of the
+        following pull requests.
+        """
+        iris = Table('iris')
+        learner = SGDClassificationLearner()
+
+        # model trained on only one value (but three in the domain)
+        model = learner(iris)
+
+        res = model(iris[0:50])
+        self.assertTupleEqual((50,), res.shape)
+
+        # probabilities must still be for three classes
+        res = model(iris[0:50], model.Probs)
+        self.assertTupleEqual((50, 3), res.shape)
 
 
 class ExpandProbabilitiesTest(unittest.TestCase):

--- a/Orange/tests/test_sgd.py
+++ b/Orange/tests/test_sgd.py
@@ -55,3 +55,20 @@ class TestSGDClassificationLearner(unittest.TestCase):
         lrn = SGDClassificationLearner()
         mod = lrn(self.iris)
         self.assertEqual(len(mod.coefficients[0]), len(mod.domain.attributes))
+
+    def test_predictions_shapes(self):
+        """
+        Test the resulting shapes of probabilities for SGD
+        """
+        # one where probabilities computed from data
+        # hinge loss do not enable predict_proba
+        lrn = SGDClassificationLearner()
+        mod = lrn(self.iris)
+        self.assertTupleEqual((50, 3), mod(self.iris[:50], mod.Probs).shape)
+        self.assertTupleEqual((50,), mod(self.iris[:50], mod.Value).shape)
+
+        # in this case probabilities are retrieved by skl_learner.predict_proba
+        lrn = SGDClassificationLearner(loss='modified_huber')
+        mod = lrn(self.iris)
+        self.assertTupleEqual((50, 3), mod(self.iris[:50], mod.Probs).shape)
+        self.assertTupleEqual((50,), mod(self.iris[:50], mod.Value).shape)

--- a/Orange/widgets/data/utils/histogram.py
+++ b/Orange/widgets/data/utils/histogram.py
@@ -268,15 +268,7 @@ class Histogram(QGraphicsWidget):
             # well as their corresponding `x` values
             y_nan_mask = np.isnan(y)
             y, bin_indices = y[~y_nan_mask], bin_indices[~y_nan_mask]
-
-            y = one_hot(y)
-            # In the event that y does not take up all the values and the
-            # largest discrete value does not appear at all, one hot encoding
-            # will produce too few columns. This causes problems, so we need to
-            # pad y with zeros to properly compute the distribution
-            if y.shape[1] != len(self.target_var.values):
-                n_missing_columns = len(self.target_var.values) - y.shape[1]
-                y = np.hstack((y, np.zeros((y.shape[0], n_missing_columns))))
+            y = one_hot(y, dim=len(self.target_var.values))
 
             bins = np.arange(self.n_bins)[:, np.newaxis]
             mask = bin_indices == bins


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

SGD (same than some other models) outputs wrong shapes of probabilities when those retrieved from values (when skl_learner do not provide probabilities). The issue is caused by the one_hot encoding function that does not consider a number of values in the domain.

SGD (skl_learner) for some of the losses provides probabilities that are not used by Orange since it uses custom predict function.

##### Description of changes

- ` one_hot` function changed to accept `dim` parameter which tells what must be a resulting number of columns
- `__call__` function for model calls `one_hot` with a `dim` parameter that has a number of values in the domain as a shape.
- SGD model now uses a predict function from SklModel (which correctly retrieve probabilities from skl_learner) if possible.



##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
