### PR TITLE
CreateInstance: Fix test after changes in orange-widget-base

### DIFF
--- a/Orange/widgets/data/owcreateinstance.py
+++ b/Orange/widgets/data/owcreateinstance.py
@@ -510,7 +510,7 @@ class OWCreateInstance(OWWidget):
         vbox.layout().addWidget(self.filter_edit)
         vbox.layout().addWidget(self.view)
 
-        box = gui.hBox(vbox)
+        box = gui.hBox(vbox, objectName="buttonBox")
         gui.rubber(box)
         for name in self.ACTIONS:
             gui.button(

--- a/Orange/widgets/data/tests/test_owcreateinstance.py
+++ b/Orange/widgets/data/tests/test_owcreateinstance.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from AnyQt.QtCore import QDateTime, QDate, QTime, QPoint
-from AnyQt.QtWidgets import QWidget, QLineEdit, QStyleOptionViewItem, QMenu
+from AnyQt.QtCore import QDateTime, QDate, QTime, QPoint, QObject
+from AnyQt.QtWidgets import QWidget, QLineEdit, QStyleOptionViewItem, QMenu, \
+    QPushButton
 
 from orangewidget.widget import StateInfo
 from orangewidget.tests.base import GuiTest
@@ -99,8 +100,7 @@ class TestOWCreateInstance(WidgetTest):
     def _get_init_buttons(self, widget=None):
         if not widget:
             widget = self.widget
-        box = widget.controlArea.layout().itemAt(0).widget().children()[3]
-        return box.children()[1:]
+        return widget.findChild(QObject, "buttonBox").findChildren(QPushButton)
 
     def test_initialize_buttons(self):
         self.widget.controls.append_to_data.setChecked(False)


### PR DESCRIPTION
##### Issue

Some change, almost certainly https://github.com/biolab/orange-widget-base/pull/130/files#diff-3a31caef28024e64070f007c502ff3e19b890e99719793535bc0cf9b88f9119dR394, broke tests for Create Instance by automagically inserting widgets into layout. (As I understood @ales-erjavec, this is exactly what he this morning warned against!)

Thruth be told, these tests were fragile and would also break at any other change in the UX.

##### Description of changes

Find buttons using `findChild` and `findChildren` rather than by their indices.

##### Includes
- [X] Code changes
