### PR TITLE
[ENH] Louvain Clustering: Add cosine similarity

### DIFF
--- a/Orange/clustering/louvain.py
+++ b/Orange/clustering/louvain.py
@@ -44,6 +44,13 @@ def matrix_to_knn_graph(data, k_neighbors, metric, progress_callback=None):
 
     """
     # We do k + 1 because each point is closest to itself, which is not useful
+    if metric == "cosine":
+        # Cosine distance on row-normalized data has the same ranking as
+        # Euclidean distance, so we use the latter, which is more efficient
+        # because it uses ball trees. We do not need actual distances. If we
+        # would, the N * k distances can be recomputed later.
+        data = data / np.linalg.norm(data, axis=1)[:, None]
+        metric = "euclidean"
     knn = NearestNeighbors(n_neighbors=k_neighbors, metric=metric).fit(data)
     nearest_neighbors = knn.kneighbors(data, return_distance=False)
     # Convert to list of sets so jaccard can be computed efficiently

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -42,7 +42,7 @@ _MAX_K_NEIGBOURS = 200
 _DEFAULT_K_NEIGHBORS = 30
 
 
-METRICS = [("Euclidean", "l2"), ("Manhattan", "l1")]
+METRICS = [("Euclidean", "l2"), ("Manhattan", "l1"), ("Cosine", "cosine")]
 
 
 class OWLouvainClustering(widget.OWWidget):


### PR DESCRIPTION
As suggested by @pavlin-policar in a comment to #4855, cosine distance can be computed as Euclidean on row-normalized data, because we care only about ranking. This allows NearestNeighbours to use ball trees.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
