### PR TITLE
Distributions: fix bins that values on the edge fall in the right bin

### DIFF
--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -320,8 +320,11 @@ def decimal_binnings(
         nbins = np.round((mx_ - mn_) / width)
         if min_bins <= nbins <= max_bins \
                 and (not bins or bins[-1].nbins != nbins):
-            bin_def = BinDefinition(mn_ + width * np.arange(nbins + 1),
-                                    label_fmt, None, width)
+            bins_ = mn_ + width * np.arange(nbins + 1)
+            # to prevent values on the edge of the bin fall in the wrong bin
+            # due to precision error on decimals that are not precise
+            bins_ = np.around(bins_, decimals=np.finfo(bins_.dtype).precision)
+            bin_def = BinDefinition(bins_, label_fmt, None, width)
             bins.append(bin_def)
     return bins
 

--- a/Orange/tests/test_discretize.py
+++ b/Orange/tests/test_discretize.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 import numpy as np
 import scipy.sparse as sp
 
-from Orange.preprocess import discretize, Discretize
+from Orange.preprocess import discretize, Discretize, decimal_binnings
 from Orange import data
 from Orange.data import Table, Instance, Domain, ContinuousVariable, DiscreteVariable
 
@@ -93,6 +93,34 @@ class TestEqualWidth(TestCase):
         dvar = disc(table, table.domain[0])
         self.assertEqual(len(dvar.values), 1)
         self.assertEqual(dvar.compute_value.points, [])
+
+
+class TestBinning(TestCase):
+    def test_decimal_binnings(self):
+        values = np.array([
+            -0.2, -0.2, -0.6, 1.0, 0.2, -0.6, 0.6, 1.0, 0.4, -0.5, -0.4, -0.4,
+            -0.6, 0.6, 0.75, 0.4, -0.2, 0.2, 0.0, 0.0, -1.0, -0.6, -0.2, -0.6,
+        ])
+        binning = decimal_binnings(values, factors=[0.2, 0.25, 0.5])
+        self.assertEqual(len(binning), 3)
+
+        np.testing.assert_array_equal(
+            binning[0].thresholds,
+            [-1, -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1]
+        )
+        self.assertEqual(binning[0].width, 0.2)
+
+        np.testing.assert_array_equal(
+            binning[1].thresholds,
+            [-1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1]
+        )
+        self.assertEqual(binning[1].width, 0.25)
+
+        np.testing.assert_array_equal(
+            binning[2].thresholds,
+            [-1, -0.5, 0, 0.5, 1]
+        )
+        self.assertEqual(binning[2].width, 0.5)
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Distributions widget sometimes put values at the edge in the wrong bin since bin borders are inaccurate on 17 or higher decimal place. Graph on dataset with a lot of values in the edge of bins:

![Screenshot 2021-04-27 at 13 18 55](https://user-images.githubusercontent.com/6421558/116233382-8169f700-a75b-11eb-9cc3-252d1fe3ece2.png)

In this example the bin -0.2<= x < 0 is empty even there are around 35 datapoints with value -0.2 in data. Also, some other bins include the values from the left and right of the interval.

##### Description of changes

With this PR I am fixing this error such that I round bin borders on a number of decimal places that are precise for the provided data type. Now I get the correct graph:

![Screenshot 2021-04-27 at 13 16 12](https://user-images.githubusercontent.com/6421558/116233755-ffc69900-a75b-11eb-9f28-1fc9cf2232af.png)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
