### PR TITLE
PaintData: Allow minimizing height

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -980,7 +980,7 @@ class OWPaintData(OWWidget):
         if self.hasAttr2:
             self.plot.setYRange(0, 1, padding=0.01)
             self.plot.showAxis('left')
-            self.plotview.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Minimum)
+            self.plotview.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         else:
             self.plot.setYRange(-.5, .5, padding=0.01)
             self.plot.hideAxis('left')


### PR DESCRIPTION
##### Issue

Fixes #6009.

##### Description of changes

Set plot's vertical size policy to `Expanding` instead of `Minimum`

##### Includes
- [X] Code changes