### PR TITLE
Catboost: do not test default learning rate in widget tests

### DIFF
--- a/Orange/widgets/model/tests/test_owgradientboosting.py
+++ b/Orange/widgets/model/tests/test_owgradientboosting.py
@@ -281,7 +281,7 @@ class TestCatGBLearnerEditor(GuiTest):
         self.assertEqual(params["l2_leaf_reg"], self.editor.lambda_)
         self.assertEqual(params["rsm"], self.editor.colsample_bylevel)
         self.assertEqual(self.editor.learning_rate, 0.3)
-        self.assertEqual(round(params["learning_rate"], 3), 0.006)
+        # params["learning_rate"] is automatically defined so don't test it
 
     @unittest.skipIf(CatGBRegressor is None, "Missing 'catboost' package")
     def test_default_parameters_reg(self):
@@ -295,8 +295,7 @@ class TestCatGBLearnerEditor(GuiTest):
         self.assertEqual(params["l2_leaf_reg"], self.editor.lambda_)
         self.assertEqual(params["rsm"], self.editor.colsample_bylevel)
         self.assertEqual(self.editor.learning_rate, 0.3)
-        self.assertEqual(round(params["learning_rate"], 3), 0.035)
-
+        # params["learning_rate"] is automatically defined so don't test it
 
 class TestOWGradientBoosting(WidgetTest, WidgetLearnerTestMixin):
     def setUp(self):


### PR DESCRIPTION
If learning_rate is None, which is the default, it is automatically defined. The previous version, 0.26.1, and the current version, 1.0, set learning_rate differently. It does not make sense to test the default learner value in the widget: the widget imposes a set value anyway and therefore does neither use now allow the automatic setting.

##### Issue

```
 ======================================================================
FAIL: test_default_parameters_reg (Orange.widgets.model.tests.test_owgradientboosting.TestCatGBLearnerEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/orange3/orange3/.tox/orange-released/lib/python3.8/site-packages/Orange/widgets/model/tests/test_owgradientboosting.py", line 298, in test_default_parameters_reg
    self.assertEqual(round(params["learning_rate"], 3), 0.035)
AssertionError: 0.037 != 0.035
```