### PR TITLE
[FIX] Fixes for scikit-learn 1.0

### DIFF
--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -176,7 +176,7 @@ class RadvizVizRank(VizRankDialog, OWComponent):
         data = self.data.transform(domain)
         projector = RadViz()
         projection = projector(data)
-        radviz_xy = projection(data)
+        radviz_xy = projection(data).X
         y = projector.preprocess(data).Y
         return -self._evaluate_projection(radviz_xy, y)
 


### PR DESCRIPTION
##### Issue

Tests fail after release of scikit-learn 1.0.

- Scikit's fit checks whether the object has `columns` to distinguish between arrays and pandas frame. `Orange.data.Table` also has `columns`, but with different content, which caused a problem when (incorrectly) passed to scikit.
- ROC has tests for tooltips, which use test results for Titanic with kNN. Scikit changed something in kNN so that all returned probabilities are 0 or 1 (when k=5, this is not entirely unexpected).

##### Changes

- I fixed the call to kNN to pass an array `X`, not the whole `Table`.
- The offending test for ROC now uses artificial test results, not results from an actual model.

**To be considered:** `Orange.data.Table`'s property `columns`, which contains an instance of this: https://github.com/biolab/orange3/blob/03e8adaf41dac18d747c7f47afd7262c493fa951/Orange/data/table.py#L190  is unknown, strange, useless and to my knowledge unused.  I assume it was there for easier access to columns when working with Orange interactively. I would just remove it without any deprecation period.


##### Includes
- [X] Code changes
- [x] Tests
- Documentation N/A
