### PR TITLE
[FIX] Color: fix coloring of computed (processed) variables

### DIFF
--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -42,7 +42,9 @@ class AttrDesc:
         new_name (str or `None`): a changed name or `None`
     """
     def __init__(self, var):
-        self.var = var
+        # these objects are stored within context settings;
+        # avoid storing compute_values
+        self.var = var.copy(compute_value=None)
         self.new_name = None
 
     def reset(self):
@@ -118,9 +120,9 @@ class DiscAttrDesc(AttrDesc):
             self.new_values = list(self.var.values)
         self.new_values[i] = value
 
-    def create_variable(self):
-        new_var = self.var.copy(name=self.name, values=self.values,
-                                compute_value=Identity(self.var))
+    def create_variable(self, base_var):
+        new_var = base_var.copy(name=self.name, values=self.values,
+                                compute_value=Identity(base_var))
         new_var.colors = np.asarray(self.colors)
         return new_var
 
@@ -209,9 +211,9 @@ class ContAttrDesc(AttrDesc):
     def palette_name(self, palette_name):
         self.new_palette_name = palette_name
 
-    def create_variable(self):
-        new_var = self.var.copy(name=self.name,
-                                compute_value=Identity(self.var))
+    def create_variable(self, base_var):
+        new_var = base_var.copy(name=self.name,
+                                compute_value=Identity(base_var))
         new_var.attributes["palette"] = self.palette_name
         return new_var
 
@@ -746,7 +748,7 @@ class OWColor(widget.OWWidget):
             for var in variables:
                 source = disc_dict if var.is_discrete else cont_dict
                 desc = source.get(var.name)
-                new_vars.append(desc.create_variable() if desc else var)
+                new_vars.append(desc.create_variable(var) if desc else var)
             return new_vars
 
         if self.data is None:

--- a/Orange/widgets/data/tests/test_owcolor.py
+++ b/Orange/widgets/data/tests/test_owcolor.py
@@ -31,6 +31,11 @@ class AttrDescTest(unittest.TestCase):
         desc.name = None
         self.assertEqual(desc.name, "x")
 
+    def test_no_compute_value(self):
+        x = ContinuousVariable("x", compute_value=lambda x: 42)
+        desc = owcolor.AttrDesc(x)
+        self.assertIsNone(desc.var.compute_value)
+
     def test_reset(self):
         x = ContinuousVariable("x")
         desc = owcolor.AttrDesc(x)
@@ -89,20 +94,20 @@ class DiscAttrTest(unittest.TestCase):
         desc.set_color(2, [7, 8, 9])
         desc.name = "z"
         desc.set_value(1, "d")
-        var = desc.create_variable()
+        var = desc.create_variable(self.var)
         self.assertIsInstance(var, DiscreteVariable)
         self.assertEqual(var.name, "z")
         self.assertEqual(var.values, ("a", "d", "c"))
         np.testing.assert_equal(var.colors, [[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         self.assertIsInstance(var.compute_value, Identity)
-        self.assertIs(var.compute_value.variable, desc.var)
+        self.assertIs(var.compute_value.variable, self.var)
 
         palette = desc.var.attributes["palette"] = object()
-        var = desc.create_variable()
+        var = desc.create_variable(self.var)
         self.assertIs(desc.var.attributes["palette"], palette)
         self.assertFalse(hasattr(var.attributes, "palette"))
         self.assertIsInstance(var.compute_value, Identity)
-        self.assertIs(var.compute_value.variable, desc.var)
+        self.assertIs(var.compute_value.variable, self.var)
 
     def test_reset(self):
         desc = self.desc
@@ -228,8 +233,8 @@ class DiscAttrTest(unittest.TestCase):
 
 class ContAttrDescTest(unittest.TestCase):
     def setUp(self):
-        x = ContinuousVariable("x")
-        self.desc = owcolor.ContAttrDesc(x)
+        self.var = ContinuousVariable("x")
+        self.desc = owcolor.ContAttrDesc(self.var)
 
     def test_palette(self):
         desc = self.desc
@@ -246,19 +251,19 @@ class ContAttrDescTest(unittest.TestCase):
         palette_name = _find_other_palette(
             colorpalettes.ContinuousPalettes[desc.palette_name]).name
         desc.palette_name = palette_name
-        var = desc.create_variable()
+        var = desc.create_variable(self.var)
         self.assertIsInstance(var, ContinuousVariable)
         self.assertEqual(var.name, "z")
         self.assertEqual(var.palette.name, palette_name)
         self.assertIsInstance(var.compute_value, Identity)
-        self.assertIs(var.compute_value.variable, desc.var)
+        self.assertIs(var.compute_value.variable, self.var)
 
         colors = desc.var.attributes["colors"] = object()
-        var = desc.create_variable()
+        var = desc.create_variable(self.var)
         self.assertIs(desc.var.attributes["colors"], colors)
         self.assertFalse(hasattr(var.attributes, "colors"))
         self.assertIsInstance(var.compute_value, Identity)
-        self.assertIs(var.compute_value.variable, desc.var)
+        self.assertIs(var.compute_value.variable, self.var)
 
     def test_reset(self):
         desc = self.desc

--- a/Orange/widgets/data/tests/test_owcolor.py
+++ b/Orange/widgets/data/tests/test_owcolor.py
@@ -701,6 +701,21 @@ class TestOWColor(WidgetTest):
     def test_string_variables(self):
         self.send_signal(self.widget.Inputs.data, Table("zoo"))
 
+    def test_changed_compute_value(self):
+        # test a bug where the widget did not register changes in compute_value
+        # because it reused an old context
+        w = self.widget
+        domain1 = Domain([ContinuousVariable("x", compute_value=lambda _: 1)])
+        data1 = self.iris.transform(domain1)
+        self.send_signal(w.Inputs.data, data1)
+        outp = self.get_output(w.Outputs.data)
+        np.testing.assert_array_equal(outp, 1)
+        domain2 = Domain([ContinuousVariable("x", compute_value=lambda _: 2)])
+        data2 = self.iris.transform(domain2)
+        self.send_signal(w.Inputs.data, data2)
+        outp = self.get_output(w.Outputs.data)
+        np.testing.assert_array_equal(outp, 2)
+
     def test_reset(self):
         self.send_signal(self.widget.Inputs.data, self.iris)
         cont_model = self.widget.cont_model


### PR DESCRIPTION
##### Issue
Fixes quasars/orange-spectroscopy#652

The Color widget currently saves `AttrDesc` in contexts. The problem is that `AttrDesc`  contains a variable. Because the contexts only match by names (and values for discrete features) the saved variables get colored instead of the ones on the input.

##### Description of changes
After this fix, the variable descriptors on the input are always used when creating colored variables instead of the ones stored in the context.

Also, compute_values do not need to be stored in settings (within `AttrDesc`) and are therefore removed.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
