### PR TITLE
Embedders: increase a timeout

### DIFF
--- a/Orange/misc/server_embedder.py
+++ b/Orange/misc/server_embedder.py
@@ -74,7 +74,7 @@ class ServerEmbedderCommunicator:
         self._cache = EmbedderCache(model_name)
 
         # default embedding timeouts are too small we need to increase them
-        self.timeout = 60
+        self.timeout = 180
         self.num_parallel_requests = 0
         self.max_parallel = max_parallel_requests
         self.content_type = None  # need to be set in a class inheriting


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Current timeout is too short and can cause an unexpected switch to local embedders. Since embedded send many images in parallel it can happen that embedded cannot handle all in 60 seconds. It usually happens when embedded pods are still turning on at the server or when more people use embedder at the same time.

##### Description of changes
Increasing timeout to 180 seconds.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
