### PR TITLE
config: Use explicit AppUserModelID on Windows

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -69,6 +69,7 @@ class Config(config.Config):
     OrganizationDomain = "biolab.si"
     ApplicationName = "Orange"
     ApplicationVersion = Orange.__version__
+    AppUserModelID = "Biolab.Orange"  # AppUserModelID for windows task bar
 
     def init(self):
         super().init()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes: https://github.com/biolab/orange3/issues/5383

Uses https://github.com/biolab/orange-canvas-core/pull/207

##### Description of changes

Use explicit AppUserModelID on Windows

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
