### PR TITLE
mainwindow: Vertically align notifications settings

### DIFF
--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -2,7 +2,7 @@ from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import (
     QFormLayout, QCheckBox, QLineEdit, QWidget, QVBoxLayout, QLabel
 )
-from orangecanvas.application.settings import UserSettingsDialog
+from orangecanvas.application.settings import UserSettingsDialog, FormLayout
 from orangecanvas.document.usagestatistics import UsageStatistics
 from orangecanvas.utils.overlay import NotificationOverlay
 
@@ -26,7 +26,7 @@ class OUserSettingsDialog(UserSettingsDialog):
         self.addTab(tab, self.tr("Reporting"),
                     toolTip="Settings related to reporting")
 
-        form = QFormLayout()
+        form = FormLayout()
         line_edit_mid = QLineEdit()
         self.bind(line_edit_mid, "text", "reporting/machine-id")
         form.addRow("Machine ID:", line_edit_mid)
@@ -58,7 +58,7 @@ class OUserSettingsDialog(UserSettingsDialog):
         self.addTab(tab, self.tr("Notifications"),
                     toolTip="Settings related to notifications")
 
-        form = QFormLayout()
+        form = FormLayout()
 
         box = QWidget()
         layout = QVBoxLayout()


### PR DESCRIPTION
To be merged after biolab/orange-canvas-core#128 is merged and released. 
Also note, this PR **doesn't raise the canvas-core requirement**. Merge #4980 first.

##### Description of changes
Aligns settings, as in the referenced PR.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
