### PR TITLE
[FIX] Scatter Plot: Replot when input features change

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -358,6 +358,7 @@ class OWScatterPlot(OWDataProjectionWidget):
         self.vizrank: ScatterPlotVizRank = None
         self.vizrank_button: QPushButton = None
         self.sampling: QGroupBox = None
+        self._xy_invalidated: bool = True
 
         self.sql_data = None  # Orange.data.sql.table.SqlTable
         self.attribute_selection_list = None  # list of Orange.data.Variable
@@ -581,6 +582,8 @@ class OWScatterPlot(OWDataProjectionWidget):
             self.attr_x, self.attr_y = self.attribute_selection_list[:2]
             self.attr_box.setEnabled(False)
             self.vizrank.setEnabled(False)
+        self._invalidated = self._invalidated or self._xy_invalidated
+        self._xy_invalidated = False
         super().handleNewSignals()
         if self._domain_invalidated:
             self.graph.update_axes()
@@ -591,7 +594,7 @@ class OWScatterPlot(OWDataProjectionWidget):
     def set_shown_attributes(self, attributes):
         if attributes and len(attributes) >= 2:
             self.attribute_selection_list = attributes[:2]
-            self._invalidated = self._invalidated \
+            self._xy_invalidated = self._xy_invalidated \
                 or self.attr_x != attributes[0] \
                 or self.attr_y != attributes[1]
         else:

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -743,6 +743,13 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         self.widget.setup_plot.assert_called_once()
         self.assertListEqual(self.widget.effective_variables, list(features))
 
+        self.widget.setup_plot.reset_mock()
+        features = self.data.domain.attributes[2:]
+        signals = [(self.widget.Inputs.features, AttributeList(features)),
+                   (self.widget.Inputs.data, self.data)]
+        self.send_signals(signals)
+        self.widget.setup_plot.assert_called_once()
+
     def test_invalidated_diff_features(self):
         self.widget.setup_plot = Mock()
         # send data and set default features


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Scatter Plot widget does not always refresh the plot on input features change. To obtain this behaviour the features must be connected before the data (see the included test).

To reproduce, open the attached workflow and change the selection in the Correlations widget. The plot in Scatter Plot does not change accordingly.
[untitled.ows.zip](https://github.com/biolab/orange3/files/8047374/untitled.ows.zip)


##### Description of changes
- introduce `_attrs_invalidated` variable in Scatter Plot widget

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
