### PR TITLE
[FIX] Fix wrong assert in heatmap

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -796,12 +796,10 @@ class OWHeatMap(widget.OWWidget):
                     matrix = Orange.distance.Euclidean(subset)
 
                 if cluster is None:
-                    assert len(matrix) < self.MaxClustering
                     cluster = hierarchical.dist_matrix_clustering(
                         matrix, linkage=hierarchical.WARD
                     )
                 if ordered and cluster_ord is None:
-                    assert len(matrix) < self.MaxOrderedClustering
                     cluster_ord = hierarchical.optimal_leaf_ordering(
                         cluster, matrix,
                     )
@@ -833,12 +831,10 @@ class OWHeatMap(widget.OWWidget):
 
                 if cluster is None:
                     assert matrix is not None
-                    assert len(matrix) < self.MaxClustering
                     cluster = hierarchical.dist_matrix_clustering(
                         matrix, linkage=hierarchical.WARD
                     )
                 if ordered and cluster_ord is None:
-                    assert len(matrix) < self.MaxOrderedClustering
                     cluster_ord = hierarchical.optimal_leaf_ordering(cluster, matrix)
 
             col_groups.append(col._replace(cluster=cluster, cluster_ordered=cluster_ord))

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -62,13 +62,18 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
 
     def test_information_message(self):
         self.widget.set_row_clustering(Clustering.OrderedClustering)
-        continuizer = Continuize()
-        cont_titanic = continuizer(self.titanic)
-        self.widget.MaxClustering = 1000
-        self.send_signal(self.widget.Inputs.data, cont_titanic)
-        self.assertTrue(self.widget.Information.active)
-        self.send_signal(self.widget.Inputs.data, self.data)
+        self.widget.MaxClustering = 20
+        self.widget.MaxOrderedClustering = 15
+        data = self.brown_selected[:, :10]
+        self.send_signal(self.widget.Inputs.data, data[:15])
         self.assertFalse(self.widget.Information.active)
+        self.send_signal(self.widget.Inputs.data, data[:16])
+        self.assertTrue(self.widget.Information.active)
+        self.assertEqual(self.widget.row_clustering, Clustering.Clustering)
+        self.send_signal(self.widget.Inputs.data, data[:20])
+        self.assertFalse(self.widget.Information.active)
+        self.send_signal(self.widget.Inputs.data, data[:21])
+        self.assertTrue(self.widget.Information.active)
 
     def test_settings_changed(self):
         self.send_signal(self.widget.Inputs.data, self.data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Heatmap widget raises an error if a dataset with exactly 1000 instances in on input and 'Clustering (opt. ordering) is selected for Row clustering.

```
-------------------------- AssertionError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 313, in _
    self.set_row_clustering(cb.itemData(idx, ClusteringRole))
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 528, in set_row_clustering
    self.__update_row_clustering()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 1089, in __update_row_clustering
    self.update_heatmaps()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 726, in update_heatmaps
    parts = self.construct_heatmaps(self.data, self.split_by_var, self.split_columns_var)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 901, in construct_heatmaps
    ordered=self.row_clustering == Clustering.OrderedClustering
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 804, in cluster_rows
    assert len(matrix) < self.MaxOrderedClustering
AssertionError
```
This is due to an wrong condition in the assert

##### Description of changes

* Remove asserts


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
