### PR TITLE
server_embedder - replace run_until_complete with asyncio.run

### DIFF
--- a/Orange/misc/server_embedder.py
+++ b/Orange/misc/server_embedder.py
@@ -123,16 +123,9 @@ class ServerEmbedderCommunicator:
         # if there is less items than 10 connection error should be raised earlier
         self.max_errors = min(len(data) * self.MAX_REPEATS, 10)
 
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            embeddings = asyncio.get_event_loop().run_until_complete(
-                self.embedd_batch(data, processed_callback, callback=callback)
-            )
-        finally:
-            loop.close()
-
-        return embeddings
+        return asyncio.run(
+            self.embedd_batch(data, processed_callback, callback=callback)
+        )
 
     async def embedd_batch(
         self,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since Orange now support python>=3.7 we do not need to use `run_until_complete` and custom loop handling in embedders.

##### Description of changes
User `asyncio.run` instead which is supported python>=3.7

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
