### PR TITLE
Increase minimum version of httpx

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     - orange-canvas-core >=0.1.24,<0.2a
     - orange-widget-base >=4.16.1
     - openpyxl
-    - httpx >=0.14,<0.20
+    - httpx >=0.21
     - baycomp >=1.0.2
     # cachecontrol (required by canvas core) <0.12.5 is incompatible with msgpack 1.0
     - cachecontrol >=0.12.6

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -25,4 +25,4 @@ baycomp>=1.0.2
 pandas>=1.3.0
 pyyaml
 openpyxl
-httpx>=0.14.0,<0.20
+httpx>=0.21.0

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ deps =
     oldest: pandas==1.3.0
     # oldest: pyyaml
     # oldest: openpyxl
-    oldest: httpx==0.14.0
+    oldest: httpx==0.21.0
 
 commands_pre =
     # Verify installed packages have compatible dependencies


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Httpx is a few versions ahead and is more stable now

When the version was updated, I also noticed that I closed the client before all responses were gathered (it was now an exception before everything was still working). Wait finished with waiting when one of the workers stopped, then gather was waiting for other workers outside context manager.

##### Description of changes
Setting minimum version to 0.21, where also some bugs are resolved.

Resolving the error described above by simplifying the code - removing wait, now gather will wait until all workers finish (each worker finishes when it has no more items to pull from the queue.

Extra: do not create more than the required number of workers

##### Includes
- [x] Code changes
- [x] Tests
- [ ] Documentation
