### PR TITLE
__main__: Implement basic darkmode provisions

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -337,7 +337,7 @@ def send_usage_statistics():
             r = requests.post(url, files={'file': json.dumps(data)})
             if r.status_code != 200:
                 log.warning("Error communicating with server while attempting to send "
-                            "usage statistics. Status code " + str(r.status_code))
+                            "usage statistics. Status code %d", r.status_code)
                 return
             # success - wipe statistics file
             log.info("Usage statistics sent.")

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -560,6 +560,9 @@ def main(argv=None):
 
                 stylesheet_string = pattern.sub("", stylesheet_string)
 
+                if 'dark' in stylesheet:
+                    app.setProperty('darkMode', True)
+
             else:
                 log.info("%r style sheet not found.", stylesheet)
 

--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -457,6 +457,20 @@ def main(argv=None):
             app.setPalette(breeze_dark())
             defaultstylesheet = "darkorange.qss"
 
+    # set pyqtgraph colors
+    def onPaletteChange():
+        p = app.palette()
+        bg = p.base().color().name()
+        fg = p.windowText().color().name()
+
+        log.info('Setting pyqtgraph background to %s', bg)
+        pyqtgraph.setConfigOption('background', bg)
+        log.info('Setting pyqtgraph foreground to %s', fg)
+        pyqtgraph.setConfigOption('foreground', fg)
+
+    app.paletteChanged.connect(onPaletteChange)
+    onPaletteChange()
+
     palette = app.palette()
     if style is None and palette.color(QPalette.Window).value() < 127:
         log.info("Switching default stylesheet to darkorange")

--- a/Orange/widgets/utils/plot/owpalette.py
+++ b/Orange/widgets/utils/plot/owpalette.py
@@ -5,8 +5,6 @@ import pyqtgraph as pg
 __all__ = ["create_palette", "OWPalette"]
 
 
-pg.setConfigOption('background', 'w')
-pg.setConfigOption('foreground', 'k')
 pg.setConfigOptions(antialias=True)
 
 


### PR DESCRIPTION
##### Description of changes
- Sets 'darkMode' property in QApplication if 'dark' is specified in stylesheet. This can be easily queried globally elsewhere to color decisions
- Sets default pyqtgraph colors from QPalette on startup

Also removed the pyqtgraph colors set on owpalette.py import (please don't call code like this :x)

This is the first step toward proper dark mode support. Most (if not all) visualizations hardcode their colors. These hardcoded colors need to be removed and delegated to global default color settings (as set in 8f92990).

Note, this only works on startup, if the OS changes its color scheme (as Mac can upon sunset/sunrise), it won't update accordingly. But it's a first step.

This was transplanted from https://github.com/biolab/orange3/pull/5287. That PR will change into setting new default colors.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
