### PR TITLE
[FIX] setup.py: Exclude benchmark directory from the install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ if not release:
         a.close()
 
 
-PACKAGES = find_packages()
+PACKAGES = find_packages(include=("Orange*",))
 
 # Extra non .py, .{so,pyd} files that are installed within the package dir
 # hierarchy


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

The benchmark directory is installed/included as a top level package in the build wheel files.

```bash
$ zipinfo -s Orange3-3.28.0-cp36-cp36m-macosx_10_6_intel.whl | tail -n 17
-rw-r--r--  2.0 unx     5325 b- defN 12-Mar-21 08:48 Orange3-3.28.0.data/data/share/help/en/orange3/htmlhelp/widgets/visualize/venndiagram.html
-rw-r--r--  2.0 unx     4933 b- defN 12-Mar-21 08:48 Orange3-3.28.0.data/data/share/help/en/orange3/htmlhelp/widgets/visualize/violinplot.html
-rw-r--r--  2.0 unx        0 b- defN 12-Mar-21 08:45 benchmark/__init__.py
-rw-r--r--  2.0 unx     5042 b- defN 12-Mar-21 08:45 benchmark/base.py
-rw-r--r--  2.0 unx     2109 b- defN 12-Mar-21 08:45 benchmark/bench_basic.py
-rw-r--r--  2.0 unx     1507 b- defN 12-Mar-21 08:45 benchmark/bench_domain.py
-rw-r--r--  2.0 unx     1976 b- defN 12-Mar-21 08:45 benchmark/bench_owkmeans.py
-rw-r--r--  2.0 unx     2016 b- defN 12-Mar-21 08:45 benchmark/bench_save.py
-rw-r--r--  2.0 unx     2023 b- defN 12-Mar-21 08:45 benchmark/bench_transform.py
-rw-r--r--  2.0 unx      488 b- defN 12-Mar-21 08:45 benchmark/bench_variable.py
-rw-r--r--  2.0 unx      378 b- defN 12-Mar-21 08:48 Orange3-3.28.0.dist-info/LICENSE
-rw-r--r--  2.0 unx     3354 b- defN 12-Mar-21 08:48 Orange3-3.28.0.dist-info/METADATA
-rw-r--r--  2.0 unx      109 b- defN 12-Mar-21 08:48 Orange3-3.28.0.dist-info/WHEEL
-rw-r--r--  2.0 unx      176 b- defN 12-Mar-21 08:48 Orange3-3.28.0.dist-info/entry_points.txt
-rw-r--r--  2.0 unx       17 b- defN 12-Mar-21 08:48 Orange3-3.28.0.dist-info/top_level.txt
?rw-rw-r--  2.0 unx   139730 b- defN 12-Mar-21 08:48 Orange3-3.28.0.dist-info/RECORD
1248 files, 34905215 bytes uncompressed, 25102177 bytes compressed:  28.1%

```
##### Description of changes

Explicit include only Orange package.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
