### PR TITLE
[FIX] TableModel: Define foreground color when providing background

### DIFF
--- a/Orange/widgets/utils/itemdelegates.py
+++ b/Orange/widgets/utils/itemdelegates.py
@@ -101,4 +101,7 @@ class TableDataDelegate(DataDelegate):
     :class:`Orange.widgets.utils.itemmodels.TableModel`
     """
     #: Roles supplied by TableModel we want DataDelegate to use.
-    DefaultRoles = (Qt.DisplayRole, Qt.TextAlignmentRole, Qt.BackgroundRole)
+    DefaultRoles = (
+        Qt.DisplayRole, Qt.TextAlignmentRole, Qt.BackgroundRole,
+        Qt.ForegroundRole
+    )

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -946,6 +946,7 @@ class TableModel(AbstractSortTableModel):
              _Qt_DisplayRole=Qt.DisplayRole,
              _Qt_EditRole=Qt.EditRole,
              _Qt_BackgroundRole=Qt.BackgroundRole,
+             _Qt_ForegroundRole=Qt.ForegroundRole,
              _ValueRole=ValueRole,
              _ClassValueRole=ClassValueRole,
              _VariableRole=VariableRole,
@@ -956,6 +957,7 @@ class TableModel(AbstractSortTableModel):
              _recognizedRoles=frozenset([Qt.DisplayRole,
                                          Qt.EditRole,
                                          Qt.BackgroundRole,
+                                         Qt.ForegroundRole,
                                          ValueRole,
                                          ClassValueRole,
                                          VariableRole,
@@ -990,6 +992,12 @@ class TableModel(AbstractSortTableModel):
             return instance[coldesc.var]
         elif role == _Qt_BackgroundRole:
             return coldesc.background
+        elif role == _Qt_ForegroundRole:
+            if coldesc.background is not None:
+                # The background is light-ish, force dark text color
+                return QColor(0, 0, 0, 200)
+            else:
+                return None
         elif role == _ValueRole and isinstance(coldesc, TableModel.Column):
             return instance[coldesc.var]
         elif role == _ClassValueRole:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

In 'Data Table' On dark styles the contrast of text on background for metas and class columns is poor.

Before 

![Screenshot_20220609_120352](https://user-images.githubusercontent.com/4716745/172822387-372d4001-4013-41f3-9a09-b65a8ee08763.png)

After

![Screenshot_20220609_120512](https://user-images.githubusercontent.com/4716745/172822440-306c0dfc-6c62-4b99-bee7-5b5ad12a11c6.png)

##### Description of changes

Define foreground color when providing background to ensure text is contrasted against the background when system text color is light.



##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
