### PR TITLE
[ENH] Faster normalization, support Dask Tables

### DIFF
--- a/Orange/data/dask.py
+++ b/Orange/data/dask.py
@@ -3,6 +3,7 @@ import pickle
 import h5py
 import dask.array as da
 import numpy as np
+import pandas
 
 from Orange.data import Table
 
@@ -101,8 +102,72 @@ class DaskTable(Table):
         selection = self._values_filter_to_indicator(filter)
         return self[selection.compute()]
 
+    def _compute_basic_stats(self, columns=None,
+                             include_metas=False, compute_variance=False):
+        rr = []
+        stats = []
+        if not columns:
+            if self.domain.attributes:
+                rr.append(dask_stats(self._X,
+                                     compute_variance=compute_variance))
+            if self.domain.class_vars:
+                rr.append(dask_stats(self._Y,
+                                     compute_variance=compute_variance))
+            if include_metas and self.domain.metas:
+                rr.append(dask_stats(self.metas,
+                                     compute_variance=compute_variance))
+            if len(rr):
+                stats = da.concatenate(rr, axis=0)
+        else:
+            nattrs = len(self.domain.attributes)
+            for column in columns:
+                c = self.domain.index(column)
+                if 0 <= c < nattrs:
+                    S = dask_stats(self._X[:, [c]],
+                                   compute_variance=compute_variance)
+                elif c >= nattrs:
+                    if self._Y.ndim == 1 and c == nattrs:
+                        S = dask_stats(self._Y[:, None],
+                                       compute_variance=compute_variance)
+                    else:
+                        S = dask_stats(self._Y[:, [c - nattrs]],
+                                       compute_variance=compute_variance)
+                else:
+                    S = dask_stats(self._metas[:, [-1 - c]],
+                                   compute_variance=compute_variance)
+                stats.append(S)
+            stats = da.concatenate(stats, axis=0)
+        stats = stats.compute()
+        return stats
+
     def _update_locks(self, *args, **kwargs):
         return
+
+
+def dask_stats(X, compute_variance=False):
+    is_numeric = np.issubdtype(X.dtype, np.number)
+
+    if X.size and is_numeric:
+        nans = da.isnan(X).sum(axis=0).reshape(-1, 1)
+        return da.concatenate((
+            da.nanmin(X, axis=0).reshape(-1, 1),
+            da.nanmax(X, axis=0).reshape(-1, 1),
+            da.nanmean(X, axis=0).reshape(-1, 1),
+            da.nanvar(X, axis=0).reshape(-1, 1) if compute_variance else \
+                da.zeros((X.shape[1], 1)),
+            nans,
+            X.shape[0] - nans), axis=1)
+    else:
+        # metas is currently a numpy table
+        nans = (pandas.isnull(X).sum(axis=0) + (X == "").sum(axis=0)) \
+            if X.size else np.zeros(X.shape[1])
+        return np.column_stack((
+            np.tile(np.inf, X.shape[1]),
+            np.tile(-np.inf, X.shape[1]),
+            np.zeros(X.shape[1]),
+            np.zeros(X.shape[1]),
+            nans,
+            X.shape[0] - nans))
 
 
 def table_to_dask(table, filename):

--- a/Orange/data/dask.py
+++ b/Orange/data/dask.py
@@ -154,7 +154,7 @@ def dask_stats(X, compute_variance=False):
             da.nanmax(X, axis=0).reshape(-1, 1),
             da.nanmean(X, axis=0).reshape(-1, 1),
             da.nanvar(X, axis=0).reshape(-1, 1) if compute_variance else \
-                da.zeros((X.shape[1], 1)),
+                da.zeros(nans.shape),
             nans,
             X.shape[0] - nans), axis=1)
     else:

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -347,7 +347,7 @@ class SqlTable(Table):
         return False
 
     def _compute_basic_stats(self, columns=None,
-                             include_metas=False, compute_var=False):
+                             include_metas=False, compute_variance=False):
         if self.approx_len() > LARGE_TABLE:
             self = self.sample_time(DEFAULT_SAMPLE_TIME)
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1930,19 +1930,19 @@ class Table(Sequence, Storage):
 
     def _compute_basic_stats(self, columns=None,
                              include_metas=False, compute_variance=False):
-        if compute_variance:
-            raise NotImplementedError("computation of variance is "
-                                      "not implemented yet")
         W = self._W if self.has_weights() else None
         rr = []
         stats = []
         if not columns:
             if self.domain.attributes:
-                rr.append(fast_stats(self._X, W))
+                rr.append(fast_stats(self._X, W,
+                                     compute_variance=compute_variance))
             if self.domain.class_vars:
-                rr.append(fast_stats(self._Y, W))
+                rr.append(fast_stats(self._Y, W,
+                                     compute_variance=compute_variance))
             if include_metas and self.domain.metas:
-                rr.append(fast_stats(self.metas, W))
+                rr.append(fast_stats(self.metas, W,
+                                     compute_variance=compute_variance))
             if len(rr):
                 stats = np.vstack(tuple(rr))
         else:
@@ -1950,14 +1950,18 @@ class Table(Sequence, Storage):
             for column in columns:
                 c = self.domain.index(column)
                 if 0 <= c < nattrs:
-                    S = fast_stats(self._X[:, [c]], W and W[:, [c]])
+                    S = fast_stats(self._X[:, [c]], W and W[:, [c]],
+                                   compute_variance=compute_variance)
                 elif c >= nattrs:
                     if self._Y.ndim == 1 and c == nattrs:
-                        S = fast_stats(self._Y[:, None], W and W[:, None])
+                        S = fast_stats(self._Y[:, None], W and W[:, None],
+                                       compute_variance=compute_variance)
                     else:
-                        S = fast_stats(self._Y[:, [c - nattrs]], W and W[:, [c - nattrs]])
+                        S = fast_stats(self._Y[:, [c - nattrs]], W and W[:, [c - nattrs]],
+                                       compute_variance=compute_variance)
                 else:
-                    S = fast_stats(self._metas[:, [-1 - c]], W and W[:, [-1 - c]])
+                    S = fast_stats(self._metas[:, [-1 - c]], W and W[:, [-1 - c]],
+                                   compute_variance=compute_variance)
                 stats.append(S[0])
         return stats
 

--- a/Orange/statistics/basic_stats.py
+++ b/Orange/statistics/basic_stats.py
@@ -34,10 +34,11 @@ class BasicStats:
             = stats[0]
 
 class DomainBasicStats:
-    def __init__(self, data, include_metas=False):
+    def __init__(self, data, include_metas=False, compute_variance=False):
         self.domain = data.domain
         self.stats = [BasicStats(s) for s in
-                      data._compute_basic_stats(include_metas=include_metas)]
+                      data._compute_basic_stats(include_metas=include_metas,
+                                                compute_variance=compute_variance)]
 
     def __getitem__(self, index):
         """

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -355,8 +355,8 @@ def stats(X, weights=None, compute_variance=False):
         return np.column_stack((
             np.nanmin(X, axis=0),
             np.nanmax(X, axis=0),
-            np.nanmean(X, axis=0) if not weighted else weighted_mean(),
-            np.nanvar(X, axis=0) if compute_variance else \
+            nanmean(X, axis=0) if not weighted else weighted_mean(),
+            nanvar(X, axis=0) if compute_variance else \
                 np.zeros(X.shape[1] if X.ndim == 2 else 1),
             nans,
             X.shape[0] - nans))

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -361,7 +361,7 @@ def stats(X, weights=None, compute_variance=False):
             nans,
             X.shape[0] - nans))
     elif is_sparse and X.size:
-        if compute_variance:
+        if compute_variance and weighted:
             raise NotImplementedError
 
         non_zero = np.bincount(X.nonzero()[1], minlength=X.shape[1])
@@ -370,7 +370,8 @@ def stats(X, weights=None, compute_variance=False):
             nanmin(X, axis=0),
             nanmax(X, axis=0),
             nanmean(X, axis=0) if not weighted else weighted_mean(),
-            np.zeros(X.shape[1]),      # variance not supported
+            nanvar(X, axis=0) if compute_variance else \
+                np.zeros(X.shape[1] if X.ndim == 2 else 1),
             X.shape[0] - non_zero,
             non_zero))
     else:

--- a/Orange/tests/test_dasktable.py
+++ b/Orange/tests/test_dasktable.py
@@ -5,7 +5,8 @@ import numpy.testing
 import dask.array as da
 
 from Orange.data import Table, Domain
-from Orange.data.dask import DaskTable
+from Orange.data.dask import DaskTable, dask_stats
+from Orange.statistics.basic_stats import DomainBasicStats
 from Orange.tests import named_file
 
 
@@ -65,3 +66,40 @@ class TableTestCase(unittest.TestCase):
                 self.same_tables(zoo, dzoo2)
                 dzoo2.close()
             dzoo.close()
+
+    def test_dask_stats(self):
+        with open_as_dask("zoo") as data:
+            stats = dask_stats(data.X)
+            self.assertIsInstance(stats, da.Array)
+            s = stats.compute()
+            self.assertEqual(s.shape, (data.X.shape[1], 6))
+            numpy.testing.assert_almost_equal(s[0],
+                                              [0., 1., 0.4257426, 0., 0., 101.])
+            stats = dask_stats(data.X, compute_variance=True)
+            s = stats.compute()
+            numpy.testing.assert_almost_equal(s[0],
+                                              [0., 1., 0.4257426, 0.2444858, 0., 101.])
+
+    def test_dask_stats_1d_matrix(self):
+        with open_as_dask("zoo") as data:
+            stats = dask_stats(data.Y)
+            self.assertIsInstance(stats, da.Array)
+            s = stats.compute()
+            self.assertEqual(s.shape, (1, 6))
+            numpy.testing.assert_almost_equal(s[0],
+                                              [0., 6., 3.41584158, 0., 0., 101.])
+
+    def test_domain_basic_stats(self):
+        with open_as_dask("housing") as data:
+            print(len(data.domain))
+            stats = DomainBasicStats(data, compute_variance=True)
+            f = stats[0]
+            self.assertEqual(f.min, 0.00632)
+            self.assertEqual(f.max, 88.9762)
+            self.assertAlmostEqual(f.mean, 3.6135236)
+            self.assertAlmostEqual(f.var, 73.8403597)
+            c = stats[13]  # class value
+            self.assertEqual(c.min, 5)
+            self.assertEqual(c.max, 50)
+            self.assertAlmostEqual(c.mean, 22.5328063)
+            self.assertAlmostEqual(c.var, 84.4195562)

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -119,6 +119,13 @@ class TestUtil(unittest.TestCase):
                                            [0, 0, 0, 0, 3, 0],
                                            [0, 0, 0, 0, 3, 0]])
 
+        r = stats(X, compute_variance=True)
+        np.testing.assert_almost_equal(r, [[0, 1, 1/3, 2/9, 2, 1],
+                                           [0, 1, 1/3, 2/9, 2, 1],
+                                           [0, 1, 1/3, 2/9, 2, 1],
+                                           [0, 0, 0, 0, 3, 0],
+                                           [0, 0, 0, 0, 3, 0]])
+
     def test_stats_weights(self):
         X = np.arange(4).reshape(2, 2).astype(float)
         weights = np.array([1, 3])
@@ -134,6 +141,9 @@ class TestUtil(unittest.TestCase):
         weights = np.array([1, 3])
         np.testing.assert_equal(stats(X, weights), [[0, 2, 1.5, 0, 1, 1],
                                                     [1, 3, 2.5, 0, 0, 2]])
+
+        with self.assertRaises(NotImplementedError):
+            stats(X, weights, compute_variance=True)
 
     def test_stats_non_numeric(self):
         X = np.array([


### PR DESCRIPTION
##### Issue
Normalization does not work for dask arrays. The computation of distributions is slow (it requires sorting). Fixes #5219


##### Description of changes
Use "fast stats" for Normalization.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
