### PR TITLE
Feature Statistics: Add padding between histogram bars and horizontal line

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -562,6 +562,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                             variable=attribute,
                             color_attribute=self.target_var,
                             border=(0, 0, 2, 0),
+                            bottom_padding=4,
                             border_color='#ccc',
                         )
                         scene.addItem(histogram)

--- a/Orange/widgets/data/utils/histogram.py
+++ b/Orange/widgets/data/utils/histogram.py
@@ -123,7 +123,8 @@ class Histogram(QGraphicsWidget):
     """
 
     def __init__(self, data, variable, parent=None, height=200,
-                 width=300, side_padding=5, top_padding=20, bar_spacing=4,
+                 width=300, side_padding=5, top_padding=20, bottom_padding=0,
+                 bar_spacing=4,
                  border=0, border_color=None, color_attribute=None, n_bins=10):
         super().__init__(parent)
         self.height, self.width = height, width
@@ -191,7 +192,7 @@ class Histogram(QGraphicsWidget):
 
         # _plot_`dim` accounts for all the paddings and spacings
         self._plot_height = self.height
-        self._plot_height -= top_padding
+        self._plot_height -= top_padding + bottom_padding
         self._plot_height -= t / 4 + b / 4
 
         self._plot_width = self.width
@@ -204,7 +205,7 @@ class Histogram(QGraphicsWidget):
             side_padding + r / 2,
             top_padding + t / 2,
             side_padding + l / 2,
-            b / 2
+            bottom_padding + b / 2
         )
         self.__layout.setSpacing(bar_spacing)
 


### PR DESCRIPTION
Adds a few pixels between the bars and the horizontal line. Such Tufte-inspired histograms look better.

I agree with @kaimikael the this still does not resolve properly #5757.

<img width="971" alt="Screenshot 2022-01-14 at 12 59 26" src="https://user-images.githubusercontent.com/2387315/149512565-e457e093-668d-4d49-8e73-1262d6ad3041.png">

