### PR TITLE
CI: Enable tests for python 3.10

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,4 +31,6 @@ jobs:
         run: pip install tox
 
       - name: Build documentation
-        run:  xvfb-run -a -s "-screen 0 1280x1024x24" tox -e build_doc
+        run: tox -e build_doc
+        env:
+          QT_QPA_PLATFORM: offscreen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -36,12 +36,12 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        os: [ubuntu-18.04]
-        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-20.04]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         tox_env: [orange-released]
         name: [Released]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
             tox_env: orange-latest
             name: Latest
@@ -77,7 +77,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install linux system dependencies
-        run: sudo apt-get install -y libxkbcommon-x11-0 
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa
 
       - name: Install Tox
         run: |
@@ -85,9 +87,9 @@ jobs:
           python -m pip install --upgrade tox tox-pip-version
 
       - name: Run Tox
-        run: xvfb-run -a -s "-screen 0 1280x1024x24" tox -e ${{ matrix.tox_env }}
+        run: catchsegv xvfb-run -a -s "$XVFBARGS" tox -e ${{ matrix.tox_env }}
         env:
-          # QT_QPA_PLATFORM: offscreen
+          XVFBARGS: "-screen 0 1280x1024x24"
           ORANGE_TEST_DB_URI: postgres://postgres_user:postgres_password@localhost:5432/postgres_db|mssql://SA:sqlServerPassw0rd@localhost:1433
 
       - name: Upload code coverage
@@ -106,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-10.15, windows-2019]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         tox_env: [orange-released]
         name: [Released]
         include:
@@ -128,7 +130,7 @@ jobs:
 
       - name: Install system dependencies on MacOS
         run: brew install libomp
-        if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11.0'
+        if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11'
 
       - name: Install dependencies
         run: |

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy.sparse as sp
+from pandas import isna
 
 from Orange.data import Instance, Table, Domain
 from Orange.util import Reprable
@@ -215,5 +216,14 @@ class Lookup(Transformation):
                and np.allclose(self.unknown, other.unknown, equal_nan=True)
 
     def __hash__(self):
-        return hash((type(self), self.variable,
-                     tuple(self.lookup_table), self.unknown))
+        return hash(
+            (
+                type(self),
+                self.variable,
+                # nan value does not have constant hash in Python3.10
+                # to avoid different hashes for the same array change to None
+                # issue: https://bugs.python.org/issue43475#msg388508
+                tuple(None if isna(x) else x for x in self.lookup_table),
+                self.unknown,
+            )
+        )

--- a/Orange/tests/test_transformation.py
+++ b/Orange/tests/test_transformation.py
@@ -99,3 +99,13 @@ class LookupTest(unittest.TestCase):
             np.testing.assert_array_equal(
                 lookup.transform(col),
                 np.array([2, 0, 2, 1, np.nan, 1], dtype=np.float64))
+
+    def test_hash_nan(self):
+        """
+        Hash should be always the same for same lookup
+        Test introduced because of bug in numpy (PY3.10) and was present when nan
+        in lookup table: https://github.com/numpy/numpy/issues/21210
+        """
+        lookup = Lookup(None, np.array([1, 2, np.nan, 2]))
+        hashes = [hash(lookup) for _ in range(10)]
+        self.assertTrue(all(x == hashes[0] for x in hashes))

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -4,7 +4,7 @@ scipy>=1.3.1
 # scikit-learn version 1.0.0 includes problematic libomp 12 which breaks xgboost
 # https://github.com/scikit-learn/scikit-learn/pull/21227
 scikit-learn>=1.0.1
-bottleneck>=1.3.2
+bottleneck>=1.3.4
 # Reading Excel files
 xlrd>=0.9.2
 # Writing Excel Files

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,10 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage
     COVERAGE_RCFILE = {toxinidir}/.coveragerc
 deps =
-    pyqt5==5.12.*
-    pyqtwebengine==5.12.*
+    pyqt5==5.12.*;platform_system=="Windows" and python_version<'3.10'
+    pyqt5==5.15.*;platform_system!="Windows" or python_version>='3.10'
+    pyqtwebengine==5.12.*;platform_system=="Windows" and python_version<'3.10'
+    pyqtwebengine==5.15.*;platform_system!="Windows" or python_version>='3.10'
     -r {toxinidir}/requirements-opt.txt
     coverage
     psycopg2-binary
@@ -49,7 +51,7 @@ deps =
     oldest: numpy==1.17.3
     oldest: scipy==1.3.1
     oldest: scikit-learn==1.0.1
-    oldest: bottleneck==1.3.2
+    oldest: bottleneck==1.3.4
     oldest: xlrd==0.9.2
     # oldest: xlsxwriter
     oldest: chardet==3.0.2
@@ -74,8 +76,7 @@ commands_pre =
     # freeze environment
     pip freeze
 commands =
-    coverage run -m unittest -v Orange.tests Orange.widgets.tests Orange.canvas.tests
-    coverage run -m unittest discover -v Orange.canvas.tests
+    coverage run -m unittest -v Orange.tests Orange.widgets.tests
     coverage combine
     coverage report
 


### PR DESCRIPTION
Bottleneck should now support python 3.10. Let's try if Orange works on Py3.10

Changes:
- deprecated windows-2016 are replaced with widows-2019 (and latest with windows-2022)
- python 3.10 is added to the matrix
- fixed the hash error in Lookup (in Python 10 hashes of nan are not guaranteed to be constant)
- some smaller fixes in CI to make it working