### PR TITLE
[FIX] Several fixes in learners/models

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -1,10 +1,6 @@
-import warnings
-
 import numpy as np
-
 import sklearn.linear_model as skl_linear_model
 
-import Orange
 from Orange.classification import SklLearner, SklModel
 from Orange.preprocess import Normalize
 from Orange.preprocess.score import LearnerScorer
@@ -44,12 +40,3 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
                  multi_class='ovr', verbose=0, n_jobs=1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-
-    def __call__(self, data):
-        if len(np.unique(data.Y)) > 1:
-            return super().__call__(data)
-        else:
-            warnings.warn("Single class in data, returning Constant Model.")
-            maj = Orange.classification.MajorityLearner()
-            const = maj(data)
-            return const

--- a/Orange/classification/outlier_detection.py
+++ b/Orange/classification/outlier_detection.py
@@ -11,10 +11,8 @@ from sklearn.svm import OneClassSVM
 from Orange.base import SklLearner, SklModel
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable, \
     Variable
-from Orange.data.table import DomainTransformationError
 from Orange.data.util import get_unique_names
 from Orange.preprocess import AdaptiveNormalize
-from Orange.statistics.util import all_nan
 from Orange.util import wrap_callback, dummy_callback
 
 __all__ = ["LocalOutlierFactorLearner", "IsolationForestLearner",
@@ -48,30 +46,6 @@ class _OutlierModel(SklModel):
         metas = np.hstack((data.metas, self.predict(self._cached_data.X)))
         progress_callback(1)
         return Table.from_numpy(domain, data.X, data.Y, metas)
-
-    def data_to_model_domain(self, data: Table, progress_callback: Callable) \
-            -> Table:
-        if data.domain == self.domain:
-            return data
-
-        progress_callback(0)
-        if self.original_domain.attributes != data.domain.attributes \
-                and data.X.size \
-                and not all_nan(data.X):
-            progress_callback(0.5)
-            new_data = data.transform(self.original_domain)
-            if all_nan(new_data.X):
-                raise DomainTransformationError(
-                    "domain transformation produced no defined values")
-            progress_callback(0.75)
-            data = new_data.transform(self.domain)
-            progress_callback(1)
-            return data
-
-        progress_callback(0.5)
-        data = data.transform(self.domain)
-        progress_callback(1)
-        return data
 
 
 class _OutlierLearner(SklLearner):

--- a/Orange/classification/rules.py
+++ b/Orange/classification/rules.py
@@ -795,7 +795,11 @@ class Rule:
         else:
             cond = "TRUE"
 
-        outcome = class_var.name + "=" + class_var.values[self.prediction]
+        # it is possible that prediction is not set yet - use _ for outcome
+        outcome = (
+            (class_var.name + "=" + class_var.values[self.prediction])
+            if self.prediction is not None else "_"
+        )
         return "IF {} THEN {} ".format(cond, outcome)
 
 
@@ -870,8 +874,8 @@ class RuleHunter:
                 new_rules = self.search_strategy.refine_rule(
                     X, Y, W, candidate_rule)
                 rules.extend(new_rules)
-                #remove default rule from list of rules
-                if best_rule.length == 0:
+                # remove default rule from list of rules
+                if best_rule.length == 0 and len(new_rules) > 0:
                     best_rule = new_rules[0]
                 for new_rule in new_rules[1:]:
                     if (new_rule.quality > best_rule.quality and

--- a/Orange/classification/svm.py
+++ b/Orange/classification/svm.py
@@ -1,6 +1,6 @@
 import sklearn.svm as skl_svm
 
-from Orange.classification import SklLearner, SklModel
+from Orange.classification import SklLearner
 from Orange.preprocess import AdaptiveNormalize
 
 __all__ = ["SVMLearner", "LinearSVMLearner", "NuSVMLearner"]
@@ -32,19 +32,8 @@ class LinearSVMLearner(SklLearner):
         self.params = vars()
 
 
-class NuSVMClassifier(SklModel):
-
-    def predict(self, X):
-        value = self.skl_model.predict(X)
-        if self.skl_model.probability:
-            prob = self.skl_model.predict_proba(X)
-            return value, prob
-        return value
-
-
 class NuSVMLearner(SklLearner):
     __wraps__ = skl_svm.NuSVC
-    __returns__ = NuSVMClassifier
     preprocessors = svm_pps
 
     def __init__(self, nu=0.5, kernel='rbf', degree=3, gamma="auto", coef0=0.0,
@@ -55,10 +44,11 @@ class NuSVMLearner(SklLearner):
 
 
 if __name__ == '__main__':
-    import Orange
+    from Orange.evaluation import CrossValidation, CA
+    from Orange.data import Table
 
-    data = Orange.data.Table('iris')
+    data_ = Table('iris')
     learners = [SVMLearner(), NuSVMLearner(), LinearSVMLearner()]
-    res = Orange.evaluation.CrossValidation(data, learners)
-    for l, ca in zip(learners, Orange.evaluation.CA(res)):
+    res = CrossValidation()(data_, learners)
+    for l, ca in zip(learners, CA()(res)):
         print("learner: {}\nCA: {}\n".format(l, ca))

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -123,11 +123,8 @@ class TestLogisticRegressionLearner(unittest.TestCase):
         t = self.iris[60:90]
         self.assertEqual(len(np.unique(t.Y)), 1)
         learn = LogisticRegressionLearner()
-        with self.assertWarns(UserWarning):
-            model = learn(t)
-        self.assertEqual(model(t[0]), 1)
-        self.assertTrue(np.all(model(t[0], ret=Model.Probs) == [0, 1, 0]))
-        self.assertTrue(np.all(model(t) == 1))
+        with self.assertRaises(ValueError):
+            learn(t)
 
     def test_sklearn_single_class(self):
         t = self.iris[60:90]

--- a/Orange/tests/test_regression.py
+++ b/Orange/tests/test_regression.py
@@ -12,24 +12,26 @@ from Orange.regression import Learner
 from Orange.tests import test_filename
 
 
-class TestRegression(unittest.TestCase):
-    def all_learners(self):
-        regression_modules = pkgutil.walk_packages(
-            path=Orange.regression.__path__,
-            prefix="Orange.regression.",
-            onerror=lambda x: None)
-        for importer, modname, ispkg in regression_modules:
-            try:
-                module = pkgutil.importlib.import_module(modname)
-            except ImportError:
-                continue
+def all_learners():
+    regression_modules = pkgutil.walk_packages(
+        path=Orange.regression.__path__,
+        prefix="Orange.regression.",
+        onerror=lambda x: None)
+    for _, modname, _ in regression_modules:
+        try:
+            module = pkgutil.importlib.import_module(modname)
+        except ImportError:
+            continue
 
-            for name, class_ in inspect.getmembers(module, inspect.isclass):
-                if issubclass(class_, Learner) and 'base' not in class_.__module__:
-                    yield class_
+        for _, class_ in inspect.getmembers(module, inspect.isclass):
+            if issubclass(class_, Learner) and 'base' not in class_.__module__:
+                yield class_
+
+
+class TestRegression(unittest.TestCase):
 
     def test_adequacy_all_learners(self):
-        for learner in self.all_learners():
+        for learner in all_learners():
             try:
                 learner = learner()
                 table = Table("iris")
@@ -39,7 +41,7 @@ class TestRegression(unittest.TestCase):
                 continue
 
     def test_adequacy_all_learners_multiclass(self):
-        for learner in self.all_learners():
+        for learner in all_learners():
             try:
                 learner = learner()
                 table = Table(test_filename("datasets/test8.tab"))
@@ -50,7 +52,7 @@ class TestRegression(unittest.TestCase):
 
     def test_missing_class(self):
         table = Table(test_filename("datasets/imports-85.tab"))
-        for learner in self.all_learners():
+        for learner in all_learners():
             try:
                 learner = learner()
                 model = learner(table)


### PR DESCRIPTION
##### Issue
- Logistic regression uses MajorityLearner when only one class in data, while SVM fails
- Softmax regression and NuSVM return the wrong shape of the probability matrix when one class missing in training data.
- Now when the `data_to_model_domain` was introduced in a Model class it is duplicated in outliers.
- Rules fail when empty list with new rules

##### Description of changes
- LogisticRegressionLearner does not use MajorityLearner when only one class in data.
- Softmax regression fixed to return the right shape of probability matrix (num cases x num classes in the domain)
- `NuSVM`: removed own predict function, adding missing dimensions is now handled by predict function on SklModel
- `data_to_model_domain` removed from outliers, added callbacks to  `data_to_model_domain` in Model class
- Rules fixed


##### Includes
- [X] Code changes
- [X] Tests
