### PR TITLE
Upgrade cirrus-actions/rebase to version 1.6

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -14,6 +14,6 @@ jobs:
           token: ${{ secrets.BIOLAB_HELPER_PAT }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@1.6
         env:
           GITHUB_TOKEN: ${{ secrets.BIOLAB_HELPER_PAT }}


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
After latest changes in git (https://github.com/actions/checkout/issues/766) rebase fails with error:

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

    git config --global --add safe.directory /github/workspace
```

##### Description of changes
Rising version to 1.6 should solve the problem

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
