### PR TITLE
[FIX] Rank: Switch to manual selection on deselect

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -8,7 +8,8 @@ from typing import Any, Callable, List, Tuple
 
 import numpy as np
 from AnyQt.QtCore import (
-    QItemSelection, QItemSelectionModel, QItemSelectionRange, Qt
+    QItemSelection, QItemSelectionModel, QItemSelectionRange, Qt,
+    pyqtSignal as Signal
 )
 from AnyQt.QtGui import QFontMetrics
 from AnyQt.QtWidgets import (
@@ -76,6 +77,8 @@ SCORES = CLS_SCORES + REG_SCORES
 
 
 class TableView(QTableView):
+    manualSelection = Signal()
+
     def __init__(self, parent=None, **kwargs):
         super().__init__(parent=parent,
                          selectionBehavior=QTableView.SelectRows,
@@ -104,6 +107,10 @@ class TableView(QTableView):
         header = self.verticalHeader()
         width = QFontMetrics(header.font()).width(max_label)
         header.setFixedWidth(min(width + 40, 400))
+
+    def mousePressEvent(self, event):
+        super().mousePressEvent(event)
+        self.manualSelection.emit()
 
 
 class TableModel(PyTableModel):
@@ -310,7 +317,7 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
         def _set_select_manual():
             self.setSelectionMethod(OWRank.SelectManual)
 
-        view.pressed.connect(_set_select_manual)
+        view.manualSelection.connect(_set_select_manual)
         view.verticalHeader().sectionClicked.connect(_set_select_manual)
         view.horizontalHeader().sectionClicked.connect(self.headerClick)
 


### PR DESCRIPTION
##### Issue

Fixes #5126.

##### Description of changes

`view.pressed(QModeIndex)` is not emitted when index is invalid. `selectionModel().selectionChanged(...)` would not distinguish between changes because of clicking and programmatic changes. Hence I overrode `mousePressEvent`, which, in super-super-class calls the `select`.

I want add tests because I don't know how to.

##### Includes
- [X] Code changes
