### PR TITLE
[FIX] owcsvimport: Fix a type error in _open for zip archive

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1102,6 +1102,13 @@ def _open(path, mode, encoding=None):
         filelist = arh.infolist()
         if len(filelist) == 1:
             f = arh.open(filelist[0], 'r')
+            # patch the f.close to also close the main archive file
+            f_close = f.close
+
+            def close_():
+                f_close()
+                arh.close()
+            f.close = close_
             if 't' in mode:
                 f = io.TextIOWrapper(f, encoding=encoding)
             return f

--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1101,9 +1101,7 @@ def _open(path, mode, encoding=None):
         arh = zipfile.ZipFile(path, 'r')
         filelist = arh.infolist()
         if len(filelist) == 1:
-            filename = filelist[0]
-            zinfo = arh.getinfo(filename)
-            f = arh.open(zinfo.filename, 'r')
+            f = arh.open(filelist[0], 'r')
             if 't' in mode:
                 f = io.TextIOWrapper(f, encoding=encoding)
             return f


### PR DESCRIPTION

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

CSVFileImport intends to but fails to read single member zip archive (raises a TypeError).

(e.g [precip.csv.zip](https://github.com/biolab/orange3/files/4971980/precip.csv.zip))


##### Description of changes

Fix a type error.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
