### PR TITLE
BarPlot: Docs - add reference to index.rst

### DIFF
--- a/doc/visual-programming/source/index.rst
+++ b/doc/visual-programming/source/index.rst
@@ -68,6 +68,7 @@ Visualize
    widgets/visualize/heatmap
    widgets/visualize/scatterplot
    widgets/visualize/lineplot
+   widgets/visualize/barplot
    widgets/visualize/venndiagram
    widgets/visualize/linearprojection
    widgets/visualize/sievediagram

--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -343,7 +343,7 @@
    },
    {
     "text": "Bar Plot",
-    "doc": null,
+    "doc": "visual-programming/source/widgets/visualize/barplot.md",
     "icon": "../Orange/widgets/visualize/icons/BarPlot.svg",
     "background": "#FFB7B1",
     "keywords": [


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
A reference to the `barplot.md` is missing in the `index.rst`.

##### Description of changes
Add the reference to the`index.rst`.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
