### PR TITLE
Fix failing tests on latest after widget-base Qt6 PR was merged

### DIFF
--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -303,7 +303,7 @@ class OWDiscretize(widget.OWWidget):
         self.default_bbox = rbox = gui.radioButtons(
             box, self, "_default_method_", callback=self._default_disc_changed)
         self.default_button_group = bg = rbox.findChild(QButtonGroup)
-        bg.buttonClicked[int].connect(self.set_default_method)
+        bg.idClicked.connect(self.set_default_method)
 
         rb = gui.hBox(rbox)
         self.left = gui.vBox(rb)

--- a/Orange/widgets/data/owimpute.py
+++ b/Orange/widgets/data/owimpute.py
@@ -184,7 +184,7 @@ class OWImpute(OWWidget):
         box.layout().addLayout(box_layout)
 
         button_group = QButtonGroup()
-        button_group.buttonClicked[int].connect(self.set_default_method)
+        button_group.idClicked.connect(self.set_default_method)
 
         for i, (method, _) in enumerate(list(METHODS.items())[1:-1]):
             imputer = self.create_imputer(method)
@@ -284,7 +284,7 @@ class OWImpute(OWWidget):
         value_stack.addWidget(self.value_double)
         method_layout.addWidget(value_stack)
 
-        button_group.buttonClicked[int].connect(
+        button_group.idClicked.connect(
             self.set_method_for_current_selection
         )
 

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -345,7 +345,7 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
         grid.setContentsMargins(0, 0, 0, 0)
         grid.setSpacing(6)
         self.selectButtons = QButtonGroup()
-        self.selectButtons.buttonClicked[int].connect(self.setSelectionMethod)
+        self.selectButtons.idClicked.connect(self.setSelectionMethod)
 
         def button(text, buttonid, toolTip=None):
             b = QRadioButton(text)

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from AnyQt.QtCore import QItemSelectionModel, QItemSelection, Qt
 
+from orangewidget.tests.utils import simulate
+
 from Orange.base import Model
 from Orange.classification import LogisticRegressionLearner, NaiveBayesLearner
 from Orange.classification.majority import ConstantModel
@@ -873,8 +875,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(float(table.model.data(table.model.index(0, 3))), 42)
 
         for idx, value in enumerate(widget.class_var.values):
-            combo.setCurrentText(value)
-            combo.activated[str].emit(value)
+            simulate.combobox_activate_item(combo, value, Qt.DisplayRole)
             self.assertEqual(table.model.rowCount(), 1)
             self.assertEqual(table.model.columnCount(), 4)
             self.assertEqual(float(table.model.data(table.model.index(0, 3))),

--- a/Orange/widgets/model/tests/test_owcalibratedlearner.py
+++ b/Orange/widgets/model/tests/test_owcalibratedlearner.py
@@ -140,7 +140,7 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
 
         widget.calibration = widget.IsotonicCalibration
         widget.threshold = widget.OptimizeCA
-        widget.controls.calibration.group.buttonClicked[int].emit(
+        widget.controls.calibration.group.idClicked.emit(
             widget.IsotonicCalibration)
 
         learner = self.get_output(widget.Outputs.learner)
@@ -148,7 +148,7 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
 
         widget.calibration = widget.NoCalibration
         widget.threshold = widget.OptimizeCA
-        widget.controls.calibration.group.buttonClicked[int].emit(
+        widget.controls.calibration.group.idClicked.emit(
             widget.NoCalibration)
         learner = self.get_output(widget.Outputs.learner)
         self.assertEqual(learner.name, "Foo + CA")

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -240,7 +240,7 @@ class TestOWNomogram(WidgetTest):
 
         # Set to output all
         self.widget.display_index = 0
-        self.widget.controls.display_index.group.buttonClicked[int].emit(0)
+        self.widget.controls.display_index.group.idClicked.emit(0)
         attrs = self.get_output(self.widget.Outputs.features)
         self.assertEqual(attrs, [age, sex, status])
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - chardet >=3.0.2
     - xlrd >=0.9.2
     - xlsxwriter
-    - anyqt >=0.0.13
+    - anyqt >=0.1.0
     - pyqt >=5.12,!=5.15.1,<6.0
     - pyqtgraph >=0.11.1
     - joblib >=0.11

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,7 +1,7 @@
 orange-canvas-core>=0.1.24,<0.2a
 orange-widget-base>=4.16.1
 
-AnyQt>=0.0.13
+AnyQt>=0.1.0
 
 pyqtgraph>=0.11.1
 matplotlib>=2.2.5

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
     oldest: orange-canvas-core==0.1.24
     oldest: orange-widget-base==4.16.1
-    oldest: AnyQt==0.0.13
+    oldest: AnyQt==0.1.0
     oldest: pyqtgraph==0.11.1
     oldest: matplotlib==2.2.5
     oldest: qtconsole==4.7.2


### PR DESCRIPTION
##### Issue
Three tests are failing after merging biolab/orange-widget-base#187.

##### Description of changes
Aims to fix failing tests by cherry-picking two commits from the PyQt6 PR: #5884.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
