### PR TITLE
Limit OpenTSNE to >=0.6.0

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -18,7 +18,7 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain>=0.13
 requests
-openTSNE>=0.4.3
+openTSNE>=0.6.0
 baycomp>=1.0.2
 pandas>=1.0.0
 pyyaml


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
https://github.com/biolab/orange3/issues/5421

##### Description of changes
Version 0.6.0 implements handle saving annoy objects in the separate files while pickling so Orange will not crash anymore.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
