### PR TITLE
[FIX] Create Class: fix incorrect value assignment

### DIFF
--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -152,9 +152,14 @@ def unique_in_order_mapping(a):
     - unique elements of the input list (in the order of appearance)
     - indices of the input list onto the returned uniques
     """
-    u, idx, inv = np.unique(a, return_index=True, return_inverse=True)
-    unique_in_order = u[np.argsort(idx)]
-    mapping = np.argsort(idx)[inv]
+    first_position = {}
+    unique_in_order = []
+    mapping = []
+    for e in a:
+        if e not in first_position:
+            first_position[e] = len(unique_in_order)
+            unique_in_order.append(e)
+        mapping.append(first_position[e])
     return unique_in_order, mapping
 
 

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -89,6 +89,15 @@ class TestHelpers(unittest.TestCase):
         u, m = unique_in_order_mapping([2, 1, 2, 3])
         np.testing.assert_equal(u, [2, 1, 3])
         np.testing.assert_equal(m, [0, 1, 0, 2])
+        u, m = unique_in_order_mapping([2, 3, 1])
+        np.testing.assert_equal(u, [2, 3, 1])
+        np.testing.assert_equal(m, [0, 1, 2])
+        u, m = unique_in_order_mapping([2, 3, 1, 1])
+        np.testing.assert_equal(u, [2, 3, 1])
+        np.testing.assert_equal(m, [0, 1, 2, 2])
+        u, m = unique_in_order_mapping([2, 3, 1, 2])
+        np.testing.assert_equal(u, [2, 3, 1])
+        np.testing.assert_equal(m, [0, 1, 2, 0])
 
     def test_value_from_string_substring(self):
         trans = ValueFromStringSubstring(StringVariable("x"), self.patterns)


### PR DESCRIPTION
##### Issue

The implementation of `unique_in_order_mapping` was wrong. Now it is simplified, slower, but seemingly correct. I was trying to be too smart with the first implementation. Premature optimization is the root of all evil.

To reproduce the bug before this commit, try the following file

```
Filename
string
meta
A
B
C
```

with the following create class settings (keep the same order):
B: C
C: C
A: A

Fixes #5473

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
