### PR TITLE
[ENH] Rank widget computation in a separate thread

### DIFF
--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -27,7 +27,7 @@ class SlowScorer(Scorer):
     name = "Slow scorer"
 
     def score_data(self, data, feature=None):
-        time.sleep(3)
+        time.sleep(1)
         return np.ones((1, len(data.domain.attributes)))
 
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Rank widget blocks Orange while computing on a larger dataset

##### Description of changes
Use `ConcurrentWidgetMixin` in the rank widget.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
