### PR TITLE
OWSelectRows: Move calendar widgets to gui

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -7,7 +7,7 @@ import numpy as np
 from AnyQt.QtWidgets import (
     QWidget, QTableWidget, QHeaderView, QComboBox, QLineEdit, QToolButton,
     QMessageBox, QMenu, QListView, QGridLayout, QPushButton, QSizePolicy,
-    QLabel, QHBoxLayout, QDateTimeEdit, QCalendarWidget)
+    QLabel, QHBoxLayout, QDateTimeEdit)
 from AnyQt.QtGui import (QDoubleValidator, QStandardItemModel, QStandardItem,
                          QFontMetrics, QPalette)
 from AnyQt.QtCore import Qt, QPoint, QPersistentModelIndex, QLocale, \
@@ -151,31 +151,6 @@ def _plural(s):
         s = s.replace(word, word[:-1])
     return s
 
-
-class CalendarWidgetWithTime(QCalendarWidget):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.timeedit = QDateTimeEdit(displayFormat="hh:mm:ss")
-        self.timeedit.setTime(self.parent().min_datetime.time())
-
-        self._time_layout = sublay = QHBoxLayout()
-        sublay.setContentsMargins(6, 6, 6, 6)
-        sublay.addStretch(1)
-        sublay.addWidget(QLabel("Time: "))
-        sublay.addWidget(self.timeedit)
-        sublay.addStretch(1)
-        self.layout().addLayout(sublay)
-
-    def minimumSize(self):
-        return self.sizeHint()
-
-    def sizeHint(self):
-        size = super().sizeHint()
-        size.setHeight(
-            size.height()
-            + self._time_layout.sizeHint().height()
-            + self.layout().spacing())
-        return size
 
 class OWSelectRows(widget.OWWidget):
     name = "Select Rows"
@@ -908,7 +883,8 @@ class DateTimeWidget(QDateTimeEdit):
             self.min_datetime = QDateTime.fromString(min_datetime, str_format)
             self.max_datetime = QDateTime.fromString(max_datetime, str_format)
             self.setCalendarPopup(True)
-            self.calendarWidget = CalendarWidgetWithTime(self)
+            self.calendarWidget = gui.CalendarWidgetWithTime(
+                self, time=self.min_datetime.time())
             self.calendarWidget.timeedit.timeChanged.connect(
                 self.set_datetime)
             self.setCalendarWidget(self.calendarWidget)

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -31,6 +31,7 @@ from orangewidget.gui import (
     VerticalLabel, tabWidget, createTabPage, table, tableItem,
     VisibleHeaderSectionContextEventFilter,
     checkButtonOffsetHint, toolButtonSizeHint, FloatSlider,
+    CalendarWidgetWithTime, DateTimeEditWCalendarTime,
     ControlGetter, VerticalScrollArea, ProgressBar,
     ControlledCallback, ControlledCallFront, ValueCallback, connectControl,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "VerticalLabel", "tabWidget", "createTabPage", "table", "tableItem",
     "VisibleHeaderSectionContextEventFilter", "checkButtonOffsetHint",
     "toolButtonSizeHint", "FloatSlider", "ControlGetter",  "VerticalScrollArea",
+    "CalendarWidgetWithTime", "DateTimeEditWCalendarTime",
     "BarRatioRole", "BarBrushRole", "SortOrderRole", "LinkRole",
     "BarItemDelegate", "IndicatorItemDelegate", "LinkStyledItemDelegate",
     "ColoredBarItemDelegate", "HorizontalGridDelegate", "VerticalItemDelegate",


### PR DESCRIPTION
##### Issue

https://github.com/biolab/orange-widget-base/pull/116 moves `CalendarWidgetWithTime` to orange-widget-base.

##### Description of changes

- Reexport the class in orange3 widget's gui.
- Use that class in `OWSelectRows`

##### Includes
- [X] Code changes
