### PR TITLE
[FIX] Data Sampler: Fix crash when requesting an empty sample

### DIFF
--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -107,7 +107,7 @@ class OWDataSampler(OWWidget):
         ibox = gui.indentedBox(sampling)
         self.sampleSizeSpin = gui.spin(
             ibox, self, "sampleSizeNumber", label="Instances: ",
-            minv=1, maxv=self._MAX_SAMPLE_SIZE,
+            minv=0, maxv=self._MAX_SAMPLE_SIZE,
             callback=set_sampling_type(self.FixedSize),
             controlWidth=90)
         gui.checkBox(
@@ -395,11 +395,15 @@ class SampleRandomN(Reprable):
             o[sample] = 0
             others = np.nonzero(o)[0]
             return others, sample
-        if self.n == len(table):
+        if self.n in (0, len(table)):
             rgen = np.random.RandomState(self.random_state)
-            sample = np.arange(self.n)
-            rgen.shuffle(sample)
-            return np.array([], dtype=int), sample
+            shuffled = np.arange(len(table))
+            rgen.shuffle(shuffled)
+            empty = np.array([], dtype=int)
+            if self.n == 0:
+                return shuffled, empty
+            else:
+                return empty, shuffled
         elif self.stratified and table.domain.has_discrete_class:
             test_size = max(len(table.domain.class_var.values), self.n)
             splitter = skl.StratifiedShuffleSplit(

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -131,6 +131,13 @@ class TestOWDataSampler(WidgetTest):
         self.widget.commit()
         return self.widget.sampleSizeSpin.value()
 
+    def set_fixed_proportion(self, proportion):
+        """Set fixed sample proportion.
+        """
+        self.select_sampling_type(self.widget.FixedProportion)
+        self.widget.sampleSizePercentageSlider.setValue(proportion)
+        self.widget.commit()
+
     def assertNoIntersection(self, sample, other):
         self.assertFalse(bool(set(sample.ids) & set(other.ids)))
 
@@ -169,6 +176,26 @@ class TestOWDataSampler(WidgetTest):
         w.commit()
         self.assertEqual(len(self.get_output(w.Outputs.data_sample)), 15)
         self.assertEqual(len(self.get_output(w.Outputs.remaining_data)), 135)
+
+    def test_empty_sample(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.iris)
+
+        self.set_fixed_sample_size(150)
+        self.assertEqual(len(self.get_output(w.Outputs.data_sample)), 150)
+        self.assertEqual(len(self.get_output(w.Outputs.remaining_data)), 0)
+
+        self.set_fixed_sample_size(0)
+        self.assertEqual(len(self.get_output(w.Outputs.data_sample)), 0)
+        self.assertEqual(len(self.get_output(w.Outputs.remaining_data)), 150)
+
+        self.set_fixed_proportion(100)
+        self.assertEqual(len(self.get_output(w.Outputs.data_sample)), 150)
+        self.assertEqual(len(self.get_output(w.Outputs.remaining_data)), 0)
+
+        self.set_fixed_proportion(0)
+        self.assertEqual(len(self.get_output(w.Outputs.data_sample)), 0)
+        self.assertEqual(len(self.get_output(w.Outputs.remaining_data)), 150)
 
     def test_send_report(self):
         w = self.widget


### PR DESCRIPTION
##### Issue

Fixes #6207.

##### Description of changes

Widget already treated a 100 % sample as special case. The same code is now also used for empty sample.

Related change: when setting the proportion, widget allowed to set 0 %, but when setting the number of instances, it enforced a minimum of 1. Now it also allows 0.

##### Includes
- [X] Code changes
- [X] Tests
