### PR TITLE
Scatter Plot: Customizable regression line

### DIFF
--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -964,17 +964,17 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         graph = self.widget.graph
         graph._orthonormal_line = Mock(return_value=None)
         graph._regression_line = Mock(return_value=None)
-        x, y, c, w = Mock(), Mock(), Mock(), Mock()
+        x, y, c = Mock(), Mock(), Mock()
 
         graph.orthonormal_regression = True
-        graph._add_line(x, y, c, w)
-        graph._orthonormal_line.assert_called_once_with(x, y, c, w)
+        graph._add_line(x, y, c)
+        graph._orthonormal_line.assert_called_once_with(x, y, c, 3, 1)
         graph._regression_line.assert_not_called()
         graph._orthonormal_line.reset_mock()
 
         graph.orthonormal_regression = False
-        graph._add_line(x, y, c, w)
-        graph._regression_line.assert_called_with(x, y, c, w)
+        graph._add_line(x, y, c)
+        graph._regression_line.assert_called_with(x, y, c, 3, 1)
         graph._orthonormal_line.assert_not_called()
 
     def test_no_regression_line(self):
@@ -984,8 +984,8 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
 
         graph.plot_widget.addItem = Mock()
 
-        x, y, c, w = Mock(), Mock(), Mock(), Mock()
-        graph._add_line(x, y, c, w)
+        x, y, c = Mock(), Mock(), Mock()
+        graph._add_line(x, y, c)
         graph.plot_widget.addItem.assert_not_called()
         self.assertEqual(graph.reg_line_items, [])
 
@@ -1146,6 +1146,22 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         font.setPointSize(15)
         for item in graph.parameter_setter.axis_items:
             self.assertFontEqual(item.style["tickFont"], font)
+
+        self.widget.graph.controls.show_reg_line.setChecked(True)
+        self.assertGreater(len(graph.parameter_setter.reg_line_label_items), 0)
+
+        key, value = ('Fonts', 'Line label', 'Font size'), 16
+        self.widget.set_visual_settings(key, value)
+        key, value = ('Fonts', 'Line label', 'Italic'), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(16)
+        for label in graph.parameter_setter.reg_line_label_items:
+            self.assertFontEqual(label.textItem.font(), font)
+
+        key, value = ('Figure', 'Lines', 'Width'), 10
+        self.widget.set_visual_settings(key, value)
+        for item in graph.reg_line_items:
+            self.assertEqual(item.pen.width(), 10)
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -213,6 +213,30 @@ class Updater:
 
             item.setPen(pen)
 
+    @staticmethod
+    def update_inf_lines(items, **settings):
+        for item in items:
+            pen = item.pen
+
+            alpha = settings.get(Updater.ALPHA_LABEL)
+            if alpha is not None:
+                color = pen.color()
+                color.setAlpha(alpha)
+                pen.setColor(color)
+
+                if hasattr(item, "label"):
+                    item.label.setColor(color)
+
+            style = settings.get(Updater.STYLE_LABEL)
+            if style is not None:
+                pen.setStyle(Updater.LINE_STYLES[style])
+
+            width = settings.get(Updater.WIDTH_LABEL)
+            if width is not None:
+                pen.setWidth(width)
+
+            item.setPen(pen)
+
 
 class CommonParameterSetter:
     """ Subclass to add 'setter' functionality to a plot. """
@@ -225,9 +249,11 @@ class CommonParameterSetter:
     AXIS_TICKS_LABEL = "Axis ticks"
     LEGEND_LABEL = "Legend"
     LABEL_LABEL = "Label"
+    LINE_LAB_LABEL = "Line label"
     X_AXIS_LABEL = "x-axis title"
     Y_AXIS_LABEL = "y-axis title"
     TITLE_LABEL = "Title"
+    LINE_LABEL = "Lines"
 
     FONT_FAMILY_SETTING = None  # set in __init__ because it requires a running QApplication
     FONT_SETTING = None  # set in __init__ because it requires a running QApplication


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5677

##### Description of changes
- Updater: implement `update_inf_lines` method
- Scatter plot ParameterSetter: 
   - enable setting regression line label font
   - enable setting regression line `width`, `opacity` and `style`

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
