### PR TITLE
Slider label widths

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -6,7 +6,8 @@ import numpy as np
 from scipy.stats import norm, rayleigh, beta, gamma, pareto, expon
 
 from AnyQt.QtWidgets import QGraphicsRectItem
-from AnyQt.QtGui import QColor, QPen, QBrush, QPainter, QPalette, QPolygonF
+from AnyQt.QtGui import QColor, QPen, QBrush, QPainter, QPalette, QPolygonF, \
+    QFontMetrics
 from AnyQt.QtCore import Qt, QRectF, QPointF, pyqtSignal as Signal
 from orangewidget.utils.listview import ListViewSearch
 import pyqtgraph as pg
@@ -498,13 +499,17 @@ class OWDistributions(OWWidget):
 
     def _set_bin_width_slider_label(self):
         if self.number_of_bins < len(self.binnings):
-            text = reduce(
-                lambda s, rep: s.replace(*rep),
-                short_time_units.items(),
+            text = self._short_text(
                 self.binnings[self.number_of_bins].width_label)
         else:
             text = ""
         self.bin_width_label.setText(text)
+
+    @staticmethod
+    def _short_text(label):
+        return reduce(
+            lambda s, rep: s.replace(*rep),
+            short_time_units.items(), label)
 
     def _on_show_probabilities_changed(self):
         label = self.controls.fitted_distribution.label
@@ -879,12 +884,16 @@ class OWDistributions(OWWidget):
             if np.any(np.isfinite(column)):
                 if self.var.is_time:
                     self.binnings = time_binnings(column, min_unique=5)
-                    self.bin_width_label.setFixedWidth(45)
                 else:
                     self.binnings = decimal_binnings(
                         column, min_width=self.min_var_resolution(self.var),
                         add_unique=10, min_unique=5)
-                    self.bin_width_label.setFixedWidth(35)
+                fm = QFontMetrics(self.font())
+                width = max(fm.size(Qt.TextSingleLine,
+                                    self._short_text(binning.width_label)
+                                    ).width()
+                            for binning in self.binnings)
+                self.bin_width_label.setFixedWidth(width)
                 max_bins = len(self.binnings) - 1
         else:
             self.binnings = []

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -96,9 +96,11 @@ class OWPythagorasTree(OWWidget):
 
         # Display settings area
         box_display = gui.widgetBox(self.controlArea, 'Display Settings')
+        # maxValue is set to a wide three-digit number to probably ensure the
+        # proper label width. The maximum is later set to match the tree depth
         self.depth_slider = gui.hSlider(
             box_display, self, 'depth_limit', label='Depth', ticks=False,
-            callback=self.update_depth)
+            maxValue=900, callback=self.update_depth)
         self.target_class_combo = gui.comboBox(
             box_display, self, 'target_class_index', label='Target class',
             orientation=Qt.Horizontal, items=[], contentsLength=8,

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -213,8 +213,11 @@ class OWPythagoreanForest(OWWidget):
 
         # Display controls area
         box_display = gui.widgetBox(self.controlArea, 'Display')
+        # maxValue is set to a wide three-digit number to probably ensure the
+        # proper label width. The maximum is later set to match the tree depth
         self.ui_depth_slider = gui.hSlider(
             box_display, self, 'depth_limit', label='Depth', ticks=False,
+            maxValue=900
         )  # type: QSlider
         self.ui_target_class_combo = gui.comboBox(
             box_display, self, 'target_class_index', label='Target class',


### PR DESCRIPTION
##### Issue

Fixes #5675.

##### Description of changes

**Distributions:** Set the width of the slider to match the maximum width
**Pythagorean Tree and Forest:** Set the width to accomodate 900, which is one of the widest three-digit integers.  ;) Checking all depths from 1 to maximal depth is not really necessary IMHO, and setting the width is cumbersome before merging https://github.com/biolab/orange-widget-base/pull/180, so I'd leave it and live with `900`.  Depths will typically be 2-digit anyway.

Labels in Pythagorean trees and forests are misaligned by a few pixels and will look better after merging https://github.com/biolab/orange-widget-base/pull/180 (though merging it is not required for this PR).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
