### PR TITLE
[FIX] Fix slicing in from_table

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -446,10 +446,7 @@ class Table(Sequence, Storage):
                 return table
 
             if isinstance(row_indices, slice):
-                start, stop, stride = row_indices.indices(source.X.shape[0])
-                n_rows = (stop - start) // stride
-                if n_rows < 0:
-                    n_rows = 0
+                n_rows = len(range(*row_indices.indices(source.X.shape[0])))
             elif row_indices is ...:
                 n_rows = len(source)
             else:


### PR DESCRIPTION
##### Issue
For reverse slices row_indices in Table.from_table did not work properly. Also, that part of `from_table` was not properly tested, probably because of some optimizations that were added later.

##### Description of changes
Handcrafted (but wrong) measuring of slice length was replaced with calling standard methods. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
