### PR TITLE
[ENH] Feature Constructor: Option to put new variable into metas

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -26,9 +26,10 @@ from typing import List, Dict, Any, Mapping, Optional
 import numpy as np
 
 from AnyQt.QtWidgets import (
-    QSizePolicy, QAbstractItemView, QComboBox, QFormLayout, QLineEdit,
+    QSizePolicy, QAbstractItemView, QComboBox, QLineEdit,
     QHBoxLayout, QVBoxLayout, QStackedWidget, QStyledItemDelegate,
-    QPushButton, QMenu, QListView, QFrame, QLabel, QMessageBox)
+    QPushButton, QMenu, QListView, QFrame, QLabel, QMessageBox,
+    QGridLayout, QWidget, QCheckBox)
 from AnyQt.QtGui import QKeySequence
 from AnyQt.QtCore import Qt, pyqtSignal as Signal, pyqtProperty as Property
 
@@ -52,19 +53,21 @@ from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 
 
 FeatureDescriptor = \
-    namedtuple("FeatureDescriptor", ["name", "expression"])
+    namedtuple("FeatureDescriptor", ["name", "expression", "meta"])
 
 ContinuousDescriptor = \
     namedtuple("ContinuousDescriptor",
-               ["name", "expression", "number_of_decimals"])
+               ["name", "expression", "meta", "number_of_decimals"])
 DateTimeDescriptor = \
     namedtuple("DateTimeDescriptor",
-               ["name", "expression"])
+               ["name", "expression", "meta"])
 DiscreteDescriptor = \
     namedtuple("DiscreteDescriptor",
-               ["name", "expression", "values", "ordered"])
+               ["name", "expression", "meta", "values", "ordered"])
 
-StringDescriptor = namedtuple("StringDescriptor", ["name", "expression"])
+StringDescriptor = \
+    namedtuple("StringDescriptor",
+               ["name", "expression", "meta"])
 
 
 def make_variable(descriptor, compute_value):
@@ -130,15 +133,16 @@ Categorical features are passed as strings
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        layout = QFormLayout(
-            fieldGrowthPolicy=QFormLayout.ExpandingFieldsGrow
-        )
+        layout = QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         self.nameedit = QLineEdit(
             placeholderText="Name...",
             sizePolicy=QSizePolicy(QSizePolicy.Minimum,
                                    QSizePolicy.Fixed)
         )
+
+        self.metaattributecb = QCheckBox("Meta attribute")
+
         self.expressionedit = QLineEdit(
             placeholderText="Expression...",
             toolTip=self.ExpressionTooltip)
@@ -165,15 +169,17 @@ Categorical features are passed as strings
             sizePolicy=QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum))
         self.functionscb.setModel(self.funcs_model)
 
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.attributescb)
-        hbox.addWidget(self.functionscb)
+        layout.addWidget(self.nameedit, 0, 0)
+        layout.addWidget(self.metaattributecb, 1, 0)
+        layout.addWidget(self.expressionedit, 0, 1, 1, 2)
+        layout.addWidget(self.attributescb, 1, 1)
+        layout.addWidget(self.functionscb, 1, 2)
+        layout.addWidget(QWidget(), 2, 0)
 
-        layout.addRow(self.nameedit, self.expressionedit)
-        layout.addRow(self.tr(""), hbox)
         self.setLayout(layout)
 
         self.nameedit.editingFinished.connect(self._invalidate)
+        self.metaattributecb.clicked.connect(self._invalidate)
         self.expressionedit.textChanged.connect(self._invalidate)
         self.attributescb.currentIndexChanged.connect(self.on_attrs_changed)
         self.functionscb.currentIndexChanged.connect(self.on_funcs_changed)
@@ -196,6 +202,7 @@ Categorical features are passed as strings
 
     def setEditorData(self, data, domain):
         self.nameedit.setText(data.name)
+        self.metaattributecb.setChecked(data.meta)
         self.expressionedit.setText(data.expression)
         self.setModified(False)
         self.featureChanged.emit()
@@ -207,7 +214,8 @@ Categorical features are passed as strings
 
     def editorData(self):
         return FeatureDescriptor(name=self.nameedit.text(),
-                                 expression=self.nameedit.text())
+                                 expression=self.nameedit.text(),
+                                 meta=self.metaattributecb.isChecked())
 
     def _invalidate(self):
         self.setModified(True)
@@ -251,8 +259,9 @@ class ContinuousFeatureEditor(FeatureEditor):
     def editorData(self):
         return ContinuousDescriptor(
             name=self.nameedit.text(),
+            expression=self.expressionedit.text(),
+            meta=self.metaattributecb.isChecked(),
             number_of_decimals=None,
-            expression=self.expressionedit.text()
         )
 
 
@@ -265,7 +274,8 @@ class DateTimeFeatureEditor(FeatureEditor):
     def editorData(self):
         return DateTimeDescriptor(
             name=self.nameedit.text(),
-            expression=self.expressionedit.text()
+            expression=self.expressionedit.text(),
+            meta=self.metaattributecb.isChecked(),
         )
 
 
@@ -286,7 +296,8 @@ class DiscreteFeatureEditor(FeatureEditor):
         layout = self.layout()
         label = QLabel(self.tr("Values (optional)"))
         label.setToolTip(tooltip)
-        layout.addRow(label, self.valuesedit)
+        layout.addWidget(label, 2, 0)
+        layout.addWidget(self.valuesedit, 2, 1, 1, 2)
 
     def setEditorData(self, data, domain):
         self.valuesedit.setText(
@@ -300,6 +311,7 @@ class DiscreteFeatureEditor(FeatureEditor):
         values = tuple(filter(None, [v.replace(r"\,", ",").strip() for v in values]))
         return DiscreteDescriptor(
             name=self.nameedit.text(),
+            meta=self.metaattributecb.isChecked(),
             values=values,
             ordered=False,
             expression=self.expressionedit.text()
@@ -310,9 +322,15 @@ class StringFeatureEditor(FeatureEditor):
     ExpressionTooltip = "A string expression\n\n" \
                         + FeatureEditor.ExpressionTooltip
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.metaattributecb.setChecked(True)
+        self.metaattributecb.setDisabled(True)
+
     def editorData(self):
         return StringDescriptor(
             name=self.nameedit.text(),
+            meta=True,
             expression=self.expressionedit.text()
         )
 
@@ -566,22 +584,22 @@ class OWFeatureConstructor(OWWidget, ConcurrentWidgetMixin):
         cont = menu.addAction("Numeric")
         cont.triggered.connect(
             lambda: self.addFeature(
-                ContinuousDescriptor(generate_newname("X{}"), "", 3))
+                ContinuousDescriptor(generate_newname("X{}"), "", False, 3))
         )
         disc = menu.addAction("Categorical")
         disc.triggered.connect(
             lambda: self.addFeature(
-                DiscreteDescriptor(generate_newname("D{}"), "", (), False))
+                DiscreteDescriptor(generate_newname("D{}"), "", False, (), False))
         )
         string = menu.addAction("Text")
         string.triggered.connect(
             lambda: self.addFeature(
-                StringDescriptor(generate_newname("S{}"), ""))
+                StringDescriptor(generate_newname("S{}"), "", True))
         )
         datetime = menu.addAction("Date/Time")
         datetime.triggered.connect(
             lambda: self.addFeature(
-                DateTimeDescriptor(generate_newname("T{}"), ""))
+                DateTimeDescriptor(generate_newname("T{}"), "", False))
         )
 
         menu.addSeparator()
@@ -897,17 +915,15 @@ class Result:
 def run(data: Table, desc, use_values, task: TaskState) -> Result:
     if task.is_interruption_requested():
         raise CancelledError  # pragma: no cover
-    new_variables = construct_variables(desc, data, use_values)
+    new_variables, new_metas = construct_variables(desc, data, use_values)
     # Explicit cancellation point after `construct_variables` which can
     # already run `compute_value`.
     if task.is_interruption_requested():
         raise CancelledError  # pragma: no cover
-    attrs = [var for var in new_variables if var.is_primitive()]
-    metas = [var for var in new_variables if not var.is_primitive()]
     new_domain = Orange.data.Domain(
-        data.domain.attributes + tuple(attrs),
+        data.domain.attributes + new_variables,
         data.domain.class_vars,
-        metas=data.domain.metas + tuple(metas)
+        metas=data.domain.metas + new_metas
     )
     try:
         for variable in new_variables:
@@ -916,7 +932,7 @@ def run(data: Table, desc, use_values, task: TaskState) -> Result:
     finally:
         for variable in new_variables:
             variable.compute_value.mask_exceptions = True
-    return Result(data, attrs, metas)
+    return Result(data, new_variables, new_metas)
 
 
 def validate_exp(exp):
@@ -989,12 +1005,13 @@ def validate_exp(exp):
 def construct_variables(descriptions, data, use_values=False):
     # subs
     variables = []
+    metas = []
     source_vars = data.domain.variables + data.domain.metas
     for desc in descriptions:
         desc, func = bind_variable(desc, source_vars, data, use_values)
         var = make_variable(desc, func)
-        variables.append(var)
-    return variables
+        [variables, metas][desc.meta].append(var)
+    return tuple(variables), tuple(metas)
 
 
 def sanitized_name(name):

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -521,7 +521,7 @@ class OWFeatureConstructor(OWWidget, ConcurrentWidgetMixin):
     descriptors = ContextSetting([])
     currentIndex = ContextSetting(-1)
     expressions_with_values = ContextSetting(False)
-    settings_version = 2
+    settings_version = 3
 
     EDITORS = [
         (ContinuousDescriptor, ContinuousFeatureEditor),

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -53,21 +53,26 @@ from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 
 
 FeatureDescriptor = \
-    namedtuple("FeatureDescriptor", ["name", "expression", "meta"])
+    namedtuple("FeatureDescriptor", ["name", "expression", "meta"],
+               defaults=[False])
 
 ContinuousDescriptor = \
     namedtuple("ContinuousDescriptor",
-               ["name", "expression", "meta", "number_of_decimals"])
+               ["name", "expression", "number_of_decimals", "meta"],
+               defaults=[False])
 DateTimeDescriptor = \
     namedtuple("DateTimeDescriptor",
-               ["name", "expression", "meta"])
+               ["name", "expression", "meta"],
+               defaults=[False])
 DiscreteDescriptor = \
     namedtuple("DiscreteDescriptor",
-               ["name", "expression", "meta", "values", "ordered"])
+               ["name", "expression", "values", "ordered", "meta"],
+               defaults=[False])
 
 StringDescriptor = \
     namedtuple("StringDescriptor",
-               ["name", "expression", "meta"])
+               ["name", "expression", "meta"],
+               defaults=[True])
 
 
 def make_variable(descriptor, compute_value):
@@ -584,22 +589,22 @@ class OWFeatureConstructor(OWWidget, ConcurrentWidgetMixin):
         cont = menu.addAction("Numeric")
         cont.triggered.connect(
             lambda: self.addFeature(
-                ContinuousDescriptor(generate_newname("X{}"), "", False, 3))
+                ContinuousDescriptor(generate_newname("X{}"), "", 3, meta=False))
         )
         disc = menu.addAction("Categorical")
         disc.triggered.connect(
             lambda: self.addFeature(
-                DiscreteDescriptor(generate_newname("D{}"), "", False, (), False))
+                DiscreteDescriptor(generate_newname("D{}"), "", (), False, meta=False))
         )
         string = menu.addAction("Text")
         string.triggered.connect(
             lambda: self.addFeature(
-                StringDescriptor(generate_newname("S{}"), "", True))
+                StringDescriptor(generate_newname("S{}"), "", meta=True))
         )
         datetime = menu.addAction("Date/Time")
         datetime.triggered.connect(
             lambda: self.addFeature(
-                DateTimeDescriptor(generate_newname("T{}"), "", False))
+                DateTimeDescriptor(generate_newname("T{}"), "", meta=False))
         )
 
         menu.addSeparator()

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -36,7 +36,7 @@ class FeatureConstructorTest(unittest.TestCase):
                      "if iris == 'Iris-versicolor' else iris_three"
         values = ('iris one', 'iris two', 'iris three')
         desc = PyListModel(
-            [DiscreteDescriptor(name=name, expression=expression, meta=False,
+            [DiscreteDescriptor(name=name, expression=expression,
                                 values=values, ordered=True)]
         )
         data = data.transform(Domain(data.domain.attributes +
@@ -54,7 +54,7 @@ class FeatureConstructorTest(unittest.TestCase):
         expression = "str(iris)[-1]"  # last letter - a or r
         values = ()
         desc = PyListModel(
-            [DiscreteDescriptor(name=name, expression=expression, meta=False,
+            [DiscreteDescriptor(name=name, expression=expression,
                                 values=values, ordered=False)]
         )
         data = data.transform(Domain(data.domain.attributes +
@@ -73,7 +73,7 @@ class FeatureConstructorTest(unittest.TestCase):
         name = 'Continuous Variable'
         expression = "pow(sepal_length + sepal_width, 2)"
         featuremodel = PyListModel(
-            [ContinuousDescriptor(name=name, expression=expression, meta=False,
+            [ContinuousDescriptor(name=name, expression=expression,
                                   number_of_decimals=2)]
         )
         data = data.transform(Domain(data.domain.attributes +
@@ -90,7 +90,7 @@ class FeatureConstructorTest(unittest.TestCase):
         name = 'Date'
         expression = '"2019-07-{:02}".format(int(MEDV/3))'
         featuremodel = PyListModel(
-            [DateTimeDescriptor(name=name, expression=expression, meta=False)]
+            [DateTimeDescriptor(name=name, expression=expression)]
         )
         data = data.transform(Domain(data.domain.attributes +
                                      construct_variables(featuremodel, data)[0],
@@ -106,7 +106,7 @@ class FeatureConstructorTest(unittest.TestCase):
         name = 'String Variable'
         expression = "str(iris) + '_name'"
         desc = PyListModel(
-            [StringDescriptor(name=name, expression=expression, meta=True)]
+            [StringDescriptor(name=name, expression=expression)]
         )
         data = data.transform(Domain(data.domain.attributes,
                                      data.domain.class_vars,
@@ -138,8 +138,8 @@ class FeatureConstructorTest(unittest.TestCase):
         domain = Domain([ContinuousVariable(x) for x in "ab"])
         data = Table.from_numpy(domain, np.arange(4).reshape(2, 2))
         desc = PyListModel(
-            [ContinuousDescriptor("x", "a + b", False, 1),
-             ContinuousDescriptor("y", "a + b", True, 1),
+            [ContinuousDescriptor("x", "a + b", 1, False),
+             ContinuousDescriptor("y", "a + b", 1, True),
              StringDescriptor("z", "a + b", True)])
         attrs, metas = construct_variables(desc, data)
         self.assertEqual([var.name for var in attrs], ["x"])
@@ -152,7 +152,7 @@ class FeatureConstructorTest(unittest.TestCase):
         name = 'Micro Variable'
         expression = micro
         desc = PyListModel(
-            [ContinuousDescriptor(name=name, expression=expression, meta=False,
+            [ContinuousDescriptor(name=name, expression=expression,
                                   number_of_decimals=2)]
         )
         data = Table.from_numpy(domain, np.arange(5).reshape(5, 1))
@@ -165,8 +165,7 @@ class FeatureConstructorTest(unittest.TestCase):
     def test_transform_sparse():
         domain = Domain([ContinuousVariable("A")])
         desc = [
-            ContinuousDescriptor(name="X", expression="A", meta=False,
-                                 number_of_decimals=2)
+            ContinuousDescriptor(name="X", expression="A", number_of_decimals=2)
         ]
         X = sp.csc_matrix(np.arange(5).reshape(5, 1))
         data = Table.from_numpy(domain, X)
@@ -374,18 +373,18 @@ class OWFeatureConstructorTests(WidgetTest):
 
     def test_create_variable_with_no_data(self):
         self.widget.addFeature(
-            ContinuousDescriptor("X1", "", False, 3))
+            ContinuousDescriptor("X1", "", 3))
 
     def test_error_invalid_expression(self):
         data = Table("iris")
         self.widget.setData(data)
         self.widget.addFeature(
-            ContinuousDescriptor("X", "0", False, 3)
+            ContinuousDescriptor("X", "0", 3)
         )
         self.widget.apply()
         self.assertFalse(self.widget.Error.invalid_expressions.is_shown())
         self.widget.addFeature(
-            ContinuousDescriptor("X", "0a", False, 3)
+            ContinuousDescriptor("X", "0a", 3)
         )
         self.widget.apply()
         self.assertTrue(self.widget.Error.invalid_expressions.is_shown())
@@ -393,12 +392,12 @@ class OWFeatureConstructorTests(WidgetTest):
     def test_transform_error(self):
         data = Table("iris")[::5]
         self.send_signal(self.widget.Inputs.data, data)
-        self.widget.addFeature(ContinuousDescriptor("X", "1/0", False, 3))
+        self.widget.addFeature(ContinuousDescriptor("X", "1/0", 3))
         self.widget.apply()
         self.wait_until_finished(self.widget)
         self.assertTrue(self.widget.Error.transform_error.is_shown())
         self.widget.removeFeature(0)
-        self.widget.addFeature(ContinuousDescriptor("X", "1", False, 3))
+        self.widget.addFeature(ContinuousDescriptor("X", "1", 3))
         self.widget.apply()
         self.wait_until_finished(self.widget)
         self.assertFalse(self.widget.Error.transform_error.is_shown())
@@ -407,7 +406,7 @@ class OWFeatureConstructorTests(WidgetTest):
         data = Table("iris")
         self.widget.setData(data)
         self.widget.addFeature(
-            ContinuousDescriptor("iris", "0", False, 3)
+            ContinuousDescriptor("iris", "0", 3)
         )
         self.widget.apply()
         output = self.get_output(self.widget.Outputs.data)
@@ -462,7 +461,7 @@ class OWFeatureConstructorTests(WidgetTest):
         self.send_signal(w.Inputs.data, Table.from_numpy(domain, [[0, 1, 2]]))
 
         w.descriptors = [StringDescriptor(
-            "y", "ana.value + berta.value + cilka.value", True)]
+            "y", "ana.value + berta.value + cilka.value")]
 
         # Reject fixing - no changes
         dlgexec.return_value=msgbox.RejectRole
@@ -476,13 +475,13 @@ class OWFeatureConstructorTests(WidgetTest):
         self.assertEqual(w.descriptors[0].expression, "ana + berta + cilka")
 
         w.descriptors = [StringDescriptor(
-            "y", "ana.value + dani.value + cilka.value", True)]
+            "y", "ana.value + dani.value + cilka.value")]
         with patch.object(w, "apply"):  # dani doesn't exist and will fail
             w.fix_expressions()
         self.assertEqual(w.descriptors[0].expression,
                          "ana + dani.value + cilka")
 
-        w.descriptors = [ContinuousDescriptor("y", "sqrt(berta)", 1, False)]
+        w.descriptors = [ContinuousDescriptor("y", "sqrt(berta)", 1)]
         w.fix_expressions()
         self.assertEqual(w.descriptors[0].expression,
                          "sqrt({'a': 0, 'b': 1, 'c': 2}[berta])")
@@ -499,8 +498,8 @@ class OWFeatureConstructorTests(WidgetTest):
                 attributes=dict(Ana=1, Cilka=2), metas={},
                 values=dict(
                     descriptors=[
-                        ContinuousDescriptor("y", "Ana + int(Cilka)", False, 1),
-                        StringDescriptor("u", "Ana.value + 'X'", True)
+                        ContinuousDescriptor("y", "Ana + int(Cilka)", 1),
+                        StringDescriptor("u", "Ana.value + 'X'")
                     ],
                     currentIndex=0)
              )]
@@ -519,7 +518,7 @@ class OWFeatureConstructorTests(WidgetTest):
                 attributes=dict(Ana=1, Cilka=2), metas={},
                 values=dict(
                     descriptors=[
-                        ContinuousDescriptor("y", "int(Cilka)", False, 1),
+                        ContinuousDescriptor("y", "int(Cilka)", 1),
                     ],
                     currentIndex=0)
              )]
@@ -546,13 +545,13 @@ class OWFeatureConstructorTests(WidgetTest):
                     attributes=dict(x=2, y=2, z=2), metas={},
                     values=dict(
                         descriptors=[
-                            ContinuousDescriptor("a", "x + 2", False, 1),
-                            DiscreteDescriptor("b", "x < 3", (), False, False),
-                            DiscreteDescriptor("c", "x > 15", (), False, True),
-                            DiscreteDescriptor("d", "y > x", ("foo", "bar"), False, False),
-                            DiscreteDescriptor("e", "x ** 2 + y == 5", ("foo", "bar"), False, True),
-                            StringDescriptor("f", "str(x)", True),
-                            DateTimeDescriptor("g", "z", False)
+                            ContinuousDescriptor("a", "x + 2", 1),
+                            DiscreteDescriptor("b", "x < 3", (), False),
+                            DiscreteDescriptor("c", "x > 15", (), True),
+                            DiscreteDescriptor("d", "y > x", ("foo", "bar"), False),
+                            DiscreteDescriptor("e", "x ** 2 + y == 5", ("foo", "bar"), True),
+                            StringDescriptor("f", "str(x)"),
+                            DateTimeDescriptor("g", "z")
                         ],
                         currentIndex=0)
                 )]
@@ -571,13 +570,13 @@ class OWFeatureConstructorTests(WidgetTest):
         w = self.widget
         self.send_signal(w.Inputs.data, Table("iris")[::5])
         features = [
-            ContinuousDescriptor("X1", "max(0, sepal_width - 5)", False, 2),
+            ContinuousDescriptor("X1", "max(0, sepal_width - 5)", 2),
             DiscreteDescriptor("D1", "HIGH if sepal_width > 5 else LOW",
-                               False, ("HIGH", "LOW"), False),
+                               ("HIGH", "LOW"), False),
             DiscreteDescriptor("D2", "'HIGH' if sepal_length > 5 else 'LOW'",
-                               False, (), False),
-            DateTimeDescriptor("T1", "0", False),
-            DateTimeDescriptor("T2", "'1900-01-01'", False),
+                               (), False),
+            DateTimeDescriptor("T1", "0"),
+            DateTimeDescriptor("T2", "'1900-01-01'"),
         ]
         for f in features:
             w.addFeature(f)
@@ -603,7 +602,7 @@ class FeatureConstructorHandlerTests(unittest.TestCase):
         self.assertTrue(
             FeatureConstructorHandler().is_valid_item(
                 OWFeatureConstructor.descriptors,
-                StringDescriptor("X", "str(A) + str(B)", True),
+                StringDescriptor("X", "str(A) + str(B)"),
                 {"A": vartype(DiscreteVariable)},
                 {"B": vartype(DiscreteVariable)}
             )
@@ -613,7 +612,7 @@ class FeatureConstructorHandlerTests(unittest.TestCase):
         self.assertTrue(
             FeatureConstructorHandler().is_valid_item(
                 OWFeatureConstructor.descriptors,
-                StringDescriptor("X", "str('foo')", True),
+                StringDescriptor("X", "str('foo')"),
                 {},
                 {}
             )
@@ -623,7 +622,7 @@ class FeatureConstructorHandlerTests(unittest.TestCase):
         self.assertFalse(
             FeatureConstructorHandler().is_valid_item(
                 OWFeatureConstructor.descriptors,
-                StringDescriptor("X", "str(X)", True),
+                StringDescriptor("X", "str(X)"),
                 {},
                 {}
             )
@@ -633,7 +632,7 @@ class FeatureConstructorHandlerTests(unittest.TestCase):
         self.assertTrue(
             FeatureConstructorHandler().is_valid_item(
                 OWFeatureConstructor.descriptors,
-                StringDescriptor("X", "A_2_f", True),
+                StringDescriptor("X", "A_2_f"),
                 {"A.2 f": vartype(DiscreteVariable)},
                 {}
             )


### PR DESCRIPTION
##### Issue

Fixes #5635.

##### Description of changes

In #5635 I wrote about putting the checkbox into table. I disagree with my ex-self: editor for modifying the feature is at the top, not in the table. If we do change the widget to have controls in the table (including all combos?!), then we'd put the checkbox there, too.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
