### PR TITLE
Adjust default issue template, minor adjustments

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,31 +1,7 @@
 <!--
-This is an issue template. Please fill in the relevant details in the
-sections below.
+If something's not right with Orange, fill out the bug report template at:
+https://github.com/biolab/orange3/issues/new?assignees=&labels=bug+report&template=bug_report.md&title=
 
-Wrap code and verbatim terminal window output into triple backticks, see:
-https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code
-
-If you're raising an issue about an add-on (e.g. installed via
-Options > Add-ons), raise an issue on the relevant add-on's issue
-tracker instead. See: https://github.com/biolab?q=orange3
+If you have an idea for a new feature, fill out the feature request template at:
+https://github.com/biolab/orange3/issues/new?assignees=&labels=&template=feature_request.md&title=
 -->
-
-##### Orange version
-<!-- From menu _Help→About→Version_ or code `Orange.version.full_version` -->
-
-
-##### Expected behavior
-
-
-
-##### Actual behavior
-
-
-
-##### Steps to reproduce the behavior
-
-
-
-##### Additional info (worksheets, data, screenshots, ...)
-
-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,18 +1,24 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a bug to help us improve
 title: ''
 labels: bug report
 assignees: ''
 
 ---
 
-<!-- Thanks for taking the time to report a bug! -->
-<!-- To fix the bug, we need to be able to reproduce it, so please let us know the following... -->
+<!-- 
+Thanks for taking the time to report a bug!
+If you're raising an issue about an add-on (i.e., installed via Options > Add-ons), raise an issue in the relevant add-on's issue tracker instead. See: https://github.com/biolab?q=orange3
+To fix the bug, we need to be able to reproduce it. Please answer the following questions to the best of your ability.
+-->
+
 
 - [ ] **What's wrong?**
 <!-- Be specific, clear, and concise. Include screenshots if relevant. -->
 <!-- If you're getting an error message, copy it, and enclose it with three backticks (```). -->
+
+
 
 
 
@@ -22,10 +28,18 @@ assignees: ''
 
 
 
+
+
 - [ ] **Which version of Orange are you using? How did you install Orange?**
+<!-- See "Help → About → Version" or `Orange.version.full_version` in code -->
+
+
 
 
 
 - [ ] **What is your operating system?**
+
+
+
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,14 +1,16 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for Orange
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-<!-- Thanks for taking the time to submit a feature request! -->
-<!-- For the best chance at our team considering your request, let us know the following... -->
+<!-- 
+Thanks for taking the time to submit a feature request!
+For the best chance at our team considering your request, please answer the following questions to the best of your ability.
+-->
 
 - [ ] **What's your use case?**
 <!-- In other words, what's your pain point? -->
@@ -17,11 +19,18 @@ assignees: ''
 
 
 
+
+
 - [ ] **What's your proposed solution?**
 <!-- Be specific, clear, and concise. -->
 
 
 
+
+
 - [ ] **Are there any alternative solutions?**
+
+
+
 
 


### PR DESCRIPTION
If upon pressing 'New Issue', you pick "Open a blank issue.", it opened up the old issue template.

This PR changes that to an empty template with a comment linking to the two issue templates.