### PR TITLE
[FIX] Calibration model: Work with numpy data

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -136,7 +136,11 @@ class Learner(ReprableWithPreprocessors):
         progress_callback(0.1, "Fitting...")
         model = self._fit_model(data)
         model.used_vals = [np.unique(y).astype(int) for y in data.Y[:, None].T]
-        model.domain = data.domain
+        if not hasattr(model, "domain") or model.domain is None:
+            # some models set domain themself and it should be respected
+            # e.g. calibration learners set the base_learner's domain which
+            # would be wrongly overwritten if we set it here for any model
+            model.domain = data.domain
         model.supports_multiclass = self.supports_multiclass
         model.name = self.name
         model.original_domain = origdomain

--- a/Orange/classification/tests/test_calibration.py
+++ b/Orange/classification/tests/test_calibration.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 
 from Orange.base import Model
+from Orange.classification import LogisticRegressionLearner
 from Orange.classification.calibration import \
     ThresholdLearner, ThresholdClassifier, \
     CalibratedLearner, CalibratedClassifier
@@ -64,6 +65,18 @@ class TestThresholdClassifier(unittest.TestCase):
         base_model.domain.class_var = Mock()
         base_model.domain.class_var.is_discrete = False
         self.assertRaises(ValueError, ThresholdClassifier, base_model, 0.5)
+
+    def test_np_data(self):
+        """
+        Test ThresholdModel with numpy data.
+        When passing numpy data to model they should be already
+        transformed to models domain since model do not know how to do it.
+        """
+        data = Table('heart_disease')
+        base_learner = LogisticRegressionLearner()
+        model = ThresholdLearner(base_learner)(data)
+        res = model(model.data_to_model_domain(data).X)
+        self.assertTupleEqual((len(data),), res.shape)
 
 
 class TestThresholdLearner(unittest.TestCase):
@@ -169,6 +182,18 @@ class TestCalibratedClassifier(unittest.TestCase):
         calprobs = self.model.calibrated_probs(self.probs)
         np.testing.assert_almost_equal(calprobs, expprobs)
 
+    def test_np_data(self):
+        """
+        Test CalibratedClassifier with numpy data.
+        When passing numpy data to model they should be already
+        transformed to models domain since model do not know how to do it.
+        """
+        data = Table('heart_disease')
+        base_learner = LogisticRegressionLearner()
+        model = CalibratedLearner(base_learner)(data)
+        res = model(model.data_to_model_domain(data).X)
+        self.assertTupleEqual((len(data),), res.shape)
+
 
 class TestCalibratedLearner(unittest.TestCase):
     @patch("Orange.classification.calibration._SigmoidCalibration.fit")
@@ -207,3 +232,7 @@ class TestCalibratedLearner(unittest.TestCase):
         for call, cls_probs in zip(sigmoid_fit.call_args_list,
                                    res.probabilities[0].T):
             np.testing.assert_equal(call[0][0], cls_probs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Calibration models do not support passing NumPy data since their `data_to_model_domain` does not transform data correctly. It should take into account the base model domain. The error is that the calibration model stores the wrong domain. It first sets the base_learners domain, but it is then overwritten with the wrong (not preprocessed) domain.

This code snipet works with other models but not with callibrations:

```
data = Table('heart_disease')
base_learner = LogisticRegressionLearner()
model = CalibratedLearner(base_learner)(data)
model(model.data_to_model_domain(data).X)
```

The correction would support explain the model on calibration learner.

##### Description of changes
This PR fixes the base learner such that it does not overwrite the domain of models that already set it. It only set the domain for other models (mostly SKL models).

If it looks ugly this error could be also resolved by completely removing the line that set the domain. Then all models would need to pass the domain to the model's constructor. It would be a major change in models and learners.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
