### PR TITLE
SliderGraph: Disable auto scale button

### DIFF
--- a/Orange/widgets/utils/slidergraph.py
+++ b/Orange/widgets/utils/slidergraph.py
@@ -36,6 +36,7 @@ class SliderGraph(PlotWidget):
         self.getViewBox().setMouseEnabled(False, False)
         self.showGrid(True, True, alpha=0.5)
         self.setRange(xRange=(0.0, 1.0), yRange=(0.0, 1.0))
+        self.hideButtons()
 
         # tuples to store horisontal lines and labels
         self.plot_horlabel = []
@@ -96,8 +97,7 @@ class SliderGraph(PlotWidget):
                 self.addItem(label)
 
         self._plot_cutpoint(cutpoint_x)
-        self.setRange(xRange=(x.min(), x.max()),
-                      yRange=(0, max(yi.max() for yi in y)))
+        self.autoRange()
 
     def clear_plot(self):
         """
@@ -198,11 +198,12 @@ class SliderGraph(PlotWidget):
         # in every case set their position
         location = int(round(self._line.value()))
         cutidx = np.searchsorted(self.x, location)
+        minx = np.min(self.x)
         for s, curve, label, inc in zip(
                 self.sequences, self.plot_horline, self.plot_horlabel,
                 self.data_increasing):
             y = s[cutidx]
-            curve.setData([-100, location], 2 * [y])
+            curve.setData([minx, location], [y, y])
             self._set_anchor(label, cutidx, inc)
             label.setPos(location, y)
             label.setPlainText("{:.3f}".format(y))


### PR DESCRIPTION
##### Issue

Fixes #5270. Twice.

##### Description of changes

First, it disables the auto scale button. This graph (used here and in dbscan) does not need it.
Second, it fixes the problem that caused the wrong scaling (lines going from -100 instead of from minimal x).

The second fix alone would also suffice, though auto scaling would still change the plot's y scale (I suppose that because of labels).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
