### PR TITLE
test_owcorrelations: Fix test for scikit-learn==0.24.0

### DIFF
--- a/Orange/widgets/data/tests/test_owcorrelations.py
+++ b/Orange/widgets/data/tests/test_owcorrelations.py
@@ -377,8 +377,10 @@ class TestKMeansCorrelationHeuristic(unittest.TestCase):
 
     def test_get_clusters_of_attributes(self):
         clusters = self.heuristic.get_clusters_of_attributes()
-        self.assertListEqual([[1, 2, 3, 4, 5, 6, 7], [8], [0]],
-                             [c.instances for c in clusters])
+        # results depend on scikit-learn k-means implementation
+        result = sorted([c.instances for c in clusters])
+        self.assertListEqual([[0], [1, 2, 3, 4, 5, 6, 7], [8]],
+                             result)
 
     def test_get_states(self):
         n_attrs = len(self.data.domain.attributes)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

test_owcorrelations fails with latest scikit-learn==0.24.0

```
Traceback (most recent call last):
  File "D:\a\orange3\orange3\.tox\py\lib\site-packages\Orange\widgets\data\tests\test_owcorrelations.py", line 381, in test_get_clusters_of_attributes
    [c.instances for c in clusters])
AssertionError: Lists differ: [[1, 2, 3, 4, 5, 6, 7], [8], [0]] != [[0], [1, 2, 3, 4, 5, 6, 7], [8]]

First differing element 0:
[1, 2, 3, 4, 5, 6, 7]
[0]

- [[1, 2, 3, 4, 5, 6, 7], [8], [0]]
?                            ---- -

+ [[0], [1, 2, 3, 4, 5, 6, 7], [8]]
?  +++++
```
##### Description of changes

Fix test.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
