### PR TITLE
[FIX] table_to_frame - handle numeric columns with dtype=object

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -371,7 +371,9 @@ def table_to_frame(tab, include_metas=False):
         elif col.is_continuous:
             dt = float
             # np.nan are not compatible with int column
-            if col.number_of_decimals == 0 and not np.any(np.isnan(vals)):
+            # using pd.isnull since np.isnan fails on array with dtype object
+            # which can happen when metas contain column with strings
+            if col.number_of_decimals == 0 and not np.any(pd.isnull(vals)):
                 dt = int
             result = (col.name, pd.Series(vals).astype(dt))
         elif col.is_string:

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -81,6 +81,18 @@ class TestPandasCompat(unittest.TestCase):
         self.assertEqual(list(df['sepal length'])[0:4], [5.1, 4.9, 4.7, 4.6])
         self.assertEqual(list(df['iris'])[0:2], ['Iris-setosa', 'Iris-setosa'])
 
+    def test_table_to_frame_object_dtype(self):
+        from Orange.data.pandas_compat import table_to_frame
+
+        domain = Domain([], metas=[ContinuousVariable("a", number_of_decimals=0)])
+        table = Table.from_numpy(
+            domain, np.empty((10, 0)), metas=np.ones((10, 1), dtype=object)
+        )
+
+        df = table_to_frame(table, include_metas=True)
+        self.assertEqual(["a"], df.columns)
+        np.testing.assert_array_equal(df["a"].values, np.ones((10,)))
+
     def test_table_to_frame_nans(self):
         from Orange.data.pandas_compat import table_to_frame
         domain = Domain(


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
`table_to_frame` fails when array (usually metas) have dtype=object and column holds numeric values. Look newly-added test.

##### Description of changes
Use `pd.isnull` instead of `np.isnan` which correctly handle columns with dtype=object.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
