### PR TITLE
Curve Fit: Retain expression on data remove

### DIFF
--- a/Orange/widgets/model/owcurvefit.py
+++ b/Orange/widgets/model/owcurvefit.py
@@ -396,12 +396,6 @@ class OWCurveFit(OWBaseLearner):
     def set_data(self, data: Optional[Table]):
         self.Warning.data_missing(shown=not bool(data))
         super().set_data(data)
-        self.__clear()
-
-    def __clear(self):
-        self.expression = ""
-        self.__param_widget.clear_all()
-        self.__on_parameters_changed([])
 
     def set_preprocessor(self, preprocessor: Preprocess):
         self.preprocessors = preprocessor

--- a/Orange/widgets/model/owcurvefit.py
+++ b/Orange/widgets/model/owcurvefit.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from AnyQt.QtCore import Signal
 from AnyQt.QtWidgets import QSizePolicy, QWidget, QGridLayout, QLabel, \
-    QLineEdit, QVBoxLayout, QPushButton, QDoubleSpinBox, QCheckBox, QGroupBox
+    QLineEdit, QVBoxLayout, QPushButton, QDoubleSpinBox, QCheckBox
 
 from orangewidget.utils.combobox import ComboBoxSearch
 from Orange.data import Table, ContinuousVariable
@@ -61,7 +61,6 @@ class ParametersWidget(QWidget):
         self.__data: List[Parameter] = []
         self.__labels: List[QLabel] = None
         self.__layout: QGridLayout = None
-        self.__button: QPushButton = None
         self.__controls: List[
             Tuple[QPushButton, QLineEdit, QDoubleSpinBox, QCheckBox,
                   QDoubleSpinBox, QCheckBox, QDoubleSpinBox]] = []
@@ -115,7 +114,7 @@ class ParametersWidget(QWidget):
 
         button_box = gui.hBox(box)
         gui.rubber(button_box)
-        self.__button = gui.button(
+        gui.button(
             button_box, self, "+", callback=self.__on_add_button_clicked,
             width=34, autoDefault=False, enabled=True,
             sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Maximum)
@@ -242,9 +241,6 @@ class ParametersWidget(QWidget):
         for param in parameters:
             self._add_row(param)
 
-    def set_add_enabled(self, enable: bool):
-        self.__button.setEnabled(enable)
-
 
 class OWCurveFit(OWBaseLearner):
     name = "Curve Fit"
@@ -288,7 +284,6 @@ class OWCurveFit(OWBaseLearner):
     def __init__(self, *args, **kwargs):
         self.__pp_data: Optional[Table] = None
         self.__param_widget: ParametersWidget = None
-        self.__function_box: QGroupBox = None
         self.__expression_edit: QLineEdit = None
         self.__feature_combo: ComboBoxSearch = None
         self.__parameter_combo: ComboBoxSearch = None
@@ -311,18 +306,16 @@ class OWCurveFit(OWBaseLearner):
     def add_main_layout(self):
         box = gui.vBox(self.controlArea, "Parameters")
         self.__param_widget = ParametersWidget(self)
-        self.__param_widget.set_add_enabled(False)
         self.__param_widget.sigDataChanged.connect(
             self.__on_parameters_changed)
         box.layout().addWidget(self.__param_widget)
 
-        self.__function_box = gui.vBox(self.controlArea, box="Expression")
-        self.__function_box.setEnabled(False)
+        function_box = gui.vBox(self.controlArea, box="Expression")
         self.__expression_edit = gui.lineEdit(
-            self.__function_box, self, "expression",
+            function_box, self, "expression",
             placeholderText="Expression...", callback=self.settings_changed
         )
-        hbox = gui.hBox(self.__function_box)
+        hbox = gui.hBox(function_box)
         combo_options = dict(sendSelectedValue=True, searchable=True,
                              contentsLength=13)
         self.__feature_combo = gui.comboBox(
@@ -411,7 +404,6 @@ class OWCurveFit(OWBaseLearner):
     def handleNewSignals(self):
         self.__preprocess_data()
         self.__init_models()
-        self.__enable_controls()
         self.__set_pending()
         self.unconditional_apply()
 
@@ -422,12 +414,6 @@ class OWCurveFit(OWBaseLearner):
         domain = self.__pp_data.domain if self.__pp_data else None
         self.__feature_model.set_domain(domain)
         self._feature = self.__feature_model[0]
-
-    def __enable_controls(self):
-        enable = bool(self.__pp_data) and \
-                 self.__pp_data.domain.has_continuous_attributes()
-        self.__param_widget.set_add_enabled(enable)
-        self.__function_box.setEnabled(enable)
 
     def __set_pending(self):
         if self.__pending_parameters:

--- a/Orange/widgets/model/tests/test_owcurvefit.py
+++ b/Orange/widgets/model/tests/test_owcurvefit.py
@@ -173,7 +173,7 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         self.housing = Table("housing")
         self.init()
         self.__add_button = \
-            self.widget._OWCurveFit__param_widget._ParametersWidget__button
+            self.widget._OWCurveFit__param_widget.findChildren(QPushButton)[0]
 
     def __init_widget(self, data=None, widget=None):
         if data is None:
@@ -181,7 +181,9 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         if widget is None:
             widget = self.widget
         self.send_signal(widget.Inputs.data, data, widget=widget)
-        widget._OWCurveFit__param_widget._ParametersWidget__button.click()
+        add_button = \
+            widget._OWCurveFit__param_widget.findChildren(QPushButton)[0]
+        add_button.click()
         widget._OWCurveFit__expression_edit.setText("p1 + ")
         simulate.combobox_activate_index(widget.controls._feature, 1)
         widget.apply_button.button.click()
@@ -410,17 +412,6 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         self.assertTrue(self.widget.Error.invalid_exp.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.invalid_exp.is_shown())
-
-    def test_enable_controls(self):
-        function_box = self.widget._OWCurveFit__function_box
-        self.assertFalse(self.__add_button.isEnabled())
-        self.assertFalse(function_box.isEnabled())
-        self.send_signal(self.widget.Inputs.data, self.housing)
-        self.assertTrue(self.__add_button.isEnabled())
-        self.assertTrue(function_box.isEnabled())
-        self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.__add_button.isEnabled())
-        self.assertFalse(function_box.isEnabled())
 
     def test_duplicated_parameter_name(self):
         self.send_signal(self.widget.Inputs.data, self.housing)

--- a/Orange/widgets/model/tests/test_owcurvefit.py
+++ b/Orange/widgets/model/tests/test_owcurvefit.py
@@ -314,7 +314,7 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         self.assertEqual(self.widget._OWCurveFit__expression_edit.text(), "p1")
 
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.rowCount(), 2)
         self.assertEqual(combo.currentText(), "Select Parameter")
 
     def test_function_combo(self):
@@ -435,7 +435,7 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         param_controls[1][1].setText("p1")
         self.assertTrue(self.widget.Warning.duplicate_parameter.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
-        self.assertFalse(self.widget.Warning.duplicate_parameter.is_shown())
+        self.assertTrue(self.widget.Warning.duplicate_parameter.is_shown())
 
     def test_parameter_name_in_features(self):
         domain = Domain([ContinuousVariable("p1")],


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The Curve Fit widget needs data on the input to initialize the learner (i.e set the expression).
Refreshing the input data clears the expression (and parameters) which is undesirable in most cases.

##### Description of changes
- retain the expression when removing the template data
- enable the expression even when no data on the input

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
