### PR TITLE
Dont show welcome screen when loading crashed workflow

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -643,8 +643,8 @@ def main(argv=None):
                  open_requests[-1])
         canvas_window.load_scheme(open_requests[-1].toLocalFile())
     else:
-        canvas_window.ask_load_swp_if_exists()
-        if want_welcome:
+        swp_loaded = canvas_window.ask_load_swp_if_exists()
+        if not swp_loaded and want_welcome:
             canvas_window.welcome_dialog()
 
     # local references prevent destruction

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.1.15,<0.2a
+orange-canvas-core>=0.1.16,<0.2a
 orange-widget-base>=4.8.1
 
 PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns


### PR DESCRIPTION
This PR raises the orange-canvas-core requirement, it should only be merged after biolab/orange-canvas-core#125 is merged and released.

There's no rush to merge this, do it when there's some other reason to raise the requirement as well.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
