### PR TITLE
[ENH] Server embedder: use queue, handle unsuccessful requests at the end

### DIFF
--- a/Orange/misc/tests/test_server_embedder.py
+++ b/Orange/misc/tests/test_server_embedder.py
@@ -167,3 +167,12 @@ class TestServerEmbedder(unittest.TestCase):
         mocked_fun.assert_has_calls(
             [call(item) for item in self.test_data], any_order=True
         )
+
+    @patch(_HTTPX_POST_METHOD, return_value=DummyResponse(b''), new_callable=AsyncMock)
+    def test_retries(self, mock):
+        self.embedder.embedd_data(self.test_data)
+        self.assertEqual(len(self.test_data) * 3, mock.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/misc/tests/test_server_embedder.py
+++ b/Orange/misc/tests/test_server_embedder.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call, patch
 import numpy as np
 from httpx import ReadTimeout
 
+import Orange
 from Orange.data import Domain, StringVariable, Table
 from Orange.misc.tests.example_embedder import ExampleServerEmbedder
 
@@ -172,6 +173,30 @@ class TestServerEmbedder(unittest.TestCase):
     def test_retries(self, mock):
         self.embedder.embedd_data(self.test_data)
         self.assertEqual(len(self.test_data) * 3, mock.call_count)
+
+    @patch(_HTTPX_POST_METHOD, regular_dummy_sr)
+    def test_callback(self):
+        mock = MagicMock()
+        self.embedder.embedd_data(self.test_data, callback=mock)
+
+        process_items = [call(x) for x in np.linspace(0, 1, len(self.test_data))]
+        mock.assert_has_calls(process_items)
+
+    @patch(_HTTPX_POST_METHOD, regular_dummy_sr)
+    def test_deprecated(self):
+        """
+        When this start to fail:
+        - remove process_callback parameter and marked places connected to this param
+        - remove set_canceled and marked places connected to this method
+        - this test
+        """
+        self.assertGreaterEqual("3.33.0", Orange.__version__)
+
+        mock = MagicMock()
+        self.embedder.embedd_data(self.test_data, processed_callback=mock)
+
+        process_items = [call(True) for _ in range(len(self.test_data))]
+        mock.assert_has_calls(process_items)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Server embedder retries sending unsuccessful requests immediately after the fauliture. 
Since it is possible that the server needs longer to compute (the request was unsuccessful because of timeout) the results (the server will cache the result when finished) it is better to retry later (there is a higher chance that the server already finished processing).

##### Description of changes
Implemented described behaviour. To achieve it I needed to change embedders to use Queue instead of just gathering the results. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
