### PR TITLE
codecov: add threshold to codecov commit status settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,4 +8,5 @@ coverage:
     project:
       default:
         target: auto
-
+        # https://docs.codecov.io/docs/commit-status#threshold
+        threshold: 1%


### PR DESCRIPTION
Attempt to fix constantly failing codecov checks. This will allow the coverage to drop by 1% before commit will show failed checks. We can set this to be even looser. 

But I don't know why is codecov reporting 0.03% decrease by this commit.