### PR TITLE
OWPythonscript: Fix return statement indentation

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -157,7 +157,7 @@ class FakeSignatureMixin:
     def setIndent(self, margins_width):
         self.setContentsMargins(max(0,
                                     round(margins_width) +
-                                    (self.indentation_level - 1 * self._char_4_width)),
+                                    ((self.indentation_level - 1) * self._char_4_width)),
                                 0, 0, 0)
 
 


### PR DESCRIPTION
##### Issue
In the new OWPythonscript editor that was just merged #5208, the return statement isn't indented.

##### Description of changes
Fixed a whoops forgot to add parentheses bug. :x

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
