### PR TITLE
OWScatterPlotBase: Animate point resize for half a second

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -933,8 +933,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             widget = self
 
             class Timeout:
-                # 0.5 - np.cos(np.arange(0.17, 1, 0.17) * np.pi) / 2
-                factors = [0.07, 0.26, 0.52, 0.77, 0.95, 1]
+                # 0.5 - np.cos(np.arange(0.17, 1, 0.09) * np.pi) / 2
+                factors = [0.07, 0.16, 0.27, 0.41, 0.55,
+                           0.68, 0.81, 0.9, 0.97, 1]
 
                 def __init__(self):
                     self._counter = 0
@@ -959,7 +960,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
                 # If encountered any strange behaviour when updating sizes,
                 # implement it with threads
                 self.begin_resizing.emit()
-                self.timer = QTimer(self.scatterplot_item, interval=50)
+                interval = int(500 / len(Timeout.factors))
+                self.timer = QTimer(self.scatterplot_item, interval=interval)
                 self.timer.timeout.connect(Timeout())
                 self.timer.start()
             else:

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -514,10 +514,10 @@ class TestOWScatterPlotBase(WidgetTest):
         step_resizing.wait(200)
         end_resizing.wait(200)
         self.assertEqual(len(begin_resizing), 2)  # reset and update
-        self.assertEqual(len(step_resizing), 5)
+        self.assertEqual(len(step_resizing), 9)
         self.assertEqual(len(end_resizing), 2)  # reset and update
-        self.assertEqual(self.graph.scatterplot_item.setSize.call_count, 6)
-        self._update_sizes_for_points(6)
+        self.assertEqual(self.graph.scatterplot_item.setSize.call_count, 10)
+        self._update_sizes_for_points(10)
         self.graph.scatterplot_item.setSize.assert_called_once()
 
     def _update_sizes_for_points(self, n: int):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Projection widgets animate point resize. The animation should last half a second.

##### Description of changes
Resize points within approximately half a second.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
