### PR TITLE
[ENH] Feature Constructor: Evaluate categorical variables to strings

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -678,6 +678,7 @@ class OWFeatureConstructor(OWWidget):
         self.closeContext()
 
         self.data = data
+        self.expressions_with_values = False
 
         if self.data is not None:
             descriptors = list(self.descriptors)


### PR DESCRIPTION
##### Issue

Fixes #5510. That is, not the original issue but @markotoplak's comment that Feature Constructor should be modified to be more user-friendly.

##### Description of changes

Values of categorical features are now evaluated to strings, not indices.

Indices were not very useful, also because they referred to indices in a list whose order was not necessarily fixed, therefore this was unstable and dangerous. For this reason -- and because this behaviour wasn't documented anyway  (see https://orangedatamining.com/widget-catalog/data/featureconstructor/) -- the only effort towards backward compatibility in this PR is to remove `.value` from expressions. Plus, the change is noted in the tooltip and documentation.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
