### PR TITLE
Customizable plot: no need for QApplication at import

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -800,7 +800,7 @@ class ProjectionWidgetTestMixin:
         key, value = ("Fonts", "Title", "Italic"), True
         self.widget.set_visual_settings(key, value)
         font.setPointSize(20)
-        self.assertFontEqual(graph.title_item.item.font(), font)
+        self.assertFontEqual(graph.parameter_setter.title_item.item.font(), font)
 
         key, value = ("Fonts", "Label", "Font size"), 10
         self.widget.set_visual_settings(key, value)
@@ -816,7 +816,7 @@ class ProjectionWidgetTestMixin:
         key, value = ("Fonts", "Categorical legend", "Italic"), True
         self.widget.set_visual_settings(key, value)
         font.setPointSize(14)
-        legend_item = list(graph.cat_legend_items)[0]
+        legend_item = list(graph.parameter_setter.cat_legend_items)[0]
         self.assertFontEqual(legend_item[1].item.font(), font)
 
         key, value = ("Fonts", "Numerical legend", "Font size"), 12
@@ -828,12 +828,12 @@ class ProjectionWidgetTestMixin:
         simulate.combobox_activate_item(self.widget.controls.attr_shape,
                                         self.data.domain[4].name)
         font.setPointSize(12)
-        self.assertFontEqual(graph.num_legend.items[0][0].font, font)
+        self.assertFontEqual(graph.parameter_setter.num_legend.items[0][0].font, font)
 
         key, value = ("Annotations", "Title", "Title"), "Foo"
         self.widget.set_visual_settings(key, value)
-        self.assertEqual(graph.title_item.item.toPlainText(), "Foo")
-        self.assertEqual(graph.title_item.text, "Foo")
+        self.assertEqual(graph.parameter_setter.title_item.item.toPlainText(), "Foo")
+        self.assertEqual(graph.parameter_setter.title_item.text, "Foo")
 
     def assertFontEqual(self, font1, font2):
         self.assertEqual(font1.family(), font2.family())

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -90,7 +90,7 @@ class OWFreeVizGraph(OWGraphWithAnchors):
                 anchor = AnchorItem(line=QLineF(0, 0, *point), text=label)
                 anchor.setVisible(np.linalg.norm(point) > r)
                 anchor.setPen(pg.mkPen((100, 100, 100)))
-                anchor.setFont(self.anchor_font)
+                anchor.setFont(self.parameter_setter.anchor_font)
                 self.plot_widget.addItem(anchor)
                 self.anchor_items.append(anchor)
         else:
@@ -98,7 +98,7 @@ class OWFreeVizGraph(OWGraphWithAnchors):
                 anchor.setLine(QLineF(0, 0, *point))
                 anchor.setText(label)
                 anchor.setVisible(np.linalg.norm(point) > r)
-                anchor.setFont(self.anchor_font)
+                anchor.setFont(self.parameter_setter.anchor_font)
 
     def update_circle(self):
         super().update_circle()

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -225,7 +225,7 @@ class OWLinProjGraph(OWGraphWithAnchors):
                 anchor._label.setToolTip(f"<b>{label}</b>")
                 label = label[:MAX_LABEL_LEN - 3] + "..." if len(label) > MAX_LABEL_LEN else label
                 anchor.setText(label)
-                anchor.setFont(self.anchor_font)
+                anchor.setFont(self.parameter_setter.anchor_font)
 
                 visible = self.always_show_axes or np.linalg.norm(point) > r
                 anchor.setVisible(visible)
@@ -237,7 +237,7 @@ class OWLinProjGraph(OWGraphWithAnchors):
                 anchor.setLine(QLineF(0, 0, *point))
                 visible = self.always_show_axes or np.linalg.norm(point) > r
                 anchor.setVisible(visible)
-                anchor.setFont(self.anchor_font)
+                anchor.setFont(self.parameter_setter.anchor_font)
 
     def update_circle(self):
         super().update_circle()

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -31,7 +31,7 @@ from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.visualize.owdistributions import LegendItem
 from Orange.widgets.visualize.utils.customizableplot import Updater, \
-    BaseParameterSetter as Setter
+    CommonParameterSetter
 from Orange.widgets.visualize.utils.plotutils import AxisItem
 from Orange.widgets.widget import OWWidget, Input, Output, Msg
 
@@ -192,61 +192,18 @@ class LinePlotViewBox(ViewBox):
         self._graph_state = SELECT
 
 
-class ParameterSetter(Setter):
+class ParameterSetter(CommonParameterSetter):
     MEAN_LABEL = "Mean"
     LINE_LABEL = "Lines"
     SEL_LINE_LABEL = "Selected lines"
     RANGE_LABEL = "Range"
     SEL_RANGE_LABEL = "Selected range"
-    initial_settings = {
-        Setter.LABELS_BOX: {
-            Setter.FONT_FAMILY_LABEL: Updater.FONT_FAMILY_SETTING,
-            Setter.TITLE_LABEL: Updater.FONT_SETTING,
-            Setter.AXIS_TITLE_LABEL: Updater.FONT_SETTING,
-            Setter.AXIS_TICKS_LABEL: Updater.FONT_SETTING,
-            Setter.LEGEND_LABEL: Updater.FONT_SETTING,
-        },
-        Setter.ANNOT_BOX: {
-            Setter.TITLE_LABEL: {Setter.TITLE_LABEL: ("", "")},
-            Setter.X_AXIS_LABEL: {Setter.TITLE_LABEL: ("", "")},
-            Setter.Y_AXIS_LABEL: {Setter.TITLE_LABEL: ("", "")},
-        },
-        Setter.PLOT_BOX: {
-            MEAN_LABEL: {
-                Updater.WIDTH_LABEL: (range(1, 15), LinePlotStyle.MEAN_WIDTH),
-                Updater.STYLE_LABEL: (list(Updater.LINE_STYLES),
-                                      Updater.DEFAULT_LINE_STYLE),
-            },
-            LINE_LABEL: {
-                Updater.WIDTH_LABEL: (range(1, 15),
-                                      LinePlotStyle.UNSELECTED_LINE_WIDTH),
-                Updater.STYLE_LABEL: (list(Updater.LINE_STYLES),
-                                      Updater.DEFAULT_LINE_STYLE),
-                Updater.ALPHA_LABEL: (range(0, 255, 5),
-                                      LinePlotStyle.UNSELECTED_LINE_ALPHA),
-                Updater.ANTIALIAS_LABEL: (None, True),
-            },
-            SEL_LINE_LABEL: {
-                Updater.WIDTH_LABEL: (range(1, 15),
-                                      LinePlotStyle.SELECTED_LINE_WIDTH),
-                Updater.STYLE_LABEL: (list(Updater.LINE_STYLES),
-                                      Updater.DEFAULT_LINE_STYLE),
-                Updater.ALPHA_LABEL: (range(0, 255, 5),
-                                      LinePlotStyle.SELECTED_LINE_ALPHA),
-                Updater.ANTIALIAS_LABEL: (None, False),
-            },
-            RANGE_LABEL: {
-                Updater.ALPHA_LABEL: (range(0, 255, 5),
-                                      LinePlotStyle.RANGE_ALPHA),
-            },
-            SEL_RANGE_LABEL: {
-                Updater.ALPHA_LABEL: (range(0, 255, 5),
-                                      LinePlotStyle.SELECTED_RANGE_ALPHA),
-            },
-        }
-    }
 
-    def __init__(self):
+    def __init__(self, master):
+        super().__init__()
+        self.master = master
+
+    def update_setters(self):
         self.mean_settings = {
             Updater.WIDTH_LABEL: LinePlotStyle.MEAN_WIDTH,
             Updater.STYLE_LABEL: Updater.DEFAULT_LINE_STYLE,
@@ -269,9 +226,55 @@ class ParameterSetter(Setter):
         self.sel_range_settings = {
             Updater.ALPHA_LABEL: LinePlotStyle.SELECTED_RANGE_ALPHA,
         }
-        super().__init__()
 
-    def update_setters(self):
+        self.initial_settings = {
+            self.LABELS_BOX: {
+                self.FONT_FAMILY_LABEL: self.FONT_FAMILY_SETTING,
+                self.TITLE_LABEL: self.FONT_SETTING,
+                self.AXIS_TITLE_LABEL: self.FONT_SETTING,
+                self.AXIS_TICKS_LABEL: self.FONT_SETTING,
+                self.LEGEND_LABEL: self.FONT_SETTING,
+            },
+            self.ANNOT_BOX: {
+                self.TITLE_LABEL: {self.TITLE_LABEL: ("", "")},
+                self.X_AXIS_LABEL: {self.TITLE_LABEL: ("", "")},
+                self.Y_AXIS_LABEL: {self.TITLE_LABEL: ("", "")},
+            },
+            self.PLOT_BOX: {
+                self.MEAN_LABEL: {
+                    Updater.WIDTH_LABEL: (range(1, 15), LinePlotStyle.MEAN_WIDTH),
+                    Updater.STYLE_LABEL: (list(Updater.LINE_STYLES),
+                                          Updater.DEFAULT_LINE_STYLE),
+                },
+                self.LINE_LABEL: {
+                    Updater.WIDTH_LABEL: (range(1, 15),
+                                          LinePlotStyle.UNSELECTED_LINE_WIDTH),
+                    Updater.STYLE_LABEL: (list(Updater.LINE_STYLES),
+                                          Updater.DEFAULT_LINE_STYLE),
+                    Updater.ALPHA_LABEL: (range(0, 255, 5),
+                                          LinePlotStyle.UNSELECTED_LINE_ALPHA),
+                    Updater.ANTIALIAS_LABEL: (None, True),
+                },
+                self.SEL_LINE_LABEL: {
+                    Updater.WIDTH_LABEL: (range(1, 15),
+                                          LinePlotStyle.SELECTED_LINE_WIDTH),
+                    Updater.STYLE_LABEL: (list(Updater.LINE_STYLES),
+                                          Updater.DEFAULT_LINE_STYLE),
+                    Updater.ALPHA_LABEL: (range(0, 255, 5),
+                                          LinePlotStyle.SELECTED_LINE_ALPHA),
+                    Updater.ANTIALIAS_LABEL: (None, False),
+                },
+                self.RANGE_LABEL: {
+                    Updater.ALPHA_LABEL: (range(0, 255, 5),
+                                          LinePlotStyle.RANGE_ALPHA),
+                },
+                self.SEL_RANGE_LABEL: {
+                    Updater.ALPHA_LABEL: (range(0, 255, 5),
+                                          LinePlotStyle.SELECTED_RANGE_ALPHA),
+                },
+            }
+        }
+
         def update_mean(**settings):
             self.mean_settings.update(**settings)
             Updater.update_lines(self.mean_lines_items, **self.mean_settings)
@@ -310,40 +313,43 @@ class ParameterSetter(Setter):
 
     @property
     def title_item(self):
-        return self.getPlotItem().titleLabel
+        return self.master.getPlotItem().titleLabel
 
     @property
     def axis_items(self):
-        return [value["item"] for value in self.getPlotItem().axes.values()]
+        return [value["item"] for value in self.master.getPlotItem().axes.values()]
 
     @property
     def legend_items(self):
-        return self.legend.items
+        return self.master.legend.items
 
     @property
     def mean_lines_items(self):
-        return [group.mean for group in self.groups]
+        return [group.mean for group in self.master.groups]
 
     @property
     def lines_items(self):
-        return [group.profiles for group in self.groups]
+        return [group.profiles for group in self.master.groups]
 
     @property
     def sel_lines_items(self):
-        return [group.sel_profiles for group in self.groups] + \
-               [group.sub_profiles for group in self.groups]
+        return [group.sel_profiles for group in self.master.groups] + \
+               [group.sub_profiles for group in self.master.groups]
 
     @property
     def range_items(self):
-        return [group.range for group in self.groups]
+        return [group.range for group in self.master.groups]
 
     @property
     def sel_range_items(self):
-        return [group.sel_range for group in self.groups]
+        return [group.sel_range for group in self.master.groups]
 
+    @property
+    def getAxis(self):
+        return self.master.getAxis
 
 # Customizable plot widget
-class LinePlotGraph(pg.PlotWidget, ParameterSetter):
+class LinePlotGraph(pg.PlotWidget):
     def __init__(self, parent):
         self.groups: List[ProfileGroup] = []
         self.bottom_axis = BottomAxisItem(orientation="bottom")
@@ -359,6 +365,8 @@ class LinePlotGraph(pg.PlotWidget, ParameterSetter):
         self.legend = self._create_legend(((1, 0), (1, 0)))
         self.getPlotItem().buttonsHidden = True
         self.setRenderHint(QPainter.Antialiasing, True)
+
+        self.parameter_setter = ParameterSetter(self)
 
     def _create_legend(self, anchor):
         legend = LegendItem()
@@ -376,7 +384,8 @@ class LinePlotGraph(pg.PlotWidget, ParameterSetter):
                 dots = pg.ScatterPlotItem(pen=c, brush=c, size=10, shape="s")
                 self.legend.addItem(dots, escape(name))
             self.legend.show()
-        Updater.update_legend_font(self.legend_items, **self.legend_settings)
+        Updater.update_legend_font(self.parameter_setter.legend_items,
+                                   **self.parameter_setter.legend_settings)
 
     def select(self, indices):
         keys = QApplication.keyboardModifiers()
@@ -451,17 +460,17 @@ class ProfileGroup:
         x, y, con = self.__get_disconnected_curve_data(self.y_data)
         pen = self.make_pen(self.color)
         curve = pg.PlotCurveItem(x=x, y=y, connect=con, pen=pen)
-        Updater.update_lines([curve], **self.graph.line_settings)
+        Updater.update_lines([curve], **self.graph.parameter_setter.line_settings)
         return curve
 
     def _get_sel_profiles_curve(self):
         curve = pg.PlotCurveItem(x=None, y=None, pen=self.make_pen(self.color))
-        Updater.update_lines([curve], **self.graph.sel_line_settings)
+        Updater.update_lines([curve], **self.graph.parameter_setter.sel_line_settings)
         return curve
 
     def _get_range_curve(self):
         color = QColor(self.color)
-        color.setAlpha(self.graph.range_settings[Updater.ALPHA_LABEL])
+        color.setAlpha(self.graph.parameter_setter.range_settings[Updater.ALPHA_LABEL])
         bottom, top = nanmin(self.y_data, axis=0), nanmax(self.y_data, axis=0)
         return pg.FillBetweenItem(
             pg.PlotDataItem(x=self.x_data, y=bottom),
@@ -470,14 +479,14 @@ class ProfileGroup:
 
     def _get_sel_range_curve(self):
         color = QColor(self.color)
-        color.setAlpha(self.graph.sel_range_settings[Updater.ALPHA_LABEL])
+        color.setAlpha(self.graph.parameter_setter.sel_range_settings[Updater.ALPHA_LABEL])
         curve1 = curve2 = pg.PlotDataItem(x=self.x_data, y=self.__mean)
         return pg.FillBetweenItem(curve1, curve2, brush=color)
 
     def _get_mean_curve(self):
         pen = self.make_pen(self.color.darker(LinePlotStyle.MEAN_DARK_FACTOR))
         curve = pg.PlotCurveItem(x=self.x_data, y=self.__mean, pen=pen)
-        Updater.update_lines([curve], **self.graph.mean_settings)
+        Updater.update_lines([curve], **self.graph.parameter_setter.mean_settings)
         return curve
 
     def _get_error_bar(self):
@@ -528,7 +537,7 @@ class ProfileGroup:
 
     def update_profiles_color(self, selection):
         color = QColor(self.color)
-        alpha = self.graph.line_settings[Updater.ALPHA_LABEL] \
+        alpha = self.graph.parameter_setter.line_settings[Updater.ALPHA_LABEL] \
             if not selection else LinePlotStyle.UNSELECTED_LINE_ALPHA_SEL
         color.setAlpha(alpha)
         pen = self.profiles.opts["pen"]
@@ -542,7 +551,7 @@ class ProfileGroup:
 
     def update_sel_profiles_color(self, subset):
         color = QColor(Qt.black) if subset else QColor(self.color)
-        color.setAlpha(self.graph.sel_line_settings[Updater.ALPHA_LABEL])
+        color.setAlpha(self.graph.parameter_setter.sel_line_settings[Updater.ALPHA_LABEL])
         pen = self.sel_profiles.opts["pen"]
         pen.setColor(color)
         self.sel_profiles.setPen(pen)
@@ -634,7 +643,7 @@ class OWLinePlot(OWWidget):
         self.group_view = None
         self.setup_gui()
 
-        VisualSettingsDialog(self, LinePlotGraph.initial_settings)
+        VisualSettingsDialog(self, self.graph.parameter_setter.initial_settings)
         self.graph.view_box.selection_changed.connect(self.selection_changed)
         self.enable_selection.connect(self.graph.view_box.enable_selection)
 
@@ -946,7 +955,7 @@ class OWLinePlot(OWWidget):
         return collection is not None and obj in collection
 
     def set_visual_settings(self, key, value):
-        self.graph.set_parameter(key, value)
+        self.graph.parameter_setter.set_parameter(key, value)
         self.visual_settings[key] = value
 
 

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -264,7 +264,7 @@ class OWRadvizGraph(OWGraphWithAnchors):
                     label = label[:MAX_LABEL_LEN - 3] + "..."
 
             anchor.setText(label)
-            anchor.setFont(self.anchor_font)
+            anchor.setFont(self.parameter_setter.anchor_font)
             label_len = min(MAX_LABEL_LEN, len(label))
             anchor.setColor(QColor(0, 0, 0))
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -1,4 +1,3 @@
-import copy
 from itertools import chain
 from xml.sax.saxutils import escape
 
@@ -24,9 +23,8 @@ from Orange.widgets.settings import (
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase, \
-    ParameterSetter as Setter
+    ScatterBaseParameterSetter
 from Orange.widgets.visualize.utils import VizRankDialogAttrPair
-from Orange.widgets.visualize.utils.customizableplot import Updater
 from Orange.widgets.visualize.utils.widget import OWDataProjectionWidget
 from Orange.widgets.widget import AttributeList, Msg, Input, Output
 
@@ -98,25 +96,31 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
         return [a for _, a in attrs]
 
 
-class ParameterSetter(Setter):
-    initial_settings = copy.deepcopy(Setter.initial_settings)
-    initial_settings[Setter.LABELS_BOX].update({
-        Setter.AXIS_TITLE_LABEL: Updater.FONT_SETTING,
-        Setter.AXIS_TICKS_LABEL: Updater.FONT_SETTING
-    })
+class ParameterSetter(ScatterBaseParameterSetter):
+
+    def __init__(self, master):
+        super().__init__(master)
+
+    def update_setters(self):
+        super().update_setters()
+        self.initial_settings[self.LABELS_BOX].update({
+            self.AXIS_TITLE_LABEL: self.FONT_SETTING,
+            self.AXIS_TICKS_LABEL: self.FONT_SETTING
+        })
 
     @property
     def axis_items(self):
         return [value["item"] for value in
-                self.plot_widget.plotItem.axes.values()]
+                self.master.plot_widget.plotItem.axes.values()]
 
 
-class OWScatterPlotGraph(OWScatterPlotBase, ParameterSetter):
+class OWScatterPlotGraph(OWScatterPlotBase):
     show_reg_line = Setting(False)
     orthonormal_regression = Setting(False)
 
     def __init__(self, scatter_widget, parent):
         super().__init__(scatter_widget, parent)
+        self.parameter_setter = ParameterSetter(self)
         self.reg_line_items = []
 
     def clear(self):

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -8,9 +8,12 @@ import numpy as np
 import scipy.sparse as sp
 
 from AnyQt.QtCore import Qt, QPointF
+from AnyQt.QtGui import QFont
 
 from pyqtgraph import PlotCurveItem
 from pyqtgraph.Point import Point
+
+from orangewidget.tests.base import DEFAULT_TIMEOUT
 
 from Orange.data import Table
 from Orange.widgets.tests.base import (
@@ -304,6 +307,73 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
         self.assertEqual(info._StateInfo__output_summary.brief, "")
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
+
+    def test_visual_settings(self, timeout=DEFAULT_TIMEOUT):
+        graph = self.widget.graph
+        font = QFont()
+        font.setItalic(True)
+        font.setFamily("Helvetica")
+
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.wait_until_finished(timeout=timeout)
+
+        key, value = ("Fonts", "Font family", "Font family"), "Helvetica"
+        self.widget.set_visual_settings(key, value)
+
+        key, value = ("Fonts", "Title", "Font size"), 20
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Title", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(20)
+        self.assertFontEqual(graph.parameter_setter.title_item.item.font(), font)
+
+        key, value = ("Fonts", "Axis title", "Font size"), 14
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis title", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(14)
+        for ax in ["bottom", "left"]:
+            axis = graph.parameter_setter.getAxis(ax)
+            self.assertFontEqual(axis.label.font(), font)
+
+        key, value = ('Fonts', 'Axis ticks', 'Font size'), 15
+        self.widget.set_visual_settings(key, value)
+        key, value = ('Fonts', 'Axis ticks', 'Italic'), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(15)
+        for ax in ["bottom", "left"]:
+            axis = graph.parameter_setter.getAxis(ax)
+            self.assertFontEqual(axis.style["tickFont"], font)
+
+        key, value = ("Fonts", "Legend", "Font size"), 16
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Legend", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(16)
+        legend_item = list(graph.parameter_setter.legend_items)[0]
+        self.assertFontEqual(legend_item[1].item.font(), font)
+
+        key, value = ("Annotations", "Title", "Title"), "Foo"
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(graph.parameter_setter.title_item.item.toPlainText(), "Foo")
+        self.assertEqual(graph.parameter_setter.title_item.text, "Foo")
+
+        key, value = ("Annotations", "x-axis title", "Title"), "Foo2"
+        self.widget.set_visual_settings(key, value)
+        axis = graph.parameter_setter.getAxis("bottom")
+        self.assertEqual(axis.label.toPlainText().strip(), "Foo2")
+        self.assertEqual(axis.labelText, "Foo2")
+
+        key, value = ("Annotations", "y-axis title", "Title"), "Foo3"
+        self.widget.set_visual_settings(key, value)
+        axis = graph.parameter_setter.getAxis("left")
+        self.assertEqual(axis.label.toPlainText().strip(), "Foo3")
+        self.assertEqual(axis.labelText, "Foo3")
+
+    def assertFontEqual(self, font1, font2):
+        self.assertEqual(font1.family(), font2.family())
+        self.assertEqual(font1.pointSize(), font2.pointSize())
+        self.assertEqual(font1.italic(), font2.italic())
 
 
 class TestSegmentsIntersection(unittest.TestCase):

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -1114,7 +1114,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         key, value = ('Fonts', 'Axis title', 'Italic'), True
         self.widget.set_visual_settings(key, value)
         font.setPointSize(16)
-        for item in graph.axis_items:
+        for item in graph.parameter_setter.axis_items:
             self.assertFontEqual(item.label.font(), font)
 
         key, value = ('Fonts', 'Axis ticks', 'Font size'), 15
@@ -1122,7 +1122,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         key, value = ('Fonts', 'Axis ticks', 'Italic'), True
         self.widget.set_visual_settings(key, value)
         font.setPointSize(15)
-        for item in graph.axis_items:
+        for item in graph.parameter_setter.axis_items:
             self.assertFontEqual(item.style["tickFont"], font)
 
 

--- a/Orange/widgets/visualize/utils/component.py
+++ b/Orange/widgets/visualize/utils/component.py
@@ -1,5 +1,4 @@
 """Common gui.OWComponent components."""
-import copy
 
 from AnyQt.QtCore import Qt, QRectF
 from AnyQt.QtGui import QColor, QFont
@@ -7,35 +6,34 @@ from AnyQt.QtWidgets import QGraphicsEllipseItem
 
 import pyqtgraph as pg
 from Orange.widgets.visualize.owscatterplotgraph import (
-    OWScatterPlotBase, ParameterSetter as Setter
+    OWScatterPlotBase, ScatterBaseParameterSetter
 )
 from Orange.widgets.visualize.utils.customizableplot import Updater
 from Orange.widgets.visualize.utils.plotutils import (
     MouseEventDelegate, DraggableItemsViewBox
 )
 
-
-class ParameterSetter(Setter):
+class AnchorParameterSetter(ScatterBaseParameterSetter):
     ANCHOR_LABEL = "Anchor"
-    initial_settings = copy.deepcopy(Setter.initial_settings)
-    initial_settings[Setter.LABELS_BOX].update({
-        ANCHOR_LABEL: Updater.FONT_SETTING
-    })
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, master):
+        super().__init__(master)
         self.anchor_font = QFont()
 
     def update_setters(self):
+        super().update_setters()
+        self.initial_settings[self.LABELS_BOX].update({
+            self.ANCHOR_LABEL: self.FONT_SETTING
+        })
+
         def update_anchors(**settings):
             self.anchor_font = Updater.change_font(self.anchor_font, settings)
-            self.update_anchors()
+            self.master.update_anchors()
 
-        super().update_setters()
         self._setters[self.LABELS_BOX][self.ANCHOR_LABEL] = update_anchors
 
 
-class OWGraphWithAnchors(OWScatterPlotBase, ParameterSetter):
+class OWGraphWithAnchors(OWScatterPlotBase):
     """
     Graph for projections in which dimensions can be manually moved
 
@@ -50,6 +48,7 @@ class OWGraphWithAnchors(OWScatterPlotBase, ParameterSetter):
         self._tooltip_delegate = MouseEventDelegate(self.help_event,
                                                     self.show_indicator_event)
         self.plot_widget.scene().installEventFilter(self._tooltip_delegate)
+        self.parameter_setter = AnchorParameterSetter(self)
 
     def clear(self):
         super().clear()

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -169,8 +169,6 @@ class CommonParameterSetter:
         Updater.ANTIALIAS_LABEL: (None, False),
     }
 
-    initial_settings: Dict[str, Dict[str, SettingsType]] = NotImplemented
-
     def __init__(self):
         def update_font_family(**settings):
             for label in self.initial_settings[self.LABELS_BOX]:
@@ -231,7 +229,7 @@ class CommonParameterSetter:
             }
         }
 
-        self.initial_settings = {}
+        self.initial_settings: Dict[str, Dict[str, SettingsType]] = NotImplemented
 
         self.update_setters()
         self._check_setters()

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -1,9 +1,7 @@
-import sys
 from typing import Tuple, List, Dict, Iterable
 
 from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QFont, QFontDatabase
-from AnyQt.QtWidgets import QApplication
 
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.LegendItem import ItemSample
@@ -15,62 +13,10 @@ _SettingType = Dict[str, ValueType]
 _LegendItemType = Tuple[ItemSample, pg.LabelItem]
 
 
-def available_font_families() -> List:
-    """
-    Function returns list of available font families.
-    Can be used to instantiate font combo boxes.
-
-    Returns
-    -------
-    fonts: list
-        List of available font families.
-    """
-    if not QApplication.instance():
-        _ = QApplication(sys.argv)
-    return QFontDatabase().families()
-
-
-def default_font_family() -> str:
-    """
-    Function returns default font family used in Qt application.
-    Can be used to instantiate initial dialog state.
-
-    Returns
-    -------
-    font: str
-        Default font family.
-    """
-    if not QApplication.instance():
-        _ = QApplication(sys.argv)
-    return QFont().family()
-
-
-def default_font_size() -> int:
-    """
-    Function returns default font size in points used in Qt application.
-    Can be used to instantiate initial dialog state.
-
-    Returns
-    -------
-    size: int
-        Default font size in points.
-    """
-    if not QApplication.instance():
-        _ = QApplication(sys.argv)
-    return QFont().pointSize()
-
-
 class Updater:
     """ Class with helper functions and constants. """
     FONT_FAMILY_LABEL, SIZE_LABEL, IS_ITALIC_LABEL = \
         "Font family", "Font size", "Italic"
-    FONT_FAMILY_SETTING: SettingsType = {
-        FONT_FAMILY_LABEL: (available_font_families(), default_font_family()),
-    }
-    FONT_SETTING: SettingsType = {
-        SIZE_LABEL: (range(4, 50), default_font_size()),
-        IS_ITALIC_LABEL: (None, False)
-    }
 
     WIDTH_LABEL, ALPHA_LABEL, STYLE_LABEL, ANTIALIAS_LABEL = \
         "Width", "Opacity", "Style", "Antialias"
@@ -80,12 +26,6 @@ class Updater:
                    "Dash dot line": Qt.DashDotLine,
                    "Dash dot dot line": Qt.DashDotDotLine}
     DEFAULT_LINE_STYLE = "Solid line"
-    LINE_SETTING: SettingsType = {
-        WIDTH_LABEL: (range(1, 15), 1),
-        ALPHA_LABEL: (range(0, 255, 5), 255),
-        STYLE_LABEL: (list(LINE_STYLES), DEFAULT_LINE_STYLE),
-        ANTIALIAS_LABEL: (None, False),
-    }
 
     @staticmethod
     def update_plot_title_text(title_item: pg.LabelItem, text: str):
@@ -205,7 +145,7 @@ class Updater:
             item.setPen(pen)
 
 
-class BaseParameterSetter:
+class CommonParameterSetter:
     """ Subclass to add 'setter' functionality to a plot. """
     LABELS_BOX = "Fonts"
     ANNOT_BOX = "Annotations"
@@ -219,6 +159,15 @@ class BaseParameterSetter:
     X_AXIS_LABEL = "x-axis title"
     Y_AXIS_LABEL = "y-axis title"
     TITLE_LABEL = "Title"
+
+    FONT_FAMILY_SETTING = None  # set in __init__ because it requires a running QApplication
+    FONT_SETTING = None  # set in __init__ because it requires a running QApplication
+    LINE_SETTING: SettingsType = {
+        Updater.WIDTH_LABEL: (range(1, 15), 1),
+        Updater.ALPHA_LABEL: (range(0, 255, 5), 255),
+        Updater.STYLE_LABEL: (list(Updater.LINE_STYLES), Updater.DEFAULT_LINE_STYLE),
+        Updater.ANTIALIAS_LABEL: (None, False),
+    }
 
     initial_settings: Dict[str, Dict[str, SettingsType]] = NotImplemented
 
@@ -254,6 +203,15 @@ class BaseParameterSetter:
             Updater.update_axis_title_text(
                 self.getAxis(axis), settings[self.TITLE_LABEL])
 
+        self.FONT_FAMILY_SETTING: SettingsType = {  # pylint: disable=invalid-name
+            Updater.FONT_FAMILY_LABEL: (QFontDatabase().families(), QFont().family()),
+        }
+
+        self.FONT_SETTING: SettingsType = {  # pylint: disable=invalid-name
+            Updater.SIZE_LABEL: (range(4, 50), QFont().pointSize()),
+            Updater.IS_ITALIC_LABEL: (None, False)
+        }
+
         self.label_font = QFont()
         self.legend_settings = {}
 
@@ -272,6 +230,8 @@ class BaseParameterSetter:
                 self.Y_AXIS_LABEL: lambda **kw: update_axis("left", **kw),
             }
         }
+
+        self.initial_settings = {}
 
         self.update_setters()
         self._check_setters()

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -403,7 +403,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         self.input_changed.connect(self.set_input_summary)
         self.output_changed.connect(self.set_output_summary)
         self.setup_gui()
-        VisualSettingsDialog(self, self.GRAPH_CLASS.initial_settings)
+        VisualSettingsDialog(self, self.graph.parameter_setter.initial_settings)
 
     # GUI
     def setup_gui(self):
@@ -627,7 +627,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
 
     # Customize plot
     def set_visual_settings(self, key, value):
-        self.graph.set_parameter(key, value)
+        self.graph.parameter_setter.set_parameter(key, value)
         self.visual_settings[key] = value
 
     @staticmethod


### PR DESCRIPTION
##### Issue
Fixes #4934. To set Updater there had to be an active QApplication when Updater was imported, because default font settings were set as class attributes. This led to some segfaults in tests, which also created a QApplication instance. 

##### Description of changes
Default font properties were moved to the `__init__` of CommonParameterSetter. Also, parameter setters are now encapsulated by corresponding graphs and not mixed into them.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
