### PR TITLE
Confusion Matrix: Add Sum of probabilities

### DIFF
--- a/Orange/widgets/evaluate/owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/owconfusionmatrix.py
@@ -101,6 +101,11 @@ class OWConfusionMatrix(widget.OWWidget):
                   "Proportion of predicted",
                   "Proportion of actual",
                   "Sum of probabilities"]
+    qu_tooltips = ["Number of correctly and incorrectly classified instances",
+                   "Proportion of predicted",
+                   "Proportion of actual",
+                   "Number of instances, distributed across columns "
+                   "according to predicted probabilities"]
 
     settings_version = 1
     settingsHandler = ClassValuesContextHandler()
@@ -150,8 +155,8 @@ class OWConfusionMatrix(widget.OWWidget):
 
         sbox = gui.hBox(box)
         gui.rubber(sbox)
-        gui.comboBox(sbox, self, "selected_quantity",
-                     items=self.quantities, label="Show: ",
+        gui.comboBox(sbox, self, "selected_quantity", label="Show: ",
+                     items=self.quantities, tooltips=self.qu_tooltips,
                      orientation=Qt.Horizontal, callback=self._update)
 
         self.tablemodel = QStandardItemModel(self)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Confusion matrix currently presents and evaluates the predicted classes. When one wants to evaluate the probability outputs it is less useful. For example, a majority class could be predicted for all instances, but the probabilities of several minority classes are still important (and differ among predictions).

##### Description of changes
Introduce `Sum of probabilities` Show option, which uses the sum of probabilities of the predicted class (instead of predicted class counter) when constructing the matrix.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
