### PR TITLE
[FIX] UrlReader: shorten TempFile extension

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -1,6 +1,7 @@
 import contextlib
 import csv
 import locale
+import os
 import pickle
 import re
 import sys
@@ -399,7 +400,8 @@ class UrlReader(FileFormat):
         self.filename = self._trim(self._resolve_redirects(self.filename))
         with contextlib.closing(self.urlopen(self.filename)) as response:
             name = self._suggest_filename(response.headers['content-disposition'])
-            with NamedTemporaryFile(suffix=name, delete=False) as f:
+            extension = os.path.splitext(name)[1]  # get only file extension
+            with NamedTemporaryFile(suffix=extension, delete=False) as f:
                 f.write(response.read())
                 # delete=False is a workaround for https://bugs.python.org/issue14243
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
It can happen that the file name is too long due to the long suffix of the temp-file (the suffix is complete path joined together with _). It invokes File name too long: 'filename' error.
This is one of the issues causing that tests cannot run on cond-forge where file paths are really long https://github.com/conda-forge/orange3-feedstock/pull/77

##### Description of changes
Temfile does not get a complete name as a suffix but just an ending which makes sure that the correct reader reads the file.

I do not know what exactly is the reason that complete path was provided as a name so I hope that I didn't break anything.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
