### PR TITLE
[FIX] pandas_compat: do not parse column of numbers (object dtype) to datetime

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -157,6 +157,16 @@ def _is_datetime(s):
         return True
     try:
         if is_object_dtype(s):
+            # pd.to_datetime would sucessfuly parse column of numbers to datetime
+            # but for column of object dtype with numbers we want to be either
+            # discret or string - following code try to parse column to numeric
+            # if connversion to numeric is sucessful return False
+            try:
+                pd.to_numeric(s)
+                return False
+            except (ValueError, TypeError):
+                pass
+
             # utc=True - to allow different timezones in a series object
             pd.to_datetime(s, infer_datetime_format=True, utc=True)
             return True

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -383,6 +383,25 @@ class TestPandasCompat(unittest.TestCase):
             ],
         )
 
+    def test_table_from_frame_no_datetim(self):
+        """
+        In case when dtype of column is object and column contains numbers only,
+        column could be recognized as a TimeVarialbe since pd.to_datetime can parse
+        numbers as datetime. That column must be result either in StringVariable
+        or DiscreteVariable since it's dtype is object.
+        """
+        from Orange.data.pandas_compat import table_from_frame
+
+        df = pd.DataFrame([[1], [2], [3]], dtype="object")
+        table = table_from_frame(df)
+        # check if exactly ContinuousVariable and not subtype TimeVariable
+        self.assertIsInstance(table.domain.metas[0], StringVariable)
+
+        df = pd.DataFrame([[1], [2], [2]], dtype="object")
+        table = table_from_frame(df)
+        # check if exactly ContinuousVariable and not subtype TimeVariable
+        self.assertIsInstance(table.domain.attributes[0], DiscreteVariable)
+
     def test_time_variable_compatible(self):
         from Orange.data.pandas_compat import table_from_frame
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Column with numbers with dtype object was parsed as a TimeVariable

##### Description of changes
I think it should be parsed as DiscreteVariable or StringVariable since dtype is object

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
