### PR TITLE
Fix discretize default cutpoints restore

### DIFF
--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -333,8 +333,6 @@ class OWDiscretize(widget.OWWidget):
             s.setMaximumWidth(60)
             s.setAlignment(Qt.AlignRight)
             gui.rubber(s.box)
-            sp = box.sizePolicy()
-            sp.setControlType(sp.SpinBox)
             return box.box
 
         self.k_general = _intbox(self.left, "default_k",

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -339,13 +339,14 @@ class OWDiscretize(widget.OWWidget):
                                  self._default_disc_changed)
         self.k_general.layout().setContentsMargins(0, 0, 0, 0)
 
-        def manual_cut_editline(text="") -> QLineEdit:
+        def manual_cut_editline(text="", enabled=True) -> QLineEdit:
             edit = QLineEdit(
                 text=text,
                 placeholderText="e.g. 0.0, 0.5, 1.0",
                 toolTip="Enter fixed discretization cut points (a comma "
                         "separated list of strictly increasing numbers e.g. "
                         "0.0, 0.5, 1.0).",
+                enabled=enabled,
             )
             @edit.textChanged.connect
             def update():
@@ -375,7 +376,8 @@ class OWDiscretize(widget.OWWidget):
             return edit
 
         self.manual_cuts_edit = manual_cut_editline(
-            text=", ".join(map(str, self.default_cutpoints))
+            text=", ".join(map(str, self.default_cutpoints)),
+            enabled=self.default_method == Methods.Custom,
         )
 
         def set_manual_default_cuts():
@@ -431,7 +433,10 @@ class OWDiscretize(widget.OWWidget):
         gui.appendRadioButton(controlbox, "Remove attribute", id=Methods.Remove)
         b = gui.appendRadioButton(controlbox, "Manual", id=Methods.Custom)
 
-        self.manual_cuts_specific = manual_cut_editline()
+        self.manual_cuts_specific = manual_cut_editline(
+            text=", ".join(map(str, self.cutpoints)),
+            enabled=self.method == Methods.Custom
+        )
         self.manual_cuts_specific.setValidator(validator)
         b.toggled[bool].connect(self.manual_cuts_specific.setEnabled)
 
@@ -487,6 +492,7 @@ class OWDiscretize(widget.OWWidget):
             self.default_method_name = method.name
             self.default_button_group.button(method).setChecked(True)
             self._default_disc_changed()
+        self.manual_cuts_edit.setEnabled(method == Methods.Custom)
 
     @Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -296,7 +296,6 @@ class OWDiscretize(widget.OWWidget):
         self.method = Methods.Default
         self.k = 5
         self.cutpoints = ()
-        self.default_cutpoints = ()
 
         box = gui.vBox(self.controlArea, self.tr("Default Discretization"))
         self._default_method_ = 0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixup for #4929

Default custom cut points are not restored due to an errant assignment in constructor

##### Description of changes

* Remove assign to 'default_cutpoints' in constructor
* Also enable/disable edit line entry to match the selected method.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
