### PR TITLE
pylintrc: Update configuration file

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -16,7 +16,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.eq_without_hash
 
 # Use multiple processes to speed up Pylint.
 jobs=0
@@ -29,15 +29,6 @@ unsafe-load-any-extension=no
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
 extension-pkg-whitelist=Orange.distance._distance,Orange.data._variable,numpy.random.mtrand
-
-# Allow optimization of some AST trees. This will activate a peephole AST
-# optimizer, which will apply various small optimizations. For instance, it can
-# be used to obtain the result of joining multiple strings with the addition
-# operator. Joining a lot of strings can lead to a maximum recursion error in
-# Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality.
-optimize-ast=no
-
 
 [MESSAGES CONTROL]
 
@@ -74,11 +65,6 @@ disable=
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=yes
 
@@ -105,12 +91,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=yes
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -185,9 +165,6 @@ callbacks=cb_,_cb,on_,_on_
 
 [BASIC]
 
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=print
-
 # Good variable names which should always be accepted, separated by a comma
 good-names=ex,Run,_,a,c,d,e,i,j,k,m,n,o,p,t,u,v,w,x,y,A,X,Y,M
 
@@ -204,53 +181,33 @@ include-naming-hint=yes
 # Regular expression matching correct method names
 # TODO: find a better way to allow long method names in test classes.
 method-rgx=[a-z_][a-zA-Z0-9_]{2,80}$
-# Naming hint for method names
-method-name-hint=[a-z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]{2,30}$
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]{2,30}$
 
 # Regular expression matching correct module names
 module-rgx=([a-z_][a-z0-9_]{2,30})$
-# Naming hint for module names
-module-name-hint=([a-z_][a-z0-9_]{2,30})$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=[A-Za-z_][A-Za-z0-9_]{2,30}$
-# Naming hint for class attribute names
-class-attribute-name-hint=[A-Za-z_][A-Za-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
 const-rgx=[A-Za-z_][A-Za-z0-9_]+$
-# Naming hint for constant names
-const-name-hint=[A-Za-z_][A-Za-z0-9_]+$
 
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-zA-Z0-9_]{2,30}$
-# Naming hint for function names
-function-name-hint=[a-z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression matching correct variable names
 variable-rgx=[a-zA-Z_][a-zA-Z0-9_]{0,30}$
-# Naming hint for variable names
-variable-name-hint=[a-zA-Z_][a-zA-Z0-9_]{0,30}$
 
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-zA-Z0-9_]*$
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-zA-Z0-9_]*$
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-zA-Z0-9_]{2,30}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.


### PR DESCRIPTION
(Re)Added checkers:
- ~~`no_self_use` was moved to extensions. If we want to keep it (which is up to discussion) it needs to be loaded explicitly.~~
- `eq_without_hash` is a new checker. It needs to be loaded explicitly, and I think we want it.

Removed options:
- `...-name-hint`: no effect from pylint 1.8, removed in pylint 2.4
- `optimize-ast`, `files-output` removed in pylint 2.0
- `no-space-check`, `bad-functions` removed in pylint 2.6
