### PR TITLE
OWSelectColumns: Fixup UI

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -195,6 +195,8 @@ class OWSelectAttributes(widget.OWWidget):
 
         self.controlArea = QWidget(self.controlArea)
         self.layout().addWidget(self.controlArea)
+
+        # init grid
         layout = QGridLayout()
         self.controlArea.setLayout(layout)
         layout.setContentsMargins(4, 4, 4, 4)
@@ -217,6 +219,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.available_attrs_view)
         layout.addWidget(box, 0, 0, 3, 1)
 
+        # 3rd column
         box = gui.vBox(self.controlArea, "Features", addToLayout=False)
         self.used_attrs = VariablesListItemModel()
         filter_edit, self.used_attrs_view = variables_filter(
@@ -244,12 +247,13 @@ class OWSelectAttributes(widget.OWWidget):
         self.class_attrs = VariablesListItemModel()
         self.class_attrs_view = VariablesListItemView(
             acceptedType=(Orange.data.DiscreteVariable,
-                          Orange.data.ContinuousVariable))
+                          Orange.data.ContinuousVariable)
+        )
         self.class_attrs_view.setModel(self.class_attrs)
         self.class_attrs_view.selectionModel().selectionChanged.connect(
             partial(update_on_change, self.class_attrs_view))
         self.class_attrs_view.dragDropActionDidComplete.connect(dropcompleted)
-        self.class_attrs_view.setMaximumHeight(72)
+
         box.layout().addWidget(self.class_attrs_view)
         layout.addWidget(box, 1, 2, 1, 1)
 
@@ -264,40 +268,30 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.meta_attrs_view)
         layout.addWidget(box, 2, 2, 1, 1)
 
+        # 2nd column
         bbox = gui.vBox(self.controlArea, addToLayout=False, margin=0)
+        self.move_attr_button = gui.button(
+            bbox, self, ">",
+            callback=partial(self.move_selected,
+                             self.used_attrs_view)
+        )
         layout.addWidget(bbox, 0, 1, 1, 1)
 
-        self.up_attr_button = gui.button(bbox, self, "Up",
-                                         callback=partial(self.move_up, self.used_attrs_view))
-        self.move_attr_button = gui.button(bbox, self, ">",
-                                           callback=partial(self.move_selected,
-                                                            self.used_attrs_view)
-                                          )
-        self.down_attr_button = gui.button(bbox, self, "Down",
-                                           callback=partial(self.move_down, self.used_attrs_view))
-
         bbox = gui.vBox(self.controlArea, addToLayout=False, margin=0)
+        self.move_class_button = gui.button(
+            bbox, self, ">",
+            callback=partial(self.move_selected,
+                             self.class_attrs_view)
+        )
         layout.addWidget(bbox, 1, 1, 1, 1)
 
-        self.up_class_button = gui.button(bbox, self, "Up",
-                                          callback=partial(self.move_up, self.class_attrs_view))
-        self.move_class_button = gui.button(bbox, self, ">",
-                                            callback=partial(self.move_selected,
-                                                             self.class_attrs_view)
-                                           )
-        self.down_class_button = gui.button(bbox, self, "Down",
-                                            callback=partial(self.move_down, self.class_attrs_view))
-
         bbox = gui.vBox(self.controlArea, addToLayout=False)
+        self.move_meta_button = gui.button(
+            bbox, self, ">",
+            callback=partial(self.move_selected,
+                             self.meta_attrs_view)
+        )
         layout.addWidget(bbox, 2, 1, 1, 1)
-        self.up_meta_button = gui.button(bbox, self, "Up",
-                                         callback=partial(self.move_up, self.meta_attrs_view))
-        self.move_meta_button = gui.button(bbox, self, ">",
-                                           callback=partial(self.move_selected,
-                                                            self.meta_attrs_view)
-                                          )
-        self.down_meta_button = gui.button(bbox, self, "Down",
-                                           callback=partial(self.move_down, self.meta_attrs_view))
 
         bbox = gui.vBox(self.controlArea, "Additional settings", addToLayout=False)
         gui.checkBox(
@@ -311,9 +305,9 @@ class OWSelectAttributes(widget.OWWidget):
         autobox.layout().insertWidget(0, reset)
         autobox.layout().insertStretch(1, 20)
 
-        layout.setRowStretch(0, 4)
+        layout.setRowStretch(0, 2)
         layout.setRowStretch(1, 0)
-        layout.setRowStretch(2, 2)
+        layout.setRowStretch(2, 1)
         layout.setHorizontalSpacing(0)
         self.controlArea.setLayout(layout)
 
@@ -384,6 +378,8 @@ class OWSelectAttributes(widget.OWWidget):
         self.meta_attrs[:] = attrs_for_role("meta")
         self.available_attrs[:] = attrs_for_role("available")
         self.info.set_input_summary(len(data), format_summary_details(data))
+
+        self.update_interface_state(self.class_attrs_view)
 
     def restore_hints(self, domain: Domain) -> Dict[Variable, Tuple[str, int]]:
         """
@@ -456,9 +452,7 @@ class OWSelectAttributes(widget.OWWidget):
             self.Warning.mismatching_domain()
 
     def enable_used_attrs(self, enable=True):
-        self.up_attr_button.setEnabled(enable)
         self.move_attr_button.setEnabled(enable)
-        self.down_attr_button.setEnabled(enable)
         self.used_attrs_view.setEnabled(enable)
         self.used_attrs_view.repaint()
 
@@ -581,6 +575,14 @@ class OWSelectAttributes(widget.OWWidget):
         self.move_meta_button.setEnabled(bool(move_meta_enabled))
         if move_meta_enabled:
             self.move_meta_button.setText(">" if available_selected else "<")
+
+        # update class_vars height
+        if self.class_attrs.rowCount() == 0:
+            height = 22
+        else:
+            height = ((self.class_attrs.rowCount() or 1) *
+                      self.class_attrs_view.sizeHintForRow(0)) + 2
+        self.class_attrs_view.setFixedHeight(height)
 
         self.__last_active_view = None
         self.__interface_update_timer.stop()

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -198,7 +198,7 @@ class OWSelectAttributes(widget.OWWidget):
         layout = QGridLayout()
         self.controlArea.setLayout(layout)
         layout.setContentsMargins(4, 4, 4, 4)
-        box = gui.vBox(self.controlArea, "Available Variables",
+        box = gui.vBox(self.controlArea, "Ignored",
                        addToLayout=False)
 
         self.available_attrs = VariablesListItemModel()
@@ -240,7 +240,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.used_attrs_view)
         layout.addWidget(box, 0, 2, 1, 1)
 
-        box = gui.vBox(self.controlArea, "Target Variable", addToLayout=False)
+        box = gui.vBox(self.controlArea, "Target", addToLayout=False)
         self.class_attrs = VariablesListItemModel()
         self.class_attrs_view = VariablesListItemView(
             acceptedType=(Orange.data.DiscreteVariable,
@@ -253,7 +253,7 @@ class OWSelectAttributes(widget.OWWidget):
         box.layout().addWidget(self.class_attrs_view)
         layout.addWidget(box, 1, 2, 1, 1)
 
-        box = gui.vBox(self.controlArea, "Meta Attributes", addToLayout=False)
+        box = gui.vBox(self.controlArea, "Metas", addToLayout=False)
         self.meta_attrs = VariablesListItemModel()
         self.meta_attrs_view = VariablesListItemView(
             acceptedType=Orange.data.Variable)

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -193,13 +193,14 @@ class OWSelectAttributes(widget.OWWidget):
             self.__last_active_view = view
             self.__interface_update_timer.start()
 
-        self.controlArea = QWidget(self.controlArea)
-        self.layout().addWidget(self.controlArea)
+        new_control_area = QWidget(self.controlArea)
+        self.controlArea.layout().addWidget(new_control_area)
+        self.controlArea = new_control_area
 
         # init grid
         layout = QGridLayout()
         self.controlArea.setLayout(layout)
-        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setContentsMargins(0, 0, 0, 0)
         box = gui.vBox(self.controlArea, "Ignored",
                        addToLayout=False)
 
@@ -293,17 +294,18 @@ class OWSelectAttributes(widget.OWWidget):
         )
         layout.addWidget(bbox, 2, 1, 1, 1)
 
-        bbox = gui.vBox(self.controlArea, "Additional settings", addToLayout=False)
+        # footer
+        gui.separator(self.buttonsArea)
+        gui.button(self.buttonsArea, self, "Reset", callback=self.reset)
+        gui.separator(self.buttonsArea)
+
+        bbox = gui.vBox(self.buttonsArea, box=True)
         gui.checkBox(
             bbox, self, "ignore_new_features", "Ignore new variables by default"
         )
-        layout.addWidget(bbox, 3, 0, 1, 3)
 
-        autobox = gui.auto_send(None, self, "auto_commit")
-        layout.addWidget(autobox, 4, 0, 1, 3)
-        reset = gui.button(None, self, "Reset", callback=self.reset, width=120)
-        autobox.layout().insertWidget(0, reset)
-        autobox.layout().insertStretch(1, 20)
+        gui.rubber(self.buttonsArea)
+        gui.auto_send(self.buttonsArea, self, "auto_commit")
 
         layout.setRowStretch(0, 2)
         layout.setRowStretch(1, 0)

--- a/Orange/widgets/data/tests/test_owselectcolumns.py
+++ b/Orange/widgets/data/tests/test_owselectcolumns.py
@@ -145,9 +145,7 @@ class TestOWSelectAttributes(WidgetTest):
         self.assertEqual(control.button.isEnabled(), button)
         self.assertEqual(control.isVisibleTo(widget), box)
         self.assertEqual(widget.used_attrs_view.isEnabled(), _list)
-        self.assertEqual(widget.up_attr_button.isEnabled(), _list)
         self.assertEqual(widget.move_attr_button.isEnabled(), _list)
-        self.assertEqual(widget.down_attr_button.isEnabled(), _list)
         if button:
             control.button.click()
             self.assertEqual(control.button.isEnabled(), False)


### PR DESCRIPTION
![Screenshot 2021-02-01 at 21 29 24](https://user-images.githubusercontent.com/24586651/106520357-945e8980-64d4-11eb-9ae0-35ee88f9d523.png)

(might not look the same with a non-master version of orange-widget-base)
##### Description of changes
- remove Up/Down buttons
- fit target box to contents
- reorganize option and autocommit into buttonsArea
- simplified names of boxes

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
