### PR TITLE
[ENH] Scatterplot: Use opacity for contrast

### DIFF
--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -635,12 +635,12 @@ class TestOWScatterPlotBase(WidgetTest):
             self.master.get_subset_mask = lambda: np.arange(10) >= 5
             graph.update_colors()
             brushes = graph.scatterplot_item.data["brush"]
-            self.assertEqual(brushes[0].color().alpha(), 0)
-            self.assertEqual(brushes[1].color().alpha(), 0)
-            self.assertEqual(brushes[4].color().alpha(), 0)
-            self.assertEqual(brushes[5].color().alpha(), 123)
-            self.assertEqual(brushes[6].color().alpha(), 123)
-            self.assertEqual(brushes[7].color().alpha(), 123)
+            a0 = brushes[0].color().alpha()
+            self.assertEqual(brushes[1].color().alpha(), a0)
+            self.assertEqual(brushes[4].color().alpha(), a0)
+            self.assertGreater(brushes[5].color().alpha(), a0)
+            self.assertGreater(brushes[6].color().alpha(), a0)
+            self.assertGreater(brushes[7].color().alpha(), a0)
 
         graph = self.graph
 


### PR DESCRIPTION
##### Issue

Ref: #5425 

Instead of introducing a new slider, the opacity slider behaves differently in presence of a subset: it still regulates the opacity of the brush of subset, but at the same time it decreases the opacity of the pen of points not in the subset. The slider is still named opacity because I don't think the user will notice that (s)he now essentially regulates the contrast.

For now I implemented this for discrete coloring. If we decide that we like it, I'll change the continuous palette and monochromatic scatterplot in the same fashion.

Comments welcome.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
