### PR TITLE
Fix Python 3.10 casting errors

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -887,7 +887,7 @@ class OWPaintData(OWWidget):
             button.setDefaultAction(action)
             self.toolButtons.append((button, tool))
 
-            toolsBox.layout().addWidget(button, i / 3, i % 3)
+            toolsBox.layout().addWidget(button, i // 3, i % 3)
             self.toolActions.addAction(action)
 
         for column in range(3):

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -388,6 +388,7 @@ class OWROCAnalysis(widget.OWWidget):
         grid.addWidget(sp, 1, 1)
         self.target_prior_sp = gui.spin(box, self, "target_prior", 1, 99,
                                         alignment=Qt.AlignRight,
+                                        spinType=float,
                                         callback=self._on_target_prior_changed)
         self.target_prior_sp.setSuffix(" %")
         self.target_prior_sp.addAction(QAction("Auto", sp))

--- a/Orange/widgets/model/owgradientboosting.py
+++ b/Orange/widgets/model/owgradientboosting.py
@@ -97,7 +97,7 @@ class BaseEditor(QWidget, gui.OWComponent):
         return {
             "n_estimators": self.n_estimators,
             "learning_rate": self.learning_rate,
-            "random_state": 0 if self.random_state else randint(1, 1e6),
+            "random_state": 0 if self.random_state else randint(1, 1000000),
             "max_depth": self.max_depth,
         }
 

--- a/Orange/widgets/model/owlinearregression.py
+++ b/Orange/widgets/model/owlinearregression.py
@@ -79,7 +79,7 @@ class OWLinearRegression(OWBaseLearner):
         gui.widgetLabel(box5, "L1")
         self.l2_ratio_slider = gui.hSlider(
             box5, self, "l2_ratio", minValue=0.01, maxValue=0.99,
-            intOnly=False, ticks=0.1, createLabel=False, width=120,
+            intOnly=False, createLabel=False, width=120,
             step=0.01, callback=self._l2_ratio_changed)
         gui.widgetLabel(box5, "L2")
         self.l2_ratio_label = gui.widgetLabel(

--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -177,7 +177,7 @@ class OWSVM(OWBaseLearner):
             alignment=Qt.AlignRight, controlWidth=100,
             callback=self.settings_changed)
         self.max_iter_spin = gui.spin(
-            self.optimization_box, self, "max_iter", 5, 1e6, 50,
+            self.optimization_box, self, "max_iter", 5, 1000000, 50,
             label="Iteration limit: ", checked="limit_iter",
             alignment=Qt.AlignRight, controlWidth=100,
             callback=self.settings_changed,

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -830,7 +830,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             Qt.PreferredSize, constraint=QSizeF(width, -1))
         self._main_graphics.resize(QSizeF(width, preferred.height()))
         mw = self._main_graphics.minimumWidth() + 4
-        self.view.setMinimumWidth(mw + self.view.verticalScrollBar().width())
+        self.view.setMinimumWidth(int(mw + self.view.verticalScrollBar().width()))
 
     def __update_font_scale(self):
         font = self.scene.font()

--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -107,7 +107,7 @@ class TSNEParametersEditor(ManifoldParametersEditor):
         self._create_spin_parameter("early_exaggeration", 1, 100,
                                     "Early exaggeration:")
         self._create_spin_parameter("learning_rate", 1, 1000, "Learning rate:")
-        self._create_spin_parameter("n_iter", 250, 1e5, "Max iterations:")
+        self._create_spin_parameter("n_iter", 250, 10000, "Max iterations:")
         self._create_radio_parameter("initialization", "Initialization:")
 
 

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -163,7 +163,7 @@ class ColoredCircle(QGraphicsItem):
         pen = QPen(QBrush(self.color), 2)
         pen.setCosmetic(True)
         painter.setPen(pen)
-        painter.setBrush(QBrush(self.color.lighter(200 - 80 * self.proportion)))
+        painter.setBrush(QBrush(self.color.lighter(int(200 - 80 * self.proportion))))
         painter.drawEllipse(self.boundingRect())
         painter.restore()
 

--- a/Orange/widgets/utils/colorgradientselection.py
+++ b/Orange/widgets/utils/colorgradientselection.py
@@ -178,8 +178,8 @@ class ColorGradientSelection(QWidget):
         if self.__threshold_low != low or self.__threshold_high != high:
             self.__threshold_high = high
             self.__threshold_low = low
-            self.slider_low.setSliderPosition(low * 100)
-            self.slider_high.setSliderPosition(high * 100)
+            self.slider_low.setSliderPosition(int(low * 100))
+            self.slider_high.setSliderPosition(int(high * 100))
             self.thresholdsChanged.emit(high, low)
 
     def __update_center_visibility(self):

--- a/Orange/widgets/utils/tests/test_dendrogram.py
+++ b/Orange/widgets/utils/tests/test_dendrogram.py
@@ -51,7 +51,7 @@ class TestDendrogramWidget(GuiTest):
 
         h = w.height_at(QPoint())
         self.assertEqual(h, height)
-        h = w.height_at(QPoint(w.size().width(), 0))
+        h = w.height_at(QPoint(int(w.size().width()), 0))
         self.assertEqual(h, 0)
 
         self.assertEqual(w.pos_at_height(0).x(), w.rect().right())

--- a/Orange/widgets/utils/tests/test_headerview.py
+++ b/Orange/widgets/utils/tests/test_headerview.py
@@ -92,7 +92,7 @@ class TestHeaderView(GuiTest):
         pos = header.sectionViewportPosition(0)
         size = header.sectionSize(0)
         # center of first section
-        point = QPoint(pos + size // 2, header.viewport().height() / 2)
+        point = QPoint(pos + size // 2, header.viewport().height() // 2)
         QTest.mousePress(header.viewport(), Qt.LeftButton, Qt.NoModifier, point)
 
         opt = QStyleOptionHeader()

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -1274,10 +1274,10 @@ class OWBoxPlot(widget.OWWidget):
                 return
 
             fm = painter.fontMetrics()
-            text = fm.elidedText(self.text(), Qt.ElideRight, width)
+            text = fm.elidedText(self.text(), Qt.ElideRight, int(width))
             painter.drawText(
-                option.rect.x(),
-                option.rect.y() + self.boundingRect().height() - self.PADDING,
+                int(option.rect.x()),
+                int(option.rect.y() + self.boundingRect().height() - self.PADDING),
                 text)
 
 

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -1007,7 +1007,7 @@ class OWNomogram(OWWidget):
 
         # Clip top and bottom (60 and 150) parts from the main view
         self.view.setSceneRect(rect.x(), rect.y() + 80, rect.width() - 10, rect.height() - 160)
-        self.view.viewport().setMaximumHeight(rect.height() - 160)
+        self.view.viewport().setMaximumHeight(int(rect.height() - 160))
         # Clip main part from top/bottom views
         # below point values are imprecise (less/more than required) but this
         # is not a problem due to clipped scene content still being drawn

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -371,9 +371,9 @@ class OWSieveDiagram(OWWidget):
 
             r = b = 255
             if pearson > 0:
-                r = g = max(255 - 20 * pearson, 55)
+                r = g = max(int(255 - 20 * pearson), 55)
             elif pearson < 0:
-                b = g = max(255 + 20 * pearson, 55)
+                b = g = max(int(255 + 20 * pearson), 55)
             else:
                 r = g = b = 224
             rect.setBrush(QBrush(QColor(r, g, b)))

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -386,12 +386,12 @@ class OWTreeGraph(OWTreeViewer2D):
             if self.target_class_index:
                 p = distr[self.target_class_index - 1] / total
                 color = colors[self.target_class_index - 1].lighter(
-                    200 - 100 * p)
+                    int(200 - 100 * p))
             else:
                 modus = np.argmax(distr)
                 p = distr[modus] / (total or 1)
                 color = colors.value_to_qcolor(int(modus))
-                color = color.lighter(300 - 200 * p)
+                color = color.lighter(int(300 - 200 * p))
             node.backgroundBrush = QBrush(color)
         self.scene.update()
 
@@ -409,7 +409,7 @@ class OWTreeGraph(OWTreeViewer2D):
                 node_insts = len(self.tree_adapter.get_instances_in_nodes(
                     [node.node_inst]))
                 node.backgroundBrush = QBrush(def_color.lighter(
-                    120 - 20 * node_insts / max_insts))
+                    int(120 - 20 * node_insts / max_insts)))
         elif self.regression_colors == self.COL_MEAN:
             minv = np.nanmin(self.dataset.Y)
             maxv = np.nanmax(self.dataset.Y)
@@ -425,7 +425,7 @@ class OWTreeGraph(OWTreeViewer2D):
             max_var = max(variances)
             for node, var in zip(nodes, variances):
                 node.backgroundBrush = QBrush(def_color.lighter(
-                    120 - 20 * var / max_var))
+                    int(120 - 20 * var / max_var)))
         self.scene.update()
 
     def _get_tree_adapter(self, model):

--- a/Orange/widgets/visualize/pythagorastreeviewer.py
+++ b/Orange/widgets/visualize/pythagorastreeviewer.py
@@ -629,12 +629,12 @@ class DiscreteTreeNode(TreeNode):
         if self.target_class_index:
             p = distribution[self.target_class_index - 1] / total
             color = self.color_palette[self.target_class_index - 1]
-            color = color.lighter(200 - 100 * p)
+            color = color.lighter(int(200 - 100 * p))
         else:
             modus = np.argmax(distribution)
             p = distribution[modus] / (total or 1)
             color = self.color_palette[int(modus)]
-            color = color.lighter(400 - 300 * p)
+            color = color.lighter(int(400 - 300 * p))
         return color
 
     @property

--- a/Orange/widgets/visualize/utils/owlegend.py
+++ b/Orange/widgets/visualize/utils/owlegend.py
@@ -99,8 +99,8 @@ class Anchorable(QGraphicsWidget):
         actual offset from the top left corner of the item so positioning can
         be done correctly."""
         off_x, off_y = offset.x(), offset.y()
-        width = self.boundingRect().width()
-        height = self.boundingRect().height()
+        width = int(self.boundingRect().width())
+        height = int(self.boundingRect().height())
 
         if self.__corner_str == self.TOP_LEFT:
             return QPoint(-off_x, -off_y)


### PR DESCRIPTION
##### Issue
Parts of Orange did not run on Python 3.10. With these changes, the tests pass on my Linux 3.10 installation with PyQt5==5.15.6 and a fork of bottleneck.

##### Description of changes
Mostly explicit casting to integers.
