### PR TITLE
[FIX] plotutils - replace MidButton with MiddleButton

### DIFF
--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -244,7 +244,7 @@ class InteractiveViewBox(pg.ViewBox):
             # uses mapRectFromParent. We don't want to copy the parts of the
             # method that work, hence we only use our code under the following
             # conditions.
-            if ev.button() & (Qt.LeftButton | Qt.MidButton) \
+            if ev.button() & (Qt.LeftButton | Qt.MiddleButton) \
                     and self.state['mouseMode'] == pg.ViewBox.RectMode \
                     and ev.isFinish():
                 zoom()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Qt.Midbutton is deprecated and removed in PyQt6

##### Description of changes
Replace it with Qt.MiddleButton

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
