### PR TITLE
Replace continuous with numeric and discrete with categorical

### DIFF
--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -5,7 +5,7 @@ __all__ = ["LearnerClassification", "ModelClassification",
 
 
 class LearnerClassification(Learner):
-    learner_adequacy_err_msg = "Discrete class variable expected."
+    learner_adequacy_err_msg = "Categorical class variable expected."
 
     def check_learner_adequacy(self, domain):
         return domain.has_discrete_class

--- a/Orange/classification/naive_bayes.py
+++ b/Orange/classification/naive_bayes.py
@@ -28,14 +28,15 @@ class NaiveBayesLearner(Learner):
             raise TypeError("Data is not a subclass of Orange.data.Storage.")
         if not all(var.is_discrete
                    for var in table.domain.variables):
-            raise NotImplementedError("Only discrete variables are supported.")
+            raise NotImplementedError("Only categorical variables are "
+                                      "supported.")
 
         cont = contingency.get_contingencies(table)
         class_freq = np.array(np.diag(
             contingency.get_contingency(table, table.domain.class_var)))
         nclss = (class_freq != 0).sum()
         if not nclss:
-            raise ValueError("Data has no defined target values")
+            raise ValueError("Data has no defined target values.")
 
         # Laplacian smoothing considers only classes that appear in the data,
         # in part to avoid cases where the probabilities are affected by empty

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1514,8 +1514,8 @@ class Table(Sequence, Storage):
 
         if any(not (var.is_discrete or var.is_continuous)
                for var in col_desc):
-            raise ValueError("contingency can be computed only for discrete "
-                             "and continuous values")
+            raise ValueError("Contingency can be computed only for categorical "
+                             "and numeric values.")
 
         # when we select a column in sparse matrix it is still two dimensional
         # and sparse - since it is just a column we can afford to transform

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -107,7 +107,7 @@ class Average(BaseImputeMethod):
                 dist = distribution.get_distribution(data, variable)
                 value = dist.modus()
             else:
-                raise TypeError("Variable must be continuous or discrete")
+                raise TypeError("Variable must be numeric or categorical.")
 
         a = variable.copy(compute_value=ReplaceUnknowns(variable, value))
         a.to_sql = ImputeSql(variable, value)
@@ -329,8 +329,8 @@ class ReplaceUnknownsRandom(Transformation):
         elif variable.is_continuous:
             counts = np.array(distribution)[1, :]
         else:
-            raise TypeError("Only discrete and continuous "
-                            "variables are supported")
+            raise TypeError("Only categorical and numeric "
+                            "variables are supported.")
         csum = np.sum(counts)
         if csum > 0:
             self.sample_prob = counts / csum

--- a/Orange/projection/radviz.py
+++ b/Orange/projection/radviz.py
@@ -22,7 +22,7 @@ class RadViz(LinearProjector):
         if data is not None:
             if len([attr for attr in data.domain.attributes
                     if attr.is_discrete and len(attr.values) > 2]):
-                raise ValueError("Can not handle discrete variables"
+                raise ValueError("Can not handle categorical variables"
                                  " with more than two values")
         return super().__call__(data)
 

--- a/Orange/regression/base_regression.py
+++ b/Orange/regression/base_regression.py
@@ -5,7 +5,7 @@ __all__ = ["LearnerRegression", "ModelRegression",
 
 
 class LearnerRegression(Learner):
-    learner_adequacy_err_msg = "Continuous class variable expected."
+    learner_adequacy_err_msg = "Numeric class variable expected."
 
     def check_learner_adequacy(self, domain):
         return domain.has_continuous_class

--- a/Orange/regression/mean.py
+++ b/Orange/regression/mean.py
@@ -22,7 +22,7 @@ class MeanLearner(Learner):
         """
         if not data.domain.has_continuous_class:
             raise ValueError("regression.MeanLearner expects a domain with a "
-                             "(single) continuous variable")
+                             "(single) numeric variable.")
         dist = distribution.get_distribution(data, data.domain.class_var)
         return MeanModel(dist)
 

--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -261,7 +261,7 @@ class OWCorrelations(OWWidget):
         removed_cons_feat = Msg("Constant features have been removed.")
 
     class Warning(OWWidget.Warning):
-        not_enough_vars = Msg("At least two continuous features are needed.")
+        not_enough_vars = Msg("At least two numeric features are needed.")
         not_enough_inst = Msg("At least two instances are needed.")
 
     def __init__(self):

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -768,7 +768,7 @@ class OWPaintData(OWWidget):
 
     class Warning(OWWidget.Warning):
         no_input_variables = Msg("Input data has no variables")
-        continuous_target = Msg("Continuous target value can not be used.")
+        continuous_target = Msg("Numeric target value can not be used.")
         sparse_not_supported = Msg("Sparse data is ignored.")
         renamed_vars = Msg("Some variables have been renamed "
                            "to avoid duplicates.\n{}")

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -105,21 +105,22 @@ class OWCalibrationPlot(widget.OWWidget):
         calibrated_model = Output("Calibrated Model", Model)
 
     class Error(widget.OWWidget.Error):
-        non_discrete_target = Msg("Calibration plot requires a discrete target")
+        non_discrete_target = Msg("Calibration plot requires a categorical "
+                                  "target variable.")
         empty_input = widget.Msg("Empty result on input. Nothing to display.")
         nan_classes = \
-            widget.Msg("Remove test data instances with unknown classes")
+            widget.Msg("Remove test data instances with unknown classes.")
         all_target_class = widget.Msg(
-            "All data instances belong to target class")
+            "All data instances belong to target class.")
         no_target_class = widget.Msg(
-            "No data instances belong to target class")
+            "No data instances belong to target class.")
 
     class Warning(widget.OWWidget.Warning):
         omitted_folds = widget.Msg(
-            "Test folds where all data belongs to (non)-target are not shown")
+            "Test folds where all data belongs to (non)-target are not shown.")
         omitted_nan_prob_points = widget.Msg(
             "Instance for which the model couldn't compute probabilities are"
-            "skipped")
+            "skipped.")
         no_valid_data = widget.Msg("No valid data for model(s) {}")
 
     class Information(widget.OWWidget.Information):

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -30,10 +30,10 @@ def check_results_adequacy(results, error_group, check_nan=True):
         return None
     if results.data is None:
         error_group.invalid_results(
-            "Results do not include information on test data")
+            "Results do not include information on test data.")
     elif not results.data.domain.has_discrete_class:
         error_group.invalid_results(
-            "Discrete outcome variable is required")
+            "Categorical target variable is required.")
     elif not results.actual.size:
         error_group.invalid_results(
             "Empty result on input. Nothing to display.")
@@ -42,7 +42,7 @@ def check_results_adequacy(results, error_group, check_nan=True):
                         (results.probabilities is not None and
                          anynan(results.probabilities))):
         error_group.invalid_results(
-            "Results contains invalid values")
+            "Results contain invalid values.")
     else:
         return results
 

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -208,7 +208,7 @@ class OWSOM(OWWidget):
     )
 
     class Warning(OWWidget.Warning):
-        ignoring_disc_variables = Msg("SOM ignores discrete variables.")
+        ignoring_disc_variables = Msg("SOM ignores categorical variables.")
         missing_colors = \
             Msg("Some data instances have undefined value of '{}'.")
         missing_values = \

--- a/Orange/widgets/visualize/owbarplot.py
+++ b/Orange/widgets/visualize/owbarplot.py
@@ -321,7 +321,7 @@ class BarPlotGraph(gui.OWComponent, pg.PlotWidget):
 
 class OWBarPlot(OWWidget):
     name = "Bar Plot"
-    description = "Visualizes comparisons among discrete categories."
+    description = "Visualizes comparisons among categorical variables."
     icon = "icons/BarPlot.svg"
     priority = 190
     keywords = ["chart"]

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -619,7 +619,7 @@ class OWLinePlot(OWWidget):
     graph_name = "graph.plotItem"
 
     class Error(OWWidget.Error):
-        not_enough_attrs = Msg("Need at least one continuous feature.")
+        not_enough_attrs = Msg("Need at least one numeric feature.")
         no_valid_data = Msg("No plot due to no valid data.")
 
     class Warning(OWWidget.Warning):

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -253,8 +253,8 @@ class OWScatterPlot(OWDataProjectionWidget):
     class Warning(OWDataProjectionWidget.Warning):
         missing_coords = Msg(
             "Plot cannot be displayed because '{}' or '{}' "
-            "is missing for all data points")
-        no_continuous_vars = Msg("Data has no continuous variables")
+            "is missing for all data points.")
+        no_continuous_vars = Msg("Data has no numeric variables.")
 
     class Information(OWDataProjectionWidget.Information):
         sampled_sql = Msg("Large SQL table; showing a sample.")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Many warnings and errors still used continuous for numeric and discrete for categorical variables.

##### Description of changes
Use correct wording.

##### Note
The PR only replaces those parts of Orange that the user can see.
Docstrings still use old terms because they correspond to classes (DiscreteVariable, ContinuousVariable).
Documentation should be fixed separately since it needs to be updated anyway.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
