### PR TITLE
Aggregate: Fix crash on changed domain

### DIFF
--- a/Orange/widgets/data/owaggregatecolumns.py
+++ b/Orange/widgets/data/owaggregatecolumns.py
@@ -76,16 +76,15 @@ class OWAggregateColumns(widget.OWWidget):
     @Inputs.data
     def set_data(self, data: Table = None):
         self.closeContext()
+        self.variables.clear()
         self.data = data
         if self.data:
             self.variable_model.set_domain(data.domain)
             self.info.set_input_summary(len(self.data),
                                         format_summary_details(self.data))
-            self.variables.clear()
             self.openContext(data)
         else:
             self.variable_model.set_domain(None)
-            self.variables.clear()
             self.info.set_input_summary(self.info.NoInput)
         self.unconditional_commit()
 

--- a/Orange/widgets/data/tests/test_owaggregatecolumns.py
+++ b/Orange/widgets/data/tests/test_owaggregatecolumns.py
@@ -155,6 +155,19 @@ class TestOWAggregateColumn(WidgetTest):
         self.send_signal(self.widget.Inputs.data, self.data1)
         self.assertEqual(self.widget.variables, saved)
 
+    def test_selection_in_context(self):
+        widget = self.widget
+
+        self.send_signal(widget.Inputs.data, self.data1)
+        self.widget.variables[:] = self.data1.domain.variables[1:3]
+
+        self.send_signal(widget.Inputs.data, self.data2)
+        self.assertEqual(widget.variables, [])
+
+        self.send_signal(widget.Inputs.data, self.data1)
+        self.assertSequenceEqual(self.widget.variables[:],
+                                 self.data1.domain.variables[1:3])
+
     def test_report(self):
         self.widget.send_report()
 


### PR DESCRIPTION
##### Issue

Fixes #5348.

##### Description of changes

Remove selection before changing the model, not afterwards.

If you select something, change the data and change it back, the selection that you made on the first data is properly retrieved, but the list view is not properly updated and looks as if nothing was selected. 

This could easily be fixed within this PR (by adding `self.variables = self.variables` after `openContext`, I suppose), but I instead wrote a general fix for this. Check out https://github.com/biolab/orange-widget-base/pull/147 if you'd like to try (and, perhaps, review and merge both).

##### Includes
- [X] Code changes
- [X] Tests
