### PR TITLE
Impute: Prevent overfitting (and exploding) in default model imputation

### DIFF
--- a/Orange/classification/simple_tree.py
+++ b/Orange/classification/simple_tree.py
@@ -78,7 +78,7 @@ class SimpleTreeLearner(Learner):
 
     name = 'simple tree'
 
-    def __init__(self, min_instances=2, max_depth=1024, max_majority=1.0,
+    def __init__(self, min_instances=2, max_depth=32, max_majority=0.95,
                  skip_prob=0.0, bootstrap=False, seed=42):
         super().__init__()
         self.min_instances = min_instances

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -162,7 +162,7 @@ class OWImpute(OWWidget):
         super().__init__()
         self.data = None  # type: Optional[Orange.data.Table]
         self.learner = None  # type: Optional[Learner]
-        self.default_learner = SimpleTreeLearner()
+        self.default_learner = SimpleTreeLearner(min_instances=10, max_depth=10)
         self.modified = False
         self.executor = qconcurrent.ThreadExecutor(self)
         self.__task = None


### PR DESCRIPTION
##### Issue

Fixes #4982.

Model-based imputation uses `SimpleTree` with default arguments, which are 2 instances in a leaf and (essentially) unlimited depth. If data includes enough numeric attributes, this led to memory overflow.

##### Description of changes

Cut trees to 10 levels with minimum of 10 instances in leaves.

##### Includes
- [X] Code changes