### PR TITLE
Remove docutils dependency

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
     - scikit-learn >=0.22.0,!=0.23.0
     - bottleneck >=1.0.0
     - chardet >=3.0.2
-    - docutils
     - xlrd >=0.9.2
     - xlsxwriter
     - anyqt >=0.0.8
@@ -57,7 +56,7 @@ requirements:
     - openTSNE >=0.4.3
     - pandas
     - pyyaml
-    - orange-canvas-core >=0.1.15,<0.2a
+    - orange-canvas-core >=0.1.16,<0.2a
     - orange-widget-base >=4.8.1
     - openpyxl
     - httpx >=0.12

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,3 +1,2 @@
-docutils
 Sphinx>=1.3
 recommonmark

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -7,6 +7,3 @@ AnyQt>=0.0.8
 
 pyqtgraph>=0.11.0
 matplotlib>=2.0.0
-
-# For add-ons' descriptions
-docutils


### PR DESCRIPTION
docutils is not directly used anywhere in Orange; it is used in orange-canvas-core.