### PR TITLE
Help url: use docs.biolab.si instead of docs.orange.biolab.si

### DIFF
--- a/Orange/widgets/__init__.py
+++ b/Orange/widgets/__init__.py
@@ -28,5 +28,5 @@ WIDGET_HELP_PATH = (
     (os.path.join(sysconfig.get_path("data"),
                   "share/help/en/orange3/htmlhelp/index.html"),
      None),
-    ("https://docs.orange.biolab.si/3/visual-programming/", ""),
+    ("https://docs.biolab.si/orange/3/visual-programming/", ""),
 )


### PR DESCRIPTION
##### Issue
The old URL, docs.orange.biolab.si, has certificates managed by us, and sometimes something goes wrong and it becomes inaccessible. docs.biolab.si is managed by cloudflare. 