### PR TITLE
Merge Data: Embiggen + and x buttons

### DIFF
--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -5,8 +5,9 @@ import numpy as np
 
 from AnyQt.QtCore import Qt, QModelIndex, pyqtSignal as Signal
 from AnyQt.QtWidgets import (
-    QWidget, QLabel, QPushButton, QVBoxLayout, QHBoxLayout
+    QWidget, QLabel, QVBoxLayout, QHBoxLayout, QSizePolicy
 )
+
 from orangewidget.utils.combobox import ComboBoxSearch
 
 import Orange
@@ -79,11 +80,10 @@ class ConditionBox(QWidget):
             return combo
 
         def get_button(label, callback):
-            button = QPushButton(label, self)
-            button.setFlat(True)
-            button.setFixedWidth(12)
-            button.clicked.connect(callback)
-            return button
+            return gui.button(
+                None, self, label, callback=callback,
+                addToLayout=False, autoDefault=False, width=34,
+                sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum))
 
         row = self.layout().count()
         row_items = self.RowItems(
@@ -125,16 +125,15 @@ class ConditionBox(QWidget):
         self.emit_list()
 
     def _reset_buttons(self):
-        def endis(button, enable, text):
-            button.setEnabled(enable)
-            button.setText(text if enable else "")
+        def endis(button, enable):
+            button.setHidden(not enable)
 
         self.rows[0].pre_label.setText(self.pre_label)
         single_row = len(self.rows) == 1
-        endis(self.rows[0].remove_button, not single_row, "×")
-        endis(self.rows[-1].add_button, True, "+")
+        endis(self.rows[0].remove_button, not single_row)
+        endis(self.rows[-1].add_button, True)
         if not single_row:
-            endis(self.rows[-2].add_button, False, "")
+            endis(self.rows[-2].add_button, False)
 
     def current_state(self):
         def get_var(model, combo):

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -30,8 +30,7 @@ class ConditionBox(QWidget):
 
     RowItems = namedtuple(
         "RowItems",
-        ("pre_label", "left_combo", "in_label", "right_combo",
-         "remove_button", "add_button"))
+        ("pre_label", "left_combo", "in_label", "right_combo", "remove_button"))
 
     def __init__(self, parent, model_left, model_right, pre_label, in_label):
         super().__init__(parent)
@@ -43,6 +42,12 @@ class ConditionBox(QWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
         self.setMouseTracking(True)
+
+    def get_button(self, label, callback):
+        return gui.button(
+            None, self, label, callback=callback,
+            addToLayout=False, autoDefault=False, width=34,
+            sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum))
 
     def add_row(self):
         def sync_combos():
@@ -79,29 +84,28 @@ class ConditionBox(QWidget):
             combo.activated.connect(sync_combos)
             return combo
 
-        def get_button(label, callback):
-            return gui.button(
-                None, self, label, callback=callback,
-                addToLayout=False, autoDefault=False, width=34,
-                sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum))
-
         row = self.layout().count()
         row_items = self.RowItems(
             QLabel("and" if row else self.pre_label),
             get_combo(self.model_left),
             QLabel(self.in_label),
             get_combo(self.model_right),
-            get_button("×", self.on_remove_row),
-            get_button("+", self.on_add_row)
+            self.get_button("×", self.on_remove_row)
         )
         layout = QHBoxLayout()
         layout.setSpacing(10)
-        self.layout().addLayout(layout)
+        self.layout().insertLayout(self.layout().count() - 1, layout)
         layout.addStretch(10)
         for item in row_items:
             layout.addWidget(item)
         self.rows.append(row_items)
         self._reset_buttons()
+
+    def add_plus_row(self):
+        layout = QHBoxLayout()
+        self.layout().addLayout(layout)
+        layout.addStretch(1)
+        layout.addWidget(self.get_button("+", self.on_add_row))
 
     def remove_row(self, row):
         self.layout().takeAt(self.rows.index(row))
@@ -125,15 +129,8 @@ class ConditionBox(QWidget):
         self.emit_list()
 
     def _reset_buttons(self):
-        def endis(button, enable):
-            button.setHidden(not enable)
-
         self.rows[0].pre_label.setText(self.pre_label)
-        single_row = len(self.rows) == 1
-        endis(self.rows[0].remove_button, not single_row)
-        endis(self.rows[-1].add_button, True)
-        if not single_row:
-            endis(self.rows[-2].add_button, False)
+        self.rows[0].remove_button.setDisabled(len(self.rows) == 1)
 
     def current_state(self):
         def get_var(model, combo):
@@ -332,6 +329,7 @@ class OWMergeData(widget.OWWidget):
         self.attr_boxes = ConditionBox(
             self, self.model, self.extra_model, "", "matches")
         self.attr_boxes.add_row()
+        self.attr_boxes.add_plus_row()
         box = gui.vBox(self.controlArea, box="Row matching")
         box.layout().addWidget(self.attr_boxes)
 

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -214,9 +214,11 @@ class TestOWMergeData(WidgetTest):
     def test_add_row_button(self):
         boxes = self.widget.attr_boxes
         boxes.set_state([(INSTANCEID, INSTANCEID), (INSTANCEID, INSTANCEID)])
-        boxes.rows[-1].add_button.clicked.emit()
+        layout = boxes.layout()
+        add_button = layout.itemAt(layout.count() - 1).itemAt(1).widget()
+        add_button.clicked.emit()
         self.assertEqual(len(boxes.rows), 3)
-        self.assertEqual(boxes.layout().count(), 3)
+        self.assertEqual(boxes.layout().count(), 4)
 
     def test_remove_row(self):
         widget = self.widget
@@ -228,38 +230,26 @@ class TestOWMergeData(WidgetTest):
 
         boxes.set_state(
             [(INDEX, INDEX), (INSTANCEID, INSTANCEID), (var0, var1)])
-        for i, row in enumerate(boxes.rows):
+        for row in boxes.rows:
             self.assertTrue(row.remove_button.isEnabled())
-            self.assertEqual(row.remove_button.text(), "×")
-            self.assertEqual(row.add_button.isEnabled(), i == 2)
-            self.assertEqual(row.add_button.text(), ["", "+"][i == 2])
 
         boxes.rows[1].remove_button.clicked.emit()
         self.assertEqual(boxes.current_state(), [(INDEX, INDEX), (var0, var1)])
-        for i, row in enumerate(boxes.rows):
+        for row in boxes.rows:
             self.assertTrue(row.remove_button.isEnabled())
-            self.assertEqual(row.remove_button.text(), "×")
-            self.assertEqual(row.add_button.isEnabled(), i == 1)
-            self.assertEqual(row.add_button.text(), ["", "+"][i])
 
         boxes.rows[1].remove_button.clicked.emit()
         self.assertEqual(boxes.current_state(), [(INDEX, INDEX)])
         row = boxes.rows[0]
         self.assertFalse(row.remove_button.isEnabled())
-        self.assertEqual(row.remove_button.text(), "")
-        self.assertTrue(row.add_button.isEnabled())
-        self.assertEqual(row.add_button.text(), "+")
 
         boxes.set_state(
             [(INDEX, INDEX), (INSTANCEID, INSTANCEID), (var0, var1)])
         boxes.rows[2].remove_button.clicked.emit()
         self.assertEqual(
             boxes.current_state(), [(INDEX, INDEX), (INSTANCEID, INSTANCEID)])
-        for i, row in enumerate(boxes.rows):
+        for row in boxes.rows:
             self.assertTrue(row.remove_button.isEnabled())
-            self.assertEqual(row.remove_button.text(), "×")
-            self.assertEqual(row.add_button.isEnabled(), i == 1)
-            self.assertEqual(row.add_button.text(), ["", "+"][i == 1])
 
     def test_dont_remove_single_row(self):
         widget = self.widget


### PR DESCRIPTION
##### Issue

Fixes #5285.

##### Description of changes

As proposed, adapt the code from Create Class.

~~The widget shows empty/disabled buttons, that is, grayed-out squares instead of hiding the button completely. I find it kind-of nice, but can change it.~~

I have also put the + button in a separate row. This looks nicer, though it uses some extra space; the widget is small, anyway. (The previous design was, I guess, OK because the buttons looked more like labels that are shown or hidden. With buttons, it is not.)

##### Includes
- [X] Code changes
- [X] Test changes