### PR TITLE
[FIX] Group by: compute mode when all values in group nan

### DIFF
--- a/Orange/widgets/data/owgroupby.py
+++ b/Orange/widgets/data/owgroupby.py
@@ -406,7 +406,7 @@ class OWGroupBy(OWWidget, ConcurrentWidgetMixin):
         self.gb_attrs = [values[row.row()] for row in sorted(rows)]
         # everything cached in result should be recomputed on gb change
         self.result = Result()
-        self.commit()
+        self.commit.deferred()
 
     def __aggregation_changed(self, agg: str) -> None:
         """
@@ -422,7 +422,7 @@ class OWGroupBy(OWWidget, ConcurrentWidgetMixin):
             else:
                 self.aggregations[attr].discard(agg)
             self.agg_table_model.update_aggregation(attr)
-        self.commit()
+        self.commit.deferred()
 
     @Inputs.data
     def set_data(self, data: Table) -> None:
@@ -450,11 +450,12 @@ class OWGroupBy(OWWidget, ConcurrentWidgetMixin):
         self.agg_table_model.set_domain(data.domain if data else None)
         self._set_gb_selection()
 
-        self.commit()
+        self.commit.now()
 
     #########################
     # Task connected methods
 
+    @gui.deferred
     def commit(self) -> None:
         self.Error.clear()
         self.Warning.clear()

--- a/Orange/widgets/data/owgroupby.py
+++ b/Orange/widgets/data/owgroupby.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Any, Dict, List, Optional, Set
 
 import pandas as pd
+from numpy import nan
 from AnyQt.QtCore import (
     QAbstractTableModel,
     QEvent,
@@ -58,7 +59,7 @@ AGGREGATIONS = {
     "Mean": Aggregation("mean", {ContinuousVariable, TimeVariable}),
     "Median": Aggregation("median", {ContinuousVariable, TimeVariable}),
     "Mode": Aggregation(
-        lambda x: pd.Series.mode(x)[0], {ContinuousVariable, TimeVariable}
+        lambda x: pd.Series.mode(x).get(0, nan), {ContinuousVariable, TimeVariable}
     ),
     "Standard deviation": Aggregation("std", {ContinuousVariable, TimeVariable}),
     "Variance": Aggregation("var", {ContinuousVariable, TimeVariable}),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes https://github.com/biolab/orange3/issues/5738

##### Description of changes
- Fix mode to work in cases when all values in the group are nan
- test case with only nan values in the group
- additionally: use gui.deferred for autocoomit

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
