### PR TITLE
[FIX] Silhouette plot text width

### DIFF
--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -22,8 +22,10 @@ from Orange.widgets import widget, gui, settings
 from Orange.widgets.utils import itemmodels, colorpalettes
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
                                                  ANNOTATED_DATA_SIGNAL_NAME)
+from Orange.widgets.utils.graphicsscene import graphicsscene_help_event
 from Orange.widgets.utils.graphicstextlist import TextListWidget
 from Orange.widgets.utils.widgetpreview import WidgetPreview
+from Orange.widgets.visualize.utils.plotutils import HelpEventDelegate
 from Orange.widgets.widget import Input, Output
 from Orange.widgets.utils.dendrogram import DendrogramWidget
 from Orange.widgets.visualize.utils.heatmap import (
@@ -245,6 +247,18 @@ class DistanceMapItem(pg.ImageItem):
             self.setToolTip("")
 
 
+class GraphicsView(pg.GraphicsView):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        scene = self.scene()
+        delegate = HelpEventDelegate(self.__helpEvent, parent=self)
+        scene.installEventFilter(delegate)
+
+    def __helpEvent(self, event):
+        graphicsscene_help_event(self.scene(), event)
+        return event.isAccepted()
+
+
 class OWDistanceMap(widget.OWWidget):
     name = "Distance Map"
     description = "Visualize a distance matrix."
@@ -330,7 +344,7 @@ class OWDistanceMap(widget.OWWidget):
 
         gui.auto_send(self.buttonsArea, self, "autocommit")
 
-        self.view = pg.GraphicsView(background="w")
+        self.view = GraphicsView(background="w")
         self.mainArea.layout().addWidget(self.view)
 
         self.grid_widget = pg.GraphicsWidget()

--- a/Orange/widgets/utils/graphicsscene.py
+++ b/Orange/widgets/utils/graphicsscene.py
@@ -1,0 +1,46 @@
+from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QTransform
+from AnyQt.QtWidgets import (
+    QGraphicsScene, QGraphicsSceneHelpEvent,QGraphicsView, QToolTip
+)
+
+__all__ = [
+    "GraphicsScene"
+]
+
+
+class GraphicsScene(QGraphicsScene):
+    """
+    A QGraphicsScene with better tool tip event dispatch.
+    """
+    def helpEvent(self, event: QGraphicsSceneHelpEvent) -> None:
+        """
+        Reimplemented.
+
+        Send the help event to every graphics item that is under the event's
+        scene position (default `QGraphicsScene` only dispatches help events
+        to `QGraphicsProxyWidget`s.
+        """
+        widget = event.widget()
+        if widget is not None and isinstance(widget.parentWidget(),
+                                             QGraphicsView):
+            view = widget.parentWidget()
+            deviceTransform = view.viewportTransform()
+        else:
+            deviceTransform = QTransform()
+        items = self.items(
+            event.scenePos(), Qt.IntersectsItemShape, Qt.DescendingOrder,
+            deviceTransform,
+        )
+        text = None
+        event.setAccepted(False)
+        for item in items:
+            self.sendEvent(item, event)
+            if event.isAccepted():
+                return
+            elif item.toolTip():
+                text = item.toolTip()
+                break
+
+        if text is not None:
+            QToolTip.showText(event.screenPos(), text, event.widget())

--- a/Orange/widgets/utils/graphicsscene.py
+++ b/Orange/widgets/utils/graphicsscene.py
@@ -5,7 +5,8 @@ from AnyQt.QtWidgets import (
 )
 
 __all__ = [
-    "GraphicsScene"
+    "GraphicsScene",
+    "graphicsscene_help_event",
 ]
 
 
@@ -21,26 +22,36 @@ class GraphicsScene(QGraphicsScene):
         scene position (default `QGraphicsScene` only dispatches help events
         to `QGraphicsProxyWidget`s.
         """
-        widget = event.widget()
-        if widget is not None and isinstance(widget.parentWidget(),
-                                             QGraphicsView):
-            view = widget.parentWidget()
-            deviceTransform = view.viewportTransform()
-        else:
-            deviceTransform = QTransform()
-        items = self.items(
-            event.scenePos(), Qt.IntersectsItemShape, Qt.DescendingOrder,
-            deviceTransform,
-        )
-        text = None
-        event.setAccepted(False)
-        for item in items:
-            self.sendEvent(item, event)
-            if event.isAccepted():
-                return
-            elif item.toolTip():
-                text = item.toolTip()
-                break
+        graphicsscene_help_event(self, event)
 
-        if text is not None:
-            QToolTip.showText(event.screenPos(), text, event.widget())
+
+def graphicsscene_help_event(
+        scene: QGraphicsScene, event: QGraphicsSceneHelpEvent
+) -> None:
+    """
+    Send the help event to every graphics item that is under the `event`
+    scene position.
+    """
+    widget = event.widget()
+    if widget is not None and isinstance(widget.parentWidget(),
+                                         QGraphicsView):
+        view = widget.parentWidget()
+        deviceTransform = view.viewportTransform()
+    else:
+        deviceTransform = QTransform()
+    items = scene.items(
+        event.scenePos(), Qt.IntersectsItemShape, Qt.DescendingOrder,
+        deviceTransform,
+    )
+    text = ""
+    event.setAccepted(False)
+    for item in items:
+        scene.sendEvent(item, event)
+        if event.isAccepted():
+            return
+        elif item.toolTip():
+            text = item.toolTip()
+            break
+
+    QToolTip.showText(event.screenPos(), text, event.widget())
+    event.setAccepted(bool(text))

--- a/Orange/widgets/utils/tests/test_graphicstextlist.py
+++ b/Orange/widgets/utils/tests/test_graphicstextlist.py
@@ -1,8 +1,11 @@
 import unittest
 
-from AnyQt.QtCore import Qt, QSizeF
+from AnyQt.QtCore import Qt, QSizeF, QPoint
+from AnyQt.QtGui import QHelpEvent
+from AnyQt.QtWidgets import QGraphicsView, QApplication, QToolTip
 
 from orangewidget.tests.base import GuiTest
+from Orange.widgets.utils.graphicsscene import GraphicsScene
 from Orange.widgets.utils.graphicstextlist import TextListWidget, scaled
 
 
@@ -56,6 +59,25 @@ class TestTextListWidget(GuiTest):
 
         w.setAlignment(Qt.AlignVCenter)
         self.assertTrue(45 <= brect(item).center().y() < 55)
+
+    def test_tool_tips(self):
+        scene = GraphicsScene()
+        view = QGraphicsView(scene)
+        w = TextListWidget()
+        text = "A" * 10
+        w.setItems([text, text])
+        scene.addItem(w)
+        view.grab()  # ensure w is laid out
+        wrect = view.mapFromScene(w.mapToScene(w.contentsRect())).boundingRect()
+        p = QPoint(wrect.topLeft() + QPoint(5, 5))
+        ev = QHelpEvent(
+            QHelpEvent.ToolTip, p, view.viewport().mapToGlobal(p)
+        )
+        try:
+            QApplication.sendEvent(view.viewport(), ev)
+            self.assertEqual(QToolTip.text(), text)
+        finally:
+            QToolTip.hideText()
 
 
 class TestUtils(unittest.TestCase):

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -10,8 +10,8 @@ import numpy as np
 import scipy.sparse as sp
 
 from AnyQt.QtWidgets import (
-    QGraphicsScene, QGraphicsView, QFormLayout, QComboBox, QGroupBox,
-    QMenu, QAction, QSizePolicy
+    QGraphicsView, QFormLayout, QComboBox, QGroupBox, QMenu, QAction,
+    QSizePolicy
 )
 from AnyQt.QtGui import QStandardItemModel, QStandardItem, QFont, QKeySequence
 from AnyQt.QtCore import Qt, QSize, QRectF, QObject
@@ -27,6 +27,7 @@ from Orange.widgets.utils import colorpalettes, apply_all, enum_get, itemmodels
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.stickygraphicsview import StickyGraphicsView
 from Orange.widgets.utils.graphicsview import GraphicsWidgetView
+from Orange.widgets.utils.graphicsscene import GraphicsScene
 from Orange.widgets.utils.colorpalettes import Palette
 
 from Orange.widgets.utils.annotated_data import (create_annotated_table,
@@ -444,7 +445,7 @@ class OWHeatMap(widget.OWWidget):
         gui.auto_send(self.buttonsArea, self, "auto_commit")
 
         # Scene with heatmap
-        class HeatmapScene(QGraphicsScene):
+        class HeatmapScene(GraphicsScene):
             widget: Optional[HeatmapGridWidget] = None
 
         self.scene = self.scene = HeatmapScene(parent=self)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -737,6 +737,7 @@ class SilhouettePlot(QGraphicsWidget):
                 layout.addItem(item, i + 1, 0, Qt.AlignCenter)
 
             textlist = TextListWidget(self, font=font)
+            textlist.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
             textlist.setFlag(TextListWidget.ItemClipsChildrenToShape, False)
             sp = textlist.sizePolicy()
             sp.setVerticalPolicy(QSizePolicy.Ignored)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -764,19 +764,25 @@ class SilhouettePlot(QGraphicsWidget):
         # type: () -> Optional[QGraphicsWidget]
         return self.__bottomScale
 
-    def __updateTextSizeConstraint(self):
+    def __updateSizeConstraints(self):
         # set/update fixed height constraint on the text annotation items so
         # it matches the silhouette's height
         for silitem, textitem in zip(self.__plotItems(), self.__textItems()):
             height = silitem.effectiveSizeHint(Qt.PreferredSize).height()
             textitem.setMaximumHeight(height)
             textitem.setMinimumHeight(height)
+        mwidth = max((silitem.effectiveSizeHint(Qt.PreferredSize).width()
+                     for silitem in self.__plotItems()), default=300)
+        # match the AxisItem's width to the bars
+        for axis in self.__axisItems():
+            axis.setMaximumWidth(mwidth)
+            axis.setMinimumWidth(mwidth)
 
     def event(self, event):
         # Reimplemented
         if event.type() == QEvent.LayoutRequest and \
                 self.parentLayoutItem() is None:
-            self.__updateTextSizeConstraint()
+            self.__updateSizeConstraints()
             self.resize(self.effectiveSizeHint(Qt.PreferredSize))
         return super().event(event)
 
@@ -1004,6 +1010,9 @@ class SilhouettePlot(QGraphicsWidget):
             if item is not None:
                 assert isinstance(item, TextListWidget)
                 yield item
+
+    def __axisItems(self):
+        return self.__topScale, self.__bottomScale
 
     def setSelection(self, indices):
         indices = np.unique(np.asarray(indices, dtype=int))

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -737,6 +737,7 @@ class SilhouettePlot(QGraphicsWidget):
                 layout.addItem(item, i + 1, 0, Qt.AlignCenter)
 
             textlist = TextListWidget(self, font=font)
+            textlist.setFlag(TextListWidget.ItemClipsChildrenToShape, False)
             sp = textlist.sizePolicy()
             sp.setVerticalPolicy(QSizePolicy.Ignored)
             textlist.setSizePolicy(sp)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -38,9 +38,6 @@ from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Msg, Input, Output
 
 
-ROW_NAMES_WIDTH = 200
-
-
 class InputValidationError(ValueError):
     message: str
 
@@ -630,10 +627,7 @@ class SilhouettePlot(QGraphicsWidget):
             item = layout.itemAt(i + 1, 3)
             assert isinstance(item, TextListWidget)
             if grp.rownames is not None:
-                metrics = QFontMetrics(self.font())
-                rownames = [metrics.elidedText(rowname, Qt.ElideRight, ROW_NAMES_WIDTH)
-                            for rowname in grp.rownames]
-                item.setItems(rownames)
+                item.setItems(grp.rownames)
                 item.setVisible(self.__rowNamesVisible)
             else:
                 item.setItems([])
@@ -1122,7 +1116,8 @@ class BarPlotItem(QGraphicsWidget):
         return super().event(event)
 
     def sizeHint(self, which, constraint=QSizeF()):
-        return QSizeF(300, (self.__barsize + self.__spacing) * self.count())
+        spacing = max(self.__spacing * (self.count() - 1), 0)
+        return QSizeF(300, self.__barsize * self.count() + spacing)
 
     def setPreferredBarSize(self, size):
         if self.__barsize != size:
@@ -1131,6 +1126,11 @@ class BarPlotItem(QGraphicsWidget):
 
     def spacing(self):
         return self.__spacing
+
+    def setSpacing(self, spacing):
+        if self.__spacing != spacing:
+            self.__spacing = spacing
+            self.updateGeometry()
 
     def setPen(self, pen):
         pen = QPen(pen)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -262,7 +262,8 @@ class OWSilhouettePlot(widget.OWWidget):
             self.cluster_var_idx = groupvars.index(domain.class_var)
         else:
             self.cluster_var_idx = 0
-        annotvars = [var for var in domain.metas if var.is_string]
+        annotvars = [var for var in domain.variables + domain.metas
+                     if var.is_string or var.is_discrete]
         self.annotation_var_model[:] = ["None"] + annotvars
         self.annotation_var_idx = 1 if annotvars else 0
         self.openContext(Orange.data.Domain(groupvars))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Closes gh-5728

##### Description of changes

* Do not clip child text items in the text annotations list.
* Allow the text to be wider (but is still limited to 750px; was 300 before)
* Generally change how the tool tips are displayed in the GraphicsTextListWidget with associated changes to all its uses (int owheatmap and owdistancemap). Before tool tips were set on individual text items, now the widget responds to QGraphicsSceneHelpEvent).
* Allow any Discrete it String variable for text Annotations.
* Also fix misaligned top/bottom axes 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
