### PR TITLE
[FIX] Neighbours - support Table derived output types

### DIFF
--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -442,6 +442,16 @@ class TestOWNeighbors(WidgetTest):
         self.send_signal(w.Inputs.data, None)
         self.assertEqual(sb.maximum(), default)
 
+    def test_inherited_table(self):
+        # pylint: disable=abstract-method
+        class Table2(Table):
+            pass
+
+        data = Table2(self.iris)
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.reference, data[0:1])
+        self.assertIsInstance(self.get_output(self.widget.Outputs.data), Table2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Neighbours always returns Table regardless of input type. For example if Corpus on input the output will still be Table.

##### Description of changes
Fix output to be of the same Table derived type as an input.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
