### PR TITLE
[FIX] Fix variables equality and hashes 

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -215,18 +215,25 @@ class TestVariable(unittest.TestCase):
 
     def test_hash_eq(self):
         a = ContinuousVariable("a")
+        a1 = ContinuousVariable("a")
         b1 = ContinuousVariable("b", compute_value=Identity(a))
         b2 = ContinuousVariable("b2", compute_value=Identity(b1))
         b3 = ContinuousVariable("b")
-        self.assertEqual(a, b2)
-        self.assertEqual(b1, b2)
-        self.assertEqual(a, b1)
+        c1 = ContinuousVariable("c", compute_value=Identity(a))
+        c2 = ContinuousVariable("c", compute_value=Identity(a))
+        self.assertNotEqual(a, b2)
+        self.assertNotEqual(b1, b2)
+        self.assertNotEqual(a, b1)
         self.assertNotEqual(b1, b3)
+        self.assertEqual(a, a1)
+        self.assertEqual(c1, c2)
 
-        self.assertEqual(hash(a), hash(b2))
-        self.assertEqual(hash(b1), hash(b2))
-        self.assertEqual(hash(a), hash(b1))
+        self.assertNotEqual(hash(a), hash(b2))
+        self.assertNotEqual(hash(b1), hash(b2))
+        self.assertNotEqual(hash(a), hash(b1))
         self.assertNotEqual(hash(b1), hash(b3))
+        self.assertEqual(hash(a), hash(a1))
+        self.assertEqual(hash(c1), hash(c2))
 
 
 def variabletest(varcls):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -353,12 +353,15 @@ class Variable(Reprable, metaclass=VariableMeta):
         var1 = self._get_identical_source(self)
         var2 = self._get_identical_source(other)
         # pylint: disable=protected-access
-        return var1.name == var2.name \
-               and var1._compute_value == var2._compute_value
+        return (
+            self.name == other.name
+            and var1.name == var2.name
+            and var1._compute_value == var2._compute_value
+        )
 
     def __hash__(self):
         var = self._get_identical_source(self)
-        return hash((var.name, type(self), var._compute_value))
+        return hash((self.name, var.name, type(self), var._compute_value))
 
     @staticmethod
     def _get_identical_source(var):

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -544,6 +544,22 @@ class TestDomainInit(unittest.TestCase):
         self.assertTrue(conversion.sparse_Y)
         self.assertFalse(conversion.sparse_metas)
 
+    def test_get_item_similar_vars(self):
+        a = DiscreteVariable("Cluster", values=["c"])
+        var1 = a.renamed("Cluster x")
+        var2 = DiscreteVariable("Cluster", values=["a", "b"])
+
+        domain = Domain(
+            [],
+            metas=[var1, var2]
+        )
+        # pylint: disable=protected-access
+        self.assertDictEqual(
+            {-1: -1, -2: -2, var1: -1, var2: -2, var1.name: -1, var2.name: -2},
+            domain._indices
+        )
+        self.assertIs(domain[domain.metas[0]], domain.metas[0])
+
 
 class TestDomainFilter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes (partially or completely) https://github.com/biolab/orange3/issues/4870

Problem is the following:
```
from Orange.data import Domain, DiscreteVariable
a = DiscreteVariable("Cluster", values=["c"])
var1 = a.renamed("Cluster x")
var2 = DiscreteVariable("Cluster", values=["a", "b"])
domain = Domain([], metas=[var1, var2])

print(var1 == var2)  # vars have completely different origin but still equal
>>> True
print(domain[var1]) # wrong attribute because of wrong comparison -> should return Cluster x
>>> Cluster
```
The problem is that `var1` and `var2` have equal hash (also `__eq__` returns True). This happens since `var1` have `compute_value` with identity pointing to the variable `a`; variables `a` and `var2` have same hash since they have the same name and same `compute_value` (`None`). 

The Domain has a dictionary with index for each variable. Variables are keys in dict, when updating dictionary index is set for variable `Cluster x` instead of `Cluster` (same hashes).

##### Description of changes
Variables are not equal if their names are not equal and their hashes are not equal either. This avoids problems in the domain (two vars with same hash).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
