### PR TITLE
[ENH] PCA: Output variance of components

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -95,6 +95,27 @@ class TestOWPCA(WidgetTest):
         out = self.get_output(self.widget.Outputs.components)
         self.assertEqual(out.domain.metas[0].name, 'components (1)')
 
+    def test_variance_attr(self):
+        self.widget.ncomponents = 2
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.wait_until_stop_blocking()
+        self.widget._variance_ratio = np.array([0.5, 0.25, 0.2, 0.05])
+        self.widget.unconditional_commit()
+
+        result = self.get_output(self.widget.Outputs.transformed_data)
+        pc1, pc2 = result.domain.attributes
+        self.assertEqual(pc1.attributes["variance"], 0.5)
+        self.assertEqual(pc2.attributes["variance"], 0.25)
+
+        result = self.get_output(self.widget.Outputs.data)
+        pc1, pc2 = result.domain.metas
+        self.assertEqual(pc1.attributes["variance"], 0.5)
+        self.assertEqual(pc2.attributes["variance"], 0.25)
+
+        result = self.get_output(self.widget.Outputs.components)
+        np.testing.assert_almost_equal(result.get_column_view("variance")[0].T,
+                                       [0.5, 0.25])
+
     def test_sparse_data(self):
         """Check that PCA returns the same results for both dense and sparse data."""
         dense_data, sparse_data = self.iris, self.iris.to_sparse()


### PR DESCRIPTION
##### Issue

Fixes two thirds of #5468.

To test before https://github.com/biolab/orange-widget-base/pull/162 is merged, change

```python
        self.varmodel[:] = zip(self._variance_ratio[:self.maxp],
                               numpy.cumsum(self._variance_ratio))
```

to 

```python
        self.varmodel.wrap(list(zip(self._variance_ratio[:self.maxp],
                               numpy.cumsum(self._variance_ratio))))
```

##### Description of changes

1. Variances are added as attributes of variables, and as extra meta columns in the components output.

2. The table with variances is shown in control area and can be used as the third mean to select components. Clicking a row selects all components up to that row. (Selecting arbitrary rows is not possible: the widget's code does not support it; interactions the other two controls would be weird; this is not typical for PCA; for atypical uses, there's Select Rows; no a/b testing of this feature will be done, thanks for not asking :).

    <img width="846" alt="Screenshot 2021-07-04 at 13 03 54" src="https://user-images.githubusercontent.com/2387315/124382629-a7b29280-dcc8-11eb-85bd-be981106c5b0.png">

3. The third point in the issue was reporting variance on new data. This can be added to the table, but I'd suggest this to be a separate issue/PR.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
