### PR TITLE
[FIX] widgets.evaluate.utils: call resizeColumnsToContents before setting hidden header sections.

### DIFF
--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -194,10 +194,10 @@ class ScoreTable(OWComponent, QObject):
     def _update_shown_columns(self):
         # pylint doesn't know that self.shown_scores is a set, not a Setting
         # pylint: disable=unsupported-membership-test
+        self.view.resizeColumnsToContents()
         header = self.view.horizontalHeader()
         for section, col_name in enumerate(self._column_names(), start=1):
             header.setSectionHidden(section, col_name not in self.shown_scores)
-        self.view.resizeColumnsToContents()
         self.shownScoresChanged.emit()
 
     def update_header(self, scorers):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #5830

##### Description of changes

Before:

![Screen-Recording-2022-02-18-at-1](https://user-images.githubusercontent.com/15876321/154664953-ad680ad7-7d1d-4858-a79a-3255dac2fa5d.gif)


After:

![Screen-Recording-2022-02-18-at-1(1)](https://user-images.githubusercontent.com/15876321/154664992-5c7856ca-70a2-45af-a96b-4b923ad27e7d.gif)





##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
