### PR TITLE
[ENH] Feature Constructor: Vectorize when possible

### DIFF
--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -2,7 +2,6 @@
 import unittest
 import ast
 import sys
-import math
 import pickle
 import copy
 from unittest.mock import patch, Mock
@@ -286,6 +285,20 @@ class FeatureFuncTest(unittest.TestCase):
         np.testing.assert_array_equal(r, iris.X[:, 1] + 10)
         self.assertEqual(f(iris[0]), iris[0]["sepal width"] + 10)
 
+    def test_vectorized(self):
+        iris = Table("iris")
+        f = FeatureFunc("exp(sepal_width)",
+                        [("sepal_width", iris.domain["sepal width"])])
+        f.func = Mock()
+        f(iris)
+        f.func.assert_called_once()
+
+        f = FeatureFunc("iris[0]",
+                        [("iris", iris.domain["iris"])])
+        f.func = Mock()
+        f(iris)
+        self.assertEqual(f.func.call_count, 150)
+
     def test_string_casting(self):
         zoo = Table("zoo")
         f = FeatureFunc("name[0]",
@@ -500,7 +513,7 @@ class OWFeatureConstructorTests(WidgetTest):
 class TestFeatureEditor(unittest.TestCase):
     def test_has_functions(self):
         self.assertIs(FeatureEditor.FUNCTIONS["abs"], abs)
-        self.assertIs(FeatureEditor.FUNCTIONS["sqrt"], math.sqrt)
+        self.assertIs(FeatureEditor.FUNCTIONS["sqrt"], np.sqrt)
 
 
 class FeatureConstructorHandlerTests(unittest.TestCase):

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -2,6 +2,7 @@
 import unittest
 import ast
 import sys
+import math
 import pickle
 import copy
 from unittest.mock import patch, Mock
@@ -293,6 +294,13 @@ class FeatureFuncTest(unittest.TestCase):
         f(iris)
         f.func.assert_called_once()
 
+        iris = Table("iris")
+        f = FeatureFunc("min(sepal_width, 2*sepal_length)",
+                        [("sepal_width", iris.domain["sepal width"])])
+        f.func = Mock()
+        f(iris)
+        f.func.assert_called_once()
+
         f = FeatureFunc("iris[0]",
                         [("iris", iris.domain["iris"])])
         f.func = Mock()
@@ -512,8 +520,9 @@ class OWFeatureConstructorTests(WidgetTest):
 
 class TestFeatureEditor(unittest.TestCase):
     def test_has_functions(self):
-        self.assertIs(FeatureEditor.FUNCTIONS["abs"], abs)
-        self.assertIs(FeatureEditor.FUNCTIONS["sqrt"], np.sqrt)
+        self.assertEqual(FeatureEditor.FUNCTIONS["abs"], abs.__doc__)
+        self.assertEqual(FeatureEditor.FUNCTIONS["sqrt"], math.sqrt.__doc__)
+        self.assertEqual(FeatureEditor.FUNCTIONS["nansum"], "")
 
 
 class FeatureConstructorHandlerTests(unittest.TestCase):


### PR DESCRIPTION
##### Issue

Resolves #5911.

##### Description of changes

- Try to compute the function on columns; fall back to per-instance if this fails.
- Import functions from `np` instead of from `math` when available.
- Show all functions in combo (avoid compiling a separate list of functions)
- Remove `cumsum`, `cumprod`, which created two-dimensional data instead of a column

##### Includes
- [X] Code changes
- [X] Tests