### PR TITLE
A workaround to show C-Index scoring method for survival data

### DIFF
--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 import unittest
 import collections
+from distutils.version import LooseVersion
 
 import numpy as np
 
@@ -9,6 +10,7 @@ from AnyQt.QtWidgets import QMenu
 from AnyQt.QtGui import QStandardItem
 from AnyQt.QtCore import QPoint, Qt
 
+import Orange
 from Orange.widgets.evaluate.utils import ScoreTable
 from Orange.widgets.tests.base import GuiTest
 
@@ -114,6 +116,13 @@ class TestScoreTable(GuiTest):
 
         model.sort(2, Qt.DescendingOrder)
         self.assertEqual(order(3), "DEC")
+
+    def test_column_settings_reminder(self):
+        if LooseVersion(Orange.__version__) >= LooseVersion("3.34"):
+            self.fail(
+                "Orange 3.32 added a workaround to show C-Index into ScoreTable.__init__. "
+                "This should have been properly fixed long ago."
+            )
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -166,6 +166,18 @@ class ScoreTable(OWComponent, QObject):
         header.setContextMenuPolicy(Qt.CustomContextMenu)
         header.customContextMenuRequested.connect(self.show_column_chooser)
 
+        # Currently, this component will never show scoring methods
+        # defined in add-ons by default. To support them properly, the
+        # "shown_scores" settings will need to be reworked.
+        # The following is a temporary solution to show the scoring method
+        # for survival data (it does not influence other problem types).
+        # It is added here so that the "C-Index" method
+        # will show up even if the users already have the setting defined.
+        # This temporary fix is here due to a paper deadline needing the feature.
+        # When removing, also remove TestScoreTable.test_column_settings_reminder
+        if isinstance(self.shown_scores, set):  # TestScoreTable does not initialize settings
+            self.shown_scores.add("C-Index")
+
         self.model = QStandardItemModel(master)
         self.model.setHorizontalHeaderLabels(["Method"])
         self.sorted_model = ScoreModel()


### PR DESCRIPTION
##### Issue

A scoring method defined in an addon is never shown by default. We have to decide how to allow this in general. I was thinking of storing different things in the "shown_scores" setting, but that is a change that would be too big for now and we have a deadline to catch.

This (or something similar) should be merged until Friday.


##### Description of changes

This PR proposes a temporary solution to show the scoring method for survival data. It should not influence other problem types so it should change nothing for people that do not use the survival analysis add-on.

This PR adds the "C-Index" method after the Settings are read so that it will also show up for users who have stored settings (changing a default would do nothing for them).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
