### PR TITLE
[FIX] Group By - fix std and sum for TimeVariable

### DIFF
--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -962,6 +962,7 @@ class TestReinterpretTransforms(TestCase):
         When this test start to fail:
         - remove this test
         - remove if clause in datetime_to_epoch function and supporting comments
+        - remove same if clause in var function in owgroupby (line 77, 78)
         - set pandas dependency version to pandas>=1.4
         """
         from datetime import datetime


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixe https://github.com/biolab/orange3/issues/6125

##### Description of changes
- use Series's std instead of GroupBy one since GB aggregations do not support DateTime data https://github.com/pandas-dev/pandas/issues/48481
- for variance, first, transform DateTime to Unix epoch since Panda's variance does not support DateTime
- std and span transform TimeDelta to seconds (Orange does not have TimeDelta type)
- I disabled the sum for TimeVariable since it doesn't make sense to compute data/times' sums.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
