### PR TITLE
[FIX] Line Plot: Single instance input fix

### DIFF
--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -802,7 +802,7 @@ class OWLinePlot(OWWidget):
 
     def plot_groups(self):
         self._remove_groups()
-        data = self.data[self.valid_data, self.graph_variables]
+        data = self.data[self.valid_data][:, self.graph_variables]
         if self.group_var is None:
             self._plot_group(data, np.where(self.valid_data)[0])
         else:

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -232,6 +232,14 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(p, 2)
         self.assertFalse(self.widget.graph.legend.isVisible())
 
+    def test_group_var_none_single_instance(self):
+        self.send_signal(self.widget.Inputs.data, self.housing[:1])
+        m, n, p = self.widget.graph.view_box._profile_items.shape
+        self.assertEqual(m, len(self.housing.domain.attributes))
+        self.assertEqual(n, 1)
+        self.assertEqual(p, 2)
+        self.assertFalse(self.widget.graph.legend.isVisible())
+
     def test_datasets(self):
         for ds in datasets.datasets():
             self.send_signal(self.widget.Inputs.data, ds)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`Line Plot` crashes when input has a single instance and no `Group by` variable is selected.
To reproduce: File (housing) -> Data Table (select one row) -> Line Plot (crash)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
