### PR TITLE
[FIX] Fix performance regression in scatterplot

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -642,12 +642,18 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         self.tip_textitem.setHtml(text)
 
     def suspend_jittering(self):
+        if self.jittering_suspended:
+            return
         self.jittering_suspended = True
-        self.update_jittering()
+        if self.jitter_size != 0:
+            self.update_jittering()
 
     def unsuspend_jittering(self):
+        if not self.jittering_suspended:
+            return
         self.jittering_suspended = False
-        self.update_jittering()
+        if self.jitter_size != 0:
+            self.update_jittering()
 
     def update_jittering(self):
         x, y = self.get_coordinates()

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -364,6 +364,29 @@ class TestOWScatterPlotBase(WidgetTest):
         x, y = scatterplot_item.getData()
         np.testing.assert_equal(a10, x)
 
+    def test_suspend_jittering(self):
+        graph = self.graph
+        graph.jitter_size = 10
+        graph.reset_graph()
+        uj = graph.update_jittering = Mock()
+        graph.unsuspend_jittering()
+        uj.assert_not_called()
+        graph.suspend_jittering()
+        uj.assert_called()
+        uj.reset_mock()
+        graph.suspend_jittering()
+        uj.assert_not_called()
+        graph.unsuspend_jittering()
+        uj.assert_called()
+        uj.reset_mock()
+
+        graph.jitter_size = 0
+        graph.reset_graph()
+        graph.suspend_jittering()
+        uj.assert_not_called()
+        graph.unsuspend_jittering()
+        uj.assert_not_called()
+
     def test_size_normalization(self):
         graph = self.graph
 


### PR DESCRIPTION
##### Issue
PR #5038 introduced jittering suspension with selection. It introduced a performance regression, because it needlessly updated point positions while the selection was being performed. For example, with 10000 data points, selection was lagging noticeably.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
