### PR TITLE
Variable: fix timezone when parsing time variable

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -630,6 +630,10 @@ class TestTimeVariable(VariableTest):
         ts2 = var.parse(datestr)
         self.assertEqual(var.repr_val(ts2), datestr)
         self.assertEqual(var.repr_val(ts1), '2015-10-18 20:48:20')
+        # TZ is reset to UTC.
+        datestr, offset = '2015-10-18T22:48:20', '+02:00'
+        ts3 = var.parse(datestr + offset)
+        self.assertEqual(var.repr_val(ts3), '2015-10-18 20:48:20')
 
     def test_parse_timestamp(self):
         var = TimeVariable("time")

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -1032,6 +1032,7 @@ class TimeVariable(ContinuousVariable):
         if datestr in MISSING_VALUES:
             return Unknown
         datestr = datestr.strip().rstrip('Z')
+        datestr = self._tzre_sub(datestr)
 
         if not self._matches_iso_format(datestr):
             try:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Sometimes, datetime variables would come in the following format
`YYYY-mm-ddTHH:MM:SS+zz:zz`
which is not accepted by the `parse()` method.

##### Description of changes
Fix datetime to the correct format before parsing.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
