### PR TITLE
[FIX] owrocanalysis: Fix test for non empty points array

### DIFF
--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -668,7 +668,7 @@ class OWROCAnalysis(widget.OWWidget):
 
             sp = curve.curve_item.childItems()[0]  # type: pg.ScatterPlotItem
             act_pos = sp.mapFromScene(pos)
-            pts = sp.pointsAt(act_pos)
+            pts = list(sp.pointsAt(act_pos))
 
             if pts:
                 mouse_pt = pts[0].pos()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

ROC Analysis raises 

```
---------------------------- ValueError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/Documents/workspace/orange3/Orange/widgets/evaluate/owrocanalysis.py", line 674, in _on_mouse_moved
    if pts:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
-------------------------------------------------------------------------------
```
on mouse hover when two (or more) hovered threshold points are close to each other in viewport.

E.g on Ionospere with logistic regression:

![Screen Shot 2021-08-27 at 15 31 16](https://user-images.githubusercontent.com/4716745/131135507-9a5c858f-9ec1-4dbb-b0f3-cd5a24a9e619.png)

run the mouse cursor over the curve on a small sized ROC Analysis plot.

##### Description of changes

* Fix test for non empty points array

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
