### PR TITLE
[ENH] Create nodes on canvas drag/drop

### DIFF
--- a/Orange/canvas/mainwindow.py
+++ b/Orange/canvas/mainwindow.py
@@ -3,6 +3,7 @@ from AnyQt.QtWidgets import (
     QFormLayout, QCheckBox, QLineEdit, QWidget, QVBoxLayout, QLabel
 )
 from orangecanvas.application.settings import UserSettingsDialog, FormLayout
+from orangecanvas.document.interactions import PluginDropHandler
 from orangecanvas.document.usagestatistics import UsageStatistics
 from orangecanvas.utils.overlay import NotificationOverlay
 
@@ -107,6 +108,9 @@ class MainWindow(OWCanvasMainWindow):
         super().__init__(*args, **kwargs)
         self.notification_overlay = NotificationOverlay(self.scheme_widget)
         self.notification_server = None
+        self.scheme_widget.setDropHandlers([
+            PluginDropHandler("orange.canvas.drophandler")
+        ])
 
     def open_canvas_settings(self):
         # type: () -> None

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -24,7 +24,7 @@ from Orange.util import OrangeDeprecationWarning
 
 from Orange.data.io import TabReader
 from Orange.tests import named_file
-from Orange.widgets.data.owfile import OWFile
+from Orange.widgets.data.owfile import OWFile, OWFileDropHandler
 from Orange.widgets.utils.filedialogs import dialog_formats, format_filter, RecentPath
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.domaineditor import ComboDelegate, VarTypeDelegate, VarTableModel
@@ -664,6 +664,22 @@ a
         self.widget._try_load()
         self.assertTrue(self.widget.Warning.load_warning.is_shown())
         self.assertIn(WARNING_MSG, str(self.widget.Warning.load_warning))
+
+
+class TestOWFileDropHandler(unittest.TestCase):
+    def test_canDropUrl(self):
+        handler = OWFileDropHandler()
+        self.assertTrue(handler.canDropUrl(QUrl("https://example.com/test.tab")))
+        self.assertTrue(handler.canDropUrl(QUrl.fromLocalFile("test.tab")))
+
+    def test_parametersFromUrl(self):
+        handler = OWFileDropHandler()
+        r = handler.parametersFromUrl(QUrl("https://example.com/test.tab"))
+        self.assertEqual(r["source"], OWFile.URL)
+        self.assertEqual(r["recent_urls"], ["https://example.com/test.tab"])
+        r = handler.parametersFromUrl(QUrl.fromLocalFile("test.tab"))
+        self.assertEqual(r["source"], OWFile.LOCAL_FILE)
+        self.assertEqual(r["recent_paths"][0].basename, "test.tab")
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 import sys
+import unittest
 
 from AnyQt.QtCore import QMimeData, QUrl, QPoint, Qt
 from AnyQt.QtGui import QDragEnterEvent, QDropEvent
@@ -8,7 +9,8 @@ from AnyQt.QtGui import QDragEnterEvent, QDropEvent
 from Orange.data import Table
 from Orange.classification import LogisticRegressionLearner
 from Orange.tests import named_file
-from Orange.widgets.data.owpythonscript import OWPythonScript, read_file_content, Script
+from Orange.widgets.data.owpythonscript import OWPythonScript, \
+    read_file_content, Script, OWPythonScriptDropHandler
 from Orange.widgets.tests.base import WidgetTest, DummySignalManager
 from Orange.widgets.widget import OWWidget
 
@@ -260,3 +262,16 @@ class TestOWPythonScript(WidgetTest):
             "__version__": 2
         })
         self.assertEqual(w.libraryListSource[0].name, "A")
+
+
+class TestOWPythonScriptDropHandler(unittest.TestCase):
+    def test_canDropFile(self):
+        handler = OWPythonScriptDropHandler()
+        self.assertTrue(handler.canDropFile(__file__))
+        self.assertFalse(handler.canDropFile("test.tab"))
+
+    def test_parametersFromFile(self):
+        handler = OWPythonScriptDropHandler()
+        r = handler.parametersFromFile(__file__)
+        item = r["scriptLibrary"][0]
+        self.assertEqual(item["filename"], __file__)

--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -1,13 +1,16 @@
 import os
 import pickle
+from typing import Any, Dict
 
 from AnyQt.QtWidgets import QSizePolicy, QStyle, QFileDialog
 from AnyQt.QtCore import QTimer
 
+from orangewidget.workflow.drophandler import SingleFileDropHandler
+
 from Orange.base import Model
 from Orange.widgets import widget, gui
 from Orange.widgets.model import owsavemodel
-from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
+from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin, RecentPath
 from Orange.widgets.utils import stdpaths
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Msg, Output
@@ -86,6 +89,19 @@ class OWLoadModel(widget.OWWidget, RecentPathsWComboMixin):
             self.Outputs.model.send(None)
         else:
             self.Outputs.model.send(model)
+
+
+class OWLoadModelDropHandler(SingleFileDropHandler):
+    WIDGET = OWLoadModel
+
+    def canDropFile(self, path: str) -> bool:
+        return path.endswith(".pkcls")
+
+    def parametersFromFile(self, path: str) -> Dict[str, Any]:
+        r = RecentPath(os.path.abspath(path), None, None,
+                       os.path.basename(path))
+        parameters = {"recent_paths": [r]}
+        return parameters
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/model/tests/test_owloadmodel.py
+++ b/Orange/widgets/model/tests/test_owloadmodel.py
@@ -11,7 +11,7 @@ import numpy as np
 from orangewidget.utils.filedialogs import RecentPath
 from Orange.data import Table
 from Orange.classification.naive_bayes import NaiveBayesLearner
-from Orange.widgets.model.owloadmodel import OWLoadModel
+from Orange.widgets.model.owloadmodel import OWLoadModel, OWLoadModelDropHandler
 from Orange.widgets.tests.base import WidgetTest
 
 
@@ -134,6 +134,18 @@ class TestOWLoadModel(WidgetTest):
             self.assertEqual(args.name, file_name.replace("\\", "/"))
         finally:
             os.remove(file_name)
+
+
+class TestOWLoadModelDropHandler(unittest.TestCase):
+    def test_canDropFile(self):
+        handler = OWLoadModelDropHandler()
+        self.assertTrue(handler.canDropFile("test.pkcls"))
+        self.assertFalse(handler.canDropFile("test.txt"))
+
+    def test_parametersFromFile(self):
+        handler = OWLoadModelDropHandler()
+        res = handler.parametersFromFile("test.pkcls")
+        self.assertEqual(res["recent_paths"][0].basename, "test.pkcls")
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -3,10 +3,12 @@ import os
 from AnyQt.QtWidgets import QSizePolicy, QStyle, QMessageBox, QFileDialog
 from AnyQt.QtCore import QTimer
 
+from orangewidget.workflow.drophandler import SingleFileDropHandler
+
 from Orange.misc import DistMatrix
 from Orange.widgets import widget, gui
 from Orange.data import get_sample_datasets_dir
-from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin
+from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin, RecentPath
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Output
 
@@ -142,6 +144,18 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
             self.report_paragraph("No data was loaded.")
         else:
             self.report_items([("File name", self.loaded_file)])
+
+
+class OWDistanceFileDropHandler(SingleFileDropHandler):
+    WIDGET = OWDistanceFile
+
+    def parametersFromFile(self, path):
+        r = RecentPath(os.path.abspath(path), None, None,
+                       os.path.basename(path))
+        return {"recent_paths": [r]}
+
+    def canDropFile(self, path: str) -> bool:
+        return os.path.splitext(path)[1].lower() == ".dst"
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/unsupervised/tests/test_owdistancefile.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancefile.py
@@ -1,0 +1,15 @@
+import unittest
+
+from Orange.widgets.unsupervised.owdistancefile import OWDistanceFileDropHandler
+
+
+class TestOWDistanceFileDropHandler(unittest.TestCase):
+    def test_canDropFile(self):
+        handler = OWDistanceFileDropHandler()
+        self.assertTrue(handler.canDropFile("test.dst"))
+        self.assertFalse(handler.canDropFile("test.bin"))
+
+    def test_parametersFromFile(self):
+        handler = OWDistanceFileDropHandler()
+        r = handler.parametersFromFile("test.dst")
+        self.assertEqual(r["recent_paths"][0].basename, "test.dst")

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,12 @@ ENTRY_POINTS = {
     "orange.canvas.help": (
         "html-index = Orange.widgets:WIDGET_HELP_PATH",
     ),
+    "orangecanvas.document.interactions.DropHandler": (
+        "File = Orange.widgets.data.owfile:OWFileDropHandler",
+        "Load Model = Orange.widgets.model.owloadmodel:OWLoadModelDropHandler",
+        "Distance File = Orange.widgets.unsupervised.owdistancefile:OWDistanceFileDropHandler",
+        "Python Script = Orange.widgets.data.owpythonscript:OWPythonScriptDropHandler",
+    ),
     "gui_scripts": (
         "orange-canvas = Orange.canvas.__main__:main",
     ),

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ ENTRY_POINTS = {
     "orange.canvas.help": (
         "html-index = Orange.widgets:WIDGET_HELP_PATH",
     ),
-    "orangecanvas.document.interactions.DropHandler": (
+    "orange.canvas.drophandler": (
         "File = Orange.widgets.data.owfile:OWFileDropHandler",
         "Load Model = Orange.widgets.model.owloadmodel:OWLoadModelDropHandler",
         "Distance File = Orange.widgets.unsupervised.owdistancefile:OWDistanceFileDropHandler",

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,11 @@ commands =
 changedir = {toxinidir}
 skip_install = true
 whitelist_externals = bash
-deps = pylint
+deps =
+    orange-widget-base
+    anyqt
+    PyQt5==5.12.*
+    pylint
 commands =
     bash .github/workflows/check_pylint_diff.sh
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Closes biolab/orange3#4918


##### Description of changes

Uses:
* biolab/orange-canvas-core#143 
* biolab/orange-widget-base#106


Implements drop handlers for 'File', 'Load Model', 'Distance File' and 'Python Script' widgets.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
