### PR TITLE
[FIX] Distribution: vectorize variance, speeds up normalization

### DIFF
--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -302,7 +302,7 @@ class Continuous(Distribution):
 
     def variance(self):
         mean = self.mean()
-        return sum(((x - mean) ** 2) * w for x, w in zip(self[0], self[1])) / sum(self[1])
+        return np.dot((self[0] - mean) ** 2, self[1]) / np.sum(self[1])
 
     def standard_deviation(self):
         return np.sqrt(self.variance())


### PR DESCRIPTION
##### Issue
Variance used python loops, making it very inefficient. This change alone speeds-up normalization for test-case from #5219 by 10x. Issue #5219 will remain open because it is still possible to substantially improve normalization.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
