### PR TITLE
OWManifoldLearning: Clean up UX

### DIFF
--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -48,7 +48,6 @@ class ManifoldParametersEditor(QWidget, gui.OWComponent):
             callback=lambda f=self.__spin_parameter_update,
                             p=name: self.__parameter_changed(f, p))
         self.layout().addRow(label, control)
-        return control
 
     def __spin_parameter_update(self, name):
         self.parameters[name] = getattr(self, name)
@@ -62,7 +61,6 @@ class ManifoldParametersEditor(QWidget, gui.OWComponent):
                             p=name: self.__parameter_changed(f, p)
         )
         self.layout().addRow(label, control)
-        return control
 
     def __combo_parameter_update(self, name):
         index = getattr(self, name + "_index")
@@ -96,7 +94,6 @@ class ManifoldParametersEditor(QWidget, gui.OWComponent):
         gui.widgetLabel(labox, label)
         gui.rubber(labox)
         self.layout().addRow(labox, rbt)
-        return rbt
 
     def __radio_parameter_update(self, name):
         index = getattr(self, name + "_index")
@@ -119,19 +116,13 @@ class TSNEParametersEditor(ManifoldParametersEditor):
 
     def __init__(self, parent):
         super().__init__(parent)
-
-        self.metric_combo = self._create_combo_parameter(
-            "metric", "Metric:")
-        self.perplexity_spin = self._create_spin_parameter(
-            "perplexity", 1, 100, "Perplexity:")
-        self.early_exaggeration_spin = self._create_spin_parameter(
-            "early_exaggeration", 1, 100, "Early exaggeration:")
-        self.lr_spin = self._create_spin_parameter(
-            "learning_rate", 1, 1000, "Learning rate:")
-        self.n_iter_spin = self._create_spin_parameter(
-            "n_iter", 250, 1e5, "Max iterations:")
-        self.init_radio = self._create_radio_parameter(
-            "initialization", "Initialization:")
+        self._create_combo_parameter("metric", "Metric:")
+        self._create_spin_parameter("perplexity", 1, 100, "Perplexity:")
+        self._create_spin_parameter("early_exaggeration", 1, 100,
+                                    "Early exaggeration:")
+        self._create_spin_parameter("learning_rate", 1, 1000, "Learning rate:")
+        self._create_spin_parameter("n_iter", 250, 1e5, "Max iterations:")
+        self._create_radio_parameter("initialization", "Initialization:")
 
 
 class MDSParametersEditor(ManifoldParametersEditor):
@@ -142,10 +133,8 @@ class MDSParametersEditor(ManifoldParametersEditor):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.max_iter_spin = self._create_spin_parameter(
-            "max_iter", 10, 10 ** 4, "Max iterations:")
-        self.random_state_radio = self._create_radio_parameter(
-            "init_type", "Initialization:")
+        self._create_spin_parameter("max_iter", 10, 10 ** 4, "Max iterations:")
+        self._create_radio_parameter("init_type", "Initialization:")
 
     def get_parameters(self):
         par = super().get_parameters()
@@ -158,8 +147,7 @@ class IsomapParametersEditor(ManifoldParametersEditor):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.n_neighbors_spin = self._create_spin_parameter(
-            "n_neighbors", 1, 10 ** 2, "Neighbors:")
+        self._create_spin_parameter("n_neighbors", 1, 10 ** 2, "Neighbors:")
 
 
 class LocallyLinearEmbeddingParametersEditor(ManifoldParametersEditor):
@@ -173,12 +161,9 @@ class LocallyLinearEmbeddingParametersEditor(ManifoldParametersEditor):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.method_combo = self._create_combo_parameter(
-            "method", "Method:")
-        self.n_neighbors_spin = self._create_spin_parameter(
-            "n_neighbors", 1, 10 ** 2, "Neighbors:")
-        self.max_iter_spin = self._create_spin_parameter(
-            "max_iter", 10, 10 ** 4, "Max iterations:")
+        self._create_combo_parameter("method", "Method:")
+        self._create_spin_parameter("n_neighbors", 1, 10 ** 2, "Neighbors:")
+        self._create_spin_parameter("max_iter", 10, 10 ** 4, "Max iterations:")
 
 
 class SpectralEmbeddingParametersEditor(ManifoldParametersEditor):
@@ -188,8 +173,7 @@ class SpectralEmbeddingParametersEditor(ManifoldParametersEditor):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.affinity_combo = self._create_combo_parameter(
-            "affinity", "Affinity:")
+        self._create_combo_parameter("affinity", "Affinity:")
 
 
 class OWManifoldLearning(OWWidget):

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -102,7 +102,7 @@ class TestOWManifoldLearning(WidgetTest):
             self.assertFalse(self.widget.Error.manifold_error.is_shown())
 
         simulate.combobox_run_through_all(
-            self.widget.tsne_editor.metric_combo, callback=__callback,
+            self.widget.tsne_editor.controls.metric_index, callback=__callback,
         )
 
     def test_unique_domain(self):


### PR DESCRIPTION
### Issue

I refreshed Manifold Learning as discussed on Tuesday on @irgolic's *Widgets showing show*.

Closes #5248.

### Description of changes

- Use `QFormLayout` so that controls are properly aligned
- ~~Replace spins with line edits~~
- Put parameters in the same box as the combo for selecting the method. These are method's parameters, and they even change when the method is changed, so I think they must be in the same box.

<img width="687" alt="Screenshot 2021-02-11 at 19 24 59" src="https://user-images.githubusercontent.com/2387315/107681231-1736cf80-6c9f-11eb-91bf-7cbd5ff5f051.png">

### Considerations

- ~~I'm having second thoughts about removing the (now unnecessary) `_create_spin_parameter`. Do we keep it, just for the case we need it in the future? The method for check boxes is also still there.~~
- ~~Number of components is still a spin, because it probably makes sense. Keep it like this or turn it into line edit, too?~~
- I haven't tried whether the widget still works. :) It seems to pass the tests, though.

##### Includes
- [X] Code changes
