### PR TITLE
[FIX] Predictions: Fix crash when clicking on empty left pane

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -1054,7 +1054,10 @@ class SharedSelectionStore:
                 flags that tell whether to Clear, Select, Deselect or Toggle
         """
         if isinstance(selection, QModelIndex):
-            rows = {selection.model().mapToSource(selection).row()}
+            if selection.model() is not None:
+                rows = {selection.model().mapToSource(selection).row()}
+            else:
+                rows = set()
         else:
             indices = selection.indexes()
             if indices:
@@ -1074,15 +1077,16 @@ class SharedSelectionStore:
             flags (QItemSelectionModel.SelectionFlags):
                 flags that tell whether to Clear, Select, Deselect or Toggle
         """
-        with self._emit_changed():
-            if flags & QItemSelectionModel.Clear:
-                self._rows.clear()
-            if flags & QItemSelectionModel.Select:
-                self._rows |= rows
-            if flags & QItemSelectionModel.Deselect:
-                self._rows -= rows
-            if flags & QItemSelectionModel.Toggle:
-                self._rows ^= rows
+        if len(rows) !=0:
+            with self._emit_changed():
+                if flags & QItemSelectionModel.Clear:
+                    self._rows.clear()
+                if flags & QItemSelectionModel.Select:
+                    self._rows |= rows
+                if flags & QItemSelectionModel.Deselect:
+                    self._rows -= rows
+                if flags & QItemSelectionModel.Toggle:
+                    self._rows ^= rows
 
     def clear_selection(self):
         """Clear selection and emit changeSelection signal to all models"""

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -24,3 +24,4 @@ pandas
 pyyaml
 openpyxl
 httpx~=0.14.0
+Cython==0.29.21


### PR DESCRIPTION
##### Issue

Fixes #5074.

Predictions widget reported an error if it was given just data, but no models, and the user clicked on the (empty) left pane.

##### Description of changes

`select` method now checks whether the model exists; if not, it set the selection to empty.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
