### PR TITLE
[ENH] Learner widgets: Inform about potential problems when overriding preprocessors

### DIFF
--- a/Orange/widgets/model/owadaboost.py
+++ b/Orange/widgets/model/owadaboost.py
@@ -102,8 +102,7 @@ class OWAdaBoost(OWBaseLearner):
             self.base_estimator = learner or self.DEFAULT_BASE_ESTIMATOR
             self.base_label.setText(
                 "Base estimator: %s" % self.base_estimator.name.title())
-        if self.auto_apply:
-            self.apply()
+        self.learner = self.model = None
 
     def get_learner_parameters(self):
         return (("Base estimator", self.base_estimator),

--- a/Orange/widgets/model/owcalibratedlearner.py
+++ b/Orange/widgets/model/owcalibratedlearner.py
@@ -62,7 +62,7 @@ class OWCalibratedLearner(OWBaseLearner):
     def set_learner(self, learner):
         self.base_learner = learner
         self._set_default_name()
-        self.unconditional_apply()
+        self.learner = self.model = None
 
     def _set_default_name(self):
 

--- a/Orange/widgets/model/owcurvefit.py
+++ b/Orange/widgets/model/owcurvefit.py
@@ -395,6 +395,7 @@ class OWCurveFit(OWBaseLearner):
 
     def set_data(self, data: Optional[Table]):
         self.Warning.data_missing(shown=not bool(data))
+        self.learner = None
         super().set_data(data)
         self.__clear()
 
@@ -419,7 +420,7 @@ class OWCurveFit(OWBaseLearner):
         self.__init_models()
         self.__enable_controls()
         self.__set_pending()
-        self.unconditional_apply()
+        super().handleNewSignals()
 
     def __preprocess_data(self):
         self.__pp_data = preprocess(self.data, self.preprocessors)

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -94,9 +94,6 @@ class OWLinearRegression(OWBaseLearner):
         self.controls.alpha_index.setEnabled(self.reg_type != self.OLS)
         self.l2_ratio_slider.setEnabled(self.reg_type == self.Elastic)
 
-    def handleNewSignals(self):
-        self.apply()
-
     def _intercept_changed(self):
         self.apply()
 

--- a/Orange/widgets/model/owstack.py
+++ b/Orange/widgets/model/owstack.py
@@ -33,22 +33,26 @@ class OWStackedLearner(OWBaseLearner):
     @Inputs.learners
     def set_learner(self, index: int, learner: Learner):
         self.learners[index] = learner
+        self._invalidate()
 
     @Inputs.learners.insert
     def insert_learner(self, index, learner):
         self.learners.insert(index, learner)
+        self._invalidate()
 
     @Inputs.learners.remove
     def remove_learner(self, index):
         self.learners.pop(index)
+        self._invalidate()
 
     @Inputs.aggregate
     def set_aggregate(self, aggregate):
         self.aggregate = aggregate
+        self._invalidate()
 
-    def handleNewSignals(self):
-        super().handleNewSignals()
-        self.apply()
+    def _invalidate(self):
+        self.learner = self.model = None
+        # ... and handleNewSignals will do the rest
 
     def create_learner(self):
         if not self.learners:


### PR DESCRIPTION
##### Issue

Resolves #5703. Fixes #5577.

##### Description of changes

- Inform when preprocessors are given and the learner has its own default preprocessors, which are thusly overriden.
- Fix invalidation of model and learner, calling of updates and outputting signals.

Missing coverage is mostly in stack learner and was already missed before. This PR won't add tests there.

##### Includes
- [X] Code changes
- [X] Tests
