### PR TITLE
[FIX] concurrent: Use a workaround for QObject wrapper deletion

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -22,7 +22,6 @@ import zipfile
 
 from xml.sax.saxutils import escape
 from functools import singledispatch
-from concurrent import futures
 from contextlib import ExitStack
 
 import typing
@@ -51,6 +50,7 @@ from pandas.api import types as pdtypes
 import Orange.data
 
 from Orange.widgets import widget, gui, settings
+from Orange.widgets.utils.concurrent import PyOwned
 from Orange.widgets.utils import textimport, concurrent as qconcurrent
 from Orange.widgets.utils.overlay import OverlayWidget
 from Orange.widgets.utils.settings import (
@@ -866,9 +866,6 @@ class OWCSVFileImport(widget.OWWidget):
         w.progress.cancel = True
         w.done.disconnect(self.__handle_result)
         w.progress.progressChanged.disconnect(self.__set_read_progress)
-        w.progress.deleteLater()
-        # wait until completion
-        futures.wait([w.future()])
         self.__watcher = None
 
     def cancel(self):
@@ -1383,7 +1380,7 @@ def clear_stack_on_cancel(f):
     return wrapper
 
 
-class TaskState(QObject):
+class TaskState(QObject, PyOwned):
     class UserCancelException(BaseException):
         """User interrupt exception."""
 

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -20,7 +20,7 @@ from AnyQt import QtGui
 from AnyQt.QtCore import Qt, QSize, QThread
 from AnyQt.QtCore import pyqtSlot as Slot
 from AnyQt.QtGui import QStandardItem, QDoubleValidator
-from AnyQt.QtWidgets import QHeaderView, QTableWidget, QLabel, QApplication
+from AnyQt.QtWidgets import QHeaderView, QTableWidget, QLabel
 
 from Orange.base import Learner
 import Orange.classification
@@ -1111,7 +1111,6 @@ class OWTestAndScore(OWWidget):
             task.cancel()
             task.progress_changed.disconnect(self.setProgressValue)
             task.watcher.finished.disconnect(self.__task_complete)
-            add_task_to_dispose_queue(task)
 
             self.progressBarFinished()
             self.setStatusMessage("")
@@ -1120,15 +1119,6 @@ class OWTestAndScore(OWWidget):
         self.cancel()
         self.__executor.shutdown(wait=False)
         super().onDeleteWidget()
-
-
-def add_task_to_dispose_queue(task: TaskState):
-    # transfer ownership of task to Qt, and delete it after completion
-    # all other signals from task should be disconnected.
-    assert task.parent() is None
-    app = QApplication.instance()
-    task.setParent(app)
-    task.watcher.finished.connect(task.deleteLater)
 
 
 class UserInterrupt(BaseException):

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -1118,7 +1118,7 @@ class OWTestAndScore(OWWidget):
 
     def onDeleteWidget(self):
         self.cancel()
-        self.__executor.shutdown(True)
+        self.__executor.shutdown(wait=False)
         super().onDeleteWidget()
 
 

--- a/Orange/widgets/utils/concurrent.py
+++ b/Orange/widgets/utils/concurrent.py
@@ -21,12 +21,12 @@ from AnyQt.QtCore import (
 )
 
 from orangewidget.utils.concurrent import (
-    FutureWatcher, FutureSetWatcher, methodinvoke
+    FutureWatcher, FutureSetWatcher, methodinvoke, PyOwned
 )
 
 __all__ = [
     "FutureWatcher", "FutureSetWatcher", "methodinvoke",
-    "TaskState", "ConcurrentMixin", "ConcurrentWidgetMixin"
+    "TaskState", "ConcurrentMixin", "ConcurrentWidgetMixin", "PyOwned"
 ]
 
 _log = logging.getLogger(__name__)
@@ -384,7 +384,7 @@ class Task(QObject):
             super().customEvent(event)
 
 
-class TaskState(QObject):
+class TaskState(QObject, PyOwned):
 
     status_changed = Signal(str)
     _p_status_changed = Signal(str)

--- a/Orange/widgets/utils/concurrent.py
+++ b/Orange/widgets/utils/concurrent.py
@@ -527,10 +527,6 @@ class ConcurrentMixin:
             self._disconnect_signals(state)
             if wait:
                 concurrent.futures.wait([state.future])
-                state.deleteLater()
-            else:
-                w = FutureWatcher(state.future, parent=state)
-                w.done.connect(state.deleteLater)
 
     def _connect_signals(self, state: TaskState):
         state.partial_result_ready.connect(self.on_partial_result)
@@ -545,8 +541,7 @@ class ConcurrentMixin:
         assert self.__task is not None
         assert self.__task.future is future
         assert self.__task.watcher.future() is future
-        self.__task, task = None, self.__task
-        task.deleteLater()
+        self.__task = None
         ex = future.exception()
         if ex is not None:
             self.on_exception(ex)

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -269,6 +269,8 @@ class PyTableModel(AbstractSortTableModel):
             stop -= 1
         else:
             start = stop = i = i if i >= 0 else len(self) + i
+        if stop < start:
+            return
         self._check_sort_order()
         self.beginRemoveRows(QModelIndex(), start, stop)
         del self._table[i]
@@ -282,6 +284,8 @@ class PyTableModel(AbstractSortTableModel):
         if isinstance(i, slice):
             start, stop, _ = _as_contiguous_range(i, len(self))
             self.removeRows(start, stop - start)
+            if len(value) == 0:
+                return
             self.beginInsertRows(QModelIndex(), start, start + len(value) - 1)
             self._table[start:start] = value
             self._rows = self._table_dim()[0]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: gh-4615

##### Description of changes

Use PyOwned from https://github.com/biolab/orange-widget-base/pull/58 

<s>Requires https://github.com/biolab/orange-widget-base/pull/58 is merged and released.</s>

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
