### PR TITLE
[FIX] listfilter: Bypass QListView.dropEvent

### DIFF
--- a/Orange/widgets/utils/listfilter.py
+++ b/Orange/widgets/utils/listfilter.py
@@ -1,4 +1,4 @@
-from AnyQt.QtWidgets import QListView, QLineEdit, QCompleter
+from AnyQt.QtWidgets import QListView, QLineEdit, QCompleter, QAbstractItemView
 from AnyQt.QtGui import QDrag
 from AnyQt.QtCore import (
     Qt, QObject, QEvent, QModelIndex,
@@ -84,6 +84,13 @@ class VariablesListItemView(QListView):
                 for s1, s2 in reversed(list(slices(rows))):
                     delslice(self.model(), s1, s2)
             self.dragDropActionDidComplete.emit(res)
+
+    def dropEvent(self, event):
+        # Bypass QListView.dropEvent on Qt >= 5.15.2.
+        # Because `startDrag` is overridden and does not dispatch to base
+        # implementation then `dropEvent` would need to be overridden also
+        # (private `d->dropEventMoved` state tracking due to QTBUG-87057 fix).
+        QAbstractItemView.dropEvent(self, event)
 
     def dragEnterEvent(self, event):
         """


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-5471

On Qt >= 5.15.2 QListView.dropEvent depends on private state tracking
that is setup in startDrag. Since startDrag is overridden here and does
not dispatch to the base implementation, this causes items loss when
performing internal move.

##### Description of changes

Bypass QListView.dropEvent

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
