### PR TITLE
[FIX] Remove pyqt5 install magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ conda config --set channel_priority strict
 conda create python=3 --yes --name orange3
 conda activate orange3
 
+# Install PyQt and PyQtWebEngine
+conda install pyqt
 # Install Orange
 conda install orange3
 ```
@@ -63,7 +65,9 @@ conda install orange3-<addon name>
 ### Installing with pip
 
 We recommend using our [standalone installer](https://orange.biolab.si/download) or conda, but Orange is also installable with pip. You will need a C/C++ compiler (on Windows we suggest using Microsoft Visual Studio Build Tools).
-
+Orange needs PyQt to run. Install either:
+- PyQt5 and PyQtWebEngine: `pip install -r requirements-pyqt.txt` 
+- PyQt6 and PyQt6-WebEngine: `pip install PyQt6 PyQt6-WebEngine`
 
 ### Installing with winget (Windows only)
 
@@ -137,6 +141,8 @@ conda activate orange3
 
 git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange3
 
+# Install PyQT and PyQtWebEngine. You can also use PyQt6
+pip install -r requirements-pyqt.txt
 pip install -e orange3
 ```
 
@@ -174,6 +180,9 @@ create a conda environment, clone your forks, and install them:
 ```Shell
 conda create python=3 --yes --name orange3
 conda activate orange3
+
+# Install PyQT and PyQtWebEngine. You can also use PyQt6
+pip install -r requirements-pyqt.txt
 
 git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange-widget-base
 pip install -e orange-widget-base

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,6 @@ try:
 except ImportError:
     have_cython = False
 
-try:
-    import PyQt5.QtCore  # pylint: disable=unused-import
-    have_pyqt5 = True
-except ImportError:
-    have_pyqt5 = False
-
-is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
-
 NAME = 'Orange3'
 
 VERSION = '3.33.0'
@@ -91,11 +83,6 @@ CLASSIFIERS = [
 
 requirements = ['requirements-core.txt', 'requirements-gui.txt']
 
-# pyqt5 is named pyqt5 on pypi and pyqt on conda
-# due to possible conflicts, skip the pyqt5 requirement in conda environments
-# that already have pyqt
-if not (is_conda and have_pyqt5):
-    requirements.append('requirements-pyqt.txt')
 
 INSTALL_REQUIRES = sorted(set(
     line.partition('#')[0].strip()


### PR DESCRIPTION
Now there is also pyqt6 and we still force our users to also install PyQt5. This trick we had is also dangerous because it behaves differently with wheels and source installs.

Reverts #5593.

After merging this PR please also consider: https://github.com/biolab/orange3/pull/6153
