### PR TITLE
[FIX] OWScatterPlotBase: Reset view before labels update

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -834,6 +834,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject, ParameterSetter):
         x, y = self.get_coordinates()
         if x is None or len(x) == 0:
             return
+
+        self._reset_view(x, y)
         if self.scatterplot_item is None:
             if self.sample_indices is None:
                 indices = np.arange(self.n_valid)
@@ -851,7 +853,6 @@ class OWScatterPlotBase(gui.OWComponent, QObject, ParameterSetter):
             self.update_labels()
 
         self.update_density()  # Todo: doesn't work: try MDS with density on
-        self._reset_view(x, y)
 
     # Sizes
     def get_sizes(self):

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -114,9 +114,9 @@ class TestOWScatterPlotBase(WidgetTest):
         xy[0][0] = 1.5
         graph.update_coordinates()
         self.assertEqual(graph.labels[0].pos().x(), 1.5)
-        xy[0][0] = 0  # This label goes out of the range
+        xy[0][0] = 0  # This label goes out of the range; reset puts it back
         graph.update_coordinates()
-        self.assertEqual(graph.labels[0].pos().x(), 2)
+        self.assertEqual(graph.labels[0].pos().x(), 0)
 
     def test_update_coordinates_and_density(self):
         graph = self.graph


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In some cases labels on projection widgets are deficiently shown.
To reproduce:
1. File (brown-selected) -> Preprocess -> MDS
2. MDS: Set `Label` to Genes
3. Preprocess (Select `Normalize Features`)
4. MDS: All labels are show
5. Preprocess (Remove normalizer)
6. MDS: Some labels (close to left and upper edge) are missing

##### Description of changes
Reset view before updating the labels.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
