### PR TITLE
Rank: Move TableView and TableModel to gui

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 from typing import Any, Callable, List, Tuple
 
 import numpy as np
+from scipy.sparse import issparse
+
 from AnyQt.QtCore import (
     QItemSelection, QItemSelectionModel, QItemSelectionRange, Qt,
     pyqtSignal as Signal
@@ -15,16 +17,14 @@ from AnyQt.QtWidgets import (
     QRadioButton, QStackedWidget, QTableView
 )
 
-from Orange.widgets.gui import TableView, BarRatioTableModel
 from orangewidget.settings import IncompatibleContext
-from scipy.sparse import issparse
-
 from Orange.data import (
     ContinuousVariable, DiscreteVariable, Domain, StringVariable, Table
 )
 from Orange.data.util import get_unique_names_duplicates
 from Orange.preprocess import score
 from Orange.widgets import gui, report
+from Orange.widgets.gui import BarRatioTableModel
 from Orange.widgets.settings import (
     ContextSetting, DomainContextHandler, Setting
 )
@@ -32,7 +32,8 @@ from Orange.widgets.unsupervised.owdistances import InterruptException
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.utils.widgetpreview import WidgetPreview
-from Orange.widgets.widget import AttributeList, Input, MultiInput, Output, Msg, OWWidget
+from Orange.widgets.widget import AttributeList, Input, MultiInput, Output, Msg, \
+    OWWidget
 
 log = logging.getLogger(__name__)
 

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -21,7 +21,7 @@ from Orange.classification import LogisticRegressionLearner
 from Orange.regression import LinearRegressionLearner
 from Orange.projection import PCA
 from Orange.widgets.data.owrank import OWRank, ProblemType, CLS_SCORES, \
-    REG_SCORES, TableModel
+    REG_SCORES, BarRatioTableModel
 from Orange.widgets.tests.base import WidgetTest, datasets
 from Orange.widgets.widget import AttributeList
 
@@ -551,25 +551,6 @@ class TestOWRank(WidgetTest):
         self.wait_until_finished()
         output = self.get_output(self.widget.Outputs.reduced_data)
         self.assertEqual(len(output), len(self.housing))
-
-
-class TestRankModel(GuiTest):
-    @staticmethod
-    def test_argsort():
-        func = TableModel()._argsortData  # pylint: disable=protected-access
-        assert_equal = np.testing.assert_equal
-
-        test_array = np.array([4.2, 7.2, np.nan, 1.3, np.nan])
-        assert_equal(func(test_array, Qt.AscendingOrder)[:3], [3, 0, 1])
-        assert_equal(func(test_array, Qt.DescendingOrder)[:3], [1, 0, 3])
-
-        test_array = np.array([4, 7, 2])
-        assert_equal(func(test_array, Qt.AscendingOrder), [2, 0, 1])
-        assert_equal(func(test_array, Qt.DescendingOrder), [1, 0, 2])
-
-        test_array = np.array(["Bertha", "daniela", "ann", "Cecilia"])
-        assert_equal(func(test_array, Qt.AscendingOrder), [2, 0, 3, 1])
-        assert_equal(func(test_array, Qt.DescendingOrder), [1, 3, 0, 2])
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -12,7 +12,6 @@ from AnyQt.QtCore import Qt, QItemSelection, QItemSelectionModel, \
 from AnyQt.QtWidgets import QCheckBox, QApplication
 
 from orangewidget.settings import Context, IncompatibleContext
-from orangewidget.tests.base import GuiTest
 
 from Orange.data import Table, Domain, ContinuousVariable, DiscreteVariable
 from Orange.modelling import RandomForestLearner, SGDLearner
@@ -21,7 +20,7 @@ from Orange.classification import LogisticRegressionLearner
 from Orange.regression import LinearRegressionLearner
 from Orange.projection import PCA
 from Orange.widgets.data.owrank import OWRank, ProblemType, CLS_SCORES, \
-    REG_SCORES, BarRatioTableModel
+    REG_SCORES
 from Orange.widgets.tests.base import WidgetTest, datasets
 from Orange.widgets.widget import AttributeList
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -1,20 +1,19 @@
 """
 Wrappers for controls used in widgets
 """
-import math
-import numpy as np
-
 import logging
 import sys
 import warnings
 import weakref
 from collections.abc import Sequence
 
+import math
+import numpy as np
+
 from AnyQt import QtWidgets, QtCore, QtGui
-from AnyQt.QtCore import Qt, QSize, QItemSelection, pyqtSignal as Signal
+from AnyQt.QtCore import Qt, QSize, QItemSelection
 from AnyQt.QtGui import QColor, QWheelEvent
-from AnyQt.QtWidgets import QWidget, QListView, QComboBox, QTableView, \
-    QItemDelegate
+from AnyQt.QtWidgets import QWidget, QListView, QComboBox
 
 from orangewidget.utils.itemdelegates import (
     BarItemDataDelegate as _BarItemDataDelegate

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -2,6 +2,7 @@
 Wrappers for controls used in widgets
 """
 import math
+import numpy as np
 
 import logging
 import sys
@@ -10,9 +11,10 @@ import weakref
 from collections.abc import Sequence
 
 from AnyQt import QtWidgets, QtCore, QtGui
-from AnyQt.QtCore import Qt, QSize, QItemSelection
+from AnyQt.QtCore import Qt, QSize, QItemSelection, pyqtSignal as Signal
 from AnyQt.QtGui import QColor, QWheelEvent
-from AnyQt.QtWidgets import QWidget, QListView, QComboBox
+from AnyQt.QtWidgets import QWidget, QListView, QComboBox, QTableView, \
+    QItemDelegate
 
 from orangewidget.utils.itemdelegates import (
     BarItemDataDelegate as _BarItemDataDelegate
@@ -40,7 +42,7 @@ from orangewidget.gui import (
     ControlledCallback, ControlledCallFront, ValueCallback, connectControl,
     is_macstyle
 )
-
+from orangewidget.utils.itemmodels import PyTableModel
 
 try:
     # Some Orange widgets might expect this here
@@ -50,11 +52,10 @@ except ImportError:
     pass  # Neither WebKit nor WebEngine are available
 
 import Orange.data
-from Orange.widgets.utils import getdeepattr
+from Orange.widgets.utils import getdeepattr, vartype
 from Orange.data import \
     ContinuousVariable, StringVariable, TimeVariable, DiscreteVariable, \
     Variable, Value
-from Orange.widgets.utils import vartype
 
 __all__ = [
     # Re-exported
@@ -78,7 +79,7 @@ __all__ = [
     "createAttributePixmap", "attributeIconDict", "attributeItem",
     "listView", "ListViewWithSizeHint", "listBox", "OrangeListBox",
     "TableValueRole", "TableClassValueRole", "TableDistribution",
-    "TableVariable", "TableBarItem", "palette_combo_box"
+    "TableVariable", "TableBarItem", "palette_combo_box", "BarRatioTableModel"
 ]
 
 
@@ -663,3 +664,73 @@ class HScrollStepMixin:
             super().wheelEvent(new_event)
         else:
             super().wheelEvent(event)
+
+
+class BarRatioTableModel(PyTableModel):
+    """A model for displaying python tables.
+    Adds a BarRatioRole that returns Data, normalized between the extremes.
+    NaNs are listed last when sorting."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._extremes = {}
+
+    def data(self, index, role=Qt.DisplayRole):
+        if role == BarRatioRole and index.isValid():
+            value = super().data(index, Qt.EditRole)
+            if not isinstance(value, float):
+                return None
+            vmin, vmax = self._extremes.get(index.column(), (-np.inf, np.inf))
+            value = (value - vmin) / ((vmax - vmin) or 1)
+            return value
+
+        if role == Qt.DisplayRole and index.column() != 0:
+            role = Qt.EditRole
+
+        value = super().data(index, role)
+
+        # Display nothing for non-existent attr value counts in column 1
+        if role == Qt.EditRole \
+                and index.column() == 1 and np.isnan(value):
+            return ''
+
+        return value
+
+    def headerData(self, section, orientation, role=Qt.DisplayRole):
+        if role == Qt.InitialSortOrderRole:
+            return Qt.DescendingOrder if section > 0 else Qt.AscendingOrder
+        return super().headerData(section, orientation, role)
+
+    def setExtremesFrom(self, column, values):
+        """Set extremes for column's ratio bars from values"""
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", ".*All-NaN slice encountered.*", RuntimeWarning)
+                vmin = np.nanmin(values)
+            if np.isnan(vmin):
+                raise TypeError
+        except TypeError:
+            vmin, vmax = -np.inf, np.inf
+        else:
+            vmax = np.nanmax(values)
+        self._extremes[column] = (vmin, vmax)
+
+    def resetSorting(self, yes_reset=False):
+        # pylint: disable=arguments-differ
+        """We don't want to invalidate our sort proxy model everytime we
+        wrap a new list. Our proxymodel only invalidates explicitly
+        (i.e. when new data is set)"""
+        if yes_reset:
+            super().resetSorting()
+
+    def _argsortData(self, data, order):
+        if data.dtype not in (float, int):
+            data = np.char.lower(data)
+        indices = np.argsort(data, kind='mergesort')
+        if order == Qt.DescendingOrder:
+            indices = indices[::-1]
+            if data.dtype == float:
+                # Always sort NaNs last
+                return np.roll(indices, -np.isnan(data).sum())
+        return indices

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -1,9 +1,12 @@
 from unittest.mock import patch
 
+import numpy as np
+
 from AnyQt.QtCore import Qt
 
 from Orange.data import ContinuousVariable
 from Orange.widgets import gui
+from Orange.widgets.gui import BarRatioTableModel
 from Orange.widgets.tests.base import GuiTest
 from Orange.widgets.utils.itemmodels import VariableListModel
 from Orange.widgets.widget import OWWidget
@@ -108,3 +111,22 @@ class ComboBoxTest(GuiTest):
         with self.assertWarns(DeprecationWarning):
             gui.comboBox(None, None, "foo", valueType=int, editable=True)
         self.assertEqual(gui_combobox.call_args[1], {"editable": True})
+
+
+class TestRankModel(GuiTest):
+    @staticmethod
+    def test_argsort():
+        func = BarRatioTableModel()._argsortData  # pylint: disable=protected-access
+        assert_equal = np.testing.assert_equal
+
+        test_array = np.array([4.2, 7.2, np.nan, 1.3, np.nan])
+        assert_equal(func(test_array, Qt.AscendingOrder)[:3], [3, 0, 1])
+        assert_equal(func(test_array, Qt.DescendingOrder)[:3], [1, 0, 3])
+
+        test_array = np.array([4, 7, 2])
+        assert_equal(func(test_array, Qt.AscendingOrder), [2, 0, 1])
+        assert_equal(func(test_array, Qt.DescendingOrder), [1, 0, 2])
+
+        test_array = np.array(["Bertha", "daniela", "ann", "Cecilia"])
+        assert_equal(func(test_array, Qt.AscendingOrder), [2, 0, 3, 1])
+        assert_equal(func(test_array, Qt.DescendingOrder), [1, 3, 0, 2])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Rank's TableView and TableModel are not independent modules that can be called for other widgets.

##### Description of changes
Move the two classes to gui.py, so other widgets can use them.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
