### PR TITLE
Better pandas integration

### DIFF
--- a/Orange/data/__init__.py
+++ b/Orange/data/__init__.py
@@ -9,3 +9,4 @@ from .table import *
 from .io_util import *
 from .io import *
 from .filter import *
+from .pandas_compat import *

--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -1,6 +1,12 @@
 """Pandas DataFrame↔Table conversion helpers"""
+from unittest.mock import patch
+
 import numpy as np
+from scipy import sparse as sp
+from scipy.sparse import csr_matrix
 import pandas as pd
+from pandas.core.arrays import SparseArray
+from pandas.core.arrays.sparse.dtype import SparseDtype
 from pandas.api.types import (
     is_categorical_dtype, is_object_dtype,
     is_datetime64_any_dtype, is_numeric_dtype,
@@ -10,72 +16,326 @@ from Orange.data import (
     Table, Domain, DiscreteVariable, StringVariable, TimeVariable,
     ContinuousVariable,
 )
+from Orange.data.table import Role
 
 __all__ = ['table_from_frame', 'table_to_frame']
 
 
-def table_from_frame(df, *, force_nominal=False):
-    """
-    Convert pandas.DataFrame to Orange.data.Table
+class OrangeDataFrame(pd.DataFrame):
+    _metadata = ["orange_variables", "orange_weights",
+                 "orange_attributes", "orange_role"]
 
-    Parameters
-    ----------
-    df : pandas.DataFrame
-    force_nominal : boolean
-        If True, interpret ALL string columns as nominal (DiscreteVariable).
+    def __init__(self, *args, **kwargs):
+        """
+        A pandas DataFrame wrapper for one of Table's numpy arrays:
+            - sets index values corresponding to Orange's global row indices
+              e.g. ['_o1', '_o2'] (allows Orange to handle selection)
+            - remembers the array's role in the Table (attribute, class var, meta)
+            - keeps the Variable objects, and uses them in back-to-table conversion,
+              should a column name match a variable's name
+            - stores weight values (legacy)
 
-    Returns
-    -------
-    Table
-    """
+        Parameters
+        ----------
+        table : Table
+        orange_role : Role, (default=Role.Attribute)
+            When converting back to an orange table, the DataFrame will
+            convert to the right role (attrs, class vars, or metas)
+        """
+        if len(args) <= 0 or not isinstance(args[0], Table):
+            super().__init__(*args, **kwargs)
+            return
+        table = args[0]
+        if 'orange_role' in kwargs:
+            role = kwargs.pop('orange_role')
+        elif len(args) >= 2:
+            role = args[1]
+        else:
+            role = Role.Attribute
 
-    def _is_discrete(s):
-        return (is_categorical_dtype(s) or
-                is_object_dtype(s) and (force_nominal or
-                                        s.nunique() < s.size**.666))
+        if role == Role.Attribute:
+            data = table.X
+            vars_ = table.domain.attributes
+        elif role == Role.ClassAttribute:
+            data = table.Y
+            vars_ = table.domain.class_vars
+        else:  # if role == Role.Meta:
+            data = table.metas
+            vars_ = table.domain.metas
 
-    def _is_datetime(s):
-        if is_datetime64_any_dtype(s):
+        index = ['_o' + str(id_) for id_ in table.ids]
+        varsdict = {var._name: var for var in vars_}
+        columns = varsdict.keys()
+
+        if sp.issparse(data):
+            data = data.asformat('csc')
+            sparrays = [SparseArray.from_spmatrix(data[:, i]) for i in range(data.shape[1])]
+            data = dict(enumerate(sparrays))
+            super().__init__(data, index=index, **kwargs)
+            self.columns = columns
+            # a hack to keep Orange df _metadata in sparse->dense conversion
+            self.sparse.to_dense = self.__patch_constructor(self.sparse.to_dense)
+        else:
+            super().__init__(data=data, index=index, columns=columns, **kwargs)
+
+        self.orange_role = role
+        self.orange_variables = varsdict
+        self.orange_weights = (dict(zip(index, table.W))
+                               if table.W.size > 0 else {})
+        self.orange_attributes = table.attributes
+
+    def __patch_constructor(self, method):
+        def new_method(*args, **kwargs):
+            with patch(
+                    'pandas.DataFrame',
+                    OrangeDataFrame
+            ):
+                df = method(*args, **kwargs)
+            df.__finalize__(self)
+            return df
+
+        return new_method
+
+    @property
+    def _constructor(self):
+        return OrangeDataFrame
+
+    def to_orange_table(self):
+        return table_from_frame(self)
+
+    def __finalize__(self, other, method=None, **_):
+        """
+        propagate metadata from other to self
+
+        Parameters
+        ----------
+        other : the object from which to get the attributes that we are going
+            to propagate
+        method : optional, a passed method name ; possibly to take different
+            types of propagation actions based on this
+
+        """
+        if method == 'concat':
+            objs = other.objs
+        elif method == 'merge':
+            objs = other.left, other.right
+        else:
+            objs = [other]
+
+        orange_role = getattr(self, 'orange_role', None)
+        dicts = {dname: getattr(self, dname, {})
+                 for dname in ('orange_variables',
+                               'orange_weights',
+                               'orange_attributes')}
+        for obj in objs:
+            other_role = getattr(obj, 'orange_role', None)
+            if other_role is not None:
+                orange_role = other_role
+
+            for dname, dict_ in dicts.items():
+                other_dict = getattr(obj, dname, {})
+                dict_.update(other_dict)
+
+        object.__setattr__(self, 'orange_role', orange_role)
+        for dname, dict_ in dicts.items():
+            object.__setattr__(self, dname, dict_)
+
+        return self
+
+    pd.DataFrame.__finalize__ = __finalize__
+
+
+def _is_discrete(s, force_nominal):
+    return (is_categorical_dtype(s) or
+            is_object_dtype(s) and (force_nominal or
+                                    s.nunique() < s.size ** .666))
+
+
+def _is_datetime(s):
+    if is_datetime64_any_dtype(s):
+        return True
+    try:
+        if is_object_dtype(s):
+            pd.to_datetime(s, infer_datetime_format=True)
             return True
-        try:
-            if is_object_dtype(s):
-                pd.to_datetime(s, infer_datetime_format=True)
-                return True
-        except Exception:  # pylint: disable=broad-except
-            pass
-        return False
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return False
+
+
+def vars_from_df(df, role=None, force_nominal=False):
+    if role is None and hasattr(df, 'orange_role'):
+        _role = df.orange_role
+    else:
+        _role = role
 
     # If df index is not a simple RangeIndex (or similar), put it into data
-    if not (df.index.is_integer() and (df.index.is_monotonic_increasing or
-                                       df.index.is_monotonic_decreasing)):
+    if not any(str(i).startswith('_o') for i in df.index) \
+            and not (df.index.is_integer() and (df.index.is_monotonic_increasing
+                                                or df.index.is_monotonic_decreasing)):
         df = df.reset_index()
 
-    attrs, metas = [], []
-    X, M = [], []
+    Xcols, Ycols, Mcols = [], [], []
+    Xexpr, Yexpr, Mexpr = [], [], []
+    attrs, class_vars, metas = [], [], []
 
-    # Iter over columns
-    for name, s in df.items():
-        name = str(name)
-        if _is_discrete(s):
+    contains_strings = _role == Role.Meta
+    for column in df.columns:
+        s = df[column]
+        if hasattr(df, 'orange_variables') and column in df.orange_variables:
+            original_var = df.orange_variables[column]
+            var = original_var.copy(compute_value=None)
+            if _role == Role.Attribute:
+                Xcols.append(column)
+                Xexpr.append(None)
+                attrs.append(var)
+            elif _role == Role.ClassAttribute:
+                Ycols.append(column)
+                Yexpr.append(None)
+                class_vars.append(var)
+            else:  # if role == Role.Meta:
+                Mcols.append(column)
+                Mexpr.append(None)
+                metas.append(var)
+        elif _is_discrete(s, force_nominal):
             discrete = s.astype('category').cat
-            attrs.append(DiscreteVariable(name, discrete.categories.astype(str).tolist()))
-            X.append(discrete.codes.replace(-1, np.nan).values)
+            var = DiscreteVariable(str(column),
+                                   discrete.categories.astype(str).tolist())
+            attrs.append(var)
+            Xcols.append(column)
+            Xexpr.append(lambda s, _: s.astype('category').cat
+                         .codes.replace(-1, np.nan).values)
         elif _is_datetime(s):
-            tvar = TimeVariable(name)
-            attrs.append(tvar)
+            var = TimeVariable(str(column))
             s = pd.to_datetime(s, infer_datetime_format=True)
-            X.append(s.astype('str').replace('NaT', np.nan).map(tvar.parse).values)
+            attrs.append(var)
+            Xcols.append(column)
+            Xexpr.append(lambda s, v: s.astype('str')
+                         .replace('NaT', np.nan).map(v.parse).values)
         elif is_numeric_dtype(s):
-            attrs.append(ContinuousVariable(name))
-            X.append(s.values)
+            var = ContinuousVariable(str(column))
+            attrs.append(var)
+            Xcols.append(column)
+            Xexpr.append(None)
         else:
-            metas.append(StringVariable(name))
-            M.append(s.values.astype(object))
+            contains_strings = True
+            var = StringVariable(str(column))
+            metas.append(var)
+            Mcols.append(column)
+            Mexpr.append(lambda s, _: s.values.astype(object))
 
-    return Table.from_numpy(Domain(attrs, None, metas),
-                            np.column_stack(X) if X else np.empty((df.shape[0], 0)),
-                            None,
-                            np.column_stack(M) if M else None)
+    # if role isn't explicitly set, try to
+    # export dataframes into one contiguous block.
+    # for this all columns must be of the same role
+    if isinstance(df, OrangeDataFrame) \
+            and not role \
+            and contains_strings \
+            and not force_nominal:
+        attrs.extend(class_vars)
+        attrs.extend(metas)
+        metas = attrs
+        Xcols.extend(Ycols)
+        Xcols.extend(Mcols)
+        Mcols = Xcols
+        Xexpr.extend(Yexpr)
+        Xexpr.extend(Mexpr)
+        Mexpr = Xexpr
+
+        attrs, class_vars = [], []
+        Xcols, Ycols = [], []
+        Xexpr, Yexpr = [], []
+
+    XYM = []
+    for Avars, Acols, Aexpr in zip(
+            (attrs, class_vars, metas),
+            (Xcols, Ycols, Mcols),
+            (Xexpr, Yexpr, Mexpr)):
+        if not Acols:
+            A = None if Acols != Xcols else np.empty((df.shape[0], 0))
+            XYM.append(A)
+            continue
+        if not any(Aexpr):
+            Adf = df if all(c in Acols
+                            for c in df.columns) else df[Acols]
+            if all(isinstance(a, SparseDtype) for a in Adf.dtypes):
+                A = csr_matrix(Adf.sparse.to_coo())
+            else:
+                A = Adf.values
+            XYM.append(A)
+            continue
+        # we'll have to copy the table to resolve any expressions
+        # TODO eliminate expr (preprocessing for pandas -> table)
+        A = np.array([expr(df[col], var) if expr else df[col].values
+                      for var, col, expr in zip(Avars, Acols, Aexpr)]).T
+        XYM.append(A)
+
+    return XYM, Domain(attrs, class_vars, metas)
+
+
+def table_from_frame(df, *, force_nominal=False):
+    XYM, domain = vars_from_df(df, force_nominal=force_nominal)
+
+    if hasattr(df, 'orange_weights') and hasattr(df, 'orange_attributes'):
+        W = [df.orange_weights[i] for i in df.index
+             if i in df.orange_weights]
+        if len(W) != len(df.index):
+            W = None
+        attributes = df.orange_attributes
+        ids = [int(i[2:]) if str(i).startswith('_o') else Table.new_id()
+               for i in df.index]
+    else:
+        W = None
+        attributes = None
+        ids = None
+
+    return Table.from_numpy(
+        domain,
+        *XYM,
+        W=W,
+        attributes=attributes,
+        ids=ids
+    )
+
+
+def table_from_frames(xdf, ydf, mdf):
+    dfs = xdf, ydf, mdf
+
+    if not all(df.shape[0] == xdf.shape[0] for df in dfs):
+        raise ValueError(f"Leading dimension mismatch "
+                         f"(not {xdf.shape[0]} == {ydf.shape[0]} == {mdf.shape[0]})")
+
+    xXYM, xDomain = vars_from_df(xdf, role=Role.Attribute)
+    yXYM, yDomain = vars_from_df(ydf, role=Role.ClassAttribute)
+    mXYM, mDomain = vars_from_df(mdf, role=Role.Meta)
+
+    XYM = (xXYM[0], yXYM[1], mXYM[2])
+    domain = Domain(xDomain.attributes, yDomain.class_vars, mDomain.metas)
+
+    index_iter = (filter(lambda ind: ind.startswith('_o'),
+                         set(df.index[i] for df in dfs))
+                  for i in range(len(xdf.shape[0])))
+    ids = (i[0] if len(i) == 1 else Table.new_id()
+           for i in index_iter)
+
+    attributes = {}
+    W = None
+    for df in dfs:
+        if isinstance(df, OrangeDataFrame):
+            W = [df.orange_weights[i] for i in df.index
+                 if i in df.orange_weights]
+            if len(W) != len(df.index):
+                W = None
+        else:
+            W = None
+        attributes.update(df.orange_attributes)
+
+    return Table.from_numpy(
+        domain,
+        *XYM,
+        W=W,
+        attributes=attributes,
+        ids=ids
+    )
 
 
 def table_to_frame(tab, include_metas=False):
@@ -132,3 +392,39 @@ def table_to_frame(tab, include_metas=False):
     original_column_order = [var.name for var in all_vars]
     unsorted_columns_df = pd.DataFrame(all_series)
     return unsorted_columns_df[original_column_order]
+
+
+def table_to_frames(table):
+    xdf = OrangeDataFrame(table, Role.Attribute)
+    ydf = OrangeDataFrame(table, Role.ClassAttribute)
+    mdf = OrangeDataFrame(table, Role.Meta)
+
+    return xdf, ydf, mdf
+
+
+def amend_table_with_frame(table, df, role):
+    arr = Role.get_arr(role, table)
+    if arr.shape[0] != df.shape[0]:
+        raise ValueError(f"Leading dimension mismatch "
+                         f"(not {arr.shape[0]} == {df.shape[0]})")
+
+    XYM, domain = vars_from_df(df, role=role)
+
+    if role == Role.Attribute:
+        table.domain = Domain(domain.attributes,
+                              table.domain.class_vars,
+                              table.domain.metas)
+        table.X = XYM[0]
+    elif role == Role.ClassAttribute:
+        table.domain = Domain(table.domain.attributes,
+                              domain.class_vars,
+                              table.domain.metas)
+        table.Y = XYM[1]
+    else:  # if role == Role.Meta:
+        table.domain = Domain(table.domain.attributes,
+                              table.domain.class_vars,
+                              domain.metas)
+        table.metas = XYM[2]
+
+    if isinstance(df, OrangeDataFrame):
+        table.attributes.update(df.orange_attributes)

--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -353,6 +353,7 @@ def table_to_frame(tab, include_metas=False):
     -------
     pandas.DataFrame
     """
+
     def _column_to_series(col, vals):
         result = ()
         if col.is_discrete:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -12,12 +12,13 @@ from threading import Lock
 
 import bottleneck as bn
 import numpy as np
-from Orange.misc.collections import frozendict
-from Orange.util import OrangeDeprecationWarning
+
 from scipy import sparse as sp
 from scipy.sparse import issparse, csc_matrix
 
 import Orange.data  # import for io.py
+from Orange.misc.collections import frozendict
+from Orange.util import OrangeDeprecationWarning
 from Orange.data import (
     _contingency, _valuecount,
     Domain, Variable, Storage, StringVariable, Unknown, Value, Instance,
@@ -1094,6 +1095,7 @@ class Table(Sequence, Storage):
         """
         Ensure that the table owns its data; copy arrays when necessary.
         """
+
         def is_view(x):
             # Sparse matrices don't have views like numpy arrays. Since indexing on
             # them creates copies in constructor we can skip this check here.
@@ -1163,12 +1165,12 @@ class Table(Sequence, Storage):
 
     def has_missing(self):
         """Return `True` if there are any missing attribute or class values."""
-        missing_x = not sp.issparse(self.X) and bn.anynan(self.X)   # do not check for sparse X
+        missing_x = not sp.issparse(self.X) and bn.anynan(self.X)  # do not check for sparse X
         return missing_x or bn.anynan(self._Y)
 
     def has_missing_attribute(self):
         """Return `True` if there are any missing attribute values."""
-        return not sp.issparse(self.X) and bn.anynan(self.X)    # do not check for sparse X
+        return not sp.issparse(self.X) and bn.anynan(self.X)  # do not check for sparse X
 
     def has_missing_class(self):
         """Return `True` if there are any missing class values."""
@@ -1496,7 +1498,7 @@ class Table(Sequence, Storage):
 
     @staticmethod
     def _range_filter_to_indicator(filter, col, fmin, fmax):
-        with np.errstate(invalid="ignore"):   # nan's are properly discarded
+        with np.errstate(invalid="ignore"):  # nan's are properly discarded
             if filter.oper == filter.Equal:
                 return col == fmin
             if filter.oper == filter.NotEqual:
@@ -1540,9 +1542,9 @@ class Table(Sequence, Storage):
                 if 0 <= c < nattrs:
                     S = fast_stats(self.X[:, [c]], W and W[:, [c]])
                 elif c >= nattrs:
-                    S = fast_stats(self._Y[:, [c-nattrs]], W and W[:, [c-nattrs]])
+                    S = fast_stats(self._Y[:, [c - nattrs]], W and W[:, [c - nattrs]])
                 else:
-                    S = fast_stats(self.metas[:, [-1-c]], W and W[:, [-1-c]])
+                    S = fast_stats(self.metas[:, [-1 - c]], W and W[:, [-1 - c]])
                 stats.append(S[0])
         return stats
 
@@ -1646,7 +1648,7 @@ class Table(Sequence, Storage):
         # it to dense and make it 1D
         if issparse(row_data):
             row_data = row_data.toarray().ravel()
-        if row_data.dtype.kind != "f": #meta attributes can be stored as type object
+        if row_data.dtype.kind != "f":  # meta attributes can be stored as type object
             row_data = row_data.astype(float)
 
         contingencies = [None] * len(col_desc)
@@ -1844,7 +1846,7 @@ class Table(Sequence, Storage):
         if dense_metas:
             densify(new_domain.metas)
         t = self.transform(new_domain)
-        t.ids = self.ids    # preserve indices
+        t.ids = self.ids  # preserve indices
         return t
 
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -654,6 +654,49 @@ class Table(Sequence, Storage):
             cls._next_instance_id += 1
             return id
 
+    def to_pandas_dfs(self):
+        return Orange.data.pandas_compat.table_to_frames(self)
+
+    @staticmethod
+    def from_pandas_dfs(xdf, ydf, mdf):
+        return Orange.data.pandas_compat.table_from_frames(xdf, ydf, mdf)
+
+    @property
+    def X_df(self):
+        return Orange.data.pandas_compat.OrangeDataFrame(
+            self, orange_role=Role.Attribute
+        )
+
+    @X_df.setter
+    def X_df(self, df):
+        Orange.data.pandas_compat.amend_table_with_frame(
+            self, df, role=Role.Attribute
+        )
+
+    @property
+    def Y_df(self):
+        return Orange.data.pandas_compat.OrangeDataFrame(
+            self, orange_role=Role.ClassAttribute
+        )
+
+    @Y_df.setter
+    def Y_df(self, df):
+        Orange.data.pandas_compat.amend_table_with_frame(
+            self, df, role=Role.ClassAttribute
+        )
+
+    @property
+    def metas_df(self):
+        return Orange.data.pandas_compat.OrangeDataFrame(
+            self, orange_role=Role.Meta
+        )
+
+    @metas_df.setter
+    def metas_df(self, df):
+        Orange.data.pandas_compat.amend_table_with_frame(
+            self, df, role=Role.Meta
+        )
+
     def save(self, filename):
         """
         Save a data table to a file. The path can be absolute or relative.
@@ -1954,3 +1997,15 @@ def assure_domain_conversion_sparsity(target, source):
     target.Y = match_density[conversion.sparse_Y](target.Y)
     target.metas = match_density[conversion.sparse_metas](target.metas)
     return target
+
+
+class Role:
+    Attribute = 0
+    ClassAttribute = 1
+    Meta = 2
+
+    @staticmethod
+    def get_arr(role, table):
+        return table.X if role == Role.Attribute else \
+               table.Y if role == Role.ClassAttribute else \
+               table.metas

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -1,7 +1,13 @@
 # pylint: disable=import-outside-toplevel
+
 import unittest
 import numpy as np
-from Orange.data import ContinuousVariable, DiscreteVariable, TimeVariable, Table
+from scipy.sparse import csr_matrix
+import scipy.sparse as sp
+
+from Orange.data import ContinuousVariable, DiscreteVariable, TimeVariable, Table, Domain, \
+    StringVariable
+from Orange.data.pandas_compat import OrangeDataFrame
 
 try:
     import pandas as pd
@@ -89,11 +95,39 @@ class TestPandasCompat(unittest.TestCase):
         cols = pd.Index([var.name for var in domain.variables + domain.metas])
         pd.testing.assert_index_equal(df.columns, cols)
 
+    def test_not_orangedf(self):
+        table = Table("iris")
+        xdf, ydf, mdf = table.to_pandas_dfs()
+        xtable = xdf.to_orange_table()
+        ytable = ydf.to_orange_table()
+        mtable = mdf.to_orange_table()
+
+        np.testing.assert_array_equal(table.X, xtable.X)
+        np.testing.assert_array_equal(table.Y, ytable.Y)
+        np.testing.assert_array_equal(table.metas, mtable.metas)
+        np.testing.assert_array_equal(table.W, xtable.W)
+        np.testing.assert_array_equal(table.W, ytable.W)
+        np.testing.assert_array_equal(table.W, mtable.W)
+        self.assertEqual(table.attributes, xtable.attributes)
+        self.assertEqual(table.attributes, ytable.attributes)
+        self.assertEqual(table.attributes, mtable.attributes)
+        np.testing.assert_array_equal(table.ids, xtable.ids)
+        np.testing.assert_array_equal(table.ids, ytable.ids)
+        np.testing.assert_array_equal(table.ids, mtable.ids)
+
+        d1 = table.domain
+        d2 = xtable.domain
+
+        vars1 = d1.variables + d1.metas
+        vars2 = d2.variables + d2.metas
+
+        for v1, v2 in zip(vars1, vars2):
+            self.assertEqual(type(v1), type(v2))
+
     @unittest.skip("Convert all Orange demo dataset. It takes about 5s which is way to slow")
     def test_table_to_frame_on_all_orange_dataset(self):
         from os import listdir
         from Orange.data.pandas_compat import table_to_frame
-        import pandas as pd
 
         dataset_directory = "Orange/datasets/"
 
@@ -112,6 +146,364 @@ class TestPandasCompat(unittest.TestCase):
             self.assertEqual(type(df), pd.DataFrame, assert_message)
             self.assertEqual(len(df), len(table), assert_message)
             self.assertEqual(len(df.columns), len(table.domain), assert_message)
+
+
+class TestTablePandas(unittest.TestCase):
+    def setUp(self):
+        if not hasattr(self, 'table'):
+            self.skipTest('Base class')
+
+    def test_basic(self):
+        xdf, ydf, mdf = self.table.to_pandas_dfs()
+        xtable = xdf.to_orange_table()
+        ytable = ydf.to_orange_table()
+        mtable = mdf.to_orange_table()
+
+        self.__arreq__(self.table.X, xtable.X)
+        self.__arreq__(self.table.Y, ytable.Y)
+        self.__arreq__(self.table.metas, mtable.metas)
+        self.__arreq__(self.table.W, xtable.W)
+        self.__arreq__(self.table.W, ytable.W)
+        self.__arreq__(self.table.W, mtable.W)
+        self.assertEqual(self.table.attributes, xtable.attributes)
+        self.assertEqual(self.table.attributes, ytable.attributes)
+        self.assertEqual(self.table.attributes, mtable.attributes)
+        self.__arreq__(self.table.ids, xtable.ids)
+        self.__arreq__(self.table.ids, ytable.ids)
+        self.__arreq__(self.table.ids, mtable.ids)
+
+        d1 = self.table.domain
+        d2 = xtable.domain
+
+        vars1 = d1.variables + d1.metas
+        vars2 = d2.variables + d2.metas
+
+        for v1, v2 in zip(vars1, vars2):
+            self.assertEqual(type(v1), type(v2))
+
+    def test_slice(self):
+        df = self.table.X_df
+        table2 = df[['c2', 'd1']].to_orange_table()
+
+        self.__arreq__(self.table.ids, table2.ids)
+        self.__arreq__(self.table.W, table2.W)
+        self.__arreq__(self.table.attributes, table2.attributes)
+
+        domain = table2.domain
+        target_domain = Domain([ContinuousVariable("c2"),
+                                DiscreteVariable("d1")])
+
+        self.assertEqual(domain, target_domain)
+
+    def test_copy(self):
+        df = self.table.X_df
+        df2 = df.copy()
+
+        np.testing.assert_array_equal(df.index, df2.index)
+        self.assertEqual(df.orange_variables, df2.orange_variables)
+        self.assertEqual(df.orange_role, df2.orange_role)
+        self.assertEqual(df.orange_attributes, df2.orange_attributes)
+        self.assertEqual(df.orange_weights, df2.orange_weights)
+
+    def test_concat_table(self):
+        domain2 = Domain(
+            [self.table.domain['c2'],
+             self.table.domain['d1']]
+        )
+        table2 = Table.from_numpy(
+            domain2,
+            np.array(
+                [[0, 0],
+                 [1, 1]]),
+            W=np.array([1, 1])
+        )
+
+        df = self.table.X_df
+        df2 = table2.X_df
+        df3 = pd.concat([df, df2])
+        table3 = df3.to_orange_table()
+
+        np.testing.assert_array_equal(table3.ids,
+                                      np.concatenate([self.table.ids,
+                                                      table2.ids]))
+        np.testing.assert_array_equal(table3.W[:-2],
+                                      self.table.W)
+        np.testing.assert_array_equal(table3.W[-2:],
+                                      table2.W)
+
+        attrs = {}
+        attrs.update(self.table.attributes)
+        attrs.update(table2.attributes)
+
+        self.assertEqual(table3.attributes, attrs)
+
+        vars1 = self.table.domain.variables
+        vars2 = table3.domain.variables
+
+        for v1, v2 in zip(vars1, vars2):
+            self.assertEqual(type(v1), type(v2))
+
+    def test_concat_df(self):
+        df2 = pd.DataFrame(np.array([[0, 0],
+                                     [1, 1]]))
+
+        df = self.table.X_df
+        df3 = pd.concat([df, df2])
+        table3 = df3.to_orange_table()
+
+        np.testing.assert_array_equal(table3.ids[:-2],
+                                      self.table.ids)
+
+        d1 = self.table.domain
+        d2 = table3.domain
+
+        vars1 = d1.attributes
+        vars2 = d2.variables + d2.metas
+
+        for v1 in vars1:
+            self.assertIn(v1, vars2)
+
+    def test_merge(self):
+        domain2 = Domain(
+            [ContinuousVariable("c2"),
+             ContinuousVariable("d15")]
+        )
+        table2 = Table.from_numpy(
+            domain2,
+            np.array(
+                [[0, 4],
+                 [-1, 15],
+                 [1, 23]])
+        )
+
+        df = self.table.X_df
+        df2 = table2.X_df
+        df3 = pd.merge(df, df2, on='c2')
+        table2 = df.to_orange_table()
+        table3 = df3.to_orange_table()
+
+        self.assertEqual(len(table2), len(table3))
+        self.assertFalse(any(table3.W))
+        self.assertEqual(self.table.attributes, table3.attributes)
+
+        d1 = table2.domain
+        d2 = table3.domain
+
+        vars1 = d1.variables + d1.metas
+        vars2 = d2.variables + d2.metas
+
+        self.assertEqual(len(vars2), len(vars1) + 1)
+
+        new_var = next(v for v in vars2
+                       if v.name == 'd15')
+        self.assertIsInstance(new_var, ContinuousVariable)
+
+        new_var_excluded = [v for v in vars2
+                            if v != new_var]
+        for v1, v2 in zip(vars1, new_var_excluded):
+            self.assertEqual(type(v1), type(v2))
+
+    def test_new_column(self):
+        df = self.table.X_df
+        table2 = df.to_orange_table()
+        df['new'] = np.array([0, 1, 0, 1, 6, 1, 1])
+        table3 = df.to_orange_table()
+
+        d1 = table2.domain
+        d2 = table3.domain
+
+        vars1 = d1.variables + d1.metas
+        vars2 = d2.variables + d2.metas
+
+        self.assertEqual(len(vars2), len(vars1) + 1)
+
+        new_var = next(v for v in vars2
+                       if v.name == 'new')
+        self.assertIsInstance(new_var, ContinuousVariable)
+
+        new_var_excluded = [v for v in vars2
+                            if v != new_var]
+        for v1, v2 in zip(vars1, new_var_excluded):
+            self.assertEqual(type(v1), type(v2))
+
+    def test_selection(self):
+        df = self.table.X_df
+
+        tsel = self.table[1:3]
+        dfsel = df[1:3].to_orange_table()
+
+        self.__arreq__(tsel.X, dfsel.X)
+        self.__arreq__(tsel.ids, dfsel.ids)
+        self.__arreq__(tsel.W, dfsel.W)
+        self.__arreq__(tsel.attributes, dfsel.attributes)
+
+
+class TestDenseTablePandas(TestTablePandas):
+    def setUp(self):
+        self.domain = Domain(
+            [ContinuousVariable("c1"),
+             ContinuousVariable("c2"),
+             DiscreteVariable("d1", values=("a", "b"))],
+            ContinuousVariable("y"),
+            [ContinuousVariable("c3"),
+             DiscreteVariable("d2", values=("c", "d")),
+             StringVariable("s1"),
+             StringVariable("s2")]
+        )
+        metas = np.array(
+            [0, 1, 0, 1, 1, 2, 1] +
+            [0, 0, 0, 0, 4, 1, 1] +
+            "a  b  c  d  e     f    g".split() +
+            list("ABCDEF") + [""], dtype=object).reshape(-1, 7).T
+        self.table = Table.from_numpy(
+            self.domain,
+            np.array(
+                [[0, 0, 0],
+                 [0, -1, 0],
+                 [7, 1, 0],
+                 [1, 1, 1],
+                 [1, 1, 1],
+                 [1, 1, 1],
+                 [1, 1, 1]]),
+            np.array(
+                [0, 1, 0, 1, 1, 1, 1]),
+            metas,
+            attributes={'haha': 'hoho'},
+            W=np.array([0, 1, 1, 0, 1, 0, 1])
+        )
+
+        self.__arreq__ = np.testing.assert_equal
+
+    def test_contiguous_x(self):
+        table = self.table
+        df = table.X_df
+        table2 = df.to_orange_table()
+        self.assertTrue(np.shares_memory(df.values, table.X))
+        self.assertTrue(np.shares_memory(df.values, table2.X))
+
+    def test_contiguous_y(self):
+        table = self.table
+        df = table.Y_df
+        table2 = df.to_orange_table()
+        self.assertTrue(np.shares_memory(df.values, table.Y))
+        self.assertTrue(np.shares_memory(df.values, table2.Y))
+
+    @unittest.skipUnless(pd.__version__ >= '1.3.0',
+                         'pandas-dev/pandas#39263')
+    def test_contiguous_metas(self):
+        table = self.table
+        df = table.metas_df
+        table2 = df.to_orange_table()
+        self.assertTrue(np.shares_memory(df.values, table.metas))
+        self.assertTrue(np.shares_memory(df.values, table2.metas))
+
+    def test_to_dfs(self):
+        table = self.table
+        dfs = table.to_pandas_dfs()
+
+        tables = [df.to_orange_table() for df in dfs]
+        for t in tables:
+            arrs = (t.X, t.Y, t.metas)
+            self.assertEqual(sum(
+                arr.size > 0
+                for arr in arrs
+            ), 1)
+
+    def test_amend(self):
+        df = self.table.X_df
+        df.iloc[0][0] = 0
+        X = self.table.X
+        self.table.X_df = df
+        self.assertTrue(np.shares_memory(df.values, X))
+
+    def test_amend_dimension_mismatch(self):
+        df = self.table.X_df
+        df = df.append([0, 1])
+        try:
+            self.table.X_df = df
+        except ValueError as e:
+            self.assertEqual(str(e),
+                             'Leading dimension mismatch (not 7 == 9)')
+        else:
+            self.fail()
+
+
+class TestSparseTablePandas(TestTablePandas):
+    features = (
+        ContinuousVariable(name="c2"),
+        ContinuousVariable(name="Continuous Feature 2"),
+        DiscreteVariable(name="d1", values=("0", "1")),
+        DiscreteVariable(name="Discrete Feature 2",
+                         values=("value1", "value2")),
+    )
+
+    class_vars = (
+        ContinuousVariable(name="Continuous Class"),
+        DiscreteVariable(name="Discrete Class", values=("m", "f"))
+    )
+
+    feature_data = (
+        (1, 0, 0, 0),
+        (0, 1, 0, 0),
+        (0, 1, 1, 0),
+        (0, 0, 0, 0),
+        (0, 1, 1, 0),
+        (0, 0, 0, 0),
+        (0, 1, 1, 0),
+    )
+
+    class_data = (
+        (1, 0),
+        (0, 1),
+        (1, 0),
+        (0, 1),
+        (1, 0),
+        (0, 1),
+        (1, 0),
+    )
+
+    def setUp(self):
+        self.domain = Domain(attributes=self.features,
+                             class_vars=self.class_vars)
+        table = Table.from_numpy(
+            self.domain,
+            np.array(self.feature_data),
+            np.array(self.class_data),
+        )
+        self.table = Table.from_numpy(
+            self.domain,
+            csr_matrix(table.X),
+            csr_matrix(table.Y),
+            W=np.array([1, 0, 1, 0, 1, 1, 1])
+        )
+
+        def arreq(t1, t2):
+            if all(sp.issparse(t) for t in (t1, t2)):
+                return self.assertEqual((t1 != t2).nnz, 0)
+            else:
+                return np.array_equal(t1, t2)
+
+        self.__arreq__ = arreq
+
+    def test_to_dense(self):
+        df = self.table.X_df
+
+        self.assertIsInstance(df, OrangeDataFrame)
+
+        ddf = df.sparse.to_dense()
+        np.testing.assert_array_equal(df.index, ddf.index)
+        np.testing.assert_array_equal(df.orange_variables, ddf.orange_variables)
+        np.testing.assert_array_equal(df.orange_attributes, ddf.orange_attributes)
+        np.testing.assert_array_equal(df.orange_role, ddf.orange_role)
+        np.testing.assert_array_equal(df.orange_weights, ddf.orange_weights)
+
+        table = self.table.to_dense()
+        table2 = ddf.to_orange_table()
+
+        np.testing.assert_array_equal(table2.X, table.X)
+        np.testing.assert_array_equal(table2.ids, table.ids)
+        np.testing.assert_array_equal(table2.W, table.W)
+        np.testing.assert_array_equal(table2.attributes, table.attributes)
 
 
 if __name__ == "__main__":

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -11,7 +11,7 @@ from numpy.testing import assert_array_equal
 
 from Orange.data import (
     ContinuousVariable, DiscreteVariable, StringVariable, TimeVariable,
-    Variable, Domain, Table, DomainConversion)
+    Domain, Table, DomainConversion)
 from Orange.data.domain import filter_visible
 from Orange.preprocess import Continuize, Impute
 from Orange.tests.base import create_pickling_tests
@@ -19,7 +19,7 @@ from Orange.util import OrangeDeprecationWarning
 
 
 def create_domain(*ss):
-    vars = dict(
+    vars_ = dict(
         age=ContinuousVariable(name="AGE"),
         gender=DiscreteVariable(name="Gender", values=("M", "F")),
         incomeA=ContinuousVariable(name="incomeA"),
@@ -31,7 +31,7 @@ def create_domain(*ss):
         arrival=TimeVariable("arrival"))
 
     def map_vars(s):
-        return [vars[x] for x in s]
+        return [vars_[x] for x in s]
     return Domain(*[map_vars(s) for s in ss])
 
 

--- a/benchmark/bench_basic.py
+++ b/benchmark/bench_basic.py
@@ -1,12 +1,12 @@
-from .base import Benchmark, benchmark, pandas_only, non_pandas_only
 from Orange.data import Table
 from Orange.preprocess import Discretize
 from Orange.preprocess.discretize import EqualFreq
+from .base import Benchmark, benchmark, pandas_only, non_pandas_only
 
 # noinspection PyBroadException
 try:
     from Orange.data.filter import FilterContinuous, FilterDiscrete, Values
-except:
+except:  # pylint: disable=bare-except
     # legacy only
     pass
 


### PR DESCRIPTION
Bases off #5190.

##### Issue
At the moment, our pandas solution copies the X, Y and meta numpy arrays into one contiguous array. It also sets its column `dtypes`. This is inefficient, and loses information like global row IDs, roles, variable info. 

The proposed solution is not an attempt at migration, but rather a seamless integration (both Orange and pandas operate on numpy arrays). This will be used in Python Script, but could also be leveraged by widget code.

##### Description of changes
Added a new `table_to_frames` method, which wraps the three existing numpy arrays into three DataFrames. This is near-instantaneous, as no copying occurs, it simply wraps the preexisting data structures. Also:
- it keeps global row index information by setting pandas indices in `_o1, _o2, _o3` format
- upon conversion back to table, it copies the columns' original variables (setting `compute_value` to `None`)
- it remembers what role the converted table represented (feature/target/meta), and applies the role to all its columns upon conversion back to table

An edge case: how do you handle concatenate when one of the frames has weights and the other doesn't?

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
