### PR TITLE
[FIX] Distance Matrix: Fix crash on numeric meta vars as labels

### DIFF
--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -49,6 +49,9 @@ class DistanceMatrixModel(QAbstractTableModel):
         self.values = values
         if self.values is not None and not isinstance(self.variable,
                                                       StringVariable):
+            # Meta variables can be of type np.object
+            if values.dtype is not float:
+                values = values.astype(float)
             self.label_colors = variable.palette.values_to_qcolors(values)
         else:
             self.label_colors = None

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -9,7 +9,7 @@ from AnyQt.QtWidgets import QStyleOptionViewItem
 
 from orangewidget.tests.base import GuiTest
 
-from Orange.data import Table
+from Orange.data import Table, Domain, ContinuousVariable, StringVariable
 from Orange.distance import Euclidean
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.unsupervised.owdistancematrix import OWDistanceMatrix, \
@@ -56,6 +56,22 @@ class TestOWDistanceMatrix(WidgetTest):
         ac.setCurrentIndex(idx)
         ac.activated.emit(idx)
         self.assertIsNone(self.widget.tablemodel.label_colors)
+
+    def test_num_meta_labels(self):
+        x, y = (ContinuousVariable(c) for c in "xy")
+        s = StringVariable("s")
+        data = Table.from_list(
+            Domain([x], [], [y, s]),
+            [[0, 1, "a"],
+             [1, np.nan, "b"]]
+        )
+        distances = Euclidean(data)
+        self.widget.set_distances(distances)
+        ac = self.widget.annot_combo
+        idx = ac.model().indexOf(y)
+        ac.setCurrentIndex(idx)
+        ac.activated.emit(idx)
+        self.assertEqual(self.widget.tablemodel.labels, ["1", "?"])
 
 
 class TestDelegates(GuiTest):


### PR DESCRIPTION
##### Issue

Fixes #5651.

If meta attributes contain a numeric and string variable, meta variables have `dtype` `np.object`.

##### Description of changes

 If numeric variable is chosen as a label, its values must be cast to `float` before mapping to colors.

##### Includes
- [X] Code changes
- [X] Tests
