### PR TITLE
OWBoxplot: add tests for dask

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -160,7 +160,7 @@ class OWBoxPlot(widget.OWWidget):
         self._axis_font.setPixelSize(12)
         self._label_font = QFont()
         self._label_font.setPixelSize(11)
-        self.dataset = None
+        self.sample = self.dataset = None
         self.stats = []
         self.dist = self.conts = None
 


### PR DESCRIPTION
##### Changes
- added 2 tests to make sure sampling is working correctly for DaskTables
- changed some of the standard tests to make sure they use the already defined datasets instead of opening new Tables and subsequently not testing functionality on DaskTables