### PR TITLE
owsavebase: fix path comparison under windows

### DIFF
--- a/Orange/widgets/utils/save/owsavebase.py
+++ b/Orange/widgets/utils/save/owsavebase.py
@@ -1,6 +1,7 @@
 import os.path
 import sys
 import re
+from pathlib import Path
 
 from AnyQt.QtWidgets import QFileDialog, QGridLayout, QMessageBox
 
@@ -114,10 +115,15 @@ class OWSaveBase(widget.OWWidget, openclass=True):
         self._absolute_path = absolute_path
 
         workflow_dir = self.workflowEnv().get("basedir", None)
-        if workflow_dir and absolute_path.startswith(workflow_dir.rstrip("/")):
-            self.stored_path = os.path.relpath(absolute_path, workflow_dir)
-        else:
-            self.stored_path = absolute_path
+        if workflow_dir:
+            absolute_path_as_path = Path(absolute_path)
+            workflow_dir_as_path = Path(workflow_dir)
+            if workflow_dir_as_path in absolute_path_as_path.parents or \
+                    workflow_dir_as_path == absolute_path_as_path:
+                self.stored_path = os.path.relpath(absolute_path, workflow_dir)
+                return
+
+        self.stored_path = absolute_path
 
     def _abs_path_from_setting(self):
         """


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes #5868


##### Description of changes
I wanted to use `pathlib` to check if the `absolute_path` is under the `workflow_dir`.
Because the comparison via `startswith()` is error prone:
absolute_path: /some/folder_other/file.csv
workflow_dir: /some/folder 

Nevertheless `_absolute_path` and `stored_path` should be stored in the same format as before.
This made the whole thing a bit uglier.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
