### PR TITLE
Increase required orange-canvas-core version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     - openTSNE >=0.6.1
     - pandas >=1.3.0,!=1.5.0
     - pyyaml
-    - orange-canvas-core >=0.1.27,<0.2a
+    - orange-canvas-core >=0.1.28,<0.2a
     - orange-widget-base >=4.18.0
     - openpyxl
     - httpx >=0.21

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.1.27,<0.2a
+orange-canvas-core>=0.1.28,<0.2a
 orange-widget-base>=4.18.0
 
 AnyQt>=0.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
-    oldest: orange-canvas-core==0.1.27
+    oldest: orange-canvas-core==0.1.28
     oldest: orange-widget-base==4.18.0
     oldest: AnyQt==0.1.0
     oldest: pyqtgraph==0.12.2


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
Because of this change https://github.com/biolab/orange-canvas-core/pull/243, I think it would be nice to make sure Orange uses the newest version of orange-canvas-core

##### Description of changes
Increase the required orange-canvas-core version to 0.1.28

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
