### PR TITLE
Fix for issue #5580, where the calculation of the bins for automatic …

### DIFF
--- a/Orange/widgets/utils/colorpalettes.py
+++ b/Orange/widgets/utils/colorpalettes.py
@@ -406,7 +406,7 @@ class BinnedContinuousPalette(IndexedPalette):
             return palette.copy()
         if isinstance(palette, ContinuousPalette):
             assert len(bins) >= 2
-            mids = (bins[:-1] + bins[1:]) / 2
+            mids = bins[:-1] / 2 + bins[1:] / 2
             bin_colors = palette.values_to_colors(mids, bins[0], bins[-1])
             return cls(
                 palette.friendly_name, palette.name, bin_colors, bins,


### PR DESCRIPTION
…coloring in Scatter Plot may lead to an integer overflow.

##### Issue
Resolves #5580

##### Description of changes
Minor change in Orange/widgets/utils/colorpalettes.py at line 409, of the calculation of mean values, in order to prevent an integer overflow from happening.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
