### PR TITLE
Predictions: Show errors in regression

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -1026,7 +1026,7 @@ class RegressionItemDelegate(PredictionsItemDelegate):
             self.span = 1
         else:
             self.offset = minv
-            self.span = maxv - minv
+            self.span = maxv - minv or 1
 
     def initStyleOption(self, option, index):
         super().initStyleOption(option, index)
@@ -1048,16 +1048,8 @@ class RegressionItemDelegate(PredictionsItemDelegate):
         painter.save()
         painter.translate(rect.topLeft())
         if numpy.isfinite(xvalue):
-            painter.setBrush(QBrush(Qt.blue))
-            painter.drawRect(QRectF(0, 0,
-                                    numpy.nanmin([xvalue, xactual]), height))
-            if numpy.isfinite(xactual):
-                if xvalue > xactual:
-                    painter.setBrush(QBrush(Qt.red))
-                    painter.drawRect(QRectF(xactual, 0, xvalue - xactual, height))
-                elif xvalue < xactual:
-                    painter.setPen(QPen(QBrush(Qt.red), 1, Qt.DotLine))
-                    painter.drawLine(QPointF(xvalue, height / 2), QPointF(xactual, height / 2))
+            painter.setBrush(QBrush(Qt.magenta))
+            painter.drawRect(QRectF(0, 0, xvalue, height))
         if numpy.isfinite(xactual):
             painter.setPen(QPen(QBrush(Qt.black), 1))
             painter.setBrush(Qt.white)

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -368,11 +368,10 @@ class OWPredictions(OWWidget):
                 continue
             row = [QStandardItem(learner_name(pred.predictor)),
                    QStandardItem("N/A"), QStandardItem("N/A")]
+            actual = results.actual
+            predicted = results.predicted
+            probabilities = results.probabilities
             try:
-                actual = results.actual
-                predicted = results.predicted
-                probabilities = results.probabilities
-
                 if self.class_var:
                     mask = numpy.isnan(results.actual)
                 else:

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -617,7 +617,7 @@ class OWPredictions(OWWidget):
                                                 - len(self.PROB_OPTS)]
             tooltip_probs = (shown_class, )
         sort_col_indices = []
-        for col, slot in enumerate(self.predictors):
+        for col, slot in enumerate(self._non_errored_predictors()):
             target = slot.predictor.domain.class_var
             if target is not None and target.is_discrete:
                 shown_probs = self._shown_prob_indices(target, in_target=True)

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1475,7 +1475,6 @@ class TestRegressionItemDelegate(GuiTest):
         painter = Mock()
         dr = painter.drawRect
         el = painter.drawEllipse
-        dl = painter.drawLine
         index = Mock()
         rect = QRect(0, 0, 256, 16)
 
@@ -1488,7 +1487,6 @@ class TestRegressionItemDelegate(GuiTest):
 
         dr.assert_not_called()
         el.assert_not_called()
-        dl.assert_not_called()
 
         # Prediction is known
         delegate.cachedData = lambda *_: (8.0, None)
@@ -1498,7 +1496,6 @@ class TestRegressionItemDelegate(GuiTest):
         rrect = dr.call_args[0][0]
         self.assertEqual(rrect.width(), 192)
         el.assert_not_called()
-        dl.assert_not_called()
         dr.reset_mock()
 
         ### Actual is known
@@ -1514,7 +1511,6 @@ class TestRegressionItemDelegate(GuiTest):
         el.assert_called_once()
         center = el.call_args[0][0]
         self.assertEqual(center.x(), 192)
-        dl.assert_not_called()
         dr.reset_mock()
         el.reset_mock()
 
@@ -1528,11 +1524,6 @@ class TestRegressionItemDelegate(GuiTest):
         el.assert_called_once()
         center = el.call_args[0][0]
         self.assertEqual(center.x(), 192)
-        dl.assert_called_once()
-        lline = dl.call_args[0]
-        self.assertEqual(lline[0].x(), 128)
-        self.assertEqual(lline[1].x(), 192)
-        dl.reset_mock()
         dr.reset_mock()
         el.reset_mock()
 
@@ -1540,15 +1531,12 @@ class TestRegressionItemDelegate(GuiTest):
         delegate.cachedData = lambda *_: (9.0, None)
         delegate.drawBar(painter, Mock(), index, rect)
 
-        self.assertEqual(dr.call_count, 2)
-        rrect = dr.call_args_list[0][0][0]
-        self.assertEqual(rrect.width(), 192)
-        rrect = dr.call_args_list[1][0][0]
-        self.assertEqual(rrect.width(), 32)
+        dr.assert_called_once()
+        rrect = dr.call_args[0][0]
+        self.assertEqual(rrect.width(), 224)
         el.assert_called_once()
         center = el.call_args[0][0]
         self.assertEqual(center.x(), 192)
-        dl.assert_not_called()
         dr.reset_mock()
         el.reset_mock()
 

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -611,6 +611,7 @@ class TestOWPredictions(WidgetTest):
         widget = self.widget
         prob_combo = widget.controls.shown_probs
         set_prob_ind = widget.predictionsview.model().setProbInd
+        widget._non_errored_predictors = lambda: widget.predictors[:4]
 
         widget.data = Table.from_list(
             Domain([], DiscreteVariable("c", values=tuple("abc"))), [])
@@ -632,7 +633,7 @@ class TestOWPredictions(WidgetTest):
             if isinstance(delegate, ClassificationItemDelegate):
                 self.assertEqual(list(delegate.shown_probabilities), [])
                 self.assertEqual(delegate.tooltip, "")
-        set_prob_ind.assert_called_with([[], [], [], [], None])
+        set_prob_ind.assert_called_with([[], [], [], []])
 
         widget.shown_probs = widget.DATA_PROBS
         widget._update_prediction_delegate()
@@ -643,7 +644,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(widget._delegates[3].shown_probabilities, [None, None, None])
         for delegate in widget._delegates[:-1]:
             self.assertEqual(delegate.tooltip, "p(a, b, c)")
-        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [1, 2], [], None])
+        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [1, 2], []])
 
         widget.shown_probs = widget.MODEL_PROBS
         widget._update_prediction_delegate()
@@ -655,7 +656,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(widget._delegates[2].tooltip, "p(c, b, d)")
         self.assertEqual(widget._delegates[3].shown_probabilities, [4])
         self.assertEqual(widget._delegates[3].tooltip, "p(e)")
-        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [2, 1, 3], [4], None])
+        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [2, 1, 3], [4]])
 
         widget.shown_probs = widget.BOTH_PROBS
         widget._update_prediction_delegate()
@@ -667,7 +668,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(widget._delegates[2].tooltip, "p(b, c)")
         self.assertEqual(widget._delegates[3].shown_probabilities, [])
         self.assertEqual(widget._delegates[3].tooltip, "")
-        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [1, 2], [], None])
+        set_prob_ind.assert_called_with([[0, 1, 2], [0, 1], [1, 2], []])
 
         n_fixed = len(widget.PROB_OPTS)
         widget.shown_probs = n_fixed  # a
@@ -678,7 +679,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(widget._delegates[3].shown_probabilities, [None])
         for delegate in widget._delegates[:-1]:
             self.assertEqual(delegate.tooltip, "p(a)")
-        set_prob_ind.assert_called_with([[0], [0], [], [], None])
+        set_prob_ind.assert_called_with([[0], [0], [], []])
 
         n_fixed = len(widget.PROB_OPTS)
         widget.shown_probs = n_fixed + 1  # b
@@ -689,7 +690,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(widget._delegates[3].shown_probabilities, [None])
         for delegate in widget._delegates[:-1]:
             self.assertEqual(delegate.tooltip, "p(b)")
-        set_prob_ind.assert_called_with([[1], [1], [1], [], None])
+        set_prob_ind.assert_called_with([[1], [1], [1], []])
 
         n_fixed = len(widget.PROB_OPTS)
         widget.shown_probs = n_fixed + 2  # c
@@ -700,7 +701,7 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(widget._delegates[3].shown_probabilities, [None])
         for delegate in widget._delegates[:-1]:
             self.assertEqual(delegate.tooltip, "p(c)")
-        set_prob_ind.assert_called_with([[2], [], [2], [], None])
+        set_prob_ind.assert_called_with([[2], [], [2], []])
 
     def test_update_delegates_continuous(self):
         self._mock_predictors()


### PR DESCRIPTION
##### Issue

Fixes #5901

##### Description of changes

- Refactor item delegates into two classes, one for classification and one for regression (to avoid checks in methods)
- Add information about the actual class/outcome to `PredictionModel`
- Show actual class by using narrower lines in distribution bar
- Show the line for regression and mark the true value
- **Fix** a bug in assigning of indices for sorting by probabilities: if any models failed and their respective columns were not shows, the indices for sorting by that column were nevertheless created and inserted. Therefore, if the 3rd model has failed, the 3rd column showed the 4th model, but sorting by that column would sort by the 3rd model (and probably fail).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
