### PR TITLE
[FIX] table_from_frame: replace nan with String.Unknown for string variable

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -280,7 +280,12 @@ def vars_from_df(df, role=None, force_nominal=False):
                 raise ValueError("String variable must be in metas.")
             _role = Role.Meta
             var = StringVariable(str(column))
-            expr = lambda s, _: np.asarray(s, dtype=object)
+            expr = lambda s, _: np.asarray(
+                # to object so that fillna can replace with nans if Unknown in nan
+                # replace nan with object Unknown assure that all values are string
+                s.astype(object).fillna(StringVariable.Unknown).astype(str),
+                dtype=object
+            )
 
         cols[_role].append(column)
         exprs[_role].append(expr)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
1. When transforming pandas data frame to table string columns that contain nan values will 
keep them after the transformation but Orange uses an empty string for the unknown value in the StringVarable. 

   For example:
      df = pd.DataFrame(
           [["a", "b"], ["c", "d"], ["e", "f"], [np.nan, np.nan]],
       )

   will be transformed to the table with two string variables and nan values will be kept even `String.Unknow = ""`

2. When a column is recognized to be a string and has an object type, it still can contain some values that are not strings. Cast column to string.

##### Description of changes
Changed that nan values are transformed to `String.Unknown` for columns that will be transformed to the string variable and values are transformed to strings.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
