### PR TITLE
Scatterplot Graph: Use no brush when same color

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1064,17 +1064,17 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         Returns:
             (tuple): a list of pens and list of brushes
         """
-
+        alpha_subset, alpha_unset = self._alpha_for_subsets()
         if subset is not None:
-            colors = [QColor(*color, alpha)
-                      for alpha in self._alpha_for_subsets()]
-            brushes = [QBrush(color) for color in colors]
-            brush = np.where(subset, *brushes)
+            qcolor = QColor(*color, alpha_subset)
+            brush = np.where(subset, QBrush(qcolor), QBrush(QColor(0, 0, 0, 0)))
+            pen = np.where(subset,
+                           _make_pen(qcolor, 1.5),
+                           _make_pen(QColor(*color, alpha_unset), 1.5))
         else:
             qcolor = QColor(*color, self.alpha_value)
             brush = np.full(self.n_shown, QBrush(qcolor))
-        qcolor = QColor(*color, self.alpha_value)
-        pen = [_make_pen(qcolor, 1.5)] * self.n_shown
+            pen = [_make_pen(qcolor, 1.5)] * self.n_shown
         return pen, brush
 
     def _get_continuous_colors(self, c_data, subset):

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -681,8 +681,14 @@ class TestOWScatterPlotBase(WidgetTest):
         data = graph.scatterplot_item.data
         self.assertTrue(all(pen.color().hue() == hue for pen in data["pen"]))
         self.assertTrue(all(pen.color().hue() == hue for pen in data["brush"]))
-        self.assertEqual(len(set(map(id, data["pen"]))), 1)
+        self.assertEqual(len(set(map(id, data["pen"]))), 2)
+        self.assertEqual(data["pen"][3].color(), data["pen"][4].color())
+        self.assertNotEqual(data["pen"][4].color().alpha(),
+                            data["pen"][5].color().alpha())
         self.assertEqual(len(set(map(id, data["brush"]))), 2)  # transparent and colored
+        self.assertEqual(data["brush"][3].color(), data["brush"][4].color())
+        self.assertNotEqual(data["brush"][4].color().alpha(),
+                            data["brush"][5].color().alpha())
 
     def test_colors_update_legend_and_density(self):
         graph = self.graph


### PR DESCRIPTION
##### Issue

Fixes #5922.

##### Description of changes

Use same method for coloring when same value as for other settings.

##### Includes
- [X] Code changes
- [x] Tests
