### PR TITLE
[FIX] owheatmap: Fix assertion error when restoring selection

### DIFF
--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -662,8 +662,8 @@ class OWHeatMap(widget.OWWidget):
 
         self.update_heatmaps()
         if data is not None and self.__pending_selection is not None:
-            assert self.scene.widget is not None
-            self.scene.widget.selectRows(self.__pending_selection)
+            if self.scene.widget is not None:
+                self.scene.widget.selectRows(self.__pending_selection)
             self.selected_rows = self.__pending_selection
             self.__pending_selection = None
 

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -205,6 +205,20 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(w.Inputs.data, iris, widget=w)
         self.assertEqual(len(self.get_output(w.Outputs.selected_data)), 21)
 
+    def test_saved_selection_when_not_possible(self):
+        # Has stored selection but ot enough columns for clustering.
+        iris = Table("iris")[:, ["petal width"]]
+        w = self.create_widget(
+            OWHeatMap, stored_settings={
+                "__version__": 3,
+                "col_clustering_method": "Clustering",
+                "selected_rows": [1, 2, 3],
+            }
+        )
+        self.send_signal(w.Inputs.data, iris)
+        out = self.get_output(w.Outputs.selected_data)
+        self.assertSequenceEqual(list(out.ids), list(iris.ids[[1, 2, 3]]))
+
     def test_set_split_var(self):
         data = self.brown_selected[::3]
         w = self.widget


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Heatmap widget raises an assertion error when restoring selection and the input data has only a single column and columns clustering is selected.

```
-------------------------- AssertionError Exception ---------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/scheme/signalmanager.py", line 1125, in __process_next
    if self.__process_next_helper(use_max_active=True):
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/scheme/signalmanager.py", line 1164, in __process_next_helper
    self.process_node(selected_node)
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/scheme/signalmanager.py", line 707, in process_node
    self.send_to_node(node, signals_in)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/workflow/widgetsscheme.py", line 805, in send_to_node
    self.process_signals_for_widget(node, widget, signals)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/workflow/widgetsscheme.py", line 819, in process_signals_for_widget
    process_signals_for_widget(widget, signals, workflow)
  File "/Users/aleserjavec/.local/opt/python3.8/Python.framework/Versions/3.8/lib/python3.8/functools.py", line 875, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/workflow/widgetsscheme.py", line 920, in process_signals_for_widget
    process_signal_input(input_meta, widget, signal, workflow)
  File "/Users/aleserjavec/.local/opt/python3.8/Python.framework/Versions/3.8/lib/python3.8/functools.py", line 875, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/workflow/widgetsscheme.py", line 883, in process_signal_input_default
    notify_input_helper(
  File "/Users/aleserjavec/.local/opt/python3.8/Python.framework/Versions/3.8/lib/python3.8/functools.py", line 875, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/utils/signals.py", line 643, in set_input_helper
    handler(*args)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/utils/signals.py", line 198, in summarize_wrapper
    method(widget, value)
  File "/Users/aleserjavec/Documents/workspace/orange3/Orange/widgets/visualize/owheatmap.py", line 665, in set_dataset
    assert self.scene.widget is not None
AssertionError
-------------------------------------------------------------------------------
```
Easiest way to test is to *File -> Heatmap*, select column clustering and select a couple of rows in the heatmap, then duplicate/copy/paste the *Heatmap*, add *File -> Select Columns*, select single column in Select Columns and connect *Select Columns -> Heatmap (2)*
##### Description of changes

Fix assertion error when restoring selection

##### Includes
- [X] Code changes
- [X] Tests
