### PR TITLE
gui.comboBox: replace *args with argument list

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -467,12 +467,22 @@ class ControlledList(list):
         super().remove(item)
 
 
-def comboBox(*args, **kwargs):
-    if "valueType" in kwargs:
-        del kwargs["valueType"]
+def comboBox(widget, master, value, box=None, label=None, labelWidth=None,
+             orientation=Qt.Vertical, items=(), callback=None,
+             sendSelectedValue=None, emptyString=None, editable=False,
+             contentsLength=None, searchable=False, *, model=None,
+             tooltips=None, **misc):
+    if "valueType" in misc:
+        del misc["valueType"]
         warnings.warn("Argument 'valueType' is deprecated and ignored",
                       DeprecationWarning)
-    return gui_comboBox(*args, **kwargs)
+    return gui_comboBox(
+        widget, master, value, box, label, labelWidth, orientation, items,
+        callback, sendSelectedValue, emptyString, editable,
+        contentsLength, searchable, model=model, tooltips=tooltips, **misc)
+
+
+comboBox.__doc__ = gui_comboBox.__doc__
 
 
 class CallBackListView(ControlledCallback):

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -110,7 +110,6 @@ class ComboBoxTest(GuiTest):
     def test_warn_value_type(self, gui_combobox):
         with self.assertWarns(DeprecationWarning):
             gui.comboBox(None, None, "foo", valueType=int, editable=True)
-        self.assertEqual(gui_combobox.call_args[1], {"editable": True})
 
 
 class TestRankModel(GuiTest):

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.26,<0.2a
-orange-widget-base>=4.17.0
+orange-widget-base>=4.18.0
 
 AnyQt>=0.1.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,8 @@ deps =
     latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
-    oldest: orange-canvas-core==0.1.26
-    oldest: orange-widget-base==4.17.0
+    oldest: orange-canvas-core==0.1.27
+    oldest: orange-widget-base==4.18.0
     oldest: AnyQt==0.1.0
     oldest: pyqtgraph==0.11.1
     oldest: matplotlib==2.2.5


### PR DESCRIPTION
##### Issue

`Orange.widgets.gui` redefines `comboBox`, but uses `*args` and `**kwargs` for arguments, so we can't get any assistance from GUIs.

**Requires https://github.com/biolab/orange-widget-base/pull/203 to be merged and released.**

##### Description of changes

List arguments. Also add a `tooltips` argument, which is why it requires a new release of orange-widget-base.

##### Includes
- [X] Code changes
