### PR TITLE
Reintroduce PerfectMatch for domain context matching

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -116,6 +116,9 @@ class SelectAttributesDomainContextHandler(DomainContextHandler):
         return decoded
 
     def match(self, context, domain, attrs, metas):
+        if context.attributes == attrs and context.metas == metas:
+            return self.PERFECT_MATCH
+
         if not "domain_role_hints" in context.values:
             return self.NO_MATCH
 

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -203,6 +203,9 @@ class DomainContextHandler(ContextHandler):
                 metas.get(attr_name, -1) == attr_type)
 
     def match(self, context, domain, attrs, metas):
+        if context.attributes == attrs and context.metas == metas:
+            return self.PERFECT_MATCH
+
         matches = []
         try:
             for setting, data, _ in \

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -178,7 +178,7 @@ class TestOWLinearProjection(WidgetTest, AnchorProjectionWidgetTestMixin,
 
         self.widget.setup_plot.reset_mock()
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.widget.setup_plot.assert_not_called()
+        self.widget.setup_plot.assert_called_once()
 
     def test_two_classes_dataset(self):
         self.widget.radio_placement.buttons[1].click()

--- a/Orange/widgets/visualize/tests/test_owradviz.py
+++ b/Orange/widgets/visualize/tests/test_owradviz.py
@@ -128,4 +128,4 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
 
         self.widget.setup_plot.reset_mock()
         self.send_signal(self.widget.Inputs.data, self.data)
-        self.widget.setup_plot.assert_not_called()
+        self.widget.setup_plot.assert_called_once()


### PR DESCRIPTION
##### Issue

Fixes #5051 to the extent (I believe) possible.

##### Description of changes

When the variables and metas are the same as those in some previous context, always use this context. Currently, the handler chooses the most recent context that has all relevant variables.

Some unexpected behaviour will remain, but I believe that it is impossible to define what has to happen in each particular instance becuase it depends on the combination of widgets and the user's intentions.

The fix introduces a slight bug: the context stores `variables` and `metas`, not `attributes, `class_vars` and `metas`. Two domains may be treated as the same although they're not, which could cause problems in any (mis)behaving(?) widgets. The problem is that this bug cannot be fixed without a backward incompatible change in data stored in domain context handlers.


The changes in tests were required because the test relied to (and essentially tested) the behaviour of context handler and not that of the widget.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
