### PR TITLE
SelectAttributesDomainContextHandler: Fix match when empty list

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -124,8 +124,9 @@ class SelectAttributesDomainContextHandler(DomainContextHandler):
         value = context.values["domain_role_hints"][0]
         assigned = [desc for desc, (role, _) in value.items()
                     if role != "available"]
-        return assigned and \
-               sum(all_vars.get(attr) == vtype for attr, vtype in assigned) \
+        if not assigned:
+            return self.NO_MATCH
+        return sum(all_vars.get(attr) == vtype for attr, vtype in assigned) \
                / len(assigned)
 
     def filter_value(self, setting, data, domain, attrs, metas):


### PR DESCRIPTION
##### Issue

Probably fixes #4691. If not, it still fixes a bug.

##### Description of changes

@Hrovatin, I see what's the problem, but can't replicate the circumstance where it would occur. I think it requires having some other stored contexts that do not refer to this particular data.

This PR does fix a potential bug and I suppose this is what you ran into, so please check whether it still happens after this. Even if it doesn't fix your issue, this change needs to be merged (if it's correct).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation