### PR TITLE
[FIX] Hierarchical Clustering: Color by metas

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -627,9 +627,9 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.labels.setMinimumWidth(1 if labels else -1)
 
         if not self.pruning and self.color_by is not None:
+            col = self.items.get_column_view(self.color_by)[0].astype(float)
             self.label_model.set_colors(
-                self.color_by.palette.values_to_qcolors(
-                    self.items.get_column_view(self.color_by)[0][indices]))
+                self.color_by.palette.values_to_qcolors(col[indices]))
         else:
             self.label_model.set_colors(None)
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
The widget crashes when selected `Color by` variable is from metas (and therefore has type object).

##### Description of changes
- cast column to float

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
