### PR TITLE
table_from_frame - speedups

### DIFF
--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -69,6 +69,15 @@ class TestPandasCompat(unittest.TestCase):
         self.assertEqual(names, ['index', '1', '2'])
         self.assertEqual(types, [DiscreteVariable, ContinuousVariable, TimeVariable])
 
+    def test_table_from_frame_keep_ids(self):
+        """ Test if indices are correctly transferred to Table"""
+        from Orange.data.pandas_compat import table_from_frame
+        df = OrangeDataFrame(Table('iris')[:6])
+        df.index = [1, "_oa", "_o", "1", "_o20", "_o30"]
+        table = table_from_frame(df)
+        self.assertEqual(table.ids[-2:].tolist(), [20, 30])
+        self.assertTrue(np.issubdtype(table.ids.dtype, np.number))
+
     def test_table_to_frame(self):
         from Orange.data.pandas_compat import table_to_frame
         table = Table("iris")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`table_from_frame` can be slow when transforming big dataframes

##### Description of changes
In this PR I identify places where transformation is slow and proposed changes.

I tested the speedup on the data frame with 6M rows and ~10 columns and succeeded in speedup the whole transformation from 16s to 2.5s.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
