### PR TITLE
Box Plot: Treat nan's as 0's

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -83,23 +83,21 @@ DiscDataRange = namedtuple("DiscDataRange", ["value", "group_value"])
 
 
 class BoxData:
-    def __init__(self, dist, group_val=None):
-        self.dist = dist
-        self.n = n = np.sum(dist[1])
-        if n == 0:
+    def __init__(self, col, group_val=None):
+        self.n = len(col) - np.sum(np.isnan(col))
+        if self.n == 0:
             return
-        self.a_min = float(dist[0, 0])
-        self.a_max = float(dist[0, -1])
-        self.mean = float(np.sum(dist[0] * dist[1]) / n)
-        self.var = float(np.sum(dist[1] * (dist[0] - self.mean) ** 2) / n)
-        self.dev = math.sqrt(self.var)
-        a, freq = np.asarray(dist)
-        q25, median, q75 = _quantiles(a, freq, [0.25, 0.5, 0.75])
-        self.median = median
-        # The code below omits the q25 or q75 in the plot when they are None
-        self.q25 = None if q25 == median else q25
-        self.q75 = None if q75 == median else q75
-        self.data_range = ContDataRange(q25, q75, group_val)
+        self.a_min = np.nanmin(col)
+        self.a_max = np.nanmax(col)
+        self.mean = np.nanmean(col)
+        self.var = np.nanvar(col)
+        self.dev = np.sqrt(self.var)
+        self.q25, self.median, self.q75 = np.nanquantile(col, [0.25, 0.5, 0.75])
+        self.data_range = ContDataRange(self.q25, self.q75, group_val)
+        if self.q25 == self.median:
+            self.q25 = None
+        if self.q75 == self.median:
+            self.q75 = None
 
 
 class FilterGraphicsRectItem(QGraphicsRectItem):
@@ -385,10 +383,14 @@ class OWBoxPlot(widget.OWWidget):
                 return 3
             if attr.is_continuous:
                 # One-way ANOVA
-                col = data.get_column_view(attr)[0].astype(float)
+                col, sparse = data.get_column_view(attr)
+                col = col.astype(float)
+                if sparse:
+                    col[np.isnan(col)] = 0
                 groups = (col[group_col == i] for i in range(n_groups))
-                groups = (col[~np.isnan(col)] for col in groups)
-                groups = [group for group in groups if len(group)]
+                if not sparse:
+                    groups = (col[~np.isnan(col)] for col in groups)
+                groups = [group for group in groups if len(group) > 1]
                 p = f_oneway(*groups)[1] if len(groups) > 1 else 2
             else:
                 p = self._chi_square(group_var, attr)[1]
@@ -421,11 +423,8 @@ class OWBoxPlot(widget.OWWidget):
             if group is None:
                 return -1
             if attr.is_continuous:
-                group_col = data.get_column_view(group)[0].astype(float)
-                groups = (attr_col[group_col == i]
-                          for i in range(len(group.values)))
-                groups = (col[~np.isnan(col)] for col in groups)
-                groups = [group for group in groups if len(group)]
+                groups = self._group_cols(data, group, attr_col, sparse)
+                groups = [group for group in groups if len(group) > 1]
                 p = f_oneway(*groups)[1] if len(groups) > 1 else 2
             else:
                 p = self._chi_square(group, attr)[1]
@@ -439,7 +438,10 @@ class OWBoxPlot(widget.OWWidget):
         attr = self.attribute
         if self.order_grouping_by_importance:
             if attr.is_continuous:
-                attr_col = data.get_column_view(attr)[0].astype(float)
+                attr_col, sparse = data.get_column_view(attr)
+                attr_col = attr_col.astype(float)
+                if sparse:
+                    attr_col[np.isnan(attr_col)] = 0
             self._sort_list(self.group_vars, self.group_list, compute_stat)
         else:
             self._sort_list(self.group_vars, self.group_list, None)
@@ -525,7 +527,29 @@ class OWBoxPlot(widget.OWWidget):
             if isinstance(box, FilterGraphicsRectItem):
                 box.setSelected(box.data_range in selection)
 
+    def _group_cols(self, data, group, attr, sparse=False):
+        if isinstance(attr, np.ndarray):
+            attr_col = attr
+        else:
+            attr_col, sparse = data.get_column_view(group)[0].astype(float)
+            if np.any(np.isnan(attr_col)):
+                attr_col = attr_col.copy()
+                attr_col[np.isnan(attr_col)] = 0
+        group_col = data.get_column_view(group)[0].astype(float)
+        groups = [attr_col[group_col == i] for i in range(len(group.values))]
+        if not sparse:
+            groups = [col[~np.isnan(col)] for col in groups]
+        return groups
+
     def compute_box_data(self):
+        def attr_col_data():
+            attr_col, sparse = dataset.get_column_view(attr)
+            attr_col = attr_col.astype(float)
+            if sparse:
+                attr_col = attr_col.copy()
+                attr_col[np.isnan(attr_col)] = 0
+            return attr_col, sparse
+
         attr = self.attribute
         if not attr:
             return
@@ -538,29 +562,34 @@ class OWBoxPlot(widget.OWWidget):
             return
         if self.group_var:
             self.dist = None
-            self.conts = contingency.get_contingency(
-                dataset, attr, self.group_var)
             missing_val_str = f"missing '{self.group_var.name}'"
             group_var_labels = self.group_var.values + ("",)
             if self.attribute.is_continuous:
                 stats, label_texts = [], []
-                for cont, value in zip(self.conts.array_with_unknowns,
-                                       group_var_labels):
-                    if np.sum(cont[1]):
-                        stats.append(BoxData(cont, value))
+                attr_col, sparse = attr_col_data()
+                for group, value in \
+                        zip(self._group_cols(dataset, self.group_var,
+                                             attr_col, sparse),
+                            group_var_labels):
+                    if group.size:
+                        stats.append(BoxData(group, value))
                         label_texts.append(value or missing_val_str)
                 self.stats = stats
                 self.label_txts_all = label_texts
             else:
+                self.conts = contingency.get_contingency(
+                    dataset, attr, self.group_var)
                 self.label_txts_all = [
                     v or missing_val_str for v, c in zip(
                         group_var_labels, self.conts.array_with_unknowns)
                     if np.sum(c) > 0]
         else:
-            self.dist = distribution.get_distribution(dataset, attr)
             self.conts = None
             if self.attribute.is_continuous:
-                self.stats = [BoxData(self.dist, None)]
+                attr_col, _ = attr_col_data()
+                self.stats = [BoxData(attr_col)]
+            else:
+                self.dist = distribution.get_distribution(dataset, attr)
             self.label_txts_all = [""]
         self.label_txts = [txts for stat, txts in zip(self.stats,
                                                       self.label_txts_all)
@@ -876,7 +905,7 @@ class OWBoxPlot(widget.OWWidget):
     def draw_axis(self):
         """Draw the horizontal axis and sets self.scale_x"""
         misssing_stats = not self.stats
-        stats = self.stats or [BoxData(np.array([[0.], [1.]]), self.attribute)]
+        stats = self.stats or [BoxData(np.array([0.]), self.attribute)]
         mean_labels = self.mean_labels or [self.mean_label(stats[0], self.attribute, "")]
         bottom = min(stat.a_min for stat in stats)
         top = max(stat.a_max for stat in stats)

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -8,9 +8,8 @@ from AnyQt.QtCore import QItemSelectionModel
 
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain, \
     DiscreteVariable
-from Orange.widgets.visualize.owboxplot import (
-    OWBoxPlot, FilterGraphicsRectItem, _quantiles
-)
+from Orange.widgets.visualize.owboxplot import OWBoxPlot, FilterGraphicsRectItem
+
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.tests import test_filename
 
@@ -281,8 +280,8 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
                  if isinstance(item, FilterGraphicsRectItem)]
         items[0].setSelected(True)
         return [100, 103, 104, 108, 110, 111, 112, 115, 116,
-                120, 123, 124, 126, 128, 132, 133, 136, 137,
-                139, 140, 141, 143, 144, 145, 146, 147, 148]
+                120, 123, 124, 128, 132, 133, 136, 137, 139,
+                140, 141, 143, 144, 145, 146, 147]
 
     def _select_list_items(self, _list):
         for name in _list.model().sourceModel():
@@ -358,43 +357,6 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         for box in self.widget.box_scene.items():
             if isinstance(box, FilterGraphicsRectItem):
                 box.setSelected(True)
-
-
-class TestUtils(unittest.TestCase):
-    def test(self):
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 8 + 1), [1.] * 8, [0.0, 0.25, 0.5, 0.75, 1.0]),
-            [1., 2.5, 4.5, 6.5, 8.]
-        )
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 8 + 1), [1.] * 8, [0.0, 0.25, 0.5, 0.75, 1.0]),
-            [1., 2.5, 4.5, 6.5, 8.]
-        )
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 4 + 1), [1., 2., 1., 2],
-                       [0.0, 0.25, 0.5, 0.75, 1.0]),
-            [1.0, 2.0, 2.5, 4.0, 4.0]
-        )
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 4 + 1), [2., 1., 1., 2.],
-                       [0.0, 0.25, 0.5, 0.75, 1.0]),
-            [1.0, 1.0, 2.5, 4.0, 4.0]
-        )
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 4 + 1), [1., 1., 1., 1.],
-                       [0.0, 0.25, 0.5, 0.75, 1.0]),
-            [1.0, 1.5, 2.5, 3.5, 4.0]
-        )
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 4 + 1), [1., 1., 1., 1.],
-                       [0.0, 0.25, 0.5, 0.75, 1.0], interpolation="higher"),
-            [1, 2, 3, 4, 4]
-        )
-        np.testing.assert_array_equal(
-            _quantiles(range(1, 4 + 1), [1., 1., 1., 1.],
-                       [0.0, 0.25, 0.5, 0.75, 1.0], interpolation="lower"),
-            [1, 1, 2, 3, 4]
-        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### Issue

Fixes #5699. Also fixes #5679.

##### Description of changes

- Avoid computing the continuous contingency matrices, which may change the behaviour of the widget.
- #5679 is fixed as a side-effect of not computing contingency matrices for numeric attributes.
- Prepare the data for computation of statistics and showing it in the plot in the same way. There are still some difference in p-values at the third decimal.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
