### PR TITLE
[FIX] Save base: Fix migrate_settings

### DIFF
--- a/Orange/widgets/utils/save/owsavebase.py
+++ b/Orange/widgets/utils/save/owsavebase.py
@@ -315,7 +315,8 @@ class OWSaveBase(widget.OWWidget, openclass=True):
         if "last_dir" in settings:
             settings["stored_path"] = settings.pop("last_dir")
         if "filename" in settings:
-            settings["stored_name"] = os.path.split(settings.pop("filename"))[1]
+            settings["stored_name"] = os.path.split(
+                settings.pop("filename") or "")[1]
 
     # As of Qt 5.9, QFileDialog.setDefaultSuffix does not support double
     # suffixes, not even in non-native dialogs. We handle each OS separately.


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
migrate_settting did not correctly handle the case when `filename` was None.

##### Description of changes
Change migrate_settting to correctly handle the case when `filename` was None.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
