### PR TITLE
tsne: require opentsne>=0.4.3

### DIFF
--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -5,8 +5,6 @@ foldable pip install -U setuptools pip codecov
 
 if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install pandas==0.20.3; fi
 
-pip install numba==0.41.0 llvmlite==0.26.0
-
 # Install dependencies sequentially
 cat requirements-core.txt \
     requirements-gui.txt \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - python-louvain >=0.13
     - requests
     - matplotlib-base >=2.0.0
-    - openTSNE >=0.3.11
+    - openTSNE >=0.4.3
     - pandas
     - pyyaml
     - orange-canvas-core >=0.1.15,<0.2a

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,32 +33,37 @@ requirements:
 
   run:
     - python
-    - setuptools
-    - numpy         >=1.16.0
-    - scipy
-    - scikit-learn  >=0.22
-    - bottleneck    >=1.0.0
-    - chardet       >=3.0.2
+    - setuptools >=36.3
+    - numpy >=1.16.0
+    - scipy >=0.16.1
+    - scikit-learn >=0.22.0,!=0.23.0
+    - bottleneck >=1.0.0
+    - chardet >=3.0.2
     - docutils
-    - xlrd          >=0.9.2
+    - xlrd >=0.9.2
+    - xlsxwriter
+    - anyqt >=0.0.8
+    - pyqt >=5.12
+    - pyqtgraph ~=0.10.0|~=0.11.0
+    - joblib >=0.9.4
     - keyring
-    - keyrings.alt  # for alternative keyring implementations
-    - pyqt          >=5.12
-    - pyqtgraph     ~=0.10.0|~=0.11.0
-    - anyqt         >=0.0.8
-    - joblib
-    - python.app    # [osx]
-    - commonmark
+    - keyrings.alt
+    - pip >=9.0
+    - python.app  # [osx]
     - serverfiles
-    - matplotlib    >=2.0.0
-    - opentsne      >=0.3.11
+    - python-louvain >=0.13
+    - requests
+    - matplotlib-base >=2.0.0
+    - openTSNE >=0.3.11
     - pandas
     - pyyaml
-    - orange-canvas-core  >=0.1.9
-    - orange-widget-base  >=4.4.0
+    - orange-canvas-core >=0.1.15,<0.2a
+    - orange-widget-base >=4.6.0
     - openpyxl
-    - python-louvain      >=0.13
-    - xlsxwriter
+    - httpx >=0.12
+    - baycomp >=1.0.2
+    # cachecontrol (required by canvas core) <0.12.5 is incompatible with msgpack 1.0
+    - cachecontrol >=0.12.6
 
 test:
   # Python imports

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -18,7 +18,7 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain>=0.13
 requests
-openTSNE>=0.3.11
+openTSNE>=0.4.3
 baycomp>=1.0.2
 pandas
 pyyaml


### PR DESCRIPTION
##### Changes
Bump minimum required version of openTSNE to 0.4.3. This also gets rid of numba. I removed the only mention of numba I was able to find in this repo. There are no mentions of numba in orange-canvas and orange-widget-base, so I think this was the only one.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
