### PR TITLE
Rearrange a few widgets' UX to decrease their heights

### DIFF
--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -2,6 +2,7 @@ from functools import reduce
 from types import SimpleNamespace
 
 from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QGridLayout
 
 import Orange.data
 from Orange.util import Reprable
@@ -72,25 +73,32 @@ class OWContinuize(widget.OWWidget):
     def __init__(self):
         super().__init__()
 
-        box = gui.vBox(self.controlArea, "Categorical Features")
-        gui.radioButtonsInBox(
-            box, self, "multinomial_treatment",
+        layout = QGridLayout()
+        gui.widgetBox(self.controlArea, orientation=layout)
+
+        box = gui.radioButtonsInBox(
+            None, self, "multinomial_treatment", box="Categorical Features",
             btnLabels=[x[0] for x in self.multinomial_treats],
             callback=self.settings_changed)
+        gui.rubber(box)
+        layout.addWidget(box, 0, 0, 2, 1)
 
-        box = gui.vBox(self.controlArea, "Numeric Features")
-        gui.radioButtonsInBox(
-            box, self, "continuous_treatment",
+        box = gui.radioButtonsInBox(
+            None, self, "continuous_treatment", box = "Numeric Features",
             btnLabels=[x[0] for x in self.continuous_treats],
             callback=self.settings_changed)
+        box.layout().addStretch(10)
+        layout.addWidget(box, 0, 1, 2, 1)
 
-        box = gui.vBox(self.controlArea, "Categorical Outcome(s)")
-        gui.radioButtonsInBox(
-            box, self, "class_treatment",
+        box = gui.radioButtonsInBox(
+            None, self, "class_treatment", box="Categorical Outcome(s)",
             btnLabels=[t[0] for t in self.class_treats],
             callback=self.settings_changed)
+        box.layout().addStretch(10)
+        layout.addWidget(box, 0, 2)
 
-        gui.auto_apply(self.buttonsArea, self, "autosend", box=False)
+        ac = gui.auto_apply(None, self, "autosend", box=False)
+        layout.addWidget(ac, 1, 2)
 
         self.data = None
         self.info.set_input_summary(self.info.NoInput)

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -9,7 +9,7 @@ from typing import List, Any, Dict, Tuple, Type, Optional
 import numpy as np
 
 from AnyQt.QtWidgets import (
-    QGroupBox, QRadioButton, QPushButton, QHBoxLayout,
+    QGroupBox, QRadioButton, QPushButton, QHBoxLayout, QGridLayout,
     QVBoxLayout, QStackedWidget, QComboBox,
     QButtonGroup, QStyledItemDelegate, QListView, QDoubleSpinBox
 )
@@ -172,18 +172,19 @@ class OWImpute(OWWidget):
         self.controlArea.layout().addLayout(main_layout)
 
         box = QGroupBox(title=self.tr("Default Method"), flat=False)
-        box_layout = QVBoxLayout(box)
+        box_layout = QGridLayout(box)
+        box_layout.setContentsMargins(5, 0, 0, 0)
         main_layout.addWidget(box)
 
         button_group = QButtonGroup()
         button_group.buttonClicked[int].connect(self.set_default_method)
 
-        for method, _ in list(METHODS.items())[1:-1]:
+        for i, (method, _) in enumerate(list(METHODS.items())[1:-1]):
             imputer = self.create_imputer(method)
             button = QRadioButton(imputer.name)
             button.setChecked(method == self.default_method_index)
             button_group.addButton(button, method)
-            box_layout.addWidget(button)
+            box_layout.addWidget(button, i % 3, i // 3)
 
         self.default_button_group = button_group
 

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -1,4 +1,6 @@
 from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QFrame
+
 from Orange.data import Table
 from Orange.preprocess.remove import Remove
 from Orange.widgets import gui, widget
@@ -33,7 +35,7 @@ class OWPurgeDomain(widget.OWWidget):
     sortValues = Setting(True)
     sortClasses = Setting(True)
 
-    want_main_area = True
+    want_main_area = False
     resizing_enabled = False
     buttons_area_orientation = Qt.Vertical
 
@@ -70,12 +72,24 @@ class OWPurgeDomain(widget.OWWidget):
         self.removedMetas = "-"
         self.reducedMetas = "-"
 
+        def add_line(parent):
+            frame = QFrame()
+            frame.setFrameShape(QFrame.HLine)
+            frame.setFrameShadow(QFrame.Sunken)
+            parent.layout().addSpacing(6)
+            parent.layout().addWidget(frame)
+            parent.layout().addSpacing(6)
+
         boxAt = gui.vBox(self.controlArea, "Features")
         for not_first, (value, label) in enumerate(self.feature_options):
             if not_first:
                 gui.separator(boxAt, 2)
             gui.checkBox(boxAt, self, value, label,
                          callback=self.optionsChanged)
+        add_line(boxAt)
+        gui.label(boxAt, self,
+                  "Sorted: %(resortedAttrs)s, "
+                  "reduced: %(reducedAttrs)s, removed: %(removedAttrs)s")
 
         boxAt = gui.vBox(self.controlArea, "Classes", addSpace=True)
         for not_first, (value, label) in enumerate(self.class_options):
@@ -83,6 +97,10 @@ class OWPurgeDomain(widget.OWWidget):
                 gui.separator(boxAt, 2)
             gui.checkBox(boxAt, self, value, label,
                          callback=self.optionsChanged)
+        add_line(boxAt)
+        gui.label(boxAt, self,
+                  "Sorted: %(resortedClasses)s,"
+                  "reduced: %(reducedClasses)s, removed: %(removedClasses)s")
 
         boxAt = gui.vBox(self.controlArea, "Meta attributes", addSpace=True)
         for not_first, (value, label) in enumerate(self.meta_options):
@@ -90,14 +108,9 @@ class OWPurgeDomain(widget.OWWidget):
                 gui.separator(boxAt, 2)
             gui.checkBox(boxAt, self, value, label,
                          callback=self.optionsChanged)
-
-        box3 = gui.vBox(self.mainArea, 'Statistics', addSpace=True)
-        for i, (label, value) in enumerate(self.stat_labels):
-            # add a separator after each group of three
-            if i != 0 and i % 3 == 0:
-                gui.separator(box3, 2)
-            gui.label(box3, self, "{}: %({})s".format(label, value))
-        gui.rubber(self.mainArea)
+        add_line(boxAt)
+        gui.label(boxAt, self,
+                  "Reduced: %(reducedMetas)s, removed: %(removedMetas)s")
 
         gui.auto_send(self.buttonsArea, self, "autoSend")
         gui.rubber(self.controlArea)

--- a/Orange/widgets/data/owpurgedomain.py
+++ b/Orange/widgets/data/owpurgedomain.py
@@ -33,7 +33,7 @@ class OWPurgeDomain(widget.OWWidget):
     sortValues = Setting(True)
     sortClasses = Setting(True)
 
-    want_main_area = False
+    want_main_area = True
     resizing_enabled = False
     buttons_area_orientation = Qt.Vertical
 
@@ -91,12 +91,13 @@ class OWPurgeDomain(widget.OWWidget):
             gui.checkBox(boxAt, self, value, label,
                          callback=self.optionsChanged)
 
-        box3 = gui.vBox(self.controlArea, 'Statistics', addSpace=True)
+        box3 = gui.vBox(self.mainArea, 'Statistics', addSpace=True)
         for i, (label, value) in enumerate(self.stat_labels):
             # add a separator after each group of three
             if i != 0 and i % 3 == 0:
                 gui.separator(box3, 2)
             gui.label(box3, self, "{}: %({})s".format(label, value))
+        gui.rubber(self.mainArea)
 
         gui.auto_send(self.buttonsArea, self, "autoSend")
         gui.rubber(self.controlArea)

--- a/Orange/widgets/data/tests/test_owpivot.py
+++ b/Orange/widgets/data/tests/test_owpivot.py
@@ -18,12 +18,11 @@ from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate
 from Orange.widgets.utils.state_summary import format_summary_details
 
+
 class TestOWPivot(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWPivot)
-        self.agg_checkboxes = [checkbox for checkbox in
-                               self.widget.controlArea.children()[7].children()
-                               if isinstance(checkbox, QCheckBox)]
+        self.agg_checkboxes = self.widget.aggregation_checkboxes
         self.assertGreater(len(self.agg_checkboxes), 0)
         self.iris = Table("iris")
         self.heart_disease = Table("heart_disease")

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -10,9 +10,11 @@ from collections import namedtuple, deque, OrderedDict
 import numpy as np
 import sklearn.metrics as skl_metrics
 
-from AnyQt.QtWidgets import QListView, QLabel, QGridLayout, QFrame, QAction, QToolTip
-from AnyQt.QtGui import QColor, QPen, QBrush, QPainter, QPalette, QFont, QCursor
-from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QListView, QLabel, QGridLayout, QFrame, QAction, \
+    QToolTip, QSizePolicy
+from AnyQt.QtGui import QColor, QPen, QBrush, QPainter, QPalette, QFont, \
+    QCursor, QFontMetrics
+from AnyQt.QtCore import Qt, QSize
 import pyqtgraph as pg
 
 import Orange
@@ -339,32 +341,29 @@ class OWROCAnalysis(widget.OWWidget):
         self._tooltip_cache = None
 
         box = gui.vBox(self.controlArea, "Plot")
-        tbox = gui.vBox(box, "Target Class")
-        tbox.setFlat(True)
-
         self.target_cb = gui.comboBox(
-            tbox, self, "target_index", callback=self._on_target_changed,
+            box, self, "target_index",
+            label="Target", orientation=Qt.Horizontal,
+            callback=self._on_target_changed,
             contentsLength=8, searchable=True)
 
-        cbox = gui.vBox(box, "Classifiers")
-        cbox.setFlat(True)
+        gui.widgetLabel(box, "Classifiers")
+        line_height = 4 * QFontMetrics(self.font()).lineSpacing()
         self.classifiers_list_box = gui.listBox(
-            cbox, self, "selected_classifiers", "classifier_names",
+            box, self, "selected_classifiers", "classifier_names",
             selectionMode=QListView.MultiSelection,
-            callback=self._on_classifiers_changed)
+            callback=self._on_classifiers_changed,
+            sizeHint=QSize(0, line_height))
 
-        abox = gui.vBox(box, "Combine ROC Curves From Folds")
-        abox.setFlat(True)
+        abox = gui.vBox(self.controlArea, "Curves")
         gui.comboBox(abox, self, "roc_averaging",
                      items=["Merge Predictions from Folds", "Mean TP Rate",
                             "Mean TP and FP at Threshold", "Show Individual Curves"],
                      callback=self._replot)
 
-        hbox = gui.vBox(box, "ROC Convex Hull")
-        hbox.setFlat(True)
-        gui.checkBox(hbox, self, "display_convex_curve",
+        gui.checkBox(abox, self, "display_convex_curve",
                      "Show convex ROC curves", callback=self._replot)
-        gui.checkBox(hbox, self, "display_convex_hull",
+        gui.checkBox(abox, self, "display_convex_hull",
                      "Show ROC convex hull", callback=self._replot)
 
         box = gui.vBox(self.controlArea, "Analysis")
@@ -394,7 +393,7 @@ class OWROCAnalysis(widget.OWWidget):
                                         callback=self._on_target_prior_changed)
         self.target_prior_sp.setSuffix(" %")
         self.target_prior_sp.addAction(QAction("Auto", sp))
-        grid.addWidget(QLabel("Prior target class probability:"))
+        grid.addWidget(QLabel("Prior probability:"))
         grid.addWidget(self.target_prior_sp, 2, 1)
 
         self.plotview = pg.GraphicsView(background="w")


### PR DESCRIPTION
##### Issue

Fixes (partially) #4608.

##### Description of changes

I changed the widgets roughly along the lines we set we discussing the issue, except for making ROC scrollable. If the user wants smaller graphs, (s)he can hide the control area, like in other widgets, IMHO.
