### PR TITLE
[FIX] Fix compatibility with scikit-learn 0.23

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -520,11 +520,14 @@ class SklLearner(Learner, metaclass=WrapperMeta):
     def _get_sklparams(self, values):
         skllearner = self.__wraps__
         if skllearner is not None:
-            spec = inspect.getargs(skllearner.__init__.__code__)
+            spec = list(
+                inspect.signature(skllearner.__init__).parameters.keys()
+            )
             # first argument is 'self'
-            assert spec.args[0] == "self"
-            params = {name: values[name] for name in spec.args[1:]
-                      if name in values}
+            assert spec[0] == "self"
+            params = {
+                name: values[name] for name in spec[1:] if name in values
+            }
         else:
             raise TypeError("Wrapper does not define '__wraps__'")
         return params

--- a/Orange/projection/base.py
+++ b/Orange/projection/base.py
@@ -196,11 +196,14 @@ class SklProjector(Projector, metaclass=WrapperMeta):
     def _get_sklparams(self, values):
         sklprojection = self.__wraps__
         if sklprojection is not None:
-            spec = inspect.getargs(sklprojection.__init__.__code__)
+            spec = list(
+                inspect.signature(sklprojection.__init__).parameters.keys()
+            )
             # first argument is 'self'
-            assert spec.args[0] == "self"
-            params = {name: values[name] for name in spec.args[1:]
-                      if name in values}
+            assert spec[0] == "self"
+            params = {
+                name: values[name] for name in spec[1:] if name in values
+            }
         else:
             raise TypeError("Wrapper does not define '__wraps__'")
         return params

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,7 +1,7 @@
 pip>=9.0
 numpy>=1.16.0
 scipy>=0.16.1
-scikit-learn>=0.22.0,<0.23  # temp fix: https://github.com/biolab/orange3/pull/4768
+scikit-learn>=0.22.0,!=0.23.0  # 0.23.0 have error with slow k-means, it will be fixed in 0.23.1
 bottleneck>=1.0.0
 # Reading Excel files
 xlrd>=0.9.2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The new scikit-learn release yesterday caused orange learners to start failing:
- Learners parameters cannot be retrieved with learner.__init__.__code__ anymore since init is not called directly.
- KMeans is significantly slower: https://github.com/scikit-learn/scikit-learn/issues/17208

##### Description of changes
- Use `inspect.signature` instead of `__code__` to get parameters.
- I suggest temporary pin scikit-learn to != 0.23.0.

##### Discussion
Should we release orange with these fixes after it is merged? Since I think we will not make a major release soon, people installing Orange with pip/conda will still get the newest version of scikit-learn. The same is for tests on add-ons. We just need a release for pip and condo. The installed do not need to be updated since it has packages packed together with orange.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
