### PR TITLE
Save widgets: Don't disable auto_save because of missing (relative) path

### DIFF
--- a/Orange/widgets/utils/save/owsavebase.py
+++ b/Orange/widgets/utils/save/owsavebase.py
@@ -122,23 +122,21 @@ class OWSaveBase(widget.OWWidget, openclass=True):
         """
         Compute absolute path from `stored_path` from settings.
 
-        Auto save is disabled unless stored_path is relative and exists.
+        Absolute stored path is used only if it exists.
+        Auto save is disabled unless stored_path is relative.
         """
         workflow_dir = self.workflowEnv().get("basedir")
         if os.path.isabs(self.stored_path):
-            path = self.stored_path
-            self.auto_save = False
+            if os.path.exists(self.stored_path):
+                self.auto_save = False
+                return self.stored_path
         elif workflow_dir:
-            path = os.path.join(workflow_dir, self.stored_path)
-        else:
-            path = None
+            return os.path.normpath(
+                os.path.join(workflow_dir, self.stored_path))
 
-        if path and os.path.exists(path):
-            return path
-        else:
-            self.stored_path = workflow_dir or _userhome
-            self.auto_save = False
-            return self.stored_path
+        self.stored_path = workflow_dir or _userhome
+        self.auto_save = False
+        return self.stored_path
 
     @property
     def filename(self):

--- a/Orange/widgets/utils/save/tests/test_owsavebase.py
+++ b/Orange/widgets/utils/save/tests/test_owsavebase.py
@@ -103,7 +103,8 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             b = b.replace("\\", "/")
         self.assertEqual(a.rstrip("/"), b.rstrip("/"))
 
-    @patch("os.path.exists", lambda name: name == "/home/u/orange/a/b")
+    @patch("os.path.exists",
+           lambda name: name in ["/home/u/orange/a/b", "/foo/bar"])
     def test_open_moved_workflow(self):
         """Stored relative paths are properly changed on load"""
         home = _userhome
@@ -126,6 +127,15 @@ class TestOWSaveBaseWithWriters(WidgetTest):
                                      auto_save=True))
             self.assertPathEqual(w.last_dir, home)
             self.assertPathEqual(w.filename, home_c_foo)
+            self.assertFalse(w.auto_save)
+
+            w = self.create_widget(
+                self.OWSaveMockWriter,
+                stored_settings=dict(stored_path="/foo/bar",
+                                     stored_name="c.foo",
+                                     auto_save=True))
+            self.assertPathEqual(w.last_dir, "/foo/bar")
+            self.assertPathEqual(w.filename, "/foo/bar/c.foo")
             self.assertFalse(w.auto_save)
 
             w = self.create_widget(
@@ -162,9 +172,9 @@ class TestOWSaveBaseWithWriters(WidgetTest):
                 stored_settings=dict(stored_path="a/d",
                                      stored_name="c.foo",
                                      auto_save=True))
-            self.assertPathEqual(w.last_dir, "/home/u/orange/")
-            self.assertPathEqual(w.filename, "/home/u/orange/c.foo")
-            self.assertFalse(w.auto_save)
+            self.assertPathEqual(w.last_dir, "/home/u/orange/a/d")
+            self.assertPathEqual(w.filename, "/home/u/orange/a/d/c.foo")
+            self.assertTrue(w.auto_save)
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -182,7 +192,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
                                      auto_save=True))
             self.assertPathEqual(w.last_dir, "/home/u/orange/")
             self.assertPathEqual(w.filename, "/home/u/orange/c.foo")
-            self.assertFalse(w.auto_save)
+            self.assertTrue(w.auto_save)
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -191,7 +201,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
                                      auto_save=True))
             self.assertPathEqual(w.last_dir, "/home/u/orange/")
             self.assertPathEqual(w.filename, "/home/u/orange/c.foo")
-            self.assertFalse(w.auto_save)
+            self.assertTrue(w.auto_save)
 
     def test_move_workflow(self):
         """Widget correctly stores relative paths"""


### PR DESCRIPTION
##### Issue

Fixes #4932.

##### Description of changes

Change the limitations related to auto save and use of recent paths. In this PR

- auto_save is disabled if the path is absolute (previously, it was also disabled if the path was relative, but didn't exist);
- as before, auto save is also disabled if the recent path is relative and we don't have workflow_dir;
- absolute path is used only if it exists (like before; in the future, absolute paths will not be saved in .ows at all).


##### Includes
- [X] Code changes
- [X] Tests
- [x] Documentation
