### PR TITLE
[FIX] ProjectionWidgetMixinTests: set shape attribute only when discrete var available

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -825,8 +825,15 @@ class ProjectionWidgetTestMixin:
         self.widget.set_visual_settings(key, value)
         simulate.combobox_activate_item(self.widget.controls.attr_color,
                                         self.data.domain[0].name)
-        simulate.combobox_activate_item(self.widget.controls.attr_shape,
-                                        self.data.domain[4].name)
+        variables = self.data.domain.variables + self.data.domain.metas
+        discrete_var = next(
+            (x for x in variables if isinstance(x, DiscreteVariable)), None
+        )
+        if discrete_var:
+            # activate item only when discrete variable available
+            simulate.combobox_activate_item(
+                self.widget.controls.attr_shape, discrete_var.name
+            )
         font.setPointSize(12)
         self.assertFontEqual(graph.num_legend.items[0][0].font, font)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Some projection widgets (e.g. Annotator in Bioinformatics addon) have test data without Discrete variables so `attr_shape` cannot be set to any variable.

##### Description of changes
Set `attr_shape` to first Discrete variable in the domain if exists.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
