### PR TITLE
[FIX] Radviz VizRank: Implement on_selection_changed

### DIFF
--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -139,6 +139,9 @@ class RadvizVizRank(VizRankDialog, OWComponent):
                                          len(master.model_selected)))
         return True
 
+    def on_selection_changed(self, selected, _):
+        self.on_row_clicked(selected.indexes()[0])
+
     def on_row_clicked(self, index):
         self.selectionChanged.emit(index.data(self._AttrRole))
 

--- a/Orange/widgets/visualize/tests/test_owradviz.py
+++ b/Orange/widgets/visualize/tests/test_owradviz.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import unittest
 from unittest.mock import Mock
 import numpy as np
 
@@ -129,3 +130,17 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
         self.widget.setup_plot.reset_mock()
         self.send_signal(self.widget.Inputs.data, self.data)
         self.widget.setup_plot.assert_called_once()
+
+    def test_score_plots_feature_update(self):
+        self.send_signal(self.widget.Inputs.data, self.data)
+        selected_vars = set(self.widget.selected_vars)
+        output1 = self.get_output(self.widget.Outputs.components)
+        self.widget.vizrank.toggle()
+        self.process_events(until=lambda: not self.widget.vizrank.keep_running)
+        self.assertNotEqual(selected_vars, set(self.widget.selected_vars))
+        output2 = self.get_output(self.widget.Outputs.components)
+        self.assertNotEqual(output1, output2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5310

##### Description of changes
Implement `on_selection_changed` in RadvizVizRank.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
