### PR TITLE
Drop test and support for python 3.7

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python: [3.7]
+        python: [3.9]
         os: [ubuntu-18.04]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,16 +37,16 @@ jobs:
       fail-fast: False
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: ubuntu-20.04
-            python-version: 3.8
+            python-version: '3.10'
             tox_env: orange-latest
             name: Latest
           - os: ubuntu-18.04
-            python-version: 3.7
+            python-version: 3.8
             tox_env: orange-oldest
             name: Oldest dependencies
           - os: ubuntu-20.04
@@ -113,20 +113,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11, windows-2019]
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: windows-latest
-            python-version: 3.8
+            python-version: '3.10'
             tox_env: orange-latest
             name: Latest
           - os: macos-11
-            python-version: 3.8
+            python-version: '3.10'
             tox_env: orange-latest
             name: Latest
           - os: windows-latest
-            python-version: 3.9
+            python-version: '3.10'
             tox_env: pyqt6
             name: PyQt6
           - os: macos-11

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -6,7 +6,7 @@ scipy>=1.3.1
 scikit-learn>=1.0.1
 bottleneck>=1.3.4
 # Reading Excel files
-xlrd>=0.9.2
+xlrd>=1.2.0
 # Writing Excel Files
 xlsxwriter
 # Encoding detection

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -5,6 +5,6 @@ AnyQt>=0.1.0
 
 # ignore pyqtgraph 0.12.4 due to https://github.com/pyqtgraph/pyqtgraph/issues/2237
 pyqtgraph>=0.12.2,!=0.12.4
-matplotlib>=2.2.5
+matplotlib>=3.2.0
 qtconsole>=4.7.2
 pygments>=2.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     oldest: orange-widget-base==4.18.0
     oldest: AnyQt==0.1.0
     oldest: pyqtgraph==0.11.1
-    oldest: matplotlib==2.2.5
+    oldest: matplotlib==3.2.0
     oldest: qtconsole==4.7.2
     oldest: pygments==2.8.0
     oldest: pip==18.0
@@ -52,7 +52,7 @@ deps =
     oldest: scipy==1.3.1
     oldest: scikit-learn==1.0.1
     oldest: bottleneck==1.3.4
-    oldest: xlrd==0.9.2
+    oldest: xlrd==1.2.0
     # oldest: xlsxwriter
     oldest: chardet==3.0.2
     oldest: joblib==0.11


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Numpy and Pandas already dropped the support for Python 3.7. I think it is time for Orange too. Supporting (soon) 4 versions is enough.

##### Description of changes
Dropping Python 3.7 support and tests. 
This PR also upgrades minimum versions of xlrd and matplotlib:
- xlrd 1.2.0 is the first version that supports python 3.8 (the oldest test failed with the older version).
-  for matplotlib only windows wheels (not Linux and macOS) are available for Python 3.8 in older versions and version prior 3.2.0 dont build well with the oldest supported numpy. They are also older than the oldest supported Numpy. 3.2.0 is older than 2 and a half years and is the first to provide python 3.8 wheels for Linux. 

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
