### PR TITLE
[FIX] plotutils: Fix and implicit conversion to int warning error

### DIFF
--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -427,7 +427,7 @@ class ElidedLabelsAxis(pg.AxisItem):
     def generateDrawSpecs(self, p):
         axis_spec, tick_specs, text_specs = super().generateDrawSpecs(p)
         bounds = self.mapRectFromParent(self.geometry())
-        max_width = 0.9 * bounds.width() / (len(text_specs) or 1)
+        max_width = int(0.9 * bounds.width() / (len(text_specs) or 1))
         elide = QFontMetrics(QWidget().font()).elidedText
         text_specs = [(rect, flags, elide(text, Qt.ElideRight, max_width))
                       for rect, flags, text in text_specs]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Distributions widget raises an  error on Python 3.10 due to implicit int conversion (warning on 3.9). 

```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/home/ales/.envs/orange3/lib/python3.10/site-packages/pyqtgraph/graphicsItems/AxisItem.py", line 593, in paint
    specs = self.generateDrawSpecs(painter)
  File "/home/ales/devel/orange3/Orange/widgets/visualize/utils/plotutils.py", line 432, in generateDrawSpecs
    text_specs = [(rect, flags, elide(text, Qt.ElideRight, max_width))
  File "/home/ales/devel/orange3/Orange/widgets/visualize/utils/plotutils.py", line 432, in <listcomp>
    text_specs = [(rect, flags, elide(text, Qt.ElideRight, max_width))
TypeError: elidedText(self, str, Qt.TextElideMode, int, flags: int = 0): argument 3 has unexpected type 'float'
```
Workflow: *File (iris)* -> *Distributions*

##### Description of changes

Fix and implicit conversion to int error


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
