### PR TITLE
LoadModel Widget: fix open dialog title

### DIFF
--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -64,7 +64,7 @@ class OWLoadModel(widget.OWWidget, RecentPathsWComboMixin):
     def browse_file(self):
         start_file = self.last_path() or stdpaths.Documents
         filename, _ = QFileDialog.getOpenFileName(
-            self, 'Open Distance File', start_file, self.FILTER)
+            self, 'Open Model File', start_file, self.FILTER)
         if not filename:
             return
         self.add_path(filename)


### PR DESCRIPTION
The title was 'Open Distance File', most likely copy-pasted and forgotten to update. I changed it to 'Open Model File'.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
