### PR TITLE
Feature Constructor: Fix a problem with some unicode characters

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -14,6 +14,7 @@ import random
 import logging
 import ast
 import types
+import unicodedata
 
 from traceback import format_exception_only
 from collections import namedtuple, OrderedDict
@@ -917,7 +918,8 @@ def bind_variable(descriptor, env, data):
 
     exp_ast = ast.parse(descriptor.expression, mode="eval")
     freev = unique(freevars(exp_ast, []))
-    variables = {sanitized_name(v.name): v for v in env}
+    variables = {unicodedata.normalize("NFKC", sanitized_name(v.name)): v
+                 for v in env}
     source_vars = [(name, variables[name]) for name in freev
                    if name in variables]
 

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -133,6 +133,22 @@ class FeatureConstructorTest(unittest.TestCase):
         np.testing.assert_array_equal(ndata.X[:, 0],
                                       data.X[:, :2].sum(axis=1))
 
+    @staticmethod
+    def test_unicode_normalization():
+        micro = "\u00b5"
+        domain = Domain([ContinuousVariable(micro)])
+        name = 'Micro Variable'
+        expression = micro
+        desc = PyListModel(
+            [ContinuousDescriptor(name=name, expression=expression,
+                                  number_of_decimals=2)]
+        )
+        data = Table.from_numpy(domain, np.arange(5).reshape(5, 1))
+        data = data.transform(Domain(data.domain.attributes,
+                                     [],
+                                     construct_variables(desc, data)))
+        np.testing.assert_equal(data.X, data.metas)
+
 
 class TestTools(unittest.TestCase):
     def test_free_vars(self):


### PR DESCRIPTION
##### Issue

Fixes #5305.

##### Description of changes

Normalize encoding of variable names as (seemingly) encoded by Python parser.

##### Includes
- [X] Code changes
- [X] Tests
