### PR TITLE
[FIX] Select Columns: Fix attributes sorting

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -362,9 +362,10 @@ class OWSelectAttributes(widget.OWWidget):
         all_vars = data.domain.variables + data.domain.metas
 
         def attrs_for_role(role):
-            return [attr for _, attr in sorted(
-                (domain_hints[attr][1], attr)
-                for attr in all_vars if domain_hints[attr][0] == role)]
+            selected_attrs = [
+                attr for attr in all_vars if domain_hints[attr][0] == role
+            ]
+            return sorted(selected_attrs, key=lambda attr: domain_hints[attr][1])
 
         domain = data.domain
         domain_hints = {}

--- a/Orange/widgets/data/tests/test_owselectcolumns.py
+++ b/Orange/widgets/data/tests/test_owselectcolumns.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
+import numpy as np
 from AnyQt.QtCore import QMimeData, QPoint, Qt
 from AnyQt.QtGui import QDragEnterEvent
 
@@ -396,3 +397,17 @@ class TestOWSelectAttributes(WidgetTest):
         self.assertEqual(input_sum.call_args[0][0].brief, "")
         output_sum.assert_called_once()
         self.assertEqual(output_sum.call_args[0][0].brief, "")
+
+    def test_domain_new_feature(self):
+        """ Test scenario when new attribute is added at position 0 """
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, data)
+
+        data1 = Table(
+            Domain(
+                (ContinuousVariable("a"),) + data.domain.attributes,
+                data.domain.class_var),
+            np.hstack((np.ones((len(data), 1)), data.X)),
+            data.Y
+        )
+        self.send_signal(self.widget.Inputs.data, data1)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Select Columns widget fails when getting data with additional attributes.

##### Description of changes
Fixed sorting of attributes that it does not compare Variables while sorting.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
