### PR TITLE
[ENH] Table: Add methods get_column and set_column

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -69,7 +69,7 @@ class DomainConversion:
                 sourceindex = source.index(sourcevar)
                 if var.is_discrete and var is not sourcevar:
                     mapping = var.get_mapper_from(sourcevar)
-                    return lambda table: mapping(table.get_column_view(sourceindex)[0])
+                    return lambda table: mapping(table.get_column(sourceindex))
                 return source.index(var)
             return var.compute_value  # , which may also be None
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -208,7 +208,7 @@ class Columns:
             setattr(self, v.name.replace(" ", "_"), v)
 
 
-def compute_column(func, *args, **kwargs):
+def _compute_column(func, *args, **kwargs):
     col = func(*args, **kwargs)
     if isinstance(col, np.ndarray) and col.ndim != 1:
         err = f"{type(col)} must return a column, not {col.ndim}d array"
@@ -311,9 +311,9 @@ class _ArrayConversion:
                         shared = col.compute_shared(sourceri)
                         _idcache_save(shared_cache, (col.compute_shared, source), shared)
                     col_array = match_density(
-                        compute_column(col, sourceri, shared_data=shared))
+                        _compute_column(col, sourceri, shared_data=shared))
                 else:
-                    col_array = match_density(compute_column(col, sourceri))
+                    col_array = match_density(_compute_column(col, sourceri))
             elif col < 0:
                 col_array = match_density(
                     source.metas[row_indices, -1 - col]
@@ -1631,7 +1631,7 @@ class Table(Sequence, Storage):
         if isinstance(index, Variable) and index not in self.domain:
             if index.compute_value is None:
                 raise ValueError(f"variable {index.name} is not in domain")
-            return compute_column(index.compute_value, self)
+            return _compute_column(index.compute_value, self)
 
         mapper = None
         if not isinstance(index, Integral):

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -6,7 +6,6 @@ import warnings
 import numpy as np
 import scipy.sparse as sp
 
-import Orange
 from Orange.data import (
     ContinuousVariable, DiscreteVariable, StringVariable,
     Domain, Table, IsDefined, FilterContinuous, Values, FilterString,
@@ -533,10 +532,6 @@ class TestTableGetColumn(TableColumnViewTests):
         np.testing.assert_equal(col, data.X[:, 0])
         self.assertIs(col.base, data.X)
 
-        col = data.get_column(y, view=True)
-        np.testing.assert_equal(col, data.X[:, 0])
-        self.assertIs(col.base, data.X)
-
         col = data.get_column(y, copy=True)
         np.testing.assert_equal(col, data.X[:, 0])
         self.assertIsNone(col.base)
@@ -552,21 +547,10 @@ class TestTableGetColumn(TableColumnViewTests):
         np.testing.assert_equal(col2, [2, 4, 6])
         self.assertIsNone(col2.base)
 
-        self.assertRaises(ValueError, data.get_column, y2, view=True)
-
-    def test_get_column_wrong_arguments(self):
-        self.assertRaises(
-            ValueError, self.data.get_column, self.data.domain["y"],
-            copy=True, view=True)
-
     def test_get_column_discrete(self):
         data, d = self.data, self.data.domain["d"]
 
         col = data.get_column(d)
-        np.testing.assert_equal(col, [0, 0, 1])
-        self.assertIs(col.base, data.X)
-
-        col = data.get_column(d, view=True)
         np.testing.assert_equal(col, [0, 0, 1])
         self.assertIs(col.base, data.X)
 
@@ -576,7 +560,7 @@ class TestTableGetColumn(TableColumnViewTests):
 
         e = DiscreteVariable("d", values=("a", "b"))
         assert e == d
-        col = data.get_column(e, view=True)
+        col = data.get_column(e)
         np.testing.assert_equal(col, [0, 0, 1])
         self.assertIs(col.base, data.X)
 
@@ -589,10 +573,6 @@ class TestTableGetColumn(TableColumnViewTests):
         assert e == d  # because that's how Variable mapping works
         col = data.get_column(e)
         np.testing.assert_equal(col, [0, 0, 2])
-
-        e = DiscreteVariable("d", values=("a", "b", "c"))
-        assert e == d  # because that's how Variable mapping works
-        self.assertRaises(ValueError, data.get_column, e, view=True)
 
         with data.unlocked(data.X):
             data.X = sp.csr_matrix(data.X)
@@ -612,19 +592,11 @@ class TestTableGetColumn(TableColumnViewTests):
         self.assertFalse(sp.issparse(col))
         np.testing.assert_equal(col, orig_y)
 
-        self.assertRaises(ValueError, data.get_column, y, view=True)
-
         col = data.get_column(y, copy=True)
         self.assertFalse(sp.issparse(col))
         np.testing.assert_equal(col, orig_y)
 
     def test_get_column_no_variable(self):
-        self.assertRaises(ValueError, self.data.get_column,
-                          ContinuousVariable("y3"), view=True)
-
-        self.assertRaises(ValueError, self.data.get_column,
-                          ContinuousVariable("y3"), copy=True)
-
         self.assertRaises(ValueError, self.data.get_column,
                           ContinuousVariable("y3"))
 
@@ -632,10 +604,6 @@ class TestTableGetColumn(TableColumnViewTests):
         data = self.data
 
         col = data.get_column(0)
-        np.testing.assert_equal(col, data.X[:, 0])
-        self.assertIs(col.base, data.X)
-
-        col = data.get_column(0, view=True)
         np.testing.assert_equal(col, data.X[:, 0])
         self.assertIs(col.base, data.X)
 
@@ -655,10 +623,6 @@ class TestTableGetColumn(TableColumnViewTests):
         data = self.data
 
         col = data.get_column("y")
-        np.testing.assert_equal(col, data.X[:, 0])
-        self.assertIs(col.base, data.X)
-
-        col = data.get_column("y", view=True)
         np.testing.assert_equal(col, data.X[:, 0])
         self.assertIs(col.base, data.X)
 

--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -177,7 +177,7 @@ class EqualWidth(Discretization):
                 stats = BasicStats(data, attribute)
                 points = self._split_eq_width(stats.min, stats.max)
             else:
-                values, _ = data.get_column_view(attribute)
+                values = data.get_column(attribute)
                 if values.size:
                     mn, mx = ut.nanmin(values), ut.nanmax(values)
                     points = self._split_eq_width(mn, mx)
@@ -204,7 +204,7 @@ class FixedWidth(Discretization):
         self.digits = digits
 
     def __call__(self, data: Table, attribute):
-        values, _ = data.get_column_view(attribute)
+        values = data.get_column(attribute)
         points = []
         if values.size:
             mn, mx = ut.nanmin(values), ut.nanmax(values)
@@ -229,7 +229,7 @@ class FixedTimeWidth(Discretization):
     def __call__(self, data: Table, attribute):
         fmt = ["%Y", "%y %b", "%y %b %d", "%y %b %d %H:%M", "%y %b %d %H:%M",
                 "%H:%M:%S"][self.unit]
-        values, _ = data.get_column_view(attribute)
+        values = data.get_column(attribute)
         times = []
         if values.size:
             mn, mx = ut.nanmin(values), ut.nanmax(values)
@@ -295,7 +295,7 @@ class Binning(Discretization):
 
     def __call__(self, data: Table, attribute):
         attribute = data.domain[attribute]
-        values, _ = data.get_column_view(attribute)
+        values = data.get_column(attribute)
         values = values.astype(float)
         if not values.size:
             return self._create_binned_var(None, attribute)

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -88,7 +88,7 @@ class DropInstances(BaseImputeMethod):
     description = ""
 
     def __call__(self, data, variable):
-        col, _ = data.get_column_view(variable)
+        col = data.get_column(variable)
         return np.isnan(col)
 
 
@@ -192,7 +192,7 @@ class ReplaceUnknownsModel(Reprable):
         if isinstance(data, Orange.data.Instance):
             data = Orange.data.Table.from_list(data.domain, [data])
         domain = data.domain
-        column = np.array(data.get_column_view(self.variable)[0], copy=True)
+        column = data.get_column(self.variable, copy=True)
 
         mask = np.isnan(column)
         if not np.any(mask):

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -208,13 +208,9 @@ def purge_var_M(var, data, flags):
 
 def has_at_least_two_values(data, var):
     ((dist, unknowns),) = data._compute_distributions([var])
-    # TODO this check is suboptimal for sparse since get_column_view
-    # densifies the data. Should be irrelevant after Pandas.
-    _, sparse = data.get_column_view(var)
     if var.is_continuous:
         dist = dist[1, :]
-    min_size = 0 if sparse and unknowns else 1
-    return np.sum(dist > 0.0) > min_size
+    return np.sum(dist > 0.0) > 1
 
 
 def remove_constant(var, data):
@@ -233,7 +229,7 @@ def remove_constant(var, data):
 
 
 def remove_unused_values(var, data):
-    unique = nanunique(data.get_column_view(var)[0].astype(float)).astype(int)
+    unique = nanunique(data.get_column(var)).astype(int)
     if len(unique) == len(var.values):
         return var
     used_values = [var.values[i] for i in unique]

--- a/Orange/tests/test_xlsx_reader.py
+++ b/Orange/tests/test_xlsx_reader.py
@@ -215,7 +215,7 @@ class TestMissingValues(unittest.TestCase):
     @test_xlsx_xls
     def test_read_errors(self, reader: Callable[[str], io.FileFormat]):
         table = read_file(reader, "missing")
-        values = table.get_column_view("C")[0]
+        values = table.get_column("C")
         self.assertTrue(np.isnan(values).all())
 
 

--- a/Orange/widgets/data/owaggregatecolumns.py
+++ b/Orange/widgets/data/owaggregatecolumns.py
@@ -207,7 +207,7 @@ class OWAggregateColumns(widget.OWWidget):
     def _compute_column(self, variables):
         arr = np.empty((len(self.data), len(variables)))
         for i, var in enumerate(variables):
-            arr[:, i] = self.data.get_column_view(var)[0].astype(float)
+            arr[:, i] = self.data.get_column(var)
         func = self.Operations[self.operation].func
         return func(arr, axis=1)
 

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -499,7 +499,7 @@ class OWCreateClass(widget.OWWidget):
             return
         counters = {StringVariable: _string_counts,
                     DiscreteVariable: _discrete_counts}
-        data = self.data.get_column_view(attr)[0]
+        data = self.data.get_column(attr)
         self.match_counts = [[int(np.sum(x)) for x in matches]
                              for matches in counters[type(attr)]()]
         _set_labels()

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -2318,11 +2318,10 @@ def table_column_data(
         var: Union[Orange.data.Variable, int],
         dtype=None
 ) -> MArray:
-    col, copy = table.get_column_view(var)
+    col = table.get_column(var)
     var = table.domain[var]  # type: Orange.data.Variable
     if var.is_primitive() and not np.issubdtype(col.dtype, np.inexact):
         col = col.astype(float)
-        copy = True
 
     if dtype is None:
         if isinstance(var, Orange.data.TimeVariable):
@@ -2344,9 +2343,8 @@ def table_column_data(
 
     if dtype != col.dtype:
         col = col.astype(dtype)
-        copy = True
 
-    if not copy:
+    if col.base is not None:
         col = col.copy()
     return MArray(col, mask=mask)
 

--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -769,7 +769,7 @@ class OWFeatureConstructor(OWWidget, ConcurrentWidgetMixin):
     @staticmethod
     def check_attrs_values(attr, data):
         for var in attr:
-            col, _ = data.get_column_view(var)
+            col = data.get_column(var)
             mask = ~np.isnan(col)
             grater_or_equal = np.greater_equal(
                 col, len(var.values), out=mask, where=mask
@@ -1291,7 +1291,7 @@ class FeatureFunc:
         return self.__call_table(table)[0]
 
     def extract_column(self, table: Table, var: Variable):
-        data, _ = table.get_column_view(var)
+        data = table.get_column(var)
         if var.is_string:
             return data
         elif var.is_discrete and not self.use_values:

--- a/Orange/widgets/data/owmelt.py
+++ b/Orange/widgets/data/owmelt.py
@@ -153,7 +153,7 @@ class OWMelt(widget.OWWidget):
         self.commit.now()
 
     def _is_unique(self, var):
-        col = self.data.get_column_view(var)[0]
+        col = self.data.get_column(var)
         col = col[self._notnan_mask(col)]
         return len(col) == len(set(col))
 
@@ -200,7 +200,7 @@ class OWMelt(widget.OWWidget):
         # Get identifiers, remove rows with missing id data
         id_names = ()
         if self.idvar:
-            idvalues, _ = self.data.get_column_view(self.idvar)
+            idvalues = self.data.get_column(self.idvar)
             idmask = self._notnan_mask(idvalues)
             x = self.data.X[idmask]
             idvalues = idvalues[idmask]

--- a/Orange/widgets/data/owmergedata.py
+++ b/Orange/widgets/data/owmergedata.py
@@ -468,10 +468,8 @@ class OWMergeData(widget.OWWidget):
             if var not in domain:
                 return True
             both_defined = (lefti != -1) * (righti != -1)
-            left_col = \
-                self.data.get_column_view(var)[0][lefti[both_defined]]
-            right_col = \
-                self.extra_data.get_column_view(var)[0][righti[both_defined]]
+            left_col = self.data.get_column(var)[lefti[both_defined]]
+            right_col = self.extra_data.get_column(var)[righti[both_defined]]
             if var.is_primitive():
                 left_col = left_col.astype(float)
                 right_col = right_col.astype(float)
@@ -496,9 +494,8 @@ class OWMergeData(widget.OWWidget):
         if var == INSTANCEID:
             return np.fromiter(
                 (inst.id for inst in data), count=len(data), dtype=int)
-        col = data.get_column_view(var)[0]
+        col = data.get_column(var)
         if var.is_primitive():
-            col = col.astype(float, copy=False)
             nans = np.isnan(col)
             mask *= ~nans
             if var.is_discrete:

--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -164,7 +164,7 @@ class OWNeighbors(OWWidget):
         distances = self.distances[indices]
         with neighbours.unlocked(neighbours.metas):
             if distances.size > 0:
-                neighbours.get_column(dist_var, view=1)[:] = distances
+                neighbours.set_column(dist_var, distances)
         return neighbours
 
 

--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -164,7 +164,7 @@ class OWNeighbors(OWWidget):
         distances = self.distances[indices]
         with neighbours.unlocked(neighbours.metas):
             if distances.size > 0:
-                neighbours.get_column_view(dist_var)[0][:] = distances
+                neighbours.get_column(dist_var, view=1)[:] = distances
         return neighbours
 
 

--- a/Orange/widgets/data/owoutliers.py
+++ b/Orange/widgets/data/owoutliers.py
@@ -43,7 +43,7 @@ def run(data: Table, learner: Learner, state: TaskState) -> Results:
     model = learner(data, wrap_callback(callback, end=0.6))
     pred = model(data, wrap_callback(callback, start=0.6, end=0.99))
 
-    col = pred.get_column_view(model.outlier_var)[0]
+    col = pred.get_column(model.outlier_var)
     inliers_ind = np.where(col == 1)[0]
     outliers_ind = np.where(col == 0)[0]
 

--- a/Orange/widgets/data/owpivot.py
+++ b/Orange/widgets/data/owpivot.py
@@ -95,8 +95,8 @@ class Pivot:
         if self._col_var and not self._col_var.is_discrete:
             raise TypeError("Column variable should be DiscreteVariable")
 
-        self._row_var_col = table.get_column_view(row_var)[0].astype(float)
-        self._col_var_col = table.get_column_view(self._col_var)[0].astype(float)
+        self._row_var_col = table.get_column(row_var)
+        self._col_var_col = table.get_column(self._col_var)
         self._row_var_groups = nanunique(self._row_var_col)
         self._col_var_groups = nanunique(self._col_var_col)
 
@@ -260,7 +260,7 @@ class Pivot:
                 if fun in self._depen_agg_done:
                     X[:, k] = group_tab.X[:, self._depen_agg_done[fun][v] - offset]
                 else:
-                    X[i, k] = fun(sub_table.get_column_view(v)[0])
+                    X[i, k] = fun(sub_table.get_column(v))
 
         #rename leading vars (seems the easiest) if needed
         current = [var.name for var in attrs]
@@ -962,7 +962,7 @@ class OWPivot(OWWidget):
 
             if self.data:
                 col_var = self.col_feature or self.row_feature
-                col = self.data.get_column_view(col_var)[0].astype(float)
+                col = self.data.get_column(col_var)
                 if len(nanunique(col)) >= self.MAX_VALUES:
                     self.table_view.clear()
                     self.Warning.too_many_values()

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -500,7 +500,7 @@ class OWSelectRows(widget.OWWidget):
                     invalidate_datetime()
 
                 datetime_format = (var.have_date, var.have_time)
-                column = self.data.get_column_view(var_idx)[0]
+                column = self.data.get_column(var_idx)
                 w = DateTimeWidget(self, column, datetime_format)
                 w.set_datetime(lc[0])
                 box.controls = [w]

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -140,7 +140,7 @@ class OWTranspose(OWWidget, ConcurrentWidgetMixin):
         variable = self.feature_type == self.FROM_VAR and \
             self.feature_names_column
         if variable and self.data:
-            names = self.data.get_column_view(variable)[0]
+            names = self.data.get_column(variable)
             if len(names) != len(set(names)):
                 self.Warning.duplicate_names(variable)
         if self.data and self.data.domain.has_discrete_attributes():

--- a/Orange/widgets/data/owunique.py
+++ b/Orange/widgets/data/owunique.py
@@ -84,7 +84,7 @@ class OWUnique(widget.OWWidget):
 
     def _compute_unique_data(self):
         uniques = {}
-        keys = zip(*[self.data.get_column_view(attr)[0]
+        keys = zip(*[self.data.get_column(attr)
                      for attr in self.selected_vars or self.var_model])
         for i, key in enumerate(keys):
             uniques.setdefault(key, []).append(i)

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -305,8 +305,8 @@ class TestOWCreateClass(WidgetTest):
 
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
-        classes = outdata.get_column_view("class")[0]
-        attr = outdata.get_column_view("name")[0].astype(str)
+        classes = outdata.get_column("class")
+        attr = outdata.get_column("name").astype(str)
         has_a = np.char.find(attr, "a") != -1
         np.testing.assert_equal(classes[has_a], 0)
         np.testing.assert_equal(classes[~has_a], 1)
@@ -385,8 +385,8 @@ class TestOWCreateClass(WidgetTest):
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
         self.assertEqual(outdata.domain.class_var.values, ("Cls1", "Cls2"))
-        classes = outdata.get_column_view("class")[0]
-        attr = outdata.get_column_view("thal")[0]
+        classes = outdata.get_column("class")
+        attr = outdata.get_column("thal")
         thal = self.heart.domain["thal"]
         reversable = np.equal(attr, thal.values.index("reversable defect"))
         fixed = np.equal(attr, thal.values.index("fixed defect"))
@@ -402,7 +402,7 @@ class TestOWCreateClass(WidgetTest):
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
         self.assertEqual(outdata.domain.class_var.values, ("C1", ))
-        classes = outdata.get_column_view("class")[0]
+        classes = outdata.get_column("class")
         np.testing.assert_equal(classes, 0)
 
         thal = self.heart.domain["thal"]
@@ -426,8 +426,8 @@ class TestOWCreateClass(WidgetTest):
         widget.apply()
         outdata = self.get_output(self.widget.Outputs.data)
         self.assertEqual(outdata.domain.class_var.values, ("C1", "C2"))
-        classes = outdata.get_column_view("class")[0]
-        attr = outdata.get_column_view("gender")[0]
+        classes = outdata.get_column("class")
+        attr = outdata.get_column("gender")
         female = np.equal(attr, gender.values.index("female"))
         np.testing.assert_equal(classes[female], 0)
         # pylint: disable=invalid-unary-operand-type

--- a/Orange/widgets/data/tests/test_owcreateinstance.py
+++ b/Orange/widgets/data/tests/test_owcreateinstance.py
@@ -325,7 +325,7 @@ class TestContinuousVariableEditor(GuiTest):
     def setUp(self):
         self.callback = Mock()
         data = Table("iris")
-        values = data.get_column_view(data.domain[0])[0]
+        values = data.get_column(data.domain[0])
         self.min_value = np.min(values)
         self.max_value = np.max(values)
         self.editor = ContinuousVariableEditor(

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -172,8 +172,7 @@ class FeatureConstructorTest(unittest.TestCase):
         data_ = data.transform(Domain(data.domain.attributes,
                                       [],
                                       construct_variables(desc, data)[0]))
-        np.testing.assert_equal(
-            data.get_column_view(0)[0], data_.get_column_view(0)[0]
+        np.testing.assert_equal(data.get_column(0), data_.get_column(0)
         )
 
 

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -254,7 +254,7 @@ class TestOWNeighbors(WidgetTest):
         self.assertEqual(len(neighbours.domain.metas), 3)
         self.assertEqual(neighbours.metas.shape, (4, 3))
         np.testing.assert_almost_equal(
-            neighbours.get_column_view("distance")[0], indices + 1000)
+            neighbours.get_column("distance"), indices + 1000)
         np.testing.assert_almost_equal(neighbours.X, data2.X[indices])
 
     def test_apply(self):

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -378,7 +378,7 @@ class TestOWRank(WidgetTest):
         """Check NaNs are sorted last"""
         data = self.iris.copy()
         with data.unlocked():
-            data.get_column('petal length', view=True)[:] = np.nan
+            data.set_column('petal length', np.nan)
         self.send_signal(self.widget.Inputs.data, data)
         self.wait_until_finished()
 

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -378,7 +378,7 @@ class TestOWRank(WidgetTest):
         """Check NaNs are sorted last"""
         data = self.iris.copy()
         with data.unlocked():
-            data.get_column_view('petal length')[0][:] = np.nan
+            data.get_column('petal length', view=True)[:] = np.nan
         self.send_signal(self.widget.Inputs.data, data)
         self.wait_until_finished()
 

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -390,7 +390,7 @@ class TestOWSelectRows(WidgetTest):
 
         annotated = self.get_output(self.widget.Outputs.annotated_data)
         self.assertEqual(len(annotated), 150)
-        annotations = annotated.get_column_view(ANNOTATED_DATA_FEATURE_NAME)[0]
+        annotations = annotated.get_column(ANNOTATED_DATA_FEATURE_NAME)
         np.testing.assert_equal(annotations[:50], True)
         np.testing.assert_equal(annotations[50:], False)
 

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -101,13 +101,13 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin, dbt):
         self.widget.set_selection()
 
         output = self.get_output(self.widget.Outputs.selected_data)
-        output, _ = output.get_column_view(0)
+        output = output.get_column(0)
         output_original = output.tolist()
 
         self.widget.tabs.currentWidget().sortByColumn(1, Qt.AscendingOrder)
 
         output = self.get_output(self.widget.Outputs.selected_data)
-        output, _ = output.get_column_view(0)
+        output = output.get_column(0)
         output_sorted = output.tolist()
 
         # the two outputs should not be the same.

--- a/Orange/widgets/data/utils/histogram.py
+++ b/Orange/widgets/data/utils/histogram.py
@@ -134,7 +134,7 @@ class Histogram(QGraphicsWidget):
         self.data = data
         self.attribute = data.domain[variable]
 
-        self.x = data.get_column_view(self.attribute)[0].astype(np.float64)
+        self.x = data.get_column(self.attribute)
         self.x_nans = np.isnan(self.x)
         self.x = self.x[~self.x_nans]
 
@@ -156,7 +156,7 @@ class Histogram(QGraphicsWidget):
         self.color_attribute = color_attribute
         if self.color_attribute is not None:
             self.target_var = data.domain[color_attribute]
-            self.y = data.get_column_view(color_attribute)[0]
+            self.y = data.get_column(color_attribute)
             self.y = self.y[~self.x_nans]
             if not np.issubdtype(self.y.dtype, np.number):
                 self.y = self.y.astype(np.float64)

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -788,7 +788,7 @@ class OWPredictions(OWWidget):
             self.Outputs.evaluation_results.send(None)
             return
 
-        nanmask = numpy.isnan(self.data.get_column_view(self.class_var)[0])
+        nanmask = numpy.isnan(self.data.get_column(self.class_var))
         data = self.data[~nanmask]
         results = Results(data, store_data=True)
         results.folds = [...]

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -58,18 +58,18 @@ class TestOWPredictions(WidgetTest):
         data = self.iris[::10].copy()
         with data.unlocked():
             data.Y[1] = np.nan
-        yvec, _ = data.get_column_view(data.domain.class_var)
+        yvec = data.get_column(data.domain.class_var)
         self.send_signal(self.widget.Inputs.data, data)
         self.send_signal(self.widget.Inputs.predictors, ConstantLearner()(data), 1)
         pred = self.get_output(self.widget.Outputs.predictions)
         self.assertIsInstance(pred, Table)
         np.testing.assert_array_equal(
-            yvec, pred.get_column_view(data.domain.class_var)[0])
+            yvec, pred.get_column(data.domain.class_var))
 
         evres = self.get_output(self.widget.Outputs.evaluation_results)
         self.assertIsInstance(evres, Results)
         self.assertIsInstance(evres.data, Table)
-        ev_yvec, _ = evres.data.get_column_view(data.domain.class_var)
+        ev_yvec = evres.data.get_column(data.domain.class_var)
 
         self.assertTrue(np.all(~np.isnan(ev_yvec)))
         self.assertTrue(np.all(~np.isnan(evres.actual)))
@@ -145,7 +145,7 @@ class TestOWPredictions(WidgetTest):
         self.send_signal(self.widget.Inputs.predictors, majority_titanic, 1)
         self.send_signal(self.widget.Inputs.data, no_class)
         out = self.get_output(self.widget.Outputs.predictions)
-        np.testing.assert_allclose(out.get_column_view("constant")[0], 0)
+        np.testing.assert_allclose(out.get_column("constant"), 0)
 
         predmodel = self.widget.predictionsview.model()
         self.assertTrue(np.isnan(

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -600,7 +600,7 @@ class OWDistanceMap(widget.OWWidget):
             labels = [v.name for v in self.items]
         elif isinstance(self.items, Orange.data.Table):
             var = self.annot_combo.model()[self.annotation_idx]
-            column, _ = self.items.get_column_view(var)
+            column = self.items.get_column(var)
             labels = [var.str_val(value) for value in column]
 
         self._set_labels(labels)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -281,7 +281,7 @@ class OWDistanceMatrix(widget.OWWidget):
             labels = [v.name for v in self.items]
         elif isinstance(self.items, Table):
             var = self.annot_combo.model()[self.annotation_idx]
-            column, _ = self.items.get_column_view(var)
+            column = self.items.get_column(var)
             labels = [var.str_val(value) for value in column]
         if labels:
             self.tableview.horizontalHeader().show()

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -770,7 +770,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             domain = Orange.data.Domain(attrs, classes, metas + (clust_var,))
             data = items.transform(domain)
             with data.unlocked(data.metas):
-                data.get_column(clust_var, view=True)[:] = c
+                data.set_column(clust_var, c)
 
             if selected_indices:
                 selected_data = data[mask]

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -607,7 +607,7 @@ class OWHierarchicalClustering(widget.OWWidget):
                 attr = self.matrix.row_items.domain.attributes
                 labels = [str(attr[i]) for i in indices]
             elif isinstance(self.annotation, Orange.data.Variable):
-                col_data, _ = self.items.get_column_view(self.annotation)
+                col_data = self.items.get_column(self.annotation)
                 labels = [self.annotation.str_val(val) for val in col_data]
                 labels = [labels[idx] for idx in indices]
             else:
@@ -627,7 +627,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.labels.setMinimumWidth(1 if labels else -1)
 
         if not self.pruning and self.color_by is not None:
-            col = self.items.get_column_view(self.color_by)[0].astype(float)
+            col = self.items.get_column(self.color_by)
             self.label_model.set_colors(
                 self.color_by.palette.values_to_qcolors(col[indices]))
         else:
@@ -770,7 +770,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             domain = Orange.data.Domain(attrs, classes, metas + (clust_var,))
             data = items.transform(domain)
             with data.unlocked(data.metas):
-                data.get_column_view(clust_var)[0][:] = c
+                data.get_column(clust_var, view=True)[:] = c
 
             if selected_indices:
                 selected_data = data[mask]

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -545,8 +545,8 @@ class OWKMeans(widget.OWWidget):
         new_domain = add_columns(domain, metas=[cluster_var, silhouette_var])
         new_table = self.data.transform(new_domain)
         with new_table.unlocked(new_table.metas):
-            new_table.get_column(cluster_var, view=True)[:] = clust_ids
-            new_table.get_column(silhouette_var, view=True)[:] = scores
+            new_table.set_column(cluster_var, clust_ids)
+            new_table.set_column(silhouette_var, scores)
 
         domain_attributes = set(domain.attributes)
         centroid_attributes = [

--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -545,8 +545,8 @@ class OWKMeans(widget.OWWidget):
         new_domain = add_columns(domain, metas=[cluster_var, silhouette_var])
         new_table = self.data.transform(new_domain)
         with new_table.unlocked(new_table.metas):
-            new_table.get_column_view(cluster_var)[0][:] = clust_ids
-            new_table.get_column_view(silhouette_var)[0][:] = scores
+            new_table.get_column(cluster_var, view=True)[:] = clust_ids
+            new_table.get_column(silhouette_var, view=True)[:] = scores
 
         domain_attributes = set(domain.attributes)
         centroid_attributes = [

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -387,7 +387,7 @@ class OWLouvainClustering(widget.OWWidget):
         new_domain = add_columns(domain, metas=[cluster_var])
         new_table = self.data.transform(new_domain)
         with new_table.unlocked(new_table.metas):
-            new_table.get_column_view(cluster_var)[0][:] = new_partition
+            new_table.get_column(cluster_var, view=True)[:] = new_partition
 
         self.Outputs.annotated_data.send(new_table)
 

--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -387,7 +387,7 @@ class OWLouvainClustering(widget.OWWidget):
         new_domain = add_columns(domain, metas=[cluster_var])
         new_table = self.data.transform(new_domain)
         with new_table.unlocked(new_table.metas):
-            new_table.get_column(cluster_var, view=True)[:] = new_partition
+            new_table.set_column(cluster_var, new_partition)
 
         self.Outputs.annotated_data.send(new_table)
 

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -579,9 +579,7 @@ class OWSOM(OWWidget):
         # this function
         assert self.colors is not None
 
-        color_column = \
-            self.data.get_column_view(self.attr_color)[0].astype(float,
-                                                                 copy=False)
+        color_column = self.data.get_column(self.attr_color)
         if self.attr_color.is_discrete:
             with np.errstate(invalid="ignore"):
                 int_col = color_column.astype(int)
@@ -851,7 +849,7 @@ class OWSOM(OWWidget):
             self.colors = self.attr_color.palette
             return
 
-        col = self.data.get_column_view(self.attr_color)[0].astype(float)
+        col = self.data.get_column(self.attr_color)
         col = col[np.isfinite(col)]
         if not col.size:
             self.Warning.no_defined_colors(self.attr_color)

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -446,13 +446,13 @@ class TestOWKMeans(WidgetTest):
                 100):
             self.send_signal(self.widget.Inputs.data, table)
             outtable = self.get_output(widget.Outputs.annotated_data)
-            outtable = outtable.get_column_view("Silhouette")[0]
+            outtable = outtable.get_column("Silhouette")
         self.assertTrue(np.all(np.isnan(outtable)))
         self.assertTrue(widget.Warning.no_silhouettes.is_shown())
 
         self.send_signal(self.widget.Inputs.data, table[:100])
         outtable = self.get_output(widget.Outputs.annotated_data)
-        outtable = outtable.get_column_view("Silhouette")[0]
+        outtable = outtable.get_column("Silhouette")
         np.testing.assert_array_less(outtable, 1.01)
         np.testing.assert_array_less(-0.01, outtable)
         self.assertFalse(widget.Warning.no_silhouettes.is_shown())

--- a/Orange/widgets/unsupervised/tests/test_owlouvain.py
+++ b/Orange/widgets/unsupervised/tests/test_owlouvain.py
@@ -55,7 +55,7 @@ class TestOWLouvain(WidgetTest):
         self.commit_and_wait()
         output = self.get_output(self.widget.Outputs.annotated_data)
 
-        clustering = output.get_column_view('Cluster')[0].astype(int)
+        clustering = output.get_column('Cluster').astype(int)
         counts = np.bincount(clustering)
         np.testing.assert_equal(counts, sorted(counts, reverse=True))
 
@@ -65,7 +65,7 @@ class TestOWLouvain(WidgetTest):
         meta_var = ContinuousVariable(name='meta_var')
         table = Table.from_domain(domain=Domain([], metas=[meta_var]), n_rows=5)
         with table.unlocked():
-            table.get_column_view(meta_var)[0][:] = meta
+            table.get_column(meta_var, view=True)[:] = meta
 
         self.send_signal(self.widget.Inputs.data, table)
         self.commit_and_wait()

--- a/Orange/widgets/unsupervised/tests/test_owlouvain.py
+++ b/Orange/widgets/unsupervised/tests/test_owlouvain.py
@@ -65,7 +65,7 @@ class TestOWLouvain(WidgetTest):
         meta_var = ContinuousVariable(name='meta_var')
         table = Table.from_domain(domain=Domain([], metas=[meta_var]), n_rows=5)
         with table.unlocked():
-            table.get_column(meta_var, view=True)[:] = meta
+            table.set_column(meta_var, meta)
 
         self.send_signal(self.widget.Inputs.data, table)
         self.commit_and_wait()

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -114,8 +114,7 @@ class TestOWPCA(WidgetTest):
         self.assertEqual(pc2.attributes["variance"], 0.25)
 
         result = self.get_output(self.widget.Outputs.components)
-        np.testing.assert_almost_equal(result.get_column_view("variance")[0].T,
-                                       [0.5, 0.25])
+        np.testing.assert_almost_equal(result.get_column("variance"), [0.5, 0.25])
 
     def test_sparse_data(self):
         """Check that PCA returns the same results for both dense and sparse data."""

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -929,12 +929,7 @@ class TableModel(AbstractSortTableModel):
         coldesc = self.columns[column]
         if isinstance(coldesc, TableModel.Column) \
                 and role == TableModel.ValueRole:
-            col_data = numpy.asarray(self.source.get_column_view(coldesc.var)[0])
-
-            if coldesc.var.is_continuous:
-                # continuous from metas have dtype object; cast it to float
-                col_data = col_data.astype(float)
-            return col_data
+            return self.source.get_column(coldesc.var)
         else:
             return numpy.asarray([self.index(i, column).data(role)
                                   for i in range(self.rowCount())])

--- a/Orange/widgets/visualize/owbarplot.py
+++ b/Orange/widgets/visualize/owbarplot.py
@@ -496,7 +496,7 @@ class OWBarPlot(OWWidget):
         if self.data:
             indices = np.arange(len(self.data))
             if self.group_var:
-                group_by = self.data.get_column_view(self.group_var)[0]
+                group_by = self.data.get_column(self.group_var)
                 indices = np.argsort(group_by, kind="mergesort")
         return indices
 
@@ -564,7 +564,7 @@ class OWBarPlot(OWWidget):
     def get_values(self) -> Optional[np.ndarray]:
         if not self.data or not self.selected_var:
             return None
-        return self.grouped_data.get_column_view(self.selected_var)[0]
+        return self.grouped_data.get_column(self.selected_var)
 
     def get_labels(self) -> Optional[Union[List, np.ndarray]]:
         if not self.data:
@@ -608,7 +608,7 @@ class OWBarPlot(OWWidget):
             return [create_color(np.nan, id_) for id_ in self.grouped_data.ids]
         else:
             assert self.color_var.is_discrete
-            col = self.grouped_data.get_column_view(self.color_var)[0]
+            col = self.grouped_data.get_column(self.color_var)
             return [create_color(i, id_) for id_, i in
                     zip(self.grouped_data.ids, col)]
 

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -352,7 +352,7 @@ class OWBoxPlot(widget.OWWidget):
                 return 3
             if attr.is_continuous:
                 # One-way ANOVA
-                col = data.get_column_view(attr)[0].astype(float)
+                col = data.get_column(attr)
                 groups = (col[group_col == i] for i in range(n_groups))
                 groups = (col[~np.isnan(col)] for col in groups)
                 groups = [group for group in groups if len(group) > 1]
@@ -370,8 +370,8 @@ class OWBoxPlot(widget.OWWidget):
         group_var = self.group_var
         if self.order_by_importance and group_var is not None:
             n_groups = len(group_var.values)
-            group_col = data.get_column_view(group_var)[0] if \
-                domain.has_continuous_attributes(
+            group_col = data.get_column(group_var) \
+                if domain.has_continuous_attributes(
                     include_class=True, include_metas=True) else None
             self._sort_list(self.attrs, self.attr_list, compute_score)
         else:
@@ -403,7 +403,7 @@ class OWBoxPlot(widget.OWWidget):
         attr = self.attribute
         if self.order_grouping_by_importance:
             if attr.is_continuous:
-                attr_col = data.get_column_view(attr)[0].astype(float)
+                attr_col = data.get_column(attr)
             self._sort_list(self.group_vars, self.group_list, compute_stat)
         else:
             self._sort_list(self.group_vars, self.group_list, None)
@@ -493,8 +493,8 @@ class OWBoxPlot(widget.OWWidget):
         if isinstance(attr, np.ndarray):
             attr_col = attr
         else:
-            attr_col = data.get_column_view(group)[0].astype(float)
-        group_col = data.get_column_view(group)[0].astype(float)
+            attr_col = data.get_column(group)
+        group_col = data.get_column(group)
         groups = [attr_col[group_col == i] for i in range(len(group.values))]
         groups = [col[~np.isnan(col)] for col in groups]
         return groups
@@ -516,7 +516,7 @@ class OWBoxPlot(widget.OWWidget):
             group_var_labels = self.group_var.values + ("",)
             if self.attribute.is_continuous:
                 stats, label_texts = [], []
-                attr_col = dataset.get_column_view(attr)[0].astype(float)
+                attr_col = dataset.get_column(attr)
                 for group, value in \
                         zip(self._group_cols(dataset, self.group_var, attr_col),
                             group_var_labels):
@@ -535,7 +535,7 @@ class OWBoxPlot(widget.OWWidget):
         else:
             self.conts = None
             if self.attribute.is_continuous:
-                attr_col = dataset.get_column_view(attr)[0].astype(float)
+                attr_col = dataset.get_column(attr)
                 self.stats = [BoxData(attr_col)]
             else:
                 self.dist = distribution.get_distribution(dataset, attr)

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -538,13 +538,13 @@ class OWDistributions(OWWidget):
         if self.var is None:
             return
 
-        column = self.data.get_column_view(self.var)[0].astype(float)
+        column = self.data.get_column(self.var)
         valid_mask = np.isfinite(column)
         if not np.any(valid_mask):
             self.Error.no_defined_values_var(self.var.name)
             return
         if self.cvar:
-            ccolumn = self.data.get_column_view(self.cvar)[0].astype(float)
+            ccolumn = self.data.get_column(self.cvar)
             valid_mask *= np.isfinite(ccolumn)
             if not np.any(valid_mask):
                 self.Error.no_defined_values_pair(self.var.name, self.cvar.name)
@@ -881,7 +881,7 @@ class OWDistributions(OWWidget):
     def recompute_binnings(self):
         if self.is_valid and self.var.is_continuous:
             # binning is computed on valid var data, ignoring any cvar nans
-            column = self.data.get_column_view(self.var)[0].astype(float)
+            column = self.data.get_column(self.var)
             if np.any(np.isfinite(column)):
                 if self.var.is_time:
                     self.binnings = time_binnings(column, min_unique=5)
@@ -1142,7 +1142,7 @@ class OWDistributions(OWWidget):
 
     def _get_output_indices_disc(self):
         group_indices = np.zeros(len(self.data), dtype=np.int32)
-        col = self.data.get_column_view(self.var)[0].astype(float)
+        col = self.data.get_column(self.var)
         for group_idx, val_idx in enumerate(self.selection, start=1):
             group_indices[col == val_idx] = group_idx
         values = [self.var.values[i] for i in self.selection]
@@ -1150,7 +1150,7 @@ class OWDistributions(OWWidget):
 
     def _get_output_indices_cont(self):
         group_indices = np.zeros(len(self.data), dtype=np.int32)
-        col = self.data.get_column_view(self.var)[0].astype(float)
+        col = self.data.get_column(self.var)
         values = []
         for group_idx, group in enumerate(self.grouped_selection(), start=1):
             x0 = x1 = None
@@ -1182,7 +1182,7 @@ class OWDistributions(OWWidget):
 
     def _get_histogram_indices(self):
         group_indices = np.zeros(len(self.data), dtype=np.int32)
-        col = self.data.get_column_view(self.var)[0].astype(float)
+        col = self.data.get_column(self.var)
         values = []
         for bar_idx in range(len(self.bar_items)):
             x0, x1, mask = self._get_cont_baritem_indices(col, bar_idx)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -1115,7 +1115,7 @@ class OWHeatMap(widget.OWWidget):
         var = self.annotation_color_var
         if var is None:
             return None
-        column_data = column_data_from_table(self.input_data, var)
+        column_data = self.input_data.get_column(var)
         merges = self._merge_row_indices()
         if merges is not None:
             column_data = aggregate(var, column_data, merges)
@@ -1360,26 +1360,15 @@ def column_str_from_table(
         column: Union[int, Orange.data.Variable],
 ) -> np.ndarray:
     var = table.domain[column]
-    data, _ = table.get_column_view(column)
+    data = table.get_column(column)
     return np.asarray([var.str_val(v) for v in data], dtype=object)
-
-
-def column_data_from_table(
-        table: Orange.data.Table,
-        column: Union[int, Orange.data.Variable],
-) -> np.ndarray:
-    var = table.domain[column]
-    data, _ = table.get_column_view(column)
-    if var.is_primitive() and data.dtype.kind != "f":
-        data = data.astype(float)
-    return data
 
 
 def color_annotation_data(
         table: Table, var: Union[int, str, Variable]
 ) -> Tuple[np.ndarray, ColorMap, Variable]:
     var = table.domain[var]
-    column_data = column_data_from_table(table, var)
+    column_data = table.get_column(var)
     data, colormap = colorize(var, column_data)
     return data, colormap, var
 

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -404,8 +404,8 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         elif np.sum(np.all(np.isfinite(self.data.X), axis=1)) < 2:
             msg = "Not enough valid data instances"
         else:
-            is_enabled = not np.isnan(self.data.get_column_view(
-                self.attr_color)[0].astype(float)).all()
+            is_enabled = \
+                not np.isnan(self.data.get_column(self.attr_color)).all()
         self.btn_vizrank.setToolTip(msg)
         self.btn_vizrank.setEnabled(is_enabled)
         if is_enabled:
@@ -522,15 +522,10 @@ class OWLinearProjection(OWAnchorProjectionWidget):
 
 def column_data(table, var, dtype):
     dtype = np.dtype(dtype)
-    col, copy = table.get_column_view(var)
-    if not isinstance(col.dtype.type, np.inexact):
-        col = col.astype(float)
-        copy = True
+    col = table.get_column(var)
     if dtype != col.dtype:
         col = col.astype(dtype)
-        copy = True
-
-    if not copy:
+    if col.base is not None:
         col = col.copy()
     return col
 

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -906,7 +906,7 @@ class OWLinePlot(OWWidget):
         if self.group_var is None:
             self._plot_group(data, np.arange(len(data)))
         else:
-            class_col_data, _ = self.data.get_column_view(self.group_var)
+            class_col_data = self.data.get_column(self.group_var)
             for index in range(len(self.group_var.values)):
                 indices = np.flatnonzero(class_col_data == index)
                 if len(indices) == 0:

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -1296,8 +1296,8 @@ class OWNomogram(OWWidget):
 
         orig_clv = original.class_var
         orig_data = classifier.original_data
-        values = (orig_clv.values[int(i)] for i in
-                  np.unique(orig_data.get_column_view(orig_clv)[0]))
+        values = (orig_clv.values[int(i)]
+                  for i in np.unique(orig_data.get_column(orig_clv)))
         class_var = DiscreteVariable(original.class_var.name, values)
         return Domain(attrs, class_var, original.metas)
 

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -392,8 +392,7 @@ class OWRadviz(OWAnchorProjectionWidget):
         is_enabled = self.data is not None and \
             len(self.primitive_variables) > 3 and \
             self.attr_color is not None and \
-            not np.isnan(self.data.get_column_view(
-                self.attr_color)[0].astype(float)).all() and \
+            not np.isnan(self.data.get_column(self.attr_color)).all() and \
             np.sum(np.all(np.isfinite(self.data.X), axis=1)) > 1 and \
             np.all(np.nan_to_num(np.nanstd(self.data.X, 0)) != 0)
         self.btn_vizrank.setEnabled(is_enabled)

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -438,8 +438,7 @@ class OWScatterPlot(OWDataProjectionWidget):
             err_msg = "Not enough features for ranking"
         elif self.attr_color is None:
             err_msg = "Color variable is not selected"
-        elif np.isnan(self.data.get_column_view(
-                self.attr_color)[0].astype(float)).all():
+        elif np.isnan(self.data.get_column(self.attr_color)).all():
             err_msg = "Color variable has no values"
         self.vizrank_button.setEnabled(not err_msg)
         self.vizrank_button.setToolTip(err_msg)

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -348,7 +348,7 @@ class OWSilhouettePlot(widget.OWWidget):
         if self._matrix is None:
             return
 
-        labels, _ = self.data.get_column_view(self.cluster_var)
+        labels = self.data.get_column(self.cluster_var)
         labels = np.asarray(labels, dtype=float)
         cluster_mask = np.isnan(labels)
         dist_mask = np.isnan(self._matrix).all(axis=0)
@@ -435,7 +435,7 @@ class OWSilhouettePlot(widget.OWWidget):
 
         if self._silplot is not None:
             if annot_var is not None:
-                column, _ = self.data.get_column_view(annot_var)
+                column = self.data.get_column(annot_var)
                 if self._mask is not None:
                     assert column.shape == self._mask.shape
                     # pylint: disable=invalid-unary-operand-type

--- a/Orange/widgets/visualize/owviolinplot.py
+++ b/Orange/widgets/visualize/owviolinplot.py
@@ -996,7 +996,7 @@ class OWViolinPlot(OWWidget):
         def compute_score(attr):
             if attr is group_var:
                 return 3
-            col = self.data.get_column_view(attr)[0].astype(float)
+            col = self.data.get_column(attr)
             groups = (col[group_col == i] for i in range(n_groups))
             groups = (col[~np.isnan(col)] for col in groups)
             groups = [group for group in groups if len(group)]
@@ -1010,7 +1010,7 @@ class OWViolinPlot(OWWidget):
         group_var = self.group_var
         if self.order_by_importance and group_var is not None:
             n_groups = len(group_var.values)
-            group_col = self.data.get_column_view(group_var)[0].astype(float)
+            group_col = self.data.get_column(group_var)
             self._sort_list(self._value_var_model, self._value_var_view,
                             compute_score)
         else:
@@ -1022,7 +1022,7 @@ class OWViolinPlot(OWWidget):
                 return 3
             if group is None:
                 return -1
-            col = self.data.get_column_view(group)[0].astype(float)
+            col = self.data.get_column(group)
             groups = (value_col[col == i] for i in range(len(group.values)))
             groups = (col[~np.isnan(col)] for col in groups)
             groups = [group for group in groups if len(group)]
@@ -1035,7 +1035,7 @@ class OWViolinPlot(OWWidget):
             return
         value_var = self.value_var
         if self.order_grouping_by_importance:
-            value_col = self.data.get_column_view(value_var)[0].astype(float)
+            value_col = self.data.get_column(value_var)
             self._sort_list(self._group_var_model, self._group_var_view,
                             compute_stat)
         else:
@@ -1068,10 +1068,10 @@ class OWViolinPlot(OWWidget):
         if not self.data:
             return
 
-        y = self.data.get_column_view(self.value_var)[0].astype(float)
+        y = self.data.get_column(self.value_var)
         x = None
         if self.group_var:
-            x = self.data.get_column_view(self.group_var)[0].astype(float)
+            x = self.data.get_column(self.group_var)
         self.graph.set_data(y, self.value_var, x, self.group_var)
 
     def apply_selection(self):

--- a/Orange/widgets/visualize/tests/test_owprojectionwidget.py
+++ b/Orange/widgets/visualize/tests/test_owprojectionwidget.py
@@ -184,7 +184,7 @@ class TestOWDataProjectionWidget(WidgetTest, ProjectionWidgetTestMixin,
         points = self.widget.graph.scatterplot_item.points()
         self.widget.graph.select_by_click(None, [points[1]])
         annotated = self.get_output(self.widget.Outputs.annotated_data)
-        np.testing.assert_equal(annotated.get_column_view('Selected')[0], np.array([0, 0, 1]))
+        np.testing.assert_equal(annotated.get_column('Selected'), np.array([0, 0, 1]))
 
     def test_saved_selection(self):
         self.send_signal(self.widget.Inputs.data, self.data)

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -143,9 +143,7 @@ class OWProjectionWidgetBase(OWWidget, openclass=True):
             assert attr.is_discrete
             return attr.values
 
-        all_data = self.data.get_column_view(attr)[0]
-        if all_data.dtype == object and attr.is_primitive():
-            all_data = all_data.astype(float)
+        all_data = self.data.get_column(attr)
         if filter_valid and self.valid_data is not None:
             all_data = all_data[self.valid_data]
         if not needs_merging:


### PR DESCRIPTION
##### Issue

There are two differences between `data.get_column_view(x)[0]` and `data.transform(Domain([x]).X[:, 0]`.

1. The former is simple and short.
2. The latter works. 

<img width="478" alt="Screen Shot 2022-07-12 at 11 55 39" src="https://user-images.githubusercontent.com/2387315/178464721-bad30bae-868e-4092-a0cb-bcfe1e749702.png">

If using Text to Columns used `get_column_view`, Apply Domain could not apply the second transformation because the required attribute (discretized petal length) is not in the domain.

Using `transform` works because it invokes `compute_value`.

##### Description of changes

Add `Table.get_column` which should be preferred over `Table.get_column_view`, and *must* be used in places where the variable is not guaranteed to exist (in particular, in `compute_value` functions).

If the column exists, it calls `get_column_view`, otherwise it uses `compute_value`.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
