### PR TITLE
[MNT] Replace np.bool and np.object with bool and object

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -467,7 +467,7 @@ class Table(Sequence, Storage):
 
             dtype = np.float64
             if any(isinstance(var, StringVariable) for var in domain.metas):
-                dtype = np.object
+                dtype = object
             self.metas = get_columns(row_indices, conversion.metas,
                                      n_rows, dtype,
                                      is_sparse=conversion.sparse_metas,
@@ -1262,7 +1262,7 @@ class Table(Sequence, Storage):
                 if self.domain[col_idx].is_primitive():
                     return ~np.isnan(col.astype(float))
                 else:
-                    return col.astype(np.bool)
+                    return col.astype(bool)
             if isinstance(filter, FilterDiscrete):
                 return self._discrete_filter_to_indicator(filter, col)
             if isinstance(filter, FilterContinuous):
@@ -1800,7 +1800,7 @@ def _optimize_indices(indices, maxlen):
 
     if len(indices) >= 1:
         indices = np.asarray(indices)
-        if indices.dtype != np.bool:
+        if indices.dtype != bool:
             begin = indices[0]
             end = indices[-1]
             steps = np.diff(indices) if len(indices) > 1 else np.array([1])

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -519,7 +519,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
             return None
         valid_data = self.data[self.valid_data]
         return np.fromiter((ex.id in self.subset_indices for ex in valid_data),
-                           dtype=np.bool, count=len(valid_data))
+                           dtype=bool, count=len(valid_data))
 
     # Plot
     def get_embedding(self):


### PR DESCRIPTION
##### Issue

`numpy.bool` and `numpy.object` are [deprecated in Numpy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), which results in numerous warnings like

```
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

`bool` and `np.bool` are equal in the sense that `bool == np.bool` returns `True`. Same for `object`.

##### Includes
- [X] Code changes
