### PR TITLE
[FIX] Pythagorantrees/forests: change context handler

### DIFF
--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -57,7 +57,7 @@ class OWPythagorasTree(OWWidget):
     graph_name = 'scene'
 
     # Settings
-    settingsHandler = settings.DomainContextHandler()
+    settingsHandler = settings.ClassValuesContextHandler()
 
     depth_limit = settings.ContextSetting(10)
     target_class_index = settings.ContextSetting(0)
@@ -155,6 +155,8 @@ class OWPythagorasTree(OWWidget):
 
         if model is not None:
             self.data = model.instances
+
+            self._update_target_class_combo()
             self.tree_adapter = self._get_tree_adapter(self.model)
             self.ptree.clear()
 
@@ -169,11 +171,12 @@ class OWPythagorasTree(OWWidget):
             self._update_legend_colors()
             self._update_legend_visibility()
             self._update_info_box()
-            self._update_target_class_combo()
 
             self._update_main_area()
 
-        self.openContext(self.model)
+            self.openContext(
+                model.domain.class_var if model.domain is not None else None
+            )
 
         self.update_depth()
 
@@ -277,8 +280,7 @@ class OWPythagorasTree(OWWidget):
 
     def _clear_target_class_combo(self):
         self.target_class_combo.clear()
-        self.target_class_index = 0
-        self.target_class_combo.setCurrentIndex(self.target_class_index)
+        self.target_class_index = -1
 
     def _set_max_depth(self):
         """Set the depth to the max depth and update appropriate actors."""
@@ -339,7 +341,8 @@ class OWPythagorasTree(OWWidget):
             values = list(ContinuousTreeNode.COLOR_METHODS.keys())
         label.setText(label_text)
         self.target_class_combo.addItems(values)
-        self.target_class_combo.setCurrentIndex(self.target_class_index)
+        # set it to 0, context will change if required
+        self.target_class_index = 0
 
     def _update_legend_colors(self):
         if self.legend is not None:

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -174,9 +174,9 @@ class OWPythagoreanForest(OWWidget):
     graph_name = 'scene'
 
     # Settings
-    settingsHandler = settings.DomainContextHandler()
+    settingsHandler = settings.ClassValuesContextHandler()
 
-    depth_limit = settings.ContextSetting(10)
+    depth_limit = settings.Setting(10)
     target_class_index = settings.ContextSetting(0)
     size_calc_idx = settings.Setting(0)
     zoom = settings.Setting(200)
@@ -274,15 +274,18 @@ class OWPythagoreanForest(OWWidget):
         self.rf_model = model
 
         if model is not None:
+            self.instances = model.instances
+            self._update_target_class_combo()
+
             self.forest = self._get_forest_adapter(self.rf_model)
             self.forest_model[:] = self.forest.trees
-            self.instances = model.instances
 
             self._update_info_box()
-            self._update_target_class_combo()
             self._update_depth_slider()
 
-        self.openContext(model)
+            self.openContext(
+                model.domain.class_var if model.domain is not None else None
+            )
         # Restore item selection
         if self.selected_index is not None:
             index = self.list_view.model().index(self.selected_index)
@@ -324,15 +327,15 @@ class OWPythagoreanForest(OWWidget):
             values = list(ContinuousTreeNode.COLOR_METHODS.keys())
         label.setText(label_text)
         self.ui_target_class_combo.addItems(values)
-        self.ui_target_class_combo.setCurrentIndex(self.target_class_index)
+        # set it to 0, context will change if required
+        self.target_class_index = 0
 
     def _clear_info_box(self):
         self.ui_info.setText('No forest on input.')
 
     def _clear_target_class_combo(self):
         self.ui_target_class_combo.clear()
-        self.target_class_index = 0
-        self.ui_target_class_combo.setCurrentIndex(self.target_class_index)
+        self.target_class_index = -1
 
     def _clear_depth_slider(self):
         self.ui_depth_slider.parent().setEnabled(False)

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -396,6 +396,21 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.tree, forest.trees[1])
         self.assertEqual(self.widget.ptree._depth_limit, 1)
 
+    def test_context(self):
+        iris_tree = TreeLearner()(Table("iris"))
+        self.send_signal(self.widget.Inputs.tree, self.titanic)
+        self.widget.target_class_index = 1
+
+        self.send_signal(self.widget.Inputs.tree, iris_tree)
+        self.assertEqual(0, self.widget.target_class_index)
+
+        self.widget.target_class_index = 2
+        self.send_signal(self.widget.Inputs.tree, self.titanic)
+        self.assertEqual(1, self.widget.target_class_index)
+
+        self.send_signal(self.widget.Inputs.tree, iris_tree)
+        self.assertEqual(2, self.widget.target_class_index)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/visualize/tests/test_owpythagoreanforest.py
+++ b/Orange/widgets/visualize/tests/test_owpythagoreanforest.py
@@ -221,3 +221,20 @@ class TestOWPythagoreanForest(WidgetTest):
         output = self.get_output(self.widget.Outputs.tree)
         self.assertIsNotNone(output)
         self.assertIs(output.skl_model, self.titanic.trees[idx].skl_model)
+
+    def test_context(self):
+        iris = Table("iris")
+        iris_tree = RandomForestLearner()(iris)
+        iris_tree.instances = iris
+        self.send_signal(self.widget.Inputs.random_forest, self.titanic)
+        self.widget.target_class_index = 1
+
+        self.send_signal(self.widget.Inputs.random_forest, iris_tree)
+        self.assertEqual(0, self.widget.target_class_index)
+
+        self.widget.target_class_index = 2
+        self.send_signal(self.widget.Inputs.random_forest, self.titanic)
+        self.assertEqual(1, self.widget.target_class_index)
+
+        self.send_signal(self.widget.Inputs.random_forest, iris_tree)
+        self.assertEqual(2, self.widget.target_class_index)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Pythagorantrees and Pythagorantrees use domain context handler without having any context variable with variables from the domain

##### Description of changes
DomainContextHandler replaced with ClassValuesContextHandler
Besides: Fixed warnings about setting index (for the selected item) when an empty combo box

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
