### PR TITLE
Feature Statistics: Output all statistics, not just selected

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -84,19 +84,19 @@ def format_time_diff(start, end, round_up_after=2):
 
     # Check which resolution is most appropriate
     if years >= round_up_after:
-        return '~%d years' % years
+        return f'~{years} years'
     elif months >= round_up_after:
-        return '~%d months' % months
+        return f'~{months} months'
     elif weeks >= round_up_after:
-        return '~%d weeks' % weeks
+        return f'~{weeks} weeks'
     elif days >= round_up_after:
-        return '~%d days' % days
+        return f'~{days} days'
     elif hours >= round_up_after:
-        return '~%d hours' % hours
+        return f'~{hours} hours'
     elif minutes >= round_up_after:
-        return '~%d minutes' % minutes
+        return f'~{minutes} minutes'
     else:
-        return '%d seconds' % seconds
+        return f'{seconds} seconds'
 
 
 class FeatureStatisticsTableModel(AbstractSortTableModel):
@@ -227,7 +227,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
 
     def __filter_attributes(self, attributes, matrix):
         """Filter out variables which shouldn't be visualized."""
-        attributes, matrix = np.asarray(attributes), matrix
+        attributes = np.asarray(attributes)
         mask = [idx for idx, attr in enumerate(attributes)
                 if not isinstance(attr, self.HIDDEN_VAR_TYPES)]
         return attributes[mask], matrix[:, mask]
@@ -576,7 +576,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                 if isinstance(attribute, TimeVariable):
                     return format_time_diff(self._min[row], self._max[row])
                 elif isinstance(attribute, DiscreteVariable):
-                    return "%.3g" % self._dispersion[row]
+                    return f"{self._dispersion[row]:.3g}"
                 else:
                     return render_value(self._dispersion[row])
             elif column == self.Columns.MIN:
@@ -586,10 +586,9 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                 if not isinstance(attribute, DiscreteVariable):
                     return render_value(self._max[row])
             elif column == self.Columns.MISSING:
-                return '%d (%d%%)' % (
-                    self._missing[row],
-                    100 * self._missing[row] / self.n_instances
-                )
+                missing = self._missing[row]
+                perc = int(round(100 * missing / self.n_instances))
+                return f'{missing} ({perc} %)'
             return None
 
         roles = {Qt.BackgroundRole: background,
@@ -776,7 +775,7 @@ class OWFeatureStatistics(widget.OWWidget):
         gui.auto_send(self.buttonsArea, self, "auto_commit")
 
     @staticmethod
-    def sizeHint():
+    def sizeHint():  # pylint: disable=arguments-differ
         return QSize(1050, 500)
 
     @Inputs.data
@@ -867,7 +866,7 @@ class OWFeatureStatistics(widget.OWWidget):
             metas=[StringVariable('Feature')]
         )
         statistics = Table(domain, data, metas=var_names)
-        statistics.name = '%s (Feature Statistics)' % self.data.name
+        statistics.name = '{self.data.name} (Feature Statistics)'
         self.Outputs.statistics.send(statistics)
 
     def send_report(self):

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -851,16 +851,17 @@ class OWFeatureStatistics(widget.OWWidget):
     def commit(self):
         if not self.selected_vars:
             self.Outputs.reduced_data.send(None)
+        else:
+            # Send a table with only selected columns to output
+            self.Outputs.reduced_data.send(self.data[:, self.selected_vars])
+
+        if not self.data:
             self.Outputs.statistics.send(None)
             return
 
-        # Send a table with only selected columns to output
-        variables = self.selected_vars
-        self.Outputs.reduced_data.send(self.data[:, variables])
-
         # Send the statistics of the selected variables to ouput
-        labels, data = self.model.get_statistics_matrix(variables, return_labels=True)
-        var_names = np.atleast_2d([var.name for var in variables]).T
+        labels, data = self.model.get_statistics_matrix(return_labels=True)
+        var_names = np.atleast_2d([var.name for var in self.model.variables]).T
         domain = Domain(
             attributes=[ContinuousVariable(name) for name in labels],
             metas=[StringVariable('Feature')]

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -450,7 +450,6 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
 
     def test_output_combinations(self):
-        domain = self.data.domain
         # No selection -> reduced_data is not output, statistics is present
         self.widget.unconditional_commit()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -325,7 +325,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.send_signal(self.widget.Inputs.data, self.data)
         self.select_rows = partial(select_rows, widget=self.widget)
 
-    def test_changing_data_updates_ouput(self):
+    def test_changing_data_updates_output(self):
         # Test behaviour of widget when auto commit is OFF
         self.widget.auto_commit = False
 
@@ -334,33 +334,27 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.select_rows([0])
         # By default, nothing should be sent since auto commit is off
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
         # When we commit, the data should be on the output
         self.widget.unconditional_commit()
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.statistics))
 
         # Send some new data
         iris = Table('iris')
         self.send_signal(self.widget.Inputs.data, iris)
         # By default, there should be nothing on the output
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
         # Nothing should change after commit, since we haven't selected any rows
         self.widget.unconditional_commit()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
 
         # Now let's switch back to the original data, where we selected row 0
         self.send_signal(self.widget.Inputs.data, self.data)
         # Again, since auto commit is off, nothing should be on the output
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
         # Since the row selection is saved into context settings, the appropriate
         # thing should be sent to output
         self.widget.unconditional_commit()
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.statistics))
 
     def test_changing_data_updates_output_with_autocommit(self):
         # Test behaviour of widget when auto commit is ON
@@ -371,20 +365,17 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.select_rows([0])
         # Selecting rows should send data to output
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.statistics))
 
         # Send some new data
         iris = Table('iris')
         self.send_signal(self.widget.Inputs.data, iris)
         # Don't select anything, so the outputs should be empty
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
 
         # Now let's switch back to the original data, where we had selected row 0,
         # we expect that to be sent to output
         self.send_signal(self.widget.Inputs.data, self.data)
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.statistics))
 
     def test_sends_single_attribute_table_to_output(self):
         # Check if selecting a single attribute row
@@ -453,12 +444,32 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         self.select_rows([0])
         self.widget.unconditional_commit()
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.statistics))
 
         self.widget.table_view.clearSelection()
         self.widget.unconditional_commit()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        self.assertIsNone(self.get_output(self.widget.Outputs.statistics))
+
+    def test_output_combinations(self):
+        domain = self.data.domain
+        # No selection -> reduced_data is not output, statistics is present
+        self.widget.unconditional_commit()
+        self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
+        self.assertEqual(len(self.get_output(self.widget.Outputs.statistics)),
+                         self.widget.model.rowCount())
+
+        # Has selection -> all outputs present
+        self.select_rows([0, 1])
+        self.widget.unconditional_commit()
+        outp = self.get_output(self.widget.Outputs.reduced_data)
+        self.assertEqual(len(outp), len(self.data))
+        self.assertEqual(len(outp.domain.variables), 2)
+        self.assertEqual(len(self.get_output(self.widget.Outputs.statistics)),
+                         self.widget.model.rowCount())
+
+        # No data -> no output
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
+        self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
 
 
 class TestFeatureStatisticsUI(WidgetTest):

--- a/doc/visual-programming/source/widgets/data/featurestatistics.md
+++ b/doc/visual-programming/source/widgets/data/featurestatistics.md
@@ -42,6 +42,6 @@ Once we have found a subset of potentially interesting features, or we have foun
 
 ![](images/feature_statistics_example1.png)
 
-Alternatively, if we want to store feature statistics, we can use the *Statistics* output and manipulate those values as needed. In this example, we simply select all the features and display the statistics in a table.
+Alternatively, if we want to store feature statistics, we can use the *Statistics* output and manipulate those values as needed. In this example, we display the statistics in a table.
 
 ![](images/feature_statistics_example2.png)


### PR DESCRIPTION
##### Issue

Resolves #5908.

##### Description of changes

Feature Statistics now outputs statistics for all variables, ignoring selection. (`Reduce Data` output works as before.)

Documentation is mildly outdated. In paragraph "*Alternatively, if we want to store feature statistics, we can use the *Statistics* output and manipulate those values as needed. In this example, we simply select all the features and display the statistics in a table.*", I removed "*simply select all the features and *", so it does not suggest that features have to be selected for this. The screenshot shows them as selected, but this is rather irrelevant.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
