### PR TITLE
Set minimal version of orange-widget-base to 4.13

### DIFF
--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.19,<0.2a
-orange-widget-base>=4.12.0
+orange-widget-base>=4.13.0
 
 PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
 PyQtWebEngine>=5.12


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/5460

##### Description of changes
Set minimal version of orange-widget-base to 4.13 since it is the first version that implements `itemdelegates`

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
