### PR TITLE
Table: extend aggregate module by preprocessing

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -11,7 +11,7 @@ from functools import reduce
 from itertools import chain
 from numbers import Real, Integral
 from threading import Lock
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Tuple
 
 import bottleneck as bn
 import numpy as np
@@ -2248,7 +2248,8 @@ class Table(Sequence, Storage):
         t.ids = self.ids  # preserve indices
         return t
 
-    def groupby(self, columns: List[Variable]) -> "OrangeTableGroupBy":
+    def groupby(self, columns: List[Variable],
+                preprocess_settings: Tuple[str, float, str] = None) -> "OrangeTableGroupBy":
         """
         Group Table by variables defined in the columns list. Behaviour is
         similar to Pandas groupby.
@@ -2257,13 +2258,17 @@ class Table(Sequence, Storage):
         ----------
         columns
             List of variables used to determine the groups
+        preprocess_settings
+            A DataFrame function to be applied to each group before aggregation.
+            Tuple of the function name, the parameter of the function, and the
+            time variable name to use as index, if needed.
 
         Returns
         -------
         GroupBy object of type OrangeTableGroupBy which holds information about
         groups.
         """
-        return Orange.data.aggregate.OrangeTableGroupBy(self, columns)
+        return Orange.data.aggregate.OrangeTableGroupBy(self, columns, preprocess_settings)
 
 
 def _dereferenced(array):

--- a/Orange/data/tests/test_aggregate.py
+++ b/Orange/data/tests/test_aggregate.py
@@ -10,6 +10,7 @@ from Orange.data import (
     StringVariable,
     Table,
     table_to_frame,
+    TimeVariable
 )
 
 
@@ -138,6 +139,26 @@ class DomainTest(unittest.TestCase):
         gb = data.groupby([data.domain["a"]])
         output = gb.aggregate({data.domain["a"]: ["mean"]})
         self.assertIsInstance(output, AlternativeTable)
+
+    def test_range_selection(self):
+        gb = self.data.groupby([self.data.domain["a"]], ('head', 2, None))
+        output = gb.aggregate({self.data.domain["cvar"]: [("Mean", "mean")]})
+
+        np.testing.assert_array_almost_equal(output.X, [[0.15], [1.5]], decimal=3)
+        np.testing.assert_array_almost_equal(output.metas, [[1], [2]], decimal=3)
+
+    def test_time_range_selection(self):
+        time = TimeVariable("time")
+        new_domain = Domain(self.data.domain.attributes + (time, ))
+        table = self.data.transform(new_domain)
+        time_values = np.array([0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6])
+        table[:, time] = time_values.reshape(-1, 1)
+
+        gb = table.groupby([table.domain["a"]], ('last', 1.5, 'time'))
+        output = gb.aggregate({table.domain["cvar"]: [("Mean", "mean")]})
+
+        np.testing.assert_array_almost_equal(output.X, [[0.433], [2.0]], decimal=3)
+        np.testing.assert_array_almost_equal(output.metas, [[1], [2]], decimal=3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

These are the modifications of OrangeTableGroupBy and Table.groupby() to allow preprocessing / range selection for each group, mentioned in [https://github.com/biolab/orange3/pull/5541#issuecomment-935617593](https://github.com/biolab/orange3/pull/5541#issuecomment-935617593) 

This allows preprocessing via scripting. Optionally, one could make a widget that is based on this.

##### Description of changes
The Table.groupby() functions gets a new parameter with which the preprocessing can be set.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
