### PR TITLE
[FIX] OWContinuize: Fix treatment of continuous features.

### DIFF
--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -62,6 +62,11 @@ class TestOWContinuize(WidgetTest):
         output_sum.assert_called_once()
         self.assertEqual(output_sum.call_args[0][0].brief, "")
 
+    def test_continuous(self):
+        table = Table("housing")
+        self.send_signal(self.widget.Inputs.data, table)
+        self.widget.unconditional_commit()
+
     def test_one_column_equal_values(self):
         """
         No crash on a column with equal values and with selected option


### PR DESCRIPTION
##### Issue

Fixes #4801. Probably caused by #4466.

##### Description of changes

Continuous treatments were identified in two ways, by enums `Continuize` and a newly introduced `Normalize`. However, `Continuize.Leave` does not match with `Normalize.Leave`, which was the source of problems.

All continuous treatments are now defined by `OWContinuize.Normalize`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
