### PR TITLE
httpx 0.16.0 now

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -23,4 +23,4 @@ baycomp>=1.0.2
 pandas
 pyyaml
 openpyxl
-httpx~=0.14.0
+httpx>=0.14.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -23,4 +23,4 @@ baycomp>=1.0.2
 pandas
 pyyaml
 openpyxl
-httpx>=0.14.0
+httpx>=0.14.0,<0.17


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
```
orange-canvas 
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 567, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 884, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 775, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (httpx 0.16.1 (/usr/lib/python3.9/site-packages), Requirement.parse('httpx~=0.14.0'), {'Orange3'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/orange-canvas", line 33, in <module>
    sys.exit(load_entry_point('Orange3==3.28.0.dev0+bce268a', 'gui_scripts', 'orange-canvas')())
  File "/usr/bin/orange-canvas", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3.9/site-packages/Orange/__init__.py", line 4, in <module>
    from Orange import data
  File "/usr/lib/python3.9/site-packages/Orange/data/__init__.py", line 4, in <module>
    from .variable import *
  File "/usr/lib/python3.9/site-packages/Orange/data/variable.py", line 14, in <module>
    from Orange.util import Registry, Reprable, OrangeDeprecationWarning
  File "/usr/lib/python3.9/site-packages/Orange/util.py", line 5, in <module>
    import pkg_resources
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3239, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3222, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 3251, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 569, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 582, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 770, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'httpx~=0.14.0' distribution was not found and is required by Orange3

```
##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
