### PR TITLE
CI: Raise required oldest sicpy to 1.9

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -38,8 +38,8 @@ requirements:
   run:
     - python
     - setuptools >=41.0.0
-    - numpy >=1.17.3
-    - scipy >=1.3.1
+    - numpy >=1.19.5
+    - scipy >=1.9
     - scikit-learn >=1.0.1
     - bottleneck >=1.3.4
     - chardet >=3.0.2

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,6 +1,6 @@
 pip>=18.0
-numpy>=1.17.3
-scipy>=1.3.1
+numpy>=1.19.5
+scipy>=1.9
 # scikit-learn version 1.0.0 includes problematic libomp 12 which breaks xgboost
 # https://github.com/scikit-learn/scikit-learn/pull/21227
 scikit-learn>=1.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -48,8 +48,8 @@ deps =
     oldest: qtconsole==4.7.2
     oldest: pygments==2.8.0
     oldest: pip==18.0
-    oldest: numpy==1.17.3
-    oldest: scipy==1.3.1
+    oldest: numpy==1.19.5
+    oldest: scipy==1.9
     oldest: scikit-learn==1.0.1
     oldest: bottleneck==1.3.4
     oldest: xlrd==1.2.0


### PR DESCRIPTION
##### Issue

Tests on oldest fail after #6174, "Feature Statistics: Use deferred commit + **minor warning fix** due to the "minor warning fix" part. In scipy 1.9, `scipy.stats.mode` introduced argument `keepdims` and warns if it's not set. In Scipy 1.8 this argument did not exist.

We overlooked this because we got so used to some test configurations failing that we don't even check. Me very included.

##### Description of changes

We could
- ignore this failing configuration (obviously: no),
- remove `keepdims` argument and live with warning, but this would hunt us some day,
- do something fancy to pass the argument only when necessary,
- raise required version of Scipy from 1.3 to 1.9, which would then cascade to some other libraries (numpy 1.17 -> 1.19.5)

I see no reason against the latter. Does anybody?
