### PR TITLE
Fix errors visible after removing pyqtgraph's except hook override

### DIFF
--- a/Orange/widgets/utils/tests/concurrent_example.py
+++ b/Orange/widgets/utils/tests/concurrent_example.py
@@ -69,7 +69,7 @@ class OWConcurrentWidget(OWDataProjectionWidget, ConcurrentWidgetMixin):
         if self.task is not None:
             self.cancel()
             self.run_button.setText("Resume")
-            self.commit()
+            self.commit.deferred()
         # Resume task
         else:
             self._run()


### PR DESCRIPTION
##### Issue
Merging https://github.com/biolab/orange-widget-base/pull/204 showed an error in `-latest` tests.
