### PR TITLE
Add option InheritEq and fix several missing __eq__s and __hash__s

### DIFF
--- a/Orange/data/filter.py
+++ b/Orange/data/filter.py
@@ -31,6 +31,12 @@ class Filter(Reprable):
     def __call__(self, data):
         return
 
+    def __eq__(self, other):
+        return type(self) is type(other) and self.negate == other.negate
+
+    def __hash__(self):
+        return hash(self.negate)
+
 
 class IsDefined(Filter):
     """
@@ -53,7 +59,7 @@ class IsDefined(Filter):
 
     def __init__(self, columns=None, negate=False):
         super().__init__(negate)
-        self.columns = columns
+        self.columns = tuple(columns) if columns is not None else None
 
     def __call__(self, data):
         if isinstance(data, Instance):
@@ -69,6 +75,12 @@ class IsDefined(Filter):
         if self.negate:
             r = np.logical_not(r)
         return data[r]
+
+    def __eq__(self, other):
+        return super().__eq__(other) and self.columns == other.columns
+
+    def __hash__(self):
+        return super().__hash__() ^ hash(self.columns)
 
 
 class HasClass(Filter):

--- a/Orange/data/filter.py
+++ b/Orange/data/filter.py
@@ -80,7 +80,7 @@ class IsDefined(Filter):
         return super().__eq__(other) and self.columns == other.columns
 
     def __hash__(self):
-        return super().__hash__() ^ hash(self.columns)
+        return hash((super().__hash__(), hash(self.columns)))
 
 
 class HasClass(Filter):

--- a/Orange/data/sql/filter.py
+++ b/Orange/data/sql/filter.py
@@ -2,6 +2,8 @@ from Orange.data import filter
 
 
 class IsDefinedSql(filter.IsDefined):
+    InheritEq = True
+
     def to_sql(self):
         sql = " AND ".join([
             '%s IS NOT NULL' % column

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -252,6 +252,12 @@ class TestVariable(unittest.TestCase):
             ContinuousVariable("x", compute_value=Valid())
             self.assertEqual(warns, [])
 
+            class AlsoValid:
+                InheritEq = True
+
+            ContinuousVariable("x", compute_value=AlsoValid())
+            self.assertEqual(warns, [])
+
             class Invalid:
                 pass
 

--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -266,6 +266,14 @@ class TestVariable(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as warns:
 
+            class InheritEqInherited(AlsoValid):
+                pass
+
+            ContinuousVariable("x", compute_value=InheritEqInherited())
+            self.assertNotEqual(warns, [])
+
+        with warnings.catch_warnings(record=True) as warns:
+
             class MissingHash:
                 def __eq__(self, other):
                     return self is other

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -373,9 +373,11 @@ class Variable(Reprable, metaclass=VariableMeta):
         if compute_value is not None \
                 and not isinstance(compute_value, (types.BuiltinFunctionType,
                                                    types.FunctionType)) \
-                and not redefines_eq_and_hash(compute_value):
+                and not redefines_eq_and_hash(compute_value) \
+                and not type(compute_value).__dict__.get("InheritEq", False):
             warnings.warn(f"{type(compute_value).__name__} should define "
-                          f"__eq__ and __hash__ to be used for compute_value")
+                          "__eq__ and __hash__ to be used for compute_value\n"
+                          "or set InheritEq = True if inherited methods suffice")
 
         self._compute_value = compute_value
         self.unknown_str = MISSING_VALUES

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -207,6 +207,14 @@ class ReplaceUnknownsModel(Reprable):
         column[mask] = predicted
         return column
 
+    def __eq__(self, other):
+        return type(self) is type(other) \
+               and self.variable == other.variable \
+               and self.model == other.model
+
+    def __hash__(self):
+        return super().__hash__() ^ hash(self.variable) ^ hash(self.model)
+
 
 class Model(BaseImputeMethod):
     _name = "Model-based imputer"

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -213,7 +213,7 @@ class ReplaceUnknownsModel(Reprable):
                and self.model == other.model
 
     def __hash__(self):
-        return hash((super().__hash__(), hash(self.variable), hash(self.model)))
+        return hash((type(self), hash(self.variable), hash(self.model)))
 
 
 class Model(BaseImputeMethod):

--- a/Orange/preprocess/impute.py
+++ b/Orange/preprocess/impute.py
@@ -213,7 +213,7 @@ class ReplaceUnknownsModel(Reprable):
                and self.model == other.model
 
     def __hash__(self):
-        return super().__hash__() ^ hash(self.variable) ^ hash(self.model)
+        return hash((super().__hash__(), hash(self.variable), hash(self.model)))
 
 
 class Model(BaseImputeMethod):

--- a/Orange/preprocess/transformation.py
+++ b/Orange/preprocess/transformation.py
@@ -84,6 +84,8 @@ class Transformation(Reprable):
 class Identity(Transformation):
     """Return an untransformed value of `c`.
     """
+    InheritEq = True
+
     def transform(self, c):
         return c
 
@@ -125,6 +127,9 @@ class Indicator(_Indicator):
     Return an indicator value that equals 1 if the variable has the specified
     value and 0 otherwise.
     """
+
+    InheritEq = True
+
     def transform(self, c):
         if sp.issparse(c):
             if self.value != 0:
@@ -146,6 +151,9 @@ class Indicator1(_Indicator):
     Return an indicator value that equals 1 if the variable has the specified
     value and -1 otherwise.
     """
+
+    InheritEq = True
+
     def transform(self, column):
         # The result of this is always dense
         if sp.issparse(column):

--- a/Orange/tests/test_filter.py
+++ b/Orange/tests/test_filter.py
@@ -69,6 +69,27 @@ class TestIsDefinedFilter(unittest.TestCase):
         self.assertTrue(filter_(instance_with_missing))
         self.assertFalse(filter_(instance_without_missing))
 
+    def test_eq_hash(self):
+        f1 = IsDefined()
+        f1n = IsDefined(negate=True)
+        f1nc = IsDefined(negate=True, columns=("a", "b"))
+        g1 = IsDefined()
+        g1n = IsDefined(negate=True)
+        g1nc = IsDefined(negate=True, columns=("a", "b"))
+
+        self.assertEqual(f1, g1)
+        self.assertEqual(f1n, g1n)
+        self.assertEqual(f1nc, g1nc)
+        self.assertNotEqual(f1, None)
+        self.assertNotEqual(f1, [1, 2, 3])
+        self.assertNotEqual(f1, f1n)
+        self.assertNotEqual(f1, f1nc)
+        self.assertNotEqual(f1nc, f1n)
+
+        self.assertEqual(hash(f1), hash(g1))
+        self.assertEqual(hash(f1n), hash(g1n))
+        self.assertEqual(hash(f1nc), hash(g1nc))
+
     @patch('Orange.data.Table._filter_is_defined', NIMOCK)
     def test_is_defined_filter_not_implemented(self):
         self.test_is_defined_filter_table()


### PR DESCRIPTION
##### Issue

Missing `__eq__` and `__hash__` in classes used for `compute_value` seems to have become the large source of warnings. In many cases, `__eq__` and `__hash__` are not needed, but the tests we have still require providing the two methods (which then just call inherited methods).

This cannot be avoided automatically, I think. The warning cannot detect whether the instance's attributes were added by instances actual type or by its parent. Furthermore, in theory, the parent's attributes can be used differently and hence require reimplementing hash.

##### Description of changes

The class can now add a class attribute `InheritEq = True`. If set, it supresses the warning. The attribute is checked for in type's `__dict__` and is thus not inheritable.

##### Includes
- [X] Code changes
- [X] Tests
