### PR TITLE
Tree Viewer: Hide details

### DIFF
--- a/Orange/tree.py
+++ b/Orange/tree.py
@@ -12,7 +12,7 @@ class Node:
     """Tree node base class; instances of this class are also used as leaves
 
     Attributes:
-        attr (Odange.data.Variable): The attribute used for splitting
+        attr (Orange.data.Variable): The attribute used for splitting
         attr_idx (int): The index of the attribute used for splitting
         value (object): value used for prediction (e.g. class distribution)
         children (list of Node): child branches

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -7,9 +7,11 @@ from AnyQt.QtWidgets import (
 )
 from AnyQt.QtGui import QColor, QBrush, QPen, QFontMetrics
 from AnyQt.QtCore import Qt, QPointF, QSizeF, QRectF
+
 from orangewidget.utils.combobox import ComboBoxSearch
 
 from Orange.base import TreeModel, SklModel
+from Orange.widgets import gui
 from Orange.widgets.utils.signals import Input, Output
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.owtreeviewer2d import \
@@ -177,6 +179,7 @@ class OWTreeGraph(OWTreeViewer2D):
     settingsHandler = ClassValuesContextHandler()
     target_class_index = ContextSetting(0)
     regression_colors = Setting(0)
+    show_intermediate = Setting(False)
 
     replaces = [
         "Orange.widgets.classify.owclassificationtreegraph.OWClassificationTreeGraph",
@@ -202,6 +205,13 @@ class OWTreeGraph(OWTreeViewer2D):
         combo.activated[int].connect(self.color_changed)
         self.display_box.layout().addRow(self.color_label, combo)
 
+        box = gui.hBox(None)
+        gui.rubber(box)
+        gui.checkBox(box, self, "show_intermediate",
+                     "Show details in non-leaves",
+                     callback=self.set_node_info)
+        self.display_box.layout().addRow(box)
+
     def set_node_info(self):
         """Set the content of the node"""
         for node in self.scene.nodes():
@@ -218,7 +228,9 @@ class OWTreeGraph(OWTreeViewer2D):
     def _update_node_info_attr_name(self, node, text):
         attr = self.tree_adapter.attribute(node.node_inst)
         if attr is not None:
-            text += "<hr/>{}".format(attr.name)
+            if text:
+                text += "<hr/>"
+            text += attr.name
         return text
 
     def activate_loaded_settings(self):
@@ -344,12 +356,18 @@ class OWTreeGraph(OWTreeViewer2D):
         self.report_plot(self.scene)
 
     def update_node_info(self, node):
-        if self.domain.class_var.is_discrete:
-            self.update_node_info_cls(node)
+        if self.tree_adapter.has_children(node.node_inst) and not self.show_intermediate:
+            text = ""
+        elif self.domain.class_var.is_discrete:
+            text = self.node_content_cls(node)
         else:
-            self.update_node_info_reg(node)
+            text = self.node_content_reg(node)
 
-    def update_node_info_cls(self, node):
+        text = self._update_node_info_attr_name(node, text)
+        node.setHtml(
+            f'<p style="line-height: 120%; margin-bottom: 0">{text}</p>')
+
+    def node_content_cls(self, node):
         """Update the printed contents of the node for classification trees"""
         node_inst = node.node_inst
         distr = self.tree_adapter.get_distribution(node_inst)[0]
@@ -366,21 +384,16 @@ class OWTreeGraph(OWTreeViewer2D):
             text += f"100%, {total}/{total}"
         else:
             text += f"{100 * tabs:2.1f}%, {int(total * tabs)}/{total}"
+        return text
 
-        text = self._update_node_info_attr_name(node, text)
-        node.setHtml(
-            f'<p style="line-height: 120%; margin-bottom: 0">{text}</p>')
-
-    def update_node_info_reg(self, node):
+    def node_content_reg(self, node):
         """Update the printed contents of the node for regression trees"""
         node_inst = node.node_inst
         mean, var = self.tree_adapter.get_distribution(node_inst)[0]
         insts = self.tree_adapter.num_samples(node_inst)
         text = f"<b>{mean:.1f}</b> ± {var:.1f}<br/>"
         text += f"{insts} instances"
-        text = self._update_node_info_attr_name(node, text)
-        node.setHtml(
-            f'<p style="line-height: 120%; margin-bottom: 0">{text}</p>')
+        return text
 
     def toggle_node_color_cls(self):
         """Update the node color for classification trees"""

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -1,9 +1,14 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring, protected-access
 from os import path
+import unittest
+from unittest.mock import Mock
+import numpy as np
 
 from Orange.classification import TreeLearner
-from Orange.data import Table
+from Orange.data import Table, ContinuousVariable, DiscreteVariable, Domain
+from Orange.tree import DiscreteNode, MappedDiscreteNode, Node, NumericNode, \
+    TreeModel
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.visualize.owtreeviewer import OWTreeGraph
 
@@ -27,6 +32,42 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
             "datasets", "same_entropy.tab"))
         cls.data_same_entropy = tree(data_same_entropy)
         cls.data_same_entropy.instances = data_same_entropy
+
+        vara = DiscreteVariable("aaa", values=("e", "f", "g"))
+        root = DiscreteNode(vara, 0, np.array([42, 8]))
+        root.subset = np.arange(50)
+
+        varb = DiscreteVariable("bbb", values=tuple("ijkl"))
+        child0 = MappedDiscreteNode(varb, 1, np.array([0, 1, 0, 0]), (38, 5))
+        child0.subset = np.arange(16)
+        child1 = Node(None, 0, (13, 3))
+        child1.subset = np.arange(16, 30)
+        varc = ContinuousVariable("ccc")
+        child2 = NumericNode(varc, 2, 42, (78, 12))
+        child2.subset = np.arange(30, 50)
+        root.children = (child0, child1, child2)
+
+        child00 = Node(None, 0, (15, 4))
+        child00.subset = np.arange(10)
+        child01 = Node(None, 0, (10, 5))
+        child01.subset = np.arange(10, 16)
+        child0.children = (child00, child01)
+
+        child20 = Node(None, 0, (90, 4))
+        child20.subset = np.arange(30, 35)
+        child21 = Node(None, 0, (70, 9))
+        child21.subset = np.arange(35, 50)
+        child2.children = (child20, child21)
+
+        domain = Domain([vara, varb, varc], ContinuousVariable("y"))
+        t = [[i, j, k]
+             for i in range(3)
+             for j in range(4)
+             for k in (40, 44)]
+        x = np.array((t * 3)[:50])
+        data = Table.from_numpy(
+            domain, x, np.arange(len(x)))
+        cls.tree = TreeModel(data, root)
 
     def setUp(self):
         self.widget = self.create_widget(OWTreeGraph)
@@ -86,3 +127,94 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
                 "sent to widget after receiving a dataset with variables with "
                 "same entropy." % n_tries
             )
+
+    def test_update_node_info(self):
+        widget = self.widget
+        self.send_signal(widget.Inputs.tree, self.signal_data)
+
+        node = Mock()
+
+        widget.tree_adapter = Mock()
+        widget.tree_adapter.attribute = lambda *_: ContinuousVariable("foo")
+        widget.node_content_cls = lambda *_: "bar<br/>ban"
+
+        widget.tree_adapter.has_children = lambda *_: True
+        widget.show_intermediate = False
+        widget.update_node_info(node)
+        args = node.setHtml.call_args[0][0]
+        self.assertIn("foo", args)
+        self.assertNotIn("bar", args)
+
+        widget.tree_adapter.has_children = lambda *_: True
+        widget.show_intermediate = True
+        widget.update_node_info(node)
+        args = node.setHtml.call_args[0][0]
+        self.assertIn("bar<br/>ban<hr/>foo", args)
+
+        widget.tree_adapter.has_children = lambda *_: False
+        widget.show_intermediate = True
+        widget.update_node_info(node)
+        args = node.setHtml.call_args[0][0]
+        self.assertIn("bar<br/>ban<hr/>foo", args)
+
+        widget.tree_adapter.has_children = lambda *_: False
+        widget.show_intermediate = False
+        widget.update_node_info(node)
+        args = node.setHtml.call_args[0][0]
+        self.assertIn("bar<br/>ban<hr/>foo", args)
+
+    def test_tree_labels(self):
+        w = self.widget
+        w.show_intermediate = True
+
+        self.send_signal(w.Inputs.tree, self.tree)
+
+        txt = w.root_node.toPlainText()
+        self.assertIn("42.0 ± 8.0", txt)
+        self.assertIn("50 instances", txt)
+        self.assertIn("aaa", txt)
+
+        children = [edge.node2
+                    for edge in w.root_node.graph_edges()]
+
+        txt = children[0].toPlainText()
+        self.assertIn("38.0 ± 5.0", txt)
+        self.assertIn("16 instances", txt)
+        self.assertIn("bbb", txt)
+
+        txt = children[1].toPlainText()
+        self.assertIn("13.0 ± 3.0", txt)
+        self.assertIn("14 instances", txt)
+
+        txt = children[2].toPlainText()
+        self.assertIn("78.0 ± 12.0", txt)
+        self.assertIn("20 instances", txt)
+        self.assertIn("ccc", txt)
+
+        w.controls.show_intermediate.click()
+
+        txt = w.root_node.toPlainText()
+        self.assertNotIn("42.0 ± 8.0", txt)
+        self.assertNotIn("50 instances", txt)
+        self.assertIn("aaa", txt)
+
+        children = [edge.node2
+                    for edge in w.root_node.graph_edges()]
+
+        txt = children[0].toPlainText()
+        self.assertNotIn("38.0 ± 5.0", txt)
+        self.assertNotIn("16 instances", txt)
+        self.assertIn("bbb", txt)
+
+        txt = children[1].toPlainText()
+        self.assertIn("13.0 ± 3.0", txt)
+        self.assertIn("14 instances", txt)
+
+        txt = children[2].toPlainText()
+        self.assertNotIn("78.0 ± 12.0", txt)
+        self.assertNotIn("20 instances", txt)
+        self.assertIn("ccc", txt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

Trees are used mostly for education purposes. In this context, showing majority classes in internal nodes is often annoying at first (at least, it adds unnecessary details), but can be useful later. I'd like it to be hidden, but with option for showing it.

##### Description of changes

Add a checkbox for showing/hiding details.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
