### PR TITLE
[FIX] Fix report in Predictions

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -610,6 +610,8 @@ class OWPredictions(OWWidget):
             self.report_table("Data & Predictions", merge_data_with_predictions(),
                               header_rows=1, header_columns=1)
 
+            self.report_table("Scores", self.score_table.view)
+
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_splitter()

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -572,10 +572,12 @@ class OWPredictions(OWWidget):
     def send_report(self):
         def merge_data_with_predictions():
             data_model = self.dataview.model()
-            predictions_model = self.predictionsview.model()
+            predictions_view = self.predictionsview
+            predictions_model = predictions_view.model()
 
             # use ItemDelegate to style prediction values
-            style = lambda x: self.predictionsview.itemDelegate().displayText(x, QLocale())
+            delegates = [predictions_view.itemDelegateForColumn(i)
+                         for i in range(predictions_model.columnCount())]
 
             # iterate only over visible columns of data's QTableView
             iter_data_cols = list(filter(lambda x: not self.dataview.isColumnHidden(x),
@@ -591,8 +593,10 @@ class OWPredictions(OWWidget):
             # print data & predictions
             for i in range(data_model.rowCount()):
                 yield [data_model.headerData(i, Qt.Vertical, Qt.DisplayRole)] + \
-                      [style(predictions_model.data(predictions_model.index(i, j)))
-                       for j in range(predictions_model.columnCount())] + \
+                      [delegate.displayText(
+                          predictions_model.data(predictions_model.index(i, j)),
+                          QLocale())
+                       for j, delegate in enumerate(delegates)] + \
                       [data_model.data(data_model.index(i, j))
                        for j in iter_data_cols]
 

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -412,6 +412,8 @@ class TestOWPredictions(WidgetTest):
         colors = self.widget._get_colors()
         self.assertEqual(3, len(colors))
 
+        self.widget.send_report()  # just a quick check that it doesn't crash
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
##### Issue

- Fixes #4652. Report crashed since we removed info label in favour of summaries (my mistake!)
- Report also didn't have anything in the prediction columns. This was added.
- Report did not include the table with scores at the bottom. Added, too.

##### Includes
- [X] Code changes
- [X] Tests, minimalistic
