### PR TITLE
[FIX] Implement predict() in simple tree and simple RF models

### DIFF
--- a/Orange/classification/simple_random_forest.py
+++ b/Orange/classification/simple_random_forest.py
@@ -71,9 +71,14 @@ class SimpleRandomForestModel(Model):
             tree.seed = learner.seed + i
             self.estimators_.append(tree(data))
 
-    def predict_storage(self, data):
-        p = np.zeros((data.X.shape[0], self.cls_vals))
+    def predict(self, X):
+        p = np.zeros((X.shape[0], self.cls_vals))
+        X = np.ascontiguousarray(X)  # so that it is a no-op for individual trees
         for tree in self.estimators_:
-            p += tree(data, tree.Probs)
+            # SimpleTrees do not have preprocessors and domain conversion
+            # was already handled within this class so we can call tree.predict() directly
+            # instead of going through tree.__call__
+            _, pt = tree.predict(X)
+            p += pt
         p /= len(self.estimators_)
         return p.argmax(axis=1), p

--- a/Orange/classification/simple_tree.py
+++ b/Orange/classification/simple_tree.py
@@ -157,8 +157,8 @@ class SimpleTreeModel(Model):
             learner.bootstrap,
             learner.seed)
 
-    def predict_storage(self, data):
-        X = np.ascontiguousarray(data.X)
+    def predict(self, X):
+        X = np.ascontiguousarray(X)
         if self.type == Classification:
             p = np.zeros((X.shape[0], self.cls_vals))
             _tree.predict_classification(

--- a/Orange/regression/simple_random_forest.py
+++ b/Orange/regression/simple_random_forest.py
@@ -62,9 +62,14 @@ class SimpleRandomForestModel(SRFM):
         self.estimators_ = []
         self.learn(learner, data)
 
-    def predict_storage(self, data):
-        p = np.zeros(data.X.shape[0])
+    def predict(self, X):
+        p = np.zeros(X.shape[0])
+        X = np.ascontiguousarray(X)  # so that it is a no-op for individual trees
         for tree in self.estimators_:
-            p += tree(data)
+            # SimpleTrees do not have preprocessors and domain conversion
+            # was already handled within this class so we can call tree.predict() directly
+            # instead of going through tree.__call__
+            pt = tree.predict(X)
+            p += pt
         p /= len(self.estimators_)
         return p


### PR DESCRIPTION
##### Issue
This avoids creating intermediate tables in `predict()`, which then create problems onwards because, currently, creating a table with an array locks the array given. The array remains locked even when the intermediate table is disregarded. 

This PR is a fix for some crashes in biolab/orange3-explain#54.

The big issue here, which remains, is how Orange's Tables behave: if arrays were copied in init, only internal arrays would be locked. Anyway, I believe the code is now a bit cleaner.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
