### PR TITLE
[ENH] Sort values naturally when reading files

### DIFF
--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -22,6 +22,7 @@ from Orange.data.io_util import Compression, open_compressed, \
     isnastr, guess_data_type, sanitize_variable
 from Orange.data.util import get_unique_names_duplicates
 from Orange.data.variable import VariableMeta
+from Orange.misc.collections import natural_sorted
 from Orange.util import Registry, flatten, namegen
 
 __all__ = ["FileFormatBase", "Flags", "DataTableMixin", "PICKLE_PROTOCOL"]
@@ -278,7 +279,7 @@ class _TableBuilder:
     def _disc_no_vals_column(data: np.ndarray, col: int, **_) -> \
             _ColumnProperties:
         vals, coltype = _TableBuilder._disc_column(data, col)
-        return _ColumnProperties(valuemap=sorted(set(vals) - {""}),
+        return _ColumnProperties(valuemap=natural_sorted(set(vals) - {""}),
                                  values=vals, coltype=coltype,
                                  orig_values=vals)
 

--- a/Orange/data/io_util.py
+++ b/Orange/data/io_util.py
@@ -8,6 +8,7 @@ from Orange.data import (
     is_discrete_values, MISSING_VALUES, Variable,
     DiscreteVariable, StringVariable, ContinuousVariable, TimeVariable,
 )
+from Orange.misc.collections import natural_sorted
 
 __all__ = ["Compression", "open_compressed", "detect_encoding", "isnastr",
            "guess_data_type", "sanitize_variable"]
@@ -121,7 +122,7 @@ def guess_data_type(orig_values, namask=None):
     if namask is None:
         namask = isnastr(orig_values)
     if is_discrete:
-        valuemap = sorted(is_discrete)
+        valuemap = natural_sorted(is_discrete)
         coltype = DiscreteVariable
     else:
         # try to parse as float

--- a/Orange/data/tests/test_io.py
+++ b/Orange/data/tests/test_io.py
@@ -4,10 +4,10 @@ import numpy as np
 from Orange.data import ContinuousVariable, DiscreteVariable, StringVariable, \
     TimeVariable
 from Orange.data.io_util import guess_data_type
+from Orange.misc.collections import natural_sorted
 
 
 class TestTableFilters(unittest.TestCase):
-
     def test_guess_data_type_continuous(self):
         # should be ContinuousVariable
         valuemap, values, coltype = guess_data_type(list(range(1, 100)))
@@ -42,7 +42,7 @@ class TestTableFilters(unittest.TestCase):
         in_values = list(map(lambda x: str(x) + "a", range(24))) + ["a"] * 76
         valuemap, values, coltype = guess_data_type(in_values)
         self.assertEqual(DiscreteVariable, coltype)
-        self.assertEqual(sorted(set(in_values)), valuemap)
+        self.assertEqual(natural_sorted(set(in_values)), valuemap)
         np.testing.assert_array_equal(in_values, values)
 
     def test_guess_data_type_string(self):
@@ -93,3 +93,21 @@ class TestTableFilters(unittest.TestCase):
         valuemap, _, coltype = guess_data_type(in_values)
         self.assertEqual(TimeVariable, coltype)
         self.assertIsNone(valuemap)
+
+    def test_guess_data_type_values_order(self):
+        """
+        Test if values are ordered naturally
+        """
+        in_values = [
+            "something1", "something12", "something2", "something1",
+            "something20", "something1", "something2", "something12",
+            "something1", "something12"
+        ]
+        res = ["something1", "something2", "something12", "something20"]
+        valuemap, _, coltype = guess_data_type(in_values)
+        self.assertEqual(DiscreteVariable, coltype)
+        self.assertListEqual(res, valuemap)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/misc/collections.py
+++ b/Orange/misc/collections.py
@@ -1,3 +1,7 @@
+import re
+from typing import List
+
+
 class frozendict(dict):
     def clear(self):
         raise AttributeError("FrozenDict does not support method 'clear'")
@@ -20,3 +24,32 @@ class frozendict(dict):
     def __delitem__(self, _key):
         raise AttributeError("FrozenDict does not allow deleting elements")
 
+
+def natural_sorted(values: List) -> List:
+    """
+    Sort values with natural sort or human order - [sth1, sth2, sth10] or
+    [1, 2, 10]
+
+    Parameters
+    ----------
+    values
+        List with values to sort
+
+    Returns
+    -------
+    List with sorted values
+    """
+    def atoi(text):
+        return int(text) if text.isdigit() else text
+
+    def natural_keys(element):
+        """
+        alist.sort(key=natural_keys) or sorted(alist, key=natural_keys) sorts
+        in human order
+        """
+        if isinstance(element, (str, bytes)):
+            return [atoi(c) for c in re.split(r'(\d+)', element)]
+        else:
+            return element
+
+    return sorted(values, key=natural_keys)

--- a/Orange/misc/tests/test_collections.py
+++ b/Orange/misc/tests/test_collections.py
@@ -1,6 +1,6 @@
 import unittest
 
-from Orange.misc.collections import frozendict
+from Orange.misc.collections import frozendict, natural_sorted
 
 
 class TestFrozenDict(unittest.TestCase):
@@ -27,6 +27,38 @@ class TestFrozenDict(unittest.TestCase):
         self.assertEqual(set(d.keys()), {"a", "b"})
         self.assertEqual(set(d.values()), {12, 13})
         self.assertEqual(set(d.items()), {("a", 12), ("b", 13)})
+
+
+class TestUtils(unittest.TestCase):
+    def test_natural_sorted(self):
+        data = [
+            "something1",
+            "something20",
+            "something2",
+            "something12"
+        ]
+        res = [
+            "something1",
+            "something2",
+            "something12",
+            "something20"
+        ]
+        self.assertListEqual(res, natural_sorted(data))
+
+    def test_natural_sorted_text(self):
+        data = ["b", "aa", "c", "dd"]
+        res = ["aa", "b", "c", "dd"]
+        self.assertListEqual(res, natural_sorted(data))
+
+    def test_natural_sorted_numbers_str(self):
+        data = ["1", "20", "2", "12"]
+        res = ["1", "2", "12", "20"]
+        self.assertListEqual(res, natural_sorted(data))
+
+    def test_natural_sorted_numbers(self):
+        data = [1, 20, 2, 12]
+        res = [1, 2, 12, 20]
+        self.assertListEqual(res, natural_sorted(data))
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -10,6 +10,7 @@ from AnyQt.QtWidgets import QComboBox, QTableView, QSizePolicy
 
 from Orange.data import DiscreteVariable, ContinuousVariable, StringVariable, \
     TimeVariable, Domain
+from Orange.misc.collections import natural_sorted
 from Orange.data.util import get_unique_names_duplicates
 from Orange.statistics.util import unique
 from Orange.widgets import gui
@@ -326,7 +327,10 @@ class DomainEditor(QTableView):
             elif tpe == type(orig_var):
                 var = orig_var.copy(name=new_name)
             elif tpe == DiscreteVariable:
-                values = list(str(i) for i in unique(col_data) if not self._is_missing(i))
+                values = natural_sorted(
+                    list(str(i) for i in unique(col_data)
+                         if not self._is_missing(i))
+                )
                 round_numbers = numbers_are_round(orig_var, col_data)
                 col_data = [np.nan if self._is_missing(x) else values.index(str(x))
                             for x in self._iter_vals(col_data)]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/4778

##### Description of changes
When reading files sort values naturally (before alphabetical sort was used).
Natural sort sorts numbers inside string as numbers: `"sth2"` is before `"sth12"`

#### Discussion

#4778 also said that `Ordered` is not used it is partially true. It sets the `ordered` flag in the DiscreteVariable. This flag tells whether values are ordered in the variable so that other widgets would respect that. I think values are in a current situation always ordered variable and all widgets respect this order (at least none expect FeatureStatistics care about this flag). So I think this flag can be removed. It is used only in the future statistics widget where if this flag is set the min and the max values are shown for the discrete variable.

In case we decide to leave this variable as it is we need to write better documentation for this checkbox.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
