### PR TITLE
statistics.util: avoid memory wasting np.nanmean and np.nanvar

### DIFF
--- a/Orange/distance/tests/test_distance.py
+++ b/Orange/distance/tests/test_distance.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 from math import sqrt
 
 import numpy as np
@@ -715,12 +714,6 @@ class ManhattanDistanceTest(FittedDistanceTest, CommonNormalizedTests):
 
 class CosineDistanceTest(FittedDistanceTest, CommonFittedTests):
     Distance = distance.Cosine
-
-    def test_no_data(self):
-        with patch("warnings.warn") as warn:
-            super().test_no_data()
-            self.assertEqual(warn.call_args[0],
-                             ("Mean of empty slice", RuntimeWarning))
 
     def test_cosine_disc(self):
         assert_almost_equal = np.testing.assert_almost_equal

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -347,15 +347,15 @@ def stats(X, weights=None, compute_variance=False):
             w_X = X.multiply(sp.csr_matrix(np.c_[weights] / sum(weights)))
             return np.asarray(w_X.sum(axis=0)).ravel()
         else:
-            return np.nansum(X * np.c_[weights] / sum(weights), axis=0)
+            return bn.nansum(X * np.c_[weights] / sum(weights), axis=0)
 
     if X.size and is_numeric and not is_sparse:
         nans = np.isnan(X).sum(axis=0)
         return np.column_stack((
             np.nanmin(X, axis=0),
             np.nanmax(X, axis=0),
-            np.nanmean(X, axis=0) if not weighted else weighted_mean(),
-            np.nanvar(X, axis=0) if compute_variance else \
+            nanmean(X, axis=0) if not weighted else weighted_mean(),
+            nanvar(X, axis=0) if compute_variance else \
                 np.zeros(X.shape[1] if X.ndim == 2 else 1),
             nans,
             X.shape[0] - nans))
@@ -456,7 +456,7 @@ def nansum(x, axis=None):
 def nanmean(x, axis=None):
     """ Equivalent of np.nanmean that supports sparse or dense matrices. """
     if not sp.issparse(x):
-        means = np.nanmean(x, axis=axis)
+        means = bn.nanmean(x, axis=axis)
     elif axis is None:
         means, _ = mean_variance_axis(x, axis=0)
         means = np.nanmean(means)
@@ -474,7 +474,7 @@ def nanvar(x, axis=None, ddof=0):
         avg = np.nansum(x.data) / n_vals
         return (np.nansum((x.data - avg) ** 2) + avg ** 2 * n_zeros) / (n_vals - ddof)
 
-    return _apply_func(x, np.nanvar, nanvar_sparse, axis=axis)
+    return _apply_func(x, bn.nanvar, nanvar_sparse, axis=axis)
 
 
 def nanstd(x, axis=None, ddof=0):

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -236,9 +236,9 @@ class TestUtil(unittest.TestCase):
     def test_nanvar(self, array):
         for X in self.data:
             X_sparse = array(X)
-            np.testing.assert_array_equal(
+            np.testing.assert_almost_equal(
                 nanvar(X_sparse),
-                np.nanvar(X))
+                np.nanvar(X), decimal=14)  # np.nanvar and bn.nanvar differ slightly
 
     def test_nanvar_with_ddof(self):
         x = np.random.uniform(0, 10, (20, 100))


### PR DESCRIPTION
np.nanmean and np.nanvar create (masked) table copies. This uses unnecessary memory.

##### Issue
Before, sending a table into OWDataTable made a temporary copy, which is a problem with large tables. Probably not that important in practice, since if a copy does not fit then you won't be able to do much, but still ...

##### Description of changes
Replaced `np.nanmean` and `np.nanvar` with bottleneck equivalents.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
