### PR TITLE
[FIX] Remove PyQt5 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ conda install orange3-<addon name>
 
 ### Installing with pip
 
-We recommend using our [standalone installer](https://orange.biolab.si/download) or conda, but Orange is also installable with pip. You will need a C/C++ compiler (on Windows we suggest using Microsoft Visual Studio Build Tools).
+We recommend using our [standalone installer](https://orange.biolab.si/download) or conda, but Orange is also installable with pip. You will need a C/C++ compiler (on Windows we suggest using Microsoft Visual Studio Build Tools). For Orange to run, you will also need to install `pyqt5` and `pyqtwebengine`.
 
 
 ### Installing with winget (Windows only)

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,8 +1,13 @@
 orange-canvas-core>=0.1.21,<0.2a
 orange-widget-base>=4.13.0
 
-PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
-PyQtWebEngine>=5.12
+# Orange indeed requires PyQt5 to run. Here, PyQt5 and its webengine are
+# commented out because they produce conflicts in conda environments.
+# pip users need to install them manually.
+#
+# PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
+# PyQtWebEngine>=5.12
+
 AnyQt>=0.0.11
 
 pyqtgraph>=0.11.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,17 @@ if sys.version_info < (3, 4):
     sys.exit('Orange requires Python >= 3.4')
 
 try:
+    import PyQt5.QtCore
+    if PyQt5.QtCore.QT_VERSION < 0x050C00:  # 5.12
+        raise ImportError("Unsupported PyQt5 version is installed")
+except ImportError:
+    sys.exit('''Orange requires PyQt5 >= 5.12, which needs to be installed manually.
+On a pip-based installation, run:
+    pip install PyQt5>=5.12 pyqtwebengine>=5.12
+On a conda-based installation, run:
+    conda install pyqt>=5.12''')
+
+try:
     import numpy
     have_numpy = True
 except ImportError:


### PR DESCRIPTION
The PyQt5 dependency conflicts with conda, where the same package is called pyqt. Installing pyqt5 inside a conda environment may be catastrophic. Removing the dependency makes pip installation into conda environments safer; such installations frequently occur when users installs an add-on not available in the conda repos that requires a newer version of Orange . The same issue appears when Anaconda users try to update Orange with the Add-on dialog box. Or when someone who installed Orange with conda downloads the master branch and does "pip install -e .".

Some related bug reports: gh-5559. gh-5070

Orange added the PyQt5 dependency about a year ago to make pip installations friendlier (gh-4849). Unfortunately, that caused more problems than it fixed.

For some context: ContinuumIO/anaconda-issues#1554

This needs at least the following addtional work:
- [x] Fix CI
- [x] Update pip installation instructions

But then, I am not sure how we should approach fixing #4763, which should be reopened. Perhaps Orange could print a warning if a non-supported version of Qt is used?

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
