### PR TITLE
guess_data_type: Ignore missing values for numeric variables

### DIFF
--- a/Orange/data/tests/test_io_util.py
+++ b/Orange/data/tests/test_io_util.py
@@ -1,0 +1,14 @@
+import unittest
+
+from Orange.data import ContinuousVariable, guess_data_type
+
+
+class TestIoUtil(unittest.TestCase):
+    def test_guess_continuous_w_nans(self):
+        self.assertIs(
+            guess_data_type(["9", "", "98", "?", "98", "98", "98"])[2],
+            ContinuousVariable)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -53,7 +53,8 @@ def is_discrete_values(values):
     # the type is numeric
     try:
         isinstance(next(iter(values)), Number) or \
-        [float(v) for _, v in zip(range(min(3, len(values))), values)]
+        [v not in MISSING_VALUES and float(v)
+         for _, v in zip(range(min(3, len(values))), values)]
     except ValueError:
         is_numeric = False
         max_values = int(round(len(values)**.7))


### PR DESCRIPTION
##### Issue

Fixes #5196.

##### Description of changes

When guessing data types, Orange tests whether values can be converted to float. It didn't skip missing values and erroneously constructed categorical or string variables.

##### Includes
- [X] Code changes
- [X] Tests
