### PR TITLE
Fix tree tooltips

### DIFF
--- a/Orange/widgets/utils/__init__.py
+++ b/Orange/widgets/utils/__init__.py
@@ -37,9 +37,8 @@ def getdeepattr(obj, attr, *arg, **kwarg):
 
 
 def to_html(s):
-    return s.replace("<=", "&#8804;").replace(">=", "&#8805;"). \
-        replace("<", "&#60;").replace(">", "&#62;").replace("=\\=", "&#8800;")
-
+    return s.replace("<=", "≤").replace(">=", "≥"). \
+        replace("<", "&lt;").replace(">", "&gt;").replace("=\\=", "≠")
 
 getHtmlCompatibleString = to_html
 

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -313,8 +313,9 @@ class OWTreeGraph(OWTreeViewer2D):
         return node_obj
 
     def node_tooltip(self, node):
-        return "<br>".join(to_html(str(rule))
-                           for rule in self.tree_adapter.rules(node.node_inst))
+        return "<p>" + "<br>".join(
+            to_html(str(rule))
+            for rule in self.tree_adapter.rules(node.node_inst)) + "</p>"
 
     def update_selection(self):
         if self.model is None:


### PR DESCRIPTION
##### Issue

Fixes #5871.

##### Description of changes

The problem appeared only at nodes directly below the root because the text didn't contain any html tags (later, we have `<br>`), so Qt didn't recognize it as rich text. Adding a `<p>` tag solves it.

The other commit, which replaces unicode points with symbols, is cosmetic.

##### Includes
- [X] Code changes
