### PR TITLE
Feature Constructor: Don't fix the number of decimals

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -235,7 +235,7 @@ class ContinuousFeatureEditor(FeatureEditor):
     def editorData(self):
         return ContinuousDescriptor(
             name=self.nameedit.text(),
-            number_of_decimals=3,
+            number_of_decimals=None,
             expression=self.expressionedit.text()
         )
 


### PR DESCRIPTION
##### Issue

Feature Constructor sets the number of decimals.

Fixes #4639.

##### Description of changes

Set it to `None`, so `"%g"` is used for printing.

##### Includes
- [X] Code changes
