### PR TITLE
[FIX] Calibration: Fix crash on empty folds

### DIFF
--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -487,7 +487,7 @@ class OWCalibrationPlot(widget.OWWidget):
         if results is not None:
             problems = [
                 msg for condition, msg in (
-                    (len(results.folds) > 1,
+                    (results.folds is not None and len(results.folds) > 1,
                      "each training data sample produces a different model"),
                     (results.models is None,
                      "test results do not contain stored models - try testing "

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -687,7 +687,8 @@ class OWPredictions(OWWidget):
         nanmask = numpy.isnan(self.data.get_column_view(self.class_var)[0])
         data = self.data[~nanmask]
         results = Results(data, store_data=True)
-        results.folds = None
+        results.folds = [...]
+        results.models = numpy.array([[p.predictor for p in self.predictors]])
         results.row_indices = numpy.arange(len(data))
         results.actual = data.Y.ravel()
         results.predicted = numpy.vstack(

--- a/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
+++ b/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
@@ -642,7 +642,7 @@ class TestOWCalibrationPlot(WidgetTest, EvaluateTest):
     @patch("Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier")
     @patch("Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner")
     def test_no_folds(self, *_):
-        """Warn about omitted points with nan probabiities"""
+        """Don't crash on malformed Results with folds=None"""
         widget = self.widget
 
         self.results.folds = None

--- a/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
+++ b/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
@@ -1,5 +1,6 @@
 import copy
 import warnings
+import unittest
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -637,3 +638,19 @@ class TestOWCalibrationPlot(WidgetTest, EvaluateTest):
         self.assertTrue(widget.Warning.omitted_nan_prob_points.is_shown())
         self._set_list_selection(widget.controls.selected_classifiers, [0, 2])
         self.assertFalse(widget.Warning.omitted_folds.is_shown())
+
+    @patch("Orange.widgets.evaluate.owcalibrationplot.ThresholdClassifier")
+    @patch("Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner")
+    def test_no_folds(self, *_):
+        """Warn about omitted points with nan probabiities"""
+        widget = self.widget
+
+        self.results.folds = None
+        self.send_signal(widget.Inputs.evaluation_results, self.results)
+        widget.selected_classifiers = [0]
+        widget.commit.now()
+        self.assertIsNotNone(self.get_output(widget.Outputs.calibrated_model))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -10,6 +10,7 @@ from AnyQt.QtCore import QItemSelectionModel, QItemSelection, Qt
 
 from Orange.base import Model
 from Orange.classification import LogisticRegressionLearner, NaiveBayesLearner
+from Orange.classification.majority import ConstantModel
 from Orange.data.io import TabReader
 from Orange.evaluation.scoring import TargetScore
 from Orange.preprocess import Remove
@@ -507,6 +508,9 @@ class TestOWPredictions(WidgetTest):
         def check_evres(expected):
             out = self.get_output(w.Outputs.evaluation_results)
             self.assertSequenceEqual(out.learner_names, expected)
+            self.assertEqual(out.folds, [...])
+            self.assertEqual(out.models.shape, (1, len(out.learner_names)))
+            self.assertIsInstance(out.models[0, 0], ConstantModel)
 
         check_evres(["P1", "P2", "P3"])
 


### PR DESCRIPTION
##### Issue

Fixes #5854.

##### Description of changes

The problem was essentially in Predictions, which created a malformed instance of `Results`. Folds should be `[...]`, not `None`.

- Fixed Predictions to output proper folds.
- Add `models` to `Results` that come from `Predictions`, so they can be calibrated by Calibration
- Make Calibration more resilient -- accept `folds=None` if any other widget misbehaves in the same way as Predictions


##### Includes
- [X] Code changes
- [X] Tests
