### PR TITLE
Distance: Fix check and error message for Mahalanobis distance

### DIFF
--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -185,8 +185,8 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
 
         def _check_tractability():
             if metric is distance.Mahalanobis:
-                if self.axis == 1:
-                    # when computing distances by columns, we want < 100 rows
+                if self.axis == 0:
+                    # when computing distances by columns, we want < 1000 rows
                     if len(data) > 1000:
                         self.Error.data_too_large_for_mahalanobis("rows")
                         return False

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -214,15 +214,17 @@ class TestOWDistances(WidgetTest):
 
         # by columns -- cannot handle too many rows
         self.send_signal(self.widget.Inputs.data, bigrows)
+        assert_no_error()
+        axis_buttons[0].click()
+        assert_error_shown()
+        axis_buttons[1].click()
+        assert_no_error()
+
+        self.send_signal(self.widget.Inputs.data, bigcols)
         assert_error_shown()
         axis_buttons[0].click()
         assert_no_error()
         axis_buttons[1].click()
-        assert_error_shown()
-
-        self.send_signal(self.widget.Inputs.data, bigcols)
-        assert_no_error()
-        axis_buttons[0].click()
         assert_error_shown()
 
         self.send_signal(widget.Inputs.data, self.iris)


### PR DESCRIPTION
##### Issue

Fixes #6166. @ajdapretnar, does it?

I believe the idea was that we don't want to compute inverses of matrices larger than 1000x1000, which is required by Mahalanobis, AFAIK. (The comment was wrong, it should say 1000, not 100). Therefore, the only problem was that axis was wrong -- as you already discovered.

If 2000x2000 computes in reasonable time, we can increase this limit. But let us have some limit; also, this check was certainly introduced for a reason.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
