### PR TITLE
[MNT] Replace deprecated numpy type aliases

### DIFF
--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -138,7 +138,7 @@ def assure_array_sparse(a, sparse_class: Callable = sp.csc_matrix):
     if not sp.issparse(a):
         # since x can be a list, cast to np.array
         # since x can come from metas with string, cast to float
-        a = np.asarray(a).astype(np.float)
+        a = np.asarray(a).astype(float)
     return sparse_class(a)
 
 

--- a/Orange/preprocess/fss.py
+++ b/Orange/preprocess/fss.py
@@ -93,7 +93,7 @@ class SelectBestFeatures(Reprable):
     def score_only_nice_features(self, data, method):
         # dtype must be defined because array can be empty
         mask = np.array([isinstance(a, method.feature_type)
-                         for a in data.domain.attributes], dtype=np.bool)
+                         for a in data.domain.attributes], dtype=bool)
         features = [f for f in data.domain.attributes
                     if isinstance(f, method.feature_type)]
         scores = [method(data, f) for f in features]

--- a/Orange/projection/freeviz.py
+++ b/Orange/projection/freeviz.py
@@ -115,7 +115,7 @@ class FreeViz(LinearProjector):
         # handle repulsive force
         mask = (diffclass &
                 (distances > np.finfo(distances.dtype).eps * 100))
-        assert mask.shape == F.shape and mask.dtype == np.bool
+        assert mask.shape == F.shape and mask.dtype == bool
         if p == 1:
             F[mask] = 1 / distances[mask]
         else:

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -446,7 +446,7 @@ class SampleBootstrap(Reprable):
         rgen = np.random.RandomState(self.random_state)
         sample = rgen.randint(0, self.size, self.size)
         sample.sort()  # not needed for the code below, just for the user
-        insample = np.ones((self.size,), dtype=np.bool)
+        insample = np.ones((self.size,), dtype=bool)
         insample[sample] = False
         remaining = np.flatnonzero(insample)
         return remaining, sample

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -2481,7 +2481,7 @@ def apply_transform_discete(var, trs):
     dest_codes = positions(dest_values)
     if mapping is not None:
         # construct a lookup table
-        lookup = np.full(len(source_values), np.nan, dtype=np.float)
+        lookup = np.full(len(source_values), np.nan, dtype=float)
         for ci, cj in mapping:
             if ci is not None and cj is not None:
                 i, j = source_codes[ci], dest_codes[cj]
@@ -2631,7 +2631,7 @@ def as_float_or_nan(
     where conversion failed with NaN.
     """
     if out is None:
-        out = np.full(arr.shape, np.nan, np.float if dtype is None else dtype)
+        out = np.full(arr.shape, np.nan, float if dtype is None else dtype)
     if np.issubdtype(arr.dtype, np.inexact) or \
             np.issubdtype(arr.dtype, np.integer):
         np.copyto(out, arr, casting="unsafe", where=where)

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -496,7 +496,7 @@ class OWMergeData(widget.OWWidget):
             return np.arange(len(data))
         if var == INSTANCEID:
             return np.fromiter(
-                (inst.id for inst in data), count=len(data), dtype=np.int)
+                (inst.id for inst in data), count=len(data), dtype=int)
         col = data.get_column_view(var)[0]
         if var.is_primitive():
             col = col.astype(float, copy=False)

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -128,7 +128,7 @@ def delete(command, data, ):
         condition = indices_to_mask(command.indices, len(data))
     else:
         indices = np.asarray(command.indices)
-        if indices.dtype == np.bool:
+        if indices.dtype == bool:
             condition = indices
         else:
             condition = indices_to_mask(indices, len(data))

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -424,7 +424,7 @@ class OWPredictions(OWWidget):
                 sortind = numpy.argsort(
                     [sort_source.mapToSource(sort_source.index(i, 0)).row()
                      for i in range(n)])
-                sortind = numpy.array(sortind, numpy.int)
+                sortind = numpy.array(sortind, int)
                 sortindicatorshown = True
             else:
                 sortind = None
@@ -859,7 +859,7 @@ class SortProxyModel(QSortFilterProxyModel):
 
     def setSortIndices(self, indices):
         if indices is not None:
-            indices = numpy.array(indices, dtype=numpy.int)
+            indices = numpy.array(indices, dtype=int)
             if indices.shape != (self.rowCount(),):
                 raise ValueError("indices.shape != (self.rowCount(),)")
             indices.flags.writeable = False

--- a/Orange/widgets/visualize/utils/lac.py
+++ b/Orange/widgets/visualize/utils/lac.py
@@ -91,7 +91,7 @@ def lac(conts, k, nsteps=30, window_size=1):
     print("Done")
 
     w = [np.empty((k, len(c[0]),)) for c in conts]
-    active = np.ones(k, dtype=np.bool)
+    active = np.ones(k, dtype=bool)
 
     for i in range(1, nsteps + 1):
         for l, (c, cw) in enumerate(conts):


### PR DESCRIPTION
##### Issue

`np.int`, `np.float` and `np.bool` are deprecated and should be replaced with `int`, `float` and `bool` to avoid warnings (https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).

##### Description of changes

~~Besides those, I also replaced most `int64` and `float64`, which are the same as `int` and `float` on supported platforms.~~

##### Includes
- [X] Code changes

Coverage tests don't and won't pass: the missed lines were already missed before.