### PR TITLE
DiscretizedScale: Move to proper place, fix a minor problem

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -628,7 +628,7 @@ class ContinuousVariable(Variable):
         """
         return _variable.val_from_str_add_cont(self, s)
 
-    def repr_val(self, val):
+    def repr_val(self, val: float):
         """
         Return the value as a string with the prescribed number of decimals.
         """

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -2,7 +2,6 @@ import sys
 import itertools
 import warnings
 from xml.sax.saxutils import escape
-from math import log10, floor, ceil
 from datetime import datetime, timezone
 
 import numpy as np
@@ -27,7 +26,7 @@ from Orange.widgets.visualize.utils.customizableplot import Updater, \
     CommonParameterSetter
 from Orange.widgets.visualize.utils.plotutils import (
     HelpEventDelegate as EventDelegate, InteractiveViewBox as ViewBox,
-    PaletteItemSample, SymbolItemSample, AxisItem, PlotWidget
+    PaletteItemSample, SymbolItemSample, AxisItem, PlotWidget, DiscretizedScale
 )
 
 SELECTION_WIDTH = 5
@@ -132,62 +131,6 @@ def bound_anchor_pos(corner, parentpos):
     if iry < 0.1 and pry > 0.9:
         iry = pry = 1.0
     return (irx, iry), (prx, pry)
-
-
-class DiscretizedScale:
-    """
-    Compute suitable bins for continuous value from its minimal and
-    maximal value.
-
-    The width of the bin is a power of 10 (including negative powers).
-    The minimal value is rounded up and the maximal is rounded down. If this
-    gives less than 3 bins, the width is divided by four; if it gives
-    less than 6, it is halved.
-
-    .. attribute:: offset
-        The start of the first bin.
-
-    .. attribute:: width
-        The width of the bins
-
-    .. attribute:: bins
-        The number of bins
-
-    .. attribute:: decimals
-        The number of decimals used for printing out the boundaries
-    """
-    def __init__(self, min_v, max_v):
-        """
-        :param min_v: Minimal value
-        :type min_v: float
-        :param max_v: Maximal value
-        :type max_v: float
-        """
-        super().__init__()
-        dif = max_v - min_v if max_v != min_v else 1
-        if np.isnan(dif):
-            min_v = 0
-            dif = decimals = 1
-        else:
-            decimals = -floor(log10(dif))
-        resolution = 10 ** -decimals
-        bins = ceil(dif / resolution)
-        if bins < 6:
-            decimals += 1
-            if bins < 3:
-                resolution /= 4
-            else:
-                resolution /= 2
-            bins = ceil(dif / resolution)
-        self.offset = resolution * floor(min_v // resolution)
-        self.bins = bins
-        self.decimals = max(decimals, 0)
-        self.width = resolution
-
-    def get_bins(self):
-        # if width is a very large int, dtype of width * np.arange is object
-        # hence we cast it to float
-        return self.offset + float(self.width) * np.arange(self.bins + 1)
 
 
 class ScatterPlotItem(pg.ScatterPlotItem):

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1,6 +1,7 @@
 import sys
 import itertools
 import warnings
+from typing import Callable
 from xml.sax.saxutils import escape
 from datetime import datetime, timezone
 
@@ -1456,7 +1457,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
                 SymbolItemSample(pen=color, brush=color, size=10, symbol=symbol),
                 escape(label))
 
-    def _update_continuous_color_legend(self, label_formatter):
+    def _update_continuous_color_legend(self, label_formatter: Callable[[float], str]):
         self.color_legend.clear()
         if self.scale is None or self.scatterplot_item is None:
             return

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -185,7 +185,9 @@ class DiscretizedScale:
         self.width = resolution
 
     def get_bins(self):
-        return self.offset + self.width * np.arange(self.bins + 1)
+        # if width is a very large int, dtype of width * np.arange is object
+        # hence we cast it to float
+        return self.offset + float(self.width) * np.arange(self.bins + 1)
 
 
 class ScatterPlotItem(pg.ScatterPlotItem):

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -1,5 +1,6 @@
 import itertools
 from math import log10, floor, ceil
+from typing import Union, Optional, Callable
 
 import numpy as np
 
@@ -480,10 +481,10 @@ class DiscretizedScale:
             else:
                 resolution /= 2
             bins = ceil(dif / resolution)
-        self.offset = resolution * floor(min_v // resolution)
+        self.offset: Union[int, float] = resolution * floor(min_v // resolution)
         self.bins = bins
         self.decimals = max(decimals, 0)
-        self.width = resolution
+        self.width: Union[int, float] = resolution
 
     def get_bins(self):
         # if width is a very large int, dtype of width * np.arange is object
@@ -494,7 +495,8 @@ class DiscretizedScale:
 class PaletteItemSample(ItemSample):
     """A color strip to insert into legends for discretized continuous values"""
 
-    def __init__(self, palette, scale, label_formatter=None):
+    def __init__(self, palette, scale,
+                 label_formatter: Optional[Callable[[float], str]] = None):
         """
         :param palette: palette used for showing continuous values
         :type palette: BinnedContinuousPalette
@@ -507,7 +509,9 @@ class PaletteItemSample(ItemSample):
         self.scale = scale
         if label_formatter is None:
             label_formatter = "{{:.{}f}}".format(scale.decimals).format
-        cuts = [label_formatter(scale.offset + i * scale.width)
+        # offset and width can be in, but label_formatter expects float
+        # (because it can be ContinuousVariable.str_val), hence cast to float
+        cuts = [label_formatter(float(scale.offset + i * scale.width))
                 for i in range(scale.bins + 1)]
         self.labels = [QStaticText("{} - {}".format(fr, to))
                        for fr, to in zip(cuts, cuts[1:])]


### PR DESCRIPTION
##### Issue

`DiscretizedScale` was defined in module `owscatterplotgraph`. It belongs to `plotutils`.

When values were ints that didn't fit into 64 bits, numpy stored thresholds as instances of `object` instead of `float`. This is now fixed by explicit conversion to `float`.

##### Includes
- [X] Code changes