### PR TITLE
Require pyqtgraph==0.11.0

### DIFF
--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -5,5 +5,5 @@ PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select c
 PyQtWebEngine>=5.12
 AnyQt>=0.0.11
 
-pyqtgraph>=0.11.0
+pyqtgraph==0.11.0
 matplotlib>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ commands =
 [testenv:future_compatibility]
 deps =
     {[testenv]deps}
-    git+git://github.com/pyqtgraph/pyqtgraph.git#egg=pyqtgraph
     git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
 


### PR DESCRIPTION
##### Issue
Failing future compatibility test due to changes in pyqtgraph master.
Many of our widgets, which use pyqtgraph, stop working properly on the master branch.

##### Description of changes
Remove pyqtgraph master testing in future compatibility.
Clamp required pyqtgraph version to 0.11.0.

It'd be good to see exactly what's wrong and get into contact with @pyqtgraph. Maybe they made a breaking change not caught by their tests, or we're using their libraries wrong, in which case they'd be able to advise us on what to do.

For the time being, this PR stops our builds from failing and prevents any future compatibility issues.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
