### PR TITLE
[FIX] CSV File Import: sort discrete values naturally

### DIFF
--- a/Orange/misc/collections.py
+++ b/Orange/misc/collections.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import List, Iterable
 
 
 class frozendict(dict):
@@ -25,7 +25,7 @@ class frozendict(dict):
         raise AttributeError("FrozenDict does not allow deleting elements")
 
 
-def natural_sorted(values: List) -> List:
+def natural_sorted(values: Iterable) -> List:
     """
     Sort values with natural sort or human order - [sth1, sth2, sth10] or
     [1, 2, 10]

--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -51,6 +51,7 @@ import pandas as pd
 from pandas.api import types as pdtypes
 
 import Orange.data
+from Orange.misc.collections import natural_sorted
 
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils.concurrent import PyOwned
@@ -1790,7 +1791,7 @@ def pandas_to_table(df):
     for header, series in df.items():  # type: (Any, pd.Series)
         if pdtypes.is_categorical_dtype(series):
             coldata = series.values  # type: pd.Categorical
-            categories = [str(c) for c in coldata.categories]
+            categories = natural_sorted(str(c) for c in coldata.categories)
             var = Orange.data.DiscreteVariable.make(
                 str(header), values=categories
             )

--- a/Orange/widgets/data/tests/data-csv-types.tab
+++ b/Orange/widgets/data/tests/data-csv-types.tab
@@ -1,6 +1,6 @@
 time	numeric1	discrete1	numeric2	discrete2	string
 2020-05-05	1	0		a	a
-2020-05-06	2	1		a	b
+2020-05-06	12	1		a	b
 2020-05-07	3	0		a	c
 2020-05-08	4	1		b	d
 2020-05-09	5	1		b	e

--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -198,6 +198,32 @@ class TestOWCSVFileImport(WidgetTest):
         self.assertIsInstance(domain["numeric2"], ContinuousVariable)
         self.assertIsInstance(domain["string"], StringVariable)
 
+    def test_discrete_values_sort(self):
+        """ Values in the discrete variable should be naturally sorted """
+        dirname = os.path.dirname(__file__)
+        path = os.path.join(dirname, "data-csv-types.tab")
+        options = owcsvimport.Options(
+            encoding="ascii", dialect=csv.excel_tab(),
+            columntypes=[
+                (range(0, 1), ColumnType.Auto),
+                (range(1, 2), ColumnType.Categorical),
+                (range(2, 5), ColumnType.Auto)
+            ]
+        )
+        widget = self.create_widget(
+            owcsvimport.OWCSVFileImport,
+            stored_settings={
+                "_session_items": [
+                    (path, options.as_dict())
+                ],
+                "__version__": 2  # guessing works for versions >= 2
+            }
+        )
+        widget.commit()
+        self.wait_until_finished(widget)
+        output = self.get_output("Data", widget)
+        self.assertTupleEqual(('1', '3', '4', '5', '12'), output.domain.attributes[1].values)
+
     def test_backward_compatibility(self):
         """
         Check that widget have old behaviour on workflows with version < 2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
File widget sorts discrete values naturally (implemented a few months ago) while CSV File Import doesn't. 

##### Description of changes
- Sort discrete values naturally when loading CSV file.
- Change type annotation for `natural_sorted` function.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
