### PR TITLE
Remove PyQt5 requirements from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,6 @@ try:
 except ImportError:
     have_cython = False
 
-try:
-    import PyQt5.QtCore  # pylint: disable=unused-import
-    have_pyqt5 = True
-except ImportError:
-    have_pyqt5 = False
-
-is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
-
 NAME = 'Orange3'
 
 VERSION = '3.33.0'
@@ -90,13 +82,6 @@ CLASSIFIERS = [
 ]
 
 requirements = ['requirements-core.txt', 'requirements-gui.txt']
-
-# pyqt5 is named pyqt5 on pypi and pyqt on conda
-# due to possible conflicts, skip the pyqt5 requirement in conda environments
-# that already have pyqt
-if not (is_conda and have_pyqt5):
-    requirements.append('requirements-pyqt.txt')
-
 INSTALL_REQUIRES = sorted(set(
     line.partition('#')[0].strip()
     for file in (os.path.join(os.path.dirname(__file__), file)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
PyQt5 requirement disables users from using PyQt6 
I tried to check PyQt more generally but noticed the following things:
- `pip install .` will build the wheel in a separate isolated process and will not see whether PyQt is in the requirement (so PyQt will always be installed independently from the environment)
- `pip install orange3` installs from wheels that always have pyqt5 requirements inside (and setup.py is not there)

So checking whether PyQt is installed or not does make sense. PyQt will always be put in dependencies. 

##### Description of changes
To avoid confusion in Conda environments (having PyQt both from PyPi and conda), I am removing this dependency.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
