### PR TITLE
SVM: Set default coef0 in polynomial kernel to 1

### DIFF
--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -54,7 +54,7 @@ class OWSVM(OWBaseLearner):
     #: gamma
     gamma = Setting(0.0)
     #: coef0 (adative constant)
-    coef0 = Setting(0.0)
+    coef0 = Setting(1.0)
 
     #: numerical tolerance
     tol = Setting(0.001)


### PR DESCRIPTION
##### Issue

While the scikit-learn's default is indeed 0, we use its defaults in lower-level code, but user-friendlier defaults in the widget. A default of 1 is user-friendlier (0 is generally useless).

##### Includes
- [X] Code changes
