### PR TITLE
[ENH] Projections: Allow transparent subset

### DIFF
--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -567,6 +567,21 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         self.send_signal(w.Inputs.data_subset, data[::30])
         self.assertEqual(len(w.subset_indices), 5)
 
+    def test_opacity_warning(self):
+        data = Table("iris")
+        w = self.widget
+        self.send_signal(w.Inputs.data, data)
+        w.graph.controls.alpha_value.setSliderPosition(10)
+        self.assertFalse(w.Warning.transparent_subset.is_shown())
+        self.send_signal(w.Inputs.data_subset, data[::30])
+        self.assertTrue(w.Warning.transparent_subset.is_shown())
+        w.graph.controls.alpha_value.setSliderPosition(200)
+        self.assertFalse(w.Warning.transparent_subset.is_shown())
+        w.graph.controls.alpha_value.setSliderPosition(10)
+        self.assertTrue(w.Warning.transparent_subset.is_shown())
+        self.send_signal(w.Inputs.data_subset, None)
+        self.assertFalse(w.Warning.transparent_subset.is_shown())
+
     def test_metas_zero_column(self):
         """
         Prevent crash when metas column is zero.

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -614,9 +614,9 @@ class TestOWScatterPlotBase(WidgetTest):
             self.assertEqual(brushes[0].color().alpha(), 0)
             self.assertEqual(brushes[1].color().alpha(), 0)
             self.assertEqual(brushes[4].color().alpha(), 0)
-            self.assertEqual(brushes[5].color().alpha(), 255)
-            self.assertEqual(brushes[6].color().alpha(), 255)
-            self.assertEqual(brushes[7].color().alpha(), 255)
+            self.assertEqual(brushes[5].color().alpha(), 123)
+            self.assertEqual(brushes[6].color().alpha(), 123)
+            self.assertEqual(brushes[7].color().alpha(), 123)
 
         graph = self.graph
 

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -250,6 +250,7 @@ class OWProjectionWidgetBase(OWWidget, openclass=True):
 
     def colors_changed(self):
         self.graph.update_colors()
+        self._update_opacity_warning()
         self.cb_class_density.setEnabled(self.can_draw_density())
 
     # Labels
@@ -378,6 +379,8 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
             "input data")
         subset_independent = Msg(
             "No subset data instances appear in input data")
+        transparent_subset = Msg(
+            "Increase opacity if subset is difficult to see")
 
     settingsHandler = DomainContextHandler()
     selection = Setting(None, schema_only=True)
@@ -473,7 +476,6 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
     @check_sql_input
     def set_subset_data(self, subset):
         self.subset_data = subset
-        self.controls.graph.alpha_value.setEnabled(subset is None)
 
     def handleNewSignals(self):
         self._handle_subset_data()
@@ -482,6 +484,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
             self.setup_plot()
         else:
             self.graph.update_point_props()
+        self._update_opacity_warning()
         self.unconditional_commit()
 
     def _handle_subset_data(self):
@@ -496,6 +499,10 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
                 self.Warning.subset_independent()
             elif self.subset_indices - ids:
                 self.Warning.subset_not_subset()
+
+    def _update_opacity_warning(self):
+        self.Warning.transparent_subset(
+            shown=self.subset_indices and self.graph.alpha_value < 128)
 
     def set_input_summary(self, data):
         summary = len(data) if data else self.info.NoInput


### PR DESCRIPTION
##### Issue

Resolves #5109.

##### Description of changes

- No longer disable opacity in presence of data subset
- If opacity is low and subset is present, inform the user (s)he should increase opacity if (s)he can't see the subset

##### Includes
- [X] Code changes
- [X] Tests