### PR TITLE
doc: Use sphinx>=4.2.0 which is compatible with newest docutils

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,2 +1,2 @@
-Sphinx>=1.3
+Sphinx>=4.2.0
 recommonmark


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Read the docs use old sphinx version by default, and it is not compatible with docutils >= 0.81

##### Description of changes
Upgrading sphinx version for docuitils

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
