### PR TITLE
Table.numpy: Convert non-csr/csc matrices to csr

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1751,6 +1751,8 @@ def _check_arrays(*arrays, dtype=None, shape_1=None):
                              % (ninstances(array), shape_1))
 
         if sp.issparse(array):
+            if not (sp.isspmatrix_csr(array) or sp.isspmatrix_csc(array)):
+                array = array.tocsr()
             array.data = np.asarray(array.data)
             has_inf = _check_inf(array.data)
         else:

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import scipy.sparse as sp
 
 from Orange.data import (
     ContinuousVariable, DiscreteVariable, StringVariable,
@@ -84,6 +85,28 @@ class TestTableInit(unittest.TestCase):
             self.assertRaises(ValueError, func, dom, X, Y, metas, W[:4])
             self.assertRaises(ValueError, func, dom, X, Y, metas[:4])
             self.assertRaises(ValueError, func, dom, X, Y[:4])
+
+    def test_from_numpy_sparse(self):
+        domain = Domain([ContinuousVariable(c) for c in "abc"])
+        x = np.arange(12).reshape(4, 3)
+
+        t = Table.from_numpy(domain, x, None, None)
+        self.assertFalse(sp.issparse(t.X))
+
+        t = Table.from_numpy(domain, sp.csr_matrix(x))
+        self.assertTrue(sp.isspmatrix_csr(t.X))
+
+        t = Table.from_numpy(domain, sp.csc_matrix(x))
+        self.assertTrue(sp.isspmatrix_csc(t.X))
+
+        t = Table.from_numpy(domain, sp.coo_matrix(x))
+        self.assertTrue(sp.isspmatrix_csr(t.X))
+
+        t = Table.from_numpy(domain, sp.lil_matrix(x))
+        self.assertTrue(sp.isspmatrix_csr(t.X))
+
+        t = Table.from_numpy(domain, sp.bsr_matrix(x))
+        self.assertTrue(sp.isspmatrix_csr(t.X))
 
 
 class TestTableFilters(unittest.TestCase):


### PR DESCRIPTION
##### Issue

Fixes #4836.

##### Description of changes

`Table.__getitem__` and possibly also other methods only work with csr and csc matrices. Operations on other types of sparse matrices would be slow. Table `from_numpy` now convert sparse matrices that are not csr or csc to csr.

##### Includes
- [X] Code changes
- [X] Tests
