### PR TITLE
[ENH] Enable multitarget problem types for OWTestAndScore and OWPredictions

### DIFF
--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -6,15 +6,13 @@ __all__ = ["LearnerClassification", "ModelClassification",
 
 class LearnerClassification(Learner):
 
-    def check_learner_adequacy(self, domain):
-        is_adequate = True
-        if len(domain.class_vars) > 1:
-            is_adequate = False
-            self.learner_adequacy_err_msg = "Too many target variables."
+    def incompatibility_reason(self, domain):
+        reason = None
+        if len(domain.class_vars) > 1 and not self.supports_multiclass:
+            reason = "Too many target variables."
         elif not domain.has_discrete_class:
-            is_adequate = False
-            self.learner_adequacy_err_msg = "Categorical class variable expected."
-        return is_adequate
+            reason = "Categorical class variable expected."
+        return reason
 
 
 class ModelClassification(Model):

--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -5,10 +5,16 @@ __all__ = ["LearnerClassification", "ModelClassification",
 
 
 class LearnerClassification(Learner):
-    learner_adequacy_err_msg = "Categorical class variable expected."
 
     def check_learner_adequacy(self, domain):
-        return domain.has_discrete_class
+        is_adequate = True
+        if len(domain.class_vars) > 1:
+            is_adequate = False
+            self.learner_adequacy_err_msg = "Too many target variables."
+        elif not domain.has_discrete_class:
+            is_adequate = False
+            self.learner_adequacy_err_msg = "Categorical class variable expected."
+        return is_adequate
 
 
 class ModelClassification(Model):

--- a/Orange/evaluation/clustering.py
+++ b/Orange/evaluation/clustering.py
@@ -32,6 +32,10 @@ class ClusteringResults(Results):
 class ClusteringScore(Score):
     considers_actual = False
 
+    @staticmethod
+    def is_compatible(domain) -> bool:
+        return True
+
     # pylint: disable=arguments-differ
     def from_predicted(self, results, score_function):
         # Clustering scores from labels

--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -16,7 +16,7 @@ import numpy as np
 import sklearn.metrics as skl_metrics
 from sklearn.metrics import confusion_matrix
 
-from Orange.data import DiscreteVariable, ContinuousVariable
+from Orange.data import DiscreteVariable, ContinuousVariable, Domain
 from Orange.misc.wrapper_meta import WrapperMeta
 
 __all__ = ["CA", "Precision", "Recall", "F1", "PrecisionRecallFSupport", "AUC",
@@ -112,13 +112,25 @@ class Score(metaclass=ScoreMetaType):
              for predicted in results.predicted),
             dtype=np.float64, count=len(results.predicted))
 
+    @staticmethod
+    def is_compatible(domain: Domain) -> bool:
+        raise NotImplementedError
+
 
 class ClassificationScore(Score, abstract=True):
     class_types = (DiscreteVariable, )
 
+    @staticmethod
+    def is_compatible(domain: Domain) -> bool:
+        return domain.has_discrete_class
+
 
 class RegressionScore(Score, abstract=True):
     class_types = (ContinuousVariable, )
+
+    @staticmethod
+    def is_compatible(domain: Domain) -> bool:
+        return domain.has_continuous_class
 
 
 # pylint: disable=invalid-name

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -224,7 +224,8 @@ class Model(BaseImputeMethod):
         variable = data.domain[variable]
         domain = domain_with_class_var(data.domain, variable)
 
-        if self.learner.check_learner_adequacy(domain):
+        incompatibility_reason = self.learner.incompatibility_reason(domain)
+        if incompatibility_reason is None:
             data = data.transform(domain)
             model = self.learner(data)
             assert model.domain.class_var == variable
@@ -239,7 +240,7 @@ class Model(BaseImputeMethod):
 
     def supports_variable(self, variable):
         domain = Orange.data.Domain([], class_vars=variable)
-        return self.learner.check_learner_adequacy(domain)
+        return self.learner.incompatibility_reason(domain) is None
 
 
 def domain_with_class_var(domain, class_var):

--- a/Orange/regression/base_regression.py
+++ b/Orange/regression/base_regression.py
@@ -6,15 +6,13 @@ __all__ = ["LearnerRegression", "ModelRegression",
 
 class LearnerRegression(Learner):
 
-    def check_learner_adequacy(self, domain):
-        is_adequate = True
-        if len(domain.class_vars) > 1:
-            is_adequate = False
-            self.learner_adequacy_err_msg = "Too many target variables."
+    def incompatibility_reason(self, domain):
+        reason = None
+        if len(domain.class_vars) > 1 and not self.supports_multiclass:
+            reason = "Too many target variables."
         elif not domain.has_continuous_class:
-            is_adequate = False
-            self.learner_adequacy_err_msg = "Numeric class variable expected."
-        return is_adequate
+            reason = "Numeric class variable expected."
+        return reason
 
 
 class ModelRegression(Model):

--- a/Orange/regression/base_regression.py
+++ b/Orange/regression/base_regression.py
@@ -5,10 +5,16 @@ __all__ = ["LearnerRegression", "ModelRegression",
 
 
 class LearnerRegression(Learner):
-    learner_adequacy_err_msg = "Numeric class variable expected."
 
     def check_learner_adequacy(self, domain):
-        return domain.has_continuous_class
+        is_adequate = True
+        if len(domain.class_vars) > 1:
+            is_adequate = False
+            self.learner_adequacy_err_msg = "Too many target variables."
+        elif not domain.has_continuous_class:
+            is_adequate = False
+            self.learner_adequacy_err_msg = "Numeric class variable expected."
+        return is_adequate
 
 
 class ModelRegression(Model):

--- a/Orange/tests/dummy_learners.py
+++ b/Orange/tests/dummy_learners.py
@@ -33,8 +33,9 @@ class DummyPredictor(SklModelClassification):
 class DummyMulticlassLearner(SklLearner):
     supports_multiclass = True
 
-    def check_learner_adequacy(self, domain):
-        return all(c.is_discrete for c in domain.class_vars)
+    def incompatibility_reason(self, domain):
+        reason = 'Not all class variables are discrete'
+        return None if all(c.is_discrete for c in domain.class_vars) else reason
 
     def fit(self, X, Y, W):
         rows, class_vars = Y.shape

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -2,28 +2,59 @@
 # pylint: disable=missing-docstring
 import pickle
 import unittest
+from distutils.version import LooseVersion
 
+import Orange
 from Orange.base import SklLearner, Learner, Model
 from Orange.data import Domain, Table
 from Orange.preprocess import Discretize, Randomize, Continuize
 from Orange.regression import LinearRegressionLearner
+from Orange.util import OrangeDeprecationWarning
+
+
+class DummyLearnerDeprecated(Learner):
+
+    def fit(self, *_, **__):
+        return unittest.mock.Mock()
+
+    def check_learner_adequacy(self, _):
+        return True
 
 
 class DummyLearner(Learner):
+
     def fit(self, *_, **__):
         return unittest.mock.Mock()
 
 
 class DummySklLearner(SklLearner):
+
     def fit(self, *_, **__):
         return unittest.mock.Mock()
 
 
 class DummyLearnerPP(Learner):
+
     preprocessors = (Randomize(),)
 
 
 class TestLearner(unittest.TestCase):
+
+    def test_if_deprecation_warning_is_raised(self):
+        with self.assertWarns(OrangeDeprecationWarning):
+            DummyLearnerDeprecated()(Table('iris'))
+
+    def test_check_learner_adequacy_deprecated(self):
+        """This test is to be included in the 3.32 release and will fail in
+        version 3.34. This serves as a reminder to remove the deprecated method
+        and this test."""
+        if LooseVersion(Orange.__version__) >= LooseVersion("3.34"):
+            self.fail(
+                "`Orange.base.Learner.check_learner_adequacy` was deprecated in "
+                "version 3.32, and there have been two minor versions in "
+                "between. Please remove the deprecated method."
+            )
+
     def test_uses_default_preprocessors_unless_custom_pps_specified(self):
         """Learners should use their default preprocessors unless custom
         preprocessors were passed in to the constructor"""

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -358,7 +358,7 @@ class OWPredictions(OWWidget):
         else:
             target = None
         model.clear()
-        scorers = usable_scorers(self.class_var) if self.class_var else []
+        scorers = usable_scorers(self.data.domain) if self.data else []
         self.score_table.update_header(scorers)
         self.scorer_errors = errors = []
         for pred in self.predictors:

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -282,7 +282,7 @@ class OWPredictions(OWWidget):
             self.class_values += self.data.domain.class_var.values
         for slot in self.predictors:
             class_var = slot.predictor.domain.class_var
-            if class_var.is_discrete:
+            if class_var and class_var.is_discrete:
                 for value in class_var.values:
                     if value not in self.class_values:
                         self.class_values.append(value)
@@ -318,7 +318,8 @@ class OWPredictions(OWWidget):
 
             predictor = slot.predictor
             try:
-                if predictor.domain.class_var.is_discrete:
+                class_var = predictor.domain.class_var
+                if class_var and predictor.domain.class_var.is_discrete:
                     pred, prob = predictor(classless_data, Model.ValueProbs)
                 else:
                     pred = predictor(classless_data, Model.Value)
@@ -371,7 +372,10 @@ class OWPredictions(OWWidget):
                 predicted = results.predicted
                 probabilities = results.probabilities
 
-                mask = numpy.isnan(results.actual)
+                if self.class_var:
+                    mask = numpy.isnan(results.actual)
+                else:
+                    mask = numpy.any(numpy.isnan(results.actual), axis=1)
                 no_targets = mask.sum() == len(results.actual)
                 results.actual = results.actual[~mask]
                 results.predicted = results.predicted[:, ~mask]
@@ -486,7 +490,7 @@ class OWPredictions(OWWidget):
         for p in self._non_errored_predictors():
             values = p.results.unmapped_predicted
             target = p.predictor.domain.class_var
-            if target.is_discrete:
+            if target and target.is_discrete:
                 # order probabilities in order from Show prob. for
                 prob = self._reordered_probabilities(p)
                 values = numpy.array(target.values)[values.astype(int)]
@@ -558,7 +562,9 @@ class OWPredictions(OWWidget):
                 p.predictor.domain.class_var.colors,
                 p.predictor.domain.class_var.values
             ), key=itemgetter(1))))
-            for p in predictors if p.predictor.domain.class_var.is_discrete
+            for p in predictors
+            if p.predictor.domain.class_var and
+            p.predictor.domain.class_var.is_discrete
         ]
         return color_values if color_values else [([], [])]
 
@@ -613,12 +619,7 @@ class OWPredictions(OWWidget):
         sort_col_indices = []
         for col, slot in enumerate(self.predictors):
             target = slot.predictor.domain.class_var
-            if target.is_continuous:
-                delegate = PredictionsItemDelegate(
-                    None, colors, (), (), target.format_str,
-                    parent=self.predictionsview)
-                sort_col_indices.append(None)
-            else:
+            if target is not None and target.is_discrete:
                 shown_probs = self._shown_prob_indices(target, in_target=True)
                 if self.shown_probs in (self.MODEL_PROBS, self.BOTH_PROBS):
                     tooltip_probs = [self.class_values[i]
@@ -628,6 +629,13 @@ class OWPredictions(OWWidget):
                     parent=self.predictionsview)
                 sort_col_indices.append([col for col in shown_probs
                                          if col is not None])
+
+            else:
+                delegate = PredictionsItemDelegate(
+                    None, colors, (), (), target.format_str if target is not None else None,
+                    parent=self.predictionsview)
+                sort_col_indices.append(None)
+
             # QAbstractItemView does not take ownership of delegates, so we must
             self._delegates.append(delegate)
             self.predictionsview.setItemDelegateForColumn(col, delegate)
@@ -680,7 +688,7 @@ class OWPredictions(OWWidget):
     def _commit_evaluation_results(self):
         slots = [p for p in self._non_errored_predictors()
                  if p.results.predicted is not None]
-        if not slots:
+        if not slots or not self.class_var:
             self.Outputs.evaluation_results.send(None)
             return
 
@@ -707,7 +715,8 @@ class OWPredictions(OWWidget):
         newmetas = []
         newcolumns = []
         for slot in self._non_errored_predictors():
-            if slot.predictor.domain.class_var.is_discrete:
+            target = slot.predictor.domain.class_var
+            if target and target.is_discrete:
                 self._add_classification_out_columns(slot, newmetas, newcolumns)
             else:
                 self._add_regression_out_columns(slot, newmetas, newcolumns)
@@ -724,7 +733,7 @@ class OWPredictions(OWWidget):
             names.append(uniq)
 
         metas += uniq_newmetas
-        domain = Orange.data.Domain(attrs, self.class_var, metas=metas)
+        domain = Orange.data.Domain(attrs, self.data.domain.class_vars, metas=metas)
         predictions = self.data.transform(domain)
         if newcolumns:
             newcolumns = numpy.hstack(
@@ -865,7 +874,8 @@ class PredictionsItemDelegate(ItemDelegate):
         super().__init__(parent)
         self.class_values = class_values  # will be None for continuous
         self.colors = [QColor(*c) for c in colors]
-        self.target_format = target_format  # target format for cont. vars
+        # target format for cont. vars
+        self.target_format = target_format if target_format else '%.2f'
         self.shown_probabilities = self.fmt = self.tooltip = None  # set below
         self.setFormat(shown_probabilities, tooltip_probabilities)
 

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -517,10 +517,10 @@ class OWTestAndScore(OWWidget):
     # - we don't gain much with it
     # - it complicates the unit tests
     def _update_scorers(self):
-        if self.data and self.data.domain.class_var:
-            new_scorers = usable_scorers(self.data.domain.class_var)
-        else:
-            new_scorers = []
+        new_scorers = []
+        if self.data:
+            new_scorers = usable_scorers(self.data.domain)
+
         # Don't unnecessarily reset the combo because this would always reset
         # comparison_criterion; we also set it explicitly, though, for clarity
         if new_scorers != self.scorers:

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -188,6 +188,7 @@ class TestOWPredictions(WidgetTest):
                 (self.widget.Inputs.data, data),
                 (self.widget.Inputs.predictors, model)
             ])
+
         iris = self.iris
         learner = ConstantLearner()
         heart_disease = Table("heart_disease")
@@ -253,6 +254,7 @@ class TestOWPredictions(WidgetTest):
         """
         Test whether sorting of probabilities by FilterSortProxy is correct.
         """
+
         def get_items_order(model):
             return model.mapToSourceRows(np.arange(model.rowCount()))
 
@@ -878,6 +880,27 @@ class TestOWPredictions(WidgetTest):
             self.assertEqual(float(table.model.data(table.model.index(0, 3))),
                              idx)
 
+    def test_multi_target_input(self):
+        widget = self.widget
+
+        domain = Domain([ContinuousVariable('var1')],
+                        class_vars=[
+                            ContinuousVariable('c1'),
+                            DiscreteVariable('c2', values=('no', 'yes'))
+                        ])
+        data = Table.from_list(domain, [[1, 5, 0], [2, 10, 1]])
+
+        mock_model = Mock(spec=Model, return_value=np.asarray([0.2, 0.1]))
+        mock_model.name = 'Mockery'
+        mock_model.domain = domain
+        mock_learner = Mock(return_value=mock_model)
+        model = mock_learner(data)
+
+        self.send_signal(widget.Inputs.data, data)
+        self.send_signal(widget.Inputs.predictors, model, 1)
+        pred = self.get_output(widget.Outputs.predictions)
+        self.assertIsInstance(pred, Table)
+
     def test_report(self):
         widget = self.widget
 
@@ -1022,7 +1045,6 @@ class SharedSelectionStoreTest(SelectionModelTest):
             self.assertEqual(list(selected), exp_selected)
             self.assertEqual(list(deselected), exp_deselected)
 
-
         store.model.setSortIndices([4, 0, 1, 2, 3])
         store.select_rows({3, 4}, QItemSelectionModel.Select)
         assert_called([4, 0], [])
@@ -1132,7 +1154,7 @@ class PredictionsModelTest(unittest.TestCase):
         cls.probs = [np.array([[80, 10, 10],
                                [30, 70, 0],
                                [15, 80, 5],
-                               [0,  10, 90],
+                               [0, 10, 90],
                                [55, 40, 5]]) / 100,
                      np.array([[80, 0, 20],
                                [90, 5, 5],

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -225,6 +225,10 @@ class TestOWTestAndScore(WidgetTest):
             class NewScore(Score):
                 class_types = (DiscreteVariable, ContinuousVariable)
 
+                @staticmethod
+                def is_compatible(domain: Domain) -> bool:
+                    return True
+
             class NewClassificationScore(ClassificationScore):
                 pass
 

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -16,7 +16,7 @@ from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.evaluation import Results, TestOnTestData, scoring
 from Orange.evaluation.scoring import ClassificationScore, RegressionScore, \
     Score
-from Orange.base import Learner
+from Orange.base import Learner, Model
 from Orange.modelling import ConstantLearner
 from Orange.regression import MeanLearner
 from Orange.widgets.evaluate.owtestandscore import (
@@ -178,7 +178,7 @@ class TestOWTestAndScore(WidgetTest):
         table = Table.from_list(
             Domain(
                 [ContinuousVariable("a"), ContinuousVariable("b")],
-                [DiscreteVariable("c", values=("y", ))]),
+                [DiscreteVariable("c", values=("y",))]),
             list(zip(
                 [42.48, 16.84, 15.23, 23.8],
                 [1., 2., 3., 4.],
@@ -192,6 +192,7 @@ class TestOWTestAndScore(WidgetTest):
 
     def test_data_errors(self):
         """ Test all data_errors """
+
         def assertErrorShown(data, is_shown, message):
             self.send_signal("Data", data)
             self.assertEqual(is_shown, self.widget.Error.train_data_error.is_shown())
@@ -378,7 +379,7 @@ class TestOWTestAndScore(WidgetTest):
         self.assertTupleEqual(self._test_scores(
             table, table, LogisticRegressionLearner(),
             OWTestAndScore.TestOnTest, None),
-                              (1, 1, 1, 1, 1))
+            (1, 1, 1, 1, 1))
 
     def test_scores_log_reg_bad(self):
         table_train = Table.from_list(
@@ -393,7 +394,7 @@ class TestOWTestAndScore(WidgetTest):
         self.assertTupleEqual(self._test_scores(
             table_train, table_test, LogisticRegressionLearner(),
             OWTestAndScore.TestOnTest, None),
-                              (0, 0, 0, 0, 0))
+            (0, 0, 0, 0, 0))
 
     def test_scores_log_reg_bad2(self):
         table_train = Table.from_list(
@@ -723,6 +724,42 @@ class TestOWTestAndScore(WidgetTest):
         view_text = "\t".join([str(model.data(model.index(0, i)))
                                for i in (0, 3, 4, 5, 6, 7)]) + "\r\n"
         self.assertEqual(clipboard_text, view_text)
+
+    def test_multi_target_input(self):
+        class NewScorer(Score):
+            class_types = (
+                ContinuousVariable,
+                DiscreteVariable,
+            )
+
+            @staticmethod
+            def is_compatible(domain: Domain) -> bool:
+                return True
+
+            def compute_score(self, results):
+                return [0.75]
+
+        domain = Domain([ContinuousVariable('var1')],
+                        class_vars=[
+                            ContinuousVariable('c1'),
+                            DiscreteVariable('c2', values=('no', 'yes'))
+                        ])
+        data = Table.from_list(domain, [[1, 5, 0], [2, 10, 1], [2, 10, 1]])
+
+        mock_model = Mock(spec=Model, return_value=np.asarray([[0.2, 0.1, 0.2]]))
+        mock_model.name = 'Mockery'
+        mock_model.domain = domain
+        mock_learner = Mock(spec=Learner, return_value=mock_model)
+        mock_learner.name = 'Mockery'
+
+        self.widget.resampling = OWTestAndScore.TestOnTrain
+        self.send_signal(self.widget.Inputs.train_data, data)
+        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0)
+        self.send_signal(self.widget.Inputs.learner, mock_learner, 1)
+        _ = self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
+        self.assertTrue(len(self.widget.scorers) == 1)
+        self.assertTrue(NewScorer in self.widget.scorers)
+        self.assertTrue(len(self.widget._successful_slots()) == 1)
 
 
 class TestHelpers(unittest.TestCase):

--- a/Orange/widgets/utils/owlearnerwidget.py
+++ b/Orange/widgets/utils/owlearnerwidget.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import warnings
 
 from AnyQt.QtCore import QTimer, Qt
 
@@ -12,6 +13,7 @@ from Orange.widgets.utils import getmembers
 from Orange.widgets.utils.signals import Output, Input
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.widget import OWWidget, WidgetMetaClass, Msg
+from Orange.util import OrangeDeprecationWarning
 
 
 class OWBaseLearnerMeta(WidgetMetaClass):
@@ -246,8 +248,26 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
         self.Error.sparse_not_supported.clear()
         if self.data is not None and self.learner is not None:
             self.Error.data_error.clear()
-            if not self.learner.check_learner_adequacy(self.data.domain):
-                self.Error.data_error(self.learner.learner_adequacy_err_msg)
+
+            incompatibility_reason = None
+            for cls in type(self.learner).mro():
+                if 'incompatibility_reason' in cls.__dict__:
+                    # pylint: disable=assignment-from-none
+                    incompatibility_reason = \
+                        self.learner.incompatibility_reason(self.data.domain)
+                    break
+                if 'check_learner_adequacy' in cls.__dict__:
+                    warnings.warn(
+                        "check_learner_adequacy is deprecated and will be removed "
+                        "in upcoming releases. Learners should instead implement "
+                        "the incompatibility_reason method.",
+                        OrangeDeprecationWarning)
+                    if not self.learner.check_learner_adequacy(self.data.domain):
+                        incompatibility_reason = self.learner.learner_adequacy_err_msg
+                    break
+
+            if incompatibility_reason is not None:
+                self.Error.data_error(incompatibility_reason)
             elif not len(self.data):
                 self.Error.data_error("Dataset is empty.")
             elif len(ut.unique(self.data.Y)) < 2:
@@ -258,6 +278,7 @@ class OWBaseLearner(OWWidget, metaclass=OWBaseLearnerMeta, openclass=True):
                 self.Error.sparse_not_supported()
             else:
                 self.valid_data = True
+
         return self.valid_data
 
     def settings_changed(self, *args, **kwargs):


### PR DESCRIPTION
##### Issue
In survival analysis, it is expected to have two target variables. First is the duration of time until the event of interest, and the second is the indicator of censorship.

Preferably, the Survival Analysis add-on would then use the same infrastructure for testing and scoring survival models as it is currently in place for classification and regression related problems. To achieve this, we need to loosen the constraint of a single target variable for the input data.

##### Description of changes

With this pull request, the task was not to change the interface to accommodate for all future tasks one would like to support but to:

- allow the use of multitarget data and make no breaking changes to the existing codebase (do not change the default behaviour),
- for a start, make survival models/scorers available in Orange.
<strike>
Since the registration of Scorers is already implemented, the next step was how to find the usable scorers given the input data. The Scorer base class now holds additional [information](https://github.com/biolab/orange3/compare/master...JakaKokosar:multi_target?expand=1#diff-ebac791194327a764153704a5e2567261585ad3971623c2138be81e8c02b8da5R69) to recognise Scorers that are built-in and those implemented through add-ons.

**If Scorer is defined as built-in, nothing changes**. For non-built-in scorers, we look into Table attributes to determine the 'problem type' of input data. For example, for the survival analysis, As Survival data widget will set class variables to the output table and set attributes of the table as follows:
```python
{
	..., 
	'problem_type': 'time_to_event'
}
```
Usable scorers are those that match the same problem_type with input data. This is not necessarily the best solution and could use further debate. At this stage, no significant changes to the code-base were needed. In theory, everything else should be handled by Learners, Models and Scorers defined for related tasks https://github.com/biolab/orange3-survival-analysis/pull/27. 
<strike/>

Some examples:
<img width="1271" alt="Screenshot 2022-02-17 at 15 37 02" src="https://user-images.githubusercontent.com/15876321/154507168-99b5dd4f-7d32-41b1-8059-ab17b9b71233.png">

<img width="1341" alt="Screenshot 2022-02-17 at 15 37 15" src="https://user-images.githubusercontent.com/15876321/154507220-9e3bf1c9-c8b4-43c8-b6c5-653626cf6c78.png">

<img width="1212" alt="Screenshot 2022-02-17 at 15 38 15" src="https://user-images.githubusercontent.com/15876321/154507254-9c4f7e9f-8a75-42d6-acea-fe5a92c941e7.png">

<img width="1202" alt="Screenshot 2022-02-17 at 15 57 55" src="https://user-images.githubusercontent.com/15876321/154508179-8004a458-d898-4090-bceb-5c2ddd44e2b1.png">





##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
