### PR TITLE
Fix wrong casing in Group-by docs and add to index

### DIFF
--- a/doc/visual-programming/source/index.rst
+++ b/doc/visual-programming/source/index.rst
@@ -63,6 +63,7 @@ Data
    widgets/data/melt
    widgets/data/neighbors
    widgets/data/unique
+   widgets/data/groupby
 
 
 Visualize

--- a/doc/visual-programming/source/widgets/data/groupby.md
+++ b/doc/visual-programming/source/widgets/data/groupby.md
@@ -36,4 +36,4 @@ In the **Data Table** widget, we can see that both females and males have lower 
 You can also observe differences between median **cholesterol** level and mean value of **major vessel colored** between groups.
 
 
-![](images/Group-by-Example.png)
+![](images/Group-by-example.png)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Image in groupby documentation have wrong casing\
Groupby is not in index

##### Description of changes
Add groupby to index
Fix wrong casing

##### Includes

- [X] Documentation
