### PR TITLE
Paint Data: Skip points brushed outside

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1214,7 +1214,10 @@ class OWPaintData(OWWidget):
             data = create_data(cmd.pos.x(), cmd.pos.y(),
                                self.brushRadius / 1000,
                                int(1 + self.density / 20), cmd.rstate)
-            self._add_command(Append([QPointF(*p) for p in zip(*data.T)]))
+            data = data[(np.min(data, axis=1) >= 0)
+                        & (np.max(data, axis=1) <= 1), :]
+            if data.size:
+                self._add_command(Append([QPointF(*p) for p in zip(*data.T)]))
         elif isinstance(cmd, Jitter):
             point = np.array([cmd.pos.x(), cmd.pos.y()])
             delta = - apply_jitter(self.__buffer[:, :2], point,


### PR DESCRIPTION
##### Issue & Description of changes

Fixes #5705 by removing points that the brush creates outside the [0, 1] interval.

The widget still applies clipping in the `Append` command. This is probably no longer needed, but let it stay for the case that some other operation also uses it (or would use it in the feature).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
