### PR TITLE
[FIX] Edit Domain (and perhaps other widgets) could cause missing data later in the workflow

### DIFF
--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -83,6 +83,12 @@ class Discretizer(Transformation):
         dvar.to_sql = to_sql
         return dvar
 
+    def __eq__(self, other):
+        return super().__eq__(other) and self.points == other.points
+
+    def __hash__(self):
+        return hash((type(self), self.variable, tuple(self.points)))
+
 
 class BinSql:
     def __init__(self, var, points):

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -32,6 +32,12 @@ class ReplaceUnknowns(Transformation):
         else:
             return np.where(np.isnan(c), self.value, c)
 
+    def __eq__(self, other):
+        return super().__eq__(other) and self.value == other.value
+
+    def __hash__(self):
+        return hash((type(self), self.variable, float(self.value)))
+
 
 class BaseImputeMethod(Reprable):
     name = ""
@@ -315,6 +321,12 @@ class ReplaceUnknownsRandom(Transformation):
 
         c[nanindices] = sample
         return c
+
+    def __eq__(self, other):
+        return super().__eq__(other) and self.distribution == other.distribution
+
+    def __hash__(self):
+        return hash((type(self), self.variable, self.distribution))
 
 
 class Random(BaseImputeMethod):

--- a/Orange/preprocess/tests/test_discretize.py
+++ b/Orange/preprocess/tests/test_discretize.py
@@ -5,8 +5,10 @@ import unittest
 from time import struct_time, mktime
 
 import numpy as np
+
+from Orange.data import ContinuousVariable
 from Orange.preprocess.discretize import \
-    _time_binnings, time_binnings, BinDefinition
+ _time_binnings, time_binnings, BinDefinition, Discretizer
 
 
 # pylint: disable=redefined-builtin
@@ -17,12 +19,12 @@ def create(year=1970, month=1, day=1, hour=0, min=0, sec=0):
 class TestTimeBinning(unittest.TestCase):
     def setUp(self):
         self.dates = [mktime(x) for x in
-            [(1975, 6, 9, 10, 0, 0, 0, 161, 0),
-             (1975, 6, 9, 10, 50, 0, 0, 161, 0),
-             (1975, 6, 9, 11, 40, 0, 0, 161, 0),
-             (1975, 6, 9, 12, 30, 0, 0, 161, 0),
-             (1975, 6, 9, 13, 20, 0, 0, 161, 0),
-             (1975, 6, 9, 14, 10, 0, 0, 161, 0)]]
+                      [(1975, 6, 9, 10, 0, 0, 0, 161, 0),
+                       (1975, 6, 9, 10, 50, 0, 0, 161, 0),
+                       (1975, 6, 9, 11, 40, 0, 0, 161, 0),
+                       (1975, 6, 9, 12, 30, 0, 0, 161, 0),
+                       (1975, 6, 9, 13, 20, 0, 0, 161, 0),
+                       (1975, 6, 9, 14, 10, 0, 0, 161, 0)]]
 
     def test_binning(self):
         def tr1(s):
@@ -750,6 +752,29 @@ class TestBinDefinition(unittest.TestCase):
         np.testing.assert_equal(bindef.thresholds, thresholds)
         self.assertEqual(bindef.start, 1)
         self.assertEqual(bindef.nbins, 2)
+
+
+class TestDiscretizer(unittest.TestCase):
+    def test_equality(self):
+        v1 = ContinuousVariable("x")
+        v2 = ContinuousVariable("x", number_of_decimals=42)
+        v3 = ContinuousVariable("y")
+        assert v1 == v2
+
+        t1 = Discretizer(v1, [0, 2, 1])
+        t1a = Discretizer(v2, [0, 2, 1])
+        t2 = Discretizer(v3, [0, 2, 1])
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = Discretizer(v1, [0, 2, 1])
+        t1a = Discretizer(v2, [1, 2, 0])
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
 
 
 if __name__ == '__main__':

--- a/Orange/preprocess/tests/test_impute.py
+++ b/Orange/preprocess/tests/test_impute.py
@@ -1,0 +1,56 @@
+import unittest
+
+from Orange.data import DiscreteVariable, ContinuousVariable
+from Orange.preprocess.impute import ReplaceUnknownsRandom, ReplaceUnknowns
+from Orange.statistics.distribution import Discrete
+
+
+class TestReplaceUnknowns(unittest.TestCase):
+    def test_equality(self):
+        v1 = ContinuousVariable("x")
+        v2 = ContinuousVariable("x")
+        v3 = ContinuousVariable("y")
+
+        t1 = ReplaceUnknowns(v1, 0)
+        t1a = ReplaceUnknowns(v2, 0)
+        t2 = ReplaceUnknowns(v3, 0)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = ReplaceUnknowns(v1, 0)
+        t1a = ReplaceUnknowns(v1, 1)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+
+class TestReplaceUnknownsRandom(unittest.TestCase):
+    def test_equality(self):
+        v1 = DiscreteVariable("x", tuple("abc"))
+        v2 = DiscreteVariable("x", tuple("abc"))
+        v3 = DiscreteVariable("y", tuple("abc"))
+
+        d1 = Discrete([1, 2, 3], v1)
+        d2 = Discrete([1, 2, 3], v2)
+        d3 = Discrete([1, 2, 3], v3)
+
+        t1 = ReplaceUnknownsRandom(v1, d1)
+        t1a = ReplaceUnknownsRandom(v2, d2)
+        t2 = ReplaceUnknownsRandom(v3, d3)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        d1[1] += 1
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/preprocess/tests/test_transformation.py
+++ b/Orange/preprocess/tests/test_transformation.py
@@ -1,0 +1,86 @@
+import unittest
+
+from Orange.data import DiscreteVariable
+from Orange.preprocess.transformation import \
+    Transformation, _Indicator, Normalizer, Lookup
+
+
+class TestTransformEquality(unittest.TestCase):
+    def setUp(self):
+        self.disc1 = DiscreteVariable("d1", values=tuple("abc"))
+        self.disc1a = DiscreteVariable("d1", values=tuple("abc"))
+        self.disc2 = DiscreteVariable("d2", values=tuple("abc"))
+        assert self.disc1 == self.disc1a
+
+    def test_transformation(self):
+        t1 = Transformation(self.disc1)
+        t1a = Transformation(self.disc1a)
+        t2 = Transformation(self.disc2)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+    def test_indicator(self):
+        t1 = _Indicator(self.disc1, 0)
+        t1a = _Indicator(self.disc1a, 0)
+        t2 = _Indicator(self.disc2, 0)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = _Indicator(self.disc1, 0)
+        t1a = _Indicator(self.disc1a, 1)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+    def test_normalizer(self):
+        t1 = Normalizer(self.disc1, 0, 1)
+        t1a = Normalizer(self.disc1a, 0, 1)
+        t2 = Normalizer(self.disc2, 0, 1)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = Normalizer(self.disc1, 0, 1)
+        t1a = Normalizer(self.disc1a, 1, 1)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        t1 = Normalizer(self.disc1, 0, 1)
+        t1a = Normalizer(self.disc1a, 0, 2)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+    def test_lookup(self):
+        t1 = Lookup(self.disc1, [0, 2, 1], 1)
+        t1a = Lookup(self.disc1a, [0, 2, 1], 1)
+        t2 = Lookup(self.disc2, [0, 2, 1], 1)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = Lookup(self.disc1, [0, 2, 1], 1)
+        t1a = Lookup(self.disc1a, [1, 2, 0], 1)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        t1 = Lookup(self.disc1, [0, 2, 1], 1)
+        t1a = Lookup(self.disc1a, [0, 2, 1], 2)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Orange/preprocess/tests/test_transformation.py
+++ b/Orange/preprocess/tests/test_transformation.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from Orange.data import DiscreteVariable
 from Orange.preprocess.transformation import \
     Transformation, _Indicator, Normalizer, Lookup
@@ -61,9 +63,9 @@ class TestTransformEquality(unittest.TestCase):
         self.assertNotEqual(hash(t1), hash(t1a))
 
     def test_lookup(self):
-        t1 = Lookup(self.disc1, [0, 2, 1], 1)
-        t1a = Lookup(self.disc1a, [0, 2, 1], 1)
-        t2 = Lookup(self.disc2, [0, 2, 1], 1)
+        t1 = Lookup(self.disc1, np.array([0, 2, 1]), 1)
+        t1a = Lookup(self.disc1a, np.array([0, 2, 1]), 1)
+        t2 = Lookup(self.disc2, np.array([0, 2, 1]), 1)
         self.assertEqual(t1, t1)
         self.assertEqual(t1, t1a)
         self.assertNotEqual(t1, t2)
@@ -71,13 +73,13 @@ class TestTransformEquality(unittest.TestCase):
         self.assertEqual(hash(t1), hash(t1a))
         self.assertNotEqual(hash(t1), hash(t2))
 
-        t1 = Lookup(self.disc1, [0, 2, 1], 1)
-        t1a = Lookup(self.disc1a, [1, 2, 0], 1)
+        t1 = Lookup(self.disc1, np.array([0, 2, 1]), 1)
+        t1a = Lookup(self.disc1a, np.array([1, 2, 0]), 1)
         self.assertNotEqual(t1, t1a)
         self.assertNotEqual(hash(t1), hash(t1a))
 
-        t1 = Lookup(self.disc1, [0, 2, 1], 1)
-        t1a = Lookup(self.disc1a, [0, 2, 1], 2)
+        t1 = Lookup(self.disc1, np.array([0, 2, 1]), 1)
+        t1a = Lookup(self.disc1a, np.array([0, 2, 1]), 2)
         self.assertNotEqual(t1, t1a)
         self.assertNotEqual(hash(t1), hash(t1a))
 

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -143,7 +143,7 @@ class Lookup(Transformation):
         :param variable: The variable whose transformed value is returned.
         :type variable: int or str or :obj:`~Orange.data.DiscreteVariable`
         :param lookup_table: transformations for each value of `self.variable`
-        :type lookup_table: np.array or list or tuple
+        :type lookup_table: np.array
         :param unknown: The value to be used as unknown value.
         :type unknown: float or int
         """
@@ -162,14 +162,10 @@ class Lookup(Transformation):
         return np.where(mask, self.unknown, values)
 
     def __eq__(self, other):
-        def nan_equal(x, y):
-            return x == y or np.isnan(x) and np.isnan(y)
-
         return super().__eq__(other) \
-               and len(self.lookup_table) == len(other.lookup_table) \
-               and all(nan_equal(x, y) or np.isnan(x) and np.isnan(y)
-                       for x, y in zip(self.lookup_table, other.lookup_table)) \
-               and nan_equal(self.unknown, other.unknown)
+               and np.allclose(self.lookup_table, other.lookup_table,
+                               equal_nan=True) \
+               and np.allclose(self.unknown, other.unknown, equal_nan=True)
 
     def __hash__(self):
         return hash((type(self), self.variable,

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -48,13 +48,6 @@ class Transformation(Reprable):
         raise NotImplementedError(
             "ColumnTransformations must implement method 'transform'.")
 
-
-class Identity(Transformation):
-    """Return an untransformed value of `c`.
-    """
-    def transform(self, c):
-        return c
-
     def __eq__(self, other):
         return type(other) is type(self) and self.variable == other.variable
 
@@ -62,42 +55,46 @@ class Identity(Transformation):
         return hash((type(self), self.variable))
 
 
-class Indicator(Transformation):
+class Identity(Transformation):
+    """Return an untransformed value of `c`.
+    """
+    def transform(self, c):
+        return c
+
+
+class _Indicator(Transformation):
+    def __init__(self, variable, value):
+        """
+        :param variable: The variable whose transformed value is returned.
+        :type variable: int or str or :obj:`~Orange.data.Variable`
+
+        :param value: The value to which the indicator refers
+        :type value: int or float
+        """
+        super().__init__(variable)
+        self.value = value
+
+    def __eq__(self, other):
+        return super().__eq__(other) and self.value == other.value
+
+    def __hash__(self):
+        return hash((type(self), self.variable, self.value))
+
+
+class Indicator(_Indicator):
     """
     Return an indicator value that equals 1 if the variable has the specified
     value and 0 otherwise.
     """
-    def __init__(self, variable, value):
-        """
-        :param variable: The variable whose transformed value is returned.
-        :type variable: int or str or :obj:`~Orange.data.Variable`
-
-        :param value: The value to which the indicator refers
-        :type value: int or float
-        """
-        super().__init__(variable)
-        self.value = value
-
     def transform(self, c):
         return c == self.value
 
 
-class Indicator1(Transformation):
+class Indicator1(_Indicator):
     """
     Return an indicator value that equals 1 if the variable has the specified
     value and -1 otherwise.
     """
-    def __init__(self, variable, value):
-        """
-        :param variable: The variable whose transformed value is returned.
-        :type variable: int or str or :obj:`~Orange.data.Variable`
-
-        :param value: The value to which the indicator refers
-        :type value: int or float
-        """
-        super().__init__(variable)
-        self.value = value
-
     def transform(self, c):
         return (c == self.value) * 2 - 1
 
@@ -129,6 +126,13 @@ class Normalizer(Transformation):
         else:
             return (c - self.offset) * self.factor
 
+    def __eq__(self, other):
+        return super().__eq__(other) \
+               and self.offset == other.offset and self.factor == other.factor
+
+    def __hash__(self):
+        return hash((type(self), self.variable, self.offset, self.factor))
+
 
 class Lookup(Transformation):
     """
@@ -156,3 +160,17 @@ class Lookup(Transformation):
         column[mask] = 0
         values = self.lookup_table[column]
         return np.where(mask, self.unknown, values)
+
+    def __eq__(self, other):
+        def nan_equal(x, y):
+            return x == y or np.isnan(x) and np.isnan(y)
+
+        return super().__eq__(other) \
+               and len(self.lookup_table) == len(other.lookup_table) \
+               and all(nan_equal(x, y) or np.isnan(x) and np.isnan(y)
+                       for x, y in zip(self.lookup_table, other.lookup_table)) \
+               and nan_equal(self.unknown, other.unknown)
+
+    def __hash__(self):
+        return hash((type(self), self.variable,
+                     tuple(self.lookup_table), self.unknown))

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -189,6 +189,12 @@ class WeightedIndicator(Indicator):
             t *= self.weight
         return t
 
+    def __eq__(self, other):
+        return super().__eq__(other) and self.weight == other.weight
+
+    def __hash__(self):
+        return hash((type(self), self.variable, self.value, self.weight))
+
 
 def make_indicator_var(source, value_ind, weight=None):
     if weight is None:

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -86,6 +86,17 @@ class ValueFromStringSubstring(Transformation):
         res[nans] = np.nan
         return res
 
+    def __eq__(self, other):
+        return super().__eq__(other) \
+               and self.patterns == other.patterns \
+               and self.case_sensitive == other.case_sensitive \
+               and self.match_beginning == other.match_beginning
+
+    def __hash__(self):
+        return hash((type(self), self.variable,
+                     tuple(self.patterns),
+                     self.case_sensitive, self.match_beginning))
+
 
 class ValueFromDiscreteSubstring(Lookup):
     """

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -2545,6 +2545,14 @@ class DictMissingConst(dict):
     def __missing__(self, key):
         return self.__missing
 
+    def __eq__(self, other):
+        return super().__eq__(other) and isinstance(other, DictMissingConst) \
+            and (self.__missing == other[()]  # get `__missing`
+                 or np.isnan(self.__missing) and np.isnan(other[()]))
+
+    def __hash__(self):
+        return hash((self.__missing, frozenset(self.items())))
+
 
 def make_dict_mapper(
         mapping: Mapping, dtype: Optional[DType] = None
@@ -2822,6 +2830,14 @@ class LookupMappingTransform(Transformation):
 
     def __reduce_ex__(self, protocol):
         return type(self), (self.variable, self.mapping, self.dtype)
+
+    def __eq__(self, other):
+        return self.variable == other.variable \
+               and self.mapping == other.mapping \
+               and self.dtype == other.dtype
+
+    def __hash__(self):
+        return hash((type(self), self.variable, self.mapping, self.dtype))
 
 
 @singledispatch

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -8,7 +8,7 @@ import numpy as np
 from Orange.data import Table, DiscreteVariable, ContinuousVariable, Domain
 from Orange.preprocess import transformation
 from Orange.widgets.data import owcontinuize
-from Orange.widgets.data.owcontinuize import OWContinuize
+from Orange.widgets.data.owcontinuize import OWContinuize, WeightedIndicator
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.state_summary import format_summary_details
 
@@ -275,6 +275,34 @@ class TestOWContinuizeUtils(unittest.TestCase):
             self.assertIsInstance(nvar.compute_value, transformation.Indicator)
             self.assertEqual(nvar.compute_value.value, i)
             self.assertIs(nvar.compute_value.variable, var)
+
+
+class TestWeightedIndicator(unittest.TestCase):
+    def test_equality(self):
+        disc1 = DiscreteVariable("d1", values=tuple("abc"))
+        disc1a = DiscreteVariable("d1", values=tuple("abc"))
+        disc2 = DiscreteVariable("d2", values=tuple("abc"))
+        assert disc1 == disc1a
+
+        t1 = WeightedIndicator(disc1, 0, 1)
+        t1a = WeightedIndicator(disc1a, 0, 1)
+        t2 = WeightedIndicator(disc2, 0, 1)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = WeightedIndicator(disc1, 0, 1)
+        t1a = WeightedIndicator(disc1a, 1, 1)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        t1 = WeightedIndicator(disc1, 0, 1)
+        t1a = WeightedIndicator(disc1a, 0, 2)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -122,6 +122,59 @@ class TestHelpers(unittest.TestCase):
             self.assertFalse(case_sensitive)
             self.assertTrue(match_beginning)
 
+    def test_valuefromstringsubstring_equality(self):
+        str1 = StringVariable("d1")
+        str1a = StringVariable("d1")
+        str2 = StringVariable("d2")
+        assert str1 == str1a
+
+        t1 = ValueFromStringSubstring(str1, ["abc", "def"])
+        t1a = ValueFromStringSubstring(str1a, ["abc", "def"])
+        t2 = ValueFromStringSubstring(str2, ["abc", "def"])
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = ValueFromStringSubstring(str1, ["abc", "def"])
+        t1a = ValueFromStringSubstring(str1a, ["abc", "ghi"])
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        t1 = ValueFromStringSubstring(str1, ["abc", "def"], True)
+        t1a = ValueFromStringSubstring(str1a, ["abc", "def"], False)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        t1 = ValueFromStringSubstring(str1, ["abc", "def"], True, True)
+        t1a = ValueFromStringSubstring(str1a, ["abc", "def"], True, False)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+
+    def test_valuefromsdiscretesubstring_equality(self):
+        str1 = DiscreteVariable("d1", values=("abc", "ghi"))
+        str1a = DiscreteVariable("d1", values=("abc", "ghi"))
+        str2 = DiscreteVariable("d2", values=("abc", "ghi"))
+        assert str1 == str1a
+
+        t1 = ValueFromDiscreteSubstring(str1, ["abc", "def"])
+        t1a = ValueFromDiscreteSubstring(str1a, ["abc", "def"])
+        t2 = ValueFromDiscreteSubstring(str2, ["abc", "def"])
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        t1 = ValueFromDiscreteSubstring(str1, ["abc", "def"])
+        t1a = ValueFromDiscreteSubstring(str1a, ["abc", "ghi"])
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
 
 class TestOWCreateClass(WidgetTest):
     def setUp(self):

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -932,7 +932,7 @@ class TestUtils(TestCase):
         self.assertEqual(d[1], 1)
         self.assertEqual(d[-1], "<->")
         # must be sufficiently different from defaultdict to warrant existence
-        self.assertEqual(d, {1: 1, 2: 2})
+        self.assertEqual(d, DictMissingConst("<->", {1: 1, 2: 2}))
 
     def test_as_float_or_nan(self):
         a = np.array(["a", "1.1", ".2", "NaN"], object)
@@ -995,6 +995,42 @@ class TestLookupMappingTransform(TestCase):
         assert_array_equal(r, [np.nan, 0, 1, np.nan])
         r_ = lookup_.transform(c)
         assert_array_equal(r_, [np.nan, 0, 1, np.nan])
+
+    def test_equality(self):
+        v1 = DiscreteVariable("v1", values=tuple("abc"))
+        v2 = DiscreteVariable("v1", values=tuple("abc"))
+        v3 = DiscreteVariable("v3", values=tuple("abc"))
+
+        map1 = DictMissingConst(np.nan, {"a": 2, "b": 0, "c": 1})
+        map2 = DictMissingConst(np.nan, {"a": 2, "b": 0, "c": 1})
+        map3 = DictMissingConst(np.nan, {"a": 2, "b": 0, "c": 1})
+
+        t1 = LookupMappingTransform(v1, map1, float)
+        t1a = LookupMappingTransform(v2, map2, float)
+        t2 = LookupMappingTransform(v3, map3, float)
+        self.assertEqual(t1, t1)
+        self.assertEqual(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        self.assertEqual(hash(t1), hash(t1a))
+        self.assertNotEqual(hash(t1), hash(t2))
+
+        map1a = DictMissingConst(np.nan, {"a": 2, "b": 1, "c": 0})
+        t1 = LookupMappingTransform(v1, map1, float)
+        t1a = LookupMappingTransform(v1, map1a, float)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        map1a = DictMissingConst(2, {"a": 2, "b": 0, "c": 1})
+        t1 = LookupMappingTransform(v1, map1, float)
+        t1a = LookupMappingTransform(v1, map1a, float)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
+
+        t1 = LookupMappingTransform(v1, map1, float)
+        t1a = LookupMappingTransform(v1, map1, int)
+        self.assertNotEqual(t1, t1a)
+        self.assertNotEqual(hash(t1), hash(t1a))
 
 
 class TestGroupLessFrequentItemsDialog(GuiTest):


### PR DESCRIPTION
##### Issue

Fixes #4895.

Equality of variables also checks equality of their `compute_value`. This can only work if `Transformation` and derived classes have `__eq__` and `__hash__`.

To fix #4895, it would suffice to change `oweditdomain.LookupMappingTransform`. The PR does it for other classes too, to prevent similar future mishaps.

##### Description of changes

Define `__eq__` and `__hash__` where needed.

Any add-ons that don't have will now misbehave in a different way -- before this, `__eq__` always returned `False`, even when transforms were the same. Now it will sometimes return `True` even though they may be different. This will happen if the class defines additional fields that are not checked by the base class.

The base class can neither check children's extra attributes, neither can it raise an exception (e.g. in a meta class), because many derived classes (even some that define extra attributes) do not need `__eq__`.

##### Includes
- [X] Code changes
- [X] Tests