### PR TITLE
DiscreteVariable: Remove 'ordered' argument

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -498,16 +498,6 @@ class TestDiscreteVariable(VariableTest):
         var2 = var.copy(values=("W", "M"))
         self.assertEqual(var2.values, ("W", "M"))
 
-    def test_remove_ordered(self):
-        """
-        ordered is deprecated when this test starts to fail remove ordered
-        parameter. Remove also this test.
-        Ordered parameter should still be allowed in __init__ for backward
-        compatibilities in data-sets pickled with older versions, I suggest
-        adding **kwargs which is ignored
-        """
-        self.assertLess(Orange.__version__, "3.29.0")
-
     def test_pickle_backward_compatibility(self):
         """
         Test that pickle made with an older version of Orange are correctly
@@ -522,11 +512,9 @@ class TestDiscreteVariable(VariableTest):
                 this_dir, "..", "..", "tests", "datasets"
             )
             # pickle with values as list
-            with self.assertWarns(OrangeDeprecationWarning):
-                Table(os.path.join(datasets_dir, "sailing-orange-3-20.pkl"))
+            Table(os.path.join(datasets_dir, "sailing-orange-3-20.pkl"))
             # pickle with values as tuple list
-            with self.assertWarns(OrangeDeprecationWarning):
-                Table(os.path.join(datasets_dir, "iris-orange-3-25.pkl"))
+            Table(os.path.join(datasets_dir, "iris-orange-3-25.pkl"))
 
 
 @variabletest(ContinuousVariable)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -34,7 +34,10 @@ def make_variable(cls, compute_value, *args):
     if compute_value is not None:
         return cls(*args, compute_value=compute_value)
     else:
-        # For compatibility with old pickles
+        # For compatibility with old pickles: remove the second arg if it's
+        # bool `compute_value` (args[3]) can't be bool, so this should be safe
+        if len(args) > 2 and isinstance(args[2], bool):
+            args = args[:2] + args[3:]
         return cls(*args)
 
 
@@ -626,8 +629,7 @@ class DiscreteVariable(Variable):
     presorted_values = []
 
     def __init__(
-            self, name="", values=(), ordered=None, compute_value=None,
-            *, sparse=False
+            self, name="", values=(), compute_value=None, *, sparse=False
     ):
         """ Construct a discrete variable descriptor with the given values. """
         values = tuple(values)  # some people (including me) pass a generator
@@ -637,23 +639,6 @@ class DiscreteVariable(Variable):
         super().__init__(name, compute_value, sparse=sparse)
         self._values = values
         self._value_index = {value: i for i, value in enumerate(values)}
-
-        if ordered is not None:
-            warnings.warn(
-                "ordered is deprecated and does not have effect. It will be "
-                "removed in future versions.",
-                OrangeDeprecationWarning
-            )
-
-    @property
-    def ordered(self):
-        warnings.warn(
-            "ordered is deprecated. It will be removed in future versions.",
-            # DeprecationWarning warning is used instead of OrangeDeprecation
-            # warning otherwise tests fail (__repr__ still asks for ordered)
-            DeprecationWarning
-        )
-        return None
 
     @property
     def values(self):

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -15,7 +15,7 @@ from Orange import data
 from Orange.data.io import FileFormat, TabReader, CSVReader, PickleReader
 from Orange.data.io_base import PICKLE_PROTOCOL
 from Orange.data.table import get_sample_datasets_dir
-from Orange.data import Table, Variable
+from Orange.data import Table
 from Orange.tests import test_dirname
 from Orange.util import OrangeDeprecationWarning
 
@@ -173,16 +173,12 @@ class TestReader(unittest.TestCase):
             # load pickles created with Orange 3.20
             # in next version there is a change in variables.py - line 738
             # which broke back compatibility - tests introduced after the fix
-            with self.assertWarns(OrangeDeprecationWarning):
-                data1 = Table("datasets/sailing-orange-3-20.pkl")
-            with self.assertWarns(OrangeDeprecationWarning):
-                data2 = Table("datasets/sailing-orange-3-20.pkl.gz")
+            data1 = Table("datasets/sailing-orange-3-20.pkl")
+            data2 = Table("datasets/sailing-orange-3-20.pkl.gz")
 
             # load pickles created with Orange 3.21
-            with self.assertWarns(OrangeDeprecationWarning):
-                data3 = Table("datasets/sailing-orange-3-21.pkl")
-            with self.assertWarns(OrangeDeprecationWarning):
-                data4 = Table("datasets/sailing-orange-3-21.pkl.gz")
+            data3 = Table("datasets/sailing-orange-3-21.pkl")
+            data4 = Table("datasets/sailing-orange-3-21.pkl.gz")
 
             examples_count = 20
             self.assertEqual(examples_count, len(data1))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Ordered is deprecated and should be removed from constructor.

##### Description of changes
Remove 'ordered' argument from DiscreteVariable's constructor.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
