### PR TITLE
Table: Assign name to transposed table

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -2294,6 +2294,7 @@ class Table(Sequence, Storage):
             cls._init_ids(self)
             self.attributes = deepcopy(table.attributes)
             self.attributes["old_domain"] = table.domain
+            self.name = table.name
             progress_callback(1)
             return self
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -3128,6 +3128,11 @@ class TestTableTranspose(unittest.TestCase):
         self.assertDictEqual(table.domain.attributes[0].attributes,
                              {"attr1": "a1", "attr2": "aa1"})
 
+    def test_transpose_name(self):
+        table = Table("iris")
+        transposed = Table.transpose(table)
+        self.assertEqual(table.name, transposed.name)
+
     def _compare_tables(self, table1, table2):
         self.assertEqual(table1.n_rows, table2.n_rows)
         np.testing.assert_array_equal(table1.X, table2.X)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
A transposed table is missing a table name.

##### Description of changes
Assign original table name to transposed table name.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
