### PR TITLE
Datainfo: Reimplement to show rich text

### DIFF
--- a/Orange/widgets/data/tests/test_owdatainfo.py
+++ b/Orange/widgets/data/tests/test_owdatainfo.py
@@ -1,6 +1,11 @@
-# Test methods with long descriptive names can omit docstrings
-# pylint: disable=missing-docstring,unsubscriptable-object
-from Orange.data import Table
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from scipy import sparse as sp
+
+from Orange.data import \
+    Table, Domain, ContinuousVariable, DiscreteVariable, StringVariable
 from Orange.widgets.data.owdatainfo import OWDataInfo
 from Orange.widgets.tests.base import WidgetTest
 
@@ -10,18 +15,75 @@ class TestOWDataInfo(WidgetTest):
         self.widget = self.create_widget(OWDataInfo)
 
     def test_data(self):
-        """No crash on iris"""
-        data = Table("iris")
-        self.send_signal(self.widget.Inputs.data, data)
+        # I guess we don't want to test specific output tests, just different
+        # combinations that must not crash
+        a, b, c = (DiscreteVariable(n) for n in "abc")
+        x, y, z = (ContinuousVariable(n) for n in "xyz")
+        m, n = (StringVariable(n) for n in "nm")
+        self.widget.send_report()
+        for attrs, classes, metas in (((a, b, c), (), ()),
+                                      ((a, b, c, x), (y,), ()),
+                                      ((a, b, c), (y, x), (m, )),
+                                      ((a, b), (y, x, c), (m, )),
+                                      ((a, ), (b, c), (m, )),
+                                      ((a, b, x), (c, ), (m, y)),
+                                      ((), (c, ), (m, y))):
+            data = Table.from_numpy(
+                Domain(attrs, classes, metas),
+                np.zeros((3, len(attrs))),
+                np.zeros((3, len(classes))),
+                np.full((3, len(metas)), object()))
+            data.attributes = {"att 1": 1, "att 2": True, "att 3": 3}
+            if metas:
+                data.name = "name"
+            self.send_signal(self.widget.Inputs.data, data)
+            self.widget.send_report()
+        self.send_signal(self.widget.Inputs.data, None)
+        self.widget.send_report()
 
-    def test_empty_data(self):
-        """No crash on empty data"""
-        data = Table("iris")
-        self.send_signal(self.widget.Inputs.data,
-                         Table.from_domain(data.domain))
+        data.attributes = {"foo": "bar"}
+        self.send_signal(self.widget.Inputs.data, None)
+        self.widget.send_report()
 
-    def test_data_attributes(self):
-        """No crash on data attributes of different types"""
-        data = Table("iris")
-        data.attributes = {"att 1": 1, "att 2": True, "att 3": 3}
+    def test_sparse(self):
+        x, y, z, u, w = (ContinuousVariable(n) for n in "xyzuw")
+        data = Table.from_numpy(
+            Domain([x, y], z, [u, w]),
+            sp.csc_matrix(np.random.randint(0, 1, (5, 2))),
+            sp.csc_matrix(np.random.randint(0, 1, (5, 1))),
+            sp.csc_matrix(np.random.randint(0, 1, (5, 2))))
         self.send_signal(self.widget.Inputs.data, data)
+        self.widget.send_report()
+
+    def test_sql(self):
+        class SqlTable(Table):
+            connection_params = {"foo": "bar"}
+
+        class Thread:
+            def __init__(self, target):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        w = self.widget
+
+        domain = Domain([ContinuousVariable("y")])
+
+        with patch("Orange.widgets.data.owdatainfo.SqlTable", new=SqlTable), \
+                patch("threading.Thread", new=Thread), \
+                patch.object(self.widget, "_p_size", wraps=self.widget._p_size) as p_size:
+
+            self.send_signal(w.Inputs.data, Table.from_numpy(domain, [[42]]))
+            p_size.assert_called_once()
+            p_size.reset_mock()
+
+            d = SqlTable.from_numpy(domain, [[42]])
+            self.send_signal(w.Inputs.data, d)
+            self.assertEqual(p_size.call_count, 2)
+            self.assertEqual(p_size.call_args_list[0], ((d, ),))
+            self.assertEqual(p_size.call_args_list[1], ((d, ), dict(exact=True)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue

- Data Info widget used labels as widget attributes, which made it untranslatable.
- The code itself was an endless spago that was putting together various texts.

##### Description of changes

- Data is stored in dictionary, which is used to fill out the widget and the report.
- Each value is computed by a separate different method.
- Widget no longer contains n boxes but two (basic properties and table attributes), which contain rich texts.

The latter can be reformed back into boxes, though I prefer the new form.

Before:

<img width="390" alt="Screen Shot 2022-11-08 at 20 57 25" src="https://user-images.githubusercontent.com/2387315/200663584-7738ebcc-12c7-4f35-84e2-76eec1c31ada.png">

Now:

<img width="553" alt="Screen Shot 2022-11-08 at 20 54 07" src="https://user-images.githubusercontent.com/2387315/200663611-31984a05-5e2e-4ebf-80e2-9a6dce255e6a.png">

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
