### PR TITLE
customizableplot.available_font_families: Fix for non-existent default family

### DIFF
--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -28,8 +28,11 @@ def available_font_families() -> List:
     if not QApplication.instance():
         _ = QApplication(sys.argv)
     fonts = QFontDatabase().families()
-    default = fonts.pop(fonts.index(default_font_family()))
+    default = default_font_family()
+
     defaults = [default]
+    if default in fonts:
+        fonts.remove(default)
 
     guessed_name = default.split()[0]
     i = 0
@@ -263,7 +266,7 @@ class CommonParameterSetter:
                 self.getAxis(axis), settings[self.TITLE_LABEL])
 
         self.FONT_FAMILY_SETTING: SettingsType = {  # pylint: disable=invalid-name
-            Updater.FONT_FAMILY_LABEL: (available_font_families(), QFont().family()),
+            Updater.FONT_FAMILY_LABEL: (available_font_families(), default_font_family()),
         }
 
         self.FONT_SETTING: SettingsType = {  # pylint: disable=invalid-name

--- a/Orange/widgets/visualize/utils/tests/test_customizableplot.py
+++ b/Orange/widgets/visualize/utils/tests/test_customizableplot.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from Orange.widgets.visualize.utils import customizableplot
+
+
+class TestFonts(unittest.TestCase):
+    def test_available_font_families(self):
+        with patch.object(customizableplot, "QFont") as font, \
+                patch.object(customizableplot, "QFontDatabase") as db:
+            font.return_value = Mock()
+            font.return_value.family = Mock(return_value="mock regular")
+
+            db.return_value = Mock()
+            db.return_value.families = Mock(
+                return_value=["a", ".d", "e", ".b", "mock regular", "c"])
+            self.assertEqual(customizableplot.available_font_families(),
+                             ["mock regular", "", "a", ".b", "c", ".d", "e"])
+
+            db.return_value = Mock()
+            db.return_value.families = Mock(
+                return_value=["a", ".d", "e", ".b", "mock regular",
+                              "mock bold", "mock italic", "c", "mock semi"])
+            self.assertEqual(customizableplot.available_font_families(),
+                             ["mock regular", "mock bold", "mock italic",
+                              "mock semi", "",
+                              "a", ".b", "c", ".d", "e"])
+
+            # It seems it's possible that default font family does not exist
+            # (see gh-5036)
+            db.return_value.families.return_value = ["a", ".d", "e", ".b", "c"]
+            self.assertEqual(customizableplot.available_font_families(),
+                             ["mock regular", "", "a", ".b", "c", ".d", "e"])
+            self.assertIn(customizableplot.default_font_family(),
+                          customizableplot.available_font_families())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #5036.

It seems that the default font doesn't always exist.

##### Description of changes

Check whether the default font family exists. If not, just return a sorted list of families, without pushing the default to the top.

 Also: tests for `available_font_family`.

##### Includes
- [X] Code changes
- [X] Tests
