### PR TITLE
FeatureConstructor: Don't replace missing strings with ?

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -1266,7 +1266,7 @@ class FeatureFunc:
     def extract_column(self, table: Table, var: Variable):
         data, _ = table.get_column_view(var)
         if var.is_string:
-            return list(map(var.str_val, data))
+            return data
         elif var.is_discrete and not self.use_values:
             values = np.array([*var.values, None], dtype=object)
             idx = data.astype(int)

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -20,7 +20,7 @@ from Orange.widgets.data.owfeatureconstructor import (
     DiscreteDescriptor, ContinuousDescriptor, StringDescriptor,
     construct_variables, OWFeatureConstructor,
     FeatureEditor, DiscreteFeatureEditor, FeatureConstructorHandler,
-    DateTimeDescriptor)
+    DateTimeDescriptor, StringFeatureEditor)
 
 from Orange.widgets.data.owfeatureconstructor import (
     freevars, validate_exp, FeatureFunc
@@ -404,6 +404,20 @@ class OWFeatureConstructorTests(WidgetTest):
         self.widget.apply()
         self.wait_until_finished(self.widget)
         self.assertTrue(self.widget.Error.more_values_needed.is_shown())
+
+    def test_missing_strings(self):
+        domain = Domain([], metas=[StringVariable("S1")])
+        data = Table.from_list(domain, [["A"], ["B"], [None]])
+        self.widget.setData(data)
+
+        editor = StringFeatureEditor()
+        editor.nameedit.setText("S2")
+        editor.expressionedit.setText("S1 + S1")
+        self.widget.addFeature(editor.editorData())
+        self.widget.apply()
+        output = self.get_output(self.widget.Outputs.data)
+        np.testing.assert_equal(output.metas,
+                                [["A", "AA"], ["B", "BB"], ["", ""]])
 
     @patch("Orange.widgets.data.owfeatureconstructor.QMessageBox")
     def test_fix_values(self, msgbox):


### PR DESCRIPTION
##### Issue

Fixes #5982.

String values were mapped through `StringVariable.str_val`, which was unnecessary (**is it?**) and replaced missing values with "?".

##### Description of changes

This PR just removes mapping, so the example in #5982 gives the desired input.

This treats missing strings as something that can be worked with, e.g. added. Given that missing strings are represented by empty strings, we do not have a good way of preventing it; replacing them with `None` would be ... artificial.

##### Includes
- [X] Code changes
- [X] Tests