### PR TITLE
ModelClassification: Implement predict_proba

### DIFF
--- a/Orange/classification/base_classification.py
+++ b/Orange/classification/base_classification.py
@@ -16,7 +16,8 @@ class LearnerClassification(Learner):
 
 
 class ModelClassification(Model):
-    pass
+    def predict_proba(self, data):
+        return self(data, ret=Model.Probs)
 
 
 class SklModelClassification(SklModel, ModelClassification):

--- a/Orange/classification/catgb.py
+++ b/Orange/classification/catgb.py
@@ -4,8 +4,8 @@ import numpy as np
 
 import catboost
 
-from Orange.base import CatGBBaseLearner
-from Orange.classification import Learner
+from Orange.base import CatGBBaseLearner, CatGBModel
+from Orange.classification import Learner, Model
 from Orange.data import Variable, DiscreteVariable, Table
 from Orange.preprocess.score import LearnerScorer
 
@@ -21,5 +21,10 @@ class _FeatureScorerMixin(LearnerScorer):
         return model.cat_model.feature_importances_, model.domain.attributes
 
 
+class CatGBClsModel(CatGBModel, Model):
+    pass
+
+
 class CatGBClassifier(CatGBBaseLearner, Learner, _FeatureScorerMixin):
     __wraps__ = catboost.CatBoostClassifier
+    __returns__ = CatGBClsModel

--- a/Orange/classification/xgb.py
+++ b/Orange/classification/xgb.py
@@ -6,7 +6,7 @@ import numpy as np
 import xgboost
 
 from Orange.base import XGBBase
-from Orange.classification import Learner
+from Orange.classification import Learner, SklModel
 from Orange.data import Variable, DiscreteVariable, Table
 from Orange.preprocess.score import LearnerScorer
 
@@ -24,6 +24,7 @@ class _FeatureScorerMixin(LearnerScorer):
 
 class XGBClassifier(XGBBase, Learner, _FeatureScorerMixin):
     __wraps__ = xgboost.XGBClassifier
+    __returns__ = SklModel
 
     def __init__(self,
                  max_depth=None,
@@ -87,6 +88,7 @@ class XGBClassifier(XGBBase, Learner, _FeatureScorerMixin):
 
 class XGBRFClassifier(XGBBase, Learner, _FeatureScorerMixin):
     __wraps__ = xgboost.XGBRFClassifier
+    __returns__ = SklModel
 
     def __init__(self,
                  max_depth=None,

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -269,6 +269,19 @@ class ModelTest(unittest.TestCase):
                     (1, len(data.domain.class_var.values)), res.shape
                 )
 
+    def test_predict_proba(self):
+        data = Table("heart_disease")
+        for learner in all_learners():
+            with self.subTest(learner.__name__):
+                if learner in (ThresholdLearner, CalibratedLearner):
+                    model = learner(LogisticRegressionLearner())(data)
+                else:
+                    model = learner()(data)
+                probs = model.predict_proba(data)
+                shape = (len(data), len(data.domain.class_var.values))
+                self.assertEqual(probs.shape, shape)
+                self.assertTrue(np.all(np.sum(probs, axis=1) - 1 < 0.0001))
+
 
 class ExpandProbabilitiesTest(unittest.TestCase):
     def prepareTable(self, rows, attr, vars, class_var_domain):

--- a/Orange/tree.py
+++ b/Orange/tree.py
@@ -376,3 +376,6 @@ class TreeModel(TreeModelInterface):
         conditions = OrderedDict()
         self.root.parent = None
         _compute_subtree(self.root)
+
+    def predict_proba(self, data):
+        return self(data, ret=TreeModelInterface.Probs)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implement `predict_proba` for classification models to be consistent with sklearn models interface.

##### Description of changes
- add predict_proba to ModelClassification class
- add predict_proba to TreeModel class
- introduce new class CatGBClsModel

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
