### PR TITLE
fix UrlReader did not support URL like http://filename.txt?a=1&b=2 .

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -406,7 +406,14 @@ class UrlReader(FileFormat):
         filename = filename.strip()
         if not urlparse(filename).scheme:
             filename = 'http://' + filename
-        filename = quote(filename, safe="/:")
+
+        # check ? avoid quote redundantly on URL like http://filename.txt?a=1&b=2.
+        mark = filename.find('?')
+        if mark >= 0:
+            filename = quote(filename[:mark], safe="/:") + filename[mark:]
+        else:
+            filename = quote(filename, safe="/:")
+
         super().__init__(filename)
 
     @staticmethod

--- a/Orange/tests/test_url_reader.py
+++ b/Orange/tests/test_url_reader.py
@@ -25,6 +25,15 @@ class TestUrlReader(unittest.TestCase):
                "vestnik-clanki/detektiranje-utrdb-v-šahu-.txt"
         self.assertRaises(OSError, UrlReader(path).read)
 
+    def test_base_url_with_parameters(self):
+        data = UrlReader("https://datasets.biolab.si/core/grades.xlsx?a=1&b=2").read()
+        self.assertEqual(16, len(data))
+
+    def test_special_characters_with_parameters(self):
+        path = "http://file.biolab.si/text-semantics/data/elektrotehniski-" \
+               "vestnik-clanki/detektiranje-utrdb-v-šahu-.txt?a=1&b=2"
+        self.assertRaises(OSError, UrlReader(path).read)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue


##### Description of changes
Fix `UrlReader` did not support URL like `http://filename.txt?a=1&b=2` , witch did quoted to `http://filename.txt%3Fa%3D1%26b%3D2`


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
