### PR TITLE
Fixup following change to spinboxes in orange-widget-base

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owdbscan.py
+++ b/Orange/widgets/unsupervised/tests/test_owdbscan.py
@@ -68,9 +68,9 @@ class TestOWDBSCAN(WidgetTest):
         self.send_signal(w.Inputs.data, self.iris)
 
         # change parameters
-        self.widget.controls.eps.valueChanged.emit(0.5)
+        self.widget.controls.eps.setValue(0.5)
         output1 = self.get_output(w.Outputs.annotated_data)
-        self.widget.controls.eps.valueChanged.emit(1)
+        self.widget.controls.eps.setValue(1)
         output2 = self.get_output(w.Outputs.annotated_data)
 
         # on this data higher eps has greater sum of clusters - less nan
@@ -80,7 +80,7 @@ class TestOWDBSCAN(WidgetTest):
 
         # try when no data
         self.send_signal(w.Inputs.data, None)
-        self.widget.controls.eps.valueChanged.emit(0.5)
+        self.widget.controls.eps.setValue(0.5)
         output = self.get_output(w.Outputs.annotated_data)
         self.assertIsNone(output)
 
@@ -91,9 +91,9 @@ class TestOWDBSCAN(WidgetTest):
         self.send_signal(w.Inputs.data, self.iris)
 
         # change parameters
-        self.widget.controls.min_samples.valueChanged.emit(5)
+        self.widget.controls.min_samples.setValue(5)
         output1 = self.get_output(w.Outputs.annotated_data)
-        self.widget.controls.min_samples.valueChanged.emit(1)
+        self.widget.controls.min_samples.setValue(1)
         output2 = self.get_output(w.Outputs.annotated_data)
 
         # on this data lower min_samples has greater sum of clusters - less nan
@@ -103,7 +103,7 @@ class TestOWDBSCAN(WidgetTest):
 
         # try when no data
         self.send_signal(w.Inputs.data, None)
-        self.widget.controls.min_samples.valueChanged.emit(3)
+        self.widget.controls.min_samples.setValue(3)
         output = self.get_output(w.Outputs.annotated_data)
         self.assertIsNone(output)
 

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -48,7 +48,6 @@ class TestOWManifoldLearning(WidgetTest):
                        self.widget.n_components_spin.maximum()):
             self.assertEqual(self.widget.data, self.iris)
             self.widget.n_components_spin.setValue(i)
-            self.widget.n_components_spin.onEnter()
             self.widget.apply_button.button.click()
             self._compare_tables(self.get_output(self.widget.Outputs.transformed_data), i)
 

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -227,13 +227,13 @@ class TestOWNomogram(WidgetTest):
 
         # Output more attributer than there are -> output all
         self.widget.n_attributes = 5
-        self.widget.n_spin.valueChanged.emit(5)
+        self.widget.n_spin.setValue(5)
         attrs = self.get_output(self.widget.Outputs.features)
         self.assertEqual(attrs, [age, sex, status])
 
         # Output the first two
         self.widget.n_attributes = 2
-        self.widget.n_spin.valueChanged.emit(2)
+        self.widget.n_spin.setValue(2)
         attrs = self.get_output(self.widget.Outputs.features)
         self.assertEqual(attrs, [age, sex])
 
@@ -250,7 +250,7 @@ class TestOWNomogram(WidgetTest):
 
     def test_reset_settings(self):
         self.widget.n_attributes = 5
-        self.widget.n_spin.valueChanged.emit(5)
+        self.widget.n_spin.setValue(5)
         self.widget.reset_settings()
         self.assertEqual(10, self.widget.n_attributes)
 

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.16,<0.2a
-orange-widget-base>=4.8.1
+orange-widget-base>=4.10.0
 
 PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
 PyQtWebEngine>=5.12


### PR DESCRIPTION
To be merged after https://github.com/biolab/orange-widget-base/pull/108 is merged.
Note, this PR raises the requirement to orange-widget-base's master branch, something which must be corrected before drafting a release. This means that the referenced orange-widget-base PR does NOT have to be released before merging this.

##### Description of changes
- Raises orange-widget-base requirement to 0.10.0 (at time of writing, not yet released).
- Fixes deprecation warnings related to https://github.com/biolab/orange-widget-base/pull/108.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
