### PR TITLE
[FIX] Edit Domain: Multiple item rename/merge

### DIFF
--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from AnyQt.QtCore import QItemSelectionModel, Qt, QItemSelection
 from AnyQt.QtWidgets import QAction, QComboBox, QLineEdit, \
-    QStyleOptionViewItem, QDialog
+    QStyleOptionViewItem, QDialog, QMenu
 from AnyQt.QtTest import QTest, QSignalSpy
 
 from Orange.widgets.utils import colorpalettes
@@ -38,6 +38,7 @@ from Orange.widgets.data.oweditdomain import (
     GroupItemsDialog)
 from Orange.widgets.data.owcolor import OWColor, ColorRole
 from Orange.widgets.tests.base import WidgetTest, GuiTest
+from Orange.widgets.tests.utils import contextMenu
 from Orange.tests import test_filename, assert_array_nanequal
 from Orange.widgets.utils.state_summary import format_summary_details
 
@@ -543,6 +544,23 @@ class TestEditors(GuiTest):
         self.assertSequenceEqual(
             list(spy), [[]], 'variable_changed should emit exactly once'
         )
+
+    def test_discrete_editor_context_menu(self):
+        w = DiscreteVariableEditor()
+        v = Categorical("C", ("a", "b", "c"),
+                        (("A", "1"), ("B", "b")), False)
+        w.set_data_categorical(v, [])
+        view = w.values_edit
+        model = view.model()
+
+        pos = view.visualRect(model.index(0, 0)).center()
+        with patch.object(QMenu, "setVisible", return_value=None) as m:
+            contextMenu(view.viewport(), pos)
+            m.assert_called()
+
+        menu = view.findChild(QMenu)
+        self.assertIsNotNone(menu)
+        menu.close()
 
     def test_time_editor(self):
         w = TimeVariableEditor()

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -6,8 +6,8 @@ import contextlib
 
 from AnyQt.QtCore import Qt, QObject, QEventLoop, QTimer, QLocale, QPoint
 from AnyQt.QtTest import QTest
-from AnyQt.QtGui import QMouseEvent
-from AnyQt.QtWidgets import QApplication
+from AnyQt.QtGui import QMouseEvent, QContextMenuEvent
+from AnyQt.QtWidgets import QApplication, QWidget
 
 from Orange.data import Table, Domain, ContinuousVariable
 
@@ -321,6 +321,25 @@ def mouseMove(widget, pos=QPoint(), delay=-1):  # pragma: no-cover
         QTest.qWait(delay)
 
     QApplication.sendEvent(widget, me)
+
+
+def contextMenu(
+        widget: QWidget, pos=QPoint(), reason=QContextMenuEvent.Mouse,
+        modifiers=Qt.NoModifier, delay=-1
+) -> None:
+    """
+    Simulate a context menu event on `widget`.
+
+    `pos` is the event origin specified in widget's local coordinates. If not
+    specified. Then widget.rect().center() is used instead.
+    """
+    if pos.isNull():
+        pos = widget.rect().center()
+    globalPos = widget.mapToGlobal(pos)
+    ev = QContextMenuEvent(reason, pos, globalPos, modifiers)
+    if delay >= 0:
+        QTest.qWait(delay)
+    QApplication.sendEvent(widget, ev)
 
 
 def table_dense_sparse(test_case):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref gh-4914

Enable merging by inline simultaneous multiple item rename.

##### Description of changes

* Re-enable inline multiple item edit 
* Move the functionality to the delegate an make it behave the same for edits triggered by platform edit key (Enter/Return or F2), is also available via context menu.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
