### PR TITLE
Deprecate CD diagrams

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -11,6 +11,7 @@ Examples
 """
 
 import math
+import warnings
 
 import numpy as np
 import sklearn.metrics as skl_metrics
@@ -21,6 +22,8 @@ from Orange.misc.wrapper_meta import WrapperMeta
 
 __all__ = ["CA", "Precision", "Recall", "F1", "PrecisionRecallFSupport", "AUC",
            "MSE", "RMSE", "MAE", "R2", "compute_CD", "graph_ranks", "LogLoss"]
+
+from Orange.util import OrangeDeprecationWarning
 
 
 class ScoreMetaType(WrapperMeta):
@@ -388,7 +391,11 @@ def compute_CD(avranks, n, alpha="0.05", test="nemenyi"):
     according to given alpha (either alpha="0.05" or alpha="0.1") for average
     ranks and number of tested datasets N. Test can be either "nemenyi" for
     for Nemenyi two tailed test or "bonferroni-dunn" for Bonferroni-Dunn test.
+
+    This function is deprecated and will be removed in Orange 3.34.
     """
+    warnings.warn("compute_CD is deprecated and will be removed in Orange 3.34.",
+                  OrangeDeprecationWarning, stacklevel=2)
     k = len(avranks)
     d = {("nemenyi", "0.05"): [0, 0, 1.959964, 2.343701, 2.569032, 2.727774,
                                2.849705, 2.94832, 3.030879, 3.101730, 3.163684,
@@ -420,6 +427,8 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None,
     The image is ploted on `plt` imported using
     `import matplotlib.pyplot as plt`.
 
+    This function is deprecated and will be removed in Orange 3.34.
+
     Args:
         avranks (list of float): average ranks of methods.
         names (list of str): names of methods.
@@ -437,6 +446,8 @@ def graph_ranks(avranks, names, cd=None, cdmethod=None, lowv=None, highv=None,
         filename (str, optional): output file name (with extension). If not
             given, the function does not write a file.
     """
+    warnings.warn("graph_ranks is deprecated and will be removed in Orange 3.34.",
+                  OrangeDeprecationWarning, stacklevel=2)
     try:
         import matplotlib.pyplot as plt
         from matplotlib.backends.backend_agg import FigureCanvasAgg

--- a/Orange/tests/test_evaluation_scoring.py
+++ b/Orange/tests/test_evaluation_scoring.py
@@ -2,8 +2,11 @@
 # pylint: disable=missing-docstring
 
 import unittest
+from distutils.version import LooseVersion
+
 import numpy as np
 
+import Orange
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain
 from Orange.data import Table
 from Orange.classification import LogisticRegressionLearner, SklTreeLearner, NaiveBayesLearner,\
@@ -13,6 +16,7 @@ from Orange.evaluation import AUC, CA, Results, Recall, \
 from Orange.evaluation.scoring import Specificity
 from Orange.preprocess import discretize, Discretize
 from Orange.tests import test_filename
+from Orange.util import OrangeDeprecationWarning
 
 
 class TestScoreMetaType(unittest.TestCase):
@@ -320,15 +324,21 @@ class TestAUC(unittest.TestCase):
 class TestComputeCD(unittest.TestCase):
     def test_compute_CD(self):
         avranks = [1.9, 3.2, 2.8, 3.3]
-        cd = scoring.compute_CD(avranks, 30)
+        with self.assertWarns(OrangeDeprecationWarning):
+            cd = scoring.compute_CD(avranks, 30)
         np.testing.assert_almost_equal(cd, 0.856344)
 
-        cd = scoring.compute_CD(avranks, 30, test="bonferroni-dunn")
+        with self.assertWarns(OrangeDeprecationWarning):
+            cd = scoring.compute_CD(avranks, 30, test="bonferroni-dunn")
         np.testing.assert_almost_equal(cd, 0.798)
 
-        # Do what you will, just don't crash
-        scoring.graph_ranks(avranks, "abcd", cd)
-        scoring.graph_ranks(avranks, "abcd", cd, cdmethod=0)
+    def test_CD_deprecated(self):
+        if LooseVersion(Orange.__version__) >= LooseVersion("3.34"):
+            self.fail(
+                "`scoring.compute_CD` and `scoring.graph_ranks` were deprecated in "
+                "version 3.33. Please remove the deprecated methods, TestComputeCD, "
+                "and references in documentation."
+            )
 
 
 class TestLogLoss(unittest.TestCase):


### PR DESCRIPTION
CD diagrams crash headless tests on Linux. Because Orange does not use these functions we should just remove them.