### PR TITLE
[FIX] owcsvimport: Reduce sample size

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1327,7 +1327,7 @@ class OWCSVFileImport(widget.OWWidget):
 
 
 @singledispatch
-def sniff_csv(file, samplesize=2 ** 20, delimiters=None):
+def sniff_csv(file, samplesize=4 * 2 ** 10, delimiters=None):
     sniffer = csv.Sniffer()
     sample = file.read(samplesize)
     dialect = sniffer.sniff(sample, delimiters=delimiters)
@@ -1353,7 +1353,9 @@ class HeaderSniffer(csv.Sniffer):
 
 @sniff_csv.register(str)
 @sniff_csv.register(bytes)
-def sniff_csv_with_path(path, encoding="utf-8", samplesize=2 ** 20, delimiters=None):
+def sniff_csv_with_path(
+        path, encoding="utf-8", samplesize=4 * 2 ** 10, delimiters=None
+):
     with _open(path, "rt", encoding=encoding) as f:
         return sniff_csv(f, samplesize, delimiters)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Opening some files for the first time can take a surprising amount of time before the detailed import options dialog is displayed.

Example file

[dataset.csv](https://github.com/biolab/orange3/files/8609703/dataset.csv)

The time is spent in `csv.Sniffer.sniff`

##### Description of changes

Reduce sample text size from 1MiB to 4KiB 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
