### PR TITLE
[FIX] Projections: Fix color density for continuous color palettes

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1176,8 +1176,9 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             if c_data is None:
                 return
             visible_c_data = self._filter_visible(c_data)
-            mask = np.bitwise_and(np.isfinite(visible_c_data),
-                                  visible_c_data < MAX_COLORS - 1)
+            mask = np.isfinite(visible_c_data)
+            if not self.master.is_continuous_color():
+                mask = np.bitwise_and(mask, visible_c_data < MAX_COLORS - 1)
             pens = self.scatterplot_item.data['pen']
             rgb_data = [
                 pen.color().getRgb()[:3] if pen is not None else (255, 255, 255)


### PR DESCRIPTION
##### Issue

Fixes #5638.

The obvious symptom was that colors density was sometimes not shown. In reality, even when shown, it was sometimes incorrect.

The code ignores the points that are not colored because the corresponding "color index" exceeds the number of availiable colors. This filter should only be applied when coloring according to discrete palettes, not continuous ones.

##### Description of changes

Check that colors are discrete before filtering them.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
