### PR TITLE
Translation fixes: Pivot and Edit Domain

### DIFF
--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -5,7 +5,7 @@ from itertools import count
 import numpy as np
 
 from AnyQt.QtWidgets import QGridLayout, QLabel, QLineEdit, QSizePolicy, QWidget
-from AnyQt.QtCore import QSize, Qt
+from AnyQt.QtCore import Qt
 
 from Orange.data import StringVariable, DiscreteVariable, Domain
 from Orange.data.table import Table
@@ -14,6 +14,7 @@ from Orange.preprocess.transformation import Transformation, Lookup
 from Orange.widgets import gui, widget
 from Orange.widgets.settings import DomainContextHandler, ContextSetting
 from Orange.widgets.utils.itemmodels import DomainModel
+from Orange.widgets.utils.localization import pl
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Msg, Input, Output
 
@@ -472,8 +473,9 @@ class OWCreateClass(widget.OWWidget):
                 if n_before and (lab or patt):
                     lab_total.setText("+ {}".format(n_before))
                     if n_matched:
-                        tip = "{} of the {} matching instances are already " \
-                              "covered above".format(n_before, n_total)
+                        tip = f"{n_before} o" \
+                              f"f {n_total} matching {pl(n_total, 'instance')} " \
+                              f"{pl(n_before, 'is|are')} already covered above."
                     else:
                         tip = "All matching instances are already covered above"
                     lab_total.setToolTip(tip)
@@ -562,23 +564,30 @@ class OWCreateClass(widget.OWWidget):
         # within the loop
         # pylint: disable=undefined-loop-variable
         def _cond_part():
-            rule = "<b>{}</b> ".format(class_name)
+            rule = f"<b>{class_name}</b> "
             if patt:
-                rule += "if <b>{}</b> contains <b>{}</b>".format(
-                    self.attribute.name, patt)
+                rule += f"if <b>{self.attribute.name}</b> contains <b>{patt}</b>"
             else:
                 rule += "otherwise"
             return rule
 
         def _count_part():
+            aca = "already covered above"
             if not n_matched:
-                return "all {} matching instances are already covered " \
-                       "above".format(n_total)
-            elif n_matched < n_total and patt:
-                return "{} matching instances (+ {} that are already " \
-                       "covered above".format(n_matched, n_total - n_matched)
+                if n_total == 1:
+                    return f"the single matching instance is {aca}"
+                elif n_total == 2:
+                    return f"both matching instances are {aca}"
+                else:
+                    return f"all {n_total} matching instances are {aca}"
+            elif not patt:
+                return f"{n_matched} {pl(n_matched, 'instance')}"
             else:
-                return "{} matching instances".format(n_matched)
+                m = f"{n_matched} matching {pl(n_matched, 'instance')}"
+                if n_matched < n_total:
+                    n_already = n_total - n_matched
+                    m += f" (+{n_already} that {pl(n_already, 'is|are')} {aca})"
+                return m
 
         if not self.attribute:
             return

--- a/Orange/widgets/data/owcreateinstance.py
+++ b/Orange/widgets/data/owcreateinstance.py
@@ -490,6 +490,7 @@ class OWCreateInstance(OWWidget):
                            "removed from the list.")
 
     want_main_area = False
+    BUTTONS = ["Median", "Mean", "Random", "Input"]
     ACTIONS = ["median", "mean", "random", "input"]
     HEADER = [["name", "Variable"],
               ["variable", "Value"]]
@@ -535,10 +536,10 @@ class OWCreateInstance(OWWidget):
 
         box = gui.hBox(vbox, objectName="buttonBox")
         gui.rubber(box)
-        for name in self.ACTIONS:
+        for name, action in zip(self.BUTTONS, self.ACTIONS):
             gui.button(
-                box, self, name.capitalize(),
-                lambda *args, fun=name: self._initialize_values(fun),
+                box, self, name,
+                lambda *args, fun=action: self._initialize_values(fun),
                 autoDefault=False
             )
         gui.rubber(box)

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -19,6 +19,7 @@ from orangewidget.utils import listview
 from Orange.data import (
     Variable, ContinuousVariable, DiscreteVariable, TimeVariable, Domain, Table)
 import Orange.preprocess.discretize as disc
+from Orange.widgets.utils.localization import pl
 from Orange.widgets import widget, gui
 from Orange.widgets.utils import unique_everseen
 from Orange.widgets.utils.itemmodels import DomainModel
@@ -308,14 +309,12 @@ def format_desc(hint: VarHint) -> str:
     desc = Options[hint.method_id].short_desc
     if hint.method_id == Methods.FixedWidthTime:
         width, unit = hint.args
-        unit = time_units[unit]
         try:
             width = int(width)
         except ValueError:
-            unit += "(s)"
+            unit = f"{time_units[unit]}(s)"
         else:
-            if width != 1:
-                unit += "s"
+            unit = f"{pl(width, time_units[unit])}"
         return desc.format(width, unit)
     return desc.format(*hint.args)
 
@@ -643,7 +642,7 @@ class OWDiscretize(widget.OWWidget):
 
         self.width_time_unit = u = QComboBox(self)
         u.setContentsMargins(0, 0, 0, 0)
-        u.addItems([unit + "(s)" for unit in time_units])
+        u.addItems([f"{unit}(s)" for unit in time_units])
         validator = QIntValidator()
         validator.setBottom(1)
         self.width_time_line = button(Methods.FixedWidthTime,

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -23,7 +23,7 @@ from AnyQt.QtWidgets import (
     QLineEdit, QAction, QActionGroup, QGroupBox,
     QStyledItemDelegate, QStyleOptionViewItem, QStyle, QSizePolicy,
     QDialogButtonBox, QPushButton, QCheckBox, QComboBox, QStackedLayout,
-    QDialog, QRadioButton, QGridLayout, QLabel, QSpinBox, QDoubleSpinBox,
+    QDialog, QRadioButton, QLabel, QSpinBox, QDoubleSpinBox,
     QAbstractItemView, QMenu, QToolTip
 )
 from AnyQt.QtGui import (
@@ -703,7 +703,7 @@ class GroupItemsDialog(QDialog):
         label3 = QLabel("occurrences")
         label4 = QLabel("most frequent values")
 
-        self.frequent_abs_spin = spin2 = QSpinBox()
+        self.frequent_abs_spin = spin2 = QSpinBox(alignment=Qt.AlignRight)
         max_val = len(data)
         spin2.setMinimum(1)
         spin2.setMaximum(max_val)
@@ -713,7 +713,7 @@ class GroupItemsDialog(QDialog):
         )
         spin2.valueChanged.connect(self._frequent_abs_spin_changed)
 
-        self.frequent_rel_spin = spin3 = QDoubleSpinBox()
+        self.frequent_rel_spin = spin3 = QDoubleSpinBox(alignment=Qt.AlignRight)
         spin3.setMinimum(0)
         spin3.setDecimals(1)
         spin3.setSingleStep(0.1)
@@ -723,7 +723,7 @@ class GroupItemsDialog(QDialog):
         spin3.setSuffix(" %")
         spin3.valueChanged.connect(self._frequent_rel_spin_changed)
 
-        self.n_values_spin = spin4 = QSpinBox()
+        self.n_values_spin = spin4 = QSpinBox(alignment=Qt.AlignRight)
         spin4.setMinimum(0)
         spin4.setMaximum(len(variable.categories))
         spin4.setValue(
@@ -736,21 +736,29 @@ class GroupItemsDialog(QDialog):
         )
         spin4.valueChanged.connect(self._n_values_spin_spin_changed)
 
-        grid_layout = QGridLayout()
+        grid_layout = QVBoxLayout()
         # first row
-        grid_layout.addWidget(radio1, 0, 0, 1, 2)
+        row = QHBoxLayout()
+        row.addWidget(radio1)
+        grid_layout.addLayout(row)
         # second row
-        grid_layout.addWidget(radio2, 1, 0, 1, 2)
-        grid_layout.addWidget(spin2, 1, 2)
-        grid_layout.addWidget(label2, 1, 3)
+        row = QHBoxLayout()
+        row.addWidget(radio2)
+        row.addWidget(spin2)
+        row.addWidget(label2)
+        grid_layout.addLayout(row)
         # third row
-        grid_layout.addWidget(radio3, 2, 0, 1, 2)
-        grid_layout.addWidget(spin3, 2, 2)
-        grid_layout.addWidget(label3, 2, 3)
+        row = QHBoxLayout()
+        row.addWidget(radio3)
+        row.addWidget(spin3)
+        row.addWidget(label3)
+        grid_layout.addLayout(row)
         # fourth row
-        grid_layout.addWidget(radio4, 3, 0)
-        grid_layout.addWidget(spin4, 3, 1)
-        grid_layout.addWidget(label4, 3, 2, 1, 2)
+        row = QHBoxLayout()
+        row.addWidget(radio4)
+        row.addWidget(spin4)
+        row.addWidget(label4)
+        grid_layout.addLayout(row)
 
         group_box = QGroupBox()
         group_box.setLayout(grid_layout)


### PR DESCRIPTION
##### Issue

Pivot used enum names as checkbox labels. This can't be translated. It also pickled enums, which is not recommended.

Edit Domain had a dialog that made assumptions about widths of labels (it simplified the laying out by assuming that two labels are much longer than the third; in Slovenian translation, this cause some ugly white space)

##### Includes
- [X] Code changes
- [X] Tests
