### PR TITLE
Fix update check setting to be True by default

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -32,7 +32,7 @@ OFFICIAL_ADDON_LIST = "https://orange.biolab.si/addons/list"
 WIDGETS_ENTRY = "orange.widgets"
 
 spec = [
-    ("startup/check-updates", bool, False, "Check for updates"),
+    ("startup/check-updates", bool, True, "Check for updates"),
 
     ("startup/launch-count", int, 0, ""),
 


### PR DESCRIPTION
Update check was inconsistent. It was on by default until the preferences dialog was open. Opening the preferences dialog disabled it even when there was no user input.