### PR TITLE
Feature Statistics: Move controls to the top

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -710,7 +710,7 @@ class OWFeatureStatistics(widget.OWWidget):
         reduced_data = Output('Reduced Data', Table, default=True)
         statistics = Output('Statistics', Table)
 
-    want_main_area = True
+    want_control_area = False
     buttons_area_orientation = Qt.Vertical
 
     settingsHandler = DomainContextHandler()
@@ -738,11 +738,13 @@ class OWFeatureStatistics(widget.OWWidget):
         # shortcut = QShortcut(QKeySequence('Ctrl+f'), self, self.filter_text.setFocus)
         # shortcut.setWhatsThis('Filter variables by name')
 
+        box = gui.hBox(None, box=False)
+        box.setContentsMargins(0, 0, 0, 0)
+
         self.color_var_model = DomainModel(
             valid_types=(ContinuousVariable, DiscreteVariable),
             placeholder='None',
         )
-        box = gui.vBox(self.controlArea, 'Histogram')
         self.cb_color_var = gui.comboBox(
             box, master=self, value='color_var', model=self.color_var_model,
             label='Color:', orientation=Qt.Horizontal, contentsLength=13,
@@ -750,8 +752,9 @@ class OWFeatureStatistics(widget.OWWidget):
         )
         self.cb_color_var.activated.connect(self.__color_var_changed)
 
-        gui.rubber(self.controlArea)
-        gui.auto_send(self.buttonsArea, self, "auto_commit")
+        gui.rubber(box)
+        gui.auto_send(box, self, "auto_commit", box=None)
+        self.mainArea.layout().addWidget(box)
 
         self.info.set_input_summary(self.info.NoInput)
         self.info.set_output_summary(self.info.NoOutput)


### PR DESCRIPTION
##### Issue

Fixes #5173, currently moving controls on top, without box. Feel free to explore other options (bottom, box). :)

Noted from #5173: dilemma between consistency and practicality. Collapsability isn't an issue, IMHO, because the width of the splitter is already comparable to the space taken by these combo and button.

##### Includes
- [X] Code changes