### PR TITLE
[FIX] PythagoreanTree: Fix crushing when number of classes decreases

### DIFF
--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -192,6 +192,7 @@ class PythagorasTreeViewer(QGraphicsWidget):
     def clear(self):
         """Clear the entire widget state."""
         self.clear_tree()
+        self._target_class_index = 0
 
     def clear_tree(self):
         """Clear only the tree, keeping tooltip and color functions."""


### PR DESCRIPTION
##### Issue
Fixes #4670. The `_target_class_index` was not resetting when new tree is built hence it was giving an error when the number of classes decreases.
##### Description of changes
Set `_target_class_index` to 0 in `clear()`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
