### PR TITLE
Lift minimum versions of orange-canvas-core and widget-base

### DIFF
--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
-orange-canvas-core>=0.1.14,<0.2a
-orange-widget-base>=4.5.0
+orange-canvas-core>=0.1.15,<0.2a
+orange-widget-base>=4.6.0
 
 # PyQt4/PyQt5 compatibility
 AnyQt>=0.0.8


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Before release, we would like to make sure that the user has the newest versions of canvas-core and widget-base. In both packages are some changes which are important for orange to work properly.

##### Description of changes
Lift versions of both packages

