### PR TITLE
Add GitHub URL for PyPi 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,10 @@ LONG_DESCRIPTION_CONTENT_TYPE = 'text/markdown'
 AUTHOR = 'Bioinformatics Laboratory, FRI UL'
 AUTHOR_EMAIL = 'info@biolab.si'
 URL = 'http://orange.biolab.si/'
+PROJECT_URLS = {
+    'Documentation': 'https://orange3.readthedocs.io',
+    'Source': 'https://github.com/biolab/orange3',
+}
 LICENSE = 'GPLv3+'
 
 KEYWORDS = [

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,11 @@ AUTHOR = 'Bioinformatics Laboratory, FRI UL'
 AUTHOR_EMAIL = 'info@biolab.si'
 URL = 'http://orange.biolab.si/'
 PROJECT_URLS = {
-    'Documentation': 'https://orange3.readthedocs.io',
-    'Source': 'https://github.com/biolab/orange3',
+    'Homepage': 'https://orangedatamining.com/',
+    'Documentation': 'https://orangedatamining.com/docs',
+    'Source Code': 'https://github.com/biolab/orange3',
+    'Issue Tracker': 'https://github.com/biolab/orange3/issues',
+    'Donate': 'https://github.com/sponsors/biolab'
 }
 LICENSE = 'GPLv3+'
 

--- a/setup.py
+++ b/setup.py
@@ -509,6 +509,7 @@ def setup_package():
         author=AUTHOR,
         author_email=AUTHOR_EMAIL,
         url=URL,
+        project_urls=PROJECT_URLS,
         license=LICENSE,
         keywords=KEYWORDS,
         classifiers=CLASSIFIERS,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
