### PR TITLE
[FIX] Fix running OWS with widgets with WebView in Orange.canvas.run

### DIFF
--- a/Orange/canvas/run.py
+++ b/Orange/canvas/run.py
@@ -11,6 +11,9 @@ from orangecanvas.registry import WidgetRegistry, cache
 from orangecanvas.scheme.node import UserMessage
 from orangecanvas.scheme import signalmanager
 
+# Imported to make webwidget addons work
+from Orange.widgets.utils.webview import WebviewWidget  # pylint: disable=unused-import
+
 
 def main(argv=None):
     app = QApplication(list(argv) if argv else [])


### PR DESCRIPTION
##### Issue
Fix of running OWS with widgets with WebView in Orange.canvas.run (more details here: https://github.com/biolab/orange-canvas-core/pull/209)

##### Description of changes
Importing WebviewWidget soon is enough to make the WebView work.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
