### PR TITLE
Properly separate warnings by threads

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -1,7 +1,6 @@
 import os
 import logging
 from itertools import chain
-from warnings import catch_warnings
 from urllib.parse import urlparse
 from typing import List
 
@@ -13,6 +12,7 @@ from AnyQt.QtCore import Qt, QTimer, QSize
 
 from Orange.data.table import Table, get_sample_datasets_dir
 from Orange.data.io import FileFormat, UrlReader, class_from_qualified_name
+from Orange.util import log_warnings
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting, ContextSetting, \
     PerfectDomainContextHandler, SettingProvider
@@ -366,7 +366,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         except Exception:
             return self.Error.sheet_error
 
-        with catch_warnings(record=True) as warnings:
+        with log_warnings() as warnings:
             try:
                 data = self.reader.read()
             except Exception as ex:

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -6,11 +6,12 @@ from unittest.mock import Mock, patch
 import pickle
 import tempfile
 import warnings
+import time
 
 import numpy as np
 import scipy.sparse as sp
 
-from AnyQt.QtCore import QMimeData, QPoint, Qt, QUrl
+from AnyQt.QtCore import QMimeData, QPoint, Qt, QUrl, QThread, QObject
 from AnyQt.QtGui import QDragEnterEvent, QDropEvent
 from AnyQt.QtWidgets import QComboBox
 
@@ -622,3 +623,34 @@ a
         widget.reader.sheet = "no such sheet"
         widget._select_active_sheet()
         self.assertEqual(combo.currentIndex(), 0)
+
+    @patch("os.path.exists", new=lambda _: True)
+    def test_warning_from_another_thread(self):
+        class AnotherWidget(QObject):
+            # This must be a method, not a staticmethod to run in the thread
+            def issue_warning(self):  # pylint: disable=no-self-use
+                time.sleep(0.1)
+                warnings.warn("warning from another thread")
+                warning_thread.quit()
+
+        def read():
+            warning_thread.start()
+            time.sleep(0.2)
+            return Table(TITANIC_PATH)
+
+        warning_thread = QThread()
+        another_widget = AnotherWidget()
+        another_widget.moveToThread(warning_thread)
+        warning_thread.started.connect(another_widget.issue_warning)
+
+        reader = Mock()
+        reader.read = read
+        self.widget._get_reader = lambda: reader
+        self.widget.last_path = lambda: "foo"
+        self.widget._update_sheet_combo = Mock()
+        self.widget._try_load()
+        self.assertFalse(self.widget.Warning.load_warning.is_shown())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #5008: the File widget seems to be the only widget that uses `catch_warnings` to record and show warnings.

##### Description of changes

The code is a bit of a hack: it's based on checking stack frames, and it patches an internal function in `warnings`. I don't see a way around any of that.

@markotoplak, can you check? If you confirm, I can add tests for context manager (besides the current tests for the widget).

There are two other potential problems

- `catch_warnings(record=True)` is used in some tests. If these are executed in parallel, they may "steal" each other's warnings.
- We call `catch_warnings()` to supress warnings in various places. Two are in code (`data.io` and the Rank widget), others in tests. This is not thread safe, but won't have very noticeable consequences.
- `catch_warnings()` is called in libraries we use. We have no control over that, and can't fix that; Python has to do it.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
