### PR TITLE
domain: Deprecate __len__

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -245,8 +245,13 @@ class Domain:
     def metas(self):
         return self._metas
 
+    @deprecated("len(Domain.variables)")
     def __len__(self):
-        """The number of variables (features and class attributes)."""
+        """The number of variables (features and class attributes).
+
+        The current behavior returns the length of only features and
+        class attributes. In the near future, it will include the
+        length of metas, too, and __iter__ will act accordingly."""
         return len(self._variables)
 
     def __bool__(self):


### PR DESCRIPTION
##### Description of changes
As discussed last week, we deprecate `__len__` before we change its behavior along with `__iter__`'s, to iterate/len metas as well.

After this is released, merge #5190.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
