### PR TITLE
Raise canvas-core version to fix some problems with Qt 5.9

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - chardet >=3.0.2
     - xlrd >=0.9.2
     - xlsxwriter
-    - anyqt >=0.0.8
+    - anyqt >=0.0.11
     - pyqt >=5.12,!=5.15.1
     - pyqtgraph >=0.11.0
     - joblib >=0.9.4
@@ -56,7 +56,7 @@ requirements:
     - openTSNE >=0.4.3
     - pandas
     - pyyaml
-    - orange-canvas-core >=0.1.16,<0.2a
+    - orange-canvas-core >=0.1.18,<0.2a
     - orange-widget-base >=4.8.1
     - openpyxl
     - httpx >=0.12

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,9 +1,9 @@
-orange-canvas-core>=0.1.16,<0.2a
+orange-canvas-core>=0.1.18,<0.2a
 orange-widget-base>=4.8.1
 
 PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
 PyQtWebEngine>=5.12
-AnyQt>=0.0.8
+AnyQt>=0.0.11
 
 pyqtgraph>=0.11.0
 matplotlib>=2.0.0


### PR DESCRIPTION
Even though the supported canvas-core version already requires anyqt>=0.0.11, I have also raised it here.