### PR TITLE
Add Orange.util.get_entry_point

### DIFF
--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -11,12 +11,18 @@ from Orange.data import Table
 from Orange.data.util import vstack, hstack, array_equal
 from Orange.statistics.util import stats
 from Orange.tests.test_statistics import dense_sparse
-from Orange.util import wrap_callback
+from Orange.util import wrap_callback, get_entry_point
 
 SOMETHING = 0xf00babe
 
 
 class TestUtil(unittest.TestCase):
+    def test_get_entry_point(self):
+        # pylint: disable=import-outside-toplevel
+        from Orange.canvas.__main__ import main as real_main
+        main = get_entry_point("Orange3", "gui_scripts", "orange-canvas")
+        self.assertIs(main, real_main)
+
     def test_export_globals(self):
         self.assertEqual(sorted(export_globals(globals(), __name__)),
                          ['SOMETHING', 'TestUtil'])

--- a/Orange/util.py
+++ b/Orange/util.py
@@ -42,6 +42,19 @@ def resource_filename(path):
     return pkg_resources.resource_filename("Orange", path)
 
 
+def get_entry_point(dist, group, name):
+    """
+    Load and return the entry point from the distribution.
+
+    Unlike `pkg_resources.load_entry_point`, this function does not check
+    for requirements. Calling this function is preferred because of developers
+    who experiment with different versions and have inconsistent configurations.
+    """
+    dist = pkg_resources.get_distribution(dist)
+    ep = dist.get_entry_info(group, name)
+    return ep.resolve()
+
+
 def deprecated(obj):
     """
     Decorator. Mark called object deprecated.


### PR DESCRIPTION
##### Issue

`pkg_resources.load_entry_point` checks the requirements, which may fail due to inconsistent versions on developers' machines.

See, eg. https://github.com/biolab/orange3-network/issues/187

##### Description of changes

Introduce a new function (with intentionally different name to avoid the confusion), whose code is copied from `load_entry_point`, but skips the check.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
