### PR TITLE
Change dataset url to get rid of double domain

### DIFF
--- a/Orange/tests/test_url_reader.py
+++ b/Orange/tests/test_url_reader.py
@@ -14,6 +14,6 @@ class TestUrlReader(unittest.TestCase):
     def test_zipped(self):
         """ Test zipped files with two extensions"""
         data = UrlReader(
-            "http://datasets.orange.biolab.si/core/philadelphia-crime.csv.xz"
+            "http://datasets.biolab.si/core/philadelphia-crime.csv.xz"
         ).read()
         self.assertEqual(9666, len(data))


### PR DESCRIPTION
This will allow us to drop a letsencrypt after a while. 