### PR TITLE
test_copy_sparse: improve test (try to change values)

### DIFF
--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -460,6 +460,10 @@ class TableTestCase(unittest.TestCase):
         self.assertNotEqual(id(t._Y), id(copy._Y))
         self.assertNotEqual(id(t.metas), id(copy.metas))
 
+        # ensure that copied sparse arrays do not share data
+        t.X[0, 0] = 42
+        self.assertEqual(copy.X[0, 0], 5.1)
+
     def test_concatenate(self):
         d1 = data.Domain(
             [data.ContinuousVariable(n) for n in "abc"],


### PR DESCRIPTION
Our `Table.copy()` is a deep copy (so `copy()` as in numpy, not `copy()` as usually used in Python), which Vesna kindly pointed out to me today. It relies on the `Table`'s constructor, which relies on `from_table`, which in turn relies on `from_table_rows`. Then, it does `ensure_copy` on the resulting table. Because `ensure_copy` does nothing for sparse matrices (it expects that selections in `from_table_rows` will create copies), I am putting a test on it if we ever change how `copy()`, `from_table()` or `from_table_rows()` behave.

Here are some fun ways to make a shallow or a deep copy of a Table.

```
from Orange.data import Table, Domain

"Some ways to do a DEEP copy"

"an obvious one, copy() as inspired by numpy"
iris = Table("iris")
iris2 = iris.copy()
iris.X[0, 0] = 42
print(iris2.X[0, 0])
"5.1"

"also works for sparse"
iris = Table("iris").to_sparse()
iris2 = iris.copy()
iris.X[0, 0] = 42
print(iris2.X[0, 0])
"5.1"

"reorder features so that they can not form a slice"
iris = Table("iris")
dom2 = Domain([iris.domain.attributes[i] for i in [0, 2, 1]])
iris2 = iris.transform(dom2)
iris.X[0, 0] = 42
print(iris2.X[0, 0])
"5.1"

"Some ways to make SHALLOW copies"

"from_table with a another, but same domain"
iris = Table("iris")
dom2 = iris.domain.copy()
iris2 = iris.transform(dom2)
iris.X[0, 0] = 42
print(iris2.X[0, 0])
"42.0"

"just for fun, if we have something that can be a slice. :)"
iris = Table("iris")
dom2 = Domain([iris.domain.attributes[i] for i in [0, 2]])
iris2 = iris.transform(dom2)
iris.X[0, 0] = 42
print(iris2.X[0, 0])
"42.0"
```

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
