### PR TITLE
[FIX] Line Plot: Reset axis ticks on data change

### DIFF
--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -99,6 +99,8 @@ class LinePlotAxisItem(pg.AxisItem):
 
     def set_ticks(self, ticks):
         self._ticks = dict(enumerate(ticks, 1)) if ticks else {}
+        if not ticks:
+            self.setTicks(None)
 
     def tickStrings(self, values, scale, spacing):
         return [self._ticks.get(v * scale, "") for v in values]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In some cases tick texts retain after changing data on widget's input.
To reproduce:
- File(Iris) -> Select columns (Click Reset just in case) -> Line Plot (Check Mean)
- In Select column move all features to Available variables -> Ticks on Line plot retain

##### Description of changes
Remove tick texts on data change.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
