### PR TITLE
Distributions: Remember number of bins

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -903,6 +903,7 @@ class OWDistributions(OWWidget):
         self.controls.number_of_bins.setMaximum(max_bins)
         self.number_of_bins = min(
             max_bins, self._user_var_bins.get(self.var, self.number_of_bins))
+        self._user_var_bins[self.var] = self.number_of_bins
         self._set_bin_width_slider_label()
 
     @staticmethod


### PR DESCRIPTION
##### Issue

Fixes #5924.

When changing variable, the widget uses the stored number of bins for that variable (not stored in settings, just temporarily). If the variable is shown for the first time, it just keeps the same number of bins as shown currently.

Number of bins was stored for each variable only when the user releases the slider. This thus didn't save the initial setting.

The problem occurred when 
- the widget was showing a numeric variable (the widget initially chooses a sensible number of bins),
- user **does not** move the slider (hence the number of bins is not stored),
- user switches to categorical variable (bins are not used, but the number of bins is reset to maximum due to implementational details)
- user switch back to numeric variable: the number of bins for that variable was not set, hence keeping the current setting, which is the maximum.

##### Description of changes

Store the setting when changing the variable.

##### Includes
- [X] Code changes
- No tests. I could write a test to check for this specific bug, but it's unlikely to reoccur.