### PR TITLE
__main__: Restart on exit code 96

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 from urllib.request import urlopen, Request
 
 import pkg_resources
+import psutil
 import yaml
 
 from AnyQt.QtGui import QFont, QColor, QPalette, QDesktopServices, QIcon
@@ -39,6 +40,7 @@ from orangecanvas.application.application import CanvasApplication
 from orangecanvas.application.outputview import TextStream, ExceptHook
 from orangecanvas.document.usagestatistics import UsageStatistics
 from orangecanvas.gui.splashscreen import SplashScreen
+from orangecanvas.utils.after_exit import run_after_exit
 from orangecanvas.utils.overlay import Notification, NotificationServer
 from orangecanvas.main import (
     fix_win_pythonw_std_stream, fix_set_proxy_env, fix_macos_nswindow_tabbing,
@@ -360,6 +362,7 @@ def send_usage_statistics():
     return thread
 
 
+# pylint: disable=too-many-locals
 def main(argv=None):
     # Allow termination with CTRL + C
     signal.signal(signal.SIGINT, signal.SIG_DFL)
@@ -699,6 +702,11 @@ def main(argv=None):
     gc.collect()
 
     del app
+
+    if status == 96:
+        log.info('Restarting via exit code 96.')
+        run_after_exit([sys.executable, sys.argv[0]])
+
     return status
 
 

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -24,7 +24,6 @@ from unittest.mock import patch
 from urllib.request import urlopen, Request
 
 import pkg_resources
-import psutil
 import yaml
 
 from AnyQt.QtGui import QFont, QColor, QPalette, QDesktopServices, QIcon
@@ -362,7 +361,7 @@ def send_usage_statistics():
     return thread
 
 
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals,too-many-branches
 def main(argv=None):
     # Allow termination with CTRL + C
     signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.1.18,<0.2a
+orange-canvas-core>=0.1.19,<0.2a
 orange-widget-base>=4.11.0
 
 PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns


### PR DESCRIPTION
https://github.com/biolab/orange-canvas-core/pull/153
https://github.com/biolab/orange-widget-base/pull/113

Decoupled from #5064.

This should be merged after https://github.com/biolab/orange-canvas-core/pull/157 is merged and released.

I considered running `execv` with the arguments Orange was run with previously (e.g., open a workflow), but it didn't seem much more intuitive than a feature that would automatically open the previously opened workflow on starting Orange (idea?).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
