### PR TITLE
[FIX] impute: Remove class vars from input data for ReplaceUnknownsModel

### DIFF
--- a/Orange/tests/test_impute.py
+++ b/Orange/tests/test_impute.py
@@ -229,9 +229,12 @@ class TestModel(unittest.TestCase):
         domain = data.Domain(
             (data.DiscreteVariable("A", values=("0", "1", "2")),
              data.ContinuousVariable("B"),
-             data.ContinuousVariable("C"))
+             data.ContinuousVariable("C")),
+            # the class is here to ensure the backmapper in model does not
+            # run and raise exception
+            data.DiscreteVariable("Z", values=("P", "M"))
         )
-        table = data.Table.from_numpy(domain, np.array(X))
+        table = data.Table.from_numpy(domain, np.array(X), [0,] * 3)
 
         v = impute.Model(MajorityLearner())(table, domain[0])
         self.assertTrue(np.all(np.isfinite(v.compute_value(table))))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

`impute.Model` does not work on input dataset with `class_vars` since gh-3925 due to error raised by backmapping.

```python
import Orange
from Orange.modelling import ConstantLearner
from Orange.preprocess import impute

data = Orange.data.Table("brown-selected")
impvar = impute.Model(ConstantLearner())(data, data.domain[0])
impvar.compute_value(data)
```

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/aleserjavec/Documents/workspace/orange3/Orange/preprocess/impute.py", line 175, in __call__
    predicted = self.model(data[mask])
  File "/Users/aleserjavec/Documents/workspace/orange3/Orange/base.py", line 437, in __call__
    backmappers, n_values = self.get_backmappers(data)
  File "/Users/aleserjavec/Documents/workspace/orange3/Orange/base.py", line 248, in get_backmappers
    f"Model for '{modelclass.name}' "
Orange.data.table.DomainTransformationError: Model for 'alpha 0' cannot predict 'function'
```
##### Description of changes

Remove class vars from input data for ReplaceUnknownsModel

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
