### PR TITLE
Merge data: fix errors in context

### DIFF
--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -221,8 +221,13 @@ class MergeDataContextHandler(ContextHandler):
         context = widget.current_context
         if context is None:
             return
-        pairs = context.values.get("attr_pairs", [])
-        widget.attr_pairs = [self.decode_pair(widget, pair) for pair in pairs]
+        pairs = context.values.get("attr_pairs")
+        if pairs:
+            # attr_pairs is schema only setting which means it is not always
+            # present. When not present leave widgets default.
+            widget.attr_pairs = [
+                self.decode_pair(widget, pair) for pair in pairs
+            ]
 
     def match(self, context, variables1, variables2):
         def matches(part, variables):
@@ -232,9 +237,10 @@ class MergeDataContextHandler(ContextHandler):
         if (variables1, variables2) == (context.variables1, context.variables2):
             return self.PERFECT_MATCH
 
-        left, right = zip(*context.values["attr_pairs"])
-        if matches(left, variables1) and matches(right, variables2):
-            return 0.5
+        if "attr_pairs" in context.values:
+            left, right = zip(*context.values["attr_pairs"])
+            if matches(left, variables1) and matches(right, variables2):
+                return 0.5
 
         return self.NO_MATCH
 

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -4,6 +4,7 @@
 # pylint: disable=too-many-lines,too-many-public-methods, protected-access
 from itertools import chain
 import unittest
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import numpy as np
@@ -1075,6 +1076,37 @@ class MergeDataContextHandlerTest(unittest.TestCase):
         widget.current_context = None
         handler.settings_from_widget(widget)  # mustn't crash
         handler.settings_to_widget(widget)  # mustn't crash
+
+    def test_attr_pairs_not_present(self):
+        data = Table("iris")
+
+        context = SimpleNamespace(values={})
+        widget = SimpleNamespace(
+            current_context=context, attr_pairs=("a", "b")
+        )
+        handler = MergeDataContextHandler()
+
+        handler.settings_to_widget(widget)  # mustn't crash
+        # no attr_pairs in context -> handler must not change widget.attr_pairs
+        self.assertTupleEqual(widget.attr_pairs, ("a", "b"))
+
+        context = SimpleNamespace(
+            values={
+                "attr_pairs": [((data.domain[0], 100), (data.domain[1], 100))]
+            }
+        )
+        widget = SimpleNamespace(
+            current_context=context,
+            attr_pairs=("a", "b"),
+            data=data,
+            extra_data=data,
+        )
+
+        handler.settings_to_widget(widget)  # mustn't crash
+        # values taken from context
+        self.assertListEqual(
+            widget.attr_pairs, [(data.domain[0], data.domain[1])]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/4870

##### Description of changes
Custom context didn't take into account that attr_pairs is schema_only. Handle cases when it is not present in context

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
