### PR TITLE
Instance: Prevent hashing

### DIFF
--- a/Orange/data/instance.py
+++ b/Orange/data/instance.py
@@ -177,6 +177,10 @@ class Instance:
                        type(m1) == type(m2) == float and isnan(m1) and isnan(m2)
                        for m1, m2 in zip(self._metas, other._metas))
 
+    @classmethod
+    def __hash__(cls):
+        raise TypeError(f"unhashable type: '{type(cls.__name__)}'")
+
     def __iter__(self):
         return chain(iter(self._x), iter(self._y))
 

--- a/Orange/tests/test_instance.py
+++ b/Orange/tests/test_instance.py
@@ -313,3 +313,13 @@ class TestInstance(unittest.TestCase):
         inst3 = Instance(domain, vals)
 
         self.assertNotEqual(inst2.id, inst3.id)
+
+    def test_no_hash(self):
+        domain = self.mock_domain()
+        inst = Instance(domain)
+        with self.assertRaises(TypeError):
+            {inst}  # pylint: disable=pointless-statement
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

`Instance` defines `__eq__`, thus it has to define `__hash__` to ensure that two equal objects have equal hashes.

However, `Instance` is mutable and shouldn't have `__hash__` at all. Thus it must raise `TypeError`.

If we some day decide to make `Instance` immutable, we can also implement a proper hash.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
