### PR TITLE
owscatterplotgraph: Align point and selection outline

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1222,14 +1222,14 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             if sels == 1:
                 pen = np.where(
                     self._filter_visible(self.selection),
-                    _make_pen(QColor(255, 190, 0, 255), SELECTION_WIDTH + 1),
+                    _make_pen(QColor(255, 190, 0, 255), SELECTION_WIDTH),
                     nopen)
             else:
                 palette = colorpalettes.LimitedDiscretePalette(
                     number_of_colors=sels + 1)
                 pen = np.choose(
                     self._filter_visible(self.selection),
-                    [nopen] + [_make_pen(palette[i], SELECTION_WIDTH + 1)
+                    [nopen] + [_make_pen(palette[i], SELECTION_WIDTH)
                                for i in range(sels)])
         return pen, [QBrush(QColor(255, 255, 255, 0))] * self.n_shown
 


### PR DESCRIPTION
##### Issue
The selection outline of scatterplot points was off-center by a pixel. This is due to the way pyqtgraph optimizes symbol drawing in `SymbolAtlas`, and also the reason for why points look like they jitter by a pixel when changing symbol size.

Before:
![Screenshot 2020-10-18 at 16 47 13](https://user-images.githubusercontent.com/24586651/96371350-9a1ca300-1161-11eb-9725-e6af20cea58a.png)
After:
![Screenshot 2020-10-18 at 16 46 47](https://user-images.githubusercontent.com/24586651/96371351-9b4dd000-1161-11eb-9e6a-4a7273ed1b89.png)


##### Description of changes
Is there a reason for the pen to have width one larger than the set selection width? If this is necessary, it should be +2 to avoid the offset issue.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
