### PR TITLE
DomainContextHandler: Remove method settings_to_widget

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -108,7 +108,7 @@ class SelectAttributesDomainContextHandler(DomainContextHandler):
                      for var, role_i in value.items()}
         return super().encode_setting(context, setting, value)
 
-    def decode_setting(self, setting, value, domain=None):
+    def decode_setting(self, setting, value, domain=None, *_args):
         decoded = super().decode_setting(setting, value, domain)
         if setting.name == 'domain_role_hints':
             decoded = {domain[name]: role_i

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -71,7 +71,7 @@ class SelectRowsContextHandler(DomainContextHandler):
                 ))
         return encoded
 
-    def decode_setting(self, setting, value, domain=None):
+    def decode_setting(self, setting, value, domain=None, *_args):
         value = super().decode_setting(setting, value, domain)
         if setting.name == 'conditions':
             CONTINUOUS = vartype(ContinuousVariable("x"))

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -138,24 +138,6 @@ class DomainContextHandler(ContextHandler):
                 and not self._var_exists(setting, value, attrs, metas):
             del data[setting.name]
 
-    def settings_to_widget(self, widget, domain, *args):
-        # TODO: If https://github.com/biolab/orange-widget-base/pull/56 is:
-        #  - merged, remove this method.
-        #  - rejected, remove this comment.
-        context = widget.current_context
-        if context is None:
-            return
-
-        widget.retrieveSpecificSettings()
-
-        for setting, data, instance in \
-                self.provider.traverse_settings(data=context.values, instance=widget):
-            if not isinstance(setting, ContextSetting) or setting.name not in data:
-                continue
-
-            value = self.decode_setting(setting, data[setting.name], domain)
-            _apply_setting(setting, instance, value)
-
     @staticmethod
     def encode_variable(var):
         return var.name, 100 + vartype(var)


### PR DESCRIPTION
Remove `settings_to_widget`, which should be no longer necessary after https://github.com/biolab/orange-widget-base/pull/56

The change will break derived classes that override `decode_settings`. None, I suppose. (Except the two that this PR already fixes.)