### PR TITLE
Require orange-widget-base 4.7.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - pandas
     - pyyaml
     - orange-canvas-core >=0.1.15,<0.2a
-    - orange-widget-base >=4.6.0
+    - orange-widget-base >=4.7.0
     - openpyxl
     - httpx >=0.12
     - baycomp >=1.0.2

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.15,<0.2a
-orange-widget-base>=4.6.0
+orange-widget-base>=4.7.0
 
 PyQt5>=5.12
 PyQtWebEngine>=5.12


### PR DESCRIPTION
##### Issue
Scatterplot, for example, fails on master with orange-widget-base 4.6.0.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
