### PR TITLE
Hierarchical Clustering: Add Subset signal

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -368,7 +368,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self._main_graphics.setLayout(scenelayout)
         self.scene.addItem(self._main_graphics)
 
-        self.dendrogram = DendrogramWidget()
+        self.dendrogram = DendrogramWidget(pen_width=2)
         self.dendrogram.setSizePolicy(QSizePolicy.MinimumExpanding,
                                       QSizePolicy.MinimumExpanding)
         self.dendrogram.selectionChanged.connect(self._invalidate_output)

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -10,7 +10,7 @@ from AnyQt.QtWidgets import (
     QGraphicsWidget, QGraphicsScene, QGridLayout, QSizePolicy,
     QAction, QComboBox, QGraphicsGridLayout, QGraphicsSceneMouseEvent, QLabel
 )
-from AnyQt.QtGui import QPen, QFont, QKeySequence, QPainterPath
+from AnyQt.QtGui import QPen, QFont, QKeySequence, QPainterPath, QColor
 from AnyQt.QtCore import Qt, QSizeF, QPointF, QRectF, QLineF, QEvent, \
     QModelIndex
 from AnyQt.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
@@ -137,8 +137,11 @@ class SelectedLabelsModel(PyListModel):
             font = QFont(self.__font)
             font.setBold(index.row() in self.subset)
             return font
-        if role == Qt.BackgroundRole and self.__colors is not None:
-            return self.__colors[index.row()]
+        if role == Qt.BackgroundRole:
+            if self.__colors is not None:
+                return self.__colors[index.row()]
+            elif not any(self) and self.subset:  # no labels, no color, but subset
+                return QColor(0, 0, 0)
         if role == Qt.UserRole and self.subset:
             return index.row() in self.subset
 
@@ -589,7 +592,8 @@ class OWHierarchicalClustering(widget.OWWidget):
 
             if self.annotation is None:
                 if self.subset_rows and self.color_by is None:
-                    labels = [" •"[row in self.subset_rows] for row in indices]
+                    # Model fails if number of labels and of colors mismatch
+                    labels = [""] * len(indices)
                 else:
                     labels = []
             elif self.annotation == "Enumeration":

--- a/Orange/widgets/utils/dendrogram.py
+++ b/Orange/widgets/utils/dendrogram.py
@@ -145,7 +145,7 @@ def update_pen(pen, brush=None, width=None, style=None,
     return pen
 
 
-def path_stroke(path, width=1, join_style=Qt.MiterJoin):
+def path_stroke(path, width=1, join_style=Qt.RoundJoin):
     stroke = QPainterPathStroker()
     stroke.setWidth(width)
     stroke.setJoinStyle(join_style)
@@ -153,7 +153,7 @@ def path_stroke(path, width=1, join_style=Qt.MiterJoin):
     return stroke.createStroke(path)
 
 
-def path_outline(path, width=1, join_style=Qt.MiterJoin):
+def path_outline(path, width=1, join_style=Qt.RoundJoin):
     stroke = path_stroke(path, width, join_style)
     return stroke.united(path)
 
@@ -249,6 +249,7 @@ class DendrogramWidget(QGraphicsWidget):
 
     def __init__(self, parent=None, root=None, orientation=Left,
                  hoverHighlightEnabled=True, selectionMode=ExtendedSelection,
+                 *, pen_width=1,
                  **kwargs):
         super().__init__(None, **kwargs)
         # Filter all events from children (`ClusterGraphicsItem`s)
@@ -271,6 +272,7 @@ class DendrogramWidget(QGraphicsWidget):
         self._cluster_parent = {}
         self.__hoverHighlightEnabled = hoverHighlightEnabled
         self.__selectionMode = selectionMode
+        self._pen_width = pen_width
         self.setContentsMargins(0, 0, 0, 0)
         self.setRoot(root)
         if parent is not None:
@@ -348,8 +350,7 @@ class DendrogramWidget(QGraphicsWidget):
         self._root = root
         if root is not None:
             foreground = self.palette().color(QPalette.WindowText)
-            pen = make_pen(foreground, width=1, cosmetic=True,
-                           join_style=Qt.MiterJoin)
+            pen = make_pen(foreground, width=self._pen_width, cosmetic=True)
             for node in postorder(root):
                 item = DendrogramWidget.ClusterGraphicsItem(self._itemgroup)
                 item.setAcceptHoverEvents(True)
@@ -447,12 +448,12 @@ class DendrogramWidget(QGraphicsWidget):
             # Restore the previous item
             highlight = self.palette().color(QPalette.WindowText)
             set_pen(self._highlighted_item,
-                    make_pen(highlight, width=1, cosmetic=True))
+                    make_pen(highlight, width=self._pen_width, cosmetic=True))
 
         self._highlighted_item = item
         if item:
             hpen = make_pen(self.palette().color(QPalette.Highlight),
-                            width=2, cosmetic=True)
+                            width=self._pen_width + 1, cosmetic=True)
             set_pen(item, hpen)
 
     def leafItems(self):

--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -82,10 +82,10 @@ class TextListBase(QGraphicsWidget):
             self.setParentItem(parent)
 
     def data(self, row, role=Qt.DisplayRole):
-        raise NotImplemented
+        raise NotImplementedError
 
     def count(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     def reset(self):
         self.__clear()
@@ -132,7 +132,6 @@ class TextListBase(QGraphicsWidget):
         Remove all items.
         """
         self.__clear()
-        self.__items = []
         self.__widthCache.clear()
         self.updateGeometry()
 
@@ -144,11 +143,18 @@ class TextListBase(QGraphicsWidget):
             return item.mapRectToParent(item.boundingRect())
 
         if self.__orientation == Qt.Vertical:
-            y = lambda pos: pos.y()
+            def y(pos):
+                return pos.y()
         else:
-            y = lambda pos: pos.x()
-        top = lambda idx: brect(items[idx]).top()
-        bottom = lambda idx: brect(items[idx]).bottom()
+            def y(pos):
+                return pos.x()
+
+        def top(idx):
+            return brect(items[idx]).top()
+
+        def bottom(idx):
+            return brect(items[idx]).bottom()
+
         items = self.__textitems
         if not items:
             return None

--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -2,13 +2,16 @@ import bisect
 import math
 from typing import Optional, Union, Any, Iterable, List, Callable, cast
 
-from AnyQt.QtCore import Qt, QSizeF, QEvent, QMarginsF, QPointF
+from AnyQt.QtCore import (
+    Qt, QSizeF, QEvent, QMarginsF, QPointF, QAbstractItemModel
+)
 from AnyQt.QtGui import QFont, QFontMetrics, QFontInfo, QPalette
 from AnyQt.QtWidgets import (
     QGraphicsWidget, QSizePolicy, QGraphicsItemGroup, QGraphicsSimpleTextItem,
     QGraphicsItem, QGraphicsScene, QGraphicsSceneResizeEvent, QToolTip,
     QGraphicsSceneHelpEvent
 )
+
 from . import apply_all
 from .graphicslayoutitem import scaled
 
@@ -29,30 +32,27 @@ class _FuncArray:
         return self.length
 
 
-class TextListWidget(QGraphicsWidget):
+class TextListBase(QGraphicsWidget):
     """
-    A linear text list widget.
+    A base class for linear text list view and widget.
 
     Displays a list of uniformly spaced text lines.
 
     Parameters
     ----------
     parent: Optional[QGraphicsItem]
-    items: Iterable[str]
     alignment: Qt.Alignment
     orientation: Qt.Orientation
     """
     def __init__(
             self,
             parent: Optional[QGraphicsItem] = None,
-            items: Iterable[str] = (),
             alignment: Union[Qt.AlignmentFlag, Qt.Alignment] = Qt.AlignLeading,
             orientation: Qt.Orientation = Qt.Vertical,
             autoScale=False,
             elideMode=Qt.ElideNone,
             **kwargs: Any
     ) -> None:
-        self.__items: List[str] = []
         self.__textitems: List[QGraphicsSimpleTextItem] = []
         self.__group: Optional[QGraphicsItemGroup] = None
         self.__spacing = 0
@@ -78,19 +78,14 @@ class TextListWidget(QGraphicsWidget):
         if parent is not None:
             self.setParentItem(parent)
 
-        if items is not None:
-            self.setItems(items)
+    def data(self, row, role=Qt.DisplayRole):
+        raise NotImplemented
 
-    def setItems(self, items: Iterable[str]) -> None:
-        """
-        Set items for display
+    def count(self):
+        raise NotImplemented
 
-        Parameters
-        ----------
-        items: Iterable[str]
-        """
+    def reset(self):
         self.__clear()
-        self.__items = list(items)
         self.__widthCache.clear()
         self.__setup()
         self.__layout()
@@ -138,12 +133,6 @@ class TextListWidget(QGraphicsWidget):
         self.__widthCache.clear()
         self.updateGeometry()
 
-    def count(self) -> int:
-        """
-        Return the number of items
-        """
-        return len(self.__items)
-
     def indexAt(self, pos: QPointF) -> Optional[int]:
         """
         Return the index of item at `pos`.
@@ -185,20 +174,32 @@ class TextListWidget(QGraphicsWidget):
 
     def __width_for_font(self, font: QFont) -> float:
         """Return item width for the font"""
-        key = font.key()
-        if key in self.__widthCache:
-            return self.__widthCache[key]
-        fm = QFontMetrics(font)
-        width = max((fm.boundingRect(text).width() for text in self.__items),
-                    default=0)
-        self.__widthCache[key] = width
+        if self.data(0, Qt.FontRole) is not None:
+            if None in self.__widthCache:
+                return self.__widthCache[None]
+            width = max(
+                (QFontMetrics(self.data(row, Qt.FontRole))
+                 .boundingRect(self.data(row))
+                 .width()
+                 for row in range(self.count())
+                 ), default=0)
+            self.__widthCache[None] = width
+        else:
+            key = font.key()
+            if key in self.__widthCache:
+                return self.__widthCache[key]
+            fm = QFontMetrics(font)
+            width = max((fm.boundingRect(self.data(row)).width()
+                         for row in range(self.count())),
+                        default=0)
+            self.__widthCache[key] = width
         return width
 
     def __naturalsh(self) -> QSizeF:
         """Return the natural size hint (preferred sh with no constraints)."""
         fm = QFontMetrics(self.font())
         spacing = self.__spacing
-        N = len(self.__items)
+        N = self.count()
         width = self.__width_for_font(self.font())
         height = N * fm.height() + max(N - 1, 0) * spacing
         return QSizeF(width, height)
@@ -225,7 +226,7 @@ class TextListWidget(QGraphicsWidget):
             viewport = event.widget()
             view = viewport.parentWidget()
             rect = view.mapFromScene(rect).boundingRect()
-            QToolTip.showText(event.screenPos(), self.__items[idx],
+            QToolTip.showText(event.screenPos(), self.data(idx),
                               view, rect)
             event.setAccepted(True)
 
@@ -234,7 +235,7 @@ class TextListWidget(QGraphicsWidget):
             self.updateGeometry()
             if self.__autoScale:
                 self.__layout()
-            else:
+            elif self.data(0, Qt.FontRole) is None:
                 font = self.font()
                 apply_all(self.__textitems, lambda it: it.setFont(font))
 
@@ -245,23 +246,10 @@ class TextListWidget(QGraphicsWidget):
                 item.setBrush(brush)
         super().changeEvent(event)
 
-    def __setup(self) -> None:
-        self.__clear()
-        font = self.__effectiveFont if self.__autoScale else self.font()
-        assert self.__group is None
-        group = QGraphicsItemGroup()
-        brush = self.palette().brush(QPalette.Text)
-        for text in self.__items:
-            t = QGraphicsSimpleTextItem(group)
-            t.setBrush(brush)
-            t.setFont(font)
-            t.setText(text)
-            t.setData(0, text)
-            self.__textitems.append(t)
-        group.setParentItem(self)
-        self.__group = group
-
     def __layout(self) -> None:
+        if not self.__textitems:
+            return
+
         margins = QMarginsF(*self.getContentsMargins())
         if self.__orientation == Qt.Horizontal:
             # transposed margins
@@ -281,7 +269,7 @@ class TextListWidget(QGraphicsWidget):
         if align_horizontal == 0:
             align_horizontal = Qt.AlignLeft
 
-        N = len(self.__items)
+        N = self.count()
 
         if not N:
             return
@@ -306,7 +294,8 @@ class TextListWidget(QGraphicsWidget):
             fm = QFontMetrics(font)
             fontheight = fm.height()
 
-        if self.__autoScale and self.__effectiveFont != font:
+        if self.__autoScale and self.__effectiveFont != font \
+                and self.data(0, Qt.FontRole) is None:
             self.__effectiveFont = font
             apply_all(self.__textitems, lambda it: it.setFont(font))
 
@@ -315,7 +304,8 @@ class TextListWidget(QGraphicsWidget):
                 textwidth = math.ceil(crect.width())
             else:
                 textwidth = math.ceil(crect.height())
-            for text, item in zip(self.__items, self.__textitems):
+            for row, item in enumerate(self.__textitems):
+                text = self.data(row)
                 textelide = fm.elidedText(
                     text, self.__elideMode, textwidth, Qt.TextSingleLine
                 )
@@ -364,6 +354,122 @@ class TextListWidget(QGraphicsWidget):
         if self.__group is not None:
             remove([self.__group], self.scene())
             self.__group = None
+
+    def __setup(self) -> None:
+        self.__clear()
+        font = self.__effectiveFont if self.__autoScale else self.font()
+        assert self.__group is None
+        group = QGraphicsItemGroup()
+        brush = self.palette().brush(QPalette.Text)
+        for row in range(self.count()):
+            text = self.data(row)
+            t = QGraphicsSimpleTextItem(group)
+            t.setBrush(self.data(row, Qt.ForegroundRole) or brush)
+            t.setFont(self.data(row, Qt.FontRole) or font)
+            t.setText(text)
+            t.setData(0, text)
+            t.setToolTip(self.data(row, Qt.ToolTipRole))
+            self.__textitems.append(t)
+        group.setParentItem(self)
+        self.__group = group
+
+
+class TextListWidget(TextListBase):
+    """
+    A linear text list widget.
+
+    Displays a list of uniformly spaced text lines.
+
+    Parameters
+    ----------
+    parent: Optional[QGraphicsItem]
+    items: Iterable[str]
+    alignment: Qt.Alignment
+    orientation: Qt.Orientation
+    """
+    def __init__(
+            self,
+            parent: Optional[QGraphicsItem] = None,
+            items: Iterable[str] = (),
+            alignment: Union[Qt.AlignmentFlag, Qt.Alignment] = Qt.AlignLeading,
+            orientation: Qt.Orientation = Qt.Vertical,
+            autoScale=False,
+            elideMode=Qt.ElideNone,
+            **kwargs: Any
+    ) -> None:
+        self.__items: List[str] = []
+        super().__init__(parent, alignment, orientation, autoScale, elideMode,
+                         **kwargs)
+        if items is not None:
+            self.setItems(items)
+
+    def setItems(self, items: Iterable[str]) -> None:
+        self.__items = list(items)
+        self.reset()
+
+    def clear(self) -> None:
+        """Remove all items."""
+        self.__items = []
+        super().clear()
+
+    def count(self) -> int:
+        """Return the number of items"""
+        return len(self.__items)
+
+    def data(self, row, role=Qt.DisplayRole):
+        if row < len(self.__items):
+            if role == Qt.DisplayRole:
+                return self.__items[row]
+        return None
+
+
+class TextListView(TextListBase):
+    """
+    A linear text list view.
+
+    Displays a list of uniformly spaced text lines.
+
+    Parameters
+    ----------
+    parent: Optional[QGraphicsItem]
+    items: Iterable[str]
+    alignment: Qt.Alignment
+    orientation: Qt.Orientation
+    """
+    def __init__(
+            self,
+            parent: Optional[QGraphicsItem] = None,
+            alignment: Union[Qt.AlignmentFlag, Qt.Alignment] = Qt.AlignLeading,
+            orientation: Qt.Orientation = Qt.Vertical,
+            autoScale=False,
+            elideMode=Qt.ElideNone,
+            **kwargs: Any
+    ) -> None:
+        self.__model = None
+        super().__init__(parent, alignment, orientation, autoScale, elideMode,
+                         **kwargs)
+
+    def setModel(self, model: QAbstractItemModel) -> None:
+        self.__model = model
+        self.reset()
+        model.dataChanged.connect(self.reset)
+        model.rowsInserted.connect(self.reset)
+        model.rowsRemoved.connect(self.reset)
+        model.rowsMoved.connect(self.reset)
+        model.modelReset.connect(self.reset)
+
+    def model(self):
+        return self.__model
+
+    def count(self) -> int:
+        if self.__model is None:
+            return 0
+        return self.__model.rowCount()
+
+    def data(self, row, role=Qt.DisplayRole):
+        if self.__model is None:
+            return None
+        return self.__model.index(row, 0).data(role)
 
 
 def effective_point_size_for_height(


### PR DESCRIPTION
##### Issue

Closes #6126 and more.

- Labels for the subset are shown in bold.
- Adds option to show additional icons, colored by values of some variable; if subset is present, only squares for the rows in the subset are filled.
- If there are no labels and no icons, subset is indicated by small dots.
- Refactors most of `TextListWidget`'s code into a base class (`TextListBase`) and derives a new class, `TextListView` that gets data from a model. Hierarchical Clustering than uses it instead of `TextListWidget`. Distance Matrix and Silhouette can do the same.

- Since class is not used as default for coloring, the first string attribute is used for annotation. If there are none, it uses class, otherwise the first non-None option.
- Enumeration is now shown only if there are not other options (except "None"); enumeration served no purpose, imho.
- Fix this

     ```python
---------------------------- IndexError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/janez/orange3/Orange/widgets/unsupervised/owhierarchicalclustering.py", line 143, in data
    return self.__colors[index.row()]
IndexError: index 101 is out of bounds for axis 0 with size 101
```

    This probably happens when data is changed and colors are set before labels or vice versa.
Draft: ready to use for demonstration purposes, but needs polishing and testing. In particular, I need to check that resizing (of widget, of fonts ...) is handled properly.


To do:
- [ ] Check what these changes do to other widgets the use `TextListWidget`
- [ ] Change default linkage to Ward (otherwise unrelated to this PR)


<img width="790" alt="Screen Shot 2022-09-24 at 20 20 33" src="https://user-images.githubusercontent.com/2387315/192113243-9843803f-1d98-4d97-bc26-d924a1b25dd8.png">

<img width="790" alt="Screen Shot 2022-09-24 at 20 20 51" src="https://user-images.githubusercontent.com/2387315/192113249-9f7eeebf-f51c-4caa-8c16-670cdee24f2a.png">

<img width="790" alt="Screen Shot 2022-09-24 at 20 21 00" src="https://user-images.githubusercontent.com/2387315/192113253-9a2dddc8-9588-4cbb-975d-dabcb2511f27.png">

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
