### PR TITLE
Fix ugly links in docs

### DIFF
--- a/doc/visual-programming/source/loading-your-data/index.md
+++ b/doc/visual-programming/source/loading-your-data/index.md
@@ -1,6 +1,6 @@
 # Loading your Data
 
-Orange comes with its [own data format](https://docs.biolab.si//3/data-mining-library/tutorial/data.html#data-input), but can also handle native Excel, comma- or tab-delimited data files. The input data set is usually a table, with data instances (samples) in rows and data attributes in columns. Attributes can be of different *types* (numeric, categorical, datetime, and text) and have assigned *roles* (input features, meta attributes, and class). Data attribute type and role can be provided in the data table header. They can also be changed in the [File](../widgets/data/file.md) widget, while data role can also be modified with [Select Columns](../widgets/data/selectcolumns.md) widget.
+Orange comes with its [own data format](https://docs.biolab.si/3/data-mining-library/tutorial/data.html#data-input), but can also handle native Excel, comma- or tab-delimited data files. The input data set is usually a table, with data instances (samples) in rows and data attributes in columns. Attributes can be of different *types* (numeric, categorical, datetime, and text) and have assigned *roles* (input features, meta attributes, and class). Data attribute type and role can be provided in the data table header. They can also be changed in the [File](../widgets/data/file.md) widget, while data role can also be modified with [Select Columns](../widgets/data/selectcolumns.md) widget.
 
 ### In a Nutshell
 

--- a/doc/visual-programming/source/widgets/data/pythonscript.md
+++ b/doc/visual-programming/source/widgets/data/pythonscript.md
@@ -42,7 +42,7 @@ Note: You should not modify the input objects in place.
 Examples
 --------
 
-Python Script widget is intended to extend functionalities for advanced users. Classes from Orange library are described in the [documentation](https://docs.biolab.si//3/data-mining-library/#reference). To find further information about orange Table class see [Table](https://docs.biolab.si//3/data-mining-library/reference/data.table.html), [Domain](https://docs.biolab.si//3/data-mining-library/reference/data.domain.html), and [Variable](https://docs.biolab.si//3/data-mining-library/reference/data.variable.html) documentation.
+Python Script widget is intended to extend functionalities for advanced users. Classes from Orange library are described in the [documentation](https://docs.biolab.si/3/data-mining-library/#reference). To find further information about orange Table class see [Table](https://docs.biolab.si/3/data-mining-library/reference/data.table.html), [Domain](https://docs.biolab.si/3/data-mining-library/reference/data.domain.html), and [Variable](https://docs.biolab.si/3/data-mining-library/reference/data.variable.html) documentation.
 
 One can, for example, do batch filtering by attributes. We used zoo.tab for the example and we filtered out all the attributes that have more than 5 discrete values. This in our case removed only 'leg' attribute, but imagine an example where one would have many such attributes.
 


### PR DESCRIPTION
Changes such as https://docs.biolab.si//3/ -> https://docs.biolab.si/3/

This was caused by a wrong nginx rewrite rule from quite some time ago. Old and new links currently work.