### PR TITLE
Discrete variable: remove ordered attribute

### DIFF
--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -288,8 +288,7 @@ class _TableBuilder:
                                values="", **_) -> _ColumnProperties:
         vals, coltype = _TableBuilder._disc_column(data, col)
         return _ColumnProperties(valuemap=Flags.split(values), values=vals,
-                                 coltype=coltype, orig_values=vals,
-                                 coltype_kwargs={"ordered": True})
+                                 coltype=coltype, orig_values=vals)
 
     @staticmethod
     def _unknown_column(data: np.ndarray, col: int, **_) -> _ColumnProperties:
@@ -607,8 +606,12 @@ class _FileWriter:
             if var.is_continuous or var.is_string:
                 return var.TYPE_HEADERS[0]
             elif var.is_discrete:
-                return Flags.join(var.values) if var.ordered else \
-                    var.TYPE_HEADERS[0]
+                # if number of values is 1 order is not important if more
+                # values write order in file
+                return (
+                    Flags.join(var.values) if len(var.values) >= 2
+                    else var.TYPE_HEADERS[0]
+                )
             raise NotImplementedError
 
         return ['continuous'] * data.has_weights() + \

--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -97,8 +97,9 @@ def table_to_frame(tab, include_metas=False):
         result = ()
         if col.is_discrete:
             codes = pd.Series(vals).fillna(-1).astype(int)
-            result = (col.name, pd.Categorical.from_codes(codes=codes, categories=col.values,
-                                                          ordered=col.ordered))
+            result = (col.name, pd.Categorical.from_codes(
+                codes=codes, categories=col.values, ordered=True
+            ))
         elif col.is_time:
             result = (col.name, pd.to_datetime(vals, unit='s').to_series().reset_index()[0])
         elif col.is_continuous:

--- a/Orange/data/tests/test_io_base.py
+++ b/Orange/data/tests/test_io_base.py
@@ -128,7 +128,7 @@ class TestTableBuilder(InitTestData):
         np.testing.assert_array_equal(column.orig_values,
                                       ["red", "red", "green"])
         self.assertEqual(column.coltype, DiscreteVariable)
-        self.assertDictEqual(column.coltype_kwargs, {'ordered': True})
+        self.assertDictEqual(column.coltype_kwargs, {})
 
     def test_unknown_type_column(self):
         data = np.array(self.header0)

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -279,15 +279,12 @@ class TestDiscreteVariable(VariableTest):
         self.assertEqual(
             repr(var),
             "DiscreteVariable(name='a', values=('F', 'M'))")
-        var.ordered = True
-        self.assertEqual(
-            repr(var),
-            "DiscreteVariable(name='a', values=('F', 'M'), ordered=True)")
 
         var = DiscreteVariable.make("a", values="1234567")
         self.assertEqual(
             repr(var),
-            "DiscreteVariable(name='a', values=('1', '2', '3', '4', '5', '6', '7'))")
+            "DiscreteVariable(name='a', values=('1', '2', '3', '4', '5', '6', '7'))"
+        )
 
     def test_no_nonstringvalues(self):
         self.assertRaises(TypeError, DiscreteVariable, "foo", values=("a", 42))
@@ -488,7 +485,6 @@ class TestDiscreteVariable(VariableTest):
         var = super().varcls_modified(name)
         var.add_value("A")
         var.add_value("B")
-        var.ordered = True
         return var
 
     def test_copy_checks_len_values(self):
@@ -507,6 +503,16 @@ class TestDiscreteVariable(VariableTest):
 
         var2 = var.copy(values=("W", "M"))
         self.assertEqual(var2.values, ("W", "M"))
+
+    def test_remove_ordered(self):
+        """
+        ordered is deprecated when this test starts to fail remove ordered
+        parameter. Remove also this test.
+        Ordered parameter should still be allowed in __init__ for backward
+        compatibilities in data-sets pickled with older versions, I suggest
+        adding **kwargs which is ignored
+        """
+        self.assertLess(Orange.__version__, "3.29.0")
 
 
 @variabletest(ContinuousVariable)
@@ -697,10 +703,7 @@ PickleDiscreteVariable = create_pickling_tests(
     "PickleDiscreteVariable",
     ("with_name", lambda: DiscreteVariable(name="Feature 0")),
     ("with_str_value", lambda: DiscreteVariable(name="Feature 0",
-                                                values=("F", "M"))),
-    ("ordered", lambda: DiscreteVariable(name="Feature 0",
-                                         values=("F", "M"),
-                                         ordered=True)),
+                                                values=("F", "M")))
 )
 
 
@@ -712,7 +715,7 @@ PickleStringVariable = create_pickling_tests(
 
 class VariableTestMakeProxy(unittest.TestCase):
     def test_make_proxy_disc(self):
-        abc = DiscreteVariable("abc", values="abc", ordered=True)
+        abc = DiscreteVariable("abc", values="abc")
         abc1 = abc.make_proxy()
         abc2 = abc1.make_proxy()
         self.assertEqual(abc, abc1)
@@ -721,7 +724,7 @@ class VariableTestMakeProxy(unittest.TestCase):
         self.assertEqual(hash(abc), hash(abc1))
         self.assertEqual(hash(abc1), hash(abc2))
 
-        abcx = DiscreteVariable("abc", values="abc", ordered=True)
+        abcx = DiscreteVariable("abc", values="abc")
         self.assertEqual(abc, abcx)
         self.assertIsNot(abc, abcx)
 

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -169,7 +169,6 @@ def merge_transforms(exp):
             new_var = DiscreteVariable(
                 exp.var.name,
                 values=exp.var.values,
-                ordered=exp.var.ordered,
                 compute_value=merge_lookup(A, B),
                 sparse=exp.var.sparse,
             )

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -217,12 +217,10 @@ class Discrete(Distribution):
         return data.Value(self.variable, value_indices)
 
     def min(self):
-        if self.variable.ordered:
-            return self.variable.values[0]
+        return None
 
     def max(self):
-        if self.variable.ordered:
-            return self.variable.values[-1]
+        return None
 
     def sum(self, *args, **kwargs):
         res = super().sum(*args, **kwargs)

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -32,7 +32,7 @@ class TestDiscreteDistribution(unittest.TestCase):
             data.Domain(
                 attributes=[
                     data.DiscreteVariable('rgb', values=('r', 'g', 'b', 'a')),
-                    data.DiscreteVariable('num', values=('1', '2', '3'), ordered=True),
+                    data.DiscreteVariable('num', values=('1', '2', '3')),
                 ]
             ),
             X=np.array([
@@ -201,8 +201,8 @@ class TestDiscreteDistribution(unittest.TestCase):
         self.assertEqual(self.rgb.min(), None)
         self.assertEqual(self.rgb.max(), None)
         # Min and max should work for ordinal variables
-        self.assertEqual(self.num.min(), '1')
-        self.assertEqual(self.num.max(), '3')
+        self.assertEqual(self.num.min(), None)
+        self.assertEqual(self.num.max(), None)
 
     def test_array_with_unknowns(self):
         d = data.Table("zoo")

--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1543,12 +1543,11 @@ def pandas_to_table(df):
             coldata = series.values  # type: pd.Categorical
             categories = [str(c) for c in coldata.categories]
             var = Orange.data.DiscreteVariable.make(
-                str(header), values=categories, ordered=coldata.ordered
+                str(header), values=categories
             )
             # Remap the coldata into the var.values order/set
             coldata = pd.Categorical(
-                coldata.astype("str"), categories=var.values,
-                ordered=coldata.ordered,
+                coldata.astype(coldata), categories=var.values
             )
             codes = coldata.codes
             assert np.issubdtype(codes.dtype, np.integer)

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -72,7 +72,6 @@ def make_variable(descriptor, compute_value):
         return Orange.data.DiscreteVariable(
             descriptor.name,
             values=descriptor.values,
-            ordered=descriptor.ordered,
             compute_value=compute_value)
     elif isinstance(descriptor, StringDescriptor):
         return Orange.data.StringVariable(
@@ -539,7 +538,7 @@ class OWFeatureConstructor(OWWidget):
             if editor.editorData().name != unique:
                 self.Warning.renamed_var()
                 feature = feature.__class__(unique, *feature[1:])
-                
+
             self.featuremodel[self.currentIndex] = feature
             self.descriptors = list(self.featuremodel)
 

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -517,12 +517,10 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                 else:
                     return render_value(self._dispersion[row])
             elif column == self.Columns.MIN:
-                if not isinstance(attribute, DiscreteVariable) \
-                        or attribute.ordered:
+                if not isinstance(attribute, DiscreteVariable):
                     return render_value(self._min[row])
             elif column == self.Columns.MAX:
-                if not isinstance(attribute, DiscreteVariable) \
-                        or attribute.ordered:
+                if not isinstance(attribute, DiscreteVariable):
                     return render_value(self._max[row])
             elif column == self.Columns.MISSING:
                 return '%d (%d%%)' % (

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -28,7 +28,7 @@ from Orange.widgets.data.oweditdomain import (
     OWEditDomain,
     ContinuousVariableEditor, DiscreteVariableEditor, VariableEditor,
     TimeVariableEditor, Categorical, Real, Time, String,
-    Rename, Annotate, CategoriesMapping, ChangeOrdered, report_transform,
+    Rename, Annotate, CategoriesMapping, report_transform,
     apply_transform, apply_transform_var, apply_reinterpret, MultiplicityRole,
     AsString, AsCategorical, AsContinuous, AsTime,
     table_column_data, ReinterpretVariableEditor, CategoricalVector,
@@ -83,12 +83,6 @@ class TestReport(TestCase):
         )
         r = report_transform(var, [tr])
         self.assertIn('b', r)
-
-    def test_change_ordered(self):
-        var = Categorical("C", ("a", "b"), ())
-        tr = ChangeOrdered(True)
-        r = report_transform(var, [tr])
-        self.assertIn("ordered", r)
 
     def test_reinterpret(self):
         var = String("T", ())
@@ -265,21 +259,6 @@ class TestOWEditDomain(WidgetTest):
         output = self.get_output(self.widget.Outputs.data)
         self.assertEqual(str(table[0, 4]), str(output[0, 4]))
 
-    def test_change_ordered(self):
-        """Test categorical ordered flag change"""
-        table = Table.from_domain(Domain(
-            [DiscreteVariable("A", values=("a", "b"), ordered=True)]))
-        self.send_signal(self.widget.Inputs.data, table)
-        output = self.get_output(self.widget.Outputs.data)
-        self.assertTrue(output.domain[0].ordered)
-
-        editor = self.widget.findChild(DiscreteVariableEditor)
-        assert isinstance(editor, DiscreteVariableEditor)
-        editor.ordered_cb.setChecked(False)
-        self.widget.commit()
-        output = self.get_output(self.widget.Outputs.data)
-        self.assertFalse(output.domain[0].ordered)
-
     def test_restore(self):
         iris = self.iris
         viris = (
@@ -392,7 +371,6 @@ class TestEditors(GuiTest):
         w.set_data_categorical(v, values)
 
         self.assertEqual(w.name_edit.text(), v.name)
-        self.assertFalse(w.ordered_cb.isChecked())
         self.assertEqual(w.labels_model.get_dict(), dict(v.annotations))
         self.assertEqual(w.get_data(), (v, []))
         w.set_data_categorical(None, None)
@@ -409,13 +387,6 @@ class TestEditors(GuiTest):
         w.grab()  # run delegate paint method
         self.assertEqual(w.get_data(), (v, [CategoriesMapping(mapping)]))
 
-        w.set_data_categorical(
-            v, values, [CategoriesMapping(mapping), ChangeOrdered(True)]
-        )
-        self.assertTrue(w.ordered_cb.isChecked())
-        self.assertEqual(
-            w.get_data()[1], [CategoriesMapping(mapping), ChangeOrdered(True)]
-        )
         # test selection/deselection in the view
         w.set_data_categorical(v, values)
         view = w.values_edit
@@ -652,11 +623,6 @@ class TestTransforms(TestCase):
         self._assertLookupEquals(
             DD.compute_value, Lookup(D, np.array([2, 3, 1, 0]))
         )
-
-    def test_ordered_change(self):
-        D = DiscreteVariable("D", values=("a", "b"), ordered=True)
-        Do = apply_transform_var(D, [ChangeOrdered(False)])
-        self.assertFalse(Do.ordered)
 
     def test_discrete_add_drop(self):
         D = DiscreteVariable("D", values=("2", "3", "1", "0"))

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -35,7 +35,7 @@ class FeatureConstructorTest(unittest.TestCase):
         values = ('iris one', 'iris two', 'iris three')
         desc = PyListModel(
             [DiscreteDescriptor(name=name, expression=expression,
-                                values=values, ordered=False)]
+                                values=values, ordered=True)]
         )
         data = data.transform(Domain(list(data.domain.attributes) +
                                      construct_variables(desc, data),

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -71,23 +71,23 @@ rgb = [
 
 # Ordered discrete variable variations
 ints_full = VarDataPair(
-    DiscreteVariable('ints_full', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_full', values=('2', '3', '4')),
     np.array([0, 1, 1, 1, 2], dtype=float),
 )
 ints_missing = VarDataPair(
-    DiscreteVariable('ints_missing', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_missing', values=('2', '3', '4')),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
 )
 ints_all_missing = VarDataPair(
-    DiscreteVariable('ints_all_missing', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_all_missing', values=('2', '3', '4')),
     np.array([np.nan] * 5, dtype=float),
 )
 ints_bins_missing = VarDataPair(
-    DiscreteVariable('ints_bins_missing', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_bins_missing', values=('2', '3', '4')),
     np.array([np.nan, 1, 1, 1, np.nan], dtype=float),
 )
 ints_same = VarDataPair(
-    DiscreteVariable('ints_same', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_same', values=('2', '3', '4')),
     np.array([0] * 5, dtype=float),
 )
 ints = [

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -33,11 +33,11 @@ rgb_missing = VarDataPair(
 
 # Ordered discrete variable variations
 ints_full = VarDataPair(
-    DiscreteVariable('ints_full', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_full', values=('2', '3', '4')),
     np.array([0, 1, 1, 1, 2], dtype=float),
 )
 ints_missing = VarDataPair(
-    DiscreteVariable('ints_missing', values=('2', '3', '4'), ordered=True),
+    DiscreteVariable('ints_missing', values=('2', '3', '4')),
     np.array([0, 1, 1, np.nan, 2], dtype=float),
 )
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
As we already discussed in https://github.com/biolab/orange3/pull/4793 ordered attribute from the Discrete variable is not respected in most of the widgets anymore (except Feature Statistics), so it can be removed. Order defined in values tuple should be respected in any widget which needs order.

##### Description of changes
- The ordered attribute is deprecated and will stay so until 3.28.0 then it can be removed.
- Checkbox which sets ordered attribute in the edit domain is removed
- Feature statistic will never show min and max value for the discrete variable (before it happened in a case when ordered attribute was True)
- When saving data always write the order of values for discrete in the header (except in the case with only one value)

##### Includes
- [X] Code changes
- [X] Tests