### PR TITLE
Silhouette: Use variables instead of indices

### DIFF
--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -78,14 +78,15 @@ class OWSilhouettePlot(widget.OWWidget):
         "Orange.widgets.unsupervised.owsilhouetteplot.OWSilhouettePlot"
     ]
 
-    settingsHandler = settings.PerfectDomainContextHandler()
+    settingsHandler = settings.DomainContextHandler()
+    settings_version = 2
 
     #: Distance metric index
     distance_idx = settings.Setting(0)
-    #: Group/cluster variable index
-    cluster_var_idx = settings.ContextSetting(0)
-    #: Annotation variable index
-    annotation_var_idx = settings.ContextSetting(0)
+    #: Group/cluster variable
+    cluster_var = settings.ContextSetting(None)
+    #: Annotation variable
+    annotation_var = settings.ContextSetting(None)
     #: Group the (displayed) silhouettes by cluster
     group_by_cluster = settings.Setting(True)
     #: A fixed size for an instance bar
@@ -145,16 +146,17 @@ class OWSilhouettePlot(widget.OWWidget):
             orientation=Qt.Horizontal, callback=self._invalidate_distances)
         controllayout.addWidget(distbox)
 
-        box = gui.vBox(self.controlArea, "Cluster Label")
+        box = gui.vBox(self.controlArea, "Grouping")
+        self.cluster_var_model = itemmodels.VariableListModel(
+            parent=self, placeholder="(None)")
         self.cluster_var_cb = gui.comboBox(
-            box, self, "cluster_var_idx", contentsLength=14,
-            searchable=True, callback=self._invalidate_scores
+            box, self, "cluster_var", contentsLength=14,
+            searchable=True, callback=self._invalidate_scores,
+            model=self.cluster_var_model
         )
         gui.checkBox(
-            box, self, "group_by_cluster", "Group by cluster",
+            box, self, "group_by_cluster", "Show in groups",
             callback=self._replot)
-        self.cluster_var_model = itemmodels.VariableListModel(parent=self)
-        self.cluster_var_cb.setModel(self.cluster_var_model)
 
         box = gui.vBox(self.controlArea, "Bars")
         gui.widgetLabel(box, "Bar width:")
@@ -162,12 +164,12 @@ class OWSilhouettePlot(widget.OWWidget):
             box, self, "bar_size", minValue=1, maxValue=10, step=1,
             callback=self._update_bar_size)
         gui.widgetLabel(box, "Annotations:")
-        self.annotation_cb = gui.comboBox(
-            box, self, "annotation_var_idx", contentsLength=14,
-            callback=self._update_annotations)
         self.annotation_var_model = itemmodels.VariableListModel(parent=self)
-        self.annotation_var_model[:] = ["None"]
-        self.annotation_cb.setModel(self.annotation_var_model)
+        self.annotation_var_model[:] = [None]
+        self.annotation_cb = gui.comboBox(
+            box, self, "annotation_var", contentsLength=14,
+            callback=self._update_annotations,
+            model=self.annotation_var_model)
         ibox = gui.indentedBox(box, 5)
         self.ann_hidden_warning = warning = gui.widgetLabel(
             ibox, "(increase the width to show)")
@@ -258,13 +260,13 @@ class OWSilhouettePlot(widget.OWWidget):
             raise NoGroupVariable()
         self.cluster_var_model[:] = groupvars
         if domain.class_var in groupvars:
-            self.cluster_var_idx = groupvars.index(domain.class_var)
+            self.cluster_var = domain.class_var
         else:
-            self.cluster_var_idx = 0
+            self.cluster_var = groupvars[0]
         annotvars = [var for var in domain.variables + domain.metas
                      if var.is_string or var.is_discrete]
-        self.annotation_var_model[:] = ["None"] + annotvars
-        self.annotation_var_idx = 1 if annotvars else 0
+        self.annotation_var_model[:] = [None] + annotvars
+        self.annotation_var = annotvars[0] if annotvars else None
         self.openContext(Orange.data.Domain(groupvars))
 
     def _is_empty(self) -> bool:
@@ -283,7 +285,7 @@ class OWSilhouettePlot(widget.OWWidget):
         self._silhouette = None
         self._labels = None
         self.cluster_var_model[:] = []
-        self.annotation_var_model[:] = ["None"]
+        self.annotation_var_model[:] = [None]
         self._clear_scene()
         self.Error.clear()
         self.Warning.clear()
@@ -346,8 +348,7 @@ class OWSilhouettePlot(widget.OWWidget):
         if self._matrix is None:
             return
 
-        labelvar = self.cluster_var_model[self.cluster_var_idx]
-        labels, _ = self.data.get_column_view(labelvar)
+        labels, _ = self.data.get_column_view(self.cluster_var)
         labels = np.asarray(labels, dtype=float)
         cluster_mask = np.isnan(labels)
         dist_mask = np.isnan(self._matrix).all(axis=0)
@@ -396,19 +397,19 @@ class OWSilhouettePlot(widget.OWWidget):
         self._silplot.setBarHeight(self.bar_size)
         self._silplot.setRowNamesVisible(visible)
         self.ann_hidden_warning.setVisible(
-            not visible and self.annotation_var_idx > 0)
+            not visible and self.annotation_var is not None)
 
     def _replot(self):
         # Clear and replot/initialize the scene
         self._clear_scene()
         if self._silhouette is not None and self._labels is not None:
-            var = self.cluster_var_model[self.cluster_var_idx]
             self._silplot = silplot = SilhouettePlot()
             self._set_bar_height()
 
             if self.group_by_cluster:
-                silplot.setScores(self._silhouette, self._labels, var.values,
-                                  var.colors)
+                silplot.setScores(
+                    self._silhouette, self._labels,
+                    self.cluster_var.values, self.cluster_var.colors)
             else:
                 silplot.setScores(
                     self._silhouette,
@@ -428,10 +429,7 @@ class OWSilhouettePlot(widget.OWWidget):
             self._set_bar_height()
 
     def _update_annotations(self):
-        if 0 < self.annotation_var_idx < len(self.annotation_var_model):
-            annot_var = self.annotation_var_model[self.annotation_var_idx]
-        else:
-            annot_var = None
+        annot_var = self.annotation_var
         self.ann_hidden_warning.setVisible(
             self.bar_size < 5 and annot_var is not None)
 
@@ -494,10 +492,8 @@ class OWSilhouettePlot(widget.OWWidget):
             else:
                 scores = self._silhouette
 
-            var = self.cluster_var_model[self.cluster_var_idx]
-
             domain = self.data.domain
-            proposed = "Silhouette ({})".format(escape(var.name))
+            proposed = "Silhouette ({})".format(escape(self.cluster_var.name))
             names = [var.name for var in itertools.chain(domain.attributes,
                                                          domain.class_vars,
                                                          domain.metas)]
@@ -528,17 +524,42 @@ class OWSilhouettePlot(widget.OWWidget):
             return
 
         self.report_plot()
-        caption = "Silhouette plot ({} distance), clustered by '{}'".format(
-            self.Distances[self.distance_idx][0],
-            self.cluster_var_model[self.cluster_var_idx])
-        if self.annotation_var_idx and self._silplot.rowNamesVisible():
-            caption += ", annotated with '{}'".format(
-                self.annotation_var_model[self.annotation_var_idx])
+        caption = "Silhouette plot " \
+                  f"({self.Distances[self.distance_idx][0]} distance), " \
+                  f"clustered by '{self.cluster_var.name}'"
+        if self.annotation_var and self._silplot.rowNamesVisible():
+            caption += f", annotated with '{self.annotation_var.name}'"
         self.report_caption(caption)
 
     def onDeleteWidget(self):
         self.clear()
         super().onDeleteWidget()
+
+    @classmethod
+    def migrate_context(cls, context, version):
+        values = context.values
+        if version < 2:
+            discrete_vars = (
+                name
+                for name, type_ in itertools.chain(
+                    context.attributes, context.class_vars, context.metas)
+                if type_ == 1)
+            index, _ = values.pop("cluster_var_idx")
+            name = next(itertools.islice(discrete_vars, index, None)
+            )
+            values["cluster_var"] = (name, 101)
+
+            index = values.pop("annotation_var_idx")[0] - 1
+            if index == -1:
+                values["annotation_var"] = None
+            else:
+                annot_vars = (
+                    (name, type_ + 100)
+                    for name, type_ in itertools.chain(
+                        context.attributes, context.class_vars, context.metas)
+                    if type_ in (1, 3))
+                values["annotation_var"] = next(
+                    itertools.islice(annot_vars, index, None))
 
 
 class SelectAction(enum.IntEnum):

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -3,8 +3,11 @@
 # pylint: disable=missing-docstring
 import random
 import unittest
+from unittest.mock import Mock
 
 import numpy as np
+
+from orangewidget.settings import Context
 
 import Orange.distance
 from Orange.data import (
@@ -225,6 +228,69 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
 
         output = self.get_output(self.widget.Outputs.annotated_data)
         self.assertEqual(output.domain.metas[0].name, 'Silhouette (iris) (1)')
+
+    def test_report(self):
+        widget = self.widget
+        widget.report_plot = Mock()
+        widget.report_caption = Mock()
+
+        widget.send_report()
+        widget.report_plot.assert_not_called()
+        widget.report_caption.assert_not_called()
+
+        data = Table("zoo")
+        self.send_signal(widget.Inputs.data, data)
+
+        widget.annotation_var = None
+        widget.send_report()
+        widget.report_plot.assert_called()
+        widget.report_caption.assert_called()
+        text = widget.report_caption.call_args[0][0]
+        self.assertIn(data.domain.class_var.name, text)
+        self.assertNotIn("nnotated", text)
+
+        widget.annotation_var = data.domain.metas[0]
+        widget._silplot.rowNamesVisible = lambda: True
+        widget.send_report()
+        text = widget.report_caption.call_args[0][0]
+        self.assertIn(data.domain.class_var.name, text)
+        self.assertIn("nnotated", text)
+        self.assertIn(data.domain.metas[0].name, text)
+
+    def test_migration(self):
+        enc_domain = dict(
+            attributes=(('foo', 1), ('bar', 1), ('baz', 2), ('bax', 1)),
+            class_vars=(('cfoo', 1), ),
+            metas=(('mbar', 3), ('mbaz', 1)))
+
+        context = Context(
+            values=dict(cluster_var_idx=(0, -2), annotation_var_idx=(0, -2)),
+            **enc_domain
+        )
+        OWSilhouettePlot.migrate_context(context, 1)
+        values = context.values
+        self.assertNotIn("cluster_var_idx", values)
+        self.assertNotIn("annotation_var_idx", values)
+        self.assertEqual(values["cluster_var"], ("foo", 101))
+        self.assertEqual(values["annotation_var"], None)
+
+        context = Context(
+            values=dict(cluster_var_idx=(4, -2), annotation_var_idx=(4, -2)),
+            **enc_domain
+        )
+        OWSilhouettePlot.migrate_context(context, 1)
+        self.assertNotIn("cluster_var_idx", values)
+        self.assertNotIn("annotation_var_idx", values)
+        self.assertEqual(context.values["cluster_var"], ("mbaz", 101))
+        self.assertEqual(context.values["annotation_var"], ("cfoo", 101))
+
+        context = Context(
+            values=dict(cluster_var_idx=(4, -2), annotation_var_idx=(5, -2)),
+            **enc_domain
+        )
+        OWSilhouettePlot.migrate_context(context, 1)
+        self.assertEqual(context.values["cluster_var"], ("mbaz", 101))
+        self.assertEqual(context.values["annotation_var"], ("mbar", 103))
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -259,10 +259,10 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
 
     def test_migration(self):
         enc_domain = dict(
-            attributes=(('foo', 1), ('bar', 1), ('baz', 2), ('bax', 1)),
-            class_vars=(('cfoo', 1), ),
-            metas=(('mbar', 3), ('mbaz', 1)))
+            attributes=(('foo', 1), ('bar', 1), ('baz', 1), ('bax', 1),
+                        ('cfoo', 1), ('mbaz', 1)))
 
+        # No annotation
         context = Context(
             values=dict(cluster_var_idx=(0, -2), annotation_var_idx=(0, -2)),
             **enc_domain
@@ -274,23 +274,26 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(values["cluster_var"], ("foo", 101))
         self.assertEqual(values["annotation_var"], None)
 
+        # We have annotation
         context = Context(
-            values=dict(cluster_var_idx=(4, -2), annotation_var_idx=(4, -2)),
+            values=dict(cluster_var_idx=(2, -2), annotation_var_idx=(4, -2)),
             **enc_domain
         )
         OWSilhouettePlot.migrate_context(context, 1)
         self.assertNotIn("cluster_var_idx", values)
         self.assertNotIn("annotation_var_idx", values)
-        self.assertEqual(context.values["cluster_var"], ("mbaz", 101))
-        self.assertEqual(context.values["annotation_var"], ("cfoo", 101))
+        self.assertEqual(context.values["cluster_var"], ("baz", 101))
+        self.assertEqual(context.values["annotation_var"], ("bax", 101))
 
+        # We thought was had annotation, but the index is wrong due to
+        # incorrect domain
         context = Context(
-            values=dict(cluster_var_idx=(4, -2), annotation_var_idx=(5, -2)),
+            values=dict(cluster_var_idx=(4, -2), annotation_var_idx=(7, -2)),
             **enc_domain
         )
         OWSilhouettePlot.migrate_context(context, 1)
-        self.assertEqual(context.values["cluster_var"], ("mbaz", 101))
-        self.assertEqual(context.values["annotation_var"], ("mbar", 103))
+        self.assertEqual(context.values["cluster_var"], ("cfoo", 101))
+        self.assertNotIn("annotation_var_idx", values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Silhouette widget hasn't yet been refactored to use `Variable`'s instead of `int` indices.

##### Description of changes

- Use variables

##### Includes
- [X] Code changes
- [X] Tests
