### PR TITLE
Python Script: Disable auto_summary for object signals

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -537,14 +537,14 @@ class OWPythonScript(OWWidget):
             "Classifier", Model, replaces=["in_classifier"], default=True
         )
         object = MultiInput(
-            "Object", object, replaces=["in_object"], default=False
+            "Object", object, replaces=["in_object"], default=False, auto_summary=False
         )
 
     class Outputs:
         data = Output("Data", Table, replaces=["out_data"])
         learner = Output("Learner", Learner, replaces=["out_learner"])
         classifier = Output("Classifier", Model, replaces=["out_classifier"])
-        object = Output("Object", object, replaces=["out_object"])
+        object = Output("Object", object, replaces=["out_object"], auto_summary=False)
 
     signal_names = ("data", "learner", "classifier", "object")
 


### PR DESCRIPTION
##### Description of changes
Set `auto_summary` to `False` for object input and output signals to avoid warnings.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
