### PR TITLE
owdistributions: Add white background

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -386,7 +386,7 @@ class OWDistributions(OWWidget):
             plot.setZValue(zvalue)
             return plot
 
-        self.plotview = DistributionWidget(background=None)
+        self.plotview = DistributionWidget()
         self.plotview.item_clicked.connect(self._on_item_clicked)
         self.plotview.blank_clicked.connect(self._on_blank_clicked)
         self.plotview.mouse_released.connect(self._on_end_selecting)


### PR DESCRIPTION
##### Issue
OWDistributions looks out of place among other widgets with a main area, given its lack of a white background.

##### Description of changes
Unremove the white background.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
