### PR TITLE
[FIX] Feature statistics: Use deferred commit + minor warning fix

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -507,9 +507,12 @@ def nanmode(x, axis=0):
     returns zero). Also, this function returns count NaN if all values are NaN
     (scipy=1.3.0 returns some number)."""
     nans = np.isnan(np.array(x)).sum(axis=axis, keepdims=True) == x.shape[axis]
-    res = scipy.stats.stats.mode(x, axis)
-    return scipy.stats.stats.ModeResult(np.where(nans, np.nan, res.mode),
-                                        np.where(nans, np.nan, res.count))
+    res = scipy.stats.mode(x, axis, keepdims=True)
+    # type(res) is ModeResult. ModeResult is defined in scipy.stats.stats; this
+    # namespace is deprecated, but ModeResult is not exported to scipy.stats
+    # Hence we use type(res) to avoid a warning.
+    return type(res)(np.where(nans, np.nan, res.mode),
+                     np.where(nans, np.nan, res.count))
 
 
 def unique(x, return_counts=False):

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -805,7 +805,8 @@ class OWFeatureStatistics(widget.OWWidget):
         self.__restore_sorting()
         self.__color_var_changed()
 
-        self.commit()
+        self.commit_statistics()
+        self.commit.now()
 
     def __restore_selection(self):
         """Restore the selection on the table view from saved settings."""
@@ -845,8 +846,9 @@ class OWFeatureStatistics(widget.OWWidget):
             i.row() for i in self.table_view.selectionModel().selectedRows()
         ]))
         self.selected_vars = list(self.model.variables[selection_indices])
-        self.commit()
+        self.commit.deferred()
 
+    @gui.deferred
     def commit(self):
         if not self.selected_vars:
             self.Outputs.reduced_data.send(None)
@@ -854,6 +856,7 @@ class OWFeatureStatistics(widget.OWWidget):
             # Send a table with only selected columns to output
             self.Outputs.reduced_data.send(self.data[:, self.selected_vars])
 
+    def commit_statistics(self):
         if not self.data:
             self.Outputs.statistics.send(None)
             return

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -110,8 +110,8 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
     HIDDEN_VAR_TYPES = (StringVariable,)
 
     class Columns(IntEnum):
-        ICON, NAME, DISTRIBUTION, CENTER, MEDIAN, DISPERSION, MIN, MAX, \
-        MISSING = range(9)
+        ICON, NAME, DISTRIBUTION, CENTER, MODE, MEDIAN, DISPERSION, MIN, MAX, \
+        MISSING = range(10)
 
         @property
         def name(self):
@@ -119,6 +119,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                     self.NAME: 'Name',
                     self.DISTRIBUTION: 'Distribution',
                     self.CENTER: 'Mean',
+                    self.MODE: 'Mode',
                     self.MEDIAN: 'Median',
                     self.DISPERSION: 'Dispersion',
                     self.MIN: 'Min.',
@@ -159,7 +160,8 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
 
         no_data = np.array([])
         self._variable_types = self._variable_names = no_data
-        self._min = self._max = self._center = self._median = no_data
+        self._min = self._max = no_data
+        self._center = self._median = self._mode = no_data
         self._dispersion = no_data
         self._missing = no_data
         # Clear model initially to set default values
@@ -283,9 +285,16 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
             time_f=lambda x: ut.nanmean(x, axis=0),
         )
 
-        self._median = self.__compute_stat(
+        self._mode = self.__compute_stat(
             matrices,
             discrete_f=lambda x: __mode(x, axis=0),
+            continuous_f=lambda x: __mode(x, axis=0),
+            time_f=lambda x: __mode(x, axis=0),
+        )
+
+        self._median = self.__compute_stat(
+            matrices,
+            discrete_f=None,
             continuous_f=lambda x: ut.nanmedian(x, axis=0),
             time_f=lambda x: ut.nanmedian(x, axis=0),
         )
@@ -315,15 +324,10 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                      for name in ("Entropy", self.Columns.MISSING.name)]
 
         names = [var.name for var in self.variables]
-        if any(isinstance(var, DiscreteVariable) for var in self.variables):
-            majorities = [
-                var.str_val(val) if isinstance(var, DiscreteVariable) else ""
-                for var, val in zip(self.variables, self._median)]
-            metas = np.vstack((names, majorities)).T
-            meta_attrs = [StringVariable('Feature'), StringVariable('Mode')]
-        else:
-            metas = np.atleast_2d(names).T
-            meta_attrs = [StringVariable('Feature')]
+        modes = [var.str_val(val)
+                 for var, val in zip(self.variables, self._mode)]
+        metas = np.vstack((names, modes)).T
+        meta_attrs = [StringVariable('Feature'), StringVariable('Mode')]
 
         domain = Domain(attributes=attrs, metas=meta_attrs)
         statistics = Table.from_numpy(domain, x, metas=metas)
@@ -411,6 +415,13 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         elif column == self.Columns.CENTER:
             # Sorting discrete or string values by mean makes no sense
             vals = np.array(self._center)
+            vals[disc_idx] = var_name_indices[disc_idx]
+            vals[str_idx] = var_name_indices[str_idx]
+            return np.vstack((var_types_indices, np.zeros_like(vals), vals)).T
+        # Sort by: (type, mode)
+        elif column == self.Columns.MODE:
+            # Sorting discrete or string values by mode makes no sense
+            vals = np.array(self._mode)
             vals[disc_idx] = var_name_indices[disc_idx]
             vals[str_idx] = var_name_indices[str_idx]
             return np.vstack((var_types_indices, np.zeros_like(vals), vals)).T
@@ -563,6 +574,8 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
                     return self.__distributions_cache[row]
             elif column == self.Columns.CENTER:
                 return render_value(self._center[row])
+            elif column == self.Columns.MODE:
+                return render_value(self._mode[row])
             elif column == self.Columns.MEDIAN:
                 return render_value(self._median[row])
             elif column == self.Columns.DISPERSION:

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -335,7 +335,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         # By default, nothing should be sent since auto commit is off
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
         # When we commit, the data should be on the output
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
 
         # Send some new data
@@ -344,17 +344,8 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         # By default, there should be nothing on the output
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
         # Nothing should change after commit, since we haven't selected any rows
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-
-        # Now let's switch back to the original data, where we selected row 0
-        self.send_signal(self.widget.Inputs.data, self.data)
-        # Again, since auto commit is off, nothing should be on the output
-        self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
-        # Since the row selection is saved into context settings, the appropriate
-        # thing should be sent to output
-        self.widget.unconditional_commit()
-        self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
 
     def test_changing_data_updates_output_with_autocommit(self):
         # Test behaviour of widget when auto commit is ON
@@ -380,7 +371,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
     def test_sends_single_attribute_table_to_output(self):
         # Check if selecting a single attribute row
         self.select_rows([0])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         desired_domain = Domain(attributes=[continuous_full.variable])
         output = self.get_output(self.widget.Outputs.reduced_data)
@@ -389,7 +380,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
     def test_sends_multiple_attribute_table_to_output(self):
         # Check if selecting a single attribute row
         self.select_rows([0, 1])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         desired_domain = Domain(attributes=[
             continuous_full.variable, continuous_missing.variable,
@@ -399,7 +390,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
 
     def test_sends_single_class_var_table_to_output(self):
         self.select_rows([2])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         desired_domain = Domain(attributes=[], class_vars=[rgb_full.variable])
         output = self.get_output(self.widget.Outputs.reduced_data)
@@ -407,7 +398,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
 
     def test_sends_single_meta_table_to_output(self):
         self.select_rows([4])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         desired_domain = Domain(attributes=[], metas=[ints_full.variable])
         output = self.get_output(self.widget.Outputs.reduced_data)
@@ -415,7 +406,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
 
     def test_sends_multiple_var_types_table_to_output(self):
         self.select_rows([0, 2, 4])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         desired_domain = Domain(
             attributes=[continuous_full.variable],
@@ -428,7 +419,7 @@ class TestFeatureStatisticsOutputs(WidgetTest):
     def test_sends_all_samples_to_output(self):
         """All rows should be sent to output for selected column."""
         self.select_rows([0, 2])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
 
         selected_vars = Domain(
             attributes=[continuous_full.variable],
@@ -442,11 +433,11 @@ class TestFeatureStatisticsOutputs(WidgetTest):
     def test_clearing_selection_sends_none_to_output(self):
         """Clearing all the selected rows should send `None` to output."""
         self.select_rows([0])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         self.assertIsNotNone(self.get_output(self.widget.Outputs.reduced_data))
 
         self.widget.table_view.clearSelection()
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
 
     def test_output_statistics(self):
@@ -502,14 +493,14 @@ class TestFeatureStatisticsOutputs(WidgetTest):
 
     def test_output_combinations(self):
         # No selection -> reduced_data is not output, statistics is present
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         self.assertIsNone(self.get_output(self.widget.Outputs.reduced_data))
         self.assertEqual(len(self.get_output(self.widget.Outputs.statistics)),
                          self.widget.model.rowCount())
 
         # Has selection -> all outputs present
         self.select_rows([0, 1])
-        self.widget.unconditional_commit()
+        self.widget.commit.now()
         outp = self.get_output(self.widget.Outputs.reduced_data)
         self.assertEqual(len(outp), len(self.data))
         self.assertEqual(len(outp.domain.variables), 2)

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -456,8 +456,8 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         )
         np.testing.assert_equal(
             output.metas,
-            [["continuous_full", ""],
-             ["continuous_missing", ""],
+            [["continuous_full", "0"],
+             ["continuous_missing", "0"],
              ["rgb_full", "g"],
              ["rgb_missing", "g"]])
 
@@ -471,8 +471,8 @@ class TestFeatureStatisticsOutputs(WidgetTest):
         )
         np.testing.assert_equal(
             output.metas,
-            [["continuous_full"],
-             ["continuous_missing"]])
+            [["continuous_full", "0"],
+             ["continuous_missing", "0"]])
 
         data = make_table([rgb_full, rgb_missing])
         self.send_signal(self.widget.Inputs.data, data)


### PR DESCRIPTION
##### Issue

Fixes partially #6173 (everything except documentation).

##### Description of changes

1. Statistics is now committed after receiving data -- as it should be, unconditionally. A test that the widget does not send this data when auto commit is off is removed (because it's wrong).

    Reduced data is committed after receiving data (unconditionally) and when selection is changed (conditionally).

2. Mode is also computed for numeric variables. Output needs discussion, though. See https://github.com/biolab/orange3/issues/6173#issuecomment-1279185345.

3. Fixed warnings. 

    - a warning from scipy.stats.mode is fixed by setting `keepdims=True`. `False` also passes tests but I'd keep the behaviour to be safe.
    - `scipy.stats.stats` is deprecated, `scipy.stats` should be used instead. Hence we now call `scipy.stats.mode`. `ModeResult` is not exported from `scipy.stats.stats` to `scipy.stats`, so I used `type(res)` instead.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
