### PR TITLE
pyproject.toml: Bound setuptools<50.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=40.8.0",
+    "setuptools>=40.8.0,<50.0",
     "wheel",
     "oldest-supported-numpy"
 ]


### PR DESCRIPTION
### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fails to build on windows due to

https://github.com/pypa/setuptools/issues/2368

##### Description of changes

Force setuptools<50.0 during build

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
