### PR TITLE
Disable scatterplot checkbox

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -289,7 +289,8 @@ class OWScatterPlot(OWDataProjectionWidget):
             callback=self.graph.update_regression_line,
             tooltip=
             "If checked, fit line to group (minimize distance from points);\n"
-            "otherwise fit y as a function of x (minimize vertical distances)")
+            "otherwise fit y as a function of x (minimize vertical distances)",
+            disabledBy=self.cb_reg_line)
 
     def _add_controls_axis(self):
         common_options = dict(

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.18,<0.2a
-orange-widget-base>=4.8.1
+orange-widget-base>=4.9.0
 
 PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
 PyQtWebEngine>=5.12


### PR DESCRIPTION
To be merged after biolab/orange-widget-base#97 is merged and released.

##### Issue
Controls like this one (which don't do anything unless another checkbox is checked) should be disabled when the other checkbox in question is disabled.

If there's any other controls like this, they should follow this styling. With the change in orange-widget-base, this should be easier to do.

##### Description of changes
<img width="752" alt="Screenshot 2020-09-22 at 15 54 25" src="https://user-images.githubusercontent.com/24586651/93891636-e653ff00-fceb-11ea-8b96-b844440e8b66.png">


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
