### PR TITLE
[FIX] Table: from_file/from_url remove type conversion

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1077,11 +1077,6 @@ class Table(Sequence, Storage):
         reader.select_sheet(sheet)
         data = reader.read()
 
-        # Readers return plain table. Make sure to cast it to appropriate
-        # (subclass) type
-        if cls != data.__class__:
-            data = cls(data)
-
         # no need to call _init_ids as fuctions from .io already
         # construct a table with .ids
 
@@ -1093,8 +1088,6 @@ class Table(Sequence, Storage):
         from Orange.data.io import UrlReader
         reader = UrlReader(url)
         data = reader.read()
-        if cls != data.__class__:
-            data = cls(data)
         return data
 
     # Helper function for __setitem__:

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -385,6 +385,16 @@ class TestTableLocking(unittest.TestCase):
         with unpickled.unlocked():
             unpickled.X[0, 0] = 42
 
+    @staticmethod
+    def test_unlock_table_derived():
+        # pylint: disable=abstract-method
+        class ExtendedTable(Table):
+            pass
+
+        t = ExtendedTable.from_file("iris")
+        with t.unlocked():
+            pass
+
 
 class TestTableFilters(unittest.TestCase):
     def setUp(self):

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -18,7 +18,10 @@ from Orange.tests import test_filename
 
 
 class NotATable(Table):  # pylint: disable=too-many-ancestors,abstract-method
-    pass
+    @classmethod
+    def from_file(cls, *args, **kwargs):
+        table = super().from_file(*args, **kwargs)
+        return cls(table)
 
 
 class TestNaiveBayesLearner(unittest.TestCase):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2163,19 +2163,6 @@ class InterfaceTest(unittest.TestCase):
                     self.table[i, j] = new_value
                     self.assertEqual(self.table[i, j], new_value)
 
-    def test_subclasses(self):
-        from pathlib import Path
-
-        class _ExtendedTable(data.Table):
-            pass
-
-        data_file = _ExtendedTable('iris')
-        data_url = _ExtendedTable.from_url(
-            Path(os.path.dirname(__file__), 'datasets/test1.tab').as_uri())
-
-        self.assertIsInstance(data_file, _ExtendedTable)
-        self.assertIsInstance(data_url, _ExtendedTable)
-
 
 class TestTableStats(TableTests):
     def test_get_nan_frequency(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When from_file/from_url is called on from table derived class, the type is changed after the reading (with calling table constructor) and so the view is made -- which is not expected by `from_file`

##### Description of changes
In discussion with @markotoplak we decided to remove the type conversion since it is causing issues (also destroys the type when for example Corpus is pickled). Classes that are derived from Table can handle the conversion themselves.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
