### PR TITLE
OWScatterPlotBase: Fixup selection UX

### DIFF
--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import scipy.sparse as sp
 
-from AnyQt.QtGui import QFont
+from AnyQt.QtGui import QFont, QTextDocumentFragment
 from AnyQt.QtCore import QRectF, QPointF
 from AnyQt.QtTest import QSignalSpy
 from AnyQt.QtWidgets import (
@@ -676,11 +676,9 @@ class ProjectionWidgetTestMixin:
 
     def test_dragging_tooltip(self):
         """Dragging tooltip depends on data being jittered"""
-        text = self.widget.graph.tiptexts[0]
+        text = QTextDocumentFragment.fromHtml(self.widget.graph.tiptexts[0]).toPlainText()
         self.send_signal(self.widget.Inputs.data, Table("heart_disease"))
         self.assertEqual(self.widget.graph.tip_textitem.toPlainText(), text)
-        self.widget.graph.controls.jitter_size.setValue(1)
-        self.assertGreater(self.widget.graph.tip_textitem.toPlainText(), text)
 
     def test_sparse_data(self, timeout=DEFAULT_TIMEOUT):
         """Test widget for sparse data"""

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -279,6 +279,7 @@ class OWToolbar(OrientedWidget):
                         self.buttons.update(s.buttons)
                         self.groups[buttons[i+1]] = s
                         i = j
+                        self.layout().addStretch()
                         break
                     else:
                         state_buttons.append(buttons[j])
@@ -291,7 +292,6 @@ class OWToolbar(OrientedWidget):
             else:
                 self.buttons[buttons[i][0]] = gui.tool_button(buttons[i], self)
             i = i + 1
-        self.layout().addStretch()
 
     def select_state(self, state):
         # SELECT_RECTANGLE = SELECT

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -604,7 +604,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
              format("Cmd" if sys.platform == "darwin" else "Ctrl")),
             (Qt.AltModifier, "Alt: Remove")
         ]
-        all_parts = ", ".join(part for _, part in tip_parts)
+        all_parts = "<center>" + \
+                    ", ".join(part for _, part in tip_parts) + \
+                    "</center>"
         self.tiptexts = {
             int(modifier): all_parts.replace(part, "<b>{}</b>".format(part))
             for modifier, part in tip_parts
@@ -616,6 +618,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         text.setHtml(self.tiptexts[Qt.ControlModifier])
         text.setPos(4, 2)
         r = text.boundingRect()
+        text.setTextWidth(r.width())
         rect = QGraphicsRectItem(0, 0, r.width() + 8, r.height() + 4)
         rect.setBrush(QColor(224, 224, 224, 212))
         rect.setPen(QPen(Qt.NoPen))

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -540,6 +540,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         gui.OWComponent.__init__(self, scatter_widget)
 
         self.subset_is_shown = False
+        self.jittering_suspended = False
 
         self.view_box = view_box(self)
         _axis = {"left": AxisItem("left"), "bottom": AxisItem("bottom")}
@@ -639,6 +640,14 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
                 text = self.tiptexts.get(int(mod))
                 break
         self.tip_textitem.setHtml(text)
+
+    def suspend_jittering(self):
+        self.jittering_suspended = True
+        self.update_jittering()
+
+    def unsuspend_jittering(self):
+        self.jittering_suspended = False
+        self.update_jittering()
 
     def update_jittering(self):
         x, y = self.get_coordinates()
@@ -809,7 +818,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         Display coordinates to random positions within ellipses with
         radiuses of `self.jittter_size` percents of spans
         """
-        if self.jitter_size == 0:
+        if self.jitter_size == 0 or self.jittering_suspended:
             return x, y
         return self._jitter_data(x, y)
 

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -599,8 +599,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
     def _create_drag_tooltip(self, scene):
         tip_parts = [
             (Qt.ShiftModifier, "Shift: Add group"),
-            (Qt.ShiftModifier + Qt.ControlModifier,
-             "Shift-{}: Append to group".
+            (Qt.ControlModifier,
+             "{}: Append to group".
              format("Cmd" if sys.platform == "darwin" else "Ctrl")),
             (Qt.AltModifier, "Alt: Remove")
         ]
@@ -613,7 +613,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
 
         self.tip_textitem = text = QGraphicsTextItem()
         # Set to the longest text
-        text.setHtml(self.tiptexts[Qt.ShiftModifier + Qt.ControlModifier])
+        text.setHtml(self.tiptexts[Qt.ControlModifier])
         text.setPos(4, 2)
         r = text.boundingRect()
         rect = QGraphicsRectItem(0, 0, r.width() + 8, r.height() + 4)
@@ -1552,7 +1552,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         keys = QApplication.keyboardModifiers()
         if keys & Qt.AltModifier:
             self.selection_remove(indices)
-        elif keys & Qt.ShiftModifier and keys & Qt.ControlModifier:
+        elif keys & Qt.ControlModifier:
             self.selection_append(indices)
         elif keys & Qt.ShiftModifier:
             self.selection_new_group(indices)

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1556,7 +1556,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         self._update_after_selection()
 
     def selection_append(self, indices):
-        self.selection[indices] = np.max(self.selection)
+        self.selection[indices] = max(np.max(self.selection), 1)
         self._update_after_selection()
 
     def selection_new_group(self, indices):

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -12,7 +12,7 @@ from AnyQt.QtCore import Qt, QRectF, QSize, QTimer, pyqtSignal as Signal, \
 from AnyQt.QtGui import QColor, QPen, QBrush, QPainterPath, QTransform, \
     QPainter
 from AnyQt.QtWidgets import QApplication, QToolTip, QGraphicsTextItem, \
-    QGraphicsRectItem
+    QGraphicsRectItem, QGraphicsItemGroup
 
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ScatterPlotItem import Symbols
@@ -557,7 +557,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         self.labels = []
 
         self.master = scatter_widget
-        self._create_drag_tooltip(self.plot_widget.scene())
+        tooltip = self._create_drag_tooltip()
+        self.view_box.setDragTooltip(tooltip)
 
         self.selection = None  # np.ndarray
 
@@ -596,7 +597,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         legend.restoreAnchor(anchor)
         return legend
 
-    def _create_drag_tooltip(self, scene):
+    def _create_drag_tooltip(self):
         tip_parts = [
             (Qt.ShiftModifier, "Shift: Add group"),
             (Qt.ControlModifier,
@@ -624,8 +625,10 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         rect.setPen(QPen(Qt.NoPen))
         self.update_tooltip()
 
-        scene.drag_tooltip = scene.createItemGroup([rect, text])
-        scene.drag_tooltip.hide()
+        tooltip_group = QGraphicsItemGroup()
+        tooltip_group.addToGroup(rect)
+        tooltip_group.addToGroup(text)
+        return tooltip_group
 
     def update_tooltip(self, modifiers=Qt.NoModifier):
         modifiers &= Qt.ShiftModifier + Qt.ControlModifier + Qt.AltModifier

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -599,10 +599,10 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
 
     def _create_drag_tooltip(self):
         tip_parts = [
-            (Qt.ShiftModifier, "Shift: Add group"),
             (Qt.ControlModifier,
              "{}: Append to group".
              format("Cmd" if sys.platform == "darwin" else "Ctrl")),
+            (Qt.ShiftModifier, "Shift: Add group"),
             (Qt.AltModifier, "Alt: Remove")
         ]
         all_parts = "<center>" + \
@@ -631,8 +631,13 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         return tooltip_group
 
     def update_tooltip(self, modifiers=Qt.NoModifier):
-        modifiers &= Qt.ShiftModifier + Qt.ControlModifier + Qt.AltModifier
-        text = self.tiptexts.get(int(modifiers), self.tiptexts[0])
+        text = self.tiptexts[0]
+        for mod in [Qt.ControlModifier,
+                    Qt.ShiftModifier,
+                    Qt.AltModifier]:
+            if modifiers & mod:
+                text = self.tiptexts.get(int(mod))
+                break
         self.tip_textitem.setHtml(text)
 
     def update_jittering(self):
@@ -1544,12 +1549,12 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         if self.selection is None:
             self.selection = np.zeros(self.n_valid, dtype=np.uint8)
         keys = QApplication.keyboardModifiers()
-        if keys & Qt.AltModifier:
-            self.selection_remove(indices)
-        elif keys & Qt.ControlModifier:
+        if keys & Qt.ControlModifier:
             self.selection_append(indices)
         elif keys & Qt.ShiftModifier:
             self.selection_new_group(indices)
+        elif keys & Qt.AltModifier:
+            self.selection_remove(indices)
         else:
             self.selection_select(indices)
 

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -630,21 +630,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
     def update_tooltip(self, modifiers=Qt.NoModifier):
         modifiers &= Qt.ShiftModifier + Qt.ControlModifier + Qt.AltModifier
         text = self.tiptexts.get(int(modifiers), self.tiptexts[0])
-        self.tip_textitem.setHtml(text + self._get_jittering_tooltip())
-
-    def _get_jittering_tooltip(self):
-        warn_jittered = ""
-        if self.jitter_size:
-            warn_jittered = \
-                '<br/><br/>' \
-                '<span style="background-color: red; color: white; ' \
-                'font-weight: 500;">' \
-                '&nbsp;Warning: Selection is applied to unjittered data&nbsp;' \
-                '</span>'
-        return warn_jittered
+        self.tip_textitem.setHtml(text)
 
     def update_jittering(self):
-        self.update_tooltip()
         x, y = self.get_coordinates()
         if x is None or len(x) == 0 or self.scatterplot_item is None:
             return

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -158,6 +158,13 @@ class InteractiveViewBox(pg.ViewBox):
     def _dragtip_pos():
         return 10, 10
 
+    def setDragTooltip(self, tooltip):
+        scene = self.scene()
+        scene.addItem(tooltip)
+        tooltip.setPos(*self._dragtip_pos())
+        tooltip.hide()
+        scene.drag_tooltip = tooltip
+
     def updateScaleBox(self, p1, p2):
         """
         Overload to use ViewBox.mapToView instead of mapRectFromParent
@@ -184,6 +191,12 @@ class InteractiveViewBox(pg.ViewBox):
             y += 1
         self.updateScaleBox(buttonDownPos, pg.Point(x, y))
 
+    def _updateDragtipShown(self, enabled):
+        scene = self.scene()
+        dragtip = scene.drag_tooltip
+        if enabled != dragtip.isVisible():
+            dragtip.setVisible(enabled)
+
     # noinspection PyPep8Naming,PyMethodOverriding
     def mouseDragEvent(self, ev, axis=None):
         def get_mapped_rect():
@@ -196,16 +209,13 @@ class InteractiveViewBox(pg.ViewBox):
             ev.accept()
             if ev.button() == Qt.LeftButton:
                 self.safe_update_scale_box(ev.buttonDownPos(), ev.pos())
-                scene = self.scene()
-                dragtip = scene.drag_tooltip
                 if ev.isFinish():
-                    dragtip.hide()
+                    self._updateDragtipShown(False)
                     self.rbScaleBox.hide()
                     value_rect = get_mapped_rect()
                     self.graph.select_by_rectangle(value_rect)
                 else:
-                    dragtip.setPos(*self._dragtip_pos())
-                    dragtip.show()  # although possibly already shown
+                    self._updateDragtipShown(True)
                     self.safe_update_scale_box(ev.buttonDownPos(), ev.pos())
 
         def zoom():

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -211,11 +211,13 @@ class InteractiveViewBox(pg.ViewBox):
                 self.safe_update_scale_box(ev.buttonDownPos(), ev.pos())
                 if ev.isFinish():
                     self._updateDragtipShown(False)
+                    self.graph.unsuspend_jittering()
                     self.rbScaleBox.hide()
                     value_rect = get_mapped_rect()
                     self.graph.select_by_rectangle(value_rect)
                 else:
                     self._updateDragtipShown(True)
+                    self.graph.suspend_jittering()
                     self.safe_update_scale_box(ev.buttonDownPos(), ev.pos())
 
         def zoom():

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -270,7 +270,7 @@ class InteractiveViewBox(pg.ViewBox):
     def mouseClickEvent(self, ev):
         if ev.button() == Qt.RightButton:  # undo zoom
             self.scaleHistory(-1)
-        else:
+        elif ev.modifiers() == Qt.NoModifier:
             ev.accept()
             self.graph.unselect_all()
 


### PR DESCRIPTION
##### Description of changes
A couple of minor changes to keyboard shortcuts and the accompanying tooltip for selection.

I removed the 'Warning: Selection is applied to unjittered data' tooltip, I appreciate the gesture in explaining that to the user, but it doesn't seem like something somebody would complain to us about. I don't see why someone would want (or expect) to have jittered data selected. (also I can't think of a way to make it look nice)

I also wanted to make the tooltip show on click+hold, but this seemed more difficult/messier to do. The problem was in resetting its visibility, other objects (e.g., ScatterPlotItem) eat the MousePressEvent.

@janezd, could you look into making the first group's color stay the same when adding a second group to selection?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
