### PR TITLE
[ENH] Domain transformations in batches for less memory use

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -481,7 +481,7 @@ class Table(Sequence, Storage):
         :rtype: Orange.data.Table
         """
 
-        PART = 100
+        PART = 10
 
         new_cache = _thread_local.conversion_cache is None
         try:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -2025,6 +2025,13 @@ def _optimize_indices(indices, maxlen):
     if indices is ...:
         return slice(None, None, 1)
 
+    # a very common case for column selection
+    if len(indices) == 1 and not isinstance(indices[0], bool):
+        if indices[0] >= 0:
+            return slice(indices[0], indices[0] + 1, 1)
+        else:
+            return slice(indices[0], indices[0] - 1, -1)
+
     if len(indices) >= 1:
         indices = np.asarray(indices)
         if indices.dtype != bool:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -57,14 +57,12 @@ _thread_local = _ThreadLocal()
 
 
 def _idcache_save(cachedict, keys, value):
-    # key is tuple(list) not tuple(genexpr) for speed
-    cachedict[tuple([id(k) for k in keys])] = \
+    cachedict[tuple(map(id, keys))] = \
         value, [weakref.ref(k) for k in keys]
 
 
 def _idcache_restore(cachedict, keys):
-    # key is tuple(list) not tuple(genexpr) for speed
-    shared, weakrefs = cachedict.get(tuple([id(k) for k in keys]), (None, []))
+    shared, weakrefs = cachedict.get(tuple(map(id, keys)), (None, []))
     for r in weakrefs:
         if r() is None:
             return None

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -481,7 +481,7 @@ class Table(Sequence, Storage):
         :rtype: Orange.data.Table
         """
 
-        PART = 10
+        PART = 5000
 
         new_cache = _thread_local.conversion_cache is None
         try:

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -155,6 +155,9 @@ def assure_column_sparse(a):
 
 
 def assure_column_dense(a):
+    # quick check and exit for the most common case
+    if isinstance(a, np.ndarray) and len(a.shape) == 1:
+        return a
     a = assure_array_dense(a)
     # column assignments must be (n, )
     return a.reshape(-1)

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -17,6 +17,12 @@ class Transformation(Reprable):
         """
         self.variable = variable
 
+        if self.variable is not None:
+            if self.variable.is_primitive():
+                self.need_domain = Domain([self.variable])
+            else:
+                self.need_domain = Domain([], metas=[self.variable])
+
     def __call__(self, data):
         """
         Return transformed column from the data by extracting the column view
@@ -25,13 +31,10 @@ class Transformation(Reprable):
         inst = isinstance(data, Instance)
         if inst:
             data = Table.from_list(data.domain, [data])
+        data = data.transform(self.need_domain)
         if self.variable.is_primitive():
-            domain = Domain([self.variable])
-            data = Table.from_table(domain, data)
             col = data.X
         else:
-            domain = Domain([], metas=[self.variable])
-            data = Table.from_table(domain, data)
             col = data.metas
         if not sp.issparse(col):
             col = col.squeeze(axis=1)

--- a/Orange/tests/test_data_util.py
+++ b/Orange/tests/test_data_util.py
@@ -53,7 +53,7 @@ class TestSharedComputeValue(unittest.TestCase):
     def test_single_call(self):
         obj = DummyPlus(Mock(return_value=1))
         self.assertEqual(obj.compute_shared.call_count, 0)
-        data = Orange.data.Table("iris")
+        data = Orange.data.Table("iris")[45:55]  # two classes
         domain = Orange.data.Domain([at.copy(compute_value=obj)
                                      for at in data.domain.attributes],
                                     data.domain.class_vars)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1643,16 +1643,13 @@ class CreateTableWithDomainAndTable(TableTests):
                 new_table, self.table, rows=slice_)
             from_table_rows.assert_called()
 
-    @patch.object(Table, "from_table_rows", wraps=Table.from_table_rows)
-    def test_can_filter_row_with_slice_from_table(self, from_table_rows):
+    def test_can_filter_row_with_slice_from_table(self):
         # calling from_table with a domain copy will use indexing in from_table
         for slice_ in self.interesting_slices:
-            from_table_rows.reset_mock()
             new_table = data.Table.from_table(
                 self.domain.copy(), self.table, row_indices=slice_)
             self.assert_table_with_filter_matches(
                 new_table, self.table, rows=slice_)
-            from_table_rows.assert_not_called()
 
     def test_can_use_attributes_as_new_columns(self):
         a, _, _ = column_sizes(self.table)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2716,7 +2716,7 @@ class TestTableSparseDense(unittest.TestCase):
 class ConcurrencyTests(unittest.TestCase):
 
     def test_from_table_non_blocking(self):
-        iris = Table("iris")
+        iris = Table("iris")[:10]
 
         def slow_compute_value(d):
             sleep(0.1)
@@ -2815,7 +2815,7 @@ def preprocess_domain_single_stupid(domain, callback):
 class EfficientTransformTests(unittest.TestCase):
 
     def setUp(self):
-        self.iris = Table("iris")
+        self.iris = Table("iris")[:10]
 
     def test_simple(self):
         call_cv = Mock()

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2752,7 +2752,8 @@ class PreprocessComputeValue:
         self.callback = callback
 
     def __call__(self, data_):
-        self.callback(data_)
+        if self.callback:
+            self.callback(data_)
         transformed = data_.transform(self.domain)
         return transformed.X[:, 0] * 2
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -1962,7 +1962,7 @@ class TableIndexingTests(TableTests):
 
         # single element
         self.assertEqual(_optimize_indices([1], 2), slice(1, 2, 1))
-        np.testing.assert_equal(_optimize_indices([1], 1), [1])
+        self.assertEqual(_optimize_indices([-2], 5), slice(-2, -3, -1))
 
 
 class TableElementAssignmentTest(TableTests):

--- a/benchmark/bench_transform.py
+++ b/benchmark/bench_transform.py
@@ -71,11 +71,11 @@ class BenchTransform(Benchmark):
         domain = self.table.domain
         for t in transforms:
             if t == "single":
-                call_cv = Mock()
+                call_cv = None
                 domain = preprocess_domain_single(domain, call_cv)
                 self.callbacks.append((call_cv,))
             elif t == "shared":
-                call_cv, call_shared = Mock(), Mock()
+                call_cv, call_shared = None, None
                 domain = preprocess_domain_shared(domain, call_cv, call_shared)
                 self.callbacks.append((call_cv, call_shared))
             else:

--- a/benchmark/bench_transform.py
+++ b/benchmark/bench_transform.py
@@ -14,6 +14,11 @@ def add_unknown_attribute(table):
     return table.transform(new_domain)
 
 
+def add_unknown_class(table):
+    new_domain = Domain(table.domain.attributes, class_vars=[ContinuousVariable("x")])
+    return table.transform(new_domain)
+
+
 class BenchTransform(Benchmark):
 
     def setup_dense(self, rows, cols):
@@ -53,6 +58,11 @@ class BenchTransform(Benchmark):
     def bench_copy_sparse_wide(self):
         t = add_unknown_attribute(self.table)
         self.assertIsInstance(t.X, scipy.sparse.csr_matrix)
+
+    @benchmark(setup=partial(setup_dense, rows=10000, cols=100), number=5)
+    def bench_subarray_dense_long(self):
+        # adding a class should link X
+        add_unknown_class(self.table)
 
     def setup_dense_transforms(self, rows, cols, transforms):
         self.setup_dense(rows, cols)


### PR DESCRIPTION
##### Issue

Orange does domain transformations all the time. They are most obvious in Test Learner or Predict, if you pass test data in a different domain that the learner supports, but they are really everywhere. For example, all preprocessing is based on domain transformations.

Domain transformation can be chained. As currently implemented, each of these transformations is performed the whole data table and produces an intermediate table of the same length. All these intermediate tables count towards Orange's memory use.

##### Description of changes

This PR makes domain transformations work in batches. Essentially, space complexity of domain transformation, that used to be O(rows), will drop to O(1). In the future, we could easily add callbacks to from_table to get progress (some different PR). Also, different parts could be handled by different threads.

What is a good batch size? I do not know, but according to my tests with mocked feature transformations a size of 5000 does not slow anything down. Even better: the transformation are now sometimes even faster. I do not know why, but perhaps it is due to less memory allocations/deallocations with the new branch. There is still some overhead that I haven't been able to squeeze out (also, with smaller parts we lose some numpy efficiency), so for now, 5000 it is.

I tried to make history clean to separate the functional changes from refactoring. Refactoring from_table is probably the largest change in this PR.

Here is memory use (MB) in time for the script below. The red line is for master, the green line for this branch with PART=5000. The task was normalization and PCA. Please ignore the obviously inefficient normalization and focus on the rightmost part of the graph. There we can see that the final transformation into the PCA domain required additional 2000 MB for master, while for this branch we do not see any additional memory use.

![myplot](https://user-images.githubusercontent.com/552182/106206035-bba91400-61bf-11eb-8c19-1860166a667d.png)

Why is the total memory use at the end smaller for the new branch? It theory, it should not be, but Python does not release memory to the OS (it aims to recycle it within its process) except for large continuous allocations. 

For now I set part size to 10 and ran tests, and then set it to 5000 and reran them. Both passed, but we should somehow continuously test for very small part sizes. Suggestions how to do it elegantly are welcome!

The test script:
```
import os, psutil
import time
from threading import Thread

import numpy as np

from Orange.data import Table, Domain, ContinuousVariable
from Orange.preprocess import Normalize
from Orange.projection import PCA

def setup_dense(rows, cols):
    return Table.from_numpy(  # pylint: disable=W0201
        Domain([ContinuousVariable(str(i)) for i in range(cols)]),
        np.random.RandomState(0).rand(rows, cols))

class MemUse(Thread):
    def __init__(self):
        Thread.__init__(self)
        self.daemon = True
        self.measures = []
        self.last_resmem = 0
        self.start()
        self.stime = time.time()

    def run(self):
        while True:
            process = psutil.Process(os.getpid())
            resmem = process.memory_info().rss / (1024 * 1024)
            self.measures.append((time.time() - self.stime, resmem))
            if int(resmem) != int(self.last_resmem):
                print("t %8.1f     resmem %8d" % (time.time() - self.stime, int(resmem)))
            self.last_resmem = resmem
            time.sleep(0.5)

def wait(msg, sec=2):
    import gc
    gc.collect()
    gc.collect()
    print("WAIT " + msg)
    time.sleep(sec)
    gc.collect()

mem = MemUse()

data = setup_dense(100000, 1000)  # 800MB
wait("loaded data")

data2 = Normalize()(data)
wait("after normalize")

data2 = PCA(n_components=5)(data2)(data2)
wait("after pca")

tdomain = data2.domain
del data2
wait("after del")

data.transform(tdomain)
wait("after del")

print(mem.measures)
```

##### Includes
- [X] Code changes
- [ ] Tests ?
- [ ] Documentation
