### PR TITLE
Raise pandas requirement to 1.3.0

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -23,7 +23,7 @@ python-louvain>=0.13
 requests
 openTSNE>=0.6.1
 baycomp>=1.0.2
-pandas>=1.1.0
+pandas>=1.3.0
 pyyaml
 openpyxl
 httpx>=0.14.0,<0.20


### PR DESCRIPTION
Group By tests do not pass with earlier versions