### PR TITLE
[FIX] Server embedder - send bytes as content

### DIFF
--- a/Orange/misc/tests/test_server_embedder.py
+++ b/Orange/misc/tests/test_server_embedder.py
@@ -27,10 +27,11 @@ class DummyResponse:
 def make_dummy_post(response):
     @staticmethod
     # pylint: disable=unused-argument
-    async def dummy_post(url, headers, data):
+    async def dummy_post(url, headers, content=None, data=None):
         # when sleeping some workers to still compute while other are done
         # it causes that not all embeddings are computed if we do not wait all
         # workers to finish
+        assert (content is None) ^ (data is None)
         await asyncio.sleep(random() / 10)
         return DummyResponse(content=response)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
According to httpx sending bytes as data parameters is deprecated. 

##### Description of changes
Use content for sending bytes and data for sending dictionaries

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
