### PR TITLE
[FIX] OWScatterPlotBase: Ignore 'Other' when showing color regions

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -43,6 +43,9 @@ with warnings.catch_warnings():
 SELECTION_WIDTH = 5
 MAX_N_VALID_SIZE_ANIMATE = 1000
 
+# maximum number of colors (including Other)
+MAX_COLORS = 11
+
 
 class LegendItem(PgLegendItem):
     def __init__(self, size=None, offset=None, pen=None, brush=None):
@@ -1189,7 +1192,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             c_data = self.master.get_color_data()
             if c_data is None:
                 return
-            mask = np.isfinite(self._filter_visible(c_data))
+            visible_c_data = self._filter_visible(c_data)
+            mask = np.bitwise_and(np.isfinite(visible_c_data),
+                                  visible_c_data < MAX_COLORS - 1)
             pens = self.scatterplot_item.data['pen']
             rgb_data = [
                 pen.color().getRgb()[:3] if pen is not None else (255, 255, 255)

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -25,12 +25,12 @@ from Orange.widgets.utils.annotated_data import (
 from Orange.widgets.utils.plot import OWPlotGUI
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.utils.state_summary import format_summary_details
-from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
+from Orange.widgets.visualize.owscatterplotgraph import (
+    OWScatterPlotBase, MAX_COLORS
+)
 from Orange.widgets.visualize.utils.component import OWGraphWithAnchors
 from Orange.widgets.widget import OWWidget, Input, Output, Msg
 
-# maximum number of colors (including Other)
-MAX_COLORS = 11
 
 # maximum number of shapes (including Other)
 MAX_SHAPES = len(OWScatterPlotBase.CurveSymbols) - 1


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5213

##### Description of changes
Projection widgets: ignore 'Other' category when showing color regions.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
