### PR TITLE
[FIX] Embedder: catch machine id setting type error

### DIFF
--- a/Orange/misc/server_embedder.py
+++ b/Orange/misc/server_embedder.py
@@ -60,9 +60,14 @@ class ServerEmbedderCommunicator:
         # attribute that offers support for cancelling the embedding
         # if ran in another thread
         self._cancelled = False
-        self.machine_id = QSettings().value(
-            "error-reporting/machine-id", "", type=str
-        ) or str(uuid.getnode())
+
+        self.machine_id = None
+        try:
+            self.machine_id = QSettings().value(
+                "error-reporting/machine-id", "", type=str
+            ) or str(uuid.getnode())
+        except TypeError:
+            self.machine_id = str(uuid.getnode())
         self.session_id = str(random.randint(1, 1e10))
 
         self._cache = EmbedderCache(model_name)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3-imageanalytics/pull/176#issuecomment-615836576

##### Description of changes
It seems that QSettings().value() can return a TypeError when asking for machine-id in some rare cases. With this PR this error is caught.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
