### PR TITLE
[ENH] Projection plots: Customizable plots

### DIFF
--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -162,6 +162,7 @@ class OWCalibrationPlot(widget.OWWidget):
     fold_curves = settings.Setting(False)
     display_rug = settings.Setting(True)
     threshold = settings.Setting(0.5)
+    visual_settings = settings.Setting({}, schema_only=True)
     auto_commit = settings.Setting(True)
 
     graph_name = "plot"
@@ -564,8 +565,9 @@ class OWCalibrationPlot(widget.OWWidget):
         if self.score != 0:
             self.report_raw(self.get_info_text(short=False))
 
-    def set_visual_settings(self, *args):
-        self.plot.set_parameter(*args)
+    def set_visual_settings(self, key, value):
+        self.plot.set_parameter(key, value)
+        self.visual_settings[key] = value
 
 
 def gaussian_smoother(x, y, sigma=1.0):

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -76,37 +76,6 @@ class ParameterSetter(Setter):
         }
     }
 
-    def __init__(self):
-        def update_font_family(**settings):
-            for label, setter in self.setters[self.LABELS_BOX].items():
-                if label != self.FONT_FAMILY_LABEL:
-                    setter(**settings)
-
-        def update_title(**settings):
-            Updater.update_plot_title_font(self.title_item, **settings)
-
-        def update_axes_titles(**settings):
-            Updater.update_axes_titles_font(self.axis_items, **settings)
-
-        def update_axes_ticks(**settings):
-            Updater.update_axes_ticks_font(self.axis_items, **settings)
-
-        def update_title_text(**settings):
-            Updater.update_plot_title_text(
-                self.title_item, settings[self.TITLE_LABEL])
-
-        self.setters = {
-            self.LABELS_BOX: {
-                self.FONT_FAMILY_LABEL: update_font_family,
-                self.TITLE_LABEL: update_title,
-                self.AXIS_TITLE_LABEL: update_axes_titles,
-                self.AXIS_TICKS_LABEL: update_axes_ticks,
-            },
-            self.ANNOT_BOX: {
-                self.TITLE_LABEL: update_title_text,
-            }
-        }
-
     @property
     def title_item(self):
         return self.titleLabel

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -471,6 +471,7 @@ class OWCalibrationPlot(widget.OWWidget):
                 text += "</tr>"
             text += "<table>"
             return text
+        return None
 
     def _update_info(self):
         self.info_label.setText(self.get_info_text(short=True))

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -174,17 +174,16 @@ class OWBoxPlot(widget.OWWidget):
     _pen_axis_tick.setCapStyle(Qt.FlatCap)
 
     _box_brush = QBrush(QColor(0x33, 0x88, 0xff, 0xc0))
-
-    _axis_font = QFont()
-    _axis_font.setPixelSize(12)
-    _label_font = QFont()
-    _label_font.setPixelSize(11)
     _attr_brush = QBrush(QColor(0x33, 0x00, 0xff))
 
     graph_name = "box_scene"
 
     def __init__(self):
         super().__init__()
+        self._axis_font = QFont()
+        self._axis_font.setPixelSize(12)
+        self._label_font = QFont()
+        self._label_font.setPixelSize(11)
         self.dataset = None
         self.stats = []
         self.dist = self.conts = None

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -90,6 +90,7 @@ class OWFreeVizGraph(OWGraphWithAnchors):
                 anchor = AnchorItem(line=QLineF(0, 0, *point), text=label)
                 anchor.setVisible(np.linalg.norm(point) > r)
                 anchor.setPen(pg.mkPen((100, 100, 100)))
+                anchor.setFont(self.anchor_font)
                 self.plot_widget.addItem(anchor)
                 self.anchor_items.append(anchor)
         else:
@@ -97,6 +98,7 @@ class OWFreeVizGraph(OWGraphWithAnchors):
                 anchor.setLine(QLineF(0, 0, *point))
                 anchor.setText(label)
                 anchor.setVisible(np.linalg.norm(point) > r)
+                anchor.setFont(self.anchor_font)
 
     def update_circle(self):
         super().update_circle()

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -225,6 +225,7 @@ class OWLinProjGraph(OWGraphWithAnchors):
                 anchor._label.setToolTip(f"<b>{label}</b>")
                 label = label[:MAX_LABEL_LEN - 3] + "..." if len(label) > MAX_LABEL_LEN else label
                 anchor.setText(label)
+                anchor.setFont(self.anchor_font)
 
                 visible = self.always_show_axes or np.linalg.norm(point) > r
                 anchor.setVisible(visible)
@@ -236,6 +237,7 @@ class OWLinProjGraph(OWGraphWithAnchors):
                 anchor.setLine(QLineF(0, 0, *point))
                 visible = self.always_show_axes or np.linalg.norm(point) > r
                 anchor.setVisible(visible)
+                anchor.setFont(self.anchor_font)
 
     def update_circle(self):
         super().update_circle()

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -546,5 +546,6 @@ class CircularPlacement(LinearProjector):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    data = Table("iris")
-    WidgetPreview(OWLinearProjection).run(set_data=data, set_subset_data=data[::10])
+    iris = Table("iris")
+    WidgetPreview(OWLinearProjection).run(set_data=iris,
+                                          set_subset_data=iris[::10])

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -107,7 +107,7 @@ class BottomAxisItem(AxisItem):
     def set_ticks(self, ticks):
         self._ticks = dict(enumerate(ticks, 1)) if ticks else {}
 
-    def tickStrings(self, values, scale, spacing):
+    def tickStrings(self, values, scale, _):
         return [self._ticks.get(v * scale, "") for v in values]
 
 
@@ -159,29 +159,29 @@ class LinePlotViewBox(ViewBox):
     def remove_profiles(self):
         self._profile_items = None
 
-    def mouseDragEvent(self, event, axis=None):
+    def mouseDragEvent(self, ev, axis=None):
         if self._graph_state == SELECT and axis is None and self._can_select:
-            event.accept()
-            if event.button() == Qt.LeftButton:
-                self.update_selection_line(event.buttonDownPos(), event.pos())
-                if event.isFinish():
+            ev.accept()
+            if ev.button() == Qt.LeftButton:
+                self.update_selection_line(ev.buttonDownPos(), ev.pos())
+                if ev.isFinish():
                     self.selection_line.hide()
                     p1 = self.childGroup.mapFromParent(
-                        event.buttonDownPos(event.button()))
-                    p2 = self.childGroup.mapFromParent(event.pos())
+                        ev.buttonDownPos(ev.button()))
+                    p2 = self.childGroup.mapFromParent(ev.pos())
                     self.selection_changed.emit(self.get_selected(p1, p2))
         elif self._graph_state == ZOOMING or self._graph_state == PANNING:
-            event.ignore()
-            super().mouseDragEvent(event, axis=axis)
+            ev.ignore()
+            super().mouseDragEvent(ev, axis=axis)
         else:
-            event.ignore()
+            ev.ignore()
 
-    def mouseClickEvent(self, event):
-        if event.button() == Qt.RightButton:
+    def mouseClickEvent(self, ev):
+        if ev.button() == Qt.RightButton:
             self.autoRange()
             self.enableAutoRange()
         else:
-            event.accept()
+            ev.accept()
             self.selection_changed.emit(np.array(False))
 
     def reset(self):
@@ -627,6 +627,9 @@ class OWLinePlot(OWWidget):
         self.subset_indices = None
         self.__pending_selection = self.selection
         self.graph_variables = []
+        self.graph = None
+        self.group_vars = None
+        self.group_view = None
         self.setup_gui()
 
         VisualSettingsDialog(self, LinePlotGraph.initial_settings)
@@ -946,5 +949,5 @@ class OWLinePlot(OWWidget):
 
 
 if __name__ == "__main__":
-    data = Table("brown-selected")
-    WidgetPreview(OWLinePlot).run(set_data=data, set_subset_data=data[:30])
+    brown = Table("brown-selected")
+    WidgetPreview(OWLinePlot).run(set_data=brown, set_subset_data=brown[:30])

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -520,6 +520,7 @@ class OWLinePlot(OWWidget):
     show_error = Setting(False)
     auto_commit = Setting(True)
     selection = Setting(None, schema_only=True)
+    visual_settings = Setting({}, schema_only=True)
 
     graph_name = "graph.plotItem"
 
@@ -855,8 +856,9 @@ class OWLinePlot(OWWidget):
     def __in(obj, collection):
         return collection is not None and obj in collection
 
-    def set_visual_settings(self, *args):
-        self.graph.set_parameter(*args)
+    def set_visual_settings(self, key, value):
+        self.graph.set_parameter(key, value)
+        self.visual_settings[key] = value
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -204,49 +204,6 @@ class ParameterSetter(Setter):
         }
     }
 
-    def __init__(self):
-        def update_font_family(**settings):
-            for label, setter in self.setters[self.LABELS_BOX].items():
-                if label != self.FONT_FAMILY_LABEL:
-                    setter(**settings)
-
-        def update_title(**settings):
-            Updater.update_plot_title_font(self.title_item, **settings)
-
-        def update_axes_titles(**settings):
-            Updater.update_axes_titles_font(self.axis_items, **settings)
-
-        def update_axes_ticks(**settings):
-            Updater.update_axes_ticks_font(self.axis_items, **settings)
-
-        def update_legend(**settings):
-            self.legend_settings.update(**settings)
-            Updater.update_legend_font(self.legend_items, **settings)
-
-        def update_title_text(**settings):
-            Updater.update_plot_title_text(
-                self.title_item, settings[self.TITLE_LABEL])
-
-        def update_axis(axis, **settings):
-            Updater.update_axis_title_text(
-                self.getAxis(axis), settings[self.TITLE_LABEL])
-
-        self.legend_settings = {}
-        self.setters = {
-            self.LABELS_BOX: {
-                self.FONT_FAMILY_LABEL: update_font_family,
-                self.TITLE_LABEL: update_title,
-                self.AXIS_TITLE_LABEL: update_axes_titles,
-                self.AXIS_TICKS_LABEL: update_axes_ticks,
-                self.LEGEND_LABEL: update_legend,
-            },
-            self.ANNOT_BOX: {
-                self.TITLE_LABEL: update_title_text,
-                self.X_AXIS_LABEL: lambda **kw: update_axis("bottom", **kw),
-                self.Y_AXIS_LABEL: lambda **kw: update_axis("left", **kw),
-            }
-        }
-
     @property
     def title_item(self):
         return self.getPlotItem().titleLabel

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -264,6 +264,7 @@ class OWRadvizGraph(OWGraphWithAnchors):
                     label = label[:MAX_LABEL_LEN - 3] + "..."
 
             anchor.setText(label)
+            anchor.setFont(self.anchor_font)
             label_len = min(MAX_LABEL_LEN, len(label))
             anchor.setColor(QColor(0, 0, 0))
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -105,19 +105,6 @@ class ParameterSetter(Setter):
         Setter.AXIS_TICKS_LABEL: Updater.FONT_SETTING
     })
 
-    def __init__(self):
-        super().__init__()
-
-        def update_axes_titles(**settings):
-            Updater.update_axes_titles_font(self.axis_items, **settings)
-
-        def update_axes_ticks(**settings):
-            Updater.update_axes_ticks_font(self.axis_items, **settings)
-
-        labels = self.LABELS_BOX
-        self.setters[labels][self.AXIS_TITLE_LABEL] = update_axes_titles
-        self.setters[labels][self.AXIS_TICKS_LABEL] = update_axes_ticks
-
     @property
     def axis_items(self):
         return [value["item"] for value in

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -360,22 +360,11 @@ class ParameterSetter(Setter):
     }
 
     def __init__(self):
-        self.label_font = QFont()
+        super().__init__()
         self.cat_legend_settings = {}
         self.num_legend_settings = {}
 
-        def update_font_family(**settings):
-            for label, setter in self.setters[self.LABELS_BOX].items():
-                if label != self.FONT_FAMILY_LABEL:
-                    setter(**settings)
-
-        def update_title(**settings):
-            Updater.update_plot_title_font(self.title_item, **settings)
-
-        def update_label(**settings):
-            self.label_font = Updater.change_font(self.label_font, settings)
-            Updater.update_label_font(self.labels, self.label_font)
-
+    def update_setters(self):
         def update_cat_legend(**settings):
             self.cat_legend_settings.update(**settings)
             Updater.update_legend_font(self.cat_legend_items, **settings)
@@ -384,22 +373,9 @@ class ParameterSetter(Setter):
             self.num_legend_settings.update(**settings)
             Updater.update_num_legend_font(self.num_legend, **settings)
 
-        def update_title_text(**settings):
-            Updater.update_plot_title_text(
-                self.title_item, settings[self.TITLE_LABEL])
-
-        self._setters = {
-            self.LABELS_BOX: {
-                self.FONT_FAMILY_LABEL: update_font_family,
-                self.TITLE_LABEL: update_title,
-                self.LABEL_LABEL: update_label,
-                self.CAT_LEGEND_LABEL: update_cat_legend,
-                self.NUM_LEGEND_LABEL: update_num_legend,
-            },
-            self.ANNOT_BOX: {
-                self.TITLE_LABEL: update_title_text,
-            }
-        }
+        labels = self.LABELS_BOX
+        self._setters[labels][self.CAT_LEGEND_LABEL] = update_cat_legend
+        self._setters[labels][self.NUM_LEGEND_LABEL] = update_num_legend
 
     @property
     def title_item(self):

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -151,7 +151,6 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, self.data)
 
         # set view-dependent click coordinates
-        vb = self.widget.graph.view_box
         event.buttonDownPos.return_value = QPointF(2.38, 4.84)
         event.pos.return_value = QPointF(3.58, 4.76)
 
@@ -159,7 +158,7 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         line = self.widget.graph.view_box.selection_line
         self.assertFalse(line.line().isNull())
 
-        # click oon the plot resets selection
+        # click on the plot resets selection
         self.assertEqual(len(self.widget.selection), 55)
         self.widget.graph.view_box.mouseClickEvent(event)
         self.assertListEqual(self.widget.selection, [])

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, Mock
 import numpy as np
 import scipy.sparse as sp
 
-from AnyQt.QtCore import Qt
+from AnyQt.QtCore import Qt, QPointF
 
 from pyqtgraph import PlotCurveItem
 from pyqtgraph.Point import Point
@@ -152,8 +152,8 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
 
         # set view-dependent click coordinates
         vb = self.widget.graph.view_box
-        event.buttonDownPos.return_value = vb.mapFromView(Point(2.49, 5.79))
-        event.pos.return_value = vb.mapFromView(Point(2.99, 4.69))
+        event.buttonDownPos.return_value = QPointF(2.38, 4.84)
+        event.pos.return_value = QPointF(3.58, 4.76)
 
         self.widget.graph.view_box.mouseDragEvent(event)
         line = self.widget.graph.view_box.selection_line

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1540,6 +1540,13 @@ class TestScatterPlotItem(GuiTest):
             np.testing.assert_equal(x, np.arange(10, 15))
             np.testing.assert_equal(y, np.arange(20, 25))
 
+    def test_scalable_axis_item(self):
+        from pyqtgraph import __version__
+        # When upgraded to 0.11.1 check if resizing AxisItem font size works
+        # and overwritten functions generateDrawSpecs and _updateMaxTextSize
+        # in AxisItem (owscatterplotgraph) can be removed.
+        self.assertLess(__version__, "0.11.1")
+
 
 if __name__ == "__main__":
     import unittest

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1540,13 +1540,6 @@ class TestScatterPlotItem(GuiTest):
             np.testing.assert_equal(x, np.arange(10, 15))
             np.testing.assert_equal(y, np.arange(20, 25))
 
-    def test_scalable_axis_item(self):
-        from pyqtgraph import __version__
-        # When upgraded to 0.11.1 check if resizing AxisItem font size works
-        # and overwritten functions generateDrawSpecs and _updateMaxTextSize
-        # in AxisItem (owscatterplotgraph) can be removed.
-        self.assertLess(__version__, "0.11.1")
-
 
 if __name__ == "__main__":
     import unittest

--- a/Orange/widgets/visualize/utils/component.py
+++ b/Orange/widgets/visualize/utils/component.py
@@ -23,13 +23,16 @@ class ParameterSetter(Setter):
     })
 
     def __init__(self):
+        super().__init__()
+        self.anchor_font = QFont()
+
+    def update_setters(self):
         def update_anchors(**settings):
             self.anchor_font = Updater.change_font(self.anchor_font, settings)
             self.update_anchors()
 
-        super().__init__()
-        self.anchor_font = QFont()
-        self.setters[self.LABELS_BOX][self.ANCHOR_LABEL] = update_anchors
+        super().update_setters()
+        self._setters[self.LABELS_BOX][self.ANCHOR_LABEL] = update_anchors
 
 
 class OWGraphWithAnchors(OWScatterPlotBase, ParameterSetter):

--- a/Orange/widgets/visualize/utils/component.py
+++ b/Orange/widgets/visualize/utils/component.py
@@ -1,16 +1,38 @@
 """Common gui.OWComponent components."""
+import copy
+
 from AnyQt.QtCore import Qt, QRectF
-from AnyQt.QtGui import QColor
+from AnyQt.QtGui import QColor, QFont
 from AnyQt.QtWidgets import QGraphicsEllipseItem
 
 import pyqtgraph as pg
-from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
+from Orange.widgets.visualize.owscatterplotgraph import (
+    OWScatterPlotBase, ParameterSetter as Setter
+)
+from Orange.widgets.visualize.utils.customizableplot import Updater
 from Orange.widgets.visualize.utils.plotutils import (
     MouseEventDelegate, DraggableItemsViewBox
 )
 
 
-class OWGraphWithAnchors(OWScatterPlotBase):
+class ParameterSetter(Setter):
+    ANCHOR_LABEL = "Anchor"
+    initial_settings = copy.deepcopy(Setter.initial_settings)
+    initial_settings[Setter.LABELS_BOX].update({
+        ANCHOR_LABEL: Updater.FONT_SETTING
+    })
+
+    def __init__(self):
+        def update_anchors(**settings):
+            self.anchor_font = Updater.change_font(self.anchor_font, settings)
+            self.update_anchors()
+
+        super().__init__()
+        self.anchor_font = QFont()
+        self.setters[self.LABELS_BOX][self.ANCHOR_LABEL] = update_anchors
+
+
+class OWGraphWithAnchors(OWScatterPlotBase, ParameterSetter):
     """
     Graph for projections in which dimensions can be manually moved
 

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -1,6 +1,7 @@
 import sys
-from typing import Tuple, List, Dict, Callable, Iterable
+from typing import Tuple, List, Dict, Iterable
 
+from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QFont, QFontDatabase
 from AnyQt.QtWidgets import QApplication
 
@@ -69,6 +70,21 @@ class Updater:
     FONT_SETTING: SettingsType = {
         SIZE_LABEL: (range(4, 50), default_font_size()),
         IS_ITALIC_LABEL: (None, False)
+    }
+
+    WIDTH_LABEL, ALPHA_LABEL, STYLE_LABEL, ANTIALIAS_LABEL = \
+        "Width", "Opacity", "Style", "Antialias"
+    LINE_STYLES = {"Solid line": Qt.SolidLine,
+                   "Dash line": Qt.DashLine,
+                   "Dot line": Qt.DotLine,
+                   "Dash dot line": Qt.DashDotLine,
+                   "Dash dot dot line": Qt.DashDotDotLine}
+    DEFAULT_LINE_STYLE = "Solid line"
+    LINE_SETTING: SettingsType = {
+        WIDTH_LABEL: (range(1, 15), 1),
+        ALPHA_LABEL: (range(0, 255, 5), 255),
+        STYLE_LABEL: (list(LINE_STYLES), DEFAULT_LINE_STYLE),
+        ANTIALIAS_LABEL: (None, False),
     }
 
     @staticmethod
@@ -164,11 +180,36 @@ class Updater:
             font.setItalic(italic)
         return font
 
+    @staticmethod
+    def update_lines(items: List[pg.PlotCurveItem], **settings: _SettingType):
+        for item in items:
+            antialias = settings.get(Updater.ANTIALIAS_LABEL)
+            if antialias is not None:
+                item.setData(item.xData, item.yData, antialias=antialias)
+
+            pen = item.opts["pen"]
+            alpha = settings.get(Updater.ALPHA_LABEL)
+            if alpha is not None:
+                color = pen.color()
+                color.setAlpha(alpha)
+                pen.setColor(color)
+
+            style = settings.get(Updater.STYLE_LABEL)
+            if style is not None:
+                pen.setStyle(Updater.LINE_STYLES[style])
+
+            width = settings.get(Updater.WIDTH_LABEL)
+            if width is not None:
+                pen.setWidth(width)
+
+            item.setPen(pen)
+
 
 class BaseParameterSetter:
     """ Subclass to add 'setter' functionality to a plot. """
     LABELS_BOX = "Fonts"
     ANNOT_BOX = "Annotations"
+    PLOT_BOX = "Figure"
 
     FONT_FAMILY_LABEL = "Font family"
     AXIS_TITLE_LABEL = "Axis title"

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -1,0 +1,200 @@
+import sys
+from typing import Tuple, List, Dict, Callable, Iterable
+
+from AnyQt.QtGui import QFont, QFontDatabase
+from AnyQt.QtWidgets import QApplication
+
+import pyqtgraph as pg
+from pyqtgraph.graphicsItems.LegendItem import ItemSample
+
+from orangewidget.utils.visual_settings_dlg import KeyType, ValueType, \
+    SettingsType
+
+_SettingType = Dict[str, ValueType]
+_LegendItemType = Tuple[ItemSample, pg.LabelItem]
+
+
+def available_font_families() -> List:
+    """
+    Function returns list of available font families.
+    Can be used to instantiate font combo boxes.
+
+    Returns
+    -------
+    fonts: list
+        List of available font families.
+    """
+    if not QApplication.instance():
+        _ = QApplication(sys.argv)
+    return QFontDatabase().families()
+
+
+def default_font_family() -> str:
+    """
+    Function returns default font family used in Qt application.
+    Can be used to instantiate initial dialog state.
+
+    Returns
+    -------
+    font: str
+        Default font family.
+    """
+    if not QApplication.instance():
+        _ = QApplication(sys.argv)
+    return QFont().family()
+
+
+def default_font_size() -> int:
+    """
+    Function returns default font size in points used in Qt application.
+    Can be used to instantiate initial dialog state.
+
+    Returns
+    -------
+    size: int
+        Default font size in points.
+    """
+    if not QApplication.instance():
+        _ = QApplication(sys.argv)
+    return QFont().pointSize()
+
+
+class Updater:
+    """ Class with helper functions and constants. """
+    FONT_FAMILY_LABEL, SIZE_LABEL, IS_ITALIC_LABEL = \
+        "Font family", "Font size", "Italic"
+    FONT_FAMILY_SETTING: SettingsType = {
+        FONT_FAMILY_LABEL: (available_font_families(), default_font_family()),
+    }
+    FONT_SETTING: SettingsType = {
+        SIZE_LABEL: (range(4, 50), default_font_size()),
+        IS_ITALIC_LABEL: (None, False)
+    }
+
+    @staticmethod
+    def update_plot_title_text(title_item: pg.LabelItem, text: str):
+        title_item.text = text
+        title_item.setVisible(bool(text))
+        title_item.item.setPlainText(text)
+        Updater.plot_title_resize(title_item)
+
+    @staticmethod
+    def update_plot_title_font(title_item: pg.LabelItem,
+                               **settings: _SettingType):
+        font = Updater.change_font(title_item.item.font(), settings)
+        title_item.item.setFont(font)
+        title_item.item.setPlainText(title_item.text)
+        Updater.plot_title_resize(title_item)
+
+    @staticmethod
+    def plot_title_resize(title_item):
+        height = title_item.item.boundingRect().height() + 6 \
+            if title_item.text else 0
+        title_item.setMaximumHeight(height)
+        title_item.parentItem().layout.setRowFixedHeight(0, height)
+        title_item.resizeEvent(None)
+
+    @staticmethod
+    def update_axis_title_text(item: pg.AxisItem, text: str):
+        item.setLabel(text)
+        item.resizeEvent(None)
+
+    @staticmethod
+    def update_axes_titles_font(items: List[pg.AxisItem],
+                                **settings: _SettingType):
+        for item in items:
+            font = Updater.change_font(item.label.font(), settings)
+            item.label.setFont(font)
+            fstyle = ["normal", "italic"][font.italic()]
+            style = {"font-size": f"{font.pointSize()}pt",
+                     "font-family": f"{font.family()}",
+                     "font-style": f"{fstyle}"}
+            item.setLabel(None, None, None, **style)
+
+    @staticmethod
+    def update_axes_ticks_font(items: List[pg.AxisItem],
+                               **settings: _SettingType):
+        for item in items:
+            font = item.style["tickFont"] or QFont()
+            # remove when contained in setTickFont() - version 0.11.0
+            item.style['tickFont'] = font
+            item.setTickFont(Updater.change_font(font, settings))
+
+    @staticmethod
+    def update_legend_font(items: Iterable[_LegendItemType],
+                           **settings: _SettingType):
+        for sample, label in items:
+            sample.setFixedHeight(sample.height())
+            sample.setFixedWidth(sample.width())
+            label.item.setFont(Updater.change_font(label.item.font(), settings))
+            bounds = label.itemRect()
+            label.setMaximumWidth(bounds.width())
+            label.setMaximumHeight(bounds.height())
+            label.updateMin()
+            label.resizeEvent(None)
+            label.updateGeometry()
+
+    @staticmethod
+    def update_num_legend_font(legend: pg.LegendItem,
+                               **settings: _SettingType):
+        if not legend:
+            return
+        for sample, label in legend.items:
+            sample.set_font(Updater.change_font(sample.font, settings))
+            legend.setGeometry(sample.boundingRect())
+
+    @staticmethod
+    def update_label_font(items: List[pg.TextItem], font: QFont):
+        for item in items:
+            item.setFont(font)
+
+    @staticmethod
+    def change_font(font: QFont, settings: _SettingType) -> QFont:
+        assert all(s in (Updater.FONT_FAMILY_LABEL, Updater.SIZE_LABEL,
+                         Updater.IS_ITALIC_LABEL) for s in settings), settings
+
+        family = settings.get(Updater.FONT_FAMILY_LABEL)
+        if family is not None:
+            font.setFamily(family)
+        size = settings.get(Updater.SIZE_LABEL)
+        if size is not None:
+            font.setPointSize(size)
+        italic = settings.get(Updater.IS_ITALIC_LABEL)
+        if italic is not None:
+            font.setItalic(italic)
+        return font
+
+
+class BaseParameterSetter:
+    """ Subclass to add 'setter' functionality to a plot. """
+    LABELS_BOX = "Fonts"
+    ANNOT_BOX = "Annotations"
+
+    FONT_FAMILY_LABEL = "Font family"
+    AXIS_TITLE_LABEL = "Axis title"
+    AXIS_TICKS_LABEL = "Axis ticks"
+    LEGEND_LABEL = "Legend"
+    LABEL_LABEL = "Label"
+    X_AXIS_LABEL = "x-axis title"
+    Y_AXIS_LABEL = "y-axis title"
+    TITLE_LABEL = "Title"
+
+    initial_settings: Dict[str, Dict[str, SettingsType]] = NotImplemented
+
+    def __init__(self):
+        self._setters: Dict[str, Dict[str, Callable]] = NotImplemented
+
+    @property
+    def setters(self) -> Dict:
+        return self._setters
+
+    @setters.setter
+    def setters(self, setters: Dict[str, Dict[str, Callable]]):
+        assert setters.keys() == self.initial_settings.keys()
+        assert all(setters[key].keys() == self.initial_settings[key].keys()
+                   for key in setters.keys())
+
+        self._setters = setters
+
+    def set_parameter(self, key: KeyType, value: ValueType):
+        self.setters[key[0]][key[1]](**{key[2]: value})

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -155,7 +155,7 @@ class Updater:
                                **settings: _SettingType):
         if not legend:
             return
-        for sample, label in legend.items:
+        for sample, _ in legend.items:
             sample.set_font(Updater.change_font(sample.font, settings))
             legend.setGeometry(sample.boundingRect())
 
@@ -275,7 +275,7 @@ class BaseParameterSetter:
 
         self.update_setters()
         self._check_setters()
-        
+
     def update_setters(self):
         pass
 

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -1,14 +1,20 @@
+import itertools
+
 import numpy as np
 
 from AnyQt.QtCore import (
     QRectF, QLineF, QObject, QEvent, Qt, pyqtSignal as Signal
 )
-from AnyQt.QtGui import QTransform, QFontMetrics
+from AnyQt.QtGui import QTransform, QFontMetrics, QStaticText, QBrush, QPen, \
+    QFont
 from AnyQt.QtWidgets import (
     QGraphicsLineItem, QGraphicsSceneMouseEvent, QPinchGesture,
     QGraphicsItemGroup, QWidget)
 
 import pyqtgraph as pg
+import pyqtgraph.functions as fn
+from pyqtgraph.graphicsItems.LegendItem import ItemSample
+from pyqtgraph.graphicsItems.ScatterPlotItem import drawSymbol
 
 from Orange.widgets.utils.plot import SELECT, PANNING, ZOOMING
 
@@ -50,6 +56,9 @@ class AnchorItem(pg.GraphicsObject):
     def get_xy(self):
         point = self._spine.line().p2()
         return point.x(), point.y()
+
+    def setFont(self, font):
+        self._label.setFont(font)
 
     def setText(self, text):
         if text != self._text:
@@ -403,3 +412,90 @@ class ElidedLabelsAxis(pg.AxisItem):
         text_specs = [(rect, flags, elide(text, Qt.ElideRight, max_width))
                       for rect, flags, text in text_specs]
         return axis_spec, tick_specs, text_specs
+
+
+class PaletteItemSample(ItemSample):
+    """A color strip to insert into legends for discretized continuous values"""
+
+    def __init__(self, palette, scale, label_formatter=None):
+        """
+        :param palette: palette used for showing continuous values
+        :type palette: BinnedContinuousPalette
+        :param scale: an instance of DiscretizedScale that defines the
+                      conversion of values into bins
+        :type scale: DiscretizedScale
+        """
+        super().__init__(None)
+        self.palette = palette
+        self.scale = scale
+        if label_formatter is None:
+            label_formatter = "{{:.{}f}}".format(scale.decimals).format
+        cuts = [label_formatter(scale.offset + i * scale.width)
+                for i in range(scale.bins + 1)]
+        self.labels = [QStaticText("{} - {}".format(fr, to))
+                       for fr, to in zip(cuts, cuts[1:])]
+        self.font = self.font()
+        self.font.setPointSize(11)
+
+    @property
+    def bin_height(self):
+        return self.font.pointSize() + 4
+
+    @property
+    def text_width(self):
+        for label in self.labels:
+            label.prepare(font=self.font)
+        return max(label.size().width() for label in self.labels)
+
+    def set_font(self, font: QFont):
+        self.font = font
+        self.update()
+
+    def boundingRect(self):
+        return QRectF(0, 0,
+                      25 + self.text_width + self.bin_height,
+                      20 + self.scale.bins * self.bin_height)
+
+    def paint(self, p, *args):
+        p.setRenderHint(p.Antialiasing)
+        p.translate(5, 5)
+        p.setFont(self.font)
+        colors = self.palette.qcolors
+        h = self.bin_height
+        for i, color, label in zip(itertools.count(), colors, self.labels):
+            p.setPen(Qt.NoPen)
+            p.setBrush(QBrush(color))
+            p.drawRect(0, i * h, h, h)
+            p.setPen(QPen(Qt.black))
+            p.drawStaticText(h + 5, i * h + 1, label)
+
+
+class SymbolItemSample(ItemSample):
+    """Adjust position for symbols"""
+    def __init__(self, pen, brush, size, symbol):
+        super().__init__(None)
+        self.__pen = fn.mkPen(pen)
+        self.__brush = fn.mkBrush(brush)
+        self.__size = size
+        self.__symbol = symbol
+
+    def paint(self, p, *args):
+        p.translate(8, 12)
+        drawSymbol(p, self.__symbol, self.__size, self.__pen, self.__brush)
+
+
+class AxisItem(pg.AxisItem):
+    def generateDrawSpecs(self, p):
+        if self.style["tickFont"]:
+            p.setFont(self.style["tickFont"])
+        return super().generateDrawSpecs(p)
+
+    def _updateMaxTextSize(self, x):
+        if self.orientation in ["left", "right"]:
+            self.textWidth = x
+            if self.style["autoExpandTextSpace"] is True:
+                self._updateWidth()
+        else:
+            self.textHeight = x
+            if self.style["autoExpandTextSpace"] is True:
+                self._updateHeight()

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -128,7 +128,7 @@ class HelpEventDelegate(QObject):
         super().__init__(parent)
         self.delegate = delegate
 
-    def eventFilter(self, obj, event):
+    def eventFilter(self, _, event):
         if event.type() == QEvent.GraphicsSceneHelp:
             return self.delegate(event)
         else:
@@ -140,10 +140,10 @@ class MouseEventDelegate(HelpEventDelegate):
         self.delegate2 = delegate2
         super().__init__(delegate, parent=parent)
 
-    def eventFilter(self, obj, ev):
-        if isinstance(ev, QGraphicsSceneMouseEvent):
-            self.delegate2(ev)
-        return super().eventFilter(obj, ev)
+    def eventFilter(self, obj, event):
+        if isinstance(event, QGraphicsSceneMouseEvent):
+            self.delegate2(event)
+        return super().eventFilter(obj, event)
 
 
 class InteractiveViewBox(pg.ViewBox):
@@ -154,7 +154,8 @@ class InteractiveViewBox(pg.ViewBox):
         self.setMouseMode(self.PanMode)
         self.grabGesture(Qt.PinchGesture)
 
-    def _dragtip_pos(self):
+    @staticmethod
+    def _dragtip_pos():
         return 10, 10
 
     def updateScaleBox(self, p1, p2):
@@ -259,7 +260,7 @@ class InteractiveViewBox(pg.ViewBox):
         super().autoRange(padding=padding, items=items, item=item)
         self.tag_history()
 
-    def suggestPadding(self, axis): #no padding so that undo works correcty
+    def suggestPadding(self, _):  # no padding so that undo works correcty
         return 0.
 
     def scaleHistory(self, d):

--- a/Orange/widgets/visualize/utils/tests/test_plotutils.py
+++ b/Orange/widgets/visualize/utils/tests/test_plotutils.py
@@ -1,0 +1,14 @@
+import unittest
+
+
+class TestAxisItem(unittest.TestCase):
+    def test_scalable_axis_item(self):
+        from pyqtgraph import __version__
+        # When upgraded to 0.11.1 (or bigger) check if resizing AxisItem font
+        # works and overwritten functions generateDrawSpecs and
+        # _updateMaxTextSize are no longer needed.
+        self.assertLess(__version__, "0.11.1")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -381,6 +381,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
 
     settingsHandler = DomainContextHandler()
     selection = Setting(None, schema_only=True)
+    visual_settings = Setting({}, schema_only=True)
     auto_commit = Setting(True)
 
     GRAPH_CLASS = OWScatterPlotBase
@@ -625,8 +626,9 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
              "{} %".format(self.graph.jitter_size))))
 
     # Customize plot
-    def set_visual_settings(self, *args):
-        self.graph.set_parameter(*args)
+    def set_visual_settings(self, key, value):
+        self.graph.set_parameter(key, value)
+        self.visual_settings[key] = value
 
     @staticmethod
     def _get_caption_var_name(var):
@@ -664,8 +666,8 @@ class OWAnchorProjectionWidget(OWDataProjectionWidget, openclass=True):
         proj_error = Msg("An error occurred while projecting data.\n{}")
 
     def __init__(self):
-        super().__init__()
         self.projector = self.projection = None
+        super().__init__()
         self.graph.view_box.started.connect(self._manual_move_start)
         self.graph.view_box.moved.connect(self._manual_move)
         self.graph.view_box.finished.connect(self._manual_move_finish)

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -5,6 +5,8 @@ import numpy as np
 from AnyQt.QtCore import QSize, Signal
 from AnyQt.QtWidgets import QApplication
 
+from orangewidget.utils.visual_settings_dlg import VisualSettingsDialog
+
 from Orange.data import (
     Table, ContinuousVariable, Domain, Variable, StringVariable
 )
@@ -400,6 +402,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         self.input_changed.connect(self.set_input_summary)
         self.output_changed.connect(self.set_output_summary)
         self.setup_gui()
+        VisualSettingsDialog(self, self.GRAPH_CLASS.initial_settings)
 
     # GUI
     def setup_gui(self):
@@ -620,6 +623,10 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
             ("Size", self._get_caption_var_name(self.attr_size)),
             ("Jittering", self.graph.jitter_size != 0 and
              "{} %".format(self.graph.jitter_size))))
+
+    # Customize plot
+    def set_visual_settings(self, *args):
+        self.graph.set_parameter(*args)
 
     @staticmethod
     def _get_caption_var_name(var):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Partially implements #4493
Needs https://github.com/biolab/orange-widget-base/pull/74

##### Description of changes
Enable setting label (axes, labels, legend) fonts, annotations and figure properties on projection widgets and some other widgets with plots
-  Scatterplot, MDS, tSNE, Radviz, Freeviz, LinearProjection
-  Line plot
- Calibration plot

##### TODO
- [x] tick font resize for Calibration plot
- [X] save settings as schema-only settings

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
