### PR TITLE
Temporary pin scikit-learn

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,7 +1,7 @@
 pip>=9.0
 numpy>=1.16.0
 scipy>=0.16.1
-scikit-learn>=0.22.0
+scikit-learn>=0.22.0,<0.23  # temp fix: https://github.com/biolab/orange3/pull/4768
 bottleneck>=1.0.0
 # Reading Excel files
 xlrd>=0.9.2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Due to issues in https://github.com/biolab/orange3/pull/4768 we need to temporarily fix scikit version to <0.23

##### Description of changes
This is a temporary fix, that unittests will stop failing. I will modify it in https://github.com/biolab/orange3/pull/4768 when I see which version of scikit will fix issues.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
