### PR TITLE
# Fix #5723 and fully support URL with query or fragment like http://…

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -406,7 +406,13 @@ class UrlReader(FileFormat):
         filename = filename.strip()
         if not urlparse(filename).scheme:
             filename = 'http://' + filename
-        filename = quote(filename, safe="/:")
+
+        # Fix #5723 and fully support URL with query or fragment like http://filename.txt?a=1&b=2#c=3
+        def quote_byte(b):
+            return chr(b) if b < 0x80 else '%{:02X}'.format(b)
+
+        filename = ''.join(map(quote_byte, filename.encode("utf-8")))
+
         super().__init__(filename)
 
     @staticmethod

--- a/Orange/tests/test_url_reader.py
+++ b/Orange/tests/test_url_reader.py
@@ -25,6 +25,19 @@ class TestUrlReader(unittest.TestCase):
                "vestnik-clanki/detektiranje-utrdb-v-šahu-.txt"
         self.assertRaises(OSError, UrlReader(path).read)
 
+    def test_base_url_with_query(self):
+        data = UrlReader("https://datasets.biolab.si/core/grades.xlsx?a=1&b=2").read()
+        self.assertEqual(16, len(data))
+
+    def test_url_with_fragment(self):
+        data = UrlReader("https://datasets.biolab.si/core/grades.xlsx#tab=1").read()
+        self.assertEqual(16, len(data))
+
+    def test_special_characters_with_query_and_fragment(self):
+        path = "http://file.biolab.si/text-semantics/data/elektrotehniski-" \
+               "vestnik-clanki/detektiranje-utrdb-v-šahu-.txt?a=1&b=2#c=3"
+        self.assertRaises(OSError, UrlReader(path).read)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Fix #5723 and fully support URL with query or fragment like `http://filename.txt?a=1&b=2#c=3`

##### Issue
Fix #5723

##### Description of changes
Use UTF-8 encoding URL with non-ascii characters, and preserve the role of special characters like ?#&=.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
