### PR TITLE
Gui: Remove backward-compatibility imports

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -33,14 +33,6 @@ from orangewidget.gui import (
     ControlGetter, VerticalScrollArea, ProgressBar,
     ControlledCallback, ControlledCallFront, ValueCallback, connectControl,
 )
-# exposed for backcompat. Should not be imported from here, or not
-# imported at all
-from orangewidget.gui import (
-    SpinBoxWFocusOut, DoubleSpinBoxWFocusOut, LineEditWFocusOut, OrangeComboBox
-)  # pylint: disable=unused-import
-from Orange.widgets.utils.buttons import (
-    VariableTextPushButton
-)  # pylint: disable=unused-import
 
 
 try:

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -124,12 +124,12 @@ class OWLouvainClustering(widget.OWWidget):
             graph_box, self, "metric_idx", label="Distance metric",
             items=[m[0] for m in METRICS], callback=self._invalidate_graph,
             orientation=Qt.Horizontal,
-        )  # type: gui.OrangeComboBox
+        )
         self.k_neighbors_spin = gui.spin(
             graph_box, self, "k_neighbors", minv=1, maxv=_MAX_K_NEIGBOURS,
             label="k neighbors", controlWidth=80, alignment=Qt.AlignRight,
             callback=self._invalidate_graph,
-        )  # type: gui.SpinBoxWFocusOut
+        )
         self.resolution_spin = gui.hSlider(
             graph_box, self, "resolution", minValue=0, maxValue=5., step=1e-1,
             label="Resolution", intOnly=False, labelFormat="%.1f",

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -220,12 +220,12 @@ class OWPythagoreanForest(OWWidget):
             box_display, self, 'target_class_index', label='Target class',
             orientation=Qt.Horizontal, items=[], contentsLength=8,
             searchable=True
-        )  # type: gui.OrangeComboBox
+        )
         self.ui_size_calc_combo = gui.comboBox(
             box_display, self, 'size_calc_idx', label='Size',
             orientation=Qt.Horizontal,
             items=list(zip(*self.SIZE_CALCULATION))[0], contentsLength=8,
-        )  # type: gui.OrangeComboBox
+        )
         self.ui_zoom_slider = gui.hSlider(
             box_display, self, 'zoom', label='Zoom', ticks=False, minValue=100,
             maxValue=400, createLabel=False, intOnly=False,


### PR DESCRIPTION
##### Issue

These imports cause problems in https://github.com/irgolic/orange-widget-base/tree/draggable-spinbox, and they aren't used in core neither in core Orange nor in "official" add-ons.

Removed typehints could be replaced by types from orangewidget.gui, but I don't think they add much value to the code anyway.