### PR TITLE
[MNT] Fix readthedocs builds

### DIFF
--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,4 +1,3 @@
 -r requirements-core.txt
 -r requirements-doc.txt
 -r requirements-gui.txt
-PyQt5


### PR DESCRIPTION
Readthedocs was not building because of double dependencies since we added the PyQt5 dependency into requirements (a few months ago).