### PR TITLE
util.get_unique_names: Deduplicate duplicated proposals

### DIFF
--- a/Orange/data/tests/test_util.py
+++ b/Orange/data/tests/test_util.py
@@ -120,6 +120,47 @@ class TestGetUniqueNames(unittest.TestCase):
             ["foo (1)", "bar (1)", "baz (4)"]
         )
 
+    def test_get_unique_names_duplicated_proposals(self):
+        names = ["foo", "bar", "baz", "baz (3)"]
+
+        self.assertEqual(
+            get_unique_names(names, ["foo", "boo", "boo"]),
+            ['foo (1)', 'boo (1)', 'boo (2)']
+        )
+        self.assertEqual(
+            get_unique_names(names, ["foo", "boo", "boo", "baz"]),
+            ['foo (4)', 'boo (4)', 'boo (5)', 'baz (4)']
+        )
+        self.assertEqual(
+            get_unique_names([], ["foo", "boo", "boo", "baz"]),
+            ['foo', 'boo (1)', 'boo (2)', 'baz']
+        )
+        self.assertEqual(
+            get_unique_names(["foo", "bong"], ["foo", "boo", "boo", "baz"]),
+            ['foo (1)', 'boo (1)', 'boo (2)', 'baz']
+        )
+
+        self.assertEqual(
+            get_unique_names(names, ["foo", "boo", "boo"],
+                             equal_numbers=False),
+            ['foo (1)', 'boo (1)', 'boo (2)']
+        )
+        self.assertEqual(
+            get_unique_names(names, ["foo", "boo", "boo", "baz"],
+                             equal_numbers=False),
+            ['foo (1)', 'boo (1)', 'boo (2)', 'baz (4)']
+        )
+        self.assertEqual(
+            get_unique_names([], ["foo", "boo", "boo", "baz"],
+                             equal_numbers=False),
+            ['foo', 'boo (1)', 'boo (2)', 'baz']
+        )
+        self.assertEqual(
+            get_unique_names(["foo", "bong"], ["foo", "boo", "boo", "baz"],
+                             equal_numbers=False),
+            ['foo (1)', 'boo (1)', 'boo (2)', 'baz']
+        )
+
     def test_get_unique_names_from_duplicates(self):
         self.assertEqual(
             get_unique_names_duplicates(["foo", "bar", "baz"]),

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -213,8 +213,31 @@ def get_unique_names(names, proposed, equal_numbers=True):
         return get_unique_names(names, [proposed])[0]
     indices = {name: get_indices(names, name) for name in proposed}
     indices = {name: max(ind) + 1 for name, ind in indices.items() if ind}
+
+    duplicated_proposed = {name for name, count in Counter(proposed).items()
+                           if count > 1}
+    if duplicated_proposed:
+        # This could be merged with the code below, but it would make it slower
+        # because it can't be done within list comprehension
+        if equal_numbers:
+            max_index = max(indices.values(), default=1)
+            indices = {name: max_index
+                       for name in chain(indices, duplicated_proposed)}
+        else:
+            indices.update({name: 1
+                            for name in duplicated_proposed - set(indices)})
+        names = []
+        for name in proposed:
+            if name in indices:
+                names.append(f"{name} ({indices[name]})")
+                indices[name] += 1
+            else:
+                names.append(name)
+        return names
+
     if not (set(proposed) & set(names) or indices):
         return proposed
+
     if equal_numbers:
         max_index = max(indices.values())
         return [f"{name} ({max_index})" for name in proposed]


### PR DESCRIPTION
##### Issue

`util.get_unique_names` is routinely used in to avoid duplicated names. There are situations, though, when the proposed names already include duplicates due to user's choices. See, e.g. https://github.com/biolab/orange3-timeseries/issues/181.

##### Description of changes

Detect duplicated proposed names and number them sequentially.

##### Includes
- [X] Code changes
- [X] Tests
