### PR TITLE
[ENH] Transpose: Offload work onto separate thread, remove redundant instance

### DIFF
--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2197,7 +2197,7 @@ class TestRowInstance(unittest.TestCase):
 class TestTableTranspose(unittest.TestCase):
     def test_transpose_no_class(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
-        data = Table(Domain(attrs), np.arange(8).reshape((4, 2)))
+        table = Table(Domain(attrs), np.arange(8).reshape((4, 2)))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2206,19 +2206,19 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose is original
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_discrete_class(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
         domain = Domain(attrs, [DiscreteVariable("cls", values=("a", "b"))])
-        data = Table(domain, np.arange(8).reshape((4, 2)),
+        table = Table(domain, np.arange(8).reshape((4, 2)),
                      np.array([1, 1, 0, 0]))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
@@ -2232,19 +2232,19 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose is original
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_continuous_class(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
         domain = Domain(attrs, [ContinuousVariable("cls")])
-        data = Table(domain, np.arange(8).reshape((4, 2)), np.arange(4, 0, -1))
+        table = Table(domain, np.arange(8).reshape((4, 2)), np.arange(4, 0, -1))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2257,19 +2257,19 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_missing_class(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
         domain = Domain(attrs, [ContinuousVariable("cls")])
-        data = Table(domain, np.arange(8).reshape((4, 2)),
+        table = Table(domain, np.arange(8).reshape((4, 2)),
                      np.array([np.nan, 3, 2, 1]))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
@@ -2282,21 +2282,21 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_multiple_class(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
         class_vars = [ContinuousVariable("cls1"), ContinuousVariable("cls2")]
         domain = Domain(attrs, class_vars)
-        data = Table(domain, np.arange(8).reshape((4, 2)),
-                     np.arange(8).reshape((4, 2)))
+        table = Table(domain, np.arange(8).reshape((4, 2)),
+                      np.arange(8).reshape((4, 2)))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2309,14 +2309,14 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2324,7 +2324,7 @@ class TestTableTranspose(unittest.TestCase):
         domain = Domain(attrs, metas=metas)
         X = np.arange(8).reshape((4, 2))
         M = np.array(["aa", "bb", "cc", "dd"])[:, None]
-        data = Table(domain, X, metas=M)
+        table = Table(domain, X, metas=M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2337,14 +2337,14 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_discrete_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2352,7 +2352,7 @@ class TestTableTranspose(unittest.TestCase):
         domain = Domain(attrs, metas=metas)
         X = np.arange(8).reshape((4, 2))
         M = np.array([0, 1, 0, 1])[:, None]
-        data = Table(domain, X, metas=M)
+        table = Table(domain, X, metas=M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2365,14 +2365,14 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose is original
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_continuous_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2380,7 +2380,7 @@ class TestTableTranspose(unittest.TestCase):
         domain = Domain(attrs, metas=metas)
         X = np.arange(8).reshape((4, 2))
         M = np.array([0.0, 1.0, 0.0, 1.0])[:, None]
-        data = Table(domain, X, metas=M)
+        table = Table(domain, X, metas=M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2393,14 +2393,14 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose is original
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_missing_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2408,7 +2408,7 @@ class TestTableTranspose(unittest.TestCase):
         domain = Domain(attrs, metas=metas)
         X = np.arange(8).reshape((4, 2))
         M = np.array(["aa", "bb", "", "dd"])[:, None]
-        data = Table(domain, X, metas=M)
+        table = Table(domain, X, metas=M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2420,14 +2420,14 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_multiple_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2436,7 +2436,7 @@ class TestTableTranspose(unittest.TestCase):
         X = np.arange(8).reshape((4, 2))
         M = np.array([["aa", "aaa"], ["bb", "bbb"],
                       ["cc", "ccc"], ["dd", "ddd"]])
-        data = Table(domain, X, metas=M)
+        table = Table(domain, X, metas=M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2449,14 +2449,14 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_class_and_metas(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
@@ -2464,7 +2464,7 @@ class TestTableTranspose(unittest.TestCase):
         domain = Domain(attrs, [ContinuousVariable("cls")], metas)
         M = np.array([["aa", "aaa"], ["bb", "bbb"],
                       ["cc", "ccc"], ["dd", "ddd"]])
-        data = Table(domain, np.arange(8).reshape((4, 2)), np.arange(1, 5), M)
+        table = Table(domain, np.arange(8).reshape((4, 2)), np.arange(1, 5), M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2477,21 +2477,21 @@ class TestTableTranspose(unittest.TestCase):
                        metas=np.array(["c1", "c2"])[:, None])
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes, {})
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
 
     def test_transpose_attributes_of_attributes_discrete(self):
         attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
         attrs[0].attributes = {"attr1": "a", "attr2": "aa"}
         attrs[1].attributes = {"attr1": "b", "attr2": "bb"}
         domain = Domain(attrs)
-        data = Table(domain, np.arange(8).reshape((4, 2)))
+        table = Table(domain, np.arange(8).reshape((4, 2)))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2503,14 +2503,14 @@ class TestTableTranspose(unittest.TestCase):
         result = Table(domain, np.arange(8).reshape((4, 2)).T, metas=M)
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes,
+        self.assertDictEqual(table.domain.attributes[0].attributes,
                              {"attr1": "a", "attr2": "aa"})
 
     def test_transpose_attributes_of_attributes_continuous(self):
@@ -2518,7 +2518,7 @@ class TestTableTranspose(unittest.TestCase):
         attrs[0].attributes = {"attr1": "1.1", "attr2": "1.3"}
         attrs[1].attributes = {"attr1": "2.2", "attr2": "2.3"}
         domain = Domain(attrs)
-        data = Table(domain, np.arange(8).reshape((4, 2)))
+        table = Table(domain, np.arange(8).reshape((4, 2)))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2530,14 +2530,14 @@ class TestTableTranspose(unittest.TestCase):
                                        ["c2", 2.2, 2.3]], dtype=object))
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes,
+        self.assertDictEqual(table.domain.attributes[0].attributes,
                              {"attr1": "1.1", "attr2": "1.3"})
 
     def test_transpose_attributes_of_attributes_missings(self):
@@ -2545,7 +2545,7 @@ class TestTableTranspose(unittest.TestCase):
         attrs[0].attributes = {"attr1": "a", "attr2": "aa"}
         attrs[1].attributes = {"attr1": "b"}
         domain = Domain(attrs)
-        data = Table(domain, np.arange(8).reshape((4, 2)))
+        table = Table(domain, np.arange(8).reshape((4, 2)))
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2557,14 +2557,14 @@ class TestTableTranspose(unittest.TestCase):
         result = Table(domain, np.arange(8).reshape((4, 2)).T, metas=M)
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes,
+        self.assertDictEqual(table.domain.attributes[0].attributes,
                              {"attr1": "a", "attr2": "aa"})
 
     def test_transpose_class_metas_attributes(self):
@@ -2575,7 +2575,7 @@ class TestTableTranspose(unittest.TestCase):
         domain = Domain(attrs, [ContinuousVariable("cls")], metas)
         M = np.array([["aa", "aaa"], ["bb", "bbb"],
                       ["cc", "ccc"], ["dd", "ddd"]])
-        data = Table(domain, np.arange(8).reshape((4, 2)), np.arange(1, 5), M)
+        table = Table(domain, np.arange(8).reshape((4, 2)), np.arange(1, 5), M)
 
         att = [ContinuousVariable("Feature 1"), ContinuousVariable("Feature 2"),
                ContinuousVariable("Feature 3"), ContinuousVariable("Feature 4")]
@@ -2591,14 +2591,14 @@ class TestTableTranspose(unittest.TestCase):
         result = Table(domain, np.arange(8).reshape((4, 2)).T, metas=M)
 
         # transpose and compare
-        self._compare_tables(result, Table.transpose(data))
+        self._compare_tables(result, Table.transpose(table))
 
         # transpose of transpose
-        t = Table.transpose(Table.transpose(data), "Feature name")
-        self._compare_tables(data, t)
+        t = Table.transpose(Table.transpose(table), "Feature name")
+        self._compare_tables(table, t)
 
         # original should not change
-        self.assertDictEqual(data.domain.attributes[0].attributes,
+        self.assertDictEqual(table.domain.attributes[0].attributes,
                              {"attr1": "a1", "attr2": "aa1"})
 
     def test_transpose_duplicate_feature_names(self):
@@ -2623,6 +2623,425 @@ class TestTableTranspose(unittest.TestCase):
         cb = Mock()
         Table.transpose(zoo, progress_callback=cb)
         cb.assert_called()
+
+    def test_transpose_no_class_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        table = Table(Domain(attrs), np.arange(8).reshape((4, 2)))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_discrete_class_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        domain = Domain(attrs, [DiscreteVariable("cls", values=("a", "b"))])
+        table = Table(domain, np.arange(8).reshape((4, 2)),
+                     np.array([1, 1, 0, 0]))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"cls": "b"}
+        att[1].attributes = {"cls": "b"}
+        att[2].attributes = {"cls": "a"}
+        att[3].attributes = {"cls": "a"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_continuous_class_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        domain = Domain(attrs, [ContinuousVariable("cls")])
+        table = Table(domain, np.arange(8).reshape((4, 2)), np.arange(4, 0, -1))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"cls": "4"}
+        att[1].attributes = {"cls": "3"}
+        att[2].attributes = {"cls": "2"}
+        att[3].attributes = {"cls": "1"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_missing_class_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        domain = Domain(attrs, [ContinuousVariable("cls")])
+        table = Table(domain, np.arange(8).reshape((4, 2)),
+                     np.array([np.nan, 3, 2, 1]))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[1].attributes = {"cls": "3"}
+        att[2].attributes = {"cls": "2"}
+        att[3].attributes = {"cls": "1"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_multiple_class_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        class_vars = [ContinuousVariable("cls1"), ContinuousVariable("cls2")]
+        domain = Domain(attrs, class_vars)
+        table = Table(domain, np.arange(8).reshape((4, 2)),
+                     np.arange(8).reshape((4, 2)))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"cls1": "0", "cls2": "1"}
+        att[1].attributes = {"cls1": "2", "cls2": "3"}
+        att[2].attributes = {"cls1": "4", "cls2": "5"}
+        att[3].attributes = {"cls1": "6", "cls2": "7"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_metas_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        metas = [StringVariable("m1")]
+        domain = Domain(attrs, metas=metas)
+        X = np.arange(8).reshape((4, 2))
+        M = np.array(["aa", "bb", "cc", "dd"])[:, None]
+        table = Table(domain, X, metas=M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"m1": "aa"}
+        att[1].attributes = {"m1": "bb"}
+        att[2].attributes = {"m1": "cc"}
+        att[3].attributes = {"m1": "dd"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_discrete_metas_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        metas = [DiscreteVariable("m1", values=("aa", "bb"))]
+        domain = Domain(attrs, metas=metas)
+        X = np.arange(8).reshape((4, 2))
+        M = np.array([0, 1, 0, 1])[:, None]
+        table = Table(domain, X, metas=M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"m1": "aa"}
+        att[1].attributes = {"m1": "bb"}
+        att[2].attributes = {"m1": "aa"}
+        att[3].attributes = {"m1": "bb"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_continuous_metas_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        metas = [ContinuousVariable("m1")]
+        domain = Domain(attrs, metas=metas)
+        X = np.arange(8).reshape((4, 2))
+        M = np.array([0.0, 1.0, 0.0, 1.0])[:, None]
+        table = Table(domain, X, metas=M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"m1": "0"}
+        att[1].attributes = {"m1": "1"}
+        att[2].attributes = {"m1": "0"}
+        att[3].attributes = {"m1": "1"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_missing_metas_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        metas = [StringVariable("m1")]
+        domain = Domain(attrs, metas=metas)
+        X = np.arange(8).reshape((4, 2))
+        M = np.array(["aa", "bb", "", "dd"])[:, None]
+        table = Table(domain, X, metas=M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"m1": "aa"}
+        att[1].attributes = {"m1": "bb"}
+        att[3].attributes = {"m1": "dd"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_multiple_metas_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        metas = [StringVariable("m1"), StringVariable("m2")]
+        domain = Domain(attrs, metas=metas)
+        X = np.arange(8).reshape((4, 2))
+        M = np.array([["aa", "aaa"], ["bb", "bbb"],
+                      ["cc", "ccc"], ["dd", "ddd"]])
+        table = Table(domain, X, metas=M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"m1": "aa", "m2": "aaa"}
+        att[1].attributes = {"m1": "bb", "m2": "bbb"}
+        att[2].attributes = {"m1": "cc", "m2": "ccc"}
+        att[3].attributes = {"m1": "dd", "m2": "ddd"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_class_and_metas_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        metas = [StringVariable("m1"), StringVariable("m2")]
+        domain = Domain(attrs, [ContinuousVariable("cls")], metas)
+        M = np.array([["aa", "aaa"], ["bb", "bbb"],
+                      ["cc", "ccc"], ["dd", "ddd"]])
+        table = Table(domain, np.arange(8).reshape((4, 2)), np.arange(1, 5), M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"cls": "1", "m1": "aa", "m2": "aaa"}
+        att[1].attributes = {"cls": "2", "m1": "bb", "m2": "bbb"}
+        att[2].attributes = {"cls": "3", "m1": "cc", "m2": "ccc"}
+        att[3].attributes = {"cls": "4", "m1": "dd", "m2": "ddd"}
+        domain = Domain(att, metas=[StringVariable("Feature name")])
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1"]]))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes, {})
+
+    def test_transpose_attributes_of_attributes_discrete_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        attrs[0].attributes = {"attr1": "a", "attr2": "aa"}
+        attrs[1].attributes = {"attr1": "b", "attr2": "bb"}
+        domain = Domain(attrs)
+        table = Table(domain, np.arange(8).reshape((4, 2)))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        metas = [StringVariable("Feature name"),
+                 DiscreteVariable("attr1", values=("a", "b")),
+                 DiscreteVariable("attr2", values=("aa", "bb"))]
+        domain = Domain(att, metas=metas)
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1", 0.0, 0.0]], dtype=object))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes,
+                             {"attr1": "a", "attr2": "aa"})
+
+    def test_transpose_attributes_of_attributes_continuous_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        attrs[0].attributes = {"attr1": "1.1", "attr2": "1.3"}
+        attrs[1].attributes = {"attr1": "2.2", "attr2": "2.3"}
+        domain = Domain(attrs)
+        table = Table(domain, np.arange(8).reshape((4, 2)))
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        metas = [StringVariable("Feature name"), ContinuousVariable("attr1"),
+                 ContinuousVariable("attr2")]
+        domain = Domain(att, metas=metas)
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1", 1.1, 1.3]], dtype=object))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes,
+                             {"attr1": "1.1", "attr2": "1.3"})
+
+    def test_transpose_attributes_of_attributes_missings_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        attrs[0].attributes = {"attr1": "a", "attr2": "aa"}
+        attrs[1].attributes = {"attr1": "b"}
+        domain = Domain(attrs)
+        table = Table(domain, np.arange(8).reshape((4, 2)))
+
+        att = [ContinuousVariable("0"), ContinuousVariable("2"),
+               ContinuousVariable("4"), ContinuousVariable("6")]
+        metas = [StringVariable("Feature name"),
+                 DiscreteVariable("attr1", values=("b",))]
+        domain = Domain(att, metas=metas)
+        result = Table(domain, np.array([[1, 3, 5, 7]]),
+                       metas=np.array([["c2", 0.0]], dtype=object))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c1", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "2", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes,
+                             {"attr1": "a", "attr2": "aa"})
+
+    def test_transpose_class_metas_attributes_remove_inst(self):
+        attrs = [ContinuousVariable("c1"), ContinuousVariable("c2")]
+        attrs[0].attributes = {"attr1": "a1", "attr2": "aa1"}
+        attrs[1].attributes = {"attr1": "b1", "attr2": "bb1"}
+        metas = [StringVariable("m1"), StringVariable("m2")]
+        domain = Domain(attrs, [ContinuousVariable("cls")], metas)
+        M = np.array([["aa", "aaa"], ["bb", "bbb"],
+                      ["cc", "ccc"], ["dd", "ddd"]])
+        table = Table(domain, np.arange(8).reshape((4, 2)), np.arange(1, 5), M)
+
+        att = [ContinuousVariable("1"), ContinuousVariable("3"),
+               ContinuousVariable("5"), ContinuousVariable("7")]
+        att[0].attributes = {"cls": "1", "m1": "aa", "m2": "aaa"}
+        att[1].attributes = {"cls": "2", "m1": "bb", "m2": "bbb"}
+        att[2].attributes = {"cls": "3", "m1": "cc", "m2": "ccc"}
+        att[3].attributes = {"cls": "4", "m1": "dd", "m2": "ddd"}
+        metas = [StringVariable("Feature name"),
+                 DiscreteVariable("attr1", values=("a1", "b1")),
+                 DiscreteVariable("attr2", values=("aa1", "bb1"))]
+        domain = Domain(att, metas=metas)
+        result = Table(domain, np.array([[0, 2, 4, 6]]),
+                       metas=np.array([["c1", 0.0, 0.0]], dtype=object))
+
+        # transpose and compare
+        transposed = Table.transpose(table, "c2", remove_redundant_inst=True)
+        self._compare_tables(result, transposed)
+
+        # transpose of transpose is not equal to the original
+        Table.transpose(transposed, "Feature name")
+        Table.transpose(transposed, "3", remove_redundant_inst=True)
+
+        # original should not change
+        self.assertDictEqual(table.domain.attributes[0].attributes,
+                             {"attr1": "a1", "attr2": "aa1"})
 
     def _compare_tables(self, table1, table2):
         self.assertEqual(table1.n_rows, table2.n_rows)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2618,6 +2618,12 @@ class TestTableTranspose(unittest.TestCase):
         self._compare_tables(zoo, t2)
         self._compare_tables(t1, t3)
 
+    def test_transpose_callback(self):
+        zoo = Table("zoo")
+        cb = Mock()
+        Table.transpose(zoo, progress_callback=cb)
+        cb.assert_called()
+
     def _compare_tables(self, table1, table2):
         self.assertEqual(table1.n_rows, table2.n_rows)
         np.testing.assert_array_equal(table1.X, table2.X)

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 from Orange.data import Table, ContinuousVariable, StringVariable
-from Orange.widgets.settings import (Setting, ContextSetting,
-                                     DomainContextHandler)
+from Orange.widgets.settings import Setting, ContextSetting, \
+    DomainContextHandler
+from Orange.widgets.utils.concurrent import TaskState, ConcurrentWidgetMixin
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.utils.state_summary import format_summary_details
@@ -9,7 +12,27 @@ from Orange.widgets import gui
 from Orange.widgets.widget import Input, Output
 
 
-class OWTranspose(OWWidget):
+def run(
+        data: Table,
+        variable: str,
+        feature_name: str,
+        state: TaskState
+) -> Table:
+    if not data:
+        return None
+
+    def callback(i: float, status=""):
+        state.set_progress_value(i * 100)
+        if status:
+            state.set_status(status)
+        if state.is_interruption_requested():
+            raise Exception
+
+    return Table.transpose(data, variable, feature_name=feature_name,
+                           progress_callback=callback)
+
+
+class OWTranspose(OWWidget, ConcurrentWidgetMixin):
     name = "Transpose"
     description = "Transpose data table."
     icon = "icons/Transpose.svg"
@@ -45,7 +68,8 @@ class OWTranspose(OWWidget):
         value_error = Msg("{}")
 
     def __init__(self):
-        super().__init__()
+        OWWidget.__init__(self)
+        ConcurrentWidgetMixin.__init__(self)
         self.data = None
 
         # self.apply is changed later, pylint: disable=unnecessary-lambda
@@ -112,27 +136,37 @@ class OWTranspose(OWWidget):
 
     def apply(self):
         self.clear_messages()
-        transposed = None
-        if self.data:
-            try:
-                variable = self.feature_type == self.FROM_VAR and \
-                           self.feature_names_column
-                transposed = Table.transpose(
-                    self.data, variable,
-                    feature_name=self.feature_name or self.DEFAULT_PREFIX)
-                if variable:
-                    names = self.data.get_column_view(variable)[0]
-                    if len(names) != len(set(names)):
-                        self.Warning.duplicate_names(variable)
-                if self.data.domain.has_discrete_attributes():
-                    self.Warning.discrete_attrs()
-                self.info.set_output_summary(len(transposed),
-                                             format_summary_details(transposed))
-            except ValueError as e:
-                self.Error.value_error(e)
+        variable = self.feature_type == self.FROM_VAR and \
+            self.feature_names_column
+        if variable and self.data:
+            names = self.data.get_column_view(variable)[0]
+            if len(names) != len(set(names)):
+                self.Warning.duplicate_names(variable)
+        if self.data and self.data.domain.has_discrete_attributes():
+            self.Warning.discrete_attrs()
+        feature_name = self.feature_name or self.DEFAULT_PREFIX
+        self.start(run, self.data, variable, feature_name)
+
+    def on_partial_result(self, _):
+        pass
+
+    def on_done(self, transposed: Optional[Table]):
+        self.Outputs.data.send(transposed)
+        if transposed:
+            self.info.set_output_summary(len(transposed),
+                                         format_summary_details(transposed))
         else:
             self.info.set_output_summary(self.info.NoOutput)
-        self.Outputs.data.send(transposed)
+
+    def on_exception(self, ex: Exception):
+        if isinstance(ex, ValueError):
+            self.Error.value_error(ex)
+        else:
+            raise ex
+
+    def onDeleteWidget(self):
+        self.shutdown()
+        super().onDeleteWidget()
 
     def send_report(self):
         if self.feature_type == self.GENERIC:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5300
Fixes #5298

##### Description of changes
- Offload work onto a separate thread
- Remove redundant instance from transposed table - one that is used for feature names 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
