### PR TITLE
Fix calls to set_domain

### DIFF
--- a/Orange/widgets/data/owcorrelations.py
+++ b/Orange/widgets/data/owcorrelations.py
@@ -376,7 +376,8 @@ class OWCorrelations(OWWidget):
         self.vizrank.button.setEnabled(self.cont_data is not None)
 
     def set_feature_model(self):
-        self.feature_model.set_domain(self.cont_data and self.cont_data.domain)
+        self.feature_model.set_domain(
+            self.cont_data.domain if self.cont_data else None)
         data = self.data
         if self.cont_data and data.domain.has_continuous_class:
             self.feature = self.cont_data.domain[data.domain.class_var.name]

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -301,7 +301,7 @@ class OWCreateClass(widget.OWWidget):
         details = format_summary_details(data) if data else ""
         self.info.set_input_summary(summary, details)
         model = self.controls.attribute.model()
-        model.set_domain(data.domain if data else None)
+        model.set_domain(data.domain if data is not None else None)
         self.Warning.no_nonnumeric_vars(shown=data is not None and not model)
         if not model:
             self.attribute = None

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -301,7 +301,7 @@ class OWCreateClass(widget.OWWidget):
         details = format_summary_details(data) if data else ""
         self.info.set_input_summary(summary, details)
         model = self.controls.attribute.model()
-        model.set_domain(data and data.domain)
+        model.set_domain(data.domain if data else None)
         self.Warning.no_nonnumeric_vars(shown=data is not None and not model)
         if not model:
             self.attribute = None

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -352,13 +352,13 @@ class OWMergeData(widget.OWWidget):
     @check_sql_input
     def set_data(self, data):
         self.data = data
-        self.model.set_domain(data and data.domain)
+        self.model.set_domain(data.domain if data else None)
 
     @Inputs.extra_data
     @check_sql_input
     def set_extra_data(self, data):
         self.extra_data = data
-        self.extra_model.set_domain(data and data.domain)
+        self.extra_model.set_domain(data.domain if data else None)
 
     def store_combo_state(self):
         self.attr_pairs = self.attr_boxes.current_state()

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -10,7 +10,7 @@ from AnyQt.QtWidgets import (
 from orangewidget.utils.combobox import ComboBoxSearch
 
 import Orange
-from Orange.data import StringVariable, ContinuousVariable, Variable
+from Orange.data import StringVariable, ContinuousVariable, Variable, Domain
 from Orange.data.util import hstack, get_unique_names_duplicates
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting, ContextHandler, ContextSetting
@@ -207,6 +207,8 @@ class MergeDataContextHandler(ContextHandler):
     def _encode_domain(self, domain):
         if domain is None:
             return {}
+        if not isinstance(domain, Domain):
+            domain = domain.domain
         all_vars = chain(domain.variables, domain.metas)
         return dict(self.encode_variables(all_vars))
 

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -102,7 +102,7 @@ class OWTranspose(OWWidget):
         self.unconditional_apply()
 
     def set_controls(self):
-        self.feature_model.set_domain(self.data and self.data.domain)
+        self.feature_model.set_domain(self.data.domain if self.data else None)
         self.meta_button.setEnabled(bool(self.feature_model))
         if self.feature_model:
             self.feature_names_column = self.feature_model[0]

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -283,6 +283,12 @@ class TestOWCreateClass(WidgetTest):
         self.send_signal(self.widget.Inputs.data, self.heart)
         self.assertFalse(widget.Warning.no_nonnumeric_vars.is_shown())
 
+        self.send_signal(self.widget.Inputs.data, self.heart[:0])
+        self.assertFalse(widget.Warning.no_nonnumeric_vars.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, self.no_attributes[:0])
+        self.assertTrue(widget.Warning.no_nonnumeric_vars.is_shown())
+
     def test_string_data(self):
         widget = self.widget
         self.send_signal(self.widget.Inputs.data, self.zoo)

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -1063,6 +1063,12 @@ class TestOWMergeData(WidgetTest):
         self.assertIsInstance(info._StateInfo__output_summary, StateInfo.Empty)
         self.assertEqual(info._StateInfo__output_summary.details, no_output)
 
+    def test_empty_tables(self):
+        widget = self.widget
+        self.send_signal(widget.Inputs.data, self.dataA[:0])
+        self.send_signal(widget.Inputs.extra_data, self.dataB[:0])
+
+
 class MergeDataContextHandlerTest(unittest.TestCase):
     # These units are too small to test individually, so they are tested
     # within their function in the widget.


### PR DESCRIPTION
##### Issue

Fixes #5323, and the same in three other widgets.

This happenned because empty table is also considered false, hence `data and data.domain` resulted in passing a `Table` (instead of `None` or an instance of `Domain`) when the table was empty.

I'd prefer not to write tests for this, though they'd be trivial. I don't like tests that just replicate a bug. Of course one could say "but you should test that a widget does not crash on empty table", but then we should add such a test to all widgets, not just the four that happenned to have this problem.

##### Includes
- [X] Code changes
- [ ] Tests
