### PR TITLE
[FIX] Errors when converting negative timestamps on Windows

### DIFF
--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -12,7 +12,7 @@ from Orange.data import DiscreteVariable, Domain
 from Orange.data.sql.table import SqlTable
 from Orange.statistics import distribution, contingency, util as ut
 from Orange.statistics.basic_stats import BasicStats
-from Orange.util import Reprable
+from Orange.util import Reprable, utc_from_timestamp
 from .transformation import Transformation
 from . import _discretize
 
@@ -359,7 +359,8 @@ def time_binnings(data, *, min_bins=2, max_bins=50, min_unique=5, add_unique=0):
             (number_of_seconds_since_epoch, label).
     """
     mn, mx, unique = _min_max_unique(data)
-    mn, mx = time.gmtime(mn), time.gmtime(mx)
+    mn = utc_from_timestamp(mn).timetuple()
+    mx = utc_from_timestamp(mx).timetuple()
     bins = []
     if len(unique) <= max(min_unique, add_unique):
         bins.append(_unique_time_bins(unique))
@@ -464,7 +465,7 @@ def _simplified_labels(labels):
 
 
 def _unique_time_bins(unique):
-    times = [time.gmtime(x) for x in unique]
+    times = [utc_from_timestamp(x).timetuple() for x in unique]
     fmt = f'%y %b %d'
     fmt += " %H:%M" * (len({t[2:] for t in times}) > 1)
     fmt += ":%S" * bool(np.all(unique % 60 == 0))

--- a/Orange/preprocess/tests/test_discretize.py
+++ b/Orange/preprocess/tests/test_discretize.py
@@ -727,6 +727,12 @@ class TestTimeBinning(unittest.TestCase):
         dates = np.array([np.nan, np.nan])
         self.assertRaises(ValueError, time_binnings, dates)
 
+    def test_before_epoch(self):
+        hour = 24 * 60 * 60
+        dates = [-hour, 0, hour,]
+        bins = time_binnings(dates)
+        self.assertEqual(list(bins[0].thresholds), [-hour, 0, hour, 2 * hour])
+
 
 class TestBinDefinition(unittest.TestCase):
     def test_labels(self):

--- a/Orange/util.py
+++ b/Orange/util.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import inspect
+import datetime
 from contextlib import contextmanager
 
 import pkg_resources
@@ -520,6 +521,14 @@ def wrap_callback(progress_callback, start=0, end=1):
 def dummy_callback(*_, **__):
     """ A dummy callable. """
     return 1
+
+
+def utc_from_timestamp(timestamp) -> datetime.datetime:
+    """
+    Return the UTC datetime corresponding to the POSIX timestamp.
+    """
+    return datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc) + \
+           datetime.timedelta(seconds=float(timestamp))
 
 
 # For best result, keep this at the bottom

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -23,6 +23,7 @@ from AnyQt.QtWidgets import QStyledItemDelegate, QGraphicsScene, QTableView, \
 import Orange.statistics.util as ut
 from Orange.data import Table, StringVariable, DiscreteVariable, \
     ContinuousVariable, TimeVariable, Domain, Variable
+from Orange.util import utc_from_timestamp
 from Orange.widgets import widget, gui
 from Orange.widgets.data.utils.histogram import Histogram
 from Orange.widgets.settings import Setting, ContextSetting, \
@@ -69,8 +70,8 @@ def format_time_diff(start, end, round_up_after=2):
     str
 
     """
-    start = datetime.datetime.fromtimestamp(start)
-    end = datetime.datetime.fromtimestamp(end)
+    start = utc_from_timestamp(start)
+    end = utc_from_timestamp(end)
     diff = abs(end - start)  # type: datetime.timedelta
 
     # Get the different resolutions

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -122,8 +122,12 @@ time_same = VarDataPair(
     TimeVariable('time_same', have_date=True, have_time=True),
     np.array(_to_timestamps([2004] * 5), dtype=float),
 )
+time_negative = VarDataPair(
+    TimeVariable('time_negative', have_date=True, have_time=True),
+    np.array([0, -1, 24 * 60 * 60], dtype=float),
+)
 time = [
-    time_full, time_missing, time_all_missing, time_same
+    time_full, time_missing, time_all_missing, time_same, time_negative
 ]
 
 # String variable variations
@@ -246,6 +250,12 @@ class TestVariousDataSets(WidgetTest):
     @table_dense_sparse
     def test_on_data_with_continuous_values_all_the_same(self, prepare_table):
         data = make_table([ints_full, ints_same], [continuous_same, continuous_full])
+        self.send_signal(self.widget.Inputs.data, prepare_table(data))
+        self.run_through_variables()
+
+    @table_dense_sparse
+    def test_on_data_with_negative_timestamps(self, prepare_table):
+        data = make_table([time_negative])
         self.send_signal(self.widget.Inputs.data, prepare_table(data))
         self.run_through_variables()
 

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -4,7 +4,6 @@ import warnings
 from xml.sax.saxutils import escape
 from math import log10, floor, ceil
 from datetime import datetime, timezone
-from time import gmtime
 
 import numpy as np
 from AnyQt.QtCore import Qt, QRectF, QSize, QTimer, pyqtSignal as Signal, \
@@ -20,6 +19,7 @@ from pyqtgraph.graphicsItems.LegendItem import LegendItem as PgLegendItem
 from pyqtgraph.graphicsItems.TextItem import TextItem
 
 from Orange.preprocess.discretize import _time_binnings
+from Orange.util import utc_from_timestamp
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
 from Orange.widgets.utils import classdensity, colorpalettes
@@ -311,8 +311,8 @@ class AxisItem(AxisItem):
                      datetime.min.replace(tzinfo=timezone.utc).timestamp() + 1)
         maxVal = min(maxVal,
                      datetime.max.replace(tzinfo=timezone.utc).timestamp() - 1)
-        mn, mx = gmtime(minVal), gmtime(maxVal)
-
+        mn = utc_from_timestamp(minVal).timetuple()
+        mx = utc_from_timestamp(maxVal).timetuple()
         try:
             bins = _time_binnings(mn, mx, 6, 30)[-1]
         except (IndexError, ValueError):
@@ -350,10 +350,7 @@ class AxisItem(AxisItem):
         else:
             fmt = '%S.%f'
 
-        # if timezone is not set, then local timezone is used
-        # which cause exceptions for edge cases
-        return [datetime.fromtimestamp(x, tz=timezone.utc).strftime(fmt)
-                for x in values]
+        return [utc_from_timestamp(x).strftime(fmt) for x in values]
 
 
 class ScatterBaseParameterSetter(CommonParameterSetter):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes: gh-5345

`datetime.fromtimestamp` and `time.gmtime` raise OSError for negative timestamps on Windows.


##### Description of changes

Avoid use of `gmtime` and `fromtimestamp`


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
