### PR TITLE
Fix oldest-orange CI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - recommonmark
   run:
     - python
-    - setuptools >=36.3
+    - setuptools >=41.0.0
     - numpy >=1.17.3
     - scipy >=1.3.1
     - scikit-learn >=1.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=40.8.0,<50.0",
+    "setuptools>=41.0.0,<50.0",
     "wheel",
     "cython",
     "oldest-supported-numpy",

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -15,7 +15,7 @@ chardet>=3.0.2
 joblib>=0.11
 keyring
 keyrings.alt    # for alternative keyring implementations
-setuptools>=36.3
+setuptools>=41.0.0
 serverfiles		# for Data Sets synchronization
 networkx
 python-louvain>=0.13

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     oldest: joblib==0.11
     # oldest: keyring
     # oldest: keyrings.alt
-    oldest: setuptools==36.3
+    oldest: setuptools==41.0.0
     # oldest: serverfiles
     # oldest: networkx
     oldest: python-louvain==0.13


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Oldest-orange workflow started to fail since markupsafe does not build on build on setuptools=36

##### Description of changes
Changing oldest supported version of setuptools to 41

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
