### PR TITLE
[FIX] make usable_scorers backwards compatible

### DIFF
--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -11,8 +11,58 @@ from AnyQt.QtGui import QStandardItem
 from AnyQt.QtCore import QPoint, Qt
 
 import Orange
-from Orange.widgets.evaluate.utils import ScoreTable
+from Orange.widgets.evaluate.utils import ScoreTable, usable_scorers, BUILTIN_SCORERS_ORDER
 from Orange.widgets.tests.base import GuiTest
+from Orange.data import Table, DiscreteVariable, ContinuousVariable
+from Orange.util import OrangeDeprecationWarning
+from Orange.evaluation import scoring
+
+
+class TestUsableScorers(unittest.TestCase):
+    def setUp(self):
+        self.iris = Table("iris")
+        self.housing = Table("housing")
+        self.registered_scorers = {scorer.name for scorer in scoring.Score.registry.values()}
+
+    def validate_scorer_candidates(self, scorers, class_type):
+        built_in_scorers = set(BUILTIN_SCORERS_ORDER[class_type])
+        # scorer candidates are not all registered scorers
+        self.assertNotEqual(scorers, self.registered_scorers)
+        # scorer candidates are subset of registered scorers
+        self.assertTrue(scorers.issubset(self.registered_scorers))
+        # builtins scorers are in fact a subset of valid candidates
+        self.assertTrue(built_in_scorers.issubset(scorers))
+
+    def test_usable_scores(self):
+        classification_scorers = {scorer.name for scorer in usable_scorers(self.iris.domain)}
+        regression_scorers = {scorer.name for scorer in usable_scorers(self.housing.domain)}
+
+        self.validate_scorer_candidates(classification_scorers, class_type=DiscreteVariable)
+        self.validate_scorer_candidates(regression_scorers, class_type=ContinuousVariable)
+
+    def test_if_deprecation_warning_is_raised(self):
+        with self.assertWarns(OrangeDeprecationWarning):
+            classification_scorers = {scorer.name for scorer in
+                                      usable_scorers(self.iris.domain.class_var)}
+
+        with self.assertWarns(OrangeDeprecationWarning):
+            regression_scorers = {scorer.name for scorer in
+                                  usable_scorers(self.housing.domain.class_var)}
+
+        # check if we get valid scorers using deprecated approach
+        self.validate_scorer_candidates(classification_scorers, class_type=DiscreteVariable)
+        self.validate_scorer_candidates(regression_scorers, class_type=ContinuousVariable)
+
+    def test_time_bomb(self):
+        """This test is to be included in the 3.32.1 release and will fail in
+        version 3.35. This serves as a reminder to remove the deprecated method
+        and this test."""
+        if LooseVersion(Orange.__version__) >= LooseVersion("3.35"):
+            self.fail(
+                "Passing Variable to usable_scorers was deprecated in "
+                "version 3.32.1, and there have been three minor versions in "
+                "between. Please remove the deprecated method."
+            )
 
 
 class TestScoreTable(GuiTest):


### PR DESCRIPTION
##### Issue
https://github.com/biolab/orange3-explain/pull/42

##### Description of changes
I forgot to make usable_scorers backwards compatible. Sorry! :) 


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
