### PR TITLE
Distances: Move ignored attributes to metas

### DIFF
--- a/Orange/distance/base.py
+++ b/Orange/distance/base.py
@@ -34,22 +34,29 @@ def _preprocess(table, impute=True):
 
 # TODO I have put this function here as a substitute the above `_preprocess`.
 # None of them really belongs here; (re?)move them, eventually.
-def remove_discrete_features(data):
+def remove_discrete_features(data, to_metas=False):
     """Remove discrete columns from the data."""
     new_domain = Domain(
         [a for a in data.domain.attributes if a.is_continuous],
         data.domain.class_vars,
-        data.domain.metas)
+        data.domain.metas
+        + (() if not to_metas
+           else tuple(a for a in data.domain.attributes if not a.is_continuous))
+    )
     return data.transform(new_domain)
 
 
-def remove_nonbinary_features(data):
+def remove_nonbinary_features(data, to_metas=False):
     """Remove non-binary columns from the data."""
     new_domain = Domain(
         [a for a in data.domain.attributes
          if a.is_discrete and len(a.values) == 2],
         data.domain.class_vars,
-        data.domain.metas)
+        data.domain.metas +
+        (() if not to_metas
+         else tuple(a for a in data.domain.attributes
+               if not (a.is_discrete and len(a.values) == 2))
+         if to_metas else ()))
     return data.transform(new_domain)
 
 def impute(data):

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -158,7 +158,7 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
                     self.Error.no_continuous_features()
                     return False
                 self.Warning.ignoring_discrete()
-                data = distance.remove_discrete_features(data)
+                data = distance.remove_discrete_features(data, to_metas=True)
             return True
 
         def _fix_nonbinary():
@@ -171,7 +171,8 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
                     return False
                 elif nbinary < len(data.domain.attributes):
                     self.Warning.ignoring_nonbinary()
-                    data = distance.remove_nonbinary_features(data)
+                    data = distance.remove_nonbinary_features(data,
+                                                              to_metas=True)
             return True
 
         def _fix_missing():


### PR DESCRIPTION
##### Issue

Fixes #5588.

Widget Distances removed ignored attributes (e.g. discrete attributes for cosine distance, non-binary for Jaccard), making them unavailable downstream.

##### Description of changes

Move them to metas instead.

##### Includes
- [X] Code changes
- [X] Tests
