### PR TITLE
Tidy up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,12 +7,25 @@ assignees: ''
 
 ---
 
-**Bug reports that do not sufficiently describe a bug are not helpful and will most likely be ignored.**
+<!-- Thanks for taking the time to report a bug! -->
+<!-- To fix the bug, we need to be able to reproduce it, so please let us know the following... -->
 
-- [ ] **A clear and concise description.** "*I'm getting an error when I open a tree viewer*" is far from enough (what kind of error? what kind of data you give it?). "*I'm getting an error*" is even worse.
+- [ ] **What's wrong?**
+<!-- Be specific, clear, and concise. Include screenshots if relevant. -->
+<!-- If you're getting an error message, copy it, and enclose it with three backticks (```). -->
 
-- [ ] **How to reproduce the problem.** Upload a zip with a workflow and data, or describe the steps (open this widget, click there, then add this ...)
 
-- [ ] **Which version of Orange are you using? How did you install it?**
+
+- [ ] **How can we reproduce the problem?** 
+<!-- Upload a zip with the .ows file and data. -->
+<!-- Describe the steps (open this widget, click there, then add this...) -->
+
+
+
+- [ ] **Which version of Orange are you using? How did you install Orange?**
+
+
 
 - [ ] **What is your operating system?**
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,21 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+<!-- Thanks for taking the time to submit a feature request! -->
+<!-- For the best chance at our team considering your request, let us know the following... -->
 
-**Here**, write a clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+- [ ] **What's your use case?**
+<!-- In other words, what's your pain point? -->
+<!-- Is your request related to a problem, or perhaps a frustration? -->
+<!-- Tell us the story that led you to write this request. -->
 
-**Describe the solution you'd like**
 
-Add a clear and concise description of what you want to happen **here**.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+- [ ] **What's your proposed solution?**
+<!-- Be specific, clear, and concise. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+
+
+- [ ] **Are there any alternative solutions?**
+
+


### PR DESCRIPTION
It seems that sometimes people just ignore the issue template and append their request to the end. This change declutters the templates and reworks the feature request template a bit.

##### Description of changes
- Turn all prompts into questions
- Add space in-between prompts
- Move additional information to HTML comments