### PR TITLE
Doc - use sphinx-multiproject for RTD subprojects

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+   os: ubuntu-20.04
+   tools:
+      python: "3.10"
+
+sphinx:
+   # Path to the shared conf.py file.
+   configuration: doc/conf.py
+
+python:
+   install:
+   - requirements: requirements-readthedocs.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,47 @@
+"""
+This configuration use sphinx-multiproject which builds multiple
+Sphinx projects for the Read the Docs. We publish each project at read-the-docs
+as orange3 RTD project's subproject. This config file is only required for the
+Read the Docs build. Each documentation project can still be built separately
+with sphinx-build (make html).
+
+To select a documentation project that the RTD will build, set the PROJECT
+environment variable in RTD subprojects to the documentation project name
+(e.g. PROJECT=data-mining-library)
+
+To test the documentation build locally run (from doc directory):
+```
+PROJECT="<project name>" sphinx-build . ./_build
+```
+More about shpinx-multiproject:
+https://sphinx-multiproject.readthedocs.io/en/latest/index.html
+"""
+
+# pylint: disable=duplicate-code
+extensions = [
+    "multiproject",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "recommonmark",
+]
+
+# Define the projects that will share this configuration file.
+multiproject_projects = {
+    "data-mining-library": {
+        "path": "data-mining-library/source/"
+    },
+    "development": {
+        "path": "development/source/"
+    },
+    "visual-programming": {
+        "path": "visual-programming/source/"
+    },
+}

--- a/doc/data-mining-library/source/conf.py
+++ b/doc/data-mining-library/source/conf.py
@@ -80,7 +80,7 @@ release = "3"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "english"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/data-mining-library/source/reference/data.table.rst
+++ b/doc/data-mining-library/source/reference/data.table.rst
@@ -86,8 +86,6 @@ The preferred way to construct a table is to invoke a named constructor.
 Inspection
 ----------
 
-.. automethod:: Table.is_view
-.. automethod:: Table.is_copy
 .. automethod:: Table.ensure_copy
 .. automethod:: Table.has_missing
 .. automethod:: Table.has_missing_class

--- a/doc/development/source/conf.py
+++ b/doc/development/source/conf.py
@@ -79,7 +79,7 @@ release = "3"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "english"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/visual-programming/source/conf.py
+++ b/doc/visual-programming/source/conf.py
@@ -74,7 +74,7 @@ release = "3"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "english"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,3 +3,4 @@
 docutils<0.17
 Sphinx>=4.2.0
 recommonmark
+sphinx-multiproject

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -5,3 +5,4 @@ cython
 -r requirements-pyqt.txt
 # for orange data mining library catboost and xgboost required
 -r requirements-opt.txt
+-e .


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Orange3 documentation consists of multiple sphinx projects, which are built as subprojects at the Read the Docs. The documentation each subproject builds is set in advanced settings at RTD. That prevents us from using the `.readthedocs.yaml` file to set a higher version of Python since `.readthedocs.yaml` overwrites all advanced settings.
We need to change the version of Python used to build documentation (the default is 3.7) since we cannot increase some package versions in Orange.

##### Description of changes
In order to use `.readthedocs.yaml` to set a different version of Python, we need to set the documentation project somewhere outside the advanced settings in RTD. Using sphinx-multiproject enables us to set it as an environmental variable which does not get overwritten by `.readthedocs.yaml`.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
