### PR TITLE
[FIX] Feature Statistics: Error in time variable display

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -514,7 +514,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                     return "∞"
 
                 str_val = attribute.str_val(value)
-                if attribute.is_continuous:
+                if attribute.is_continuous and not attribute.is_time:
                     str_val = format_zeros(str_val)
 
                 return str_val

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -149,6 +149,10 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         self.n_attributes = self.n_instances = 0
 
         self.__attributes = self.__class_vars = self.__metas = None
+        # sets of variables for fast membership tests
+        self.__attributes_set = set()
+        self.__class_vars_set = set()
+        self.__metas_set = set()
         self.__distributions_cache = {}
 
         no_data = np.array([])
@@ -176,7 +180,9 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         # while we need a 2d array, which `_Y` provides
         self.__class_vars = self.__filter_attributes(domain.class_vars, self.table._Y)  # pylint: disable=protected-access
         self.__metas = self.__filter_attributes(domain.metas, self.table.metas)
-
+        self.__attributes_set = set(self.__metas[0])
+        self.__class_vars_set = set(self.__class_vars[0])
+        self.__metas_set = set(self.__metas[0])
         self.n_attributes = len(self.variables)
         self.n_instances = len(data)
 
@@ -191,6 +197,9 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         self.__attributes = (np.array([]), np.array([]))
         self.__class_vars = (np.array([]), np.array([]))
         self.__metas = (np.array([]), np.array([]))
+        self.__attributes_set = set()
+        self.__class_vars_set = set()
+        self.__metas_set = set()
         self.__distributions_cache.clear()
         self.endResetModel()
 
@@ -471,11 +480,11 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
     def data(self, index, role):
         # type: (QModelIndex, Qt.ItemDataRole) -> Any
         def background():
-            if attribute in self.domain.attributes:
+            if attribute in self.__attributes_set:
                 return self.COLOR_FOR_ROLE[self.ATTRIBUTE]
-            if attribute in self.domain.metas:
+            if attribute in self.__metas_set:
                 return self.COLOR_FOR_ROLE[self.META]
-            if attribute in self.domain.class_vars:
+            if attribute in self.__class_vars_set:
                 return self.COLOR_FOR_ROLE[self.CLASS_VAR]
             return None
 

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -105,7 +105,7 @@ def _to_timestamps(years):
 # Time variable variations, windows timestamps need to be valid timestamps so
 # we'll just fill it in with arbitrary years
 time_full = VarDataPair(
-    TimeVariable('time_full'),
+    TimeVariable('time_full', have_date=True, have_time=True),
     np.array(_to_timestamps([2000, 2001, 2002, 2003, 2004]), dtype=float),
 )
 time_missing = VarDataPair(
@@ -117,7 +117,7 @@ time_all_missing = VarDataPair(
     np.array(_to_timestamps([np.nan] * 5), dtype=float),
 )
 time_same = VarDataPair(
-    TimeVariable('time_same'),
+    TimeVariable('time_same', have_date=True, have_time=True),
     np.array(_to_timestamps([2004] * 5), dtype=float),
 )
 time = [


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Feature Statistics raises error when displaying time variable with a formatted representation.
```
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owfeaturestatistics.py", line 575, in data
    return roles[role]()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owfeaturestatistics.py", line 540, in display
    return render_value(self._center[row])
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owfeaturestatistics.py", line 518, in render_value
    str_val = format_zeros(str_val)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owfeaturestatistics.py", line 505, in format_zeros
    if float(str_val) == 0:
ValueError: could not convert string to float: '2001-12-31 18:12:00'
```
The error however might not on show up on macOS in ErrorReporting dialog.

This is probably the reason behind issue gh-5009.

##### Description of changes

* Fix error in formatting
* Optimize attribute/class_vars/meta membership tests in the model. Was slow *O(n_variables)* before (noticeable on n_variables > 500)


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
