### PR TITLE
Multiple targets warning

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -128,6 +128,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             "Categorical variables with >100 values may decrease performance.")
         renamed_vars = Msg("Some variables have been renamed "
                            "to avoid duplicates.\n{}")
+        multiple_targets = Msg("Most widgets do not support multiple targets")
 
     class Error(widget.OWWidget.Error):
         file_not_found = Msg("File not found.")
@@ -504,6 +505,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             if renamed:
                 self.Warning.renamed_vars(f"Renamed: {', '.join(renamed)}")
 
+        self.Warning.multiple_targets(
+            shown=table is not None and len(table.domain.class_vars) > 1)
         summary = len(table) if table else self.info.NoOutput
         details = format_summary_details(table) if table else ""
         self.info.set_output_summary(summary, details)

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -173,6 +173,7 @@ class OWSelectAttributes(widget.OWWidget):
 
     class Warning(widget.OWWidget.Warning):
         mismatching_domain = Msg("Features and data domain do not match")
+        multiple_targets = Msg("Most widgets do not support multiple targets")
 
     def __init__(self):
         super().__init__()
@@ -587,6 +588,7 @@ class OWSelectAttributes(widget.OWWidget):
 
     def commit(self):
         self.update_domain_role_hints()
+        self.Warning.multiple_targets.clear()
         if self.data is not None:
             attributes = list(self.used_attrs)
             class_var = list(self.class_attrs)
@@ -599,6 +601,7 @@ class OWSelectAttributes(widget.OWWidget):
             self.Outputs.features.send(AttributeList(attributes))
             self.info.set_output_summary(len(newdata),
                                          format_summary_details(newdata))
+            self.Warning.multiple_targets(shown=len(class_var) > 1)
         else:
             self.output_data = None
             self.Outputs.data.send(None)

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -136,8 +136,14 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         self.set_input_summary()
 
         if data is not None and data.domain.class_var is None:
-            self.Error.data_error("Data has no target variable.\n"
-                                  "You can set a target variable with the Select Columns widget.")
+            if data.domain.class_vars:
+                self.Error.data_error(
+                    "Data contains multiple target variables.\n"
+                    "Select a single one with the Select Columns widget.")
+            else:
+                self.Error.data_error(
+                    "Data has no target variable.\n"
+                    "Select one with the Select Columns widget.")
             self.data = None
 
         self.update_model()

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -1,10 +1,12 @@
+from unittest.mock import Mock
+
 import scipy.sparse as sp
 
 # pylint: disable=missing-docstring, protected-access
 from Orange.base import Learner, Model
 from Orange.classification import KNNLearner
 from Orange.data import Table, Domain
-from Orange.modelling import TreeLearner
+from Orange.modelling import TreeLearner, Fitter
 from Orange.preprocess import continuize
 from Orange.regression import MeanLearner, LinearRegressionLearner
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
@@ -149,3 +151,52 @@ class TestOWBaseLearner(WidgetTest):
         self.send_signal(widget.Inputs.data, None)
         self.assertEqual(info._StateInfo__input_summary.brief, "-")
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
+
+    def test_invalid_number_of_targets(self):
+        class MockLearner(Fitter):
+            name = 'mock'
+            __fits__ = {'classification': Mock()}
+            __returns__ = Mock()
+
+        class WidgetLR(OWBaseLearner):
+            name = "lr"
+            LEARNER = MockLearner
+
+        w = self.create_widget(WidgetLR)
+        error = w.Error.data_error
+        heart = Table("heart_disease")
+        domain = heart.domain
+
+        no_target = heart.transform(
+            Domain(domain.attributes,
+                   []))
+        two_targets = heart.transform(
+            Domain([domain["age"]],
+                   [domain["gender"], domain["chest pain"]]))
+
+        self.send_signal(w.Inputs.data, heart)
+        self.assertFalse(error.is_shown())
+        self.assertIs(w.data, heart)
+
+        self.send_signal(w.Inputs.data, no_target)
+        self.assertTrue(error.is_shown())
+        self.assertIsNone(w.data)
+        err_no_target = str(error)
+        self.assertIn("target", err_no_target)
+
+        self.send_signal(w.Inputs.data, two_targets)
+        self.assertTrue(error.is_shown())
+        self.assertIsNone(w.data)
+        err_two_targets = str(error)
+        self.assertIn("target", err_no_target)
+        self.assertNotEqual(err_no_target, err_two_targets)
+
+        self.send_signal(w.Inputs.data, None)
+        self.assertIsNone(w.data)
+        self.assertFalse(error.is_shown())
+
+        self.send_signal(w.Inputs.data, two_targets)
+        self.assertTrue(error.is_shown())
+
+        self.send_signal(w.Inputs.data, None)
+        self.assertFalse(error.is_shown())

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -139,14 +139,16 @@ class OWFreeViz(OWAnchorProjectionWidget, ConcurrentWidgetMixin):
     graph = settings.SettingProvider(OWFreeVizGraph)
 
     class Error(OWAnchorProjectionWidget.Error):
-        no_class_var = widget.Msg("Data has no target variable")
+        no_class_var = widget.Msg("Data must have a target variable.")
+        multiple_class_vars = widget.Msg(
+            "Data must have a single target variable.")
         not_enough_class_vars = widget.Msg(
-            "Target variable is not at least binary")
+            "Target variable must have at least two unique values.")
         features_exceeds_instances = widget.Msg(
             "Number of features exceeds the number of instances.")
         too_many_data_instances = widget.Msg("Data is too large.")
         constant_data = widget.Msg("All data columns are constant.")
-        not_enough_features = widget.Msg("At least two features are required")
+        not_enough_features = widget.Msg("At least two features are required.")
 
     class Warning(OWAnchorProjectionWidget.Warning):
         removed_features = widget.Msg("Categorical features with more than"
@@ -257,10 +259,12 @@ class OWFreeViz(OWAnchorProjectionWidget, ConcurrentWidgetMixin):
 
         super().check_data()
         if self.data is not None:
-            class_var, domain = self.data.domain.class_var, self.data.domain
-            if class_var is None:
+            class_vars, domain = self.data.domain.class_vars, self.data.domain
+            if not class_vars:
                 error(self.Error.no_class_var)
-            elif class_var.is_discrete and len(np.unique(self.data.Y)) < 2:
+            elif len(class_vars) > 1:
+                error(self.Error.multiple_class_vars)
+            elif class_vars[0].is_discrete and len(np.unique(self.data.Y)) < 2:
                 error(self.Error.not_enough_class_vars)
             elif len(self.data.domain.attributes) < 2:
                 error(self.Error.not_enough_features)

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from Orange.data import Table
+from Orange.data import Table, Domain
 from Orange.projection import FreeViz
 from Orange.projection.freeviz import FreeVizModel
 from Orange.widgets.tests.base import (
@@ -47,6 +47,41 @@ class TestOWFreeViz(WidgetTest, AnchorProjectionWidgetTestMixin,
         self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.no_class_var.is_shown())
         self.assertFalse(self.widget.Error.not_enough_class_vars.is_shown())
+
+    def test_number_of_targets(self):
+        data = self.heart_disease
+        domain = data.domain
+
+        no_target = data.transform(
+            Domain(domain.attributes,
+                   []))
+        two_targets = data.transform(
+            Domain([domain["age"]],
+                   [domain["gender"], domain["chest pain"]]))
+
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertFalse(self.widget.Error.no_class_var.is_shown())
+        self.assertFalse(self.widget.Error.multiple_class_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, no_target)
+        self.assertTrue(self.widget.Error.no_class_var.is_shown())
+        self.assertFalse(self.widget.Error.multiple_class_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, two_targets)
+        self.assertFalse(self.widget.Error.no_class_var.is_shown())
+        self.assertTrue(self.widget.Error.multiple_class_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertFalse(self.widget.Error.no_class_var.is_shown())
+        self.assertFalse(self.widget.Error.multiple_class_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, two_targets)
+        self.assertFalse(self.widget.Error.no_class_var.is_shown())
+        self.assertTrue(self.widget.Error.multiple_class_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertFalse(self.widget.Error.no_class_var.is_shown())
+        self.assertFalse(self.widget.Error.multiple_class_vars.is_shown())
 
     def test_optimization(self):
         self.send_signal(self.widget.Inputs.data, self.heart_disease)


### PR DESCRIPTION
##### Issue

Fixes #5144.

##### Description of changes

- File widget and Select Columns now show warnings when outputting data with multiple targets.
- Widgets that showed potentially misleading error (learners and freeviz) now explicitly state that the data has to have a **single** target.

##### Includes
- [X] Code changes
- [ ] Tests
