### PR TITLE
[FIX] Handle timezones in Edit Domain

### DIFF
--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -921,13 +921,18 @@ class TestReinterpretTransforms(TestCase):
         times = (
             ["07.02.2022", "18.04.2021"],  # date only
             ["07.02.2022 01:02:03", "18.04.2021 01:02:03"],  # datetime
+            # datetime with timezone
+            ["2021-02-08 01:02:03+01:00", "2021-02-07 01:02:03+01:00"],
             ["010203", "010203"],  # time
             ["02-07", "04-18"],
         )
-        formats = ["25.11.2021", "25.11.2021 00:00:00", "000000", "11-25"]
+        formats = [
+            "25.11.2021", "25.11.2021 00:00:00", "2021-11-25 00:00:00", "000000", "11-25"
+        ]
         expected = [
             [d("2022-02-07"), d("2021-04-18")],
             [d("2022-02-07 01:02:03"), d("2021-04-18 01:02:03")],
+            [d("2021-02-08 01:02:03+0100"), d("2021-02-07 01:02:03+0100")],
             [d("01:02:03"), d("01:02:03")],
             [d("1900-02-07"), d("1900-04-18")],
         ]
@@ -951,6 +956,16 @@ class TestReinterpretTransforms(TestCase):
             ttable.metas,
             np.array(list(chain(expected, expected)), dtype=float).transpose()
         )
+
+    def test_raise_pandas_version(self):
+        """
+        When this test start to fail:
+        - remove this test
+        - remove if clause in datetime_to_epoch function and supporting comments
+        - set pandas dependency version to pandas>=1.4
+        """
+        from datetime import datetime
+        self.assertLess(datetime.today(), datetime(2023, 1, 1))
 
     def test_reinterpret_string(self):
         table = self.data_str


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Transforming to Time variable fails when timezone is in strings

##### Description of changes
Correctly handle timezones in data time

Additionally: First I planned to raise the Pandas version to 1.4 since this version already supports subtracting different timezones. It was impossible since Pandas>=1.4 does not support Python 3.7 anymore, so building documentation fails (by readthedcos) since they build documentation on Python 3.7. Setting different versions of python for rtd is supported by the config file, but it cannot be used with multiple subprojects. We cannot raise the Pandas' version until they start supporting config files for subprojects or building on python 3.8.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
