### PR TITLE
owpredictions: Do not call resizeColumnsToContents before delegate update

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -411,8 +411,6 @@ class OWPredictions(OWWidget):
                 self._update_data_sort_order, self.predictionsview,
                 self.dataview))
 
-        self.predictionsview.resizeColumnsToContents()
-
     def _update_data_sort_order(self, sort_source_view, sort_dest_view):
         sort_dest = sort_dest_view.model()
         sort_source = sort_source_view.model()

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -175,6 +175,21 @@ class TestOWPredictions(WidgetTest):
         self.send_signal(self.widget.Inputs.predictors, cl_data, 1)
         self.send_signal(self.widget.Inputs.data, data)
 
+    def test_changed_class_var(self):
+        def set_input(data, model):
+            self.send_signals([
+                (self.widget.Inputs.data, data),
+                (self.widget.Inputs.predictors, model)
+            ])
+        iris = self.iris
+        learner = ConstantLearner()
+        heart_disease = Table("heart_disease")
+        # catch exceptions in item delegates etc. during switching inputs
+        with excepthook_catch():
+            set_input(iris[:5], learner(iris))
+            set_input(Table("housing"), None)
+            set_input(heart_disease[:5], learner(heart_disease))
+
     def test_predictor_fails(self):
         titanic = Table("titanic")
         failing_model = ConstantLearner()(titanic)


### PR DESCRIPTION


##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-5567

##### Description of changes

* Do not call resizeColumnsToContents before delegate update


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
