### PR TITLE
[FIX] UrlReader: Support urls with special characters

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -13,7 +13,8 @@ from itertools import chain
 
 from os import path, remove
 from tempfile import NamedTemporaryFile
-from urllib.parse import urlparse, urlsplit, urlunsplit, unquote as urlunquote
+from urllib.parse import urlparse, urlsplit, urlunsplit, \
+    unquote as urlunquote, quote
 from urllib.request import urlopen, Request
 from pathlib import Path
 
@@ -405,6 +406,7 @@ class UrlReader(FileFormat):
         filename = filename.strip()
         if not urlparse(filename).scheme:
             filename = 'http://' + filename
+        filename = quote(filename, safe="/:")
         super().__init__(filename)
 
     @staticmethod

--- a/Orange/tests/test_url_reader.py
+++ b/Orange/tests/test_url_reader.py
@@ -17,3 +17,14 @@ class TestUrlReader(unittest.TestCase):
             "http://datasets.biolab.si/core/philadelphia-crime.csv.xz"
         ).read()
         self.assertEqual(9666, len(data))
+
+    def test_special_characters(self):
+        # TO-DO - replace this file with a more appropriate one (e.g. .csv)
+        #  and change the assertion accordingly
+        path = "http://file.biolab.si/text-semantics/data/elektrotehniski-" \
+               "vestnik-clanki/detektiranje-utrdb-v-šahu-.txt"
+        self.assertRaises(OSError, UrlReader(path).read)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The `OWFile` widget can't read files with special characters in their urls.

##### Description of changes
Fix UrlReader: 
- use `urllib.parse.quote` to encode the url

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
