### PR TITLE
[FIX] Tests: PyQt5 5.15 compatible cleanup

### DIFF
--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -20,6 +20,11 @@ class TestOWPythonScript(WidgetTest):
         self.learner = LogisticRegressionLearner()
         self.model = self.learner(self.iris)
 
+    def tearDown(self):
+        # clear sys.last_*, these are set/used by interactive interpreter
+        sys.last_type = sys.last_value = sys.last_traceback = None
+        super().tearDown()
+
     def test_inputs(self):
         """Check widget's inputs"""
         for input_, data in (("Data", self.iris),

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -28,6 +28,10 @@ class TestListModel(GuiTest):
         self.view = gui.listView(
             self.widget.controlArea, self.widget, "foo", model=self.attrs)
 
+    def tearDown(self) -> None:
+        self.widget.deleteLater()
+        del self.widget
+
     def test_select_callback(self):
         widget = self.widget
         view = self.view

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -46,14 +46,30 @@ class MockWidget(OWWidget):
         else:
             return colorpalettes.DefaultDiscretePalette
 
+    @staticmethod
+    def reset_mocks():
+        for m in MockWidget.__dict__.values():
+            if isinstance(m, Mock):
+                m.reset_mock()
+
 
 class TestOWScatterPlotBase(WidgetTest):
     def setUp(self):
+        super().setUp()
         self.master = MockWidget()
         self.graph = OWScatterPlotBase(self.master)
 
         self.xy = (np.arange(10, dtype=float), np.arange(10, dtype=float))
         self.master.get_coordinates_data = lambda: self.xy
+
+    def tearDown(self):
+        self.master.onDeleteWidget()
+        self.master.deleteLater()
+        # Clear mocks as they keep ref to widget instance when called
+        MockWidget.reset_mocks()
+        del self.master
+        del self.graph
+        super().tearDown()
 
     # pylint: disable=keyword-arg-before-vararg
     def setRange(self, rect=None, *_, **__):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref gh-4952

##### Description of changes

* test_owpythonscript: Clear sys.last_{type,value,traceback} 
* test_gui: Remove widget in tearDown
*  test_owscatterplotbase: Reset Mock instances in class namespace 
* owpythonscript: Change shared_namespace to WeakKeyDictionary 
* owsom: Remove back ref to widget from closures in background thread 


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
