### PR TITLE
Distance Matrix: String variable with most distinct values as default label

### DIFF
--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -252,8 +252,7 @@ class OWDistanceMatrix(widget.OWWidget):
         elif isinstance(items, Table):
             annotations.extend(
                 itertools.chain(items.domain.variables, items.domain.metas))
-            if items.domain.class_var:
-                pending_idx = 2 + len(items.domain.attributes)
+            pending_idx = annotations.index(self._choose_label(items))
         self.annot_combo.model()[:] = annotations
         self.annotation_idx = pending_idx
 
@@ -262,6 +261,14 @@ class OWDistanceMatrix(widget.OWWidget):
             self._update_labels()
             self.tableview.resizeColumnsToContents()
         self.commit.now()
+
+    @staticmethod
+    def _choose_label(data: Table):
+        attr = max((attr for attr in data.domain.metas
+                    if isinstance(attr, StringVariable)),
+                   key=lambda x: len(set(data.get_column(x))),
+                   default=None)
+        return attr or data.domain.class_var or "Enumerate"
 
     def _invalidate_annotations(self):
         if self.distances is not None:

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -84,6 +84,30 @@ class TestOWDistanceMatrix(WidgetTest):
         ac.activated.emit(idx)
         self.assertEqual(self.widget.tablemodel.labels, ["1", "?"])
 
+    def test_choose_label(self):
+        self.assertIs(OWDistanceMatrix._choose_label(self.iris),
+                      self.iris.domain.class_var)
+
+        domain = Domain([ContinuousVariable(x) for x in "xyz"],
+                        ContinuousVariable("t"),
+                        [ContinuousVariable("m")] +
+                        [StringVariable(c) for c in "abc"]
+                        )
+        data = Table.from_numpy(
+            domain,
+            np.zeros((4, 3), dtype=float),
+            np.arange(4, dtype=float),
+            np.array([[0, "a", "a", "a"],
+                      [1, "b", "b", "b"],
+                      [2, "a", "c", "b"],
+                      [0, "b", "a", "a"]])
+        )
+        self.assertIs(OWDistanceMatrix._choose_label(data),
+                      domain.metas[2])
+        domain2 = Domain(domain.attributes, domain.class_var, domain.metas[:-2])
+        self.assertIs(OWDistanceMatrix._choose_label(data.transform(domain2)),
+                      domain.metas[1])
+
 
 class TestDelegates(GuiTest):
     def test_delegate(self):


### PR DESCRIPTION
##### Issue

Fixes #6226.

##### Description of changes

Choose the string variable with most distinct values as default label, otherwise class var otherwise enumerate.

##### Includes
- [X] Code changes
- [X] Tests
