### PR TITLE
OWSaveBase: fix stored relative path

### DIFF
--- a/Orange/widgets/utils/save/owsavebase.py
+++ b/Orange/widgets/utils/save/owsavebase.py
@@ -112,12 +112,12 @@ class OWSaveBase(widget.OWWidget, openclass=True):
     def last_dir(self, absolute_path):
         """Store _absolute_path and update relative path (stored_path)"""
         self._absolute_path = absolute_path
-
+        self.stored_path = absolute_path
         workflow_dir = self.workflowEnv().get("basedir", None)
-        if workflow_dir and absolute_path.startswith(workflow_dir.rstrip("/")):
-            self.stored_path = os.path.relpath(absolute_path, workflow_dir)
-        else:
-            self.stored_path = absolute_path
+        if workflow_dir:
+            relative_path = os.path.relpath(absolute_path, start=workflow_dir)
+            if not relative_path.startswith(".."):
+                self.stored_path = relative_path
 
     def _abs_path_from_setting(self):
         """

--- a/Orange/widgets/utils/save/tests/test_owsavebase.py
+++ b/Orange/widgets/utils/save/tests/test_owsavebase.py
@@ -359,6 +359,29 @@ class TestOWSaveBase(WidgetTest):
         widget = self.create_widget(OWSave)
         self.assertEqual(widget.default_filter(), OWSave.filters[0])
 
+    def test_paths(self):
+        class OWSave(OWSaveBase):
+            name = "Mock save"
+            filters = ["csv (*.csv)", "txt (*.txt)"]
+        widget = self.create_widget(OWSave)
+        # relative stored paths
+        for workflow_dir, filename in [("C:/Temp", "C:/Temp/abc.csv"),
+                                       ("C:/Temp", "c:\\Temp\\Project\\abc.csv"),
+                                       ("C:/Temp/", "C:/Temp/Project/abc.csv"),
+                                       ("c:\\Temp", "c:/Temp/Project\\abc.csv"),
+                                       ("/home/user/", "/home/someone/../user/abc.csv")]:
+            widget.workflowEnv = lambda: {"basedir": workflow_dir}
+            widget.filename = filename
+            self.assertFalse(os.path.isabs(widget.stored_path))
+        # absolute stored paths
+        for workflow_dir, filename in [("C:/Temp", "C:/Folder/abc.csv"),
+                                       ("C:/Temp/Project", "C:/Temp/abc.csv"),
+                                       ("/home/user/", "/home/abc.csv"),
+                                       ("/home/user/", "/home/someone/../../tmp/abc.csv")]:
+            widget.workflowEnv = lambda: {"basedir": workflow_dir}
+            widget.filename = filename
+            self.assertTrue(os.path.isabs(widget.stored_path))
+
 
 class TestOWSaveUtils(unittest.TestCase):
     def test_replace_extension(self):

--- a/Orange/widgets/utils/save/tests/test_owsavebase.py
+++ b/Orange/widgets/utils/save/tests/test_owsavebase.py
@@ -372,14 +372,14 @@ class TestOWSaveBase(WidgetTest):
                                        ("C:/Temp/", "C:/Temp/Project/abc.csv"),
                                        ("C:/Temp", "c:\\Temp\\Project\\abc.csv"),
                                        ("c:\\Temp", "c:/Temp/Project\\abc.csv")]:
-            widget.workflowEnv = lambda: {"basedir": workflow_dir}
+            widget.workflowEnv = lambda bd=workflow_dir: {"basedir": bd}
             widget.filename = filename
             self.assertFalse(os.path.isabs(widget.stored_path))
         # absolute stored paths
         for workflow_dir, filename in [("C:/Temp", "C:/Folder/abc.csv"),
                                        ("C:/Temp/Project", "C:/Temp/abc.csv"),
                                        ("C:\\Temp\\Project", "C:\\Temp\\abc.csv")]:
-            widget.workflowEnv = lambda: {"basedir": workflow_dir}
+            widget.workflowEnv = lambda bd=workflow_dir: {"basedir": bd}
             widget.filename = filename
             self.assertTrue(os.path.isabs(widget.stored_path))
 
@@ -393,13 +393,13 @@ class TestOWSaveBase(WidgetTest):
                                        ("/temp", "/temp/project/abc.csv"),
                                        ("/temp/", "/temp/abc.csv"),
                                        ("/temp/", "/temp/project/abc.csv")]:
-            widget.workflowEnv = lambda: {"basedir": workflow_dir}
+            widget.workflowEnv = lambda bd=workflow_dir: {"basedir": bd}
             widget.filename = filename
             self.assertFalse(os.path.isabs(widget.stored_path))
         # absolute stored paths
         for workflow_dir, filename in [("/temp", "/folder/abc.csv"),
                                        ("/temp/project", "/temp/abc.csv")]:
-            widget.workflowEnv = lambda: {"basedir": workflow_dir}
+            widget.workflowEnv = lambda bd=workflow_dir: {"basedir": bd}
             widget.filename = filename
             self.assertTrue(os.path.isabs(widget.stored_path))
 


### PR DESCRIPTION
##### Issue

Fixes #5868

##### Description of changes

Handle various combinations of file paths with slashes, backslashes, trailing slashes, etc.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
