### PR TITLE
README.md: Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
         <img src="https://readthedocs.org/projects/orange3/badge/?version=latest"></a>
 </p>
 
-# Orange
+# Orange Data Mining
 [Orange] is a data mining and visualization toolbox for novice and expert alike. To explore data with Orange, one requires __no__ programming or in-depth mathematical knowledge. We believe that workflow-based data science tools democratize data science by hiding complex underlying mechanics and exposing intuitive concepts. Anyone who owns data, or is motivated to peek into data, should have the means to do so.
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then, create a new conda environment, and install orange3:
 conda config --add channels conda-forge
 
 # Create and activate an environment for Orange
-yes | conda create python=3 --name orange3
+conda create python=3 --yes --name orange3
 conda activate orange3
 
 # Install Orange
@@ -146,7 +146,7 @@ export MY_GITHUB_USERNAME=replaceme
 create a conda environment, clone your fork, and install it:
 
 ```Shell
-yes | conda create python=3 --name orange3
+conda create python=3 --yes --name orange3
 conda activate orange3
 
 git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange3
@@ -186,7 +186,7 @@ export MY_GITHUB_USERNAME=replaceme
 create a conda environment, clone your forks, and install them:
 
 ```Shell
-yes | conda create python=3 --name orange3
+conda create python=3 --yes --name orange3
 conda activate orange3
 
 git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange-widget-base

--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@
 </p>
 <p align="center">
     <a href="https://orange.biolab.si/download" alt="Latest release">
-        <img src="https://img.shields.io/github/v/release/biolab/orange3?label=download" /></a>
+        <img src="https://img.shields.io/github/v/release/biolab/orange3?label=download" />
+    </a>
     <a href="https://orange3.readthedocs.io/en/latest/?badge=latest" alt="Documentation">
-        <img src="https://readthedocs.org/projects/orange3/badge/?version=latest"></a>
+        <img src="https://readthedocs.org/projects/orange3/badge/?version=latest">
+    </a>
+    <a href="https://discord.gg/FWrfeXV" alt="Discord">
+        <img src="https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord">                                                                                                                                                                                                                                                  </a>
 </p>
 
 # Orange Data Mining
-[Orange] is a data mining and visualization toolbox for novice and expert alike. To explore data with Orange, one requires __no__ programming or in-depth mathematical knowledge. We believe that workflow-based data science tools democratize data science by hiding complex underlying mechanics and exposing intuitive concepts. Anyone who owns data, or is motivated to peek into data, should have the means to do so.
+[Orange] is a data mining and visualization toolbox for novice and expert alike. To explore data with Orange, one requires __no programming or in-depth mathematical knowledge__. We believe that workflow-based data science tools democratize data science by hiding complex underlying mechanics and exposing intuitive concepts. Anyone who owns data, or is motivated to peek into data, should have the means to do so.
 
 <p align="center">
     <a href="https://orange.biolab.si/download">
@@ -26,7 +30,7 @@
 
 ### Easy installation
 
-For easy installation, [![Download](https://img.shields.io/github/v/release/biolab/orange3?label=download)](https://orange.biolab.si/download) the latest released Orange version from our website.
+For easy installation, [![Download](https://img.shields.io/github/v/release/biolab/orange3?label=download)](https://orange.biolab.si/download) the latest released Orange version from our website. To install an add-on, head to `Options -> Add-ons...` in the menu bar.
 
 ### Installing with Conda
 
@@ -84,28 +88,27 @@ To install Orange with [winget](https://docs.microsoft.com/en-us/windows/package
 winget install --id  UniversityofLjubljana.Orange 
 ```
 
-## Contributing
+## Developing
 
 [![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fbiolab%2Forange3%2Fbadge&label=build)](https://actions-badge.atrox.dev/biolab/orange3/goto) [![codecov](https://img.shields.io/codecov/c/github/biolab/orange3)](https://codecov.io/gh/biolab/orange3) [![Contributor count](https://img.shields.io/github/contributors-anon/biolab/orange3)](https://github.com/biolab/orange3/graphs/contributors) [![Latest GitHub commit](https://img.shields.io/github/last-commit/biolab/orange3)](https://github.com/biolab/orange3/commits/master)
 
-Want to get involved? Join us on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV), introduce yourself in #general!
+Want to write your own widget? [Use the Orange3 example addon template.](https://github.com/biolab/orange3-example-addon)
 
-Take a look at our [contributing guide](https://github.com/irgolic/orange3/blob/README-shields/CONTRIBUTING.md), it might answer some questions, and it outlines the standards we adhere to.
+Want to get involved? Join us on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV), introduce yourself in #general! 
+
+Take a look at our [contributing guide](https://github.com/irgolic/orange3/blob/README-shields/CONTRIBUTING.md) and [style guidelines](https://github.com/biolab/orange-widget-base/wiki/Widget-UI).
 
 Check out our widget development [![docs](https://readthedocs.org/projects/orange-widget-base/badge/?version=latest)](https://orange-widget-base.readthedocs.io/en/latest/?badge=latest) for a comprehensive guide on writing Orange widgets.
 
-If you're looking for a good starting point, check out our [![good first issues](https://img.shields.io/github/issues/biolab/orange3/good%20first%20issue?label=good%20first%20issues)](https://github.com/biolab/orange3/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+### The Orange ecosystem
 
+The development of core Orange is primarily split into three repositories:
 
-### The Orange Ecosystem
-
-The development of Orange is primarily split into three repositories:
-
-[biolab/orange-canvas-core](https://www.github.com/biolab/orange-canvas-core) implements canvas elements,  
-[biolab/orange-widget-base](https://www.github.com/biolab/orange-widget-base) implements a widget window's interface elements,  
+[biolab/orange-canvas-core](https://www.github.com/biolab/orange-canvas-core) implements the canvas,  
+[biolab/orange-widget-base](https://www.github.com/biolab/orange-widget-base) is a handy widget GUI library,  
 [biolab/orange3](https://www.github.com/biolab/orange3) brings it all together and implements the base data mining toolbox.	
 
-Additionally, add-ons implement additional widgets for more specific use cases. [Anyone can write an add-on.](https://github.com/biolab/orange3-example-addon) These are our first-party add-ons:
+Additionally, add-ons implement additional widgets for more specific use cases. [Anyone can write an add-on.](https://github.com/biolab/orange3-example-addon) Some of our first-party add-ons:
 
 - [biolab/orange3-text](https://www.github.com/biolab/orange3-text)
 - [biolab/orange3-bioinformatics](https://www.github.com/biolab/orange3-bioinformatics)
@@ -116,8 +119,9 @@ Additionally, add-ons implement additional widgets for more specific use cases. 
 - [biolab/orange3-geo](https://www.github.com/biolab/orange3-geo)    
 - [biolab/orange3-associate](https://www.github.com/biolab/orange3-associate)    
 - [biolab/orange3-network](https://www.github.com/biolab/orange3-network)
+- [biolab/orange3-explain](https://www.github.com/biolab/orange3-explain)
 
-### Setting up for development of core widgets
+### Setting up for Orange core development
 
 Fork the repository by pressing the fork button in top-right corner of this page. Then execute the following lines (copy them one by one!):
 
@@ -150,7 +154,7 @@ To run tests, use `unittest Orange.tests Orange.widgets.tests`
 
 ### Setting up for development of all components
 
-If you wish to also contribute to base components (the widget base and the canvas), these two repositories must also be cloned from Github instead of being installed as dependency of Orange 3 (which happens above).
+If you wish to also contribute to base components (the widget base and the canvas), these two repositories must also be cloned from Github instead of being installed as dependency of Orange3 (which happens above).
 
 First, fork all repositories to which you want to contribute. Then type:
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,72 @@
 
 [Orange]: https://orange.biolab.si/
 
+
+## Installing
+
+### Easy installation
+
+For easy installation, [![Download](https://img.shields.io/github/v/release/biolab/orange3?label=download)](https://orange.biolab.si/download) the latest released Orange version from our website.
+
+### Installing with Conda
+
+Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) for your OS. Open the Anaconda prompt and type the following (copy individual lines; skip those starting with `#`).
+
+```Shell
+# Add conda-forge to your channels for access to the latest release
+conda config --add channels conda-forge
+
+# Create and activate an environment for orange
+conda create python=3 --name orange3
+conda activate orange3
+
+# Install orange
+conda install orange3
+```
+
+For installation of any add-ons, use `conda install orange3-<addon name>`. See specific add-on repositories for details.
+
+#### Running
+
+Open Anaconda prompt and activate the environment by `conda activate orange3`. Then run `orange-canvas` or `python3 -m Orange.canvas`. Add `--help` for a list of program options.
+
+Starting up may take a while the first time.
+
+### Installing with pip
+
+To install Orange with pip, run the following.
+
+```Shell
+# Install build requirements via your system's package manager
+sudo apt install virtualenv build-essential python3-dev
+
+# Create an environment for Orange and its dependencies
+virtualenv --python=python3 --system-site-packages orange3venv
+
+# Activate the environment
+source orange3venv/bin/activate
+
+# Install Orange
+pip install orange3
+```
+
+#### Running
+
+Activate the environment by `source orange3venv/bin/activate`. Then run `orange-canvas` or `python3 -m Orange.canvas`. Add `--help` for a list of program options.
+
+Starting up may take a while the first time.
+
+### Installing with winget (Windows only)
+
+To install Orange with [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/), run:
+
+```Shell
+winget install --id  UniversityofLjubljana.Orange 
+```
+
 ## Contributing
 
-[![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fbiolab%2Forange3%2Fbadge&label=build)](https://actions-badge.atrox.dev/biolab/orange3/goto)
-[![codecov](https://img.shields.io/codecov/c/github/biolab/orange3)](https://codecov.io/gh/biolab/orange3)
-[![Contributor count](https://img.shields.io/github/contributors-anon/biolab/orange3)](https://github.com/biolab/orange3/graphs/contributors)
-[![Latest GitHub commit](https://img.shields.io/github/last-commit/biolab/orange3)](https://github.com/biolab/orange3/commits/master)
+[![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fbiolab%2Forange3%2Fbadge&label=build)](https://actions-badge.atrox.dev/biolab/orange3/goto) [![codecov](https://img.shields.io/codecov/c/github/biolab/orange3)](https://codecov.io/gh/biolab/orange3) [![Contributor count](https://img.shields.io/github/contributors-anon/biolab/orange3)](https://github.com/biolab/orange3/graphs/contributors) [![Latest GitHub commit](https://img.shields.io/github/last-commit/biolab/orange3)](https://github.com/biolab/orange3/commits/master)
 
 Want to get involved? Join us on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV), introduce yourself in #general!
 
@@ -45,100 +105,69 @@ The development of Orange is primarily split into three repositories:
 [biolab/orange-widget-base](https://www.github.com/biolab/orange-widget-base) implements a widget window's interface elements,  
 [biolab/orange3](https://www.github.com/biolab/orange3) brings it all together and implements the base data mining toolbox.	
 
-Additionally, add-ons implement additional widgets for more specific use cases. [Anyone can write an add-on.](https://github.com/biolab/orange3-example-addon) Below is a list of our first-party add-ons:
+Additionally, add-ons implement additional widgets for more specific use cases. [Anyone can write an add-on.](https://github.com/biolab/orange3-example-addon) These are our first-party add-ons:
 
-[biolab/orange3-text](https://www.github.com/biolab/orange3-text)    
-[biolab/orange3-bioinformatics](https://www.github.com/biolab/orange3-bioinformatics)    
-[biolab/orange3-timeseries](https://www.github.com/biolab/orange3-timeseries)    
-[biolab/orange3-single-cell](https://www.github.com/biolab/orange3-single-cell)    
-[biolab/orange3-imageanalytics](https://www.github.com/biolab/orange3-imageanalytics)    
-[biolab/orange3-educational](https://www.github.com/biolab/orange3-educational)    
-[biolab/orange3-geo](https://www.github.com/biolab/orange3-geo)    
-[biolab/orange3-associate](https://www.github.com/biolab/orange3-associate)    
-[biolab/orange3-network](https://www.github.com/biolab/orange3-network)
+- [biolab/orange3-text](https://www.github.com/biolab/orange3-text)
+- [biolab/orange3-bioinformatics](https://www.github.com/biolab/orange3-bioinformatics)
+- [biolab/orange3-timeseries](https://www.github.com/biolab/orange3-timeseries)    
+- [biolab/orange3-single-cell](https://www.github.com/biolab/orange3-single-cell)    
+- [biolab/orange3-imageanalytics](https://www.github.com/biolab/orange3-imageanalytics)    
+- [biolab/orange3-educational](https://www.github.com/biolab/orange3-educational)    
+- [biolab/orange3-geo](https://www.github.com/biolab/orange3-geo)    
+- [biolab/orange3-associate](https://www.github.com/biolab/orange3-associate)    
+- [biolab/orange3-network](https://www.github.com/biolab/orange3-network)
 
-### Setting up
+### Setting up for development of core widgets
 
-1. Set up a __virtual environment__. We recommend [Miniconda](https://docs.conda.io/en/latest/miniconda.html).  
-`conda create python=3 --name orange3`
-2. __Fork__ your chosen repository.  
-Press the fork button in top-right corner of the page
-3. __Clone__ it.   
-`git clone ssh://git@github.com/<your-username>/<repo-name>`
-4. __Install__ it.  
-`pip install -e .` or `python setup.py develop`
-
-Now you're ready to work with git. See GitHub's guides on [pull requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests), [forks](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/working-with-forks) if you're unfamiliar.  
-If you're having trouble, get in touch on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV).
-
-## Installing
-
-For easy installation, [![Download](https://img.shields.io/github/v/release/biolab/orange3?label=download)](https://orange.biolab.si/download) the latest released Orange version from our website.
-
-### Installing with Miniconda / Anaconda
-
-Orange requires Python 3.6 or newer.
-
-First, install [Miniconda] for your OS. Create virtual environment for Orange:
+Fork the repository by pressing the fork button in top-right corner of this page. Then execute the following lines (copy them one by one!):
 
 ```Shell
 conda create python=3 --name orange3
+conda activate orange3
+
+git clone ssh://git@github.com/<YOUR-USERNAME>/orange3
+
+pip install -e orange3
 ```
-In your Anaconda Prompt add conda-forge to your channels:
+
+
+Now you're ready to work with git. See GitHub's guides on [pull requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests), [forks](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/working-with-forks) if you're unfamiliar. If you're having trouble, get in touch on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV).
+
+#### Running
+
+Run orange with `python -m Orange.canvas` (after activating the conda environment).
+
+`python -m Orange.canvas -l 2 --no-splash --no-welcome` will skip the splash screen and welcome window, and output more debug info. Use `-l 4` for more.
+
+Add `--clear-widget-settings` to clear the widget settings before start.
+
+To explore the dark side of the orange, try `--style=fusion:breeze-dark`
+
+Argument `--help` lists all available options.
+
+To run tests, use `unittest Orange.tests Orange.widgets.tests`
+
+
+### Setting up for development of all components
+
+If you wish to also contribute to base components (the widget base and the canvas), these two repositories must also be cloned from Github instead of being installed as dependency of Orange 3 (which happens above).
+
+First, fork all repositories to which you want to contribute. Then type:
 
 ```Shell
-conda config --add channels conda-forge
+conda create python=3 --name orange3
+conda activate orange3
+
+git clone ssh://git@github.com/<YOUR-USERNAME>/orange-widget-base
+pip install -e orange-widget-base
+
+git clone ssh://git@github.com/<YOUR-USERNAME>/orange-canvas-core
+pip install -e orange-canvas-core
+
+git clone ssh://git@github.com/<YOUR-USERNAME>/orange3
+pip install -e orange3
+
+# Same for any add-on repositories
 ```
 
-This will enable access to the latest Orange release. Then install Orange3:
-
-```Shell
-conda install orange3
-```
-
-[Miniconda]: https://docs.conda.io/en/latest/miniconda.html
-
-To install the add-ons, follow a similar recipe:
-
-```Shell
-conda install orange3-<addon name>
-```
-
-See specific add-on repositories for details.
-
-### Installing with pip
-
-To install Orange with pip, run the following.
-
-```Shell
-# Install some build requirements via your system's package manager
-sudo apt install virtualenv build-essential python3-dev
-
-# Create a separate Python environment for Orange and its dependencies ...
-virtualenv --python=python3 --system-site-packages orange3venv
-# ... and make it the active one
-source orange3venv/bin/activate
-
-# Install Orange
-pip install orange3
-```
-
-### Installing with winget (Windows only)
-
-To install Orange with [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/), run:
-
-```Shell
-winget install --id  UniversityofLjubljana.Orange 
-```
-
-### Starting Orange GUI
-
-To start Orange GUI from the command line, run:
-
-```Shell
-orange-canvas
-# or
-python3 -m Orange.canvas
-```
-
-Append `--help` for a list of program options.
+It's important to install `orange-base-widget` and `orange-canvas-core` before `orange3` to ensure that `orange3` will use your local versions.

--- a/README.md
+++ b/README.md
@@ -126,10 +126,12 @@ Additionally, add-ons implement additional widgets for more specific use cases. 
 Fork the repository by pressing the fork button in top-right corner of this page. Then execute the following lines (copy them one by one!):
 
 ```Shell
+export YOUR_GITHUB_USERNAME=replaceme
+
 conda create python=3 --name orange3
 conda activate orange3
 
-git clone ssh://git@github.com/<YOUR-USERNAME>/orange3
+git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange3
 
 pip install -e orange3
 ```
@@ -159,16 +161,19 @@ If you wish to also contribute to base components (the widget base and the canva
 First, fork all repositories to which you want to contribute. Then type:
 
 ```Shell
+export YOUR_GITHUB_USERNAME=replaceme
+git clone ssh://git@github.com/
+
 conda create python=3 --name orange3
 conda activate orange3
 
-git clone ssh://git@github.com/<YOUR-USERNAME>/orange-widget-base
+git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange-widget-base
 pip install -e orange-widget-base
 
-git clone ssh://git@github.com/<YOUR-USERNAME>/orange-canvas-core
+git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange-canvas-core
 pip install -e orange-canvas-core
 
-git clone ssh://git@github.com/<YOUR-USERNAME>/orange3
+git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange3
 pip install -e orange3
 
 # Same for any add-on repositories

--- a/README.md
+++ b/README.md
@@ -34,27 +34,39 @@ For easy installation, [![Download](https://img.shields.io/github/v/release/biol
 
 ### Installing with Conda
 
-Install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) for your OS. Open the Anaconda prompt and type the following (copy individual lines; skip those starting with `#`).
+First, install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) for your OS. 
+
+Then, create a new conda environment, and install orange3:
 
 ```Shell
 # Add conda-forge to your channels for access to the latest release
 conda config --add channels conda-forge
 
-# Create and activate an environment for orange
-conda create python=3 --name orange3
+# Create and activate an environment for Orange
+yes | conda create python=3 --name orange3
 conda activate orange3
 
-# Install orange
+# Install Orange
 conda install orange3
 ```
 
-For installation of any add-ons, use `conda install orange3-<addon name>`. See specific add-on repositories for details.
+For installation of an add-on, use:
+```Shell
+conda install orange3-<addon name>
+```
+[See specific add-on repositories for details.](https://github.com/biolab/)
 
 #### Running
 
-Open Anaconda prompt and activate the environment by `conda activate orange3`. Then run `orange-canvas` or `python3 -m Orange.canvas`. Add `--help` for a list of program options.
+Activate the environment, 
+```Shell
+conda activate orange3
+``` 
+and run either `orange-canvas` or `python3 -m Orange.canvas`. 
 
-Starting up may take a while the first time.
+Add `--help` for a list of program options.
+
+Starting up for the first time may take a while.
 
 ### Installing with pip
 
@@ -78,7 +90,7 @@ pip install orange3
 
 Activate the environment by `source orange3venv/bin/activate`. Then run `orange-canvas` or `python3 -m Orange.canvas`. Add `--help` for a list of program options.
 
-Starting up may take a while the first time.
+Starting up for the first time may take a while.
 
 ### Installing with winget (Windows only)
 
@@ -92,7 +104,7 @@ winget install --id  UniversityofLjubljana.Orange
 
 [![GitHub Actions](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fbiolab%2Forange3%2Fbadge&label=build)](https://actions-badge.atrox.dev/biolab/orange3/goto) [![codecov](https://img.shields.io/codecov/c/github/biolab/orange3)](https://codecov.io/gh/biolab/orange3) [![Contributor count](https://img.shields.io/github/contributors-anon/biolab/orange3)](https://github.com/biolab/orange3/graphs/contributors) [![Latest GitHub commit](https://img.shields.io/github/last-commit/biolab/orange3)](https://github.com/biolab/orange3/commits/master)
 
-Want to write your own widget? [Use the Orange3 example addon template.](https://github.com/biolab/orange3-example-addon)
+Want to write a widget? [Use the Orange3 example add-on template.](https://github.com/biolab/orange3-example-addon)
 
 Want to get involved? Join us on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV), introduce yourself in #general! 
 
@@ -121,33 +133,38 @@ Additionally, add-ons implement additional widgets for more specific use cases. 
 - [biolab/orange3-network](https://www.github.com/biolab/orange3-network)
 - [biolab/orange3-explain](https://www.github.com/biolab/orange3-explain)
 
-### Setting up for Orange core development
+### Setting up for core Orange development
 
-Fork the repository by pressing the fork button in top-right corner of this page. Then execute the following lines (copy them one by one!):
+First, fork the repository by pressing the fork button in the top-right corner of this page.
+
+Set your GitHub username,
 
 ```Shell
-export YOUR_GITHUB_USERNAME=replaceme
+export MY_GITHUB_USERNAME=replaceme
+```
 
-conda create python=3 --name orange3
+create a conda environment, clone your fork, and install it:
+
+```Shell
+yes | conda create python=3 --name orange3
 conda activate orange3
 
-git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange3
+git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange3
 
 pip install -e orange3
 ```
-
 
 Now you're ready to work with git. See GitHub's guides on [pull requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests), [forks](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/working-with-forks) if you're unfamiliar. If you're having trouble, get in touch on [![Discord](https://img.shields.io/discord/633376992607076354?logo=discord&color=7389D8&logoColor=white&label=Discord)](https://discord.gg/FWrfeXV).
 
 #### Running
 
-Run orange with `python -m Orange.canvas` (after activating the conda environment).
+Run Orange with `python -m Orange.canvas` (after activating the conda environment).
 
 `python -m Orange.canvas -l 2 --no-splash --no-welcome` will skip the splash screen and welcome window, and output more debug info. Use `-l 4` for more.
 
 Add `--clear-widget-settings` to clear the widget settings before start.
 
-To explore the dark side of the orange, try `--style=fusion:breeze-dark`
+To explore the dark side of the Orange, try `--style=fusion:breeze-dark`
 
 Argument `--help` lists all available options.
 
@@ -156,27 +173,32 @@ To run tests, use `unittest Orange.tests Orange.widgets.tests`
 
 ### Setting up for development of all components
 
-If you wish to also contribute to base components (the widget base and the canvas), these two repositories must also be cloned from Github instead of being installed as dependency of Orange3 (which happens above).
+Should you wish to contribute Orange's base components (the widget base and the canvas), you must also clone these two repositories from Github instead of installing them as dependencies of Orange3.
 
-First, fork all repositories to which you want to contribute. Then type:
+First, fork all the repositories to which you want to contribute. 
+
+Set your GitHub username,
 
 ```Shell
-export YOUR_GITHUB_USERNAME=replaceme
-git clone ssh://git@github.com/
-
-conda create python=3 --name orange3
-conda activate orange3
-
-git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange-widget-base
-pip install -e orange-widget-base
-
-git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange-canvas-core
-pip install -e orange-canvas-core
-
-git clone ssh://git@github.com/$YOUR_GITHUB_USERNAME/orange3
-pip install -e orange3
-
-# Same for any add-on repositories
+export MY_GITHUB_USERNAME=replaceme
 ```
 
-It's important to install `orange-base-widget` and `orange-canvas-core` before `orange3` to ensure that `orange3` will use your local versions.
+create a conda environment, clone your forks, and install them:
+
+```Shell
+yes | conda create python=3 --name orange3
+conda activate orange3
+
+git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange-widget-base
+pip install -e orange-widget-base
+
+git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange-canvas-core
+pip install -e orange-canvas-core
+
+git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange3
+pip install -e orange3
+
+# Repeat for any add-on repositories
+```
+
+It's crucial to install `orange-base-widget` and `orange-canvas-core` before `orange3` to ensure that `orange3` will use your local versions.


### PR DESCRIPTION
##### Issue

Fixes #5112.

Instructions on the web site do not use virtual environments. I'd prefer keeping them that way. If anything, we can redirect advanced users to instructions on github.

##### Description of changes

Besides adding `conda activate orange3` (and testing that all conda-based instructions work on my macOs), I rearranged the page

- I moved installation to the top, and emphasized the easy installation via installer.
- I replaced "steps" with a single code snippet to make it shorter, simpler, cleaner.
- I separated installation of `orange3` alone, and installation of `orange-widget-base`, `orange-canvas-core` and `orange3`, because only a few would be interested in the latter.

