### PR TITLE
owtestandscore: Change default k (folds) from 10 to 5

### DIFF
--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -169,7 +169,7 @@ class OWTestAndScore(OWWidget):
     #: Selected resampling type
     resampling = settings.Setting(0)
     #: Number of folds for K-fold cross validation
-    n_folds = settings.Setting(3)
+    n_folds = settings.Setting(2)
     #: Stratified sampling for K-fold
     cv_stratified = settings.Setting(True)
     #: Number of repeats for ShuffleSplit sampling

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -554,7 +554,7 @@ class TestOWTestAndScore(WidgetTest):
             scores = w._scores_by_folds(slots)
             self.assertIsNone(scores[0])
             self.assertEqual(scores[1][0], 1)
-            self.assertAlmostEqual(scores[2][0], 1 / 11)
+            self.assertAlmostEqual(scores[2][0], 1 / 6)
 
     def test_comparison_binary_score(self):
         # false warning at call_arg.kwargs


### PR DESCRIPTION
##### Description of changes
The choice of k is arbitrary, so I suggest going with a lower one for faster default performance. @janezd?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
