### PR TITLE
File: Show correct initial sheet name

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -264,7 +264,7 @@ class _BaseExcelReader(FileFormat, DataTableMixin):
             cells = self.get_cells()
             table = self.data_table(cells)
             table.name = path.splitext(path.split(self.filename)[-1])[0]
-            if self.sheet:
+            if self.sheet and len(self.sheets) > 1:
                 table.name = '-'.join((table.name, self.sheet))
         except Exception:
             raise IOError("Couldn't load spreadsheet from " + self.filename)
@@ -276,6 +276,10 @@ class ExcelReader(_BaseExcelReader):
     EXTENSIONS = ('.xlsx',)
     DESCRIPTION = 'Microsoft Excel spreadsheet'
     ERRORS = ("#VALUE!", "#DIV/0!", "#REF!", "#NUM!", "#NULL!", "#NAME?")
+
+    def __init__(self, filename):
+        super().__init__(filename)
+        self.sheet = self.workbook.active.title
 
     @property
     def workbook(self) -> openpyxl.Workbook:
@@ -339,6 +343,10 @@ class XlsReader(_BaseExcelReader):
     """Reader for .xls files"""
     EXTENSIONS = ('.xls',)
     DESCRIPTION = 'Microsoft Excel 97-2004 spreadsheet'
+
+    def __init__(self, filename):
+        super().__init__(filename)
+        self.sheet = self.workbook.sheet_by_index(0).name
 
     @property
     def workbook(self) -> xlrd.Book:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -414,7 +414,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             self.sheet_combo.setCurrentIndex(idx)
         except ValueError:
             # Requested sheet does not exist in this file
-            self.reader.select_sheet(0)
+            self.reader.select_sheet(None)
             self.sheet_combo.setCurrentIndex(0)
 
     @staticmethod

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -409,14 +409,12 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         self.sheet_box.show()
 
     def _select_active_sheet(self):
-        if self.reader.sheet:
-            try:
-                idx = self.reader.sheets.index(self.reader.sheet)
-                self.sheet_combo.setCurrentIndex(idx)
-            except ValueError:
-                # Requested sheet does not exist in this file
-                self.reader.select_sheet(None)
-        else:
+        try:
+            idx = self.reader.sheets.index(self.reader.sheet)
+            self.sheet_combo.setCurrentIndex(idx)
+        except ValueError:
+            # Requested sheet does not exist in this file
+            self.reader.select_sheet(0)
             self.sheet_combo.setCurrentIndex(0)
 
     @staticmethod

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -603,3 +603,22 @@ a
             self.assertEqual(w.recent_paths[0].relpath, base_name)
         finally:
             remove(file_name)
+
+    def test_sheets(self):
+        # pylint: disable=protected-access
+        widget = self.widget
+        combo = widget.sheet_combo
+        widget.last_path = \
+            lambda: path.join(path.dirname(__file__), '..', "..", '..',
+                              'tests', 'xlsx_files', 'header_0_sheet.xlsx')
+        widget._try_load()
+        widget.reader.sheet = "my_sheet"
+        widget._select_active_sheet()
+        self.assertEqual(combo.itemText(0), "Sheet1")
+        self.assertEqual(combo.itemText(1), "my_sheet")
+        self.assertEqual(combo.itemText(2), "Sheet3")
+        self.assertEqual(combo.currentIndex(), 1)
+
+        widget.reader.sheet = "no such sheet"
+        widget._select_active_sheet()
+        self.assertEqual(combo.currentIndex(), 0)


### PR DESCRIPTION
##### Issue

Fixes #5127.

For xlsx, the initially selected sheet will be the one that is stored as active in the .xlsx. For Xls, it's gonna be the first sheet.

Active sheet should be stored as setting. This is however a bit complicated (see https://github.com/biolab/orange3/issues/4919#issuecomment-780749240)  and not worth fixing because it would have to be reimplemented anyway when fixing #4919.

##### Description of changes

Readers' constructors set `self.sheet`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
