### PR TITLE
[FIX] conda-recipe: Remove explicit host numpy pinning

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   host:
     - python
     - setuptools
-    - numpy         1.14.*
+    - numpy
     - cython
     - pip
     - wheel


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

conda cannot build the included recipe on Python 3.9 and later because numpy 1.14 is not available for them. 

##### Description of changes

Let default conda-build provide the build numpy version.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
