### PR TITLE
Tree Viewer: Align distribution tooltip and skip empty classes

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -342,13 +342,21 @@ class OWTreeGraph(OWTreeViewer2D):
         name = escape(class_var.name)
         if self.domain.class_var.is_discrete:
             total = float(sum(distr)) or 1
+            show_all = len(distr) <= 2
             content = f"{nbp}<b>Distribution of</b> '{name}'</p><p>" \
-                + "<br/>".join(
-                    f"{indent}<span style='color: {color_to_hex(color)}'>◼</span> "
-                    f"{escape(value)}: {prop:g} ({prop / total * 100:.1f} %)"
+                + "<table>" + "".join(
+                    "<tr>"
+                    f"<td><span style='color: {color_to_hex(color)}'>◼</span> "
+                    f"{escape(value)}</td>"
+                    f"<td>{indent}</td>"
+                    f"<td align='right'>{prop:g}</td>"
+                    f"<td>{indent}</td>"
+                    f"<td align='right'>{prop / total * 100:.1f} %</td>"
+                    "</tr>"
                     for value, color, prop
-                    in zip(class_var.values, class_var.colors, distr)) \
-                + "</p>"
+                    in zip(class_var.values, class_var.colors, distr)
+                    if show_all or prop > 0) \
+                + "</table>"
         else:
             mean, var = distr
             content = f"{nbp}{class_var.name} = {mean:.3g} ± {var:.3g}<br/>" + \


### PR DESCRIPTION
##### Issue

Fixes #6190.

##### Description of changes

Align numbers. Skip empty classes.

Before:

<img width="249" alt="Screen Shot 2022-11-04 at 21 20 32" src="https://user-images.githubusercontent.com/2387315/200067186-be177dbe-ade6-4e12-bab2-3950379b4032.png">

After.

<img width="233" alt="Screen Shot 2022-11-04 at 21 26 00" src="https://user-images.githubusercontent.com/2387315/200068011-0a3d2e67-f6ea-4837-9bf3-cbf47c35dbf3.png">


Much better.

Also much better for root.

<img width="279" alt="Screen Shot 2022-11-04 at 21 25 40" src="https://user-images.githubusercontent.com/2387315/200068042-625463f8-41b9-4843-aa07-e016a5cb246f.png">

And those in between.

<img width="280" alt="Screen Shot 2022-11-04 at 21 25 49" src="https://user-images.githubusercontent.com/2387315/200068079-5aade3f4-9149-4184-aa5d-0bf8ea399c3c.png">


##### Includes
- [X] Code changes
