### PR TITLE
KMeans: Don't try to normalize sparse data; show warning

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -2,6 +2,8 @@ from concurrent.futures import Future
 from typing import Optional, List, Dict
 
 import numpy as np
+import scipy.sparse as sp
+
 from AnyQt.QtCore import Qt, QTimer, QAbstractTableModel, QModelIndex, QThread, \
     pyqtSlot as Slot
 from AnyQt.QtGui import QIntValidator
@@ -130,6 +132,7 @@ class OWKMeans(widget.OWWidget):
         not_enough_data = widget.Msg(
             "Too few ({}) unique data instances for {} clusters"
         )
+        no_sparse_normalization = widget.Msg("Sparse data cannot be normalized")
 
     INIT_METHODS = (("Initialize with KMeans++", "k-means++"),
                     ("Random initialization", "random"))
@@ -490,7 +493,10 @@ class OWKMeans(widget.OWWidget):
 
     def preproces(self, data):
         if self.normalize:
-            data = Normalize()(data)
+            if sp.issparse(data.X):
+                self.Warning.no_sparse_normalization()
+            else:
+                data = Normalize()(data)
         for preprocessor in KMeans.preprocessors:  # use same preprocessors than
             data = preprocessor(data)
         return data

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -576,6 +576,9 @@ class OWKMeans(widget.OWWidget):
         self.selection = None
         self._set_input_summary()
 
+        self.controls.normalize.setDisabled(
+            bool(self.data) and sp.issparse(self.data.X))
+
         # Do not needlessly recluster the data if X hasn't changed
         if old_data and self.data and array_equal(self.data.X, old_data.X):
             if self.auto_commit:

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -341,33 +341,37 @@ class TestOWKMeans(WidgetTest):
         normalization = normalize.return_value = Mock(return_value=self.data)
         widget = self.widget
         widget.normalize = True
+        norm_check = widget.controls.normalize
 
         x = sp.csr_matrix(np.random.randint(0, 2, (5, 10)))
         data = Table.from_numpy(None, x)
 
         self.send_signal(widget.Inputs.data, data)
         self.assertTrue(widget.Warning.no_sparse_normalization.is_shown())
+        self.assertFalse(norm_check.isEnabled())
         normalization.assert_not_called()
 
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(widget.Warning.no_sparse_normalization.is_shown())
+        self.assertTrue(norm_check.isEnabled())
         normalization.assert_not_called()
 
         self.send_signal(widget.Inputs.data, data)
         self.assertTrue(widget.Warning.no_sparse_normalization.is_shown())
+        self.assertFalse(norm_check.isEnabled())
         normalization.assert_not_called()
 
         self.send_signal(widget.Inputs.data, self.data)
         self.assertFalse(widget.Warning.no_sparse_normalization.is_shown())
+        self.assertTrue(norm_check.isEnabled())
         normalization.assert_called()
         normalization.reset_mock()
 
-        self.send_signal(widget.Inputs.data, data)
-        self.assertTrue(widget.Warning.no_sparse_normalization.is_shown())
-        normalization.assert_not_called()
-
         widget.controls.normalize.click()
+
+        self.send_signal(widget.Inputs.data, data)
         self.assertFalse(widget.Warning.no_sparse_normalization.is_shown())
+        self.assertFalse(norm_check.isEnabled())
         normalization.assert_not_called()
 
     def test_report(self):


### PR DESCRIPTION
##### Issue

Fixes #4973.

##### Description of changes

K-means fails when it tries to normalize sparse data. Normalization of sparse data is impossible (because it turns it dense). Hence the widget now doesn't normalize but shows a warning instead.

##### Includes
- [X] Code changes
- [X] Tests
