### PR TITLE
UrlReader: fix issue with double extensions

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -1,7 +1,6 @@
 import contextlib
 import csv
 import locale
-import os
 import pickle
 import re
 import sys
@@ -16,6 +15,7 @@ from os import path, remove
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse, urlsplit, urlunsplit, unquote as urlunquote
 from urllib.request import urlopen, Request
+from pathlib import Path
 
 import numpy as np
 
@@ -400,7 +400,8 @@ class UrlReader(FileFormat):
         self.filename = self._trim(self._resolve_redirects(self.filename))
         with contextlib.closing(self.urlopen(self.filename)) as response:
             name = self._suggest_filename(response.headers['content-disposition'])
-            extension = os.path.splitext(name)[1]  # get only file extension
+            # using Path since splitext does not extract more extensions
+            extension = ''.join(Path(name).suffixes)  # get only file extension
             with NamedTemporaryFile(suffix=extension, delete=False) as f:
                 f.write(response.read())
                 # delete=False is a workaround for https://bugs.python.org/issue14243

--- a/Orange/tests/test_url_reader.py
+++ b/Orange/tests/test_url_reader.py
@@ -1,0 +1,19 @@
+import unittest
+
+from Orange.data.io import UrlReader
+
+
+class TestUrlReader(unittest.TestCase):
+    def test_basic_file(self):
+        data = UrlReader("https://datasets.biolab.si/core/titanic.tab").read()
+        self.assertEqual(2201, len(data))
+
+        data = UrlReader("https://datasets.biolab.si/core/grades.xlsx").read()
+        self.assertEqual(16, len(data))
+
+    def test_zipped(self):
+        """ Test zipped files with two extensions"""
+        data = UrlReader(
+            "http://datasets.orange.biolab.si/core/philadelphia-crime.csv.xz"
+        ).read()
+        self.assertEqual(9666, len(data))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In https://github.com/biolab/orange3/pull/4747 I overlooked the case when the file has two extensions (e.g. .tar.gz) - such files were not read since Orange parse them base on the extensions.

##### Description of changes
Fixed the case with two extensions.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
