### PR TITLE
[FIX] test_owfile: Fix unreliable `test_warning_from_another_thread`

### DIFF
--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -3,16 +3,16 @@
 from os import path, remove, getcwd
 from os.path import dirname
 import unittest
+from threading import Thread
 from unittest.mock import Mock, patch
 import pickle
 import tempfile
 import warnings
-import time
 
 import numpy as np
 import scipy.sparse as sp
 
-from AnyQt.QtCore import QMimeData, QPoint, Qt, QUrl, QThread, QObject, QPointF
+from AnyQt.QtCore import QMimeData, QPoint, Qt, QUrl, QPointF
 from AnyQt.QtGui import QDragEnterEvent, QDropEvent
 from AnyQt.QtWidgets import QComboBox
 
@@ -666,23 +666,13 @@ a
 
     @patch("os.path.exists", new=lambda _: True)
     def test_warning_from_another_thread(self):
-        class AnotherWidget(QObject):
-            # This must be a method, not a staticmethod to run in the thread
-            def issue_warning(self):  # pylint: disable=no-self-use
-                time.sleep(0.1)
-                warnings.warn("warning from another thread")
-                warning_thread.quit()
-
         def read():
-            warning_thread.start()
-            time.sleep(0.2)
+            thread = Thread(
+                target=lambda: warnings.warn("warning from another thread")
+            )
+            thread.start()
+            thread.join()
             return Table(TITANIC_PATH)
-
-        warning_thread = QThread()
-        another_widget = AnotherWidget()
-        another_widget.moveToThread(warning_thread)
-        warning_thread.started.connect(another_widget.issue_warning)
-
         reader = Mock()
         reader.read = read
         self.widget._get_reader = lambda: reader
@@ -693,7 +683,6 @@ a
         with self.assertWarns(UserWarning):
             self.widget._try_load()
             self.assertFalse(self.widget.Warning.load_warning.is_shown())
-
 
     @patch("os.path.exists", new=lambda _: True)
     def test_warning_from_this_thread(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix intermittent test failure:
```
FAIL: test_warning_from_another_thread (Orange.widgets.data.tests.test_owfile.TestOWFile)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/unittest/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "/Users/runner/work/orange3/orange3/.tox/orange-released/lib/python3.10/site-packages/Orange/widgets/data/tests/test_owfile.py", line 693, in test_warning_from_another_thread
    with self.assertWarns(UserWarning):
AssertionError: UserWarning not triggered
```

##### Description of changes

Replace use of `time.sleep` to sequence threaded code.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
