### PR TITLE
test_pandas: Raise contiguous metas test req

### DIFF
--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -428,7 +428,7 @@ class TestDenseTablePandas(TestTablePandas):
         self.assertTrue(np.shares_memory(df.values, table.Y))
         self.assertTrue(np.shares_memory(df.values, table2.Y))
 
-    @unittest.skipUnless(pd.__version__ >= '1.3.0',
+    @unittest.skipUnless(pd.__version__ >= '1.4.0',
                          'pandas-dev/pandas#39263')
     def test_contiguous_metas(self):
         table = self.table


### PR DESCRIPTION
##### Issue

pandas-dev/pandas#39263 is required for `test_contiguous_metas` to pass, the PR didn't make it into 1.3.0.

##### Description of changes

Raises `test_contiguous_metas` test requirement to 1.4.0.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
