### PR TITLE
[FIX] Fix line plot's send_report

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - xlsxwriter
     - anyqt >=0.0.8
     - pyqt >=5.12,!=5.15.1
-    - pyqtgraph ~=0.10.0|~=0.11.0
+    - pyqtgraph >=0.11.0
     - joblib >=0.9.4
     - keyring
     - keyrings.alt

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -5,7 +5,7 @@ PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select c
 PyQtWebEngine>=5.12
 AnyQt>=0.0.8
 
-pyqtgraph>=0.10.0
+pyqtgraph>=0.11.0
 matplotlib>=2.0.0
 
 # For add-ons' descriptions


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Send line plot's send report fails with pyqtgraph==0.10.0.

```
Traceback (most recent call last):
  File "/Users/primoz/miniconda3/envs/orange3/lib/python3.8/site-packages/pyqtgraph/graphicsItems/PlotCurveItem.py", line 183, in boundingRect
    px, py = self.pixelVectors()
  File "/Users/primoz/miniconda3/envs/orange3/lib/python3.8/site-packages/pyqtgraph/graphicsItems/GraphicsItem.py", line 251, in pixelVectors
    dti = fn.invertQTransform(dt)
  File "/Users/primoz/miniconda3/envs/orange3/lib/python3.8/site-packages/pyqtgraph/functions.py", line 2199, in invertQTransform
    inv = numpy.linalg.inv(arr)
  File "<__array_function__ internals>", line 5, in inv
  File "/Users/primoz/miniconda3/envs/orange3/lib/python3.8/site-packages/numpy/linalg/linalg.py", line 546, in inv
    ainv = _umath_linalg.inv(a, signature=signature, extobj=extobj)
  File "/Users/primoz/miniconda3/envs/orange3/lib/python3.8/site-packages/numpy/linalg/linalg.py", line 88, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
numpy.linalg.LinAlgError: Singular matrix
```

The error was discovered while testing orange3-installers https://github.com/ales-erjavec/orange3-installers/runs/1224911463

##### Description of changes
The bug was fixed in pyqtgraph==0.11.0 so increasing the minimum version of pyqtgraph.
pyqtgraph fix: https://github.com/pyqtgraph/pyqtgraph/pull/1173

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
