### PR TITLE
[ENH] Faster normalization

### DIFF
--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -347,7 +347,7 @@ class SqlTable(Table):
         return False
 
     def _compute_basic_stats(self, columns=None,
-                             include_metas=False, compute_var=False):
+                             include_metas=False, compute_variance=False):
         if self.approx_len() > LARGE_TABLE:
             self = self.sample_time(DEFAULT_SAMPLE_TIME)
 

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1954,19 +1954,19 @@ class Table(Sequence, Storage):
 
     def _compute_basic_stats(self, columns=None,
                              include_metas=False, compute_variance=False):
-        if compute_variance:
-            raise NotImplementedError("computation of variance is "
-                                      "not implemented yet")
         W = self._W if self.has_weights() else None
         rr = []
         stats = []
         if not columns:
             if self.domain.attributes:
-                rr.append(fast_stats(self._X, W))
+                rr.append(fast_stats(self._X, W,
+                                     compute_variance=compute_variance))
             if self.domain.class_vars:
-                rr.append(fast_stats(self._Y, W))
+                rr.append(fast_stats(self._Y, W,
+                                     compute_variance=compute_variance))
             if include_metas and self.domain.metas:
-                rr.append(fast_stats(self.metas, W))
+                rr.append(fast_stats(self.metas, W,
+                                     compute_variance=compute_variance))
             if len(rr):
                 stats = np.vstack(tuple(rr))
         else:
@@ -1974,14 +1974,18 @@ class Table(Sequence, Storage):
             for column in columns:
                 c = self.domain.index(column)
                 if 0 <= c < nattrs:
-                    S = fast_stats(self._X[:, [c]], W and W[:, [c]])
+                    S = fast_stats(self._X[:, [c]], W and W[:, [c]],
+                                   compute_variance=compute_variance)
                 elif c >= nattrs:
                     if self._Y.ndim == 1 and c == nattrs:
-                        S = fast_stats(self._Y[:, None], W and W[:, None])
+                        S = fast_stats(self._Y[:, None], W and W[:, None],
+                                       compute_variance=compute_variance)
                     else:
-                        S = fast_stats(self._Y[:, [c - nattrs]], W and W[:, [c - nattrs]])
+                        S = fast_stats(self._Y[:, [c - nattrs]], W and W[:, [c - nattrs]],
+                                       compute_variance=compute_variance)
                 else:
-                    S = fast_stats(self._metas[:, [-1 - c]], W and W[:, [-1 - c]])
+                    S = fast_stats(self._metas[:, [-1 - c]], W and W[:, [-1 - c]],
+                                   compute_variance=compute_variance)
                 stats.append(S[0])
         return stats
 

--- a/Orange/statistics/basic_stats.py
+++ b/Orange/statistics/basic_stats.py
@@ -34,10 +34,11 @@ class BasicStats:
             = stats[0]
 
 class DomainBasicStats:
-    def __init__(self, data, include_metas=False):
+    def __init__(self, data, include_metas=False, compute_variance=False):
         self.domain = data.domain
         self.stats = [BasicStats(s) for s in
-                      data._compute_basic_stats(include_metas=include_metas)]
+                      data._compute_basic_stats(include_metas=include_metas,
+                                                compute_variance=compute_variance)]
 
     def __getitem__(self, index):
         """

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -343,6 +343,8 @@ def stats(X, weights=None, compute_variance=False):
     is_sparse = sp.issparse(X)
 
     if X.size and is_numeric:
+        if is_sparse:
+            X = X.tocsc()
         if compute_variance:
             means, vars = nan_mean_var(X, axis=0, weights=weights)
         else:
@@ -360,7 +362,6 @@ def stats(X, weights=None, compute_variance=False):
             X.shape[0] - nans))
     elif is_sparse and X.size:
         non_zero = np.bincount(X.nonzero()[1], minlength=X.shape[1])
-        X = X.tocsc()
         return np.column_stack((
             nanmin(X, axis=0),
             nanmax(X, axis=0),

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -355,7 +355,7 @@ def stats(X, weights=None, compute_variance=False):
             nans,
             X.shape[0] - nans))
     elif is_sparse and X.size:
-        if compute_variance:
+        if compute_variance and weighted:
             raise NotImplementedError
 
         non_zero = np.bincount(X.nonzero()[1], minlength=X.shape[1])
@@ -364,7 +364,8 @@ def stats(X, weights=None, compute_variance=False):
             nanmin(X, axis=0),
             nanmax(X, axis=0),
             nanmean(X, axis=0, weights=weights),
-            np.zeros(X.shape[1]),      # variance not supported
+            nanvar(X, axis=0) if compute_variance else \
+                np.zeros(X.shape[1] if X.ndim == 2 else 1),
             X.shape[0] - non_zero,
             non_zero))
     else:

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -341,31 +341,31 @@ def stats(X, weights=None, compute_variance=False):
     """
     is_numeric = np.issubdtype(X.dtype, np.number)
     is_sparse = sp.issparse(X)
-    weighted = weights is not None and X.dtype != object
-    weights = weights if weighted else None
+
+    if X.size and is_numeric:
+        if compute_variance:
+            means, vars = nan_mean_var(X, axis=0, weights=weights)
+        else:
+            means = nanmean(X, axis=0, weights=weights)
+            vars = np.zeros(X.shape[1] if X.ndim == 2 else 1)
 
     if X.size and is_numeric and not is_sparse:
         nans = np.isnan(X).sum(axis=0)
         return np.column_stack((
             np.nanmin(X, axis=0),
             np.nanmax(X, axis=0),
-            nanmean(X, axis=0, weights=weights),
-            nanvar(X, axis=0) if compute_variance else \
-                np.zeros(X.shape[1] if X.ndim == 2 else 1),
+            means,
+            vars,
             nans,
             X.shape[0] - nans))
     elif is_sparse and X.size:
-        if compute_variance and weighted:
-            raise NotImplementedError
-
         non_zero = np.bincount(X.nonzero()[1], minlength=X.shape[1])
         X = X.tocsc()
         return np.column_stack((
             nanmin(X, axis=0),
             nanmax(X, axis=0),
-            nanmean(X, axis=0, weights=weights),
-            nanvar(X, axis=0) if compute_variance else \
-                np.zeros(X.shape[1] if X.ndim == 2 else 1),
+            means,
+            vars,
             X.shape[0] - non_zero,
             non_zero))
     else:

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -155,8 +155,9 @@ class TestUtil(unittest.TestCase):
         np.testing.assert_equal(stats(X, weights), [[0, 2, 1.5, 0, 1, 1],
                                                     [1, 3, 2.5, 0, 0, 2]])
 
-        with self.assertRaises(NotImplementedError):
-            stats(X, weights, compute_variance=True)
+        np.testing.assert_equal(stats(X, weights, compute_variance=True),
+                                [[0, 2, 1.5, 0.75, 1, 1],
+                                 [1, 3, 2.5, 0.75, 0, 2]])
 
     def test_stats_non_numeric(self):
         X = np.array([

--- a/Orange/tests/test_statistics.py
+++ b/Orange/tests/test_statistics.py
@@ -121,6 +121,13 @@ class TestUtil(unittest.TestCase):
                                            [0, 0, 0, 0, 3, 0],
                                            [0, 0, 0, 0, 3, 0]])
 
+        r = stats(X, compute_variance=True)
+        np.testing.assert_almost_equal(r, [[0, 1, 1/3, 2/9, 2, 1],
+                                           [0, 1, 1/3, 2/9, 2, 1],
+                                           [0, 1, 1/3, 2/9, 2, 1],
+                                           [0, 0, 0, 0, 3, 0],
+                                           [0, 0, 0, 0, 3, 0]])
+
     def test_stats_weights(self):
         X = np.arange(4).reshape(2, 2).astype(float)
         weights = np.array([1, 3])
@@ -147,6 +154,9 @@ class TestUtil(unittest.TestCase):
         weights = np.array([1, 3])
         np.testing.assert_equal(stats(X, weights), [[0, 2, 1.5, 0, 1, 1],
                                                     [1, 3, 2.5, 0, 0, 2]])
+
+        with self.assertRaises(NotImplementedError):
+            stats(X, weights, compute_variance=True)
 
     def test_stats_non_numeric(self):
         X = np.array([

--- a/benchmark/bench_preprocess.py
+++ b/benchmark/bench_preprocess.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+
+from Orange.data import Domain, Table, ContinuousVariable
+from Orange.preprocess import Normalize
+
+from .base import Benchmark, benchmark
+
+
+class BenchNormalize(Benchmark):
+
+    def setUp(self):
+        cols = 1000
+        rows = 1000
+        cont = [ContinuousVariable(str(i)) for i in range(cols)]
+        self.domain = Domain(cont)
+        self.single = Domain([ContinuousVariable("0")])
+        self.table = Table.from_numpy(
+            self.domain,
+            np.random.RandomState(0).randint(0, 2, (rows, len(self.domain.variables))))
+        self.normalized_domain = Normalize()(self.table).domain
+
+    @benchmark(number=5)
+    def bench_normalize_only_transform(self):
+        self.table.transform(self.normalized_domain)
+
+    @benchmark(number=5)
+    def bench_normalize_only_parameters(self):
+        # avoid benchmarking transformation
+        with patch("Orange.data.Table.transform", MagicMock()):
+            Normalize()(self.table)


### PR DESCRIPTION
##### Issue
Fixes #5219

##### Description of changes
The computation of distributions is slow (it works through contingencies and requires sorting).

This slowdown was especially problematic for dask tables.

~~The new code does not currently support weights! Supporting them would require making a weighted variance computation. Should we go there?~~ Done in #6205.

Requires #6204 and #6205.

Testing performance on 1000x1000 tables.

Before:
```
[normalize_only_parameters] with 5 loops, best of 3:
	min 233 msec per loop
	avg 235 msec per loop
[normalize_only_transform] with 5 loops, best of 3:
	min 120 msec per loop
	avg 121 msec per loop
```

After:
```
[normalize_only_parameters] with 5 loops, best of 3:
	min 71.7 msec per loop
	avg 73.3 msec per loop
[normalize_only_transform] with 5 loops, best of 3:
	min 117 msec per loop
	avg 119 msec per loop
```

The mean/variance estimation part is 3x faster. Of course, this PR has no influence on the actual transformation (the domain contains the same variables).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
