### PR TITLE
Avoid counting unknowns for big tables

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1532,16 +1532,18 @@ class Table(Sequence, Storage):
         """Return `True` if there are any missing class values."""
         return bn.anynan(self._Y)
 
-    def get_nan_frequency_attribute(self):
-        if self.X.size == 0:
+    @staticmethod
+    def __get_nan_frequency(data):
+        if data.size == 0:
             return 0
-        vals = self.X if not sp.issparse(self.X) else self.X.data
-        return np.isnan(vals).sum() / self.X.size
+        dense = data if not sp.issparse(data) else data.data
+        return np.isnan(dense).sum() / np.prod(data.shape)
+
+    def get_nan_frequency_attribute(self):
+        return self.__get_nan_frequency(self.X)
 
     def get_nan_frequency_class(self):
-        if self.Y.size == 0:
-            return 0
-        return np.isnan(self._Y).sum() / self._Y.size
+        return self.__get_nan_frequency(self.Y)
 
     def checksum(self, include_metas=True):
         # TODO: zlib.adler32 does not work for numpy arrays with dtype object

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1535,7 +1535,8 @@ class Table(Sequence, Storage):
     def get_nan_frequency_attribute(self):
         if self.X.size == 0:
             return 0
-        return np.isnan(self.X).sum() / self.X.size
+        vals = self.X if not sp.issparse(self.X) else self.X.data
+        return np.isnan(vals).sum() / self.X.size
 
     def get_nan_frequency_class(self):
         if self.Y.size == 0:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -525,10 +525,8 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         text += f"<p>{len(table)} {pl(len(table), 'instance')}"
 
-        missing_in_attr = missing_prop(table.has_missing_attribute()
-                                       and table.get_nan_frequency_attribute())
-        missing_in_class = missing_prop(table.has_missing_class()
-                                        and table.get_nan_frequency_class())
+        missing_in_attr = missing_prop(table.get_nan_frequency_attribute())
+        missing_in_class = missing_prop(table.get_nan_frequency_class())
         nattrs = len(domain.attributes)
         text += f"<br/>{nattrs} {pl(nattrs, 'feature')} {missing_in_attr}"
         if domain.has_continuous_class:

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -525,8 +525,10 @@ class OWFile(widget.OWWidget, RecentPathsWComboMixin):
 
         text += f"<p>{len(table)} {pl(len(table), 'instance')}"
 
-        missing_in_attr = missing_prop(table.get_nan_frequency_attribute())
-        missing_in_class = missing_prop(table.get_nan_frequency_class())
+        missing_in_attr = missing_in_class = ""
+        if table.X.size < OWFile.SIZE_LIMIT:
+            missing_in_attr = missing_prop(table.get_nan_frequency_attribute())
+            missing_in_class = missing_prop(table.get_nan_frequency_class())
         nattrs = len(domain.attributes)
         text += f"<br/>{nattrs} {pl(nattrs, 'feature')} {missing_in_attr}"
         if domain.has_continuous_class:

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -76,6 +76,23 @@ class TestOWFile(WidgetTest):
     def tearDown(self):
         dataset_dirs.pop()
 
+    def test_describe(self):
+        table = Table("iris")
+        description = f"<p><b>Iris flower dataset</b><br/>" \
+                      f"Classical dataset with 150 instances of Iris setosa, Iris virginica and Iris versicolor.</p>" \
+                      f"<p>150 instance(s)<br/>" \
+                      f"4 feature(s) (no missing values)<br/>" \
+                      f"Classification; categorical class with 3 values (no missing values)<br/>" \
+                      f"0 meta attribute(s)</p>"
+        self.assertEqual(description, self.widget._describe(table))
+
+        table = Table.from_numpy(domain=None, X=np.random.random((10000, 1000)))
+        description = f"<p>10000 instance(s)<br/>" \
+                      f"1000 feature(s) <br/>" \
+                      f"Data has no target variable.<br/>" \
+                      f"0 meta attribute(s)</p>"
+        self.assertEqual(description, self.widget._describe(table))
+
     def test_dragEnterEvent_accepts_urls(self):
         event = self._drag_enter_event(QUrl.fromLocalFile(TITANIC_PATH))
         self.widget.dragEnterEvent(event)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -80,17 +80,17 @@ class TestOWFile(WidgetTest):
         table = Table("iris")
         description = f"<p><b>Iris flower dataset</b><br/>" \
                       f"Classical dataset with 150 instances of Iris setosa, Iris virginica and Iris versicolor.</p>" \
-                      f"<p>150 instance(s)<br/>" \
-                      f"4 feature(s) (no missing values)<br/>" \
+                      f"<p>150 instances<br/>" \
+                      f"4 features (no missing values)<br/>" \
                       f"Classification; categorical class with 3 values (no missing values)<br/>" \
-                      f"0 meta attribute(s)</p>"
+                      f"0 meta attributes</p>"
         self.assertEqual(description, self.widget._describe(table))
 
         table = Table.from_numpy(domain=None, X=np.random.random((10000, 1000)))
-        description = f"<p>10000 instance(s)<br/>" \
-                      f"1000 feature(s) <br/>" \
+        description = f"<p>10000 instances<br/>" \
+                      f"1000 features <br/>" \
                       f"Data has no target variable.<br/>" \
-                      f"0 meta attribute(s)</p>"
+                      f"0 meta attributes</p>"
         self.assertEqual(description, self.widget._describe(table))
 
     def test_dragEnterEvent_accepts_urls(self):

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -76,22 +76,16 @@ class TestOWFile(WidgetTest):
     def tearDown(self):
         dataset_dirs.pop()
 
-    def test_describe(self):
+    def test_describe_call_get_nans(self):
         table = Table("iris")
-        description = f"<p><b>Iris flower dataset</b><br/>" \
-                      f"Classical dataset with 150 instances of Iris setosa, Iris virginica and Iris versicolor.</p>" \
-                      f"<p>150 instances<br/>" \
-                      f"4 features (no missing values)<br/>" \
-                      f"Classification; categorical class with 3 values (no missing values)<br/>" \
-                      f"0 meta attributes</p>"
-        self.assertEqual(description, self.widget._describe(table))
+        with patch.object(Table, "get_nan_frequency_attribute", return_value=0.) as mock:
+            self.widget._describe(table)
+            mock.assert_called()
 
         table = Table.from_numpy(domain=None, X=np.random.random((10000, 1000)))
-        description = f"<p>10000 instances<br/>" \
-                      f"1000 features <br/>" \
-                      f"Data has no target variable.<br/>" \
-                      f"0 meta attributes</p>"
-        self.assertEqual(description, self.widget._describe(table))
+        with patch.object(Table, "get_nan_frequency_attribute", return_value=0.) as mock:
+            self.widget._describe(table)
+            mock.assert_not_called()
 
     def test_dragEnterEvent_accepts_urls(self):
         event = self._drag_enter_event(QUrl.fromLocalFile(TITANIC_PATH))

--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -20,7 +20,7 @@ from Orange.widgets.utils.signals import AttributeList
 from Orange.base import Model, Learner
 
 
-SIZE_LIMIT = 1e7
+COMPUTE_NANS_LIMIT = 1e7
 
 
 def format_variables_string(variables):
@@ -87,7 +87,7 @@ def format_summary_details(data, format=Qt.PlainText):
     metas = format_variables_string(data.domain.metas)
 
     features_missing = ""
-    if data.X.size < SIZE_LIMIT:
+    if data.X.size < COMPUTE_NANS_LIMIT:
         features_missing = missing_values(data.get_nan_frequency_attribute())
     n_features = len(data.domain.variables) + len(data.domain.metas)
     name = getattr(data, "name", None)

--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -83,8 +83,7 @@ def format_summary_details(data, format=Qt.PlainText):
     targets = format_variables_string(data.domain.class_vars)
     metas = format_variables_string(data.domain.metas)
 
-    features_missing = missing_values(data.has_missing_attribute()
-                                      and data.get_nan_frequency_attribute())
+    features_missing = missing_values(data.get_nan_frequency_attribute())
     n_features = len(data.domain.variables) + len(data.domain.metas)
     name = getattr(data, "name", None)
     if name == "untitled":

--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -20,6 +20,9 @@ from Orange.widgets.utils.signals import AttributeList
 from Orange.base import Model, Learner
 
 
+SIZE_LIMIT = 1e7
+
+
 def format_variables_string(variables):
     """
     A function that formats the descriptive part of the input/output summary for
@@ -83,7 +86,9 @@ def format_summary_details(data, format=Qt.PlainText):
     targets = format_variables_string(data.domain.class_vars)
     metas = format_variables_string(data.domain.metas)
 
-    features_missing = missing_values(data.get_nan_frequency_attribute())
+    features_missing = ""
+    if data.X.size < SIZE_LIMIT:
+        features_missing = missing_values(data.get_nan_frequency_attribute())
     n_features = len(data.domain.variables) + len(data.domain.metas)
     name = getattr(data, "name", None)
     if name == "untitled":

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -185,7 +185,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(details, format_summary_details(data))
 
         data = Table.from_numpy(domain=None, X=np.random.random((10000, 1000)))
-        details = f'{len(data)} instances, ' \
+        details = f'{len(data):n} instances, ' \
                   f'{len(data.domain.variables)} variables\n' \
                   f'Features: {len(data.domain.variables)} numeric \n' \
                   f'Target: —'

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 import datetime
 from collections import namedtuple
 
@@ -182,6 +183,15 @@ class TestUtils(unittest.TestCase):
                   f'Features: categorical (no missing values)\n' \
                   f'Target: —'
         self.assertEqual(details, format_summary_details(data))
+
+        data = Table.from_numpy(domain=None, X=np.random.random((10000, 1000)))
+        details = f'{len(data)} instances, ' \
+                  f'{len(data.domain.variables)} variables\n' \
+                  f'Features: {len(data.domain.variables)} numeric \n' \
+                  f'Target: —'
+        with patch.object(Table, "get_nan_frequency_attribute") as mock:
+            self.assertEqual(details, format_summary_details(data))
+            self.assertFalse(mock.called)
 
         data = None
         self.assertEqual('', format_summary_details(data))

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -191,7 +191,7 @@ class TestUtils(unittest.TestCase):
                   f'Target: —'
         with patch.object(Table, "get_nan_frequency_attribute") as mock:
             self.assertEqual(details, format_summary_details(data))
-            self.assertFalse(mock.called)
+            mock.assert_not_called()
 
         data = None
         self.assertEqual('', format_summary_details(data))


### PR DESCRIPTION
##### Issue
For big tables counting unknowns takes too long (especially important for table summaries that all widgets have). Therefore we opted to skip it for big tables.

##### Description of changes
The original code was also slightly rewritten to avoid a separate NaN check, which does not seem to gain anything (just an additional pass through the data).

This PR also fixes a bug with `get_nan_frequency_attribute` and sparse tables.

This comes from the `dask` branch.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
