### PR TITLE
docs: fix simple typo, unncessary -> unnecessary

### DIFF
--- a/Orange/widgets/visualize/utils/scene.py
+++ b/Orange/widgets/visualize/utils/scene.py
@@ -10,7 +10,7 @@ class UpdateItemsOnSelectGraphicsScene(QGraphicsScene):
 
     Notes
     -----
-    .. note:: I suspect this is completely unncessary, but have not been able
+    .. note:: I suspect this is completely unnecessary, but have not been able
         to find a reasonable way to keep the selection logic inside the actual
         `QGraphicsItem` objects
 


### PR DESCRIPTION
There is a small typo in Orange/widgets/visualize/utils/scene.py.

Should read `unnecessary` rather than `unncessary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md