### PR TITLE
Indicator: Keep missing values

### DIFF
--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -87,7 +87,7 @@ class TestOWNomogram(WidgetTest):
         """Check probabilities for logistic regression classifier for various
         values of classes and radio buttons"""
         self.widget.display_index = 0  # show ALL features
-        self._test_helper(self.lr_cls, [58, 42])
+        self._test_helper(self.lr_cls, [61, 39])
 
     def test_nomogram_nb_multiclass(self):
         """Check probabilities for naive bayes classifier for various values


### PR DESCRIPTION
Class `Indicator` converts values of a variable to 0 or 1, depending on whether it matches the given constant or not. The class hasn't checked for nan's and hence converted them to 0, which is unexpected. Missing values should remain missing.

Same for `Indicator1`.

I am not sure what this is supposed 

##### Includes
- [X] Code changes
- [X] Tests
