### PR TITLE
Fix test_fss for numpy 1.23

### DIFF
--- a/Orange/tests/test_fss.py
+++ b/Orange/tests/test_fss.py
@@ -3,7 +3,9 @@
 
 import unittest
 
-from Orange.data import Table, Variable
+import numpy as np
+
+from Orange.data import Table
 from Orange.preprocess.score import ANOVA, Gini, UnivariateLinearRegression, \
     Chi2
 from Orange.preprocess import SelectBestFeatures, Impute, SelectRandomFeatures
@@ -82,7 +84,8 @@ class TestFSS(unittest.TestCase):
             self.assertEqual(len(scores), 4)
 
             score = method(d1, c.petal_length)
-            self.assertIsInstance(score, float)
+            self.assertEqual(score.ndim, 0)  # a scalar
+            self.assertTrue(np.issubdtype(score.dtype, float))
 
     def test_continuous_scores_on_discrete_features(self):
         data = Impute()(self.imports)


### PR DESCRIPTION
##### Issue
`np.ndarray` (which `contingency.Discrete` subclasses) of a single float is not an instance of float anymore. 