### PR TITLE
[FIX] Gradient Boosting: Skip tests if package not installed

### DIFF
--- a/Orange/classification/tests/test_catgb_cls.py
+++ b/Orange/classification/tests/test_catgb_cls.py
@@ -2,12 +2,16 @@ import unittest
 
 import numpy as np
 
-from Orange.classification import CatGBClassifier
+try:
+    from Orange.classification import CatGBClassifier
+except ImportError:
+    CatGBClassifier = None
 from Orange.data import Table
 from Orange.evaluation import CrossValidation, CA
 from Orange.preprocess.score import Scorer
 
 
+@unittest.skipIf(CatGBClassifier is None, "Missing 'catboost' package")
 class TestCatGBClassifier(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/Orange/classification/tests/test_xgb_cls.py
+++ b/Orange/classification/tests/test_xgb_cls.py
@@ -2,7 +2,11 @@ import unittest
 from typing import Callable
 
 from Orange.base import XGBBase
-from Orange.classification import XGBClassifier, XGBRFClassifier
+
+try:
+    from Orange.classification import XGBClassifier, XGBRFClassifier
+except ImportError:
+    XGBClassifier = XGBRFClassifier = None
 from Orange.data import Table
 from Orange.evaluation import CrossValidation, CA
 from Orange.preprocess.score import Scorer
@@ -16,6 +20,7 @@ def test_learners(func: Callable) -> Callable:
     return wrapper
 
 
+@unittest.skipIf(XGBClassifier is None, "Missing 'xgboost' package")
 class TestXGBCls(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/Orange/modelling/tests/test_catgb.py
+++ b/Orange/modelling/tests/test_catgb.py
@@ -1,12 +1,15 @@
-import sys
 import unittest
-from unittest.mock import patch
 
 from Orange.data import Table
 from Orange.evaluation import CrossValidation
-from Orange.modelling import CatGBLearner
+
+try:
+    from Orange.modelling import CatGBLearner
+except ImportError:
+    CatGBLearner = None
 
 
+@unittest.skipIf(CatGBLearner is None, "Missing 'catboost' package")
 class TestCatGBLearner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -38,18 +41,6 @@ class TestCatGBLearner(unittest.TestCase):
         booster = CatGBLearner()
         booster.score(self.iris)
         booster.score(self.housing)
-
-    def test_import_missing_library(self):
-        modules = {k: v for k, v in sys.modules.items()
-                   if "orange" not in k.lower()}  # retain built-ins
-        modules["catboost"] = None
-        # pylint: disable=reimported,redefined-outer-name
-        # pylint: disable=unused-import,import-outside-toplevel
-        with patch.dict(sys.modules, modules, clear=True):
-            def import_():
-                from Orange.modelling import CatGBLearner
-
-            self.assertRaises(ImportError, import_)
 
 
 if __name__ == "__main__":

--- a/Orange/modelling/tests/test_xgb.py
+++ b/Orange/modelling/tests/test_xgb.py
@@ -1,11 +1,13 @@
-import sys
 import unittest
-from unittest.mock import patch
 from typing import Callable, Union
 
 from Orange.data import Table
 from Orange.evaluation import CrossValidation
-from Orange.modelling import XGBLearner, XGBRFLearner
+
+try:
+    from Orange.modelling import XGBLearner, XGBRFLearner
+except ImportError:
+    XGBLearner = XGBRFLearner = None
 
 
 def test_learners(func: Callable) -> Callable:
@@ -16,6 +18,7 @@ def test_learners(func: Callable) -> Callable:
     return wrapper
 
 
+@unittest.skipIf(XGBLearner is None, "Missing 'xgboost' package")
 class TestXGB(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -51,18 +54,6 @@ class TestXGB(unittest.TestCase):
         booster = learner_class()
         booster.score(self.iris)
         booster.score(self.housing)
-
-    def test_import_missing_library(self):
-        modules = {k: v for k, v in sys.modules.items()
-                   if "orange" not in k.lower()}  # retain built-ins
-        modules["xgboost"] = None
-        # pylint: disable=reimported,redefined-outer-name
-        # pylint: disable=unused-import,import-outside-toplevel
-        with patch.dict(sys.modules, modules, clear=True):
-            def import_():
-                from Orange.modelling import XGBLearner
-
-            self.assertRaises(ImportError, import_)
 
 
 if __name__ == "__main__":

--- a/Orange/regression/tests/test_catgb_reg.py
+++ b/Orange/regression/tests/test_catgb_reg.py
@@ -3,9 +3,14 @@ import unittest
 from Orange.data import Table
 from Orange.evaluation import CrossValidation, RMSE
 from Orange.preprocess.score import Scorer
-from Orange.regression import CatGBRegressor
+
+try:
+    from Orange.regression import CatGBRegressor
+except ImportError:
+    CatGBRegressor = None
 
 
+@unittest.skipIf(CatGBRegressor is None, "Missing 'catboost' package")
 class TestCatGBRegressor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/Orange/regression/tests/test_xgb_reg.py
+++ b/Orange/regression/tests/test_xgb_reg.py
@@ -5,7 +5,11 @@ from Orange.base import XGBBase
 from Orange.data import Table
 from Orange.evaluation import CrossValidation, RMSE
 from Orange.preprocess.score import Scorer
-from Orange.regression import XGBRegressor, XGBRFRegressor
+
+try:
+    from Orange.regression import XGBRegressor, XGBRFRegressor
+except ImportError:
+    XGBRegressor = XGBRFRegressor = None
 
 
 def test_learners(func: Callable) -> Callable:
@@ -16,6 +20,7 @@ def test_learners(func: Callable) -> Callable:
     return wrapper
 
 
+@unittest.skipIf(XGBRegressor is None, "Missing 'xgboost' package")
 class TestXGBReg(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -71,6 +76,7 @@ class TestXGBReg(unittest.TestCase):
         self.assertEqual(params["n_estimators"], 42)
         self.assertEqual(params["max_depth"], 4)
 
+    @unittest.skipIf(XGBRegressor is None, "Missing 'xgboost' package")
     @test_learners
     def test_scorer(self, learner_class: XGBBase):
         booster = learner_class()

--- a/Orange/widgets/model/tests/test_owgradientboosting.py
+++ b/Orange/widgets/model/tests/test_owgradientboosting.py
@@ -2,13 +2,29 @@ import unittest
 from unittest.mock import patch, Mock
 import sys
 
-from Orange.classification import XGBClassifier, XGBRFClassifier, \
-    GBClassifier, CatGBClassifier
+from Orange.classification import GBClassifier
+
+try:
+    from Orange.classification import XGBClassifier, XGBRFClassifier
+except ImportError:
+    XGBClassifier = XGBRFClassifier = None
+try:
+    from Orange.classification import CatGBClassifier
+except ImportError:
+    CatGBClassifier = None
 from Orange.data import Table
 from Orange.modelling import GBLearner
 from Orange.preprocess.score import Scorer
-from Orange.regression import XGBRegressor, XGBRFRegressor, \
-    GBRegressor, CatGBRegressor
+from Orange.regression import GBRegressor
+
+try:
+    from Orange.regression import XGBRegressor, XGBRFRegressor
+except ImportError:
+    XGBRegressor = XGBRFRegressor = None
+try:
+    from Orange.regression import CatGBRegressor
+except ImportError:
+    CatGBRegressor = None
 from Orange.widgets.model.owgradientboosting import OWGradientBoosting, \
     LearnerItemModel, GBLearnerEditor, XGBLearnerEditor, XGBRFLearnerEditor, \
     CatGBLearnerEditor
@@ -29,12 +45,15 @@ def create_parent(editor_class):
 
 class TestLearnerItemModel(GuiTest):
     def test_model(self):
+        classifiers = [GBClassifier, XGBClassifier,
+                       XGBRFClassifier, CatGBClassifier]
         widget = create_parent(CatGBLearnerEditor)
         model = LearnerItemModel(widget)
         n_items = 4
         self.assertEqual(model.rowCount(), n_items)
         for i in range(n_items):
-            self.assertTrue(model.item(i).isEnabled())
+            self.assertEqual(model.item(i).isEnabled(),
+                             classifiers[i] is not None)
 
     @patch("Orange.widgets.model.owgradientboosting.LearnerItemModel.LEARNERS",
            [(GBLearner, "", ""),
@@ -109,6 +128,7 @@ class TestXGBLearnerEditor(GuiTest):
                 "colsample_bynode": 1, "subsample": 1, "random_state": 0}
         self.assertDictEqual(self.editor.get_arguments(), args)
 
+    @unittest.skipIf(XGBClassifier is None, "Missing 'xgboost' package")
     def test_learner_parameters(self):
         params = (("Method", "Extreme Gradient Boosting (xgboost)"),
                   ("Number of trees", 100),
@@ -122,6 +142,7 @@ class TestXGBLearnerEditor(GuiTest):
                   ("Fraction of features for each split", 1))
         self.assertTupleEqual(self.editor.get_learner_parameters(), params)
 
+    @unittest.skipIf(XGBClassifier is None, "Missing 'xgboost' package")
     def test_default_parameters_cls(self):
         data = Table("heart_disease")
         booster = XGBClassifier()
@@ -140,6 +161,7 @@ class TestXGBLearnerEditor(GuiTest):
         self.assertEqual(params["colsample_bynode"],
                          self.editor.colsample_bynode)
 
+    @unittest.skipIf(XGBRegressor is None, "Missing 'xgboost' package")
     def test_default_parameters_reg(self):
         data = Table("housing")
         booster = XGBRegressor()
@@ -171,6 +193,7 @@ class TestXGBRFLearnerEditor(GuiTest):
                 "colsample_bynode": 1, "subsample": 1, "random_state": 0}
         self.assertDictEqual(self.editor.get_arguments(), args)
 
+    @unittest.skipIf(XGBRFClassifier is None, "Missing 'xgboost' package")
     def test_learner_parameters(self):
         params = (("Method",
                    "Extreme Gradient Boosting Random Forest (xgboost)"),
@@ -185,6 +208,7 @@ class TestXGBRFLearnerEditor(GuiTest):
                   ("Fraction of features for each split", 1))
         self.assertTupleEqual(self.editor.get_learner_parameters(), params)
 
+    @unittest.skipIf(XGBRFClassifier is None, "Missing 'xgboost' package")
     def test_default_parameters_cls(self):
         data = Table("heart_disease")
         booster = XGBRFClassifier()
@@ -203,6 +227,7 @@ class TestXGBRFLearnerEditor(GuiTest):
         self.assertEqual(params["colsample_bynode"],
                          self.editor.colsample_bynode)
 
+    @unittest.skipIf(XGBRFRegressor is None, "Missing 'xgboost' package")
     def test_default_parameters_reg(self):
         data = Table("housing")
         booster = XGBRFRegressor()
@@ -233,6 +258,7 @@ class TestCatGBLearnerEditor(GuiTest):
                 "reg_lambda": 3, "colsample_bylevel": 1, "random_state": 0}
         self.assertDictEqual(self.editor.get_arguments(), args)
 
+    @unittest.skipIf(CatGBClassifier is None, "Missing 'catboost' package")
     def test_learner_parameters(self):
         params = (("Method", "Gradient Boosting (catboost)"),
                   ("Number of trees", 100),
@@ -243,6 +269,7 @@ class TestCatGBLearnerEditor(GuiTest):
                   ("Fraction of features for each tree", 1))
         self.assertTupleEqual(self.editor.get_learner_parameters(), params)
 
+    @unittest.skipIf(CatGBClassifier is None, "Missing 'catboost' package")
     def test_default_parameters_cls(self):
         data = Table("heart_disease")
         booster = CatGBClassifier()
@@ -256,6 +283,7 @@ class TestCatGBLearnerEditor(GuiTest):
         self.assertEqual(self.editor.learning_rate, 0.3)
         self.assertEqual(round(params["learning_rate"], 3), 0.006)
 
+    @unittest.skipIf(CatGBRegressor is None, "Missing 'catboost' package")
     def test_default_parameters_reg(self):
         data = Table("housing")
         booster = CatGBRegressor()
@@ -293,6 +321,7 @@ class TestOWGradientBoosting(WidgetTest, WidgetLearnerTestMixin):
         for ds in datasets.datasets():
             self.send_signal(self.widget.Inputs.data, ds)
 
+    @unittest.skipIf(XGBClassifier is None, "Missing 'xgboost' package")
     def test_xgb_params(self):
         simulate.combobox_activate_index(self.widget.controls.method_index, 1)
         editor = self.widget.editor


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5297

##### Description of changes
- skip xgboost tests when `xgboost` is not installed
- skip catboost tests when `catboost` is not installed

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
