### PR TITLE
Fix pyqtgraph==0.11.1 test failures

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -223,6 +223,27 @@ class ScatterPlotItem(pg.ScatterPlotItem):
             self._z_mapping = np.argsort(z)
             self._inv_mapping = np.argsort(self._z_mapping)
 
+    def setCoordinates(self, x, y):
+        """
+        Change the coordinates of points while keeping other properties.
+
+        Asserts that the number of points stays the same.
+
+        Note. Pyqtgraph does not offer a method for this: setting coordinates
+        invalidates other data. We therefore retrieve the data to set it
+        together with the coordinates. Pyqtgraph also does not offer a
+        (documented) method for retrieving the data, yet using
+        data[prop]` looks reasonably safe.
+
+        The alternative, updating the whole scatterplot from the Orange Table,
+        is too slow.
+        """
+        assert len(self.data) == len(x) == len(y)
+        data = dict(x=x, y=y)
+        for prop in ('pen', 'brush', 'size', 'symbol', 'data'):
+            data[prop] = self.data[prop]
+        self.setData(**data)
+
     def updateSpots(self, dataSet=None):  # pylint: disable=unused-argument
         self._update_spots_in_paint = True
         self.update()
@@ -653,8 +674,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         x, y = self.get_coordinates()
         if x is None or len(x) == 0 or self.scatterplot_item is None:
             return
-        self._update_plot_coordinates(self.scatterplot_item, x, y)
-        self._update_plot_coordinates(self.scatterplot_item_sel, x, y)
+        self.scatterplot_item.setCoordinates(x, y)
+        self.scatterplot_item_sel.setCoordinates(x, y)
         self.update_labels()
 
     # TODO: Rename to remove_plot_items
@@ -834,27 +855,6 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         return (x + magnitude * span_x * rs * np.cos(phis),
                 y + magnitude * span_y * rs * np.sin(phis))
 
-    def _update_plot_coordinates(self, plot, x, y):
-        """
-        Change the coordinates of points while keeping other properites.
-
-        Asserts that the number of points stays the same.
-
-        Note. Pyqtgraph does not offer a method for this: setting coordinates
-        invalidates other data. We therefore retrieve the data to set it
-        together with the coordinates. Pyqtgraph also does not offer a
-        (documented) method for retrieving the data, yet using
-        `plot.data[prop]` looks reasonably safe. The alternative, calling
-        update for every property would essentially reset the graph, which
-        can be time consuming.
-        """
-        assert self.n_shown == len(x) == len(y)
-        data = dict(x=x, y=y)
-        for prop in ('pen', 'brush', 'size', 'symbol', 'data',
-                     'sourceRect', 'targetRect'):
-            data[prop] = plot.data[prop]
-        plot.setData(**data)
-
     def update_coordinates(self):
         """
         Trigger the update of coordinates while keeping other features intact.
@@ -882,8 +882,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             self.plot_widget.addItem(self.scatterplot_item_sel)
             self.plot_widget.addItem(self.scatterplot_item)
         else:
-            self._update_plot_coordinates(self.scatterplot_item, x, y)
-            self._update_plot_coordinates(self.scatterplot_item_sel, x, y)
+            self.scatterplot_item.setCoordinates(x, y)
+            self.scatterplot_item_sel.setCoordinates(x, y)
             self.update_labels()
 
         self.update_density()  # Todo: doesn't work: try MDS with density on

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -1470,7 +1470,11 @@ class TestOWScatterPlotBase(WidgetTest):
     def test_no_needless_buildatlas(self):
         graph = self.graph
         graph.reset_graph()
-        self.assertIsNone(graph.scatterplot_item.fragmentAtlas.atlas)
+        atlas = graph.scatterplot_item.fragmentAtlas
+        if hasattr(atlas, "atlas"):  # pyqtgraph < 0.11.1
+            self.assertIsNone(atlas.atlas)
+        else:
+            self.assertFalse(atlas)
 
 
 class TestScatterPlotItem(GuiTest):

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -8,7 +8,7 @@ from AnyQt.QtCore import QRectF, Qt
 from AnyQt.QtGui import QColor
 from AnyQt.QtTest import QSignalSpy
 
-from pyqtgraph import mkPen
+from pyqtgraph import mkPen, mkBrush
 
 from orangewidget.tests.base import GuiTest
 from Orange.widgets.settings import SettingProvider
@@ -103,7 +103,7 @@ class TestOWScatterPlotBase(WidgetTest):
         scatterplot_item.setSize([5, 6])
         scatterplot_item.setSymbol([7, 8])
         scatterplot_item.setPen([mkPen(9), mkPen(10)])
-        scatterplot_item.setBrush([11, 12])
+        scatterplot_item.setBrush([mkBrush(11), mkBrush(12)])
         data["data"] = np.array([13, 14])
 
         xy[0][0] = 0
@@ -118,7 +118,8 @@ class TestOWScatterPlotBase(WidgetTest):
         np.testing.assert_almost_equal(data["symbol"], [7, 8])
         self.assertEqual(data["pen"][0], mkPen(9))
         self.assertEqual(data["pen"][1], mkPen(10))
-        np.testing.assert_almost_equal(data["brush"], [11, 12])
+        self.assertEqual(data["brush"][0], mkBrush(11))
+        self.assertEqual(data["brush"][1], mkBrush(12))
         np.testing.assert_almost_equal(data["data"], [13, 14])
 
     def test_update_coordinates_and_labels(self):

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -115,7 +115,7 @@ class Updater:
 
     @staticmethod
     def update_axis_title_text(item: pg.AxisItem, text: str):
-        item.setLabel(text)
+        item.setLabel(text, item.labelUnits, item.labelUnitPrefix)
         item.resizeEvent(None)
 
     @staticmethod
@@ -128,7 +128,8 @@ class Updater:
             style = {"font-size": f"{font.pointSize()}pt",
                      "font-family": f"{font.family()}",
                      "font-style": f"{fstyle}"}
-            item.setLabel(None, None, None, **style)
+            item.setLabel(item.labelText, item.labelUnits,
+                          item.labelUnitPrefix, **style)
 
     @staticmethod
     def update_axes_ticks_font(items: List[pg.AxisItem],

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -144,6 +144,11 @@ class Updater:
     def update_legend_font(items: Iterable[_LegendItemType],
                            **settings: _SettingType):
         for sample, label in items:
+            if "size" in label.opts:
+                # pyqtgraph added html-like support for size in 0.11.1, which
+                # overrides our QFont property
+                label.opts.pop("size")
+                label.setText(label.text)
             sample.setFixedHeight(sample.height())
             sample.setFixedWidth(sample.width())
             label.item.setFont(Updater.change_font(label.item.font(), settings))

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -508,10 +508,12 @@ class AxisItem(pg.AxisItem):
         self.prepareGeometryChange()
         self.update()
 
-    def generateDrawSpecs(self, p):
-        if self.style["tickFont"]:
-            p.setFont(self.style["tickFont"])
-        return super().generateDrawSpecs(p)
+    # remove after Orange requires pyqtgraph >= 0.11.1
+    if pg.__version__ <= "0.11.0":
+        def generateDrawSpecs(self, p):
+            if self.style["tickFont"]:
+                p.setFont(self.style["tickFont"])
+            return super().generateDrawSpecs(p)
 
     def drawPicture(self, p, axisSpec, tickSpecs, textSpecs):
         if self.orientation in ["bottom", "top"] and self.style["rotateTicks"]:
@@ -549,12 +551,14 @@ class AxisItem(pg.AxisItem):
         else:
             super().drawPicture(p, axisSpec, tickSpecs, textSpecs)
 
-    def _updateMaxTextSize(self, x):
-        if self.orientation in ["left", "right"]:
-            self.textWidth = x
-            if self.style["autoExpandTextSpace"] is True:
-                self._updateWidth()
-        else:
-            self.textHeight = x
-            if self.style["autoExpandTextSpace"] is True:
-                self._updateHeight()
+    # remove after Orange requires pyqtgraph >= 0.11.1
+    if pg.__version__ <= "0.11.0":
+        def _updateMaxTextSize(self, x):
+            if self.orientation in ["left", "right"]:
+                self.textWidth = x
+                if self.style["autoExpandTextSpace"] is True:
+                    self._updateWidth()
+            else:
+                self.textHeight = x
+                if self.style["autoExpandTextSpace"] is True:
+                    self._updateHeight()

--- a/Orange/widgets/visualize/utils/tests/test_plotutils.py
+++ b/Orange/widgets/visualize/utils/tests/test_plotutils.py
@@ -2,12 +2,13 @@ import unittest
 
 
 class TestAxisItem(unittest.TestCase):
-    def test_scalable_axis_item(self):
+    def test_remove_old_pyqtgraph_support(self):
         from pyqtgraph import __version__
-        # When upgraded to 0.11.1 (or bigger) check if resizing AxisItem font
-        # works and overwritten functions generateDrawSpecs and
-        # _updateMaxTextSize are no longer needed.
-        self.assertLess(__version__, "0.11.1")
+        # When 0.11.2 is released there is probably time to drop support
+        # for pyqtgraph <= 0.11.0:
+        # - remove AxisItem.generateDrawSpecs
+        # - remove AxisItem._updateMaxTextSize
+        self.assertLess(__version__, "0.11.2")
 
 
 if __name__ == '__main__':

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -5,5 +5,5 @@ PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select c
 PyQtWebEngine>=5.12
 AnyQt>=0.0.11
 
-pyqtgraph==0.11.0
+pyqtgraph>=0.11.0
 matplotlib>=2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ commands =
 [testenv:future_compatibility]
 deps =
     {[testenv]deps}
+    git+git://github.com/pyqtgraph/pyqtgraph.git#egg=pyqtgraph
     git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base
 


### PR DESCRIPTION
##### Issue
Some tests were failing with the new release of pyqtgraph. Our tests currrently pass with 0.11.0 or 0.11.1 or master.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
