### PR TITLE
Set PyQt5 as dependency

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -50,13 +50,9 @@ Verify the installation by importing the Orange package from Python and loading 
     >>> print(Orange.data.Table("iris")[0])
     [5.1, 3.5, 1.4, 0.2 | Iris-setosa]
 
-Using the graphic user interface requires some additional packages
+Using the graphic user interface requires some additional packages.
 
     pip install -r requirements-gui.txt
-
-and Qt dependencies.
-
-    pip install PyQt5 PyQtWebEngine
 
 To start Orange GUI from the command line, run:
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ virtualenv --python=python3 --system-site-packages orange3venv
 # ... and make it the active one
 source orange3venv/bin/activate
 
-# Install Qt dependencies for the GUI
-pip install PyQt5 PyQtWebEngine
-
 # Install Orange
 pip install orange3
 ```

--- a/README.pypi
+++ b/README.pypi
@@ -26,9 +26,6 @@ To install Orange with pip, run the following.
     # ... and make it the active one
     source orange3venv/bin/activate
 
-    # Install Qt dependencies for the GUI
-    pip install PyQt5 PyQtWebEngine
-
     # Install Orange
     pip install orange3
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - xlrd          >=0.9.2
     - keyring
     - keyrings.alt  # for alternative keyring implementations
-    - pyqt
+    - pyqt          >=5.12
     - pyqtgraph     ~=0.10.0|~=0.11.0
     - anyqt         >=0.0.8
     - joblib

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,7 +1,8 @@
 orange-canvas-core>=0.1.12,<0.2a
 orange-widget-base>=4.5.0
 
-# PyQt4/PyQt5 compatibility
+PyQt5>=5.12
+PyQtWebEngine>=5.12
 AnyQt>=0.0.8
 
 pyqtgraph>=0.10.0

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     # our desire to have OrangeDeprecationWarnings raised
     PYTHONWARNINGS=module
 deps =
-    pyqt5==5.13.*
+    pyqt5==5.12.*
     pyqtwebengine==5.12.*
 commands_pre =
     # Verify installed packages have compatible dependencies


### PR DESCRIPTION
##### Issue
Older versions of PyQt5 cause problems like #4763. The solution is to set minimum supported version and thereby also setting PyQWt5 as the default binding for Qt (although Orange theoretically  also supports PyQt4, PySide and PySide2)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
