### PR TITLE
owdataprojectionwidget: Update labels on attr change

### DIFF
--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -554,6 +554,8 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
             self.__pending_selection = None
             self.graph.selection = selection
             self.graph.update_selection_colors()
+            if self.graph.label_only_selected:
+                self.graph.update_labels()
 
     def selection_changed(self):
         sel = None if self.data and isinstance(self.data, SqlTable) \


### PR DESCRIPTION
##### Issue
File (Iris) -> OWScatterPlot
Enable 'Label only selection and subset', choose a label, choose some points
Change one of the attribute

The points will still be selected, but won't have labels displayed next to them. This is easily fixable by toggling the 'Label only selection and subset' option.

##### Description of changes
Retain labels next to selected points upon attribute change.

I'd love to write a test for this, but I'm honestly not sure where to do it. Could someone advise me?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
