### PR TITLE
use delete[] to delete array

### DIFF
--- a/Orange/widgets/utils/_grid_density.cpp
+++ b/Orange/widgets/utils/_grid_density.cpp
@@ -61,8 +61,8 @@ void compute_density(int r, double *gx, double *gy, int n, double *dx, double *d
 			color_decode(ind2color[main_color], rgba+offset);
 		}
 	}
-	delete color;
-	delete f;
+	delete[] color;
+	delete[] f;
 }
 
 


### PR DESCRIPTION
##### Issue
Just was setting up orange via `python setup.py develop` and ran into this compilation warning:

```
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /Users/ch/miniconda3/envs/orange3/include -arch arm64 -I/Users/ch/miniconda3/envs/orange3/include -fPIC -O2 -isystem /Users/ch/miniconda3/envs/orange3/include -arch arm64 -I/Users/ch/miniconda3/envs/orange3/lib/python3.9/site-packages/numpy/core/include -I/Users/ch/miniconda3/envs/orange3/include/python3.9 -c Orange/widgets/utils/_grid_density.cpp -o build/temp.macosx-11.1-arm64-3.9/Orange/widgets/utils/_grid_density.o
Orange/widgets/utils/_grid_density.cpp:64:2: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
        delete color;
        ^
              []
Orange/widgets/utils/_grid_density.cpp:25:15: note: allocated with 'new[]' here
        int *color = new int[n];
                     ^
Orange/widgets/utils/_grid_density.cpp:65:2: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
        delete f;
        ^
              []
Orange/widgets/utils/_grid_density.cpp:39:14: note: allocated with 'new[]' here
        double *f = new double[colors];
                    ^
2 warnings generated.
```

Not knowing anything about the context of this code, but the warning is definitely true and should be fixed.

##### Description of changes

Use `delete[]` to free array allocated with `new[]` since using `delete` on `new[]` is an error.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
