### PR TITLE
[FIX] Support numpy 1.22

### DIFF
--- a/Orange/data/io_util.py
+++ b/Orange/data/io_util.py
@@ -109,7 +109,7 @@ def isnastr(arr, out=None):
     arr = np.asarray(arr)
     if out is None and arr.shape != ():
         out = np.empty_like(arr, dtype=bool)
-    return __isnastr(arr, out=out)
+    return __isnastr(arr, out=out, casting="unsafe")
 
 
 def guess_data_type(orig_values, namask=None):
@@ -182,7 +182,7 @@ def sanitize_variable(valuemap, values, orig_values, coltype, coltype_kwargs,
 
         def mapvalues(arr):
             arr = np.asarray(arr, dtype=object)
-            return mapvalues_(arr, out=np.empty_like(arr, dtype=float))
+            return mapvalues_(arr, out=np.empty_like(arr, dtype=float), casting="unsafe")
 
         values = mapvalues(orig_values)
 

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -350,11 +350,7 @@ class TestTableLocking(unittest.TestCase):
     def test_unpickled_empty_weights(self):
         # ensure that unpickled empty arrays could be unlocked
         self.assertEqual(0, self.table.W.size)
-        # flags.owndata asserts touch numpy internals
-        # feel free to remove when they do not pass
-        self.assertTrue(self.table.W.flags.owndata)
         unpickled = pickle.loads(pickle.dumps(self.table))
-        self.assertFalse(unpickled.W.flags.owndata)
         with unpickled.unlocked():
             pass
 

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -2645,7 +2645,7 @@ def make_dict_mapper(
         arr = np.asanyarray(arr)
         if out is None and dtype is not None and arr.shape != ():
             out = np.empty_like(arr, dtype)
-        return _vmapper(arr, out, dtype=dtype, **kwargs)
+        return _vmapper(arr, out, dtype=dtype, casting="unsafe", **kwargs)
     return mapper
 
 
@@ -2684,7 +2684,7 @@ def as_float_or_nan(
             np.issubdtype(arr.dtype, np.integer):
         np.copyto(out, arr, casting="unsafe", where=where)
         return out
-    return _parse_float(arr, out, where=where, **kwargs)
+    return _parse_float(arr, out, where=where, casting="unsafe", **kwargs)
 
 
 def copy_attributes(dst: V, src: Orange.data.Variable) -> V:


### PR DESCRIPTION
- np.frompyfunc does convert outputs to the out type anymore
- Adapt a locking test for changed numpy internals
