### PR TITLE
[DOC] Fix documentation build to be compatible with parser

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,2 +1,5 @@
+# docutils changed html template in version 0.17; fixing to 0.16 until parser is not fixed
+# todo: remove docutils requirement when parser fixed in widget-base and released
+docutils<0.17
 Sphinx>=4.2.0
 recommonmark


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Currently Orange do not parse the widget list from the rtd correctly

##### Description of changes
Require docutils<0.17 for the readthedocs that documentation is compatible with the parser

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
