### PR TITLE
[FIX] PyTableModel: Allow wrapping empty lists

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -107,7 +107,9 @@ class PyTableModel(AbstractSortTableModel):
         self._editable = editable
         self._table = None
         self._roleData = {}
-        self.wrap(sequence or [])
+        if sequence is None:
+            sequence = []
+        self.wrap(sequence)
 
     def rowCount(self, parent=QModelIndex()):
         return 0 if parent.isValid() else self._rows

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -42,6 +42,14 @@ class TestPyTableModel(unittest.TestCase):
         self.model = PyTableModel()
         self.assertEqual(self.model.rowCount(), 0)
 
+    def test_init_wrap_empty(self):
+        # pylint: disable=protected-access
+        t = []
+        model = PyTableModel(t)
+        self.assertIs(model._table, t)
+        t.append([1, 2, 3])
+        self.assertEqual(list(model), [[1, 2, 3]])
+
     def test_rowCount(self):
         self.assertEqual(self.model.rowCount(), 2)
         self.assertEqual(len(self.model), 2)


### PR DESCRIPTION
##### Issue

`PyTableModel`'s constructor does not wrap an empty list but wraps another, new empty list instead.

Constructor has an argument `sequence` with default `None` and then wraps `sequence or []`. This is not OK when `sequence` is `[]`. 

##### Includes
- [X] Code changes
- [X] Tests
