### PR TITLE
Temporally skip pandas version 1.5.0 

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -22,7 +22,7 @@ python-louvain>=0.13
 requests
 openTSNE>=0.6.1
 baycomp>=1.0.2
-pandas>=1.3.0
+pandas>=1.3.0,!=1.5.0
 pyyaml
 openpyxl
 httpx>=0.21.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Pandas may have a bug (or it is just partially implemented new rule for DateTime conversion) that cause our test to fail in the latest version https://github.com/pandas-dev/pandas/issues/48678

##### Description of changes
Skip pandas version 1.5.0 until they decide whether it is a bug or feature.
If they fix/change the issue solution will probably be available in 1.5.1, so nothing needs to be changed.
If it is not a bug, we need to adapt tests.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
