### PR TITLE
OWDataProjectionWidget: Move common code to base class

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -224,7 +224,6 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
             master=self.graph, value="connected_pairs", minValue=0,
             maxValue=20, createLabel=False, callback=self._on_connected_changed
         )
-        gui.rubber(self.controlArea)
 
     def _add_controls_optimization(self):
         box = gui.vBox(self.controlArea, box=True)

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -294,7 +294,6 @@ class OWtSNE(OWDataProjectionWidget, ConcurrentWidgetMixin):
     def _add_controls(self):
         self._add_controls_start_box()
         super()._add_controls()
-        gui.rubber(self.controlArea)
 
     def _add_controls_start_box(self):
         box = gui.vBox(self.controlArea, True)

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -166,7 +166,6 @@ class OWFreeViz(OWAnchorProjectionWidget, ConcurrentWidgetMixin):
             value="hide_radius", minValue=0, maxValue=100, step=10,
             createLabel=False, callback=self.__radius_slider_changed
         )
-        gui.rubber(self.controlArea)
 
     def __add_controls_start_box(self):
         box = gui.vBox(self.controlArea, box=True)

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -314,6 +314,10 @@ class OWLinearProjection(OWAnchorProjectionWidget):
             callback=self.__placement_radio_changed
         )
 
+    def _add_buttons(self):
+        self.gui.box_zoom_select(self.buttonsArea)
+        gui.auto_send(self.buttonsArea, self, "auto_commit")
+
     @property
     def continuous_variables(self):
         if self.data is None or self.data.domain is None:

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -340,6 +340,10 @@ class OWRadviz(OWAnchorProjectionWidget):
         self.controlArea.layout().addWidget(self.btn_vizrank)
         super()._add_controls()
 
+    def _add_buttons(self):
+        self.gui.box_zoom_select(self.buttonsArea)
+        gui.auto_send(self.buttonsArea, self, "auto_commit")
+
     @property
     def primitive_variables(self):
         if self.data is None or self.data.domain is None:

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -291,7 +291,6 @@ class OWScatterPlot(OWDataProjectionWidget):
             "If checked, fit line to group (minimize distance from points);\n"
             "otherwise fit y as a function of x (minimize vertical distances)",
             disabledBy=self.cb_reg_line)
-        gui.rubber(self.controlArea)
 
     def _add_controls_axis(self):
         common_options = dict(

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -412,6 +412,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
     def setup_gui(self):
         self._add_graph()
         self._add_controls()
+        self._add_buttons()
         self.input_changed.emit(None)
         self.output_changed.emit(None)
 
@@ -429,6 +430,8 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         self._effects_box = self.gui.effects_box(area)
         self._plot_box = self.gui.plot_properties_box(area)
 
+    def _add_buttons(self):
+        gui.rubber(self.controlArea)
         self.gui.box_zoom_select(self.buttonsArea)
         gui.auto_send(self.buttonsArea, self, "auto_commit")
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Projections widgets (`OWDataProjectionWidget` children) in add-ons look odd because they are missing `gui.rubber(self.controlArea)` line.


##### Description of changes
Apply general behaviour to base class.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
