### PR TITLE
Remove UUID from useragent string

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -63,16 +63,12 @@ statistics_server_url = os.getenv(
 
 
 def ua_string():
-    settings = QSettings()
-
     is_anaconda = 'Continuum' in sys.version or 'conda' in sys.version
-    machine_id = settings.value("reporting/machine-id", "", str)
-    return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}:{uuid}'.format(
+    return 'Orange{orange_version}:Python{py_version}:{platform}:{conda}'.format(
         orange_version=current,
         py_version='.'.join(str(a) for a in sys.version_info[:3]),
         platform=sys.platform,
-        conda='Anaconda' if is_anaconda else '',
-        uuid=machine_id if settings.value("reporting/send-statistics", False, bool) else ''
+        conda='Anaconda' if is_anaconda else ''
     )
 
 


### PR DESCRIPTION
A UUID was included only if send-statistics was enabled, but we now deem this unnecessary.