### PR TITLE
[FIX] Predictions: Fix crash in error delegate when actual value is unknown

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -1124,7 +1124,7 @@ class ClassificationErrorDelegate(ErrorDelegate):
 
     def drawBar(self, painter, option, index, rect):
         value = self.cachedData(index, Qt.DisplayRole)
-        if numpy.isnan(value):
+        if value is None or numpy.isnan(value):
             return
 
         painter.save()
@@ -1210,7 +1210,7 @@ class RegressionErrorDelegate(ErrorDelegate):
         if not self.span:  # can be 0 if no errors, or None if they're hidden
             return
         error = self.cachedData(index, Qt.DisplayRole)
-        if numpy.isnan(error):
+        if error is None or numpy.isnan(error):
             return
         scaled = error / self.span
 

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1839,6 +1839,10 @@ class TestClassificationErrorDelegate(GuiTest):
         delegate.drawBar(painter, Mock(), index, rect)
         dr.assert_not_called()
 
+        delegate.cachedData = lambda *_: None
+        delegate.drawBar(painter, Mock(), index, rect)
+        dr.assert_not_called()
+
         delegate.cachedData = lambda *_: 1 / 4
         delegate.drawBar(painter, Mock(), index, rect)
         dr.assert_called_once()
@@ -1873,6 +1877,10 @@ class TestRegressionErrorDelegate(GuiTest):
         delegate = RegressionErrorDelegate("%.5f", True, 12)
 
         delegate.cachedData = lambda *_: np.nan
+        delegate.drawBar(painter, Mock(), index, rect)
+        dr.assert_not_called()
+
+        delegate.cachedData = lambda *_: None
         delegate.drawBar(painter, Mock(), index, rect)
         dr.assert_not_called()
 


### PR DESCRIPTION
##### Issue

Predictions widget crashed when drawing error bars for data instances for which the class was not given.

This happened because class was `None` but the delegates tested for `np.isnan`.

##### Description of changes

Test for `None` and `nan`.

##### Includes
- [X] Code changes
- [X] Tests
