### PR TITLE
Remove DomainContextHandler from Table and PCA

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -32,7 +32,7 @@ from Orange.data.sql.table import SqlTable
 from Orange.statistics import basic_stats
 
 from Orange.widgets import gui
-from Orange.widgets.settings import Setting, DomainContextHandler
+from Orange.widgets.settings import Setting
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Input, Output
 from Orange.widgets.utils import datacaching
@@ -425,8 +425,6 @@ class OWDataTable(OWWidget):
     auto_commit = Setting(True)
 
     color_by_class = Setting(True)
-    settingsHandler = DomainContextHandler(
-        match_values=DomainContextHandler.MATCH_VALUES_ALL)
     selected_rows = Setting([], schema_only=True)
     selected_cols = Setting([], schema_only=True)
 
@@ -493,7 +491,6 @@ class OWDataTable(OWWidget):
     @Inputs.data
     def set_dataset(self, data, tid=None):
         """Set the input dataset."""
-        self.closeContext()
         if data is not None:
             datasetname = getattr(data, "name", "Data")
             if tid in self._inputs:
@@ -560,7 +557,6 @@ class OWDataTable(OWWidget):
                 self.set_info(current.input_slot.summary)
 
         self.tabs.tabBar().setVisible(self.tabs.count() > 1)
-        self.openContext(data)
 
         if data and self.__pending_selected_rows is not None:
             self.selected_rows = self.__pending_selected_rows

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -35,12 +35,10 @@ class OWPCA(widget.OWWidget):
         components = Output("Components", Table)
         pca = Output("PCA", PCA, dynamic=False)
 
-    settingsHandler = settings.DomainContextHandler()
-
     ncomponents = settings.Setting(2)
     variance_covered = settings.Setting(100)
     auto_commit = settings.Setting(True)
-    normalize = settings.ContextSetting(True)
+    normalize = settings.Setting(True)
     maxp = settings.Setting(20)
     axis_labels = settings.Setting(10)
 
@@ -113,7 +111,6 @@ class OWPCA(widget.OWWidget):
 
     @Inputs.data
     def set_data(self, data):
-        self.closeContext()
         self.clear_messages()
         self.clear()
         self.information()
@@ -136,7 +133,6 @@ class OWPCA(widget.OWWidget):
                 self.clear_outputs()
                 return
 
-        self.openContext(data)
         self._init_projector()
 
         self.data = data


### PR DESCRIPTION
##### Issue

Fixes #4667.

##### Description of changes

`OWTable` declared, but didn't use, `DomainContextHandler`.

`OWPCA` used `DomainContextHandler`, but context matched any domain, hence the only context setting (`normalize`) was effectively non-context. I believe we discussed whether `normalize` has to be a context setting and I pushed for it, but I was probably wrong. See #4667  for more details.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
