### PR TITLE
Adapt util.unique tests for numpy 1.21

### DIFF
--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -596,9 +596,9 @@ class TestUnique(unittest.TestCase):
     def test_returns_unique_values(self, array):
         # pylint: disable=bad-whitespace
         x = array([[-1., 1., 0., 2., 3., np.nan],
-                   [ 0., 0., 0., 3., 5., np.nan],
+                   [ 0., 0., 0., 3., 5.,    42.],
                    [-1., 0., 0., 1., 7.,     6.]])
-        expected = [-1, 0, 1, 2, 3, 5, 6, 7, np.nan, np.nan]
+        expected = [-1, 0, 1, 2, 3, 5, 6, 7, 42, np.nan]
 
         np.testing.assert_equal(unique(x, return_counts=False), expected)
 
@@ -606,11 +606,15 @@ class TestUnique(unittest.TestCase):
     def test_returns_counts(self, array):
         # pylint: disable=bad-whitespace
         x = array([[-1., 1., 0., 2., 3., np.nan],
-                   [ 0., 0., 0., 3., 5., np.nan],
+                   [ 0., 0., 0., 3., 5.,    42.],
                    [-1., 0., 0., 1., 7.,     6.]])
-        expected = [2, 6, 2, 1, 2, 1, 1, 1, 1, 1]
+        expected = [-1, 0, 1, 2, 3, 5, 6, 7, 42, np.nan]
+        expected_counts = [2, 6, 2, 1, 2, 1, 1, 1, 1, 1]
 
-        np.testing.assert_equal(unique(x, return_counts=True)[1], expected)
+        vals, counts = unique(x, return_counts=True)
+
+        np.testing.assert_equal(vals, expected)
+        np.testing.assert_equal(counts, expected_counts)
 
     def test_sparse_explicit_zeros(self):
         # Use `lil_matrix` to fix sparse warning for matrix construction


### PR DESCRIPTION
##### Issue
Tests on numpy 1.21 fail. `numpy.unique` changed behaviour in 1.21. Since 1.21 it treats all NaNs as the same value; before, it outputted as many NaNs as there were in the input array. The corresponding numpy issue: numpy/numpy#2111

##### Description of changes
Orange's `util.unique` function is a thin wrapper around `numpy.unique`. Because TestUnique used a test array with 2 NaNs the results were different depending on the version. Now they use a single NaN value.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
