### PR TITLE
owscatterplotgraph.AxisItem: Improve time labels

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -344,6 +344,11 @@ class AxisItem(AxisItem):
             return super().tickValues(minVal, maxVal, size)
 
         ticks = bins.thresholds
+        # Remove ticks that will later be removed in AxisItem.generateDrawSpecs
+        # because they are out of range. Removing them here is needed so that
+        # they do not affect spaces and label format
+        ticks = ticks[(ticks[0] < minVal)
+                      :len(ticks) - (ticks[-1] > maxVal)]
 
         max_steps = max(int(size / self._label_width), 1)
         if len(ticks) > max_steps:


### PR DESCRIPTION
##### Issue

Fixes #6103 

- `Orange.widgets.visualize.owscatterplotgraph.AxisItem.tickValue` generates ticks that include the start of the first and the end of the last interval, i.e. 29 17h and 30 0h. 
- `Orange.widgets.visualize.owscatterplotgraph.AxisItem.tickStrings` uses format `"$d %Hh"` because `min_day` is not equal to`max_day`.
- Pyqtgraph's `AxisItem.generateDrawSpec` however discovers that the first and the last label are outside the data and removes them.
- 
##### Description of changes

We cannot override `AxisItem.generateDrawSpec`, but we can second-guess it: we know which label it will remove, and 
do not generate them in the first place.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
