### PR TITLE
TreeLearner: build_tree to private and add docs

### DIFF
--- a/Orange/classification/tree.py
+++ b/Orange/classification/tree.py
@@ -176,7 +176,7 @@ class TreeLearner(Learner):
         best_res[0].value = distribution.Discrete(data, class_var)
         return best_res
 
-    def build_tree(self, data, active_inst, level=1):
+    def _build_tree(self, data, active_inst, level=1):
         """Induce a tree from the given data
 
         Returns:
@@ -194,7 +194,7 @@ class TreeLearner(Learner):
         node.subset = active_inst
         if branches is not None:
             node.children = [
-                self.build_tree(data, active_inst[branches == br], level + 1)
+                self._build_tree(data, active_inst[branches == br], level + 1)
                 for br in range(n_children)]
         return node
 
@@ -209,7 +209,7 @@ class TreeLearner(Learner):
                              format(self.MAX_BINARIZATION))
 
         active_inst = np.nonzero(~np.isnan(data.Y))[0].astype(np.int32)
-        root = self.build_tree(data, active_inst)
+        root = self._build_tree(data, active_inst)
         if root is None:
             distr = distribution.Discrete(data, data.domain.class_var)
             if np.sum(distr) == 0:

--- a/Orange/regression/tree.py
+++ b/Orange/regression/tree.py
@@ -135,7 +135,7 @@ class TreeLearner(Learner):
                 best_score, best_res = sc, res
         return best_res
 
-    def build_tree(self, data, active_inst, level=1):
+    def _build_tree(self, data, active_inst, level=1):
         """Induce a tree from the given data
 
         Returns:
@@ -153,7 +153,7 @@ class TreeLearner(Learner):
         node.subset = active_inst
         if branches is not None:
             node.children = [
-                self.build_tree(data, active_inst[branches == br], level + 1)
+                self._build_tree(data, active_inst[branches == br], level + 1)
                 for br in range(n_children)]
         return node
 
@@ -168,7 +168,7 @@ class TreeLearner(Learner):
                              format(self.MAX_BINARIZATION))
 
         active_inst = np.nonzero(~np.isnan(data.Y))[0].astype(np.int32)
-        root = self.build_tree(data, active_inst)
+        root = self._build_tree(data, active_inst)
         if root is None:
             root = Node(None, 0, np.array([0., 0.]))
         root.subset = active_inst

--- a/doc/data-mining-library/source/reference/classification.rst
+++ b/doc/data-mining-library/source/reference/classification.rst
@@ -76,8 +76,6 @@ data instances:
            [ 0.17428279,  0.20342097,  0.62229625],
            [ 0.18633359,  0.79518516,  0.01848125]])
 
-For datasets that include continuous attributes,
-
 .. _`Naive Bayes`: http://en.wikipedia.org/wiki/Naive_Bayes_classifier
 .. _`scikit-learn`: http://scikit-learn.org
 
@@ -118,7 +116,29 @@ Classification Tree
 Orange includes three implemenations of classification trees. `TreeLearner`
 is home-grown and properly handles multinominal and missing values.
 The one from scikit-learn, `SklTreeLearner`, is faster. Another home-grown,
-`SimpleTreeLearner`, is simpler and stil faster.
+`SimpleTreeLearner`, is simpler and still faster.
+
+The following code loads iris dataset (four numeric attributes and discrete
+class), constructs a decision tree learner, uses it on the entire dataset
+to construct a classifier, and then prints the tree:
+
+    >>> import Orange
+    >>> iris = Orange.data.Table('iris')
+    >>> tr = Orange.classification.TreeLearner()
+    >>> classifier = tr(data)
+    >>> printed_tree = classifier.print_tree()
+    >>> for i in printed_tree.split('\n'):
+    >>>     print(i)
+    [50.  0.  0.] petal length ≤ 1.9
+    [ 0. 50. 50.] petal length > 1.9
+    [ 0. 49.  5.]     petal width ≤ 1.7
+    [ 0. 47.  1.]         petal length ≤ 4.9
+       [0. 2. 4.]         petal length > 4.9
+       [0. 0. 3.]             petal width ≤ 1.5
+       [0. 2. 1.]             petal width > 1.5
+       [0. 2. 0.]                 sepal length ≤ 6.7
+       [0. 0. 1.]                 sepal length > 6.7
+    [ 0.  1. 45.]     petal width > 1.7
 
 .. autoclass:: TreeLearner
    :members:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`build_tree()` had not reason to be public. It was misleading for users finding it in the documentation and thinking it prints the tree.
Also no documentation explaining how to print a tree.

##### Description of changes
Make `build_tree()` private.
Add an example of how to print a tree.

##### Includes
- [X] Code changes
- [ ] Tests
- [X] Documentation
