### PR TITLE
[FIX] Fix deepcopy and pickle for classes derived from `np.ndarray`

### DIFF
--- a/Orange/statistics/contingency.py
+++ b/Orange/statistics/contingency.py
@@ -179,8 +179,19 @@ class Discrete(np.ndarray):
         return (
             _create_discrete,
             (Discrete, np.copy(self), self.col_variable, self.row_variable,
-             self.col_unknowns, self.row_unknowns)
+             self.col_unknowns, self.row_unknowns, self.unknowns)
         )
+
+    def __array_finalize__(self, obj):
+        # defined in __new__, pylint: disable=attribute-defined-outside-init
+        """See http://docs.scipy.org/doc/numpy/user/basics.subclassing.html"""
+        if obj is None:
+            return
+        self.col_variable = getattr(obj, 'col_variable', None)
+        self.row_variable = getattr(obj, 'row_variable', None)
+        self.col_unknowns = getattr(obj, 'col_unknowns', None)
+        self.row_unknowns = getattr(obj, 'row_unknowns', None)
+        self.unknowns = getattr(obj, 'unknowns', None)
 
 
 class Continuous:

--- a/Orange/statistics/distribution.py
+++ b/Orange/statistics/distribution.py
@@ -30,6 +30,26 @@ def _get_variable(dat, variable, expected_type=None, expected_name=""):
 
 
 class Distribution(np.ndarray):
+    def __array_finalize__(self, obj):
+        # defined in derived classes,
+        # pylint: disable=attribute-defined-outside-init
+        """See http://docs.scipy.org/doc/numpy/user/basics.subclassing.html"""
+        if obj is None:
+            return
+        self.variable = getattr(obj, 'variable', None)
+        self.unknowns = getattr(obj, 'unknowns', 0)
+
+    def __reduce__(self):
+        state = super().__reduce__()
+        newstate = state[2] + (self.variable, self.unknowns)
+        return state[0], state[1], newstate
+
+    def __setstate__(self, state):
+        # defined in derived classes,
+        # pylint: disable=attribute-defined-outside-init
+        super().__setstate__(state[:-2])
+        self.variable, self.unknowns = state[-2:]
+
     def __eq__(self, other):
         return (
             np.array_equal(self, other) and

--- a/Orange/tests/test_contingency.py
+++ b/Orange/tests/test_contingency.py
@@ -1,6 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-
+import copy
 import unittest
 from unittest.mock import Mock
 
@@ -70,6 +70,13 @@ class TestDiscrete(unittest.TestCase):
             cont.col_unknowns, [0, 0, 0, 0, 0, 0, 0])
         np.testing.assert_almost_equal(cont.row_unknowns, [0, 0])
         self.assertEqual(1, cont.unknowns)
+
+    def test_deepcopy(self):
+        cont = contingency.Discrete(self.zoo, 0)
+        dc = copy.deepcopy(cont)
+        self.assertEqual(dc, cont)
+        self.assertEqual(dc.col_variable, cont.col_variable)
+        self.assertEqual(dc.row_variable, cont.row_variable)
 
     def test_array_with_unknowns(self):
         d = data.Table("zoo")

--- a/Orange/tests/test_distribution.py
+++ b/Orange/tests/test_distribution.py
@@ -1,7 +1,8 @@
 # Test methods with long descriptive names can omit docstrings
 # Test internal methods
 # pylint: disable=missing-docstring, protected-access
-
+import copy
+import pickle
 import unittest
 from unittest.mock import Mock
 import warnings
@@ -109,6 +110,32 @@ class TestDiscreteDistribution(unittest.TestCase):
         np.testing.assert_almost_equal(
             np.asarray(fallback), np.asarray(default))
         np.testing.assert_almost_equal(fallback.unknowns, default.unknowns)
+
+    def test_pickle(self):
+        d = data.Table("zoo")
+        d1 = distribution.Discrete(d, 0)
+        dc = pickle.loads(pickle.dumps(d1))
+        # This always worked because `other` wasn't required to have `unknowns`
+        self.assertEqual(d1, dc)
+        # This failed before implementing `__reduce__`
+        self.assertEqual(dc, d1)
+        self.assertEqual(hash(d1), hash(dc))
+        # Test that `dc` has the required attributes
+        self.assertEqual(dc.variable, d1.variable)
+        self.assertEqual(dc.unknowns, d1.unknowns)
+
+    def test_deepcopy(self):
+        d = data.Table("zoo")
+        d1 = distribution.Discrete(d, 0)
+        dc = copy.deepcopy(d1)
+        # This always worked because `other` wasn't required to have `unknowns`
+        self.assertEqual(d1, dc)
+        # This failed before implementing `__deepcopy__`
+        self.assertEqual(dc, d1)
+        self.assertEqual(hash(d1), hash(dc))
+        # Test that `dc` has the required attributes
+        self.assertEqual(dc.variable, d1.variable)
+        self.assertEqual(dc.unknowns, d1.unknowns)
 
     def test_equality(self):
         d = data.Table("zoo")
@@ -284,6 +311,30 @@ class TestContinuousDistribution(unittest.TestCase):
         self.assertIsNone(disc2.variable)
         self.assertEqual(disc2.unknowns, 0)
         assert_dist_equal(disc2, dd)
+
+    def test_pickle(self):
+        d1 = distribution.Continuous(self.iris, 0)
+        dc = pickle.loads(pickle.dumps(d1))
+        # This always worked because `other` wasn't required to have `unknowns`
+        self.assertEqual(d1, dc)
+        # This failed before implementing `__reduce__`
+        self.assertEqual(dc, d1)
+        self.assertEqual(hash(d1), hash(dc))
+        # Test that `dc` has the required attributes
+        self.assertEqual(dc.variable, d1.variable)
+        self.assertEqual(dc.unknowns, d1.unknowns)
+
+    def test_deepcopy(self):
+        d1 = distribution.Continuous(self.iris, 0)
+        dc = copy.deepcopy(d1)
+        # This always worked because `other` wasn't required to have `unknowns`
+        self.assertEqual(d1, dc)
+        # This failed before implementing `__deepcopy__`
+        self.assertEqual(dc, d1)
+        self.assertEqual(hash(d1), hash(dc))
+        # Test that `dc` has the required attributes
+        self.assertEqual(dc.variable, d1.variable)
+        self.assertEqual(dc.unknowns, d1.unknowns)
 
     def test_hash(self):
         d = self.iris


### PR DESCRIPTION
##### Issue

Fixes #5480.

##### Description of changes

Apparently and hopefully, the only classes derived from `np.ndarray` are `distribution.Discrete`, `distribution.Continuous`, `contingency.Discrete` and `DistMatrix`. The latter was already properly subclassed, so I did the same in the first three. 

`DistMatrix` also implements `__array_wrap__`; I haven't added it to the former three classes because it would change their behaviour and possible break some code without (much, if any) benefit.

##### Includes
- [X] Code changes
- [X] Tests
