### PR TITLE
Add cosine metric for Louvain clustering.

### DIFF
--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -42,7 +42,7 @@ _MAX_K_NEIGBOURS = 200
 _DEFAULT_K_NEIGHBORS = 30
 
 
-METRICS = [("Euclidean", "l2"), ("Manhattan", "l1")]
+METRICS = [("Euclidean", "l2"), ("Manhattan", "l1"), ("Cosine", "cosine")]
 
 
 class OWLouvainClustering(widget.OWWidget):


### PR DESCRIPTION
##### Issue
Adds cosine distance to Louvain clustering widget. 
I need this for "supplementary code" of a paper. I made the change in my own Orange version, but now it needs to be available to everyone.

##### Description of changes
This simply adds an option to the Louvain widget to use the cosine distance in sklearn's NearestNeighbors. However, NearestNeighbors uses brute force computation with cosine distance, if I understand it correctly (here is the base class https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/neighbors/_base.py with specified VALID_METRIC for each nearest neighbours algorithm). Thus a modification would be required to prevent the use of cosine distance on data with too many samples. (It works fine with my data that has ~1000 samples with ~500 features.)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
