### PR TITLE
Color: Warn about unused variable definitions

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -647,16 +647,15 @@ class OWColor(widget.OWWidget):
             return
 
         try:
-            f = open(fname)
+            with open(fname) as f:
+                js = json.load(f)  #: dict
+                self._parse_var_defs(js)
         except IOError:
             QMessageBox.critical(self, "File error", "File cannot be opened.")
             return
-
-        try:
-            js = json.load(f)  #: dict
-            self._parse_var_defs(js)
         except (json.JSONDecodeError, InvalidFileFormat):
             QMessageBox.critical(self, "File error", "Invalid file format.")
+            return
 
     def _parse_var_defs(self, js):
         if not isinstance(js, dict) or set(js) != {"categorical", "numeric"}:


### PR DESCRIPTION
##### Issue

Closes #5742.

The issue does not describe a bug, the mistake was on the user's side. But the user should be warned.

##### Description of changes

Add a warning when color definitions describe variables that do not appear in the data.

##### Includes
- [X] Code changes
- [X] Tests
