### PR TITLE
itemmodels.PyTableModel: Fix insertColumns

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -248,7 +248,7 @@ class PyTableModel(AbstractSortTableModel):
         self.beginInsertColumns(parent, column, column + count - 1)
         for row in self._table:
             row[column:column] = [''] * count
-        self._rows = self._table_dim()[0]
+        self._cols = self._table_dim()[1]
         self.endInsertColumns()
         return True
 

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -156,11 +156,11 @@ class TestPyTableModel(unittest.TestCase):
         model.append([2, 3])
         self.assertEqual(list(inserted)[-1][1:], [1, 1])
         del model[:]
-        self.assertEqual(list(removed)[0][1:], [0, 1])
+        self.assertEqual(list(removed)[-1][1:], [0, 1])
         model.extend([[0, 1], [0, 2]])
         self.assertEqual(list(inserted)[-1][1:], [0, 1])
         model.clear()
-        self.assertEqual(list(removed)[0][1:], [0, 1])
+        self.assertEqual(list(removed)[-1][1:], [0, 1])
         model[:] = [[1], [2]]
         self.assertEqual(list(inserted)[-1][1:], [0, 0])
 


### PR DESCRIPTION
##### Issue

`itemmodels.PyTableModel.insertColumns` updated `_rows` instead of `_cols`, which made the model temporarily invalid and caused extra columns in https://github.com/biolab/orange3-timeseries/issues/88.

##### Description of changes

Fix typo.

##### Includes
- [X] Code changes
