### PR TITLE
Test and score docs: fix comparison interpretation

### DIFF
--- a/doc/visual-programming/source/widgets/evaluate/testandscore.md
+++ b/doc/visual-programming/source/widgets/evaluate/testandscore.md
@@ -49,7 +49,7 @@ The *Learner* signal has an uncommon property: it can be connected to more than 
       - Train time - cumulative time in seconds used for training models.
       - Test time - cumulative time in seconds used for testing models.
 4. Choose the score for pairwise comparison of models and the region of practical equivalence (ROPE), in which differences are considered negligible.
-5. Pairwise comparison of models using the selected score (available only for cross-validation). The number in the table gives the probability that the model corresponding to the row is better than the model corresponding to the column. If negligible difference is enabled, the smaller number below shows the probability that the difference between the pair is negligible. The test is based on the [Bayesian interpretation of the t-test](https://link.springer.com/article/10.1007/s10994-015-5486-z) ([shorter introduction](https://baycomp.readthedocs.io/en/latest/introduction.html)).
+5. Pairwise comparison of models using the selected score (available only for cross-validation). The number in the table gives the probability that the model corresponding to the row has a higher score than the model corresponding to the column. What the higher score means depends on the metric: a higher score can either mean a model is better (for example, CA or AUC) or the opposite (for example, RMSE). If negligible difference is enabled, the smaller number below shows the probability that the difference between the pair is negligible. The test is based on the [Bayesian interpretation of the t-test](https://link.springer.com/article/10.1007/s10994-015-5486-z) ([shorter introduction](https://baycomp.readthedocs.io/en/latest/introduction.html)).
 6. Get help and produce a report.
 
 Example


### PR DESCRIPTION
##### Issue
Docs assumed that for all measures the higher value means a better model.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
