### PR TITLE
[FIX] SQL: Fix the issue with database collation setting when retrieving column values

### DIFF
--- a/Orange/data/sql/backend/base.py
+++ b/Orange/data/sql/backend/base.py
@@ -84,6 +84,21 @@ class Backend(metaclass=Registry):
         with self.execute_sql_query(query) as cur:
             return cur.description
 
+    def distinct_values_query(self, field_name: str, table_name: str) -> str:
+        """
+        Generate query for getting distinct values of field
+
+        Parameters
+        ----------
+        field_name : name of the field
+        table_name : name of the table or query to search
+
+        Returns
+        -------
+        The query for getting distinct values of field
+        """
+        raise NotImplementedError
+
     def get_distinct_values(self, field_name, table_name):
         """Return a list of distinct values of field
 
@@ -96,11 +111,7 @@ class Backend(metaclass=Registry):
         -------
         List[str] of values
         """
-        fields = [self.quote_identifier(field_name)]
-
-        query = self.create_sql_query(table_name, fields,
-                                      group_by=fields, order_by=fields,
-                                      limit=21)
+        query = self.distinct_values_query(field_name, table_name)
         with self.execute_sql_query(query) as cur:
             values = cur.fetchall()
         if len(values) > 20:

--- a/Orange/data/sql/backend/mssql.py
+++ b/Orange/data/sql/backend/mssql.py
@@ -152,3 +152,16 @@ class PymssqlBackend(Backend):
                     warnings.warn("SHOWPLAN permission denied, count approximates will not be used")
                     return None
                 raise BackendError(parse_ex(ex)) from ex
+
+    def distinct_values_query(self, field_name: str, table_name: str) -> str:
+        field = self.quote_identifier(field_name)
+        return self.create_sql_query(
+            table_name,
+            [field],
+            # workaround for collations that are not case sensitive and
+            # UTF characters sensitive - in the domain we still want to
+            # have all values (collation independent)
+            group_by=[f"{field}, Cast({field} as binary)"],
+            order_by=[field],
+            limit=21,
+        )

--- a/Orange/data/sql/backend/postgres.py
+++ b/Orange/data/sql/backend/postgres.py
@@ -180,6 +180,12 @@ class Psycopg2Backend(Backend):
             s = ''.join(row[0] for row in cur.fetchall())
         return int(re.findall(r'rows=(\d*)', s)[0])
 
+    def distinct_values_query(self, field_name: str, table_name: str) -> str:
+        fields = [self.quote_identifier(field_name)]
+        return self.create_sql_query(
+            table_name, fields, group_by=fields, order_by=fields, limit=21
+        )
+
     def __getstate__(self):
         # Drop connection_pool from state as it cannot be pickled
         state = dict(self.__dict__)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The database can have different collation settings (how to compare characters in the group by, distinct, ...). It has an impact on values we get when we retrieve all distinct values from column to create a discrete variable. If a collation is Latin it ignores utf8 characters, it can even be case insensitive. When creating variable we still want to have all possible values in the column since later when we retrieve actual data for a table (SELECT * FROM Table) we get values as they are (collation does not have an effect).

##### Description of changes
This PR implements a workaround for GROUP BY in cases when we want all values to create a variable.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
