### PR TITLE
Table lock: fix unlocking unpickled tables

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -582,7 +582,7 @@ class Table(Sequence, Storage):
         def can_unlock(x):
             if sp.issparse(x):
                 return can_unlock(x.data)
-            return x.flags.writeable or x.flags.owndata
+            return x.flags.writeable or x.flags.owndata or x.size == 0
 
         for part, flag, name in self._lock_parts_val():
             if not flag & self._unlocked \

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1430,7 +1430,7 @@ class Table(Sequence, Storage):
         return ((not self._X.shape[-1] or self._X.base is not None) and
                 (not self._Y.shape[-1] or self._Y.base is not None) and
                 (not self._metas.shape[-1] or self._metas.base is not None) and
-                (not self._weights.shape[-1] or self._W.base is not None))
+                (not self._W.shape[-1] or self._W.base is not None))
 
     def is_copy(self):
         """

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -348,6 +348,17 @@ class TestTableLocking(unittest.TestCase):
         finally:
             Table.LOCKING = default
 
+    def test_unpickled_empty_weights(self):
+        # ensure that unpickled empty arrays could be unlocked
+        self.assertEqual(0, self.table.W.size)
+        # flags.owndata asserts touch numpy internals
+        # feel free to remove when they do not pass
+        self.assertTrue(self.table.W.flags.owndata)
+        unpickled = pickle.loads(pickle.dumps(self.table))
+        self.assertFalse(unpickled.W.flags.owndata)
+        with unpickled.unlocked():
+            pass
+
     def test_unpickling_resets_locks(self):
         default = Table.LOCKING
         try:

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -374,15 +374,21 @@ class TestTableLocking(unittest.TestCase):
         finally:
             Table.LOCKING = default
 
-    def test_numpy_pickle_flags_copy(self):
-        # test should warn if numpy starts behaving differently
-        a = np.arange(10).view()
-        a.flags.writeable = False
-        self.assertFalse(a.flags.writeable)
-        self.assertIsNotNone(a.base)
-        b = pickle.loads(pickle.dumps(a))
-        self.assertTrue(b.flags.writeable)
-        self.assertIsNone(b.base)
+    def test_unpickled_owns_data(self):
+        try:
+            default = Table.LOCKING
+            Table.LOCKING = False
+            self.setUp()
+            table = self.table
+            table.X = table.X.view()
+        finally:
+            Table.LOCKING = default
+
+        unpickled = pickle.loads(pickle.dumps(table))
+        self.assertFalse(unpickled.is_view())
+        self.assertTrue(unpickled.is_copy())
+        with unpickled.unlocked():
+            unpickled.X[0, 0] = 42
 
 
 class TestTableFilters(unittest.TestCase):

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -302,7 +302,6 @@ class TestTableLocking(unittest.TestCase):
             tab.X[0, 0] = 0
             tab.Y[0] = 0
             tab.metas[0, 0] = 0
-            tab.W[0] = 0
 
             tab.X = np.random.random((5, 3))
             tab.Y = np.random.random(5)

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -720,10 +720,12 @@ class TableTestCase(unittest.TestCase):
 
     def test_from_numpy(self):
         a = np.arange(20, dtype="d").reshape((4, 5)).copy()
+        m = np.arange(4, dtype="d").reshape((4, 1)).copy()
         a[:, -1] = [0, 0, 0, 1]
         dom = data.Domain([data.ContinuousVariable(x) for x in "abcd"],
-                          data.DiscreteVariable("e", values=("no", "yes")))
-        table = data.Table(dom, a)
+                          data.DiscreteVariable("e", values=("no", "yes")),
+                          metas=[data.ContinuousVariable(x) for x in "f"])
+        table = data.Table(dom, a, metas=m)
         with table.unlocked():
             for i in range(4):
                 self.assertEqual(table[i].get_class(), "no" if i < 3 else "yes")
@@ -731,7 +733,7 @@ class TableTestCase(unittest.TestCase):
                     self.assertEqual(a[i, j], table[i, j])
 
         with table.unlocked(), self.assertRaises(IndexError):
-            table[0, -5] = 5
+            table[0, -6] = 5
 
     def test_filter_is_defined(self):
         d = data.Table("iris")

--- a/Orange/widgets/data/owcreateinstance.py
+++ b/Orange/widgets/data/owcreateinstance.py
@@ -634,8 +634,10 @@ class OWCreateInstance(OWWidget):
         data = Table.from_domain(self.data.domain, 1)
         with data.unlocked():
             data.name = "created"
-            data.X[:] = np.nan
-            data.Y[:] = np.nan
+            if data.X.size:
+                data.X[:] = np.nan
+            if data.Y.size:
+                data.Y[:] = np.nan
             for i, m in enumerate(self.data.domain.metas):
                 data.metas[:, i] = "" if m.is_string else np.nan
 

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -585,8 +585,9 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
         data = self.data.transform(Domain(self.data.domain.attributes,
                                           self.data.domain.class_vars,
                                           self.data.domain.metas + variables))
-        with data.unlocked(data.metas):
-            data.metas[:, -2:] = self.get_embedding()
+        if data.metas.size:
+            with data.unlocked(data.metas):
+                data.metas[:, -2:] = self.get_embedding()
         return data
 
     def _get_projection_variables(self):


### PR DESCRIPTION
##### Issue

@VesnaT found a pickled table that could not be unlocked, because it was a view when unpickled. I thought this can not happen, but here it is.

While writing tests I also notices that EMPTY `W` from pickled tables could not be unlocked, because when unpickled it was `W.flags.owndata == False`. 


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
