### PR TITLE
Scatterplot: Fix crash for a single time tick

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -302,7 +302,10 @@ class AxisItem(AxisItem):
             step = int(np.ceil(float(len(ticks)) / max_steps))
             ticks = ticks[::step]
 
-        spacing = min(b - a for a, b in zip(ticks[:-1], ticks[1:]))
+        # In case of a single tick, `default` will inform tickStrings
+        # about the appropriate scale.
+        spacing = min((b - a for a, b in zip(ticks[:-1], ticks[1:])),
+                      default=maxVal - minVal)
         return [(spacing, ticks)]
 
     def tickStrings(self, values, scale, spacing):

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -1130,6 +1130,10 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         with self.assertRaises(ValueError):
             float(ticks[0])
 
+        spacing, ticks = x_axis.tickValues(1581953776, 1582953776, 10)[0]
+        self.assertEqual(spacing, 1582953776 - 1581953776)
+        self.assertTrue(not ticks.size or 1581953776 <= ticks[0] <= 1582953776)
+
     def test_clear_plot(self):
         self.widget.cb_class_density.setChecked(True)
         self.send_signal(self.widget.Inputs.data, self.data)


### PR DESCRIPTION
##### Issue

Fixes #6086.

If there is only a single tick or no ticks, `min` that computed the min difference crashed.

##### Description of changes

Provide `default` argument. It equals the difference between the min and the max value, so `tickStrings` knows how to formulate the label.

##### Includes
- [X] Code changes
- [X] Tests
