### PR TITLE
[FIX] OWImpute: Preserve default method setting

### DIFF
--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -435,8 +435,8 @@ class OWImpute(OWWidget):
         ]
 
         def impute_one(method, var, data):
-            # Readability counts, pylint: disable=no-else-raise
             # type: (impute.BaseImputeMethod, Variable, Table) -> Any
+            # Readability counts, pylint: disable=no-else-raise
             if isinstance(method, impute.Model) and data.is_sparse():
                 raise SparseNotSupported()
             elif isinstance(method, impute.DropInstances):

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -353,8 +353,6 @@ class OWImpute(OWWidget):
         if data is not None:
             self.varmodel[:] = data.domain.variables
             self.openContext(data.domain)
-            self.time_widget.set_datetime(
-                QDateTime.fromSecsSinceEpoch(self.default_time))
             # restore per variable imputation state
             self._restore_state(self._variable_imputation_state)
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -222,7 +222,6 @@ class OWImpute(OWWidget):
 
         self.time_widget = gui.DateTimeEditWCalendarTime(self)
         self.time_widget.setContentsMargins(0, 0, 0, 0)
-        self.default_time = QDateTime.currentDateTime().toSecsSinceEpoch()
         self.time_widget.dateTimeChanged.connect(set_default_time)
         hlayout.addWidget(self.time_widget)
 

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -191,15 +191,12 @@ class OWImpute(OWWidget):
             button_group.addButton(button, method)
             box_layout.addWidget(button, i % 3, i // 3)
 
-        def set_to_fixed_value():
-            self.set_default_method(Method.Default)
-
         def set_default_time(datetime):
-            self.default_time = datetime.toSecsSinceEpoch()
-            if self.default_method_index != Method.Default:
-                set_to_fixed_value()
-            else:
-                self._invalidate()
+            datetime = datetime.toSecsSinceEpoch()
+            if datetime != self.default_time:
+                self.default_time = datetime
+                if self.default_method_index == Method.Default:
+                    self._invalidate()
 
         hlayout = QHBoxLayout()
         box.layout().addLayout(hlayout)
@@ -212,16 +209,29 @@ class OWImpute(OWWidget):
         locale.setNumberOptions(locale.NumberOption.RejectGroupSeparator)
         validator = QDoubleValidator()
         validator.setLocale(locale)
-        le = gui.lineEdit(
+        self.numeric_value_widget = le = gui.lineEdit(
             None, self, "default_numeric",
             validator=validator, alignment=Qt.AlignRight,
-            callback=self._invalidate, focusInCallback=set_to_fixed_value)
+            callback=self._invalidate,
+            enabled=self.default_method_index == Method.Default
+        )
         hlayout.addWidget(le)
 
         hlayout.addWidget(QLabel(", time:"))
 
         self.time_widget = gui.DateTimeEditWCalendarTime(self)
+        self.time_widget.setEnabled(self.default_method_index == Method.Default)
+        self.time_widget.setKeyboardTracking(False)
         self.time_widget.setContentsMargins(0, 0, 0, 0)
+        self.time_widget.set_datetime(
+            QDateTime.fromSecsSinceEpoch(self.default_time)
+        )
+        self.connect_control(
+            "default_time",
+            lambda value: self.time_widget.set_datetime(
+                QDateTime.fromSecsSinceEpoch(value)
+            )
+        )
         self.time_widget.dateTimeChanged.connect(set_default_time)
         hlayout.addWidget(self.time_widget)
 
@@ -330,6 +340,8 @@ class OWImpute(OWWidget):
             assert index != Method.AsAboveSoBelow
             self._default_method_index = index
             self.default_button_group.button(index).setChecked(True)
+            self.time_widget.setEnabled(index == Method.Default)
+            self.numeric_value_widget.setEnabled(index == Method.Default)
             # update variable view
             self.update_varview()
             self._invalidate()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

* The default method changes to 'Fixed values' when the widget receives first data.
   Steps:
        * create an 'Impute' widget - do not connect it yet
        * change the default method to say 'Average/Most frequent'
        * connect it to 'File', the method changes to 'Fixed values'

 * The date time setting is reset at widget creation and is not restored.


##### Description of changes

* Preserve the default method on set_data 
* Do not reset `default_time` in __init__
* Do not switch to 'Fixed values' by tabbing over controls
* Fix type hint comment location


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
