### PR TITLE
Select columns: rename Select new features to Ignore new variables by default

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -168,7 +168,7 @@ class OWSelectAttributes(widget.OWWidget):
     settingsHandler = SelectAttributesDomainContextHandler(first_match=False)
     domain_role_hints = ContextSetting({})
     use_input_features = Setting(False)
-    select_new_features = Setting(True)
+    ignore_new_features = Setting(False)
     auto_commit = Setting(True)
 
     class Warning(widget.OWWidget.Warning):
@@ -301,7 +301,7 @@ class OWSelectAttributes(widget.OWWidget):
 
         bbox = gui.vBox(self.controlArea, "Additional settings", addToLayout=False)
         gui.checkBox(
-            bbox, self, "select_new_features", "Automatically select additional/new features"
+            bbox, self, "ignore_new_features", "Ignore new variables by default"
         )
         layout.addWidget(bbox, 3, 0, 1, 3)
 
@@ -390,7 +390,7 @@ class OWSelectAttributes(widget.OWWidget):
         Define hints for selected/unselected features.
         Rules:
         - if context available, restore new features based on checked/unchecked
-          select_new_features, context hint should be took into account
+          ignore_new_features, context hint should be took into account
         - in no context, restore features based on the domain (as selected)
 
         Parameters
@@ -404,7 +404,7 @@ class OWSelectAttributes(widget.OWWidget):
         should appear
         """
         domain_hints = {}
-        if self.select_new_features or len(self.domain_role_hints) == 0:
+        if not self.ignore_new_features or len(self.domain_role_hints) == 0:
             # select_new_features selected or no context - restore based on domain
             domain_hints.update(
                 self._hints_from_seq("attribute", domain.attributes)
@@ -414,7 +414,7 @@ class OWSelectAttributes(widget.OWWidget):
                 self._hints_from_seq("class", domain.class_vars)
             )
         else:
-            # if context restored and select_new_features unselected - restore
+            # if context restored and ignore_new_features selected - restore
             # new features as available
             d = domain.attributes + domain.metas + domain.class_vars
             domain_hints.update(self._hints_from_seq("available", d))

--- a/Orange/widgets/data/tests/test_owselectcolumns.py
+++ b/Orange/widgets/data/tests/test_owselectcolumns.py
@@ -415,7 +415,7 @@ class TestOWSelectAttributes(WidgetTest):
 
     def test_select_new_features(self):
         """
-        When select_new_features checked new attributes must appear in one of
+        When ignore_new_features unchecked new attributes must appear in one of
         selected columns. Test with fist make context remember attributes of
         reduced domain and then testing with full domain. Features in missing
         in reduced domain must appears as seleceted.
@@ -445,14 +445,14 @@ class TestOWSelectAttributes(WidgetTest):
 
         # if select_new_features checked all new features goes in the selected
         # features columns - domain equal original
-        self.assertTrue(self.widget.select_new_features)
+        self.assertFalse(self.widget.ignore_new_features)
         self.assertTupleEqual(data.domain.attributes, output.domain.attributes)
         self.assertTupleEqual(data.domain.metas, output.domain.metas)
         self.assertEqual(data.domain.class_var, output.domain.class_var)
 
     def test_unselect_new_features(self):
         """
-        When select_new_features not checked new attributes must appear in one
+        When ignore_new_features checked new attributes must appear in one
         available attributes column. Test with fist make context remember
         attributes of reduced domain and then testing with full domain.
         Features in missing in reduced domain must appears as not seleceted.
@@ -468,9 +468,9 @@ class TestOWSelectAttributes(WidgetTest):
 
         # make context remember features in reduced domain
         self.send_signal(self.widget.Inputs.data, new_data)
-        # unselect select_new_features
-        self.widget.controls.select_new_features.click()
-        self.assertFalse(self.widget.select_new_features)
+        # select ignore_new_features
+        self.widget.controls.ignore_new_features.click()
+        self.assertTrue(self.widget.ignore_new_features)
         output = self.get_output(self.widget.Outputs.data)
 
         self.assertTupleEqual(
@@ -483,9 +483,9 @@ class TestOWSelectAttributes(WidgetTest):
         self.send_signal(self.widget.Inputs.data, data)
         output = self.get_output(self.widget.Outputs.data)
 
-        # if select_new_features not checked all new features goes in the
+        # if ignore_new_features checked all new features goes in the
         # available attributes column
-        self.assertFalse(self.widget.select_new_features)
+        self.assertTrue(self.widget.ignore_new_features)
         self.assertTupleEqual(new_domain.attributes, output.domain.attributes)
         self.assertTupleEqual(new_domain.metas, output.domain.metas)
         self.assertEqual(new_domain.class_var, output.domain.class_var)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implements https://github.com/biolab/orange3/pull/5226#issuecomment-769967476

##### Description of changes
With this PR we rename the `Automatically select additional/new features` option to `Ignore new variables by default`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
