### PR TITLE
PyListModelTooltip: Improve handling of tooltip argument

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -144,13 +144,11 @@ Categorical features are passed as strings
         self.attributescb.setModel(self.attrs_model)
 
         sorted_funcs = sorted(self.FUNCTIONS)
-        self.funcs_model = itemmodels.PyListModelTooltip()
+        self.funcs_model = itemmodels.PyListModelTooltip(
+            chain(["Select Function"], sorted_funcs),
+            chain([''], [self.FUNCTIONS[func].__doc__ for func in sorted_funcs])
+        )
         self.funcs_model.setParent(self)
-
-        self.funcs_model[:] = chain(["Select Function"], sorted_funcs)
-        self.funcs_model.tooltips[:] = chain(
-            [''],
-            [self.FUNCTIONS[func].__doc__ for func in sorted_funcs])
 
         self.functionscb = ComboBoxSearch(
             minimumContentsLength=16,

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -358,12 +358,17 @@ class PyTableModel(AbstractSortTableModel):
 
 
 class PyListModelTooltip(PyListModel):
-    def __init__(self, iterable=None, tooltips=[], **kwargs):
+    def __init__(self, iterable=None, tooltips=(), **kwargs):
         super().__init__(iterable, **kwargs)
+        if not isinstance(tooltips, Sequence):
+            # may be a generator; if not, fail
+            tooltips = list(tooltips)
         self.tooltips = tooltips
 
     def data(self, index, role=Qt.DisplayRole):
         if role == Qt.ToolTipRole:
+            if index.row() >= len(self.tooltips):
+                return None
             return self.tooltips[index.row()]
         else:
             return super().data(index, role)


### PR DESCRIPTION
##### Issue

The `tooltip` argument for `PyListModelTooltip` has a unsafe default (a mutable list) and does not accept generators. Also, if the number of tooltips is smaller than the number of rows, it gives index error.

##### Description of changes

- Tooltip argument is now `()`.
- To support generators, non-sequences (instances of classes without `__getitem__` are converted to lists. It would be better to convert all to lists (even if already a list), to match the behaviour of `PyListModel` with respect to `DisplayRole`, but I did it this way to maintain backward compatibility with any widgets that might have counted on having a reference to data in the model.
- Index ranges are now checked, and `None` is returned if there are too few tooltips.

##### Includes
- [X] Code changes
- [X] Tests
