### PR TITLE
Slow horizontal scrolling in `QTableView`s

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -363,7 +363,7 @@ def table_selection_to_list(table):
 TableSlot = namedtuple("TableSlot", ["input_id", "table", "summary", "view"])
 
 
-class TableView(QTableView):
+class TableView(gui.HScrollStepMixin, QTableView):
     #: Signal emitted when selection finished. It is not emitted during
     #: mouse drag selection updates.
     selectionFinished = Signal()

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -1209,7 +1209,7 @@ class SharedSelectionModel(QItemSelectionModel):
         self.clearCurrentIndex()
 
 
-class TableView(QTableView):
+class TableView(gui.HScrollStepMixin, QTableView):
     MaxSizeHintSamples = 1000
 
     def sizeHintForColumn(self, column):

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -153,6 +153,10 @@ class SymmetricSelectionModel(QItemSelectionModel):
         self.select(selection, QItemSelectionModel.ClearAndSelect)
 
 
+class TableView(gui.HScrollStepMixin, QTableView):
+    pass
+
+
 class DistanceMatrixContextHandler(ContextHandler):
     @staticmethod
     def _var_names(annotations):
@@ -213,7 +217,7 @@ class OWDistanceMatrix(widget.OWWidget):
         self.items = None
 
         self.tablemodel = DistanceMatrixModel()
-        view = self.tableview = QTableView()
+        view = self.tableview = TableView()
         view.setEditTriggers(QTableView.NoEditTriggers)
         view.setItemDelegate(TableBorderItem())
         view.setModel(self.tablemodel)


### PR DESCRIPTION
##### Issue
Horizontal scrolling is too fast when unsynthesized (e.g., using a trackpad).
When scrolling with Shift/Alt+Scroll, it scrolls a page at a time. This seems to be intentional behavior, but I don't like it.

##### Description of changes
Unsynthesized horizontal scrolling is made as fast as vertical.
Shift/Alt+Scroll will scroll in steps, just like vertical.

This applies the change to Data Table, Predictions and Distance Matrix. Is there any other widgets this should be applied to?

##### Notes

Should I move the mixin somewhere else, like a util file? I wasn't sure where to put it.

Off-topic, why is scrolling so slow in table view's with a larger amount of visible cells? Frames per second already drop with 80 cells visible! Is it reloading all of the visible cells on every scroll event? If fetching from the model is the bottleneck, maybe a threaded solution is viable, where cells remain blank until their value is fetched?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
