### PR TITLE
[FIX] Save File when workflow basedir is an empty string

### DIFF
--- a/Orange/canvas/run.py
+++ b/Orange/canvas/run.py
@@ -45,7 +45,9 @@ def main(argv=None):
     )
     widget_discovery.run(cfg.widgets_entry_points())
     model = cfg.workflow_constructor()
-    model.set_runtime_env("basedir", os.path.dirname(filename))
+    model.set_runtime_env(
+        "basedir", os.path.abspath(os.path.dirname(filename))
+    )
     sigprop = model.findChild(signalmanager.SignalManager)
     sigprop.pause()  # Pause signal propagation during load
 

--- a/Orange/widgets/utils/save/owsavebase.py
+++ b/Orange/widgets/utils/save/owsavebase.py
@@ -126,7 +126,7 @@ class OWSaveBase(widget.OWWidget, openclass=True):
             if os.path.exists(self.stored_path):
                 self.auto_save = False
                 return self.stored_path
-        elif workflow_dir:
+        elif workflow_dir is not None:
             return os.path.normpath(
                 os.path.join(workflow_dir, self.stored_path))
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

[workflow.ows.zip](https://github.com/biolab/orange3/files/6560898/workflow.ows.zip)

```
python -m Orange.canvas.run workflow.ows
```
Does not save the results.tab file while 
```
python -m Orange.canvas.run ./workflow.ows
```
does

Similarly running `orange-canvas workflow.ows` resets the Save Data's auto_save setting (this one needs similar fix in orange-canvas-core)

##### Description of changes

* Always use absolute path for workflow base dir.
* Fix check for workflow base dir in OWSaveBase.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
