### PR TITLE
Correct orange-widget-base version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - pandas
     - pyyaml
     - orange-canvas-core >=0.1.15,<0.2a
-    - orange-widget-base >=4.7.0
+    - orange-widget-base >=4.8.1
     - openpyxl
     - httpx >=0.12
     - baycomp >=1.0.2

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.15,<0.2a
-orange-widget-base>=4.7.0
+orange-widget-base>=4.8.1
 
 PyQt5>=5.12
 PyQtWebEngine>=5.12


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
As @markotoplak noticed here https://github.com/biolab/orange3/pull/4892 we forgot to increase the widget-base version.

##### Description of changes
Increasing the orange-widget-base version.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
