### PR TITLE
owheatmap: replace item.rotate with proper setTransform

### DIFF
--- a/Orange/widgets/visualize/utils/heatmap.py
+++ b/Orange/widgets/visualize/utils/heatmap.py
@@ -405,7 +405,7 @@ class HeatmapGridWidget(QGraphicsWidget):
         for i, rowitem in enumerate(parts.rows):
             if rowitem.title:
                 item = QGraphicsSimpleTextItem(rowitem.title, parent=self)
-                item.rotate(-90)
+                item.setTransform(item.transform().rotate(-90))
                 item = SimpleLayoutItem(item, parent=grid, anchor=(0, 1),
                                         anchorItem=(0, 0))
                 item.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Maximum)
@@ -567,7 +567,8 @@ class HeatmapGridWidget(QGraphicsWidget):
             col_annotation_widgets_bottom.append(labelslist)
 
         row_color_annotation_header = QGraphicsSimpleTextItem("", self)
-        row_color_annotation_header.rotate(-90)
+        row_color_annotation_header.setTransform(
+            row_color_annotation_header.transform().rotate(-90))
 
         grid.addItem(SimpleLayoutItem(
             row_color_annotation_header, anchor=(0, 1),

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -179,8 +179,8 @@ class InteractiveViewBox(pg.ViewBox):
         p2 = self.mapToView(p2)
         r = QRectF(p1, p2)
         self.rbScaleBox.setPos(r.topLeft())
-        self.rbScaleBox.resetTransform()
-        self.rbScaleBox.scale(r.width(), r.height())
+        tr = QTransform.fromScale(r.width(), r.height())
+        self.rbScaleBox.setTransform(tr)
         self.rbScaleBox.show()
 
     def safe_update_scale_box(self, buttonDownPos, currentPos):

--- a/Orange/widgets/visualize/utils/tests/test_plotutils.py
+++ b/Orange/widgets/visualize/utils/tests/test_plotutils.py
@@ -1,4 +1,10 @@
 import unittest
+from unittest.mock import patch
+
+import numpy as np
+from AnyQt.QtCore import QPointF
+
+from Orange.widgets.visualize.utils.plotutils import InteractiveViewBox
 
 
 class TestAxisItem(unittest.TestCase):
@@ -9,6 +15,20 @@ class TestAxisItem(unittest.TestCase):
         # - remove AxisItem.generateDrawSpecs
         # - remove AxisItem._updateMaxTextSize
         self.assertLess(__version__, "0.11.2")
+
+
+class TestInteractiveViewBox(unittest.TestCase):
+
+    def test_update_scale_box(self):
+        view_box = InteractiveViewBox(graph=None)
+        with patch.object(view_box, "mapToView", lambda x: x):
+            view_box.updateScaleBox(QPointF(0, 0), QPointF(2, 2))
+            tr = view_box.rbScaleBox.transform()
+            self.assertFalse(tr.isRotating())
+            trm = [[tr.m11(), tr.m12(), tr.m13()],
+                   [tr.m21(), tr.m22(), tr.m23()],
+                   [tr.m31(), tr.m32(), tr.m33()]]
+            np.testing.assert_equal(trm, [[2, 0, 0], [0, 2, 0], [0, 0, 1]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before, heatmap was using pyqtgraph's monkey-patched methods, which they now removed (see pyqtgraph/pyqtgraph#1533). This PR uses proper PyQt5 interface.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
