### PR TITLE
Rewrite summary tests to more generic

### DIFF
--- a/Orange/widgets/data/tests/test_owconcatenate.py
+++ b/Orange/widgets/data/tests/test_owconcatenate.py
@@ -5,6 +5,8 @@ from unittest.mock import patch, Mock
 
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import (
     Table, Domain, ContinuousVariable, DiscreteVariable, StringVariable
 )
@@ -416,9 +418,9 @@ class TestOWConcatenate(WidgetTest):
 
         self.send_signal(self.widget.Inputs.additional_data, None, 0)
         self.send_signal(self.widget.Inputs.additional_data, None, 1)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def _create_compute_values(self):

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, StringVariable, DiscreteVariable
 from Orange.widgets.data.owcreateclass import (
     OWCreateClass,
@@ -477,17 +479,17 @@ class TestOWCreateClass(WidgetTest):
         self.send_signal(self.widget.Inputs.data, data)
         self.widget.class_name = ""
         self.widget.apply()
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self.widget.class_name = "type"
         self.widget.apply()
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/tests/test_owcreateinstance.py
+++ b/Orange/widgets/data/tests/test_owcreateinstance.py
@@ -6,7 +6,9 @@ import numpy as np
 from AnyQt.QtCore import QDateTime, QDate, QTime, QPoint
 from AnyQt.QtWidgets import QWidget, QLineEdit, QStyleOptionViewItem, QMenu
 
+from orangewidget.widget import StateInfo
 from orangewidget.tests.base import GuiTest
+
 from Orange.data import Table, ContinuousVariable, Domain, DiscreteVariable, \
     TimeVariable
 from Orange.widgets.data.owcreateinstance import OWCreateInstance, \
@@ -60,9 +62,9 @@ class TestOWCreateInstance(WidgetTest):
         reference = self.data[:1]
         no_input, no_output = "No data on input", "No data on output"
 
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.data, self.data)
@@ -87,11 +89,11 @@ class TestOWCreateInstance(WidgetTest):
         summary, details = "0, 1", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.reference, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
 
     def _get_init_buttons(self, widget=None):

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -12,6 +12,8 @@ import scipy.sparse as sp
 
 from AnyQt.QtCore import Qt
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, DiscreteVariable, StringVariable, \
     ContinuousVariable
 from Orange.widgets.data.owmergedata import OWMergeData, INSTANCEID, INDEX, \
@@ -1033,7 +1035,7 @@ class TestOWMergeData(WidgetTest):
         summary, details = f"{len(data)}, 0", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.extra_data, data)
@@ -1052,13 +1054,13 @@ class TestOWMergeData(WidgetTest):
         summary, details = f"0, {len(data)}", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.extra_data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 class MergeDataContextHandlerTest(unittest.TestCase):

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock
 
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, ContinuousVariable
 from Orange.widgets.data.owneighbors import OWNeighbors, METRICS
 from Orange.widgets.tests.base import WidgetTest, ParameterMapping
@@ -126,7 +128,7 @@ class TestOWNeighbors(WidgetTest):
         summary, details = "150, 0", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.reference, reference)
@@ -144,13 +146,13 @@ class TestOWNeighbors(WidgetTest):
         summary, details = "0, 5", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.reference, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_compute_distances_apply_called(self):

--- a/Orange/widgets/data/tests/test_owoutliers.py
+++ b/Orange/widgets/data/tests/test_owoutliers.py
@@ -4,6 +4,8 @@
 import unittest
 from unittest.mock import patch, Mock
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.classification import LocalOutlierFactorLearner
 from Orange.widgets.data.owoutliers import OWOutliers, run
@@ -136,8 +138,8 @@ class TestOWOutliers(WidgetTest):
 
     def test_in_out_summary(self):
         info = self.widget.info
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, "No data on input")
         self.assertEqual(info._StateInfo__output_summary.details, "No data on output")
 
@@ -153,8 +155,8 @@ class TestOWOutliers(WidgetTest):
 
         self.send_signal(self.widget.Inputs.data, None)
         self.wait_until_finished()
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, "No data on input")
         self.assertEqual(info._StateInfo__output_summary.details, "No data on output")
 

--- a/Orange/widgets/data/tests/test_owpaintdata.py
+++ b/Orange/widgets/data/tests/test_owpaintdata.py
@@ -7,6 +7,8 @@ import scipy.sparse as sp
 from AnyQt.QtCore import QRectF, QPointF, QEvent, Qt
 from AnyQt.QtGui import QMouseEvent
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, DiscreteVariable, ContinuousVariable, Domain
 from Orange.widgets.data import owpaintdata
 from Orange.widgets.data.owpaintdata import OWPaintData
@@ -131,7 +133,7 @@ class TestOWPaintData(WidgetTest):
         event = QMouseEvent(QEvent.MouseButtonPress, QPointF(0.17, 0.17),
                             Qt.LeftButton, Qt.LeftButton, Qt.NoModifier)
         tool.mousePressEvent(event)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
         output = self.get_output(self.widget.Outputs.data)
         summary, details = f"{len(output)}", format_summary_details(output)
@@ -148,7 +150,7 @@ class TestOWPaintData(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
         output = self.get_output(self.widget.Outputs.data)
         summary, details = f"{len(output)}", format_summary_details(output)
@@ -156,5 +158,5 @@ class TestOWPaintData(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.widget.set_current_tool(self.widget.TOOLS[5][2])
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/data/tests/test_owselectbydataindex.py
+++ b/Orange/widgets/data/tests/test_owselectbydataindex.py
@@ -1,4 +1,7 @@
 # pylint: disable=protected-access
+
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain
 from Orange.widgets.data.owselectbydataindex import OWSelectByDataIndex
 from Orange.widgets.tests.base import WidgetTest
@@ -77,11 +80,11 @@ class TestOWSelectSubset(WidgetTest):
             data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.data_subset, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -5,6 +5,8 @@ import unittest
 from unittest.mock import Mock, patch
 from AnyQt.QtCore import Qt
 
+from orangewidget.widget import StateInfo
+
 from Orange.widgets.data.owtable import OWDataTable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.data import Table, Domain
@@ -118,9 +120,9 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin, dbt):
         info = self.widget.info
         no_input, no_output = "No data on input", "No data on output"
 
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         data = Table("zoo")
@@ -128,7 +130,7 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin, dbt):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self.widget.tabs.currentWidget().selectAll()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -141,7 +143,7 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin, dbt):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -164,9 +166,9 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin, dbt):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None, 2)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_info(self):

--- a/Orange/widgets/data/tests/test_owtransform.py
+++ b/Orange/widgets/data/tests/test_owtransform.py
@@ -4,6 +4,8 @@ from unittest.mock import Mock
 
 from numpy import testing as npt
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.preprocess import Discretize
 from Orange.widgets.data.owtransform import OWTransform
@@ -54,7 +56,7 @@ class TestOWTransform(WidgetTest):
         summary, details = "10, 0", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         # send template data
@@ -80,7 +82,7 @@ class TestOWTransform(WidgetTest):
         summary, details = "0, 150", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         # remove template data
@@ -89,9 +91,9 @@ class TestOWTransform(WidgetTest):
         self.assertEqual("No template data on input.",
                          self.widget.template_label.text())
         self.assertEqual("", self.widget.output_label.text())
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def assertTableEqual(self, table1, table2):

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring, protected-access
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.classification import NaiveBayesLearner, TreeLearner
 from Orange.regression import MeanLearner
@@ -125,7 +127,7 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
         no_output = "No data on output"
 
         self.send_signal(self.widget.Inputs.evaluation_results, self.results_1_iris)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -133,7 +135,7 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.brief, summary)
         self.assertEqual(info._StateInfo__output_summary.details, details)
         self.send_signal(self.widget.Inputs.evaluation_results, None)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_unique_output_domain(self):

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -9,6 +9,8 @@ import numpy as np
 from AnyQt.QtCore import QItemSelectionModel, QItemSelection
 from AnyQt.QtGui import QStandardItemModel
 
+from orangewidget.widget import StateInfo
+
 from Orange.base import Model
 from Orange.classification import LogisticRegressionLearner
 from Orange.data.io import TabReader
@@ -491,7 +493,7 @@ class TestOWPredictions(WidgetTest):
                   "Model: 1 model (1 failed)<ul><li>constant</li></ul>"
         self.assertEqual(info._StateInfo__input_summary.brief, "0")
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.data, data)
@@ -530,9 +532,9 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -10,6 +10,8 @@ from AnyQt.QtTest import QTest
 from AnyQt.QtWidgets import QApplication
 import baycomp
 
+from orangewidget.widget import StateInfo
+
 from Orange.classification import MajorityLearner, LogisticRegressionLearner, \
     RandomForestLearner
 from Orange.classification.majority import ConstantModel
@@ -678,13 +680,13 @@ class TestOWTestAndScore(WidgetTest):
         summary, details = f"{len(test)}", format_summary_details(test)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.test_data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_unique_output_domain(self):

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -14,6 +14,7 @@ from AnyQt.QtWidgets import (
     QComboBox, QSpinBox, QDoubleSpinBox, QSlider
 )
 
+from orangewidget.widget import StateInfo
 from orangewidget.tests.base import (
     GuiTest, WidgetTest as WidgetTestBase, DummySignalManager, DEFAULT_TIMEOUT
 )
@@ -758,8 +759,8 @@ class ProjectionWidgetTestMixin:
 
     def test_in_out_summary(self, timeout=DEFAULT_TIMEOUT):
         info = self.widget.info
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertIn(info._StateInfo__input_summary.details,
                       ["", "No data on input"])
         self.assertIn(info._StateInfo__output_summary.details,
@@ -782,8 +783,8 @@ class ProjectionWidgetTestMixin:
                          ["", "No data on output"])
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertIn(info._StateInfo__input_summary.details,
                       ["", "No data on input"])
         self.assertIn(info._StateInfo__output_summary.details,

--- a/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
+++ b/Orange/widgets/unsupervised/tests/test_owcorrespondence.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring, protected-access
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owcorrespondence \
@@ -107,7 +109,7 @@ class TestOWCorrespondence(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/unsupervised/tests/test_owdbscan.py
+++ b/Orange/widgets/unsupervised/tests/test_owdbscan.py
@@ -2,6 +2,8 @@
 import numpy as np
 from scipy.sparse import csr_matrix, csc_matrix
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest
@@ -238,7 +240,7 @@ class TestOWDBSCAN(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/unsupervised/tests/test_owdistancemap.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancemap.py
@@ -3,6 +3,8 @@
 import random
 import unittest
 
+from orangewidget.widget import StateInfo
+
 from Orange.distance import Euclidean
 from Orange.widgets.unsupervised.owdistancemap import OWDistanceMap
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -50,7 +52,7 @@ class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.distances, self.signal_data)
         self.assertEqual(info._StateInfo__input_summary.brief, matrix)
         self.assertEqual(info._StateInfo__input_summary.details, matrix)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -59,9 +61,9 @@ class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.distances, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock
 
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 from Orange import distance
 from Orange.data import Table, Domain, ContinuousVariable
 from Orange.misc import DistMatrix
@@ -235,9 +237,9 @@ class TestOWDistances(WidgetTest):
         no_input, no_output = "No data on input", "No data on output"
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.data, self.iris)

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -7,6 +7,8 @@ import numpy as np
 from AnyQt.QtCore import QPoint, Qt
 from AnyQt.QtTest import QTest
 
+from orangewidget.widget import StateInfo
+
 import Orange.misc
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.distance import Euclidean
@@ -181,7 +183,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.distances, self.distances)
         self.assertEqual(info._StateInfo__input_summary.brief, matrix_len)
         self.assertEqual(info._StateInfo__input_summary.details, matrix_len)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -190,7 +192,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.distances, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -7,6 +7,8 @@ from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QRadioButton
 from sklearn.metrics import silhouette_score
 
+from orangewidget.widget import StateInfo
+
 import Orange.clustering
 from Orange.data import Table, Domain
 from Orange.widgets import gui
@@ -540,9 +542,9 @@ class TestOWKMeans(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 

--- a/Orange/widgets/unsupervised/tests/test_owlouvain.py
+++ b/Orange/widgets/unsupervised/tests/test_owlouvain.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import numpy as np
 from sklearn.utils import check_random_state
 
+from orangewidget.widget import StateInfo
 from orangewidget.settings import Context
 
 from Orange.data import Table, Domain, ContinuousVariable
@@ -288,7 +289,7 @@ class TestOWLouvain(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -6,6 +6,8 @@ from unittest.mock import patch, Mock
 import numpy as np
 from scipy import sparse
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate, possible_duplicate_table
@@ -176,7 +178,7 @@ class TestOWManifoldLearning(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -1,5 +1,7 @@
 import scipy.sparse as sp
 
+from orangewidget.widget import StateInfo
+
 # pylint: disable=missing-docstring, protected-access
 from Orange.base import Learner, Model
 from Orange.classification import KNNLearner
@@ -147,5 +149,5 @@ class TestOWBaseLearner(WidgetTest):
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
         self.send_signal(widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)

--- a/Orange/widgets/visualize/tests/test_owbarplot.py
+++ b/Orange/widgets/visualize/tests/test_owbarplot.py
@@ -9,6 +9,8 @@ import scipy.sparse as sp
 from AnyQt.QtCore import Qt
 from AnyQt.QtGui import QFont
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest, simulate, \
     WidgetOutputsTestMixin, datasets
@@ -43,7 +45,7 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         details = format_summary_details(self.data)
         self.assertEqual(info._StateInfo__input_summary.brief, "150")
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self._select_data()
@@ -53,9 +55,9 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_input_no_cont_features(self):

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import numpy as np
 from AnyQt.QtCore import QItemSelectionModel
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain, \
     DiscreteVariable
 from Orange.widgets.visualize.owboxplot import (
@@ -364,7 +366,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self._select_data()
@@ -374,9 +376,9 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock
 import numpy as np
 from AnyQt.QtCore import QItemSelection, Qt
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, DiscreteVariable
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.annotated_data import ANNOTATED_DATA_FEATURE_NAME
@@ -534,7 +536,7 @@ class TestOWDistributions(WidgetTest):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self._set_slider(0)
@@ -546,9 +548,9 @@ class TestOWDistributions(WidgetTest):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_sort_by_freq_no_split(self):

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -9,6 +9,8 @@ from sklearn.exceptions import ConvergenceWarning
 
 from AnyQt.QtCore import Qt, QModelIndex
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.preprocess import Continuize
 from Orange.widgets.utils import colorpalettes
@@ -387,7 +389,7 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -396,9 +398,9 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -16,6 +16,8 @@ from pyqtgraph.Point import Point
 
 from orangewidget.tests.base import DEFAULT_TIMEOUT
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.widgets.tests.base import (
     WidgetTest, WidgetOutputsTestMixin, datasets
@@ -310,7 +312,7 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         sel_indices = list(range(5))
@@ -321,9 +323,9 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_visual_settings(self, timeout=DEFAULT_TIMEOUT):

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -7,6 +7,8 @@ import numpy as np
 from AnyQt.QtCore import QEvent, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, DiscreteVariable, Domain, ContinuousVariable, \
     StringVariable
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -194,7 +196,7 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self._select_data()
@@ -204,9 +206,9 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -7,6 +7,8 @@ import numpy as np
 
 from AnyQt.QtCore import QPoint, QPropertyAnimation
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.classification import (
     NaiveBayesLearner, LogisticRegressionLearner, MajorityLearner
@@ -292,7 +294,7 @@ class TestOWNomogram(WidgetTest):
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
 
     def test_dots_stop_flashing(self):

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -5,6 +5,8 @@ import unittest
 
 from os import path
 
+from orangewidget.widget import StateInfo
+
 from Orange.classification.random_forest import RandomForestLearner
 from Orange.data import Table
 from Orange.modelling import TreeLearner
@@ -419,7 +421,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         no_output = "No data on output"
 
         self.send_signal(self.widget.Inputs.tree, self.titanic)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -428,7 +430,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.tree, None)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/tests/test_owruleviewer.py
+++ b/Orange/widgets/visualize/tests/test_owruleviewer.py
@@ -2,6 +2,8 @@
 from AnyQt.QtCore import Qt
 from AnyQt.QtWidgets import QApplication
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.classification import CN2Learner
@@ -168,14 +170,14 @@ class TestOWRuleViewer(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
         self.send_signal(self.widget.Inputs.classifier, self.classifier)
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -184,14 +186,14 @@ class TestOWRuleViewer(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
         summary, details = f"{len(output)}", format_summary_details(output)
         self.assertEqual(info._StateInfo__output_summary.brief, summary)
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.classifier, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -9,6 +9,8 @@ import numpy as np
 from AnyQt.QtCore import QEvent, QPoint, Qt
 from AnyQt.QtGui import QMouseEvent
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import ContinuousVariable, DiscreteVariable, Domain, Table
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.tests.utils import simulate
@@ -188,7 +190,7 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -197,9 +199,9 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -6,6 +6,8 @@ import unittest
 
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 import Orange.distance
 from Orange.data import (
     Table, Domain, ContinuousVariable, DiscreteVariable, StringVariable)
@@ -226,7 +228,7 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -239,7 +241,7 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         summary, details = f"{len(data)}", format_summary_details(data)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -248,9 +250,9 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
     def test_unique_output_domain(self):

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -2,6 +2,8 @@
 # pylint: disable=missing-docstring, protected-access
 from os import path
 
+from orangewidget.widget import StateInfo
+
 from Orange.classification import TreeLearner
 from Orange.data import Table
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -94,7 +96,7 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
         no_output = "No data on output"
 
         self.send_signal(self.widget.Inputs.tree, self.signal_data)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -103,5 +105,5 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(info._StateInfo__output_summary.details, details)
 
         self.send_signal(self.widget.Inputs.tree, None)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -7,6 +7,8 @@ from copy import deepcopy
 
 import numpy as np
 
+from orangewidget.widget import StateInfo
+
 from Orange.data import (Table, Domain, StringVariable,
                          ContinuousVariable)
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
@@ -245,7 +247,7 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
         summary, details = "101", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -259,7 +261,7 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
         summary, details = "101, 150", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -284,7 +286,7 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
         summary, details = "150, 186", format_multiple_summaries(data_list)
         self.assertEqual(info._StateInfo__input_summary.brief, summary)
         self.assertEqual(info._StateInfo__input_summary.details, details)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
         self._select_data()
         output = self.get_output(self.widget.Outputs.selected_data)
@@ -294,9 +296,9 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
 
         self.send_signal(self.widget.Inputs.data, None, 2)
         self.send_signal(self.widget.Inputs.data, None, 3)
-        self.assertEqual(info._StateInfo__input_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__input_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__input_summary.details, no_input)
-        self.assertEqual(info._StateInfo__output_summary.brief, "-")
+        self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
 class TestVennUtilities(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Summary tests test for string rather than StateInfo.Empty instance.

##### Description of changes
Find+Replace
(summaries should be rewritten)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
