### PR TITLE
[FIX] owrocanalysis: Fix an index error in custom tick calculation

### DIFF
--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -640,14 +640,18 @@ class OWROCAnalysis(widget.OWWidget):
                 return None
             return [[(x, f"{x:.2f}") for x in a[::-1]]]
 
-        data = self.curve_data(self.target_index, self.selected_classifiers[0])
-        points = data.merged.points
+        axis_bottom = self.plot.getAxis("bottom")
+        axis_left = self.plot.getAxis("left")
 
-        axis = self.plot.getAxis("bottom")
-        axis.setTicks(enumticks(points.fpr))
-
-        axis = self.plot.getAxis("left")
-        axis.setTicks(enumticks(points.tpr))
+        if not self.selected_classifiers or len(self.selected_classifiers) > 1 \
+                or self.roc_averaging != OWROCAnalysis.Merge:
+            axis_bottom.setTicks(None)
+            axis_left.setTicks(None)
+        else:
+            data = self.curve_data(self.target_index, self.selected_classifiers[0])
+            points = data.merged.points
+            axis_bottom.setTicks(enumticks(points.fpr))
+            axis_left.setTicks(enumticks(points.tpr))
 
     def _on_mouse_moved(self, pos):
         target = self.target_index


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-5902

Also the plot displays custom ticks for the first classifier only even when multiple are displayed and for *Merge Predictions from Folds* curves even if different combining/averaging is selected.

##### Description of changes

Fix an index error in custom tick calculation
Also check so that the ticks actually apply to the displayed points

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
