### PR TITLE
[FIX] ROC shows all points, including the last

### DIFF
--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -825,6 +825,13 @@ def roc_curve_for_fold(res, fold, clf_idx, target):
         drop_intermediate=drop_intermediate
     )
 
+    # skl sets the first threshold to the highest threshold in the data + 1
+    # since we deal with probabilities, we (carefully) set it to 1
+    # Unrelated comparisons, thus pylint: disable=chained-comparison
+    if len(thresholds) > 1 and thresholds[1] <= 1:
+        thresholds[0] = 1
+    return fpr, tpr, thresholds
+
 
 def roc_curve_vertical_average(curves, samples=10):
     if not curves:

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -93,11 +93,11 @@ def roc_data_from_results(results, clf_index, target):
     :rval ROCData:
         A instance holding the computed curves.
     """
-    merged = roc_curve_for_fold(results, slice(0, -1), clf_index, target)
+    merged = roc_curve_for_fold(results, ..., clf_index, target)
     merged_curve = ROCCurve(ROCPoints(*merged),
                             ROCPoints(*roc_curve_convex_hull(merged)))
 
-    folds = results.folds if results.folds is not None else [slice(0, -1)]
+    folds = results.folds if results.folds is not None else [...]
     fold_curves = []
     for fold in folds:
         points = roc_curve_for_fold(results, fold, clf_index, target)

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -1,8 +1,3 @@
-"""
-ROC Analysis Widget
--------------------
-
-"""
 import operator
 from functools import reduce, wraps
 from collections import namedtuple, deque, OrderedDict
@@ -11,7 +6,7 @@ import numpy as np
 import sklearn.metrics as skl_metrics
 
 from AnyQt.QtWidgets import QListView, QLabel, QGridLayout, QFrame, QAction, \
-    QToolTip, QSizePolicy
+    QToolTip
 from AnyQt.QtGui import QColor, QPen, QBrush, QPainter, QPalette, QFont, \
     QCursor, QFontMetrics
 from AnyQt.QtCore import Qt, QSize
@@ -21,12 +16,14 @@ import Orange
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.evaluate.contexthandlers import \
     EvaluationResultsContextHandler
-from Orange.widgets.evaluate.utils import \
-    check_results_adequacy, results_for_preview
+from Orange.widgets.evaluate.utils import check_results_adequacy
 from Orange.widgets.utils import colorpalettes
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input
 from Orange.widgets import report
+
+from Orange.widgets.evaluate.utils import results_for_preview
+from Orange.evaluation.testing import Results
 
 
 #: Points on a ROC curve
@@ -969,5 +966,19 @@ def roc_iso_performance_slope(fp_cost, fn_cost, p):
         return (fp_cost * (1. - p)) / (fn_cost * p)
 
 
+def _create_results():  # pragma: no cover
+    probs1 = [0.984, 0.907, 0.881, 0.865, 0.815, 0.741, 0.735, 0.635,
+              0.582, 0.554, 0.413, 0.317, 0.287, 0.225, 0.216, 0.183]
+    probs = np.array([[[1 - x, x] for x in probs1]])
+    preds = (probs > 0.5).astype(float)
+    return Results(
+        data=Orange.data.Table("heart_disease")[:16],
+        row_indices=np.arange(16),
+        actual=np.array(list(map(int, "1100111001001000"))),
+        probabilities=probs, predicted=preds
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover
+    # WidgetPreview(OWROCAnalysis).run(_create_results())
     WidgetPreview(OWROCAnalysis).run(results_for_preview())

--- a/Orange/widgets/evaluate/tests/test_owrocanalysis.py
+++ b/Orange/widgets/evaluate/tests/test_owrocanalysis.py
@@ -214,7 +214,7 @@ class TestOWROCAnalysis(WidgetTest, EvaluateTest):
             pos = view.mapFromScene(pos)
             mouseMove(view.viewport(), pos)
             (_, text), _ = show_text.call_args
-            self.assertIn("(#1) 1.800\n(#2) 1.893", text)
+            self.assertIn("(#1) 1.000\n(#2) 1.000", text)
 
             # test that cache is invalidated when changing averaging mode
             self.widget.roc_averaging = OWROCAnalysis.Threshold


### PR DESCRIPTION
##### Description of changes

- Fixes #5119: The last point on the curve was not shown.
- Fixes the threshold shown at the bottom-left point (now set to 1; used to be 1 + the highest p in the data)
- Adds simpler preview data
- Shows ticks for actual FPR/TPR values, if there are <15 unique values

![roc](https://user-images.githubusercontent.com/2387315/102617407-6cd87b00-4139-11eb-88b2-211f1adf1e6a.png)


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
