### PR TITLE
Avoid scikit-learn>=1.2.0 due to changes in PCA

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - setuptools >=41.0.0
     - numpy >=1.19.5
     - scipy >=1.9
-    - scikit-learn >=1.0.1
+    - scikit-learn >=1.0.1,<1.2.0
     - bottleneck >=1.3.4
     - chardet >=3.0.2
     - xlrd >=1.2.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -3,7 +3,7 @@ numpy>=1.19.5
 scipy>=1.9
 # scikit-learn version 1.0.0 includes problematic libomp 12 which breaks xgboost
 # https://github.com/scikit-learn/scikit-learn/pull/21227
-scikit-learn>=1.0.1
+scikit-learn>=1.0.1,<1.2.0
 bottleneck>=1.3.4
 # Reading Excel files
 xlrd>=1.2.0


### PR DESCRIPTION
I like tests that pass. This is a temporary fix. #6249 should properly fix the issue.