### PR TITLE
[FIX] owpythonscript: Fix implicit float to int cast error

### DIFF
--- a/Orange/widgets/data/owpythonscript.py
+++ b/Orange/widgets/data/owpythonscript.py
@@ -286,8 +286,8 @@ class VimIndicator(QWidget):
         p.drawRoundedRect(rect, 5, 5)
         p.restore()
 
-        textstart = (width - fm.width(self.indicator_text)) / 2
-        p.drawText(textstart, height / 2 + 5, self.indicator_text)
+        textstart = (width - fm.width(self.indicator_text)) // 2
+        p.drawText(textstart, height // 2 + 5, self.indicator_text)
 
     def minimumSizeHint(self):
         fm = QFontMetrics(self.font())

--- a/Orange/widgets/data/utils/pythoneditor/editor.py
+++ b/Orange/widgets/data/utils/pythoneditor/editor.py
@@ -1369,11 +1369,11 @@ class PythonEditor(QPlainTextEdit):
             leftCursorRect = self.__cursorRect(block, column, 0)
             rightCursorRect = self.__cursorRect(block, column + 1, 0)
             if leftCursorRect.top() == rightCursorRect.top():  # if on the same visual line
-                middleHeight = (leftCursorRect.top() + leftCursorRect.bottom()) / 2
+                middleHeight = (leftCursorRect.top() + leftCursorRect.bottom()) // 2
                 if char == ' ':
                     painter.setPen(Qt.transparent)
                     painter.setBrush(QBrush(Qt.gray))
-                    xPos = (leftCursorRect.x() + rightCursorRect.x()) / 2
+                    xPos = (leftCursorRect.x() + rightCursorRect.x()) // 2
                     painter.drawRect(QRect(xPos, middleHeight, 2, 2))
                 else:
                     painter.setPen(QColor(Qt.gray).lighter(factor=120))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Python script raises type errors on Python 3.10 due to implicit float to int casts.

Error 1: Enable *Vim mode* -> immediate crash.
Error 2: In the editor enter space on the end of any line.

##### Description of changes

Fix types of passed parameters.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
