### PR TITLE
test_owtestandscore: Fix testandscore test mock

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -598,7 +598,7 @@ class TestOWTestAndScore(WidgetTest):
         w = self.widget
         self._set_three_majorities()
         self._set_comparison_score("F1")
-        f1mock = Mock(wraps=scoring.F1)
+        f1mock = Mock(wraps=scoring.F1.compute_score)
 
         iris = Table("iris")
         with patch.object(scoring.F1, "compute_score", f1mock):


### PR DESCRIPTION
##### Issue
This test was failing with a stack overflow here #5208. Not sure why it wasn't failing elsewhere, going through the trace on windows seems pretty sensible to fail.

##### Description of changes
Changes the mocked object to the correct one (thanks @janezd)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
