### PR TITLE
[ENH] config: sort example workflows

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -176,16 +176,17 @@ class Config(config.Config):
         """
         Return an iterator over the entry points yielding 'Example Workflows'
         """
-        # `iter_entry_points` yields them in unspecified order, so we insert
-        # our first
+        # `iter_entry_points` yields them in unspecified order, so we order
+        # them by name. The default is at the beginning, unless another
+        # entrypoint precedes it alphabetically (e.g. starting with '!').
         default_ep = pkg_resources.EntryPoint(
-            "Orange3", "Orange.canvas.workflows",
+            "000-Orange3", "Orange.canvas.workflows",
             dist=pkg_resources.get_distribution("Orange3"))
 
-        return itertools.chain(
-            (default_ep,),
-            pkg_resources.iter_entry_points("orange.widgets.tutorials")
-        )
+        all_ep = list(pkg_resources.iter_entry_points("orange.widgets.tutorials"))
+        all_ep.append(default_ep)
+        all_ep.sort(key=lambda x: x.name)
+        return iter(all_ep)
 
     APPLICATION_URLS = {
         #: Submit a bug report action in the Help menu

--- a/Orange/widgets/tests/test_workflows.py
+++ b/Orange/widgets/tests/test_workflows.py
@@ -2,6 +2,7 @@ from itertools import chain
 from os import listdir, environ
 from os.path import isfile, join, dirname
 import unittest
+import pkg_resources
 
 from orangecanvas.registry import WidgetRegistry
 from orangewidget.workflow import widgetsscheme
@@ -54,3 +55,19 @@ class TestWorkflows(GuiTest):
                               format(ows_file, str(e)))
                 finally:
                     new_scheme.clear()
+
+    def test_examples_order(self):
+        # register test entrypoints
+        dist_orange = pkg_resources.working_set.by_key['orange3']
+        ep_map = dist_orange.get_entry_map()
+        ep_first = pkg_resources.EntryPoint('!Testname', 'orangecontrib.any_addon.tutorials')
+        ep_last = pkg_resources.EntryPoint('exampletutorials', 'orangecontrib.other_addon.tutorials')
+        ep_map['orange.widgets.tutorials'] = {ep_first.name: ep_first, ep_last.name: ep_last}
+
+        entry_points = list(Config.examples_entry_points())
+
+        self.assertEqual(entry_points[0].name, ep_first.name)
+        self.assertEqual(entry_points[1].name, '000-Orange3')
+        self.assertEqual(entry_points[2].name, ep_last.name)
+
+        del ep_map['orange.widgets.tutorials']


### PR DESCRIPTION
##### Issue
Suggestion for biolab/orange-canvas-core#203

##### Description of changes

The tutorial entrypoints are sorted by name to make the order of the example workflows adjustable.
The entry point name for the default workflows starts with '000' so that they are at the beginning. 
Unless the entrypoint name of another add-on starts with e.g. '!'
This way, example workflows could also be placed at the very beginning.
Normally the entrypoints are called 'exampletutorials' and are appended to the defaults. With a prefix ('100', '200') the order between different add-ons can be controlled.

The sorting could also be moved to orange-canvas-core/orangecanvas/application/examples.py, because the add-on-internal sorting is already there.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
