### PR TITLE
[FIX] owheatmap: Use 'is' instead of 'eq' for column id comparison

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -573,7 +573,7 @@ class OWHeatMap(widget.OWWidget):
         self.set_split_variable(self.row_split_cb.currentData(Qt.EditRole))
 
     def set_split_variable(self, var):
-        if var != self.split_by_var:
+        if var is not self.split_by_var:
             self.split_by_var = var
             self.update_heatmaps()
 
@@ -950,7 +950,7 @@ class OWHeatMap(widget.OWWidget):
     def set_annotation_var(self, var: Union[None, Variable, int]):
         if isinstance(var, int):
             var = self.annotation_model[var]
-        if self.annotation_var != var:
+        if self.annotation_var is not var:
             self.annotation_var = var
             self.update_annotations()
 
@@ -989,7 +989,7 @@ class OWHeatMap(widget.OWWidget):
         """Set the current side color annotation variable."""
         if isinstance(var, int):
             var = self.row_side_color_model[var]
-        if self.annotation_color_var != var:
+        if self.annotation_color_var is not var:
             self.annotation_color_var = var
             self.update_row_side_colors()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-4766

##### Description of changes

Use 'is' instead of `__eq__` for column id comparisons.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
