### PR TITLE
[FIX] owfeaturestatistics: Fix implicit int conversion error on resize

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -680,7 +680,7 @@ class FeatureStatisticsTableView(QTableView):
         if logical_index is not self.model().Columns.DISTRIBUTION.index:
             return
         ratio_width, ratio_height = self.HISTOGRAM_ASPECT_RATIO
-        unit_width = new_size / ratio_width
+        unit_width = new_size // ratio_width
         new_height = unit_width * ratio_height
         effective_height = max(new_height, self.MINIMUM_HISTOGRAM_HEIGHT)
         effective_height = min(effective_height, self.MAXIMUM_HISTOGRAM_HEIGHT)

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -288,6 +288,15 @@ class TestVariousDataSets(WidgetTest):
             except Exception as e:
                 raise AssertionError(f"Failed on `{data.name}`") from e
 
+    def test_header_resize_aspect_ratio(self):
+        self.widget.show()  # must be visible for header resize to work
+        size = self.widget.size()
+        self.widget.resize(size.width() + 2000, size.height())
+        self.assertEqual(
+            self.widget.table_view.verticalHeader().defaultSectionSize(),
+            self.widget.table_view.MAXIMUM_HISTOGRAM_HEIGHT
+        )
+
 
 def select_rows(rows: List[int], widget: OWFeatureStatistics):
     """Since the widget sorts the rows, selecting rows isn't trivial."""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Feature Statistics widget raises an error on Python 3.10 (warning in Python 3.9) on widget resize due to implicit conversion to int.

```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange3/Orange/widgets/data/owfeaturestatistics.py", line 687, in bind_histogram_aspect_ratio
    self.verticalHeader().setDefaultSectionSize(effective_height)
TypeError: setDefaultSectionSize(self, int): argument 1 has unexpected type 'float'
-------------------------------------------------------------------------------

```
##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
