### PR TITLE
[FIX] Speed-up slow table_to_frame

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -368,8 +368,7 @@ def table_to_frame(tab, include_metas=False):
         elif col.is_continuous:
             dt = float
             # np.nan are not compatible with int column
-            nan_values_in_column = [t for t in vals if np.isnan(t)]
-            if col.number_of_decimals == 0 and len(nan_values_in_column) == 0:
+            if col.number_of_decimals == 0 and not np.any(np.isnan(vals)):
                 dt = int
             result = (col.name, pd.Series(vals).astype(dt))
         elif col.is_string:

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -81,6 +81,25 @@ class TestPandasCompat(unittest.TestCase):
         self.assertEqual(list(df['sepal length'])[0:4], [5.1, 4.9, 4.7, 4.6])
         self.assertEqual(list(df['iris'])[0:2], ['Iris-setosa', 'Iris-setosa'])
 
+    def test_table_to_frame_nans(self):
+        from Orange.data.pandas_compat import table_to_frame
+        domain = Domain(
+            [ContinuousVariable("a", number_of_decimals=0), ContinuousVariable("b")]
+        )
+        table = Table(
+            domain, np.column_stack((np.ones(10), np.hstack((np.ones(9), [np.nan]))))
+        )
+
+        df = table_to_frame(table)
+        table_column_names = [var.name for var in table.domain.variables]
+        frame_column_names = df.columns
+
+        self.assertEqual(sorted(table_column_names), sorted(frame_column_names))
+        self.assertEqual(df["a"].dtype, int)
+        self.assertEqual(df["b"].dtype, float)
+        self.assertEqual([1, 1, 1], list(df["a"].iloc[-3:]))
+        self.assertTrue(np.isnan(df["b"].iloc[-1]))
+
     def test_table_to_frame_metas(self):
         from Orange.data.pandas_compat import table_to_frame
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`table_to_frame` is slow on large dataset. On dataset with shape (1M, 12) it took ~20s to transform dataframe to table. The reason for slow error is list comprehension used to find out if there is any nan in numeric column.

##### Description of changes
List comprehension is now replaced with NumPy functions.
Transformation on the previously mention dataset now takes ~0.6s

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
