### PR TITLE
Datasets: Make some columns narrower

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -377,10 +377,13 @@ class OWDataSets(OWWidget):
             self.__on_selection
         )
 
+        scw = self.view.setColumnWidth
+        width = self.view.fontMetrics().width
         self.view.resizeColumnToContents(0)
-        self.view.setColumnWidth(
-            1, min(self.view.sizeHintForColumn(1),
-                   self.view.fontMetrics().width("X" * 37)))
+        scw(self.Header.title, width("X" * 37))
+        scw(self.Header.size, 20 + max(width("888 bytes "), width("9999.9 MB ")))
+        scw(self.Header.instances, 20 + width("100000000"))
+        scw(self.Header.variables, 20 + width("1000000"))
 
         header = self.view.header()
         header.restoreState(self.header_state)


### PR DESCRIPTION
##### Issue

May resolve #5091.

##### Description of changes

After losing nerves and time with different methods that didn't work, I realized that we can pretty well know what the column widths should be, so I just fixed them. If we don't like the widths, we can modify them; but I see no reason to be fancier and resize to contents.

##### Includes
- [X] Code changes
