### PR TITLE
[FIX] owpca: fix component selection when dragging selection line

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -203,9 +203,7 @@ class OWPCA(widget.OWWidget):
 
     def _on_cut_changed(self, components):
         if components == self.ncomponents \
-                or self.ncomponents == 0 \
-                or self._pca is not None \
-                and components == len(self._variance_ratio):
+                or self.ncomponents == 0:
             return
 
         self.ncomponents = components


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5464

##### Description of changes
Check for ```self._pca is not None and components == len(self._variance_ratio)``` prevented self.ncomponents to get updated when dragging vertical line. 

I think this check is unnecessary since the vertical line is bounded (on the x-axis) and will never exceed the number of computed components.




  


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
