### PR TITLE
[FIX] Fix potential infinite loop when using learners for feature scoring

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -172,8 +172,13 @@ class LearnerScorer(Scorer):
             for attr, score in zip(model_attributes, scores):
                 # Go up the chain of preprocessors to obtain the original variable, but no further
                 # than the data.domain, because the data is perhaphs already preprocessed.
-                while not (attr in data.domain) and getattr(attr, 'compute_value', False):
-                    attr = getattr(attr.compute_value, 'variable', attr)
+                while not (attr in data.domain) and attr.compute_value is not None:
+                    if hasattr(attr.compute_value, 'variable'):
+                        attr = getattr(attr.compute_value, 'variable')
+                    else:
+                        # The attributes's parent can not be identified. Thus, the attributes
+                        # score will be ignored.
+                        break
                 scores_grouped[attr].append(score)
             return [max(scores_grouped[attr])
                     if attr in scores_grouped else 0


### PR DESCRIPTION
Learners use preprocessors. Some, like `Continuize`, create multiple features from a discrete feature. Therefore, when using learners as scorers, these multiple scores need to be consolidated into a single score for the original feature.

This commit fixes an infinite loop which appeared when the (internally) transformed variable did not identify its predecessor as its `compute_value`'s `.variable`.

Related, but won't be worked on within this PR: Orange seems to have two mechanisms for identifying predecessors: (1) `variable.source_variable` and (2) `variable.compute_value.variable`. Here the code seems to only look at the second one. Do we ever use the first one? To me that would be more straightforward.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
