### PR TITLE
requirements-gui: Raise required pyqtgraph version

### DIFF
--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -4,7 +4,7 @@ orange-widget-base>=4.16.1
 AnyQt>=0.0.13
 
 # ignore pyqtgraph 0.12.4 due to https://github.com/pyqtgraph/pyqtgraph/issues/2237
-pyqtgraph>=0.11.1,!=0.12.4
+pyqtgraph>=0.12.2,!=0.12.4
 matplotlib>=2.2.5
 qtconsole>=4.7.2
 pygments>=2.8.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
SliderGraph not working due to upstream problem in pyqtgraph.
Resulting in e.g. PCA widget crashing immediately.

##### Description of changes
Bump required pyqtgraph version to at least 0.12.2, to include fix for https://github.com/pyqtgraph/pyqtgraph/issues/1484

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
