### PR TITLE
[FIX] owboxplot: Fix an error in widget cleanup during tests

### DIFF
--- a/Orange/widgets/data/utils/pythoneditor/tests/test_api.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_api.py
@@ -19,11 +19,13 @@ class _BaseTest(WidgetTest):
     """
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
 
     def tearDown(self):
         self.qpart.terminate()
+        super().tearDown()
 
 
 class Selection(_BaseTest):

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_bracket_highlighter.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_bracket_highlighter.py
@@ -19,11 +19,13 @@ class Test(WidgetTest):
     """
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
 
     def tearDown(self):
         self.qpart.terminate()
+        super().tearDown()
 
     def _verify(self, actual, expected):
         converted = []

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_draw_whitespace.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_draw_whitespace.py
@@ -18,11 +18,13 @@ class Test(WidgetTest):
     """
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
 
     def tearDown(self):
         self.qpart.terminate()
+        super().tearDown()
 
     def _ws_test(self,
                  text,

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_edit.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_edit.py
@@ -22,11 +22,13 @@ class Test(WidgetTest):
     """Base class for tests
     """
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
 
     def tearDown(self):
         self.qpart.terminate()
+        super().tearDown()
 
     def test_overwrite_edit(self):
         self.qpart.show()

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_indent.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_indent.py
@@ -21,11 +21,13 @@ class Test(WidgetTest):
     """
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
 
     def tearDown(self):
         self.qpart.terminate()
+        super().tearDown()
 
     def test_1(self):
         # Indent with Tab

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_rectangular_selection.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_rectangular_selection.py
@@ -27,12 +27,14 @@ class _Test(WidgetTest):
     """
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
 
     def tearDown(self):
         self.qpart.hide()
         self.qpart.terminate()
+        super().tearDown()
 
     def test_real_to_visible(self):
         self.qpart.text = 'abcdfg'

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_vim.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_vim.py
@@ -24,6 +24,7 @@ class _Test(WidgetTest):
     """
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(SimpleWidget)
         self.qpart = self.widget.qpart
         self.qpart.lines = ['The quick brown fox',
@@ -38,6 +39,8 @@ class _Test(WidgetTest):
     def tearDown(self):
         self.qpart.hide()
         self.qpart.terminate()
+        del self.qpart
+        super().tearDown()
 
     def _onVimModeChanged(self, _, mode):
         self.vimMode = mode

--- a/Orange/widgets/tests/test_workflows.py
+++ b/Orange/widgets/tests/test_workflows.py
@@ -4,6 +4,8 @@ from os.path import isfile, join, dirname
 import unittest
 import pkg_resources
 
+from AnyQt.QtTest import QTest
+
 from orangecanvas.registry import WidgetRegistry
 from orangewidget.workflow import widgetsscheme
 
@@ -46,6 +48,7 @@ class TestWorkflows(GuiTest):
             new_scheme.widget_manager.set_creation_policy(
                 new_scheme.widget_manager.Immediate
             )
+            new_scheme.signal_manager.pause()
             with open(ows_file, "rb") as f:
                 try:
                     with excepthook_catch(raise_on_exit=True):
@@ -55,6 +58,9 @@ class TestWorkflows(GuiTest):
                               format(ows_file, str(e)))
                 finally:
                     new_scheme.clear()
+                    new_scheme.deleteLater()
+                    del new_scheme
+                    QTest.qWait(0)
 
     def test_examples_order(self):
         # register test entrypoints

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -637,7 +637,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.Outputs.annotated_data.send(annotated_data)
 
     def eventFilter(self, obj, event):
-        if obj is self.view.viewport() and event.type() == QEvent.Resize:
+        if event.type() == QEvent.Resize and obj is self.view.viewport():
             # NOTE: not using viewport.width(), due to 'transient' scroll bars
             # (macOS). Viewport covers the whole view, but QGraphicsView still
             # scrolls left, right with scroll bar extent (other
@@ -649,8 +649,7 @@ class OWHierarchicalClustering(widget.OWWidget):
                      margin.left() - margin.right() - w_scroll)
             # layout with new width constraint
             self.__layout_main_graphics(width=width)
-        elif obj is self._main_graphics and \
-                event.type() == QEvent.LayoutRequest:
+        elif event.type() == QEvent.LayoutRequest and obj is self._main_graphics:
             # layout preserving the width (vertical re layout)
             self.__layout_main_graphics()
         return super().eventFilter(obj, event)

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -254,8 +254,7 @@ class OWBoxPlot(widget.OWWidget):
         return QSize(900, 500)
 
     def eventFilter(self, obj, event):
-        if obj is self.box_view.viewport() and \
-                event.type() == QEvent.Resize:
+        if event.type() == QEvent.Resize and obj is self.box_view.viewport():
             self.update_graph()
         return super().eventFilter(obj, event)
 

--- a/tox.ini
+++ b/tox.ini
@@ -87,10 +87,10 @@ setenv =
     QT_API=PyQt6
     ANYQT_HOOK_DENY=pyqt5
 deps =
-    PyQt6==6.2.*
-    PyQt6-Qt6==6.2.*
-    PyQt6-WebEngine==6.2.*
-    PyQt6-WebEngine-Qt6==6.2.*
+    PyQt6==6.3.*
+    PyQt6-Qt6==6.3.*
+    PyQt6-WebEngine==6.3.*
+    PyQt6-WebEngine-Qt6==6.3.*
 
 commands =
     python -m unittest -v Orange.widgets.tests

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ deps =
     PyQt6-WebEngine-Qt6==6.2.*
 
 commands =
-    python -m unittest Orange.widgets.tests
+    python -m unittest -v Orange.widgets.tests
 
 [testenv:add-ons]
 deps =


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Since https://github.com/biolab/orange-widget-base/pull/204 was released, `Orange.widgets.tests.test_workflows` fails with
```
Traceback (most recent call last):
  File "/home/runner/work/orange3/orange3/.tox/pyqt6/lib/python3.9/site-packages/Orange/widgets/visualize/owboxplot.py", line 257, in eventFilter
    if obj is self.box_view.viewport() and \
AttributeError: 'OWBoxPlot' object has no attribute 'box_view'
ERROR: InvocationError for command /home/runner/work/orange3/orange3/.tox/pyqt6/bin/python -m unittest Orange.widgets.tests (exited with code -6 (SIGABRT)) (exited with code -6)
```

##### Description of changes

Change order of conditions in eventFilter to short-circuit access to widget members which can no longer exist (empty `self.__dict__`).

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
