### PR TITLE
[FIX] owdistancemap: Fix an implicit float->int conversion error

### DIFF
--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -713,16 +713,16 @@ class TextList(TextListWidget):
         fontsize = min(self._point_size(lineheight), maxfontsize)
 
         font_ = QFont()
-        font_.setPointSize(fontsize)
+        font_.setPointSizeF(fontsize)
         self.setFont(font_)
 
     def _point_size(self, height):
         font = self.font()
-        font.setPointSize(height)
+        font.setPointSizeF(height)
         fix = 0
         while QFontMetrics(font).lineSpacing() > height and height - fix > 1:
             fix += 1
-            font.setPointSize(height - fix)
+            font.setPointSizeF(height - fix)
         return height - fix
 
 

--- a/Orange/widgets/unsupervised/tests/test_owdistancemap.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancemap.py
@@ -6,6 +6,7 @@ import unittest
 from Orange.distance import Euclidean
 from Orange.widgets.unsupervised.owdistancemap import OWDistanceMap
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
+from Orange.widgets.tests.utils import simulate
 
 
 class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
@@ -39,6 +40,16 @@ class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
         w = self.create_widget(OWDistanceMap, stored_settings=settings)
         self.send_signal(self.signal_name, self.signal_data, widget=w)
         self.assertEqual(len(self.get_output(w.Outputs.selected_data, widget=w)), 10)
+
+    def test_widget(self):
+        w = self.widget
+        self.send_signal(w.Inputs.distances, self.signal_data)
+        for i in range(w.sorting_cb.count()):
+            simulate.combobox_activate_index(w.sorting_cb, i)
+        for i in range(w.annot_combo.count()):
+            simulate.combobox_activate_index(w.annot_combo, i)
+        w.grab()
+        self.send_signal(w.Inputs.distances, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Raises error on Python 3.10

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Distance Map raises an error on Python 3.10 when setting any *Annotations* that are not *None*

```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange3/Orange/widgets/unsupervised/owdistancemap.py", line 695, in resizeEvent
    self._updateFontSize()
  File "/home/ales/devel/orange3/Orange/widgets/unsupervised/owdistancemap.py", line 713, in _updateFontSize
    fontsize = min(self._point_size(lineheight), maxfontsize)
  File "/home/ales/devel/orange3/Orange/widgets/unsupervised/owdistancemap.py", line 721, in _point_size
    font.setPointSize(height)
TypeError: setPointSize(self, int): argument 1 has unexpected type 'float'
-------------------------------------------------------------------------------
```

##### Description of changes

Fix an implicit float->int conversion error

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
