### PR TITLE
Skip PyQt version 5.15.1 in requirements

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - xlrd >=0.9.2
     - xlsxwriter
     - anyqt >=0.0.8
-    - pyqt >=5.12
+    - pyqt >=5.12,!=5.15.1
     - pyqtgraph ~=0.10.0|~=0.11.0
     - joblib >=0.9.4
     - keyring

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,7 +1,7 @@
 orange-canvas-core>=0.1.15,<0.2a
 orange-widget-base>=4.8.1
 
-PyQt5>=5.12
+PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
 PyQtWebEngine>=5.12
 AnyQt>=0.0.8
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Solves https://github.com/biolab/orange3/issues/5016

##### Description of changes
Since fix for Qt is already prepared I think it will be available in the next version. This is why I propose just skipping version 5.15.1.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
