### PR TITLE
[FIX] setup.py: do not overwrite conda's PyQt5

### DIFF
--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,8 +1,6 @@
 orange-canvas-core>=0.1.21,<0.2a
 orange-widget-base>=4.13.0
 
-PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
-PyQtWebEngine>=5.12
 AnyQt>=0.0.11
 
 pyqtgraph>=0.11.1

--- a/requirements-pyqt.txt
+++ b/requirements-pyqt.txt
@@ -1,0 +1,2 @@
+PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
+PyQtWebEngine>=5.12

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,13 @@ try:
 except ImportError:
     have_cython = False
 
+try:
+    import PyQt5.QtCore  # pylint: disable=unused-import
+    have_pyqt5 = True
+except ImportError:
+    have_pyqt5 = False
+
+is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 
 NAME = 'Orange3'
 
@@ -77,6 +84,12 @@ CLASSIFIERS = [
 ]
 
 requirements = ['requirements-core.txt', 'requirements-gui.txt']
+
+# pyqt5 is named pyqt5 on pypi and pyqt on conda
+# due to possible conflicts, skip the pyqt5 requirement in conda environments
+# that already have pyqt
+if not (is_conda and have_pyqt5):
+    requirements.append('requirements-pyqt.txt')
 
 INSTALL_REQUIRES = sorted(set(
     line.partition('#')[0].strip()


### PR DESCRIPTION
The PyQt5 dependency conflicts with conda, where the same package is called pyqt. Installing pyqt5 inside a conda environment that already contains pyqt may be catastrophic. Removing the dependency makes pip installation into conda environments safer; such installations frequently occur when users install an add-on not available in the conda repos that requires a newer version of Orange. The same issue appears when Anaconda users try to update Orange with the Add-on dialog box. Or when someone who installed Orange with conda downloads the master branch and does `pip install -e .`.

Orange added the PyQt5 dependency about a year ago to make pip installations friendlier. Unfortunately, that caused more problems than it fixed. 

##### Description of changes

This is an alternative to #5566.

This commit modifies setup.py to only installs PyQt5 in a conda environment if PyQt5 could not be imported. I presume this is safe.

While I dislike that requirements are now not so easily determined with this PR, it should not change anything for non-conda installs. For conda environments, it correctly handles the following:
- `pip install -e .` in a conda installed orange3 environment will not install double (conflicting) PyQts (fixed with this PR)
- `pip install orange3` in a fresh conda environment will still install pyqt5 from pip (as before)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
