### PR TITLE
[FIX] SqlTable use empty string instead of None for StringVariable

### DIFF
--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -178,7 +178,7 @@ class SqlTable(Table):
         if not values:
             raise IndexError('Could not retrieve row {} from table {}'.format(
                 row_index, self.name))
-        return SqlRowInstance(self.domain, values[0])
+        return Instance(self.domain, values[0])
 
     def __iter__(self):
         """ Iterating through the rows executes the query using a cursor and
@@ -187,7 +187,7 @@ class SqlTable(Table):
         attributes = self.domain.variables + self.domain.metas
 
         for row in self._query(attributes):
-            yield SqlRowInstance(self.domain, row)
+            yield Instance(self.domain, row)
 
     def _query(self, attributes=None, filters=(), rows=None):
         if attributes is not None:
@@ -653,16 +653,3 @@ class SqlTable(Table):
 
     def checksum(self, include_metas=True):
         return np.nan
-
-
-class SqlRowInstance(Instance):
-    """
-    Extends :obj:`Orange.data.Instance` to correctly handle values of meta
-    attributes.
-    """
-
-    def __init__(self, domain, data=None):
-        nvar = len(domain.variables)
-        super().__init__(domain, data[:nvar])
-        if len(data) > nvar:
-            self._metas = np.asarray(data[nvar:], dtype=object)

--- a/Orange/tests/sql/test_filter.py
+++ b/Orange/tests/sql/test_filter.py
@@ -3,8 +3,8 @@
 
 import unittest
 
-from Orange.data.sql.table import SqlTable, SqlRowInstance
-from Orange.data import filter, domain
+from Orange.data.sql.table import SqlTable
+from Orange.data import filter, domain, Instance
 from Orange.tests.sql.base import DataBaseTest as dbt
 
 
@@ -368,7 +368,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.IsDefined)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] is not None]
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -379,7 +379,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Equal, 'in')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] == 'in']
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -391,7 +391,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Equal, 'In',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] == 'in']
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -403,7 +403,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Equal, 'donec',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] == 'Donec']
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -414,7 +414,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.NotEqual, 'in')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] != 'in']
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -426,7 +426,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.NotEqual, 'In',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] != 'in']
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -438,7 +438,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.NotEqual, 'donec',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] != 'Donec']
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -449,7 +449,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Less, 'A')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0] < 'A']
 
@@ -462,7 +462,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Less, 'In',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() < 'in']
 
@@ -475,7 +475,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Less, 'donec',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() < 'donec']
 
@@ -487,7 +487,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.LessEqual, 'A')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0] <= 'A']
 
@@ -500,7 +500,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.LessEqual, 'In',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() <= 'in']
 
@@ -513,7 +513,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.LessEqual, 'donec',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() <= 'donec']
 
@@ -525,7 +525,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Greater, 'volutpat')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0] > 'volutpat']
 
@@ -538,7 +538,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Greater, 'In',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() > 'in']
 
@@ -551,7 +551,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Greater, 'donec',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() > 'donec']
 
@@ -563,7 +563,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.GreaterEqual, 'volutpat')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0] >= 'volutpat']
 
@@ -576,7 +576,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.GreaterEqual, 'In',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() >= 'in']
 
@@ -589,7 +589,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.GreaterEqual, 'donec',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].lower() >= 'donec']
 
@@ -601,7 +601,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Between, 'a', 'c')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and 'a' <= row[0] <= 'c']
 
@@ -614,7 +614,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Between, 'I', 'O',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and 'i' < row[0].lower() <= 'o']
 
@@ -627,7 +627,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Between, 'i', 'O',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and 'i' <= row[0].lower() <= 'o']
 
@@ -639,7 +639,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Contains, 'et')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and 'et' in row[0]]
 
@@ -652,7 +652,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Contains, 'eT',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and 'et' in row[0].lower()]
 
@@ -665,7 +665,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Contains, 'do',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and 'do' in row[0].lower()]
 
@@ -677,7 +677,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.Outside, 'am', 'di')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and not 'am' < row[0] < 'di']
 
@@ -690,7 +690,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.Outside, 'd', 'k',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and not 'd' < row[0].lower() < 'k']
 
@@ -702,7 +702,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.StartsWith, 'D')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].startswith('D')]
 
@@ -715,7 +715,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.StartsWith, 'D',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None
                         and row[0].lower().startswith('d')]
@@ -728,7 +728,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterString(-1, filter.FilterString.EndsWith, 's')
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None and row[0].endswith('s')]
 
@@ -741,7 +741,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
             filter.FilterString(-1, filter.FilterString.EndsWith, 'S',
                                 case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data
                         if row[0] is not None
                         and row[0].lower().endswith('s')]
@@ -754,7 +754,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterStringList(-1, ['et', 'in'])
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] in ['et', 'in']]
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -765,7 +765,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterStringList(-1, ['Et', 'In'], case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] in ['et', 'in']]
 
         self.assertEqual(len(filtered_data), len(correct_data))
@@ -776,7 +776,7 @@ class TestFilterStringSql(unittest.TestCase, dbt):
         filtered_data = filter.Values(conditions=[
             filter.FilterStringList(-1, ['donec'], case_sensitive=False)
         ])(self.table)
-        correct_data = [SqlRowInstance(filtered_data.domain, row)
+        correct_data = [Instance(filtered_data.domain, row)
                         for row in self.data if row[0] in ['Donec']]
 
         self.assertEqual(len(filtered_data), len(correct_data))

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -415,6 +415,20 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
 
+        # test if NULL is transformed to emtpy string
+        table = np.array(list("ABCDEFGHIJKLMNOPQRSTUVW") + [None]).reshape(
+            -1, 1
+        )
+        conn, table_name = self.create_sql_table(table, ["char(1)"])
+
+        sql_table = SqlTable(conn, table_name, inspect_values=False)
+        self.assertFirstMetaIsInstance(sql_table, StringVariable)
+        self.assertEqual("", sql_table.metas[-1, 0])
+
+        sql_table = SqlTable(conn, table_name, inspect_values=True)
+        self.assertFirstMetaIsInstance(sql_table, StringVariable)
+        self.assertEqual("", sql_table.metas[-1, 0])
+
     @dbt.run_on(["postgres", "mssql"])
     def test_discrete_varchar(self):
         table = np.array(['M', 'F', 'M', 'F', 'M', 'F']).reshape(-1, 1)
@@ -716,6 +730,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertGreater(len(table.domain.metas), 0)
         attr = table.domain[-1]
         self.assertIsInstance(attr, variable_type)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -296,6 +296,20 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertEqual(iris.domain.class_vars[0].name, 'iris')
 
     @dbt.run_on(["postgres", "mssql"])
+    def test_meta_type_hints(self):
+        iris = SqlTable(
+            self.conn,
+            self.iris,
+            type_hints=Domain([], metas=[self.IRIS_VARIABLE]),
+        )
+
+        self.assertEqual(len(iris.domain.metas), 1)
+        self.assertEqual(iris.domain.metas[0].name, "iris")
+        np.testing.assert_array_equal(
+            iris.metas.flatten(), [0] * 50 + [2] * 50 + [1] * 50
+        )
+
+    @dbt.run_on(["postgres", "mssql"])
     def test_metas_type_hints(self):
         iris = SqlTable(self.conn, self.iris,
                         type_hints=Domain([], [], metas=[self.IRIS_VARIABLE]))

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -113,6 +113,7 @@ class TestSqlTable(unittest.TestCase, dbt):
                                  name='col2', values=('0', '1', '2'))))
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     @unittest.mock.patch("Orange.data.sql.table.AUTO_DL_LIMIT", 100)
@@ -135,6 +136,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table.download_data()
         assert_almost_equal(sql_table.X, mat[:, :2])
         assert_almost_equal(sql_table.Y.flatten(), mat[:, 2])
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_download_data(self):
@@ -147,6 +149,7 @@ class TestSqlTable(unittest.TestCase, dbt):
             self.assertFalse(getattr(sql_table, member) is None)
         # has all necessary class members to create a standard Table
         Table.from_table(sql_table.domain, sql_table)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_query_all(self):
@@ -317,6 +320,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_continous_bigint(self):
@@ -328,6 +332,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_discrete_int(self):
@@ -339,6 +344,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_continous_int(self):
@@ -350,6 +356,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_discrete_smallint(self):
@@ -361,6 +368,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_continous_smallint(self):
@@ -372,6 +380,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_boolean(self):
@@ -383,6 +392,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_discrete_char(self):
@@ -394,6 +404,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_discrete_bigger_char(self):
@@ -403,6 +414,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertSequenceEqual(sql_table.domain[0].values, ['F', 'M'])
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_meta_char(self):
@@ -414,6 +426,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
+        self.drop_sql_table(table_name)
 
         # test if NULL is transformed to emtpy string
         table = np.array(list("ABCDEFGHIJKLMNOPQRSTUVW") + [None]).reshape(
@@ -428,6 +441,7 @@ class TestSqlTable(unittest.TestCase, dbt):
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
         self.assertEqual("", sql_table.metas[-1, 0])
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_discrete_varchar(self):
@@ -439,6 +453,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, DiscreteVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_meta_varchar(self):
@@ -450,6 +465,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_time_date(self):
@@ -474,6 +490,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_time_timetz(self):
@@ -486,6 +503,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_time_timestamp(self):
@@ -501,6 +519,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_time_timestamptz(self):
@@ -516,6 +535,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, TimeVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_double_precision(self):
@@ -527,6 +547,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_numeric(self):
@@ -538,6 +559,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_real(self):
@@ -549,6 +571,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_serial(self):
@@ -560,6 +583,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres>90200"])
     def test_smallserial(self):
@@ -571,6 +595,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres>90200"])
     def test_bigserial(self):
@@ -582,6 +607,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstAttrIsInstance(sql_table, ContinuousVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_text(self):
@@ -593,6 +619,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         sql_table = SqlTable(conn, table_name, inspect_values=True)
         self.assertFirstMetaIsInstance(sql_table, StringVariable)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_other(self):
@@ -610,6 +637,7 @@ class TestSqlTable(unittest.TestCase, dbt):
 
         filters = filter.Values([filter.FilterString(-1, filter.FilterString.Equal, 'foo')])
         self.assertEqual(len(filters(sql_table)), 0)
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres", "mssql"])
     def test_recovers_connection_after_sql_error(self):
@@ -629,6 +657,7 @@ class TestSqlTable(unittest.TestCase, dbt):
             sql_table.domain.attributes[0].to_sql(), sql_table.table_name)
         with sql_table.backend.execute_sql_query(working_query) as cur:
             cur.fetchall()
+        self.drop_sql_table(table_name)
 
     @dbt.run_on(["postgres"])
     def test_basic_stats(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- SQL table places None where missing value for StringVariable. It should use '' (empty string) instead. It breaks merge data widget with does not expect `None` in the String variable.
- SQL table tests do not cleanup the database after testing.

##### Description of changes
- Removing `SqlRowInstance` and using `Instance` instead since it seems that Instance does the same in the `__init__` that `SqlRowInstance` used to do. It also correctly replaces None with the '' (empty string). Hope I didn't missee anything.
- Remove the database tables after testing



##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
