### PR TITLE
Remove unused warnings line

### DIFF
--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -229,7 +229,6 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         box = gui.vBox(self.controlArea, "Info")
         self.infolabel = gui.widgetLabel(box, 'No data loaded.')
-        self.warnings = gui.widgetLabel(box, '')
 
         box = gui.widgetBox(self.controlArea, "Columns (Double click to edit)")
         self.domain_editor = DomainEditor(self)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
There was an unused `self.warnings` line in the Info box. It made the widget unnecessarily tall.

##### Description of changes
Remove unused `self.warnings` line.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
