### PR TITLE
[FIX] owdataset: Do not capture self in closure

### DIFF
--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -11,9 +11,9 @@ from Orange.widgets.utils.state_summary import format_summary_details
 
 
 class TestOWDataSets(WidgetTest):
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_remote",
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(side_effect=requests.exceptions.ConnectionError))
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_local",
+    @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={}))
     @patch("Orange.widgets.data.owdatasets.log", Mock())
     def test_no_internet_connection(self):
@@ -21,9 +21,9 @@ class TestOWDataSets(WidgetTest):
         self.wait_until_stop_blocking(w)
         self.assertTrue(w.Error.no_remote_datasets.is_shown())
 
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_remote",
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(side_effect=requests.exceptions.ConnectionError))
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_local",
+    @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={('core', 'foo.tab'): {}}))
     @patch("Orange.widgets.data.owdatasets.log", Mock())
     def test_only_local(self):
@@ -32,9 +32,9 @@ class TestOWDataSets(WidgetTest):
         self.assertTrue(w.Warning.only_local_datasets.is_shown())
         self.assertEqual(w.view.model().rowCount(), 1)
 
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_remote",
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(side_effect=requests.exceptions.ConnectionError))
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_local",
+    @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={('core', 'foo.tab'): {},
                               ('core', 'bar.tab'): {}}))
     @patch("Orange.widgets.data.owdatasets.log", Mock())
@@ -49,9 +49,9 @@ class TestOWDataSets(WidgetTest):
         w.filterLineEdit.setText("")
         self.assertEqual(w.view.model().rowCount(), 2)
 
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_remote",
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(return_value={('core', 'iris.tab'): {}}))
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_local",
+    @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={}))
     @patch("Orange.widgets.data.owdatasets.ensure_local",
            Mock(return_value="iris.tab"))
@@ -65,9 +65,9 @@ class TestOWDataSets(WidgetTest):
         iris = self.get_output(w.Outputs.data, w)
         self.assertEqual(len(iris), 150)
 
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_remote",
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(side_effect=requests.exceptions.ConnectionError))
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_local",
+    @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={('dir1', 'dir2', 'foo.tab'): {},
                               ('bar.tab',): {}}))
     @patch("Orange.widgets.data.owdatasets.log", Mock())
@@ -76,9 +76,9 @@ class TestOWDataSets(WidgetTest):
         self.wait_until_stop_blocking(w)
         self.assertEqual(w.view.model().rowCount(), 2)
 
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_remote",
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(return_value={('core', 'iris.tab'): {}}))
-    @patch("Orange.widgets.data.owdatasets.OWDataSets.list_local",
+    @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={}))
     @patch("Orange.widgets.data.owdatasets.ensure_local",
            Mock(return_value="iris.tab"))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

OWDataSets captures `self` in a closure executing in a worker thread.

See: https://github.com/biolab/orange3-single-cell/pull/381#issuecomment-752631590

##### Description of changes

Parameterize and move the functions out of the class.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
