### PR TITLE
Predictions: Allow choosing a target

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 import io
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 
@@ -11,6 +11,7 @@ from AnyQt.QtCore import QItemSelectionModel, QItemSelection, Qt
 from Orange.base import Model
 from Orange.classification import LogisticRegressionLearner
 from Orange.data.io import TabReader
+from Orange.evaluation.scoring import TargetScore
 from Orange.regression import LinearRegressionLearner
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.evaluate.owpredictions import (
@@ -21,7 +22,7 @@ from Orange.widgets.evaluate.owconfusionmatrix import OWConfusionMatrix
 from Orange.widgets.evaluate.owliftcurve import OWLiftCurve
 from Orange.widgets.evaluate.owrocanalysis import OWROCAnalysis
 
-from Orange.data import Table, Domain, DiscreteVariable
+from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.modelling import ConstantLearner, TreeLearner
 from Orange.evaluation import Results
 from Orange.widgets.tests.utils import excepthook_catch, \
@@ -577,6 +578,202 @@ class TestOWPredictions(WidgetTest):
         self.assertFalse(self.widget.Warning.missing_targets.is_shown())
         self.assertFalse(self.widget.Error.scorer_failed.is_shown())
 
+    def _mock_predictors(self):
+        def pred(values):
+            slot = Mock()
+            slot.predictor.domain.class_var = DiscreteVariable("c", tuple(values))
+            return slot
+
+        def predc():
+            slot = Mock()
+            slot.predictor.domain.class_var = ContinuousVariable("c")
+            return slot
+
+        widget = self.widget
+        model = Mock()
+        model.setProbInd = Mock()
+        widget.predictionsview.model = Mock(return_value=model)
+
+        widget.predictors = \
+            [pred(values) for values in ("abc", "ab", "cbd", "e")] + [predc()]
+
+    def test_update_prediction_delegate_discrete(self):
+        self._mock_predictors()
+
+        widget = self.widget
+        prob_combo = widget.controls.shown_probs
+        set_prob_ind = widget.predictionsview.model().setProbInd
+
+        widget.data = Table.from_list(
+            Domain([], DiscreteVariable("c", values=tuple("abc"))), [])
+
+        widget._update_control_visibility()
+        self.assertFalse(prob_combo.isHidden())
+
+        widget._set_class_values()
+        self.assertEqual(widget.class_values, list("abcde"))
+
+        widget._set_target_combos()
+        self.assertEqual(
+            [prob_combo.itemText(i) for i in range(prob_combo.count())],
+            widget.PROB_OPTS + list("abc"))
+
+        widget.shown_probs = widget.NO_PROBS
+        widget._update_prediction_delegate()
+        for delegate in widget._delegates:
+            self.assertEqual(list(delegate.shown_probabilities), [])
+            self.assertEqual(delegate.tooltip, "")
+        set_prob_ind.assert_called_with([[], [], [], [], None])
+
+        widget.shown_probs = widget.DATA_PROBS
+        widget._update_prediction_delegate()
+        self.assertEqual(widget._delegates[0].shown_probabilities, [0, 1, 2])
+        self.assertEqual(widget._delegates[1].shown_probabilities, [0, 1, None])
+        self.assertEqual(widget._delegates[1].shown_probabilities, [0, 1, None])
+        self.assertEqual(widget._delegates[2].shown_probabilities, [None, 1, 2])
+        self.assertEqual(widget._delegates[3].shown_probabilities, [None, None, None])
+        self.assertEqual(widget._delegates[4].shown_probabilities, ())
+        self.assertEqual(widget._delegates[4].tooltip, "")
+        for delegate in widget._delegates[:-1]:
+            self.assertEqual(delegate.tooltip, "p(a, b, c)")
+        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [1, 2], [], None])
+
+        widget.shown_probs = widget.MODEL_PROBS
+        widget._update_prediction_delegate()
+        self.assertEqual(widget._delegates[0].shown_probabilities, [0, 1, 2])
+        self.assertEqual(widget._delegates[0].tooltip, "p(a, b, c)")
+        self.assertEqual(widget._delegates[1].shown_probabilities, [0, 1])
+        self.assertEqual(widget._delegates[1].tooltip, "p(a, b)")
+        self.assertEqual(widget._delegates[2].shown_probabilities, [2, 1, 3])
+        self.assertEqual(widget._delegates[2].tooltip, "p(c, b, d)")
+        self.assertEqual(widget._delegates[3].shown_probabilities, [4])
+        self.assertEqual(widget._delegates[3].tooltip, "p(e)")
+        self.assertEqual(widget._delegates[4].shown_probabilities, ())
+        self.assertEqual(widget._delegates[4].tooltip, "")
+        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [2, 1, 3], [4], None])
+
+        widget.shown_probs = widget.BOTH_PROBS
+        widget._update_prediction_delegate()
+        self.assertEqual(widget._delegates[0].shown_probabilities, [0, 1, 2])
+        self.assertEqual(widget._delegates[0].tooltip, "p(a, b, c)")
+        self.assertEqual(widget._delegates[1].shown_probabilities, [0, 1])
+        self.assertEqual(widget._delegates[1].tooltip, "p(a, b)")
+        self.assertEqual(widget._delegates[2].shown_probabilities, [1, 2])
+        self.assertEqual(widget._delegates[2].tooltip, "p(b, c)")
+        self.assertEqual(widget._delegates[3].shown_probabilities, [])
+        self.assertEqual(widget._delegates[3].tooltip, "")
+        self.assertEqual(widget._delegates[4].shown_probabilities, ())
+        self.assertEqual(widget._delegates[4].tooltip, "")
+        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [1, 2], [], None])
+
+        n_fixed = len(widget.PROB_OPTS)
+        widget.shown_probs = n_fixed  # a
+        widget._update_prediction_delegate()
+        self.assertEqual(widget._delegates[0].shown_probabilities, [0])
+        self.assertEqual(widget._delegates[1].shown_probabilities, [0])
+        self.assertEqual(widget._delegates[2].shown_probabilities, [None])
+        self.assertEqual(widget._delegates[3].shown_probabilities, [None])
+        self.assertEqual(widget._delegates[4].shown_probabilities, ())
+        for delegate in widget._delegates[:-1]:
+            self.assertEqual(delegate.tooltip, "p(a)")
+        set_prob_ind.assert_called_with([[0], [0], [], [], None])
+
+        n_fixed = len(widget.PROB_OPTS)
+        widget.shown_probs = n_fixed + 1  # b
+        widget._update_prediction_delegate()
+        self.assertEqual(widget._delegates[0].shown_probabilities, [1])
+        self.assertEqual(widget._delegates[1].shown_probabilities, [1])
+        self.assertEqual(widget._delegates[2].shown_probabilities, [1])
+        self.assertEqual(widget._delegates[3].shown_probabilities, [None])
+        self.assertEqual(widget._delegates[4].shown_probabilities, ())
+        for delegate in widget._delegates[:-1]:
+            self.assertEqual(delegate.tooltip, "p(b)")
+        set_prob_ind.assert_called_with([[1], [1], [1], [], None])
+
+        n_fixed = len(widget.PROB_OPTS)
+        widget.shown_probs = n_fixed + 2  # c
+        widget._update_prediction_delegate()
+        self.assertEqual(widget._delegates[0].shown_probabilities, [2])
+        self.assertEqual(widget._delegates[1].shown_probabilities, [None])
+        self.assertEqual(widget._delegates[2].shown_probabilities, [2])
+        self.assertEqual(widget._delegates[3].shown_probabilities, [None])
+        self.assertEqual(widget._delegates[4].shown_probabilities, ())
+        for delegate in widget._delegates[:-1]:
+            self.assertEqual(delegate.tooltip, "p(c)")
+        set_prob_ind.assert_called_with([[2], [], [2], [], None])
+
+    def test_update_delegates_continuous(self):
+        self._mock_predictors()
+
+        widget = self.widget
+        widget.shown_probs = widget.DATA_PROBS
+        set_prob_ind = widget.predictionsview.model().setProbInd
+
+        widget.data = Table.from_list(Domain([], ContinuousVariable("c")), [])
+
+        widget._update_control_visibility()
+        self.assertTrue(widget.controls.shown_probs.isHidden())
+        self.assertTrue(widget.controls.target_class.isHidden())
+
+        widget._set_class_values()
+        self.assertEqual(widget.class_values, list("abcde"))
+
+        widget._set_target_combos()
+        self.assertEqual(widget.shown_probs, widget.NO_PROBS)
+
+        widget._update_prediction_delegate()
+        for delegate in widget._delegates:
+            self.assertEqual(list(delegate.shown_probabilities), [])
+            self.assertEqual(delegate.tooltip, "")
+        set_prob_ind.assert_called_with([[], [], [], [], None])
+
+    class _Scorer(TargetScore):
+        # pylint: disable=arguments-differ
+        def compute_score(self, _, target, **__):
+            return [42 if target is None else target]
+
+    @patch("Orange.widgets.evaluate.owpredictions.usable_scorers",
+           Mock(return_value=[_Scorer]))
+    def test_change_target(self):
+        widget = self.widget
+        table = widget.score_table
+        combo = widget.controls.target_class
+
+        log_reg_iris = LogisticRegressionLearner()(self.iris)
+        self.send_signal(widget.Inputs.predictors, log_reg_iris)
+        self.send_signal(widget.Inputs.data, self.iris)
+
+        self.assertEqual(table.model.rowCount(), 1)
+        self.assertEqual(table.model.columnCount(), 4)
+        self.assertEqual(float(table.model.data(table.model.index(0, 3))), 42)
+
+        for idx, value in enumerate(widget.class_var.values):
+            combo.setCurrentText(value)
+            combo.activated[str].emit(value)
+            self.assertEqual(table.model.rowCount(), 1)
+            self.assertEqual(table.model.columnCount(), 4)
+            self.assertEqual(float(table.model.data(table.model.index(0, 3))),
+                             idx)
+
+    def test_report(self):
+        widget = self.widget
+
+        log_reg_iris = LogisticRegressionLearner()(self.iris)
+        self.send_signal(widget.Inputs.predictors, log_reg_iris)
+        self.send_signal(widget.Inputs.data, self.iris)
+
+        widget.report_paragraph = Mock()
+        reports = set()
+        for widget.shown_probs in range(len(widget.PROB_OPTS)):
+            widget.send_report()
+            reports.add(widget.report_paragraph.call_args[0][1])
+        self.assertEqual(len(reports), len(widget.PROB_OPTS))
+
+        for widget.shown_probs, value in enumerate(
+                widget.class_var.values, start=widget.shown_probs + 1):
+            widget.send_report()
+            self.assertIn(value, widget.report_paragraph.call_args[0][1])
+
 
 class SelectionModelTest(unittest.TestCase):
     def setUp(self):
@@ -879,7 +1076,7 @@ class PredictionsModelTest(unittest.TestCase):
         self.assertEqual(val, 1)
         np.testing.assert_equal(prob, [0.1, 0.6, 0.3])
 
-        model.setProbInd([2])
+        model.setProbInd([[2], [2]])
         model.sort(0, Qt.DescendingOrder)
         val, prob = model.data(model.index(0, 0))
         self.assertEqual(val, 2)
@@ -888,7 +1085,7 @@ class PredictionsModelTest(unittest.TestCase):
         self.assertEqual(val, 1)
         np.testing.assert_equal(prob, [0.1, 0.6, 0.3])
 
-        model.setProbInd([2])
+        model.setProbInd([[2], [2]])
         model.sort(1, Qt.AscendingOrder)
         val, prob = model.data(model.index(0, 1))
         self.assertEqual(val, 0)
@@ -897,25 +1094,44 @@ class PredictionsModelTest(unittest.TestCase):
         self.assertEqual(val, 1)
         np.testing.assert_equal(prob, [0.3, 0.7, 0])
 
-        model.setProbInd([1, 0])
+        model.setProbInd([[1, 0], [1, 0]])
         model.sort(0, Qt.AscendingOrder)
         np.testing.assert_equal(model.data(model.index(0, 0))[1], [0, .1, .9])
         np.testing.assert_equal(model.data(model.index(1, 0))[1], [0.8, .1, .1])
 
-        model.setProbInd([1, 2])
+        model.setProbInd([[1, 2], [1, 2]])
         model.sort(0, Qt.AscendingOrder)
         np.testing.assert_equal(model.data(model.index(0, 0))[1], [0.8, .1, .1])
         np.testing.assert_equal(model.data(model.index(1, 0))[1], [0, .1, .9])
 
-        model.setProbInd([])
+        model.setProbInd([[], []])
         model.sort(0, Qt.AscendingOrder)
         self.assertEqual([model.data(model.index(i, 0))[0]
                           for i in range(model.rowCount())], [0, 0, 1, 1, 2])
 
-        model.setProbInd([])
+        model.setProbInd([[], []])
         model.sort(0, Qt.DescendingOrder)
         self.assertEqual([model.data(model.index(i, 0))[0]
                           for i in range(model.rowCount())], [2, 1, 1, 0, 0])
+
+    def test_sorting_classification_different(self):
+        model = PredictionsModel(self.values, self.probs)
+
+        model.setProbInd([[2], [0]])
+        model.sort(0, Qt.DescendingOrder)
+        val, prob = model.data(model.index(0, 0))
+        self.assertEqual(val, 2)
+        np.testing.assert_equal(prob, [0, 0.1, 0.9])
+        val, prob = model.data(model.index(0, 1))
+        self.assertEqual(val, 1)
+        np.testing.assert_equal(prob, [0.1, 0.6, 0.3])
+        model.sort(1, Qt.DescendingOrder)
+        val, prob = model.data(model.index(0, 0))
+        self.assertEqual(val, 1)
+        np.testing.assert_equal(prob, [0.3, 0.7, 0])
+        val, prob = model.data(model.index(0, 1))
+        self.assertEqual(val, 0)
+        np.testing.assert_equal(prob, [0.9, 0.05, 0.05])
 
     def test_sorting_regression(self):
         model = PredictionsModel(self.values, self.no_probs)


### PR DESCRIPTION
##### Issue

Fixes #5743.

##### Description of changes

It sure looks funny, especially for numeric targets, but.

I didn't want to put the combo to the main area in order to save space; in Test and Score we have plenty space on the right, here it's precious. I have put the Restore Order button and the list view for selecting probabilities at the top, and the combo for choosing the target at the bottom (with rubber in between), so they are close to their respective tables.

<img width="778" alt="Screenshot 2022-01-14 at 23 00 12" src="https://user-images.githubusercontent.com/2387315/149590979-f00c0fbe-911d-43a4-965b-b92d2704f1ec.png">

This is quite nice for discrete outcomes; less so for numeric.

<img width="778" alt="Screenshot 2022-01-14 at 23 00 22" src="https://user-images.githubusercontent.com/2387315/149591028-a2689a62-8942-4cd8-8c15-ac72297487c3.png">

I've no idea what to do here except for perhaps having a different layout in this case: just put the checkbox and the button between the tables (in that order, with rubber between), and hide the control area completely.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
