### PR TITLE
[ENH] CSV Import: guess data types

### DIFF
--- a/Orange/widgets/data/tests/data-csv-types.tab
+++ b/Orange/widgets/data/tests/data-csv-types.tab
@@ -1,0 +1,6 @@
+time	numeric1	discrete1	numeric2	discrete2	string
+2020-05-05	1	0		a	a
+2020-05-06	2	1		a	b
+2020-05-07	3	0		a	c
+2020-05-08	4	1		b	d
+2020-05-09	5	1		b	e


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements #4794

##### Description of changes

Implemented guessing strategy for CSV import which should match the strategy in `io_utils.guess_data_type`. 

This PR adds another iteration over the columns. For each column, it checks for the data type according to data. Complex operations here are:
- unique: Pandas unique is based on a hash table - less complex than Numpy's one
- casting times to date-time

@ales-erjavec is this kind of guessing acceptable or would decrease the performance of the widget too much?

#### TODO
- Tests

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
