### PR TITLE
[FIX] Ensure unlockable sparse arrays after Table.copy

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1465,9 +1465,10 @@ class Table(Sequence, Storage):
         """
 
         def is_view(x):
-            # Sparse matrices don't have views like numpy arrays. Since indexing on
-            # them creates copies in constructor we can skip this check here.
-            return not sp.issparse(x) and x.base is not None
+            if not sp.issparse(x):
+                return x.base is not None
+            else:
+                return x.data.base is not None
 
         if is_view(self._X):
             self._X = self._X.copy()

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -495,9 +495,13 @@ class TableTestCase(unittest.TestCase):
         self.assertNotEqual(id(t.metas), id(copy.metas))
 
         # ensure that copied sparse arrays do not share data
+        # and that both are unlockable
         with t.unlocked():
             t.X[0, 0] = 42
         self.assertEqual(copy.X[0, 0], 5.1)
+        with copy.unlocked():
+            copy.X[0, 0] = 43
+        self.assertEqual(t.X[0, 0], 42)
 
     def test_concatenate(self):
         d1 = data.Domain(


### PR DESCRIPTION
##### Issue
Fixes  #5746

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
