### PR TITLE
Warn about missing __eq__ for compute value; provide FeatureFunc.__eq__

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -235,6 +235,29 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(hash(a), hash(a1))
         self.assertEqual(hash(c1), hash(c2))
 
+    def test_compute_value_eq_warning(self):
+        with warnings.catch_warnings(record=True) as warns:
+            ContinuousVariable("x")
+            self.assertEqual(warns, [])
+            ContinuousVariable("x", compute_value=lambda *_: 42)
+            self.assertEqual(warns, [])
+
+            class Valid:
+                def __eq__(self, other):
+                    return self is other
+
+                def __hash__(self):
+                    return super().__hash__(self)
+
+            ContinuousVariable("x", compute_value=Valid())
+            self.assertEqual(warns, [])
+
+            class Invalid:
+                pass
+
+            ContinuousVariable("x", compute_value=Invalid())
+            self.assertNotEqual(warns, [])
+
 
 def variabletest(varcls):
     def decorate(cls):

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -1,4 +1,5 @@
 import re
+import types
 import warnings
 from collections.abc import Iterable
 
@@ -328,6 +329,14 @@ class Variable(Reprable, metaclass=VariableMeta):
             warnings.warn("Variable must have a name", OrangeDeprecationWarning,
                           stacklevel=3)
         self._name = name
+        if compute_value is not None \
+                and not isinstance(compute_value, (types.BuiltinFunctionType,
+                                                   types.FunctionType)) \
+                and (type(compute_value).__eq__ is object.__eq__
+                     or compute_value.__hash__ is object.__hash__):
+            warnings.warn(f"{type(compute_value).__name__} should define"
+                          f"__eq__ and __hash__ to be used for compute_value")
+
         self._compute_value = compute_value
         self.unknown_str = MISSING_VALUES
         self.source_variable = None

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -1189,6 +1189,15 @@ class FeatureFunc:
     def __repr__(self):
         return "{0.__name__}{1!r}".format(*self.__reduce__())
 
+    def __hash__(self):
+        return hash((self.expression, tuple(self.args),
+                     tuple(sorted(self.extra_env.items())), self.cast))
+
+    def __eq__(self, other):
+        return type(self) is type(other) \
+            and self.expression == other.expression and self.args == other.args \
+            and self.extra_env == other.extra_env and self.cast == other.cast
+
 
 def unique(seq):
     seen = set()

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -324,6 +324,14 @@ class FeatureFuncTest(unittest.TestCase):
         self.assertTrue(np.isnan(f(iris[0])))
         self.assertFalse(np.isnan(f(iris[1])))
 
+    def test_hash_eq(self):
+        iris = Table("iris")
+        f = FeatureFunc("1 / petal_length",
+                        [("petal_length", iris.domain["petal length"])])
+        g = copy.deepcopy(f)
+        self.assertEqual(f, g)
+        self.assertEqual(hash(f), hash(g))
+
 
 class OWFeatureConstructorTests(WidgetTest):
     def setUp(self):


### PR DESCRIPTION
##### Issue

Fixes #5983.

##### Description of changes

- Adds `__eq__` and `__hash__` to `owfeatureconstructor.FeatureFunc` 
- Shows a warning if variable is assigned `compute_value` that has no `__eq__` and `__hash__` (unless it's an instance of `FunctionType` or `BuiltinFunctionType`, which are not deecopied, so `object.__eq__` and `object.__hash__` will work just fine)
 
##### Includes
- [X] Code changes
- [X] Tests
