### PR TITLE
SQL: Adding support for other databases through SQLAlchemy

### DIFF
--- a/Orange/data/sql/backend/__init__.py
+++ b/Orange/data/sql/backend/__init__.py
@@ -9,3 +9,5 @@ try:
     from .mssql import PymssqlBackend
 except ImportError:
     pass
+
+from .alchemy_base import SQLAlchemyBackend, MSSqlAlchemy, MySqlAlchemy

--- a/Orange/data/sql/backend/__init__.py
+++ b/Orange/data/sql/backend/__init__.py
@@ -10,4 +10,4 @@ try:
 except ImportError:
     pass
 
-from .alchemy_base import SQLAlchemyBackend, MSSqlAlchemy, MySqlAlchemy
+from .alchemy_base import SQLAlchemyBackend, MySqlAlchemy

--- a/Orange/data/sql/backend/alchemy_base.py
+++ b/Orange/data/sql/backend/alchemy_base.py
@@ -1,0 +1,269 @@
+from contextlib import contextmanager
+from datetime import date, datetime, time
+from typing import Optional, List, Iterable, Tuple, Any, Union
+
+from sqlalchemy import create_engine, MetaData, select, Table, text, func
+from sqlalchemy.exc import NoSuchTableError, ProgrammingError
+from sqlalchemy.sql import Select
+from sqlalchemy.sql.ddl import DDLElement
+from sqlalchemy.sql.elements import and_, TextClause
+from sqlalchemy.sql.sqltypes import NullType
+from sqlalchemy.ext import compiler
+
+from Orange.data import (
+    StringVariable,
+    TimeVariable,
+    ContinuousVariable,
+    DiscreteVariable,
+    Domain,
+)
+from Orange.data.sql.backend import Backend
+from Orange.data.sql.backend.base import ToSql, BackendError, TableDesc
+
+
+class CreateTableAs(DDLElement):
+    def __init__(self, name, selectable):
+        self.name = name
+        self.selectable = selectable
+
+
+@compiler.compiles(CreateTableAs)
+def compile(element, _, **kw):
+    # in case any backend uses different syntax reimplement this function
+    # for it
+    return "CREATE TABLE %s AS %s" % (element.name, element.selectable)
+
+
+class SQLAlchemyBackend(Backend):
+    connection_string = (
+        "{dialect_driver}://{user}:{password}@{host}:"
+        "{port}/{database}?charset=utf8"
+    )
+    dialect_driver = None
+
+    def __init__(self, connection_params: dict):
+        print("init")
+        super().__init__(connection_params)
+        self.engine = create_engine(
+            self.connection_string.format(
+                dialect_driver=self.dialect_driver, **connection_params
+            )
+        )
+
+    def list_tables(self, schema: Optional[str] = None):
+        if not schema:
+            schema = None
+        tables = []
+        for t in self.engine.table_names(schema=schema):
+            s_t = (schema, t,) if schema else (t,)
+            tables.append(TableDesc(t, schema, ".".join(s_t)))
+        return tables
+
+    def create_sql_query(
+        self,
+        table_name: str,
+        fields: List[str],
+        filters: Iterable[str] = (),
+        group_by: Optional[List[str]] = None,
+        order_by: Optional[List[str]] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        use_time_sample: Optional[int] = None,
+    ) -> Select:
+        stn = table_name.split(".")
+        schema, table_name = (None, stn[0]) if len(stn) == 1 else stn
+        meta = MetaData(bind=self.engine, schema=schema)
+        try:
+            table = Table(table_name, meta, autoload=True)
+        except NoSuchTableError:
+            # when from SQL sentence - custom SQL in Orange
+            table = text(table_name)
+
+        columns = []
+        for f in fields:
+            if isinstance(table, TextClause):
+                columns.append(text(f))
+            elif "AS" in f:
+                col, label = f.split("AS")
+                columns.append(
+                    table.c[col.strip("() ")].label(label.strip("() "))
+                )
+            elif "(" in f or f == "*":
+                # fields is a function
+                # TODO: think about not allowing this
+                #  make separate functions for e.g. count
+                columns.append(text(f))
+            else:
+                columns.append(table.c[f])
+
+        query = select(columns).select_from(table)
+        # MSSQL requires an order_by when using an OFFSET or a non-simple
+        # LIMIT clause
+        # TODO: check if order_by(None) would be fine
+        if offset and not order_by:
+            order_by = [x.strip('" ') for x in fields[0].split("AS")[1:]]
+
+        if use_time_sample is not None:
+            query = query.tablesample(func.system_time(1000))
+        if filters:
+            query = query.where(and_(text(f) for f in filters))
+        if order_by is not None:
+            query = query.order_by(*[text(o) for o in order_by])
+        if limit is not None:
+            query = query.limit(limit)
+        if offset is not None:
+            query = query.offset(offset)
+        if group_by is not None:
+            query = query.group_by(*[text(g) for g in group_by])
+        print(query)
+        return query
+
+    @contextmanager
+    def execute_sql_query(
+        self, query: Union[Select, str], params: Optional[Tuple[Any]] = ()
+    ):
+        with self.engine.connect() as connection:
+            try:
+                result = connection.execute(
+                    text(query) if isinstance(query, str) else query, *params
+                )
+                yield result
+                result.close()
+            except ProgrammingError as ex:
+                raise BackendError(str(ex)) from ex
+
+    def get_fields(self, table_name: str):
+        query = self.create_sql_query(table_name, ["*"], limit=3)
+        types = {
+            c.name: c.type.python_type
+            for c in query.inner_columns
+            if not isinstance(c.type, NullType)
+        }
+
+        # for plain textual SQL query types cannot be retrieved form the query
+        # so we get missing types from data
+        with self.execute_sql_query(query) as cur:
+            res = cur.fetchall()
+            missing = set(cur.keys()) - set(types.keys())
+            for col in missing:
+                if len(res) > 0:
+                    t = set([type(r[col]) for r in res])
+                    assert len(t) == 1  # types must match
+                    (t,) = t  # unpack set
+                else:
+                    t = str
+                types[col] = t
+        return list(types.items())
+
+    def _guess_variable(
+        self,
+        field_name: str,
+        field_metadata: Tuple,
+        inspect_table: Optional[str],
+    ):
+        type_ = field_metadata[0]
+
+        if type_ == float:
+            return ContinuousVariable.make(field_name)
+
+        if type_ in (datetime, date, time):
+            return TimeVariable(
+                field_name,
+                have_date=type_ in (date, datetime),
+                have_time=type_ in (time, datetime),
+            )
+
+        if type_ == int:
+            if inspect_table:
+                values = self.get_distinct_values(field_name, inspect_table)
+                if values:
+                    return DiscreteVariable(field_name, values)
+            return ContinuousVariable(field_name)
+
+        if type_ == bool:
+            return DiscreteVariable(field_name, ["false", "true"])
+
+        if type_ == str:
+            if inspect_table:
+                values = self.get_distinct_values(field_name, inspect_table)
+                # remove trailing spaces
+                values = [v.rstrip() for v in values]
+                if values:
+                    return DiscreteVariable(field_name, values)
+
+        return StringVariable(field_name)
+
+    def create_variable(
+        self,
+        field_name: str,
+        field_metadata: Tuple[Any],
+        type_hints: Domain,
+        inspect_table: Optional[str] = None,
+    ):
+        if field_name in type_hints:
+            var = type_hints[field_name]
+        else:
+            var = self._guess_variable(
+                field_name, field_metadata, inspect_table
+            )
+
+        field_name_q = self.quote_identifier(field_name)
+        if var.is_continuous:
+            if isinstance(var, TimeVariable):
+                var.to_sql = ToSql(field_name_q)
+            else:
+                var.to_sql = ToSql(field_name_q)
+        else:  # discrete or string
+            var.to_sql = ToSql(field_name_q)
+        return var
+
+    def count_approx(self, query: Select):
+        """
+        Count is faster than fetching complete table
+        """
+        q = query.alias("subquery")
+        q = select([text("COUNT(*)")]).select_from(q)
+        with self.execute_sql_query(q) as cur:
+            return cur.fetchone()[0]
+
+    def unquote_identifier(self, quoted_name: str) -> str:
+        return quoted_name
+
+    def quote_identifier(self, name: str) -> str:
+        return name
+
+    def create_table(self, name: str, sql: str) -> None:
+        with self.engine.begin() as conn:
+            conn.execute(CreateTableAs(name, sql))
+
+    def drop_table(self, name):
+        stn = name.split(".")
+        schema, table_name = (None, stn[0]) if len(stn) == 1 else stn
+        meta = MetaData(bind=self.engine, schema=schema)
+        try:
+            table = Table(table_name, meta, autoload=True)
+        except NoSuchTableError:
+            return
+        table.drop()
+
+    def table_exists(self, name: str) -> bool:
+        return self.engine.dialect.has_table(self.engine, name)
+
+
+class MSSqlAlchemy(SQLAlchemyBackend):
+    display_name = "MS Server Alchemy"
+    dialect_driver = "mssql+pymssql"
+
+
+class MySqlAlchemy(SQLAlchemyBackend):
+    display_name = "MySQL Alchemy"
+    # we decided to use mysqlclient from pypi
+    # installed via: pip install mysqlclient
+    dialect_driver = "mysql+mysqldb"
+
+
+class SqliteAlchemy(SQLAlchemyBackend):
+    display_name = "Sqllite"
+    # requirement sqlite3 - included in the standard module
+    dialect_driver = "sqlite+pysqlite"
+    connection_string = "{dialect_driver}:///{database}"

--- a/Orange/data/sql/backend/alchemy_base.py
+++ b/Orange/data/sql/backend/alchemy_base.py
@@ -267,3 +267,15 @@ class SqliteAlchemy(SQLAlchemyBackend):
     # requirement sqlite3 - included in the standard module
     dialect_driver = "sqlite+pysqlite"
     connection_string = "{dialect_driver}:///{database}"
+
+
+class OracleAlchemy(SQLAlchemyBackend):
+    display_name = "Oracle Alchemy"
+    # installed via: pip install cx-oracle
+    import cx_Oracle
+    cx_Oracle.init_oracle_client(lib_dir=r'/Users/primoz/instantclient_19_8/')
+    dialect_driver = "oracle+cx_oracle"
+    connection_string = (
+        "{dialect_driver}://{user}:{password}@{host}:"
+        "{port}/{database}?encoding=UTF-8&nencoding=UTF-8"
+    )

--- a/Orange/data/sql/backend/alchemy_base.py
+++ b/Orange/data/sql/backend/alchemy_base.py
@@ -250,11 +250,6 @@ class SQLAlchemyBackend(Backend):
         return self.engine.dialect.has_table(self.engine, name)
 
 
-class MSSqlAlchemy(SQLAlchemyBackend):
-    display_name = "MS Server Alchemy"
-    dialect_driver = "mssql+pymssql"
-
-
 class MySqlAlchemy(SQLAlchemyBackend):
     display_name = "MySQL Alchemy"
     # we decided to use mysqlclient from pypi
@@ -263,19 +258,16 @@ class MySqlAlchemy(SQLAlchemyBackend):
 
 
 class SqliteAlchemy(SQLAlchemyBackend):
-    display_name = "Sqllite"
+    display_name = "SQLite"
     # requirement sqlite3 - included in the standard module
     dialect_driver = "sqlite+pysqlite"
     connection_string = "{dialect_driver}:///{database}"
 
-
-class OracleAlchemy(SQLAlchemyBackend):
-    display_name = "Oracle Alchemy"
-    # installed via: pip install cx-oracle
-    import cx_Oracle
-    cx_Oracle.init_oracle_client(lib_dir=r'/Users/primoz/instantclient_19_8/')
-    dialect_driver = "oracle+cx_oracle"
-    connection_string = (
-        "{dialect_driver}://{user}:{password}@{host}:"
-        "{port}/{database}?encoding=UTF-8&nencoding=UTF-8"
-    )
+    # sqllite needs just the path to the file with the database other fields
+    # must be disabled in the widget - None means disabled field
+    widget_gui_fields = {
+        "servertext": None,
+        "databasetext": ("Database file path", "The path to the SQLite database"),
+        "usernametext": None,
+        "passwordtext":None
+    }

--- a/Orange/data/sql/backend/base.py
+++ b/Orange/data/sql/backend/base.py
@@ -28,7 +28,10 @@ class Backend(metaclass=Registry):
     @classmethod
     def available_backends(cls):
         """Return a list of all available backends"""
-        return cls.registry.values()
+        return [
+            c for c in cls.registry.values()
+            if c.__name__ != "SQLAlchemyBackend"
+        ]
 
     # "meta" methods
 
@@ -220,6 +223,36 @@ class Backend(metaclass=Registry):
         """
         raise NotImplementedError
 
+    def create_table(self, name: str, sql: str) -> None:
+        """
+        Create new SQL table with provided name form the SQL query
+
+        Parameters
+        ----------
+        name
+            The name of the new table
+        sql
+            The sql query
+        """
+        raise NotImplementedError
+
+    def drop_table(self, name):
+        """
+        Drops table from the database
+
+        Parameters
+        ----------
+        name
+            Database name
+        """
+        raise NotImplementedError
+
+    def table_exists(self, name: str) -> bool:
+        """
+        Check if table exists in the database
+        """
+        raise NotImplementedError
+
 
 class TableDesc:
     def __init__(self, name, schema, sql):
@@ -229,6 +262,7 @@ class TableDesc:
 
     def __str__(self):
         return self.name
+
 
 class ToSql:
     def __init__(self, sql):

--- a/Orange/data/sql/backend/mssql.py
+++ b/Orange/data/sql/backend/mssql.py
@@ -20,6 +20,8 @@ class PymssqlBackend(Backend):
     display_name = "Ms SQL Server"
 
     def __init__(self, connection_params):
+        # to avoid editing the dictionary from upstream
+        connection_params = connection_params.copy()
         connection_params["server"] = connection_params.pop("host", None)
 
         for key in list(connection_params):

--- a/Orange/data/sql/backend/postgres.py
+++ b/Orange/data/sql/backend/postgres.py
@@ -177,8 +177,26 @@ class Psycopg2Backend(Backend):
     def count_approx(self, query):
         sql = "EXPLAIN " + query
         with self.execute_sql_query(sql) as cur:
-            s = ''.join(row[0] for row in cur.fetchall())
+            s = ''.join(  w[0] for row in cur.fetchall())
         return int(re.findall(r'rows=(\d*)', s)[0])
+
+    def create_table(self, name: str, sql: str) -> None:
+        query = f"CREATE TABLE {name} AS {sql}"
+        with self.execute_sql_query(query):
+            pass
+
+    def drop_table(self, name):
+        query = f"DROP TABLE IF EXISTS {name}"
+        with self.execute_sql_query(query):
+            pass
+
+    def table_exists(self, name: str) -> bool:
+        stmt = (
+            f"SELECT * FROM information_schema.tables " 
+            f"WHERE TABLE_NAME = '{name}'"
+        )
+        with self.execute_sql_query(stmt) as cur:
+            return bool(cur.fetchone())
 
     def __getstate__(self):
         # Drop connection_pool from state as it cannot be pickled

--- a/Orange/data/sql/backend/postgres.py
+++ b/Orange/data/sql/backend/postgres.py
@@ -177,7 +177,7 @@ class Psycopg2Backend(Backend):
     def count_approx(self, query):
         sql = "EXPLAIN " + query
         with self.execute_sql_query(sql) as cur:
-            s = ''.join(  w[0] for row in cur.fetchall())
+            s = ''.join(row[0] for row in cur.fetchall())
         return int(re.findall(r'rows=(\d*)', s)[0])
 
     def create_table(self, name: str, sql: str) -> None:

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -13,7 +13,7 @@ import numpy as np
 from Orange.data import (
     Table, Domain, Value, Instance, filter, DiscreteVariable)
 from Orange.data.sql import filter as sql_filter
-from Orange.data.sql.backend import Backend, MSSqlAlchemy
+from Orange.data.sql.backend import Backend, MySqlAlchemy
 from Orange.data.sql.backend.base import TableDesc, BackendError
 
 LARGE_TABLE = 100000
@@ -676,7 +676,7 @@ if __name__ == "__main__":
                   user="SA",
                   password="1a2B3@4c5d"),
              "Inventory",
-             backend=MSSqlAlchemy,
+             backend=MySqlAlchemy,
              inspect_values=False)
     print(table.domain)
     print(table[0])

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -76,7 +76,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         table2 = SqlTable(self.conn, self.iris)
         self.assertEqual(table1.domain[0], table2.domain[0])
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_len(self):
         with self.sql_table_from_data(zip(self.float_variable(26))) as table:
             self.assertEqual(len(table), 26)
@@ -84,14 +84,15 @@ class TestSqlTable(unittest.TestCase, dbt):
         with self.sql_table_from_data(zip(self.float_variable(0))) as table:
             self.assertEqual(len(table), 0)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_bool(self):
         with self.sql_table_from_data(()) as table:
+            print(table)
             self.assertEqual(bool(table), False)
         with self.sql_table_from_data(zip(self.float_variable(1))) as table:
             self.assertEqual(bool(table), True)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_len_with_filter(self):
         data = zip(self.discrete_variable(26))
         with self.sql_table_from_data(data) as table:
@@ -104,7 +105,7 @@ class TestSqlTable(unittest.TestCase, dbt):
             filtered_table = filter.SameValue(table.domain[0], 'x')(table)
             self.assertEqual(len(filtered_table), 0)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_XY_small(self):
         mat = np.random.randint(0, 2, (20, 3))
         conn, table_name = self.create_sql_table(mat)
@@ -114,7 +115,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     @unittest.mock.patch("Orange.data.sql.table.AUTO_DL_LIMIT", 100)
     def test_XY_large(self):
         from Orange.data.sql.table import AUTO_DL_LIMIT as DLL
@@ -136,7 +137,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_download_data(self):
         mat = np.random.randint(0, 2, (20, 3))
         conn, table_name = self.create_sql_table(mat)
@@ -148,19 +149,19 @@ class TestSqlTable(unittest.TestCase, dbt):
         # has all necessary class members to create a standard Table
         Table.from_table(sql_table.domain, sql_table)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_query_all(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         results = list(table)
 
         self.assertEqual(len(results), 150)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_unavailable_row(self):
         table = SqlTable(self.conn, self.iris)
         self.assertRaises(IndexError, lambda: table[151])
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_query_subset_of_attributes(self):
         table = SqlTable(self.conn, self.iris)
         attributes = [
@@ -202,12 +203,12 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertEqual(len(results), 140)
         self.assertSequenceEqual(results, all_results[10:])
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_getitem_single_value(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         self.assertAlmostEqual(table[0, 0], 5.1)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_type_hints(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         self.assertEqual(len(table.domain), 5)
@@ -284,7 +285,7 @@ class TestSqlTable(unittest.TestCase, dbt):
     IRIS_VARIABLE = DiscreteVariable(
         "iris", values=('Iris-setosa', 'Iris-virginica', 'Iris-versicolor'))
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_class_var_type_hints(self):
         iris = SqlTable(self.conn, self.iris,
                         type_hints=Domain([], self.IRIS_VARIABLE))
@@ -292,7 +293,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertEqual(len(iris.domain.class_vars), 1)
         self.assertEqual(iris.domain.class_vars[0].name, 'iris')
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_metas_type_hints(self):
         iris = SqlTable(self.conn, self.iris,
                         type_hints=Domain([], [], metas=[self.IRIS_VARIABLE]))
@@ -300,7 +301,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertEqual(len(iris.domain.metas), 1)
         self.assertEqual(iris.domain.metas[0].name, 'iris')
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_select_all(self):
         iris = SqlTable(self.conn, "SELECT * FROM iris",
                         type_hints=Domain([], self.IRIS_VARIABLE))
@@ -318,7 +319,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_continous_bigint(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['bigint'])
@@ -340,7 +341,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_continous_int(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['int'])
@@ -362,7 +363,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_continous_smallint(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['smallint'])
@@ -384,7 +385,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_discrete_char(self):
         table = np.array(['M', 'F', 'M', 'F', 'M', 'F']).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['char(1)'])
@@ -404,7 +405,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertSequenceEqual(sql_table.domain[0].values, ['F', 'M'])
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_meta_char(self):
         table = np.array(list('ABCDEFGHIJKLMNOPQRSTUVW')).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['char(1)'])
@@ -415,7 +416,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_discrete_varchar(self):
         table = np.array(['M', 'F', 'M', 'F', 'M', 'F']).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['varchar(1)'])
@@ -426,7 +427,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_meta_varchar(self):
         table = np.array(list('ABCDEFGHIJKLMNOPQRSTUVW')).reshape(-1, 1)
         conn, table_name = self.create_sql_table(table, ['varchar(1)'])
@@ -503,7 +504,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_double_precision(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['double precision'])
@@ -514,7 +515,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_numeric(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['numeric(15, 2)'])
@@ -525,7 +526,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_real(self):
         table = np.arange(25).reshape((-1, 1))
         conn, table_name = self.create_sql_table(table, ['real'])
@@ -597,7 +598,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         filters = filter.Values([filter.FilterString(-1, filter.FilterString.Equal, 'foo')])
         self.assertEqual(len(filters(sql_table)), 0)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_recovers_connection_after_sql_error(self):
         conn, table_name = self.create_sql_table(
             np.arange(25).reshape((-1, 1)))
@@ -661,7 +662,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertEqual(stats.nans, 0)
         self.assertEqual(stats.non_nans, 150)
 
-    @dbt.run_on(["postgres", "mssql"])
+    @dbt.run_on(["postgres", "mssql", "mysql"])
     def test_distributions(self):
         iris = SqlTable(self.conn, self.iris, inspect_values=True)
 
@@ -716,6 +717,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertGreater(len(table.domain.metas), 0)
         attr = table.domain[-1]
         self.assertIsInstance(attr, variable_type)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/data/owdatainfo.py
+++ b/Orange/widgets/data/owdatainfo.py
@@ -168,7 +168,7 @@ class OWDataInfo(widget.OWWidget):
         if SqlTable is not None and isinstance(data, SqlTable):
             connection_string = ' '.join(
                 '{}={}'.format(key, value)
-                for key, value in data.connection_params.items()
+                for key, value in data.backend.connection_params.items()
                 if value is not None and key != 'password')
             self.location = "Table '{}', using connection:\n{}"\
                             .format(data.table_name, connection_string)

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -228,16 +228,12 @@ class OWSql(OWBaseSql):
                         "Specify a table name to materialize the query")
                     return None
                 try:
-                    with self.backend.execute_sql_query("DROP TABLE IF EXISTS " +
-                                                        self.materialize_table_name):
-                        pass
-                    with self.backend.execute_sql_query("CREATE TABLE " +
-                                                        self.materialize_table_name +
-                                                        " AS " + self.sql):
-                        pass
-                    with self.backend.execute_sql_query("ANALYZE " + self.materialize_table_name):
-                        pass
+                    self.backend.drop_table(self.materialize_table_name)
+                    self.backend.create_table(self.materialize_table_name, self.sql)
+                    if not self.backend.table_exists(self.materialize_table_name):
+                        raise ValueError(f"Table {self.materialize_table_name} was not created")
                 except BackendError as ex:
+                    raise ex
                     self.Error.connection(str(ex))
                     return None
 

--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -84,6 +84,7 @@ class OWSql(OWBaseSql):
         super()._setup_gui()
         self._add_backend_controls()
         self._add_tables_controls()
+        self._update_interface()
 
     def _add_backend_controls(self):
         box = self.serverbox
@@ -100,32 +101,9 @@ class OWSql(OWBaseSql):
         self.backendcombo.currentTextChanged.connect(self.__backend_changed)
         box.layout().insertWidget(0, self.backendcombo)
 
-    def update_interface(self, backend):
-        """
-        Some databases different credentials e.g. SQLite is just a file with
-        one database and without username and password it only need database
-        path specified.
-
-        In those cases default field names are replaced with field names
-        defined in the backend class.
-        """
-        gui_settings = backend.widget_gui_fields if hasattr(backend, "widget_gui_fields") else GUI_FIELDS
-        for field, setting in gui_settings.items():
-            view: QLineEdit = getattr(self, field)
-            if setting:
-                # if the field setting is not None set placeholder and tooltip
-                view.setEnabled(True)
-                view.setPlaceholderText(setting[0])
-                view.setToolTip(setting[1])
-            else:
-                # if none set placeholder and tooltip to default and disable field
-                view.setEnabled(False)
-                view.setPlaceholderText(GUI_FIELDS[field][0])
-                view.setToolTip(GUI_FIELDS[field][1])
-
     def __backend_changed(self):
         backend = self.get_backend()
-        self.update_interface(backend)
+        self._update_interface()
         self.selected_backend = backend.display_name if backend else None
 
     def _add_tables_controls(self):
@@ -258,7 +236,6 @@ class OWSql(OWBaseSql):
                     if not self.backend.table_exists(self.materialize_table_name):
                         raise ValueError(f"Table {self.materialize_table_name} was not created")
                 except BackendError as ex:
-                    raise ex
                     self.Error.connection(str(ex))
                     return None
 

--- a/Orange/widgets/utils/owbasesql.py
+++ b/Orange/widgets/utils/owbasesql.py
@@ -16,6 +16,15 @@ from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.widget import OWWidget, Msg
 
 
+# the name of the field (placeholder and the tooltip)
+GUI_FIELDS = {
+    "servertext": ("Server", "Server"),
+    "databasetext": ("Database[/Schema]", "Database or optionally Database/Schema"),
+    "usernametext": ("Username", "Username"),
+    "passwordtext": ("Password", "Password")
+}
+
+
 class OWBaseSql(OWWidget, openclass=True):
     """Base widget for connecting to a database.
     Override `get_backend` when subclassing to get corresponding backend.
@@ -50,8 +59,8 @@ class OWBaseSql(OWWidget, openclass=True):
         vbox = gui.vBox(self.controlArea, "Server", addSpace=True)
         self.serverbox = gui.vBox(vbox)
         self.servertext = QLineEdit(self.serverbox)
-        self.servertext.setPlaceholderText("Server")
-        self.servertext.setToolTip("Server")
+        self.servertext.setPlaceholderText(GUI_FIELDS["servertext"][0])
+        self.servertext.setToolTip(GUI_FIELDS["servertext"][1])
         self.servertext.editingFinished.connect(self._load_credentials)
         if self.host:
             self.servertext.setText(self.host if not self.port else
@@ -59,21 +68,21 @@ class OWBaseSql(OWWidget, openclass=True):
         self.serverbox.layout().addWidget(self.servertext)
 
         self.databasetext = QLineEdit(self.serverbox)
-        self.databasetext.setPlaceholderText("Database[/Schema]")
-        self.databasetext.setToolTip("Database or optionally Database/Schema")
+        self.databasetext.setPlaceholderText(GUI_FIELDS["databasetext"][0])
+        self.databasetext.setToolTip(GUI_FIELDS["databasetext"][1])
         if self.database:
             self.databasetext.setText(
                 self.database if not self.schema else
                 "{}/{}".format(self.database, self.schema))
         self.serverbox.layout().addWidget(self.databasetext)
         self.usernametext = QLineEdit(self.serverbox)
-        self.usernametext.setPlaceholderText("Username")
-        self.usernametext.setToolTip("Username")
+        self.usernametext.setPlaceholderText(GUI_FIELDS["usernametext"][0])
+        self.usernametext.setToolTip(GUI_FIELDS["usernametext"][1])
 
         self.serverbox.layout().addWidget(self.usernametext)
         self.passwordtext = QLineEdit(self.serverbox)
-        self.passwordtext.setPlaceholderText("Password")
-        self.passwordtext.setToolTip("Password")
+        self.passwordtext.setPlaceholderText(GUI_FIELDS["passwordtext"][0])
+        self.passwordtext.setToolTip(GUI_FIELDS["passwordtext"][1])
         self.passwordtext.setEchoMode(QLineEdit.Password)
 
         self.serverbox.layout().addWidget(self.passwordtext)


### PR DESCRIPTION
It is still a work in progress.

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Missing support for some commonly used databases (SQLite, MySQL, Oracle) in SQL Widget, bugs in current implementations for MSSQL Server and PostgreSQL.

##### Description of changes
Added support for other commonly used databases:
- SQLite
- MySQL
- Oracle
- Accepting suggestions for others

Bug fixes

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
