### PR TITLE
MDS: Timing of updates, step button, visual improvements

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace as namespace
 import numpy as np
 import scipy.spatial.distance
 
-from AnyQt.QtCore import Qt, QTimer
+from AnyQt.QtCore import QTimer
 from AnyQt.QtTest import QSignalSpy
-from AnyQt.QtWidgets import QSizePolicy
+from AnyQt.QtWidgets import QSizePolicy, QGridLayout, QLabel
 
 import pyqtgraph as pg
 
@@ -154,7 +154,7 @@ class OWMDSGraph(OWScatterPlotBase):
         emb_y_pairs = emb_y_pairs[pairs_mask, :]
         self.pairs_curve = pg.PlotCurveItem(
             emb_x_pairs.ravel(), emb_y_pairs.ravel(),
-            pen=pg.mkPen(0.8, width=2, cosmetic=True),
+            pen=pg.mkPen(0.8, width=4, cosmetic=True),
             connect="pairs", antialias=True)
         self.pairs_curve.setSegmentedLineMode("on")
         self.pairs_curve.setZValue(-1)
@@ -238,15 +238,23 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
         gui.button(hbox, self, "PCA", callback=self.do_PCA, autoDefault=False)
         gui.button(hbox, self, "Randomize", callback=self.do_random, autoDefault=False)
         gui.button(hbox, self, "Jitter", callback=self.do_jitter, autoDefault=False)
-        gui.comboBox(box, self, "refresh_rate", label="Refresh: ",
-                     orientation=Qt.Horizontal,
-                     items=[t for t, _ in OWMDS.RefreshRate],
-                     callback=self.__refresh_rate_combo_changed)
-        hbox = gui.hBox(box)
-        self.run_button = gui.button(hbox, self, "Start", self._toggle_run)
+        gui.separator(box, height=18)
+        grid = QGridLayout()
+        gui.widgetBox(box, orientation=grid)
+        self.run_button = gui.button(None, self, "Start", self._toggle_run)
         self.step_button = gui.button(
-            hbox, self, ">", self._step,
+            None, self, "⏵⏸", self._step,
             sizePolicy=(QSizePolicy.Maximum, QSizePolicy.Fixed))
+        grid.addWidget(self.run_button, 0, 0, 1, 2)
+        grid.addWidget(self.step_button, 0, 2)
+        grid.addWidget(QLabel("Refresh:"), 1, 0)
+        grid.addWidget(
+            gui.comboBox(
+                None, self, "refresh_rate",
+                items=[t for t, _ in OWMDS.RefreshRate],
+                sizePolicy=(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed),
+                callback=self.__refresh_rate_combo_changed),
+            1, 1)
 
     def __refresh_rate_combo_changed(self):
         if self.task is not None:

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -89,16 +89,17 @@ class OWMDSGraph(OWScatterPlotBase):
 
     def set_effective_matrix(self, effective_matrix):
         self.effective_matrix = effective_matrix
+        self._similar_pairs = None
 
     def update_coordinates(self):
         super().update_coordinates()
-        self.update_pairs(reconnect=False)
+        self.update_pairs()
 
     def update_jittering(self):
         super().update_jittering()
-        self.update_pairs(reconnect=False)
+        self.update_pairs()
 
-    def update_pairs(self, reconnect):
+    def update_pairs(self):
         if self.pairs_curve:
             self.plot_widget.removeItem(self.pairs_curve)
         if self.connected_pairs == 0 \
@@ -106,7 +107,7 @@ class OWMDSGraph(OWScatterPlotBase):
                 or self.scatterplot_item is None:
             return
         emb_x, emb_y = self.scatterplot_item.getData()
-        if self._similar_pairs is None or reconnect:
+        if self._similar_pairs is None:
             # This code requires storing lower triangle of X (n x n / 2
             # doubles), n x n / 2 * 2 indices to X, n x n / 2 indices for
             # argsort result. If this becomes an issue, it can be reduced to
@@ -402,7 +403,7 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
     def do_initialization(self, init_type: int):
         self.run_button.setText("Start")
         self.__invalidate_embedding(init_type)
-        self.setup_plot()
+        self.graph.update_coordinates()
         self.commit.deferred()
 
     def __invalidate_embedding(self, initialization=PCA):
@@ -442,12 +443,12 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
 
     def _on_connected_changed(self):
         self.graph.set_effective_matrix(self.effective_matrix)
-        self.graph.update_pairs(reconnect=True)
+        self.graph.update_pairs()
 
     def setup_plot(self):
         super().setup_plot()
         if self.embedding is not None:
-            self.graph.update_pairs(reconnect=True)
+            self.graph.update_pairs()
 
     def get_size_data(self):
         if self.attr_size == "Stress":

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -3,8 +3,7 @@ orange-widget-base>=4.19.0
 
 AnyQt>=0.1.0
 
-# ignore pyqtgraph 0.12.4 due to https://github.com/pyqtgraph/pyqtgraph/issues/2237
-pyqtgraph>=0.12.2,!=0.12.4
+pyqtgraph>=0.13.1
 matplotlib>=3.2.0
 qtconsole>=4.7.2
 pygments>=2.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -43,12 +43,12 @@ deps =
     oldest: orange-canvas-core==0.1.28
     oldest: orange-widget-base==4.19.0
     oldest: AnyQt==0.1.0
-    oldest: pyqtgraph==0.12.2
+    oldest: pyqtgraph>=0.13.1
     oldest: matplotlib==3.2.0
     oldest: qtconsole==4.7.2
     oldest: pygments==2.8.0
     oldest: pip==18.0
-    oldest: numpy==1.19.5
+    oldest: numpy==1.20
     oldest: scipy==1.9
     oldest: scikit-learn==1.1.0
     oldest: bottleneck==1.3.4


### PR DESCRIPTION
##### Issue

Fixes #6228.

##### Description of changes

- Optimization ensures that at least 0.1 s passes between each refresh.
- Added step button, reorganize layout of buttons.
- I thought the widget was not updating. It was, but it was very slow because of cosmetic lines with widths different than 1. Enabling `segmentedLineMode` (available from latest pyqtgraph) makes it smooth. Drawing lines during optimization is no longer disabled.
- Graph now recomputes closest pairs only when necessary.

This PR also raises required versions
- pyqtgraph to 0.13.1; segmented line mode may also be useful for speeding up other widgets.
- (oldest) pyqt >=15.2 (I don't know what was this needed; it used to be 15.* and pip couldn't resolve it?!)
- (oldest) numpy ==  1.20, because pyqtgraph is not compatible with 1.19.5, which was pinned previously

https://user-images.githubusercontent.com/2387315/205372895-ef01cbe1-95ca-46bd-b1f6-35faf8903ca9.mov

https://user-images.githubusercontent.com/2387315/205374233-2f27cc14-073b-461e-9f8b-8f0536d15973.mov

All tests still pass and given that changes are related to speed of drawing, timing of updates and layout, I don't see what to test or how to do it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
