### PR TITLE
owlearnerwidget: Use widget's name as the default name

### DIFF
--- a/Orange/widgets/model/owcalibratedlearner.py
+++ b/Orange/widgets/model/owcalibratedlearner.py
@@ -65,14 +65,15 @@ class OWCalibratedLearner(OWBaseLearner):
         self.unconditional_apply()
 
     def _set_default_name(self):
+
         if self.base_learner is None:
-            self.name = "Calibrated learner"
+            self.set_default_learner_name("")
         else:
-            self.name = " + ".join(part for part in (
+            name = " + ".join(part for part in (
                 self.base_learner.name.title(),
                 self.CalibrationShort[self.calibration],
                 self.ThresholdShort[self.threshold]) if part)
-        self.controls.learner_name.setPlaceholderText(self.name)
+            self.set_default_learner_name(name)
 
     def calibration_options_changed(self):
         self._set_default_name()

--- a/Orange/widgets/model/tests/test_owcalibratedlearner.py
+++ b/Orange/widgets/model/tests/test_owcalibratedlearner.py
@@ -155,4 +155,4 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
 
         self.send_signal(widget.Inputs.base_learner, None)
         self.assertEqual(widget.controls.learner_name.placeholderText(),
-                         "Calibrated learner")
+                         "Calibrated Learner")

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -92,6 +92,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
 
     def __init__(self, preprocessors=None):
         super().__init__()
+        self.__default_learner_name = ""
         self.data = None
         self.valid_data = False
         self.learner = None
@@ -118,6 +119,27 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
             OrderedDict or List: (option, value) pairs or dict
         """
         return []
+
+    def default_learner_name(self) -> str:
+        """
+        Return the default learner name.
+
+        By default this is the same as the widget's name.
+        """
+        return self.__default_learner_name or self.captionTitle
+
+    def set_default_learner_name(self, name: str) -> None:
+        """
+        Set the default learner name if not otherwise specified by the user.
+        """
+        changed = name != self.__default_learner_name
+        if name:
+            self.name_line_edit.setPlaceholderText(name)
+        else:
+            self.name_line_edit.setPlaceholderText(self.captionTitle)
+        self.__default_learner_name = name
+        if not self.learner_name and changed:
+            self.learner_name_changed()
 
     @Inputs.preprocessor
     def set_preprocessor(self, preprocessor):
@@ -154,7 +176,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         if self.learner and issubclass(self.LEARNER, Fitter):
             self.learner.use_default_preprocessors = True
         if self.learner is not None:
-            self.learner.name = self.learner_name or self.captionTitle
+            self.learner.name = self.effective_learner_name()
         self.Outputs.learner.send(self.learner)
         self.outdated_settings = False
         self.Warning.outdated_learner.clear()
@@ -203,7 +225,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
 
     def _change_name(self, instance, output):
         if instance:
-            instance.name = self.learner_name or self.captionTitle
+            instance.name = self.effective_learner_name()
             if self.auto_apply:
                 output.send(instance)
 
@@ -211,8 +233,12 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         self._change_name(self.learner, self.Outputs.learner)
         self._change_name(self.model, self.Outputs.model)
 
+    def effective_learner_name(self):
+        """Return the effective learner name."""
+        return self.learner_name or self.name_line_edit.placeholderText()
+
     def send_report(self):
-        self.report_items((("Name", self.learner_name or self.captionTitle),))
+        self.report_items((("Name", self.effective_learner_name()),))
 
         model_parameters = self.get_learner_parameters()
         if model_parameters:
@@ -275,9 +301,10 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
 
     def setCaption(self, caption):
         super().setCaption(caption)
-        self.name_line_edit.setPlaceholderText(caption)
-        if not self.learner_name:
-            self.learner_name_changed()
+        if not self.__default_learner_name:
+            self.name_line_edit.setPlaceholderText(caption)
+            if not self.learner_name:
+                self.learner_name_changed()
 
     def add_bottom_buttons(self):
         self.apply_button = gui.auto_apply(self.buttonsArea, self, commit=self.apply)

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -154,7 +154,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         if self.learner and issubclass(self.LEARNER, Fitter):
             self.learner.use_default_preprocessors = True
         if self.learner is not None:
-            self.learner.name = self.learner_name or self.name
+            self.learner.name = self.learner_name or self.captionTitle
         self.Outputs.learner.send(self.learner)
         self.outdated_settings = False
         self.Warning.outdated_learner.clear()
@@ -173,7 +173,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
             except BaseException as exc:
                 self.show_fitting_failed(exc)
             else:
-                self.model.name = self.learner_name or self.name
+                self.model.name = self.learner_name or self.captionTitle
                 self.model.instances = self.data
         self.Outputs.model.send(self.model)
 
@@ -203,7 +203,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
 
     def _change_name(self, instance, output):
         if instance:
-            instance.name = self.learner_name or self.name
+            instance.name = self.learner_name or self.captionTitle
             if self.auto_apply:
                 output.send(instance)
 
@@ -212,7 +212,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         self._change_name(self.model, self.Outputs.model)
 
     def send_report(self):
-        self.report_items((("Name", self.learner_name or self.name),))
+        self.report_items((("Name", self.learner_name or self.captionTitle),))
 
         model_parameters = self.get_learner_parameters()
         if model_parameters:
@@ -269,9 +269,15 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
     def add_learner_name_widget(self):
         self.name_line_edit = gui.lineEdit(
             self.controlArea, self, 'learner_name', box='Name',
-            placeholderText=self.name,
+            placeholderText=self.captionTitle,
             tooltip='The name will identify this model in other widgets',
             orientation=Qt.Horizontal, callback=self.learner_name_changed)
+
+    def setCaption(self, caption):
+        super().setCaption(caption)
+        self.name_line_edit.setPlaceholderText(caption)
+        if not self.learner_name:
+            self.learner_name_changed()
 
     def add_bottom_buttons(self):
         self.apply_button = gui.auto_apply(self.buttonsArea, self, commit=self.apply)

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -183,3 +183,38 @@ class TestOWBaseLearner(WidgetTest):
 
         self.send_signal(w.Inputs.data, None)
         self.assertFalse(error.is_shown())
+
+    def test_default_name(self):
+        class TestLearner(Fitter):
+            name = "Test"
+            __returns__ = Mock()
+
+        class TestWidget(OWBaseLearner):
+            name = "Test"
+            LEARNER = TestLearner
+
+        def check_name(name):
+            self.assertEqual(name, w.effective_learner_name())
+            self.assertEqual(name, self.get_output(w.Outputs.learner, widget=w).name)
+
+        w = self.create_widget(TestWidget)
+
+        check_name("Test")
+        w.setCaption("Foo")
+        check_name("Foo")
+        w.set_default_learner_name("Bar")
+        check_name("Bar")
+        w.setCaption("Frob")
+        check_name("Bar")
+        w.learner_name = "This is not a test"
+        w.learner_name_changed()
+        check_name("This is not a test")
+        w.set_default_learner_name("Bar")
+        check_name("This is not a test")
+        w.setCaption("Blarg")
+        check_name("This is not a test")
+        w.learner_name = ""
+        w.learner_name_changed()
+        check_name("Bar")
+        w.set_default_learner_name("")
+        check_name("Blarg")


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: gh-5489

##### Description of changes

Use widget's name (captionTitle) as the default name

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
