### PR TITLE
XGBoost: Temporary workaround before release of v1.5

### DIFF
--- a/Orange/classification/xgb.py
+++ b/Orange/classification/xgb.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-arguments
 from typing import Tuple
+import sys
 
 import numpy as np
 
@@ -11,6 +12,9 @@ from Orange.data import Variable, DiscreteVariable, Table
 from Orange.preprocess.score import LearnerScorer
 
 __all__ = ["XGBClassifier", "XGBRFClassifier"]
+
+# Temporary workaround for https://github.com/dmlc/xgboost/issues/7156
+N_JOBS = 1 if sys.platform == "darwin" else None
 
 
 class _FeatureScorerMixin(LearnerScorer):
@@ -33,7 +37,7 @@ class XGBClassifier(XGBBase, Learner, _FeatureScorerMixin):
                  objective="binary:logistic",
                  booster=None,
                  tree_method=None,
-                 n_jobs=None,
+                 n_jobs=N_JOBS,
                  gamma=None,
                  min_child_weight=None,
                  max_delta_step=None,
@@ -96,7 +100,7 @@ class XGBRFClassifier(XGBBase, Learner, _FeatureScorerMixin):
                  objective="binary:logistic",
                  booster=None,
                  tree_method=None,
-                 n_jobs=None,
+                 n_jobs=N_JOBS,
                  gamma=None,
                  min_child_weight=None,
                  max_delta_step=None,

--- a/Orange/modelling/tests/test_xgb.py
+++ b/Orange/modelling/tests/test_xgb.py
@@ -1,5 +1,7 @@
 import unittest
 from typing import Callable, Union
+from datetime import datetime
+
 
 from Orange.data import Table
 from Orange.evaluation import CrossValidation
@@ -24,6 +26,11 @@ class TestXGB(unittest.TestCase):
     def setUpClass(cls):
         cls.iris = Table("iris")
         cls.housing = Table("housing")
+
+    def test_xgboost_workaround(self):
+        self.assertLess(datetime.today(), datetime(2021, 10, 15),
+                        "\nCheck the new release of xgboost and revert this "
+                        "commit if possible, or do something else if not.")
 
     @test_learners
     def test_cls(self, learner_class: Union[XGBLearner, XGBRFLearner]):

--- a/Orange/regression/xgb.py
+++ b/Orange/regression/xgb.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-many-arguments
 from typing import Tuple
+import sys
 
 import numpy as np
 import xgboost
@@ -10,6 +11,9 @@ from Orange.preprocess.score import LearnerScorer
 from Orange.regression import Learner
 
 __all__ = ["XGBRegressor", "XGBRFRegressor"]
+
+# Temporary workaround for https://github.com/dmlc/xgboost/issues/7156
+N_JOBS = 1 if sys.platform == "darwin" else None
 
 
 class _FeatureScorerMixin(LearnerScorer):
@@ -32,7 +36,7 @@ class XGBRegressor(XGBBase, Learner, _FeatureScorerMixin):
                  objective="reg:squarederror",
                  booster=None,
                  tree_method=None,
-                 n_jobs=None,
+                 n_jobs=N_JOBS,
                  gamma=None,
                  min_child_weight=None,
                  max_delta_step=None,
@@ -84,7 +88,7 @@ class XGBRFRegressor(XGBBase, Learner, _FeatureScorerMixin):
                  objective="reg:squarederror",
                  booster=None,
                  tree_method=None,
-                 n_jobs=None,
+                 n_jobs=N_JOBS,
                  gamma=None,
                  min_child_weight=None,
                  max_delta_step=None,


### PR DESCRIPTION
##### Issue

XGBoost fails on macOS is the number of jobs is left at default (details in https://github.com/dmlc/xgboost/issues/7156). This should be fixed in new release at around Oct 11, 2021.

##### Description of changes

- Set `n_jobs` to `1` on macOS
- Add a test that will fail after Oct 15, to remind us to remove the workaround.

##### Includes
- [X] Code changes
- [X] Tests
- N/A: Documentation
