### PR TITLE
[MNT][CI] Add libxcb-shape to linux system packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019]
+        os: [macos-11, windows-2019]
         python-version: [3.7, 3.8, 3.9, '3.10']
         tox_env: [orange-released]
         name: [Released]
@@ -121,7 +121,7 @@ jobs:
             python-version: 3.8
             tox_env: orange-latest
             name: Latest
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.8
             tox_env: orange-latest
             name: Latest
@@ -129,7 +129,7 @@ jobs:
             python-version: 3.9
             tox_env: pyqt6
             name: PyQt6
-          - os: macos-10.15
+          - os: macos-11
             python-version: 3.9
             tox_env: pyqt6
             name: PyQt6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libxcb-shape0
 
       - name: Install Tox
         run: |


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Linux gh actions runners started failing with 'qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.'

##### Description of changes

Add libxcb-shape to installed linux system packages
Also update deprecated macos-10.15 runners

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
