### PR TITLE
Resolve deprecations

### DIFF
--- a/Orange/misc/server_embedder.py
+++ b/Orange/misc/server_embedder.py
@@ -63,7 +63,7 @@ class ServerEmbedderCommunicator:
         self._model = model_name
         self.embedder_type = embedder_type
 
-        # remove in 3.33
+        # remove in 3.34
         self._cancelled = False
 
         self.machine_id = None
@@ -100,7 +100,7 @@ class ServerEmbedderCommunicator:
         data
             List with data that needs to be embedded.
         processed_callback
-            Deprecated: remove in 3.33
+            Deprecated: remove in 3.34
             A function that is called after each item is embedded
             by either getting a successful response from the server,
             getting the result from cache or skipping the item.
@@ -161,7 +161,7 @@ class ServerEmbedderCommunicator:
         EmbeddingCancelledException:
             If cancelled attribute is set to True (default=False).
         """
-        # in Orange 3.33 keep content of the if - remove if clause and complete else
+        # in Orange 3.34 keep content of the if - remove if clause and complete else
         if proc_callback is None:
             progress_items = iter(linspace(0, 1, len(data)))
 
@@ -170,7 +170,7 @@ class ServerEmbedderCommunicator:
                 callback(next(progress_items))
         else:
             warnings.warn(
-                "proc_callback is deprecated and will be removed in version 3.33, "
+                "proc_callback is deprecated and will be removed in version 3.34, "
                 "use callback instead",
                 FutureWarning,
             )
@@ -220,7 +220,7 @@ class ServerEmbedderCommunicator:
         await asyncio.gather(*tasks, return_exceptions=True)
         log.debug("All workers canceled")
 
-    # remove in 3.33
+    # remove in 3.34
     def __check_cancelled(self):
         if self._cancelled:
             raise EmbeddingCancelledException()
@@ -270,7 +270,7 @@ class ServerEmbedderCommunicator:
             getting the result from cache or skipping the item.
         """
         while not queue.empty():
-            # remove in 3.33
+            # remove in 3.34
             self.__check_cancelled()
 
             # get item from the queue
@@ -396,10 +396,10 @@ class ServerEmbedderCommunicator:
     def clear_cache(self):
         self._cache.clear_cache()
 
-    # remove in 3.33
+    # remove in 3.34
     def set_cancelled(self):
         warnings.warn(
-            "set_cancelled is deprecated and will be removed in version 3.33, "
+            "set_cancelled is deprecated and will be removed in version 3.34, "
             "the process can be canceled by raising Error in callback",
             FutureWarning,
         )

--- a/Orange/misc/tests/test_server_embedder.py
+++ b/Orange/misc/tests/test_server_embedder.py
@@ -199,7 +199,7 @@ class TestServerEmbedder(unittest.TestCase):
         - remove set_canceled and marked places connected to this method
         - this test
         """
-        self.assertGreaterEqual("3.33.0", Orange.__version__)
+        self.assertGreaterEqual("3.34.0", Orange.__version__)
 
         mock = MagicMock()
         self.embedder.embedd_data(self.test_data, processed_callback=mock)

--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 import sklearn.linear_model as skl_linear_model
@@ -9,22 +7,12 @@ from Orange.data import Variable, ContinuousVariable
 from Orange.preprocess import Normalize
 from Orange.preprocess.score import LearnerScorer
 from Orange.regression import Learner, Model, SklLearner, SklModel
-from Orange.util import OrangeDeprecationWarning
 
 
 __all__ = ["LinearRegressionLearner", "RidgeRegressionLearner",
            "LassoRegressionLearner", "SGDRegressionLearner",
            "ElasticNetLearner", "ElasticNetCVLearner",
            "PolynomialLearner"]
-
-
-def _remove_deprecated_normalize(params):
-    if params['normalize'] is False:
-        del params['normalize']
-    else:
-        warnings.warn("scikit-learn deprecated the normalize parameter; "
-                      "Orange will remove it with 3.32.0.",
-                      OrangeDeprecationWarning, stacklevel=3)
 
 
 class _FeatureScorerMixin(LearnerScorer):
@@ -54,25 +42,21 @@ class RidgeRegressionLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.Ridge
 
     # Arguments are needed for signatures, pylint: disable=unused-argument
-    def __init__(self, alpha=1.0, fit_intercept=True,
-                 normalize=False, copy_X=True, max_iter=None,
-                 tol=0.001, solver='auto', preprocessors=None):
+    def __init__(self, alpha=1.0, fit_intercept=True, copy_X=True,
+                 max_iter=None, tol=0.001, solver='auto', preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-        _remove_deprecated_normalize(self.params)
 
 
 class LassoRegressionLearner(LinearRegressionLearner):
     __wraps__ = skl_linear_model.Lasso
 
     # Arguments are needed for signatures, pylint: disable=unused-argument
-    def __init__(self, alpha=1.0, fit_intercept=True, normalize=False,
-                 precompute=False, copy_X=True, max_iter=1000,
-                 tol=0.0001, warm_start=False, positive=False,
-                 preprocessors=None):
+    def __init__(self, alpha=1.0, fit_intercept=True, precompute=False,
+                 copy_X=True, max_iter=1000, tol=0.0001, warm_start=False,
+                 positive=False, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-        _remove_deprecated_normalize(self.params)
 
 
 class ElasticNetLearner(LinearRegressionLearner):
@@ -80,12 +64,10 @@ class ElasticNetLearner(LinearRegressionLearner):
 
     # Arguments are needed for signatures, pylint: disable=unused-argument
     def __init__(self, alpha=1.0, l1_ratio=0.5, fit_intercept=True,
-                 normalize=False, precompute=False, max_iter=1000,
-                 copy_X=True, tol=0.0001, warm_start=False, positive=False,
-                 preprocessors=None):
+                 precompute=False, max_iter=1000, copy_X=True, tol=0.0001,
+                 warm_start=False, positive=False, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-        _remove_deprecated_normalize(self.params)
 
 
 class ElasticNetCVLearner(LinearRegressionLearner):
@@ -93,12 +75,11 @@ class ElasticNetCVLearner(LinearRegressionLearner):
 
     # Arguments are needed for signatures, pylint: disable=unused-argument
     def __init__(self, l1_ratio=0.5, eps=0.001, n_alphas=100, alphas=None,
-                 fit_intercept=True, normalize=False, precompute='auto',
-                 max_iter=1000, tol=0.0001, cv=5, copy_X=True,
-                 verbose=0, n_jobs=1, positive=False, preprocessors=None):
+                 fit_intercept=True, precompute='auto', max_iter=1000,
+                 tol=0.0001, cv=5, copy_X=True, verbose=0, n_jobs=1,
+                 positive=False, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
-        _remove_deprecated_normalize(self.params)
 
 
 class SGDRegressionLearner(LinearRegressionLearner):

--- a/Orange/tests/test_linear_regression.py
+++ b/Orange/tests/test_linear_regression.py
@@ -14,7 +14,6 @@ from Orange.regression import (LinearRegressionLearner,
                                ElasticNetCVLearner,
                                MeanLearner)
 from Orange.evaluation import CrossValidation, RMSE
-from Orange.util import OrangeDeprecationWarning
 
 
 class TestLinearRegressionLearner(unittest.TestCase):
@@ -119,14 +118,3 @@ class TestLinearRegressionLearner(unittest.TestCase):
         learner2 = eval(repr_text)
 
         self.assertIsInstance(learner2, LinearRegressionLearner)
-
-    def test_deprecated_normalize(self):
-        """ When this test starts to fail:
-        - remove normalize=False kwargs from Orange.regression.
-        - remove _remove_deprecated_normalize and its calls
-        - remove this test
-        """
-        import Orange  # pylint: disable=import-outside-toplevel
-        self.assertLess(Orange.__version__, "3.33")
-        with self.assertWarns(OrangeDeprecationWarning):
-            RidgeRegressionLearner(normalize=True)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests start to fail due to two deprecations that should be removed.

##### Description of changes
- sever embedders: the removal is postponed to version 3.34, it would be fewer issues with older versions of addons if we wait for one more version
- linear regression: removed normalize and everything connected

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
