### PR TITLE
Distance Matrix: Ignore coloring on string variables

### DIFF
--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -7,7 +7,7 @@ from AnyQt.QtGui import QColor, QPen, QBrush
 from AnyQt.QtCore import Qt, QAbstractTableModel, QModelIndex, \
     QItemSelectionModel, QItemSelection, QSize
 
-from Orange.data import Table, Variable
+from Orange.data import Table, Variable, StringVariable
 from Orange.misc import DistMatrix
 from Orange.widgets import widget, gui
 from Orange.widgets.data.owtable import ranges
@@ -46,7 +46,8 @@ class DistanceMatrixModel(QAbstractTableModel):
         self.labels = labels
         self.variable = variable
         self.values = values
-        if self.values is not None:
+        if self.values is not None and not isinstance(self.variable,
+                                                      StringVariable):
             self.label_colors = variable.palette.values_to_qcolors(values)
         else:
             self.label_colors = None

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -36,3 +36,13 @@ class TestOWDistanceMatrix(WidgetTest):
             commit.reset_mock()
             self.send_signal(self.widget.Inputs.distances, self.distances)
             commit.assert_called()
+
+    def test_labels(self):
+        grades = Table.from_url("https://datasets.biolab.si/core/grades-two.tab")
+        distances = Euclidean(grades)
+        self.widget.set_distances(distances)
+        ac = self.widget.annot_combo
+        idx = ac.model().indexOf(grades.domain.metas[0])
+        ac.setCurrentIndex(idx)
+        ac.activated.emit(idx)
+        self.assertIsNone(self.widget.tablemodel.label_colors)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5061. 

##### Description of changes
Ignore coloring by attribute when attribute is string.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
