### PR TITLE
[ENH] File: explicit file format choice

### DIFF
--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -31,6 +31,11 @@ __all__ = ["FileFormatBase", "Flags", "DataTableMixin", "PICKLE_PROTOCOL"]
 PICKLE_PROTOCOL = 4
 
 
+class MissingReaderException(IOError):
+    # subclasses IOError for backward compatibility
+    pass
+
+
 class Flags:
     """Parser for column flags (i.e. third header row)"""
     DELIMITER = ' '
@@ -551,7 +556,7 @@ class _FileReader:
             if fnmatch(path.basename(filename), '*' + ext):
                 return reader(filename)
 
-        raise IOError('No readers for file "{}"'.format(filename))
+        raise MissingReaderException('No readers for file "{}"'.format(filename))
 
     @classmethod
     def set_table_metadata(cls, filename, table):

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -32,6 +32,8 @@ from Orange.widgets.widget import Output, Msg
 # module's namespace so that old saved settings still work
 from Orange.widgets.utils.filedialogs import RecentPath
 
+DEFAULT_READER_TEXT = "Automatically detect type"
+
 log = logging.getLogger(__name__)
 
 
@@ -474,7 +476,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
     def _initialize_reader_combo(self):
         self.reader_combo.clear()
         filters = [format_filter(f) for f in self.available_readers]
-        self.reader_combo.addItems(["Automatically detect type"] + filters)
+        self.reader_combo.addItems([DEFAULT_READER_TEXT] + filters)
         self.reader_combo.setCurrentIndex(0)
         self.reader_combo.setDisabled(True)
         # additional readers may be added in self._get_reader()

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -9,6 +9,7 @@ from AnyQt.QtWidgets import \
     QStyle, QComboBox, QMessageBox, QGridLayout, QLabel, \
     QLineEdit, QSizePolicy as Policy, QCompleter
 from AnyQt.QtCore import Qt, QTimer, QSize, QUrl
+from AnyQt.QtGui import QBrush
 
 from orangewidget.utils.filedialogs import format_filter
 from orangewidget.workflow.drophandler import SingleUrlDropHandler
@@ -389,10 +390,15 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             if not url:
                 return self.Information.no_file_selected
 
+        def mark_problematic_reader():
+            self.reader_combo.setItemData(self.reader_combo.currentIndex(),
+                                          QBrush(Qt.red), Qt.ForegroundRole)
+
         try:
-            self.reader = self._get_reader()
+            self.reader = self._get_reader()  # also sets current reader index
             assert self.reader is not None
         except Exception:
+            mark_problematic_reader()
             return self.Error.missing_reader
 
         try:
@@ -404,6 +410,7 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
             try:
                 data = self.reader.read()
             except Exception as ex:
+                mark_problematic_reader()
                 log.exception(ex)
                 return lambda x=ex: self.Error.unknown(str(x))
             if warnings:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -168,8 +168,19 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
         readers = [f for f in FileFormat.formats
                    if getattr(f, 'read', None)
                    and getattr(f, "EXTENSIONS", None)]
+
+        def group_readers_per_addon_key(w):
+            # readers from Orange.data.io should go first
+            def package(w):
+                package = w.qualified_name().split(".")[:-1]
+                package = package[:2]
+                if ".".join(package) == "Orange.data":
+                    return ["0"]  # force "Orange" to come first
+                return package
+            return package(w), w.DESCRIPTION
+
         self.available_readers = sorted(set(readers),
-                                        key=lambda w: (w.PRIORITY, w.DESCRIPTION))
+                                        key=group_readers_per_addon_key)
 
         layout = QGridLayout()
         layout.setSpacing(4)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -253,12 +253,14 @@ class TestOWFile(WidgetTest):
             self.create_widget(OWFile, stored_settings={"recent_paths": []})
 
         widget.Outputs.data.send = Mock()
-        widget._try_load()
+        widget.load_data()
+        self.assertTrue(widget.Information.no_file_selected.is_shown())
         widget.Outputs.data.send.assert_called_with(None)
 
         widget.Outputs.data.send.reset_mock()
         widget.source = widget.URL
-        widget._try_load()
+        widget.load_data()
+        self.assertTrue(widget.Information.no_file_selected.is_shown())
         widget.Outputs.data.send.assert_called_with(None)
 
     def test_check_column_noname(self):

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -433,6 +433,17 @@ a
         self.assertEqual(self.widget.reader_combo.currentText(), DEFAULT_READER_TEXT)
         self.assertIsInstance(self.widget.reader, TabReader)
 
+    def test_select_reader_errors(self):
+        filename = FileFormat.locate("iris.tab", dataset_dirs)
+
+        no_class = RecentPath(filename, None, None, file_format="Orange.data.io.ExcelReader")
+        self.widget = self.create_widget(OWFile,
+                                         stored_settings={"recent_paths": [no_class]})
+        self.widget.load_data()
+        self.assertIn("Excel", self.widget.reader_combo.currentText())
+        self.assertTrue(self.widget.Error.unknown.is_shown())
+        self.assertFalse(self.widget.Error.missing_reader.is_shown())
+
     def test_domain_edit_no_changes(self):
         self.open_dataset("iris")
         data = self.get_output(self.widget.Outputs.data)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -422,7 +422,11 @@ a
         self.assertEqual(self.widget.reader, None)
 
         # select the tab reader
-        self.widget.reader_combo.activated.emit(1)
+        for i in range(len_with_qname):
+            text = self.widget.reader_combo.itemText(i)
+            if text.startswith("Tab-separated"):
+                break
+        self.widget.reader_combo.activated.emit(i)
         self.assertEqual(len(self.widget.reader_combo), len_with_qname - 1)
         self.assertTrue(self.widget.reader_combo.currentText().startswith("Tab-separated"))
         self.assertIsInstance(self.widget.reader, TabReader)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -458,12 +458,12 @@ a
     def test_domain_edit_on_sparse_data(self):
         iris = Table("iris").to_sparse()
 
-        f = tempfile.NamedTemporaryFile(suffix='.pickle', delete=False)
-        pickle.dump(iris, f)
-        f.close()
+        with named_file("", suffix='.pickle') as fn:
+            with open(fn, "wb") as f:
+                pickle.dump(iris, f)
 
-        self.widget.add_path(f.name)
-        self.widget.load_data()
+            self.widget.add_path(fn)
+            self.widget.load_data()
 
         output = self.get_output(self.widget.Outputs.data)
         self.assertIsInstance(output, Table)
@@ -602,9 +602,8 @@ a
         (i.e. sent by email), considering data file is stored in the same
         directory as the workflow.
         """
-        temp_file = tempfile.NamedTemporaryFile(dir=getcwd(), delete=False)
-        file_name = temp_file.name
-        temp_file.close()
+        with tempfile.NamedTemporaryFile(dir=getcwd(), delete=False) as temp_file:
+            file_name = temp_file.name
         base_name = path.basename(file_name)
         try:
             recent_path = RecentPath(
@@ -625,9 +624,8 @@ a
         """
         This test testes if paths are relocated correctly
         """
-        temp_file = tempfile.NamedTemporaryFile(dir=getcwd(), delete=False)
-        file_name = temp_file.name
-        temp_file.close()
+        with tempfile.NamedTemporaryFile(dir=getcwd(), delete=False) as temp_file:
+            file_name = temp_file.name
         base_name = path.basename(file_name)
         try:
             recent_path = RecentPath(


### PR DESCRIPTION
##### Issue
Resolves #5724

##### Description of changes

![image](https://user-images.githubusercontent.com/552182/145863533-00be9937-1aae-4311-9620-8b33ff763289.png)

For files, the reader used was already stored in `.file_format`, which could be either a reader's qualified name or `None` (which means that reader is detected depending on extension and priority).

All available readers are shown in a combo box.

For URLs, the reader selection is disabled. That part would have to be refactored a bit so that the chosen reader could be saved.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
