### PR TITLE
[FIX] Feature Constructor cast function is not picklable

### DIFF
--- a/Orange/misc/tests/test_collections.py
+++ b/Orange/misc/tests/test_collections.py
@@ -1,6 +1,7 @@
+import pickle
 import unittest
 
-from Orange.misc.collections import frozendict, natural_sorted
+from Orange.misc.collections import frozendict, natural_sorted, DictMissingConst
 
 
 class TestFrozenDict(unittest.TestCase):
@@ -59,6 +60,24 @@ class TestUtils(unittest.TestCase):
         data = [1, 20, 2, 12]
         res = [1, 2, 12, 20]
         self.assertListEqual(res, natural_sorted(data))
+
+
+class TestDictMissingConst(unittest.TestCase):
+    def test_dict_missing(self):
+        d = DictMissingConst("<->", {1: 1, 2: 2})
+        self.assertEqual(d[1], 1)
+        self.assertEqual(d[-1], "<->")
+        # d[-1] must not grow the dict
+        self.assertEqual(len(d), 2)
+        self.assertEqual(d, DictMissingConst("<->", {1: 1, 2: 2}))
+        self.assertNotEqual(
+            DictMissingConst("A", {1: 1}), DictMissingConst("B", {1: 1}),
+        )
+        dc = pickle.loads(pickle.dumps(d))
+        self.assertEqual(d, dc)
+        self.assertEqual(dict(d), dict(dc))
+        self.assertEqual(d.missing, dc.missing)
+        self.assertEqual(d[object()], dc[object()])
 
 
 if __name__ == "__main__":

--- a/Orange/preprocess/tests/test_transformation.py
+++ b/Orange/preprocess/tests/test_transformation.py
@@ -5,7 +5,8 @@ import scipy.sparse as sp
 
 from Orange.data import DiscreteVariable
 from Orange.preprocess.transformation import \
-    Transformation, _Indicator, Normalizer, Lookup, Indicator, Indicator1
+    Transformation, _Indicator, Normalizer, Lookup, Indicator, Indicator1, \
+    MappingTransform
 
 
 class TestTransformEquality(unittest.TestCase):
@@ -83,6 +84,36 @@ class TestTransformEquality(unittest.TestCase):
         t1a = Lookup(self.disc1a, np.array([0, 2, 1]), 2)
         self.assertNotEqual(t1, t1a)
         self.assertNotEqual(hash(t1), hash(t1a))
+
+    def test_mapping(self):
+        def test_equal(a, b):
+            self.assertEqual(a, b)
+            self.assertEqual(hash(a), hash(b))
+
+        t1 = MappingTransform(self.disc1, {"a": "1", "b": "2", "c":"3"})
+        t1a = MappingTransform(self.disc1a, {"a": "1", "b": "2", "c":"3"})
+        t2 = MappingTransform(self.disc2, {"a": "1", "b": "2", "c":"3"},
+                              unknown="")
+        test_equal(t1, t1a)
+        self.assertNotEqual(t1, t2)
+
+        t1 = MappingTransform(self.disc1, {"a": 1, "b": 2, "c": float("nan")},
+                              unknown=float("nan"))
+        t1_ = MappingTransform(self.disc1, {"a": 1, "b": 2, "c": float("nan")},
+                               unknown=float("nan"))
+        test_equal(t1, t1_)
+        t1_ = MappingTransform(self.disc1, {"a": 1, "b": float("nan"), "c": 2},
+                               unknown=float("nan"))
+        self.assertNotEqual(t1, t1_)
+
+        t1_ = MappingTransform(self.disc1, {}, unknown=float("nan"))
+        self.assertNotEqual(t1, t1_)
+        t1_ = MappingTransform(self.disc1, {"f": 4, "k": 2, "j": 10},
+                               unknown=float("nan"))
+        self.assertNotEqual(t1, t1_)
+
+        with self.assertRaises(ValueError):
+            MappingTransform(self.disc1, {float("nan"): 1})
 
 
 class TestIndicator(unittest.TestCase):

--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -6,7 +6,7 @@ import numpy as np
 import scipy.sparse as sp
 
 from Orange.util import export_globals, flatten, deprecated, try_, deepgetattr, \
-    OrangeDeprecationWarning
+    OrangeDeprecationWarning, nan_eq, nan_hash_stand
 from Orange.data import Table
 from Orange.data.util import vstack, hstack, array_equal
 from Orange.statistics.util import stats
@@ -71,6 +71,21 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(deepgetattr(a, 'l.__len__.__call__'), a.l.__len__.__call__)
         self.assertTrue(deepgetattr(a, 'l.__nx__.__x__', 42), 42)
         self.assertRaises(AttributeError, lambda: deepgetattr(a, 'l.__nx__.__x__'))
+
+    def test_nan_eq(self):
+        self.assertTrue(nan_eq(float("nan"), float("nan")))
+        self.assertTrue(nan_eq(1, 1.0))
+        self.assertFalse(nan_eq(float("nan"), 1))
+        self.assertFalse(nan_eq(1, float("nan")))
+        self.assertFalse(nan_eq(float("inf"), float("nan")))
+        self.assertFalse(nan_eq(float("nan"), float("inf")))
+        self.assertFalse(nan_eq(1, 2))
+        self.assertFalse(nan_eq(None, 2))
+        self.assertFalse(nan_eq(2, None))
+
+    def test_nan_hash_stand(self):
+        self.assertEqual(hash(nan_hash_stand(float("nan"))),
+                         hash(nan_hash_stand(float("nan"))))
 
     def test_vstack(self):
         numpy = np.array([[1., 2.], [3., 4.]])

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -32,7 +32,7 @@ from Orange.widgets.data.oweditdomain import (
     AsString, AsCategorical, AsContinuous, AsTime,
     table_column_data, ReinterpretVariableEditor, CategoricalVector,
     VariableEditDelegate, TransformRole,
-    RealVector, TimeVector, StringVector, make_dict_mapper, DictMissingConst,
+    RealVector, TimeVector, StringVector, make_dict_mapper,
     LookupMappingTransform, as_float_or_nan, column_str_repr,
     GroupItemsDialog, VariableListModel, StrpTime
 )
@@ -1032,13 +1032,6 @@ class TestUtils(TestCase):
         self.assertIs(r, r_)
         assert_array_equal(r, [1, 1, 2])
 
-    def test_dict_missing(self):
-        d = DictMissingConst("<->", {1: 1, 2: 2})
-        self.assertEqual(d[1], 1)
-        self.assertEqual(d[-1], "<->")
-        # must be sufficiently different from defaultdict to warrant existence
-        self.assertEqual(d, DictMissingConst("<->", {1: 1, 2: 2}))
-
     def test_as_float_or_nan(self):
         a = np.array(["a", "1.1", ".2", "NaN"], object)
         r = as_float_or_nan(a)
@@ -1071,7 +1064,7 @@ class TestLookupMappingTransform(TestCase):
     def setUp(self) -> None:
         self.lookup = LookupMappingTransform(
             StringVariable("S"),
-            DictMissingConst(np.nan, {"": np.nan, "a": 0, "b": 1}),
+            {"": np.nan, "a": 0, "b": 1},
             dtype=float,
         )
 
@@ -1093,9 +1086,9 @@ class TestLookupMappingTransform(TestCase):
         v2 = DiscreteVariable("v1", values=tuple("abc"))
         v3 = DiscreteVariable("v3", values=tuple("abc"))
 
-        map1 = DictMissingConst(np.nan, {"a": 2, "b": 0, "c": 1})
-        map2 = DictMissingConst(np.nan, {"a": 2, "b": 0, "c": 1})
-        map3 = DictMissingConst(np.nan, {"a": 2, "b": 0, "c": 1})
+        map1 = {"a": 2, "b": 0, "c": 1}
+        map2 = {"a": 2, "b": 0, "c": 1}
+        map3 = {"a": 2, "b": 0, "c": 1}
 
         t1 = LookupMappingTransform(v1, map1, float)
         t1a = LookupMappingTransform(v2, map2, float)
@@ -1107,15 +1100,15 @@ class TestLookupMappingTransform(TestCase):
         self.assertEqual(hash(t1), hash(t1a))
         self.assertNotEqual(hash(t1), hash(t2))
 
-        map1a = DictMissingConst(np.nan, {"a": 2, "b": 1, "c": 0})
+        map1a = {"a": 2, "b": 1, "c": 0}
         t1 = LookupMappingTransform(v1, map1, float)
         t1a = LookupMappingTransform(v1, map1a, float)
         self.assertNotEqual(t1, t1a)
         self.assertNotEqual(hash(t1), hash(t1a))
 
-        map1a = DictMissingConst(2, {"a": 2, "b": 0, "c": 1})
+        map1a = {"a": 2, "b": 0, "c": 1}
         t1 = LookupMappingTransform(v1, map1, float)
-        t1a = LookupMappingTransform(v1, map1a, float)
+        t1a = LookupMappingTransform(v1, map1a, float, unknown=2)
         self.assertNotEqual(t1, t1a)
         self.assertNotEqual(hash(t1), hash(t1a))
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Feature Constructor can construct `compute_value` which are not picklable (defined in local function scope):
* https://github.com/biolab/orange3/blob/cd3dfeeeb7f4ac97667e2a0335923b5fa6dfebab/Orange/widgets/data/owfeatureconstructor.py#L1032-L1033
* https://github.com/biolab/orange3/blob/cd3dfeeeb7f4ac97667e2a0335923b5fa6dfebab/Orange/widgets/data/owfeatureconstructor.py#L1042-L1047)

Fixes gh-5918

##### Description of changes

* Make the `cast` function passed to FeatureFunc picklable.
* Some refactoring of classes from oweditdomain.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
