### PR TITLE
Distance Matrix: Allow non-square matrices; Previews in summary

### DIFF
--- a/Orange/misc/distmatrix.py
+++ b/Orange/misc/distmatrix.py
@@ -95,13 +95,17 @@ class DistMatrix(np.ndarray):
         if not col_items:
             col_items = row_items
         obj = self[np.ix_(row_items, col_items)]
-        if self.row_items is not None:
+        if isinstance(self.row_items, list):
+            obj.row_items = list(np.array(self.row_items)[row_items])
+        elif self.row_items is not None:
             obj.row_items = self.row_items[row_items]
-        if self.col_items is not None:
-            if self.col_items is self.row_items and row_items is col_items:
-                obj.col_items = obj.row_items
-            else:
-                obj.col_items = self.col_items[col_items]
+
+        if self.col_items is self.row_items and col_items is row_items:
+            obj.col_items = obj.row_items
+        elif isinstance(self.col_items, list):
+            obj.col_items = list(np.array(self.col_items)[col_items])
+        elif self.col_items is not None:
+            obj.col_items = self.col_items[col_items]
         return obj
 
     @classmethod

--- a/Orange/misc/distmatrix.py
+++ b/Orange/misc/distmatrix.py
@@ -43,6 +43,7 @@ class DistMatrix(np.ndarray):
         return obj
 
     def __array_finalize__(self, obj):
+        # defined in __new___, pylint: disable=attribute-defined-outside-init
         """See http://docs.scipy.org/doc/numpy/user/basics.subclassing.html"""
         if obj is None:
             return
@@ -63,6 +64,7 @@ class DistMatrix(np.ndarray):
 
     # noinspection PyMethodOverriding,PyArgumentList
     def __setstate__(self, state):
+        # defined in __new___, pylint: disable=attribute-defined-outside-init
         self.row_items = state[-3]
         self.col_items = state[-2]
         self.axis = state[-1]
@@ -362,7 +364,7 @@ class DistMatrix(np.ndarray):
             filename: file name
         """
         n = len(self)
-        data = "{}\taxis={}".format(n, self.axis)
+        data = f"{n}\taxis={self.axis}"
         row_labels = col_labels = None
         if self.has_col_labels():
             data += "\tcol_labels"
@@ -373,7 +375,7 @@ class DistMatrix(np.ndarray):
         symmetric = self.is_symmetric()
         if not symmetric:
             data += "\tasymmetric"
-        with open(filename, "wt") as fle:
+        with open(filename, "wt", encoding="utf-8") as fle:
             fle.write(data + "\n")
             if col_labels is not None:
                 fle.write("\t".join(str(e.metas[0]) for e in col_labels) + "\n")

--- a/Orange/misc/tests/test_distmatrix.py
+++ b/Orange/misc/tests/test_distmatrix.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import unittest
 from unittest.mock import patch
 

--- a/Orange/misc/tests/test_distmatrix.py
+++ b/Orange/misc/tests/test_distmatrix.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
+from Orange.data import ContinuousVariable, StringVariable, Table, Domain
 from Orange.misc import DistMatrix
 
 
@@ -96,6 +97,62 @@ class DistMatrixTest(unittest.TestCase):
                          [1062.89, 1372.59, 651.62]])
         matrix = DistMatrix(data, list("def"), list("abc"))
         self.assertIs(matrix.auto_symmetricized(), matrix)
+
+    def test_trivial_labels(self):
+        matrix = DistMatrix(np.array([[1, 2, 3], [4, 5, 6]]))
+
+        self.assertFalse(matrix._trivial_labels(matrix.row_items))
+        self.assertIsNone(matrix.get_labels(matrix.row_items))
+
+        matrix.row_items = list("abc")
+        self.assertTrue(matrix._trivial_labels(matrix.row_items))
+        self.assertEqual(matrix.get_labels(matrix.row_items), list("abc"))
+
+        matrix.row_items = ["a", 1, "c"]
+        self.assertFalse(matrix._trivial_labels(matrix.row_items))
+        self.assertIsNone(matrix.get_labels(matrix.row_items))
+
+        c1, c2 = (ContinuousVariable(c) for c in "xy")
+        s1, s2 = (StringVariable(c) for c in "st")
+        data = Table.from_list(Domain([c1], None, [c2, s1]),
+                               [[1, 0, "a"], [2, 2, "b"], [3, 1, "c"]])
+        matrix.row_items = data
+
+        matrix.axis = 1
+        self.assertTrue(matrix._trivial_labels(matrix.row_items))
+        self.assertEqual(list(matrix.get_labels(matrix.row_items)), list("abc"))
+
+        matrix.axis = 0
+        self.assertTrue(matrix._trivial_labels(matrix.row_items))
+        self.assertEqual(list(matrix.get_labels(matrix.row_items)), list("x"))
+
+
+        data = Table.from_list(Domain([c1], None, [c2, s1, s2]),
+                               [[1, 2, "a", "2"],
+                                [2, 4, "b", "5"],
+                                [3, 0, "c", "g"]])
+        matrix.row_items = data
+
+        matrix.axis = 1
+        self.assertFalse(matrix._trivial_labels(matrix.row_items))
+        self.assertIsNone(matrix.get_labels(matrix.row_items))
+
+        matrix.axis = 0
+        self.assertTrue(matrix._trivial_labels(matrix.row_items))
+        self.assertEqual(list(matrix.get_labels(matrix.row_items)), list("x"))
+
+        data = Table.from_list(Domain([c1], None, [c2]),
+                               [[1, 2],
+                                [2, 4],
+                                [3, 0]])
+        matrix.row_items = data
+        matrix.axis = 1
+        self.assertFalse(matrix._trivial_labels(matrix.row_items))
+        self.assertIsNone(matrix.get_labels(matrix.row_items))
+
+        matrix.axis = 0
+        self.assertTrue(matrix._trivial_labels(matrix.row_items))
+        self.assertEqual(matrix.get_labels(matrix.row_items), list("x"))
 
 
 if __name__ == "__main__":

--- a/Orange/misc/tests/test_distmatrix_xlsx.py
+++ b/Orange/misc/tests/test_distmatrix_xlsx.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import os
 import unittest
 from unittest.mock import patch, Mock

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -25,6 +25,7 @@ class DistanceMatrixContextHandler(ContextHandler):
     def _var_names(annotations):
         return [a.name if isinstance(a, Variable) else a for a in annotations]
 
+    # pylint: disable=arguments-differ
     def new_context(self, matrix, annotations):
         context = super().new_context()
         context.shape = matrix.shape
@@ -34,7 +35,7 @@ class DistanceMatrixContextHandler(ContextHandler):
         context.selection = [] if context.symmetric else ([], [])
         return context
 
-    # noinspection PyMethodOverriding
+    # pylint: disable=arguments-differ
     def match(self, context, matrix, annotations):
         annotations = self._var_names(annotations)
         if context.shape != matrix.shape \
@@ -44,12 +45,14 @@ class DistanceMatrixContextHandler(ContextHandler):
         return 1 + (context.annotations == annotations)
 
     def settings_from_widget(self, widget, *args):
+        # pylint: disable=protected-access
         context = widget.current_context
         if context is not None:
             context.annotation = widget.annot_combo.currentText()
             context.selection, _ = widget._get_selection()
 
     def settings_to_widget(self, widget, *args):
+        # pylint: disable=protected-access
         context = widget.current_context
         widget.annotation_idx = context.annotations.index(context.annotation)
         widget._set_selection(context.selection)
@@ -248,12 +251,12 @@ class OWDistanceMatrix(widget.OWWidget):
         if isinstance(selmodel, SymmetricSelectionModel):
             if not isinstance(selection, list):
                 log.error("wrong data for symmetric selection")
-                return None
+                return
             selmodel.setSelectedItems(selection)
         else:
             if not isinstance(selection, tuple) and len(selection) == 2:
                 log.error("wrong data for asymmetric selection")
-                return None
+                return
             rows, cols = selection
             selection = QItemSelection()
             rowranges = list(ranges(rows))

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -1,20 +1,16 @@
 import itertools
 import logging
 from functools import partial
-from typing import NamedTuple, List, Optional, Dict, Any
 
-import numpy as np
-
-from AnyQt.QtWidgets import QTableView, QHeaderView
-from AnyQt.QtGui import QColor, QBrush, QFont
-from AnyQt.QtCore import Qt, QAbstractTableModel, QSize, QItemSelection, \
-    QItemSelectionRange
+from AnyQt.QtWidgets import QTableView
+from AnyQt.QtCore import Qt, QSize, QItemSelection, QItemSelectionRange
 
 from Orange.data import Table, Variable, StringVariable
 from Orange.misc import DistMatrix
+from Orange.widgets.utils.distmatrixmodel import \
+    DistMatrixModel, DistMatrixView
 from Orange.widgets import widget, gui
 from Orange.widgets.settings import Setting, ContextSetting, ContextHandler
-from Orange.widgets.utils.itemdelegates import FixedFormatNumericColumnDelegate
 from Orange.widgets.utils.itemmodels import VariableListModel
 from Orange.widgets.utils.itemselectionmodel import SymmetricSelectionModel, \
     BlockSelectionModel, selection_blocks, ranges
@@ -22,115 +18,6 @@ from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input, Output
 
 log = logging.getLogger(__name__)
-
-
-class LabelData(NamedTuple):
-    labels: Optional[List[str]] = None
-    colors: Optional[np.ndarray] = None
-
-
-class DistanceMatrixModel(QAbstractTableModel):
-    def __init__(self):
-        super().__init__()
-        self.distances: Optional[DistMatrix] = None
-        self.colors: Optional[np.ndarray] = None
-        self.__header_data: Dict[Any, Optional[LabelData]] = {
-            Qt.Horizontal: LabelData(),
-            Qt.Vertical: LabelData()}
-        self.__zero_diag: bool = True
-        self.__span: Optional[float] = None
-
-        self.__header_font = QFont()
-        self.__header_font.setBold(True)
-
-    def set_data(self, distances):
-        self.beginResetModel()
-        self.distances = distances
-        self.__header_data = dict.fromkeys(self.__header_data, LabelData())
-        if distances is None:
-            self.__span = self.colors = None
-            return
-        self.__span = span = np.max(distances)
-
-        self.colors = \
-            (distances * (170 / span if span > 1e-10 else 0)).astype(int)
-        self.__zero_diag = \
-            distances.is_symmetric() and np.allclose(np.diag(distances), 0)
-        self.endResetModel()
-
-    def set_labels(self, orientation, labels: Optional[List[str]],
-                   colors: Optional[np.ndarray] = None):
-        self.__header_data[orientation] = LabelData(labels, colors)
-        rc, cc = self.rowCount() - 1, self.columnCount() - 1
-        self.headerDataChanged.emit(
-            orientation, 0, rc if orientation == Qt.Vertical else cc)
-        self.dataChanged.emit(self.index(0, 0), self.index(rc, cc))
-
-    def rowCount(self, parent=None):
-        if parent and parent.isValid() or self.distances is None:
-            return 0
-        return self.distances.shape[0]
-
-    def columnCount(self, parent=None):
-        if parent and parent.isValid() or self.distances is None:
-            return 0
-        return self.distances.shape[1]
-
-    def data(self, index, role=Qt.DisplayRole):
-        if role == Qt.TextAlignmentRole:
-            return Qt.AlignCenter | Qt.AlignVCenter
-        if self.distances is None:
-            return None
-
-        row, col = index.row(), index.column()
-        if role == Qt.DisplayRole and not (self.__zero_diag and row == col):
-            return float(self.distances[row, col])
-        if role == Qt.BackgroundRole:
-            return QBrush(QColor.fromHsv(120, self.colors[row, col], 255))
-        if role == Qt.ForegroundRole:
-            return QColor(Qt.black)  # the background is light-ish
-        if role == FixedFormatNumericColumnDelegate.ColumnDataSpanRole:
-            return 0., self.__span
-        return None
-
-    def headerData(self, ind, orientation, role):
-        if role == Qt.FontRole:
-            return self.__header_font
-
-        __header_data = self.__header_data[orientation]
-        if role == Qt.DisplayRole:
-            if __header_data.labels is not None \
-                    and ind < len(__header_data.labels):
-                return __header_data.labels[ind]
-
-        colors = self.__header_data[orientation].colors
-        if colors is not None:
-            color = colors[ind].lighter(180)
-            if role == Qt.BackgroundRole:
-                return QBrush(color)
-            if role == Qt.ForegroundRole:
-                return QColor(Qt.black if color.value() > 128 else Qt.white)
-        return None
-
-
-class TableView(gui.HScrollStepMixin, QTableView):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.setWordWrap(False)
-        self.setTextElideMode(Qt.ElideNone)
-        self.setEditTriggers(QTableView.NoEditTriggers)
-        self.setItemDelegate(
-            FixedFormatNumericColumnDelegate(
-                roles=(Qt.DisplayRole, Qt.BackgroundRole, Qt.ForegroundRole,
-                       Qt.TextAlignmentRole)))
-        for header in (self.horizontalHeader(), self.verticalHeader()):
-            header.setResizeContentsPrecision(1)
-            header.setSectionResizeMode(QHeaderView.ResizeToContents)
-            header.setHighlightSections(True)
-            header.setSectionsClickable(False)
-        self.verticalHeader().setDefaultAlignment(
-            Qt.AlignRight | Qt.AlignVCenter)
 
 
 class DistanceMatrixContextHandler(ContextHandler):
@@ -196,8 +83,8 @@ class OWDistanceMatrix(widget.OWWidget):
         self.distances = None
         self.items = None
 
-        self.tablemodel = DistanceMatrixModel()
-        view = self.tableview = TableView()
+        self.tablemodel = DistMatrixModel()
+        view = self.tableview = DistMatrixView()
         view.setModel(self.tablemodel)
         view.setSelectionBehavior(QTableView.SelectItems)
         self.controlArea.layout().addWidget(view)

--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -1,138 +1,136 @@
 import itertools
+import logging
+from functools import partial
+from typing import NamedTuple, List, Optional, Dict, Any
+
+import numpy as np
 
 from AnyQt.QtWidgets import QTableView, QHeaderView
-from AnyQt.QtGui import QColor, QPen, QBrush
-from AnyQt.QtCore import Qt, QAbstractTableModel, QSize
+from AnyQt.QtGui import QColor, QBrush, QFont
+from AnyQt.QtCore import Qt, QAbstractTableModel, QSize, QItemSelection, \
+    QItemSelectionRange
 
 from Orange.data import Table, Variable, StringVariable
 from Orange.misc import DistMatrix
 from Orange.widgets import widget, gui
-from Orange.widgets.gui import OrangeUserRole
 from Orange.widgets.settings import Setting, ContextSetting, ContextHandler
 from Orange.widgets.utils.itemdelegates import FixedFormatNumericColumnDelegate
 from Orange.widgets.utils.itemmodels import VariableListModel
-from Orange.widgets.utils.itemselectionmodel import SymmetricSelectionModel
+from Orange.widgets.utils.itemselectionmodel import SymmetricSelectionModel, \
+    BlockSelectionModel, selection_blocks, ranges
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Input, Output
+
+log = logging.getLogger(__name__)
+
+
+class LabelData(NamedTuple):
+    labels: Optional[List[str]] = None
+    colors: Optional[np.ndarray] = None
 
 
 class DistanceMatrixModel(QAbstractTableModel):
     def __init__(self):
         super().__init__()
-        self.distances = None
-        self.fact = 70
-        self.labels = None
-        self.colors = None
-        self.variable = None
-        self.values = None
-        self.label_colors = None
-        self.zero_diag = True
-        self.span = None
+        self.distances: Optional[DistMatrix] = None
+        self.colors: Optional[np.ndarray] = None
+        self.__header_data: Dict[Any, Optional[LabelData]] = {
+            Qt.Horizontal: LabelData(),
+            Qt.Vertical: LabelData()}
+        self.__zero_diag: bool = True
+        self.__span: Optional[float] = None
+
+        self.__header_font = QFont()
+        self.__header_font.setBold(True)
 
     def set_data(self, distances):
         self.beginResetModel()
         self.distances = distances
+        self.__header_data = dict.fromkeys(self.__header_data, LabelData())
         if distances is None:
+            self.__span = self.colors = None
             return
-        self.span = span = float(distances.max())
+        self.__span = span = np.max(distances)
 
         self.colors = \
             (distances * (170 / span if span > 1e-10 else 0)).astype(int)
-        self.zero_diag = all(distances.diagonal() < 1e-6)
+        self.__zero_diag = \
+            distances.is_symmetric() and np.allclose(np.diag(distances), 0)
         self.endResetModel()
 
-    def set_labels(self, labels, variable=None, values=None):
-        self.labels = labels
-        self.variable = variable
-        self.values = values
-        if self.values is not None and not isinstance(self.variable,
-                                                      StringVariable):
-            # Meta variables can be of type np.object
-            if values.dtype is not float:
-                values = values.astype(float)
-            self.label_colors = variable.palette.values_to_qcolors(values)
-        else:
-            self.label_colors = None
-        self.headerDataChanged.emit(Qt.Vertical, 0, self.rowCount() - 1)
-        self.headerDataChanged.emit(Qt.Horizontal, 0, self.columnCount() - 1)
-        self.dataChanged.emit(
-            self.index(0, 0),
-            self.index(self.rowCount() - 1, self.columnCount() - 1)
-        )
+    def set_labels(self, orientation, labels: Optional[List[str]],
+                   colors: Optional[np.ndarray] = None):
+        self.__header_data[orientation] = LabelData(labels, colors)
+        rc, cc = self.rowCount() - 1, self.columnCount() - 1
+        self.headerDataChanged.emit(
+            orientation, 0, rc if orientation == Qt.Vertical else cc)
+        self.dataChanged.emit(self.index(0, 0), self.index(rc, cc))
 
-    def dimension(self, parent=None):
+    def rowCount(self, parent=None):
         if parent and parent.isValid() or self.distances is None:
             return 0
-        return len(self.distances)
+        return self.distances.shape[0]
 
-    columnCount = rowCount = dimension
-
-    def color_for_label(self, ind, light=100):
-        if self.label_colors is None:
-            return None
-        return QBrush(self.label_colors[ind].lighter(light))
-
-    def color_for_cell(self, row, col):
-        return QBrush(QColor.fromHsv(120, self.colors[row, col], 255))
+    def columnCount(self, parent=None):
+        if parent and parent.isValid() or self.distances is None:
+            return 0
+        return self.distances.shape[1]
 
     def data(self, index, role=Qt.DisplayRole):
         if role == Qt.TextAlignmentRole:
-            return Qt.AlignRight | Qt.AlignVCenter
-        row, col = index.row(), index.column()
+            return Qt.AlignCenter | Qt.AlignVCenter
         if self.distances is None:
             return None
-        if role == TableBorderItem.BorderColorRole:
-            return self.color_for_label(col), self.color_for_label(row)
-        if role == FixedFormatNumericColumnDelegate.ColumnDataSpanRole:
-            return 0., self.span
-        if row == col and self.zero_diag:
-            if role == Qt.BackgroundRole and self.variable:
-                return self.color_for_label(row, 200)
-            return
-        if role == Qt.DisplayRole:
+
+        row, col = index.row(), index.column()
+        if role == Qt.DisplayRole and not (self.__zero_diag and row == col):
             return float(self.distances[row, col])
         if role == Qt.BackgroundRole:
-            return self.color_for_cell(row, col)
+            return QBrush(QColor.fromHsv(120, self.colors[row, col], 255))
         if role == Qt.ForegroundRole:
             return QColor(Qt.black)  # the background is light-ish
+        if role == FixedFormatNumericColumnDelegate.ColumnDataSpanRole:
+            return 0., self.__span
         return None
 
     def headerData(self, ind, orientation, role):
-        if not self.labels:
-            return None
-        if role == Qt.DisplayRole and ind < len(self.labels):
-            return self.labels[ind]
-        # On some systems, Qt doesn't respect the following role in the header
-        if role == Qt.BackgroundRole:
-            return self.color_for_label(ind, 150)
-        if role == Qt.ForegroundRole and self.label_colors is not None:
-            return QColor(Qt.black)
+        if role == Qt.FontRole:
+            return self.__header_font
+
+        __header_data = self.__header_data[orientation]
+        if role == Qt.DisplayRole:
+            if __header_data.labels is not None \
+                    and ind < len(__header_data.labels):
+                return __header_data.labels[ind]
+
+        colors = self.__header_data[orientation].colors
+        if colors is not None:
+            color = colors[ind].lighter(180)
+            if role == Qt.BackgroundRole:
+                return QBrush(color)
+            if role == Qt.ForegroundRole:
+                return QColor(Qt.black if color.value() > 128 else Qt.white)
         return None
 
 
-class TableBorderItem(FixedFormatNumericColumnDelegate):
-    BorderColorRole = next(OrangeUserRole)
-
-    def paint(self, painter, option, index):
-        super().paint(painter, option, index)
-        colors = self.cachedData(index, self.BorderColorRole)
-        vcolor, hcolor = colors or (None, None)
-        if vcolor is not None or hcolor is not None:
-            painter.save()
-            x1, y1, x2, y2 = option.rect.getCoords()
-            if vcolor is not None:
-                painter.setPen(
-                    QPen(QBrush(vcolor), 1, Qt.SolidLine, Qt.RoundCap))
-                painter.drawLine(x1, y1, x1, y2)
-            if hcolor is not None:
-                painter.setPen(
-                    QPen(QBrush(hcolor), 1, Qt.SolidLine, Qt.RoundCap))
-                painter.drawLine(x1, y1, x2, y1)
-            painter.restore()
-
-
 class TableView(gui.HScrollStepMixin, QTableView):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.setWordWrap(False)
+        self.setTextElideMode(Qt.ElideNone)
+        self.setEditTriggers(QTableView.NoEditTriggers)
+        self.setItemDelegate(
+            FixedFormatNumericColumnDelegate(
+                roles=(Qt.DisplayRole, Qt.BackgroundRole, Qt.ForegroundRole,
+                       Qt.TextAlignmentRole)))
+        for header in (self.horizontalHeader(), self.verticalHeader()):
+            header.setResizeContentsPrecision(1)
+            header.setSectionResizeMode(QHeaderView.ResizeToContents)
+            header.setHighlightSections(True)
+            header.setSectionsClickable(False)
+        self.verticalHeader().setDefaultAlignment(
+            Qt.AlignRight | Qt.AlignVCenter)
 
 
 class DistanceMatrixContextHandler(ContextHandler):
@@ -142,17 +140,19 @@ class DistanceMatrixContextHandler(ContextHandler):
 
     def new_context(self, matrix, annotations):
         context = super().new_context()
-        context.dim = matrix.shape[0]
+        context.shape = matrix.shape
+        context.symmetric = matrix.is_symmetric()
         context.annotations = self._var_names(annotations)
         context.annotation = context.annotations[1]
-        context.selection = []
+        context.selection = [] if context.symmetric else ([], [])
         return context
 
     # noinspection PyMethodOverriding
     def match(self, context, matrix, annotations):
         annotations = self._var_names(annotations)
-        if context.dim != matrix.shape[0] or \
-                context.annotation not in annotations:
+        if context.shape != matrix.shape \
+                or context.symmetric is not matrix.is_symmetric() \
+                or context.annotation not in annotations:
             return 0
         return 1 + (context.annotations == annotations)
 
@@ -160,12 +160,12 @@ class DistanceMatrixContextHandler(ContextHandler):
         context = widget.current_context
         if context is not None:
             context.annotation = widget.annot_combo.currentText()
-            context.selection = widget.tableview.selectionModel().selectedItems()
+            context.selection, _ = widget._get_selection()
 
     def settings_to_widget(self, widget, *args):
         context = widget.current_context
         widget.annotation_idx = context.annotations.index(context.annotation)
-        widget.tableview.selectionModel().setSelectedItems(context.selection)
+        widget._set_selection(context.selection)
 
 
 class OWDistanceMatrix(widget.OWWidget):
@@ -182,10 +182,8 @@ class OWDistanceMatrix(widget.OWWidget):
         distances = Output("Distances", DistMatrix, dynamic=False)
         table = Output("Selected Data", Table, replaces=["Table"])
 
-    class Error(widget.OWWidget.Error):
-        not_symmetric = widget.Msg("Distance matrix is not symmetric.")
-
     settingsHandler = DistanceMatrixContextHandler()
+    settings_version = 2
     auto_commit = Setting(True)
     annotation_idx = ContextSetting(1)
     selection = ContextSetting([])
@@ -200,24 +198,7 @@ class OWDistanceMatrix(widget.OWWidget):
 
         self.tablemodel = DistanceMatrixModel()
         view = self.tableview = TableView()
-        view.setWordWrap(False)
-        view.setTextElideMode(Qt.ElideNone)
-        view.setEditTriggers(QTableView.NoEditTriggers)
-        view.setItemDelegate(
-            TableBorderItem(
-                roles=(Qt.DisplayRole, Qt.BackgroundRole, Qt.ForegroundRole)))
         view.setModel(self.tablemodel)
-        view.setShowGrid(False)
-        for header in (view.horizontalHeader(), view.verticalHeader()):
-            header.setResizeContentsPrecision(1)
-            header.setSectionResizeMode(QHeaderView.ResizeToContents)
-            header.setHighlightSections(True)
-            header.setSectionsClickable(False)
-        view.verticalHeader().setDefaultAlignment(
-            Qt.AlignRight | Qt.AlignVCenter)
-        selmodel = SymmetricSelectionModel(view.model(), view)
-        selmodel.selectionChanged.connect(self.commit.deferred)
-        view.setSelectionModel(selmodel)
         view.setSelectionBehavior(QTableView.SelectItems)
         self.controlArea.layout().addWidget(view)
 
@@ -237,39 +218,51 @@ class OWDistanceMatrix(widget.OWWidget):
     @Inputs.distances
     def set_distances(self, distances):
         self.closeContext()
-
-        self.Error.not_symmetric.clear()
-        if distances is not None:
-            if not distances.is_symmetric():
-                self.Error.not_symmetric()
-                distances = None
-
         self.distances = distances
         self.tablemodel.set_data(self.distances)
-        self.selection = []
-        self.tableview.selectionModel().clear()
+        self.items = None
 
-        self.items = items = distances is not None and distances.row_items
         annotations = ["None", "Enumerate"]
-        pending_idx = 1
-        if items and not distances.axis:
-            annotations.append("Attribute names")
-            pending_idx = 2
-        elif isinstance(items, list) and \
-                all(isinstance(item, Variable) for item in items):
-            annotations.append("Name")
-            pending_idx = 2
-        elif isinstance(items, Table):
-            annotations.extend(
-                itertools.chain(items.domain.variables, items.domain.metas))
-            pending_idx = annotations.index(self._choose_label(items))
+        view = self.tableview
+
+        if distances is not None:
+            pending_idx = 1
+
+            if not distances.is_symmetric():
+                seltype = BlockSelectionModel
+                if distances.row_items is not None \
+                        or distances.col_items is not None:
+                    annotations.append("Labels")
+                    pending_idx = 2
+            else:
+                seltype = SymmetricSelectionModel
+                self.items = items = distances.row_items
+
+                if items and not distances.axis:
+                    annotations.append("Attribute names")
+                    pending_idx = 2
+                elif isinstance(items, list) and \
+                        all(isinstance(item, Variable) for item in items):
+                    annotations.append("Name")
+                    pending_idx = 2
+                elif isinstance(items, Table):
+                    annotations.extend(
+                        itertools.chain(items.domain.variables, items.domain.metas))
+                    pending_idx = annotations.index(self._choose_label(items))
+
+            selmodel = seltype(view.model(), view)
+            selmodel.selectionChanged.connect(self.commit.deferred)
+            view.setSelectionModel(selmodel)
+        else:
+            pending_idx = 0
+            view.selectionModel().clear()
+
         self.annot_combo.model()[:] = annotations
         self.annotation_idx = pending_idx
-
-        if items:
+        if distances is not None:
             self.openContext(distances, annotations)
-            self._update_labels()
-            self.tableview.resizeColumnsToContents()
+        self._update_labels()
+        view.resizeColumnsToContents()
         self.commit.now()
 
     @staticmethod
@@ -285,90 +278,163 @@ class OWDistanceMatrix(widget.OWWidget):
             self._update_labels()
 
     def _update_labels(self):
-        var = column = None
+        def enumeration(n):
+            return [str(i + 1) for i in range(n)]
+
+        hor_labels = ver_labels = None
+        colors = None
+
         if self.annotation_idx == 0:
-            labels = None
+            pass
+
         elif self.annotation_idx == 1:
-            labels = [str(i + 1) for i in range(self.distances.shape[0])]
+            ver_labels, hor_labels = map(enumeration, self.distances.shape)
+
         elif self.annot_combo.model()[self.annotation_idx] == "Attribute names":
             attr = self.distances.row_items.domain.attributes
-            labels = [str(attr[i]) for i in range(self.distances.shape[0])]
+            ver_labels = hor_labels = [
+                str(attr[i]) for i in range(self.distances.shape[0])]
+
+        elif self.annot_combo.model()[self.annotation_idx] == "Labels":
+            if self.distances.col_items is not None:
+                hor_labels = [
+                    str(x)
+                    for x in self.distances.get_labels(self.distances.col_items)]
+            else:
+                hor_labels = enumeration(self.distances.shape[1])
+            if self.distances.row_items is not None:
+                ver_labels = [
+                    str(x)
+                    for x in self.distances.get_labels(self.distances.row_items)]
+            else:
+                ver_labels = enumeration(self.distances.shape[0])
+
         elif self.annotation_idx == 2 and \
                 isinstance(self.items, widget.AttributeList):
-            labels = [v.name for v in self.items]
+            ver_labels = hor_labels = [v.name for v in self.items]
+
         elif isinstance(self.items, Table):
             var = self.annot_combo.model()[self.annotation_idx]
             column = self.items.get_column(var)
-            labels = [var.str_val(value) for value in column]
-        if labels:
-            self.tableview.horizontalHeader().show()
-            self.tableview.verticalHeader().show()
-        else:
-            self.tableview.horizontalHeader().hide()
-            self.tableview.verticalHeader().hide()
-        self.tablemodel.set_labels(labels, var, column)
+            if var.is_primitive():
+                colors = var.palette.values_to_qcolors(column)
+            ver_labels = hor_labels = [var.str_val(value) for value in column]
+
+        for header, labels in ((self.tableview.horizontalHeader(), hor_labels),
+                               (self.tableview.verticalHeader(), ver_labels)):
+            self.tablemodel.set_labels(header.orientation(), labels, colors)
+            if labels is None:
+                header.hide()
+            else:
+                header.show()
         self.tableview.resizeColumnsToContents()
 
     @gui.deferred
     def commit(self):
         sub_table = sub_distances = None
         if self.distances is not None:
-            inds = self.tableview.selectionModel().selectedItems()
-            if inds:
-                sub_distances = self.distances.submatrix(inds)
-                if self.distances.axis and isinstance(self.items, Table):
-                    sub_table = self.items[inds]
+            inds, symmetric = self._get_selection()
+            if symmetric:
+                if inds:
+                    sub_distances = self.distances.submatrix(inds)
+                    if self.distances.axis and isinstance(self.items, Table):
+                        sub_table = self.items[inds]
+            elif all(inds):
+                sub_distances = self.distances.submatrix(*inds)
         self.Outputs.distances.send(sub_distances)
         self.Outputs.table.send(sub_table)
+
+    def _get_selection(self):
+        selmodel = self.tableview.selectionModel()
+        if isinstance(selmodel, SymmetricSelectionModel):
+            return self.tableview.selectionModel().selectedItems(), True
+        else:
+            row_spans, col_spans = selection_blocks(selmodel.selection())
+            rows = list(itertools.chain.from_iterable(
+                itertools.starmap(range, row_spans)))
+            cols = list(itertools.chain.from_iterable(
+                itertools.starmap(range, col_spans)))
+            return (rows, cols), False
+
+    def _set_selection(self, selection):
+        selmodel = self.tableview.selectionModel()
+        if isinstance(selmodel, SymmetricSelectionModel):
+            if not isinstance(selection, list):
+                log.error("wrong data for symmetric selection")
+                return None
+            selmodel.setSelectedItems(selection)
+        else:
+            if not isinstance(selection, tuple) and len(selection) == 2:
+                log.error("wrong data for asymmetric selection")
+                return None
+            rows, cols = selection
+            selection = QItemSelection()
+            rowranges = list(ranges(rows))
+            colranges = list(ranges(cols))
+
+            index = self.tablemodel.index
+            for rowstart, rowend in rowranges:
+                for colstart, colend in colranges:
+                    selection.append(
+                        QItemSelectionRange(
+                            index(rowstart, colstart),
+                            index(rowend - 1, colend - 1)
+                        )
+                    )
+            selmodel.select(selection, selmodel.ClearAndSelect)
 
     def send_report(self):
         if self.distances is None:
             return
         model = self.tablemodel
-        dim = self.distances.shape[0]
-        col_cell = model.color_for_cell
+        index = model.index
+        ndec = self.tableview.itemDelegate().ndecimals
+        header = model.headerData
+        h, w = self.distances.shape
 
-        def _rgb(brush):
-            return "rgb({}, {}, {})".format(*brush.color().getRgb())
-        if model.labels:
-            col_label = model.color_for_label
-            label_colors = [_rgb(col_label(i)) for i in range(dim)]
-            self.report_raw('<table style="border-collapse:collapse">')
-            self.report_raw("<tr><td></td>")
-            self.report_raw("".join(
-                '<td style="background-color: {}">{}</td>'.format(*cv)
-                for cv in zip(label_colors, model.labels)))
+        hor_header = bool(header(0, Qt.Horizontal, Qt.DisplayRole))
+        ver_header = bool(header(0, Qt.Vertical, Qt.DisplayRole))
+
+        def cell(func, num):
+            label, brush = (func(role)
+                            for role in (Qt.DisplayRole, Qt.BackgroundRole))
+            if brush:
+                style = f' style="background-color: {brush.color().name()}"'
+            else:
+                style = ""
+            label = "" if label is None else f"{label:.{ndec}f}" if num else label
+            self.report_raw(f"<td {style}>{label}</td>\n")
+
+        self.report_raw('<table style="border-collapse:collapse">')
+        if hor_header:
+            self.report_raw("<tr>")
+            if ver_header:
+                self.report_raw("<td></td>")
+            for col in range(w):
+                cell(partial(header, col, Qt.Horizontal), False)
             self.report_raw("</tr>")
-            for i in range(dim):
-                self.report_raw("<tr>")
-                self.report_raw(
-                    '<td style="background-color: {}">{}</td>'.
-                    format(label_colors[i], model.labels[i]))
-                self.report_raw(
-                    "".join(
-                        '<td style="background-color: {};'
-                        'border-top:1px solid {}; border-left:1px solid {};">'
-                        '{:.3f}</td>'.format(
-                            _rgb(col_cell(i, j)),
-                            label_colors[i], label_colors[j],
-                            self.distances[i, j])
-                        for j in range(dim)))
-                self.report_raw("</tr>")
-            self.report_raw("</table>")
-        else:
-            self.report_raw('<table>')
-            for i in range(dim):
-                self.report_raw(
-                    "<tr>" +
-                    "".join('<td style="background-color: {}">{:.3f}</td>'.
-                            format(_rgb(col_cell(i, j)), self.distances[i, j])
-                            for j in range(dim)) +
-                    "</tr>")
-            self.report_raw("</table>")
+
+        for row in range(h):
+            self.report_raw("<tr>")
+            if ver_header:
+                cell(partial(header, row, Qt.Vertical), False)
+            for col in range(w):
+                cell(index(row, col).data, True)
+            self.report_raw("</tr>")
+        self.report_raw("</table>")
+
+    @classmethod
+    def migrate_context(cls, context, version):
+        if version < 2:
+            context.shape = (context.dim, context.dim)
+            context.symmetric = True
 
 
 if __name__ == "__main__":  # pragma: no cover
     import Orange.distance
-    data = Orange.data.Table("iris")
+    data = Orange.data.Table("zoo")
     dist = Orange.distance.Euclidean(data)
+    # dist = DistMatrix([[1, 2, 3], [4, 5, 6]])
+    # dist.row_items = DistMatrix._labels_to_tables(["aa", "bb"])
+    # dist.col_items = DistMatrix._labels_to_tables(["cc", "dd", "ee"])
     WidgetPreview(OWDistanceMatrix).run(dist)

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -1,3 +1,5 @@
+# pylint: disable=protected-access
+
 import unittest
 from functools import partial
 from unittest.mock import patch

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -4,18 +4,14 @@ from unittest.mock import patch
 
 import numpy as np
 from AnyQt.QtCore import Qt
-from AnyQt.QtGui import QColor
 
 from orangewidget.settings import Context
-from orangewidget.tests.base import GuiTest
 
 from Orange.misc import DistMatrix
 from Orange.data import Table, Domain, ContinuousVariable, StringVariable
 from Orange.distance import Euclidean
-from Orange.widgets.utils.itemdelegates import FixedFormatNumericColumnDelegate
 from Orange.widgets.tests.base import WidgetTest
-from Orange.widgets.unsupervised.owdistancematrix import OWDistanceMatrix, \
-    DistanceMatrixModel
+from Orange.widgets.unsupervised.owdistancematrix import OWDistanceMatrix
 
 
 class TestOWDistanceMatrix(WidgetTest):
@@ -243,76 +239,6 @@ class TestOWDistanceMatrix(WidgetTest):
         self.send_signal(widget.Inputs.distances, matrix)
         self.assertEqual(widget._get_selection(), (([0], [0, 2]), False))
         self.assertEqual(widget.annotation_idx, 0)
-
-
-class TestModel(GuiTest):
-    def assert_brush_value(self, brush, value):
-        self.assert_brush_color(brush, QColor.fromHsv(120, int(value), 255))
-
-    def assert_brush_color(self, brush, color):
-        self.assertEqual(brush.color().getRgb()[:3], color.getRgb()[:3])
-
-    def test_data(self):
-        model = DistanceMatrixModel()
-
-        dist = DistMatrix(np.array([[1.0, 2, 3], [0, 10, 5]]))
-        model.set_data(dist)
-
-        self.assertEqual(model.rowCount(), 2)
-        self.assertEqual(model.columnCount(), 3)
-        index = model.index(0, 1)
-        self.assertEqual(
-            index.data(FixedFormatNumericColumnDelegate.ColumnDataSpanRole),
-            (0, 10))
-        self.assertEqual(index.data(Qt.DisplayRole), 2)
-        self.assert_brush_value(index.data(Qt.BackgroundRole), 2 / 10 * 170)
-
-    def test_header_data(self):
-        model = DistanceMatrixModel()
-
-        dist = DistMatrix(np.array([[1.0, 2, 3], [0, 10, 5]]))
-        model.set_data(dist)
-
-        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.DisplayRole))
-        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.BackgroundRole))
-        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.ForegroundRole))
-        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.DisplayRole))
-        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.BackgroundRole))
-        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.ForegroundRole))
-
-        model.set_labels(Qt.Horizontal, list("abc"))
-        self.assertEqual(model.headerData(1, Qt.Horizontal, Qt.DisplayRole), "b")
-        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.DisplayRole))
-        # These shouldn't fail; what they return ... we don't care here
-        model.headerData(1, Qt.Horizontal, Qt.BackgroundRole)
-        model.headerData(1, Qt.Horizontal, Qt.ForegroundRole)
-        model.headerData(1, Qt.Vertical, Qt.BackgroundRole)
-        model.headerData(1, Qt.Vertical, Qt.ForegroundRole)
-
-        model.set_labels(Qt.Vertical, list("de"))
-        self.assertEqual(model.headerData(1, Qt.Horizontal, Qt.DisplayRole), "b")
-        self.assertEqual(model.headerData(1, Qt.Vertical, Qt.DisplayRole), "e")
-
-        model.set_labels(Qt.Horizontal, None)
-        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.DisplayRole))
-        self.assertEqual(model.headerData(1, Qt.Vertical, Qt.DisplayRole), "e")
-
-        colors = np.array([QColor(1, 2, 3), QColor(4, 5, 6), QColor(7, 8, 9)])
-        model.set_labels(Qt.Horizontal, list("abc"), colors)
-
-        self.assert_brush_color(
-            model.headerData(1, Qt.Horizontal, Qt.BackgroundRole),
-            colors[1].lighter(180))
-        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.BackgroundRole))
-
-        vcolors = np.array([QColor(12, 13, 14), QColor(9, 10, 11)])
-        model.set_labels(Qt.Vertical, list("de"), vcolors)
-        self.assert_brush_color(
-            model.headerData(1, Qt.Horizontal, Qt.BackgroundRole),
-            colors[1].lighter(180))
-        self.assert_brush_color(
-            model.headerData(1, Qt.Vertical, Qt.BackgroundRole),
-            vcolors[1].lighter(180))
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/utils/distmatrixmodel.py
+++ b/Orange/widgets/utils/distmatrixmodel.py
@@ -1,0 +1,120 @@
+from typing import NamedTuple, List, Optional, Dict, Any
+
+import numpy as np
+
+from AnyQt.QtWidgets import QTableView, QHeaderView
+from AnyQt.QtGui import QColor, QBrush, QFont
+from AnyQt.QtCore import Qt, QAbstractTableModel
+
+from Orange.misc import DistMatrix
+from Orange.widgets import gui
+from Orange.widgets.utils.itemdelegates import FixedFormatNumericColumnDelegate
+
+
+class LabelData(NamedTuple):
+    labels: Optional[List[str]] = None
+    colors: Optional[np.ndarray] = None
+
+
+class DistMatrixModel(QAbstractTableModel):
+    def __init__(self):
+        super().__init__()
+        self.distances: Optional[DistMatrix] = None
+        self.colors: Optional[np.ndarray] = None
+        self.__header_data: Dict[Any, Optional[LabelData]] = {
+            Qt.Horizontal: LabelData(),
+            Qt.Vertical: LabelData()}
+        self.__zero_diag: bool = True
+        self.__span: Optional[float] = None
+
+        self.__header_font = QFont()
+        self.__header_font.setBold(True)
+
+    def set_data(self, distances):
+        self.beginResetModel()
+        self.distances = distances
+        self.__header_data = dict.fromkeys(self.__header_data, LabelData())
+        if distances is None:
+            self.__span = self.colors = None
+            return
+        self.__span = span = np.max(distances)
+
+        self.colors = \
+            (distances * (170 / span if span > 1e-10 else 0)).astype(int)
+        self.__zero_diag = \
+            distances.is_symmetric() and np.allclose(np.diag(distances), 0)
+        self.endResetModel()
+
+    def set_labels(self, orientation, labels: Optional[List[str]],
+                   colors: Optional[np.ndarray] = None):
+        self.__header_data[orientation] = LabelData(labels, colors)
+        rc, cc = self.rowCount() - 1, self.columnCount() - 1
+        self.headerDataChanged.emit(
+            orientation, 0, rc if orientation == Qt.Vertical else cc)
+        self.dataChanged.emit(self.index(0, 0), self.index(rc, cc))
+
+    def rowCount(self, parent=None):
+        if parent and parent.isValid() or self.distances is None:
+            return 0
+        return self.distances.shape[0]
+
+    def columnCount(self, parent=None):
+        if parent and parent.isValid() or self.distances is None:
+            return 0
+        return self.distances.shape[1]
+
+    def data(self, index, role=Qt.DisplayRole):
+        if role == Qt.TextAlignmentRole:
+            return Qt.AlignCenter | Qt.AlignVCenter
+        if self.distances is None:
+            return None
+
+        row, col = index.row(), index.column()
+        if role == Qt.DisplayRole and not (self.__zero_diag and row == col):
+            return float(self.distances[row, col])
+        if role == Qt.BackgroundRole:
+            return QBrush(QColor.fromHsv(120, self.colors[row, col], 255))
+        if role == Qt.ForegroundRole:
+            return QColor(Qt.black)  # the background is light-ish
+        if role == FixedFormatNumericColumnDelegate.ColumnDataSpanRole:
+            return 0., self.__span
+        return None
+
+    def headerData(self, ind, orientation, role):
+        if role == Qt.FontRole:
+            return self.__header_font
+
+        __header_data = self.__header_data[orientation]
+        if role == Qt.DisplayRole:
+            if __header_data.labels is not None \
+                    and ind < len(__header_data.labels):
+                return __header_data.labels[ind]
+
+        colors = self.__header_data[orientation].colors
+        if colors is not None:
+            color = colors[ind].lighter(150)
+            if role == Qt.BackgroundRole:
+                return QBrush(color)
+            if role == Qt.ForegroundRole:
+                return QColor(Qt.black if color.value() > 128 else Qt.white)
+        return None
+
+
+class DistMatrixView(gui.HScrollStepMixin, QTableView):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.setWordWrap(False)
+        self.setTextElideMode(Qt.ElideNone)
+        self.setEditTriggers(QTableView.NoEditTriggers)
+        self.setItemDelegate(
+            FixedFormatNumericColumnDelegate(
+                roles=(Qt.DisplayRole, Qt.BackgroundRole, Qt.ForegroundRole,
+                       Qt.TextAlignmentRole)))
+        for header in (self.horizontalHeader(), self.verticalHeader()):
+            header.setResizeContentsPrecision(1)
+            header.setSectionResizeMode(QHeaderView.ResizeToContents)
+            header.setHighlightSections(True)
+            header.setSectionsClickable(False)
+        self.verticalHeader().setDefaultAlignment(
+            Qt.AlignRight | Qt.AlignVCenter)

--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -170,7 +170,7 @@ def _nobr(s):
 
 
 @summarize.register
-def summarize_(data: Table):
+def summarize_(data: Table):  # pylint: disable=function-redefined
     def previewer():
         view = TableView(selectionMode=TableView.NoSelection)
         view.setModel(TableModel(data))
@@ -183,7 +183,7 @@ def summarize_(data: Table):
 
 
 @summarize.register
-def summarize_(matrix: DistMatrix):
+def summarize_(matrix: DistMatrix):  # pylint: disable=function-redefined
     def previewer():
         view = DistMatrixView(selectionMode=TableView.NoSelection)
         model = DistMatrixModel()
@@ -206,7 +206,6 @@ def summarize_(matrix: DistMatrix):
 
         return view
 
-    # pylint: disable=function-redefined
     h, w = matrix.shape
     return PartialSummary(
         f"{w}×{h}",
@@ -238,7 +237,7 @@ def summarize_(attributes: AttributeList):  # pylint: disable=function-redefined
 
 
 @summarize.register
-def summarize_(preprocessor: Preprocess):
+def summarize_(preprocessor: Preprocess):  # pylint: disable=function-redefined
     if isinstance(preprocessor, PreprocessorList):
         if preprocessor.preprocessors:
             details = "<br/>".join(map(_name_of, preprocessor.preprocessors))

--- a/Orange/widgets/utils/state_summary.py
+++ b/Orange/widgets/utils/state_summary.py
@@ -6,6 +6,8 @@ from AnyQt.QtCore import Qt
 from orangewidget.utils.signals import summarize, PartialSummary
 from Orange.widgets.utils.itemmodels import TableModel
 from Orange.widgets.utils.tableview import TableView
+from Orange.widgets.utils.distmatrixmodel import \
+    DistMatrixModel, DistMatrixView
 
 from Orange.data import (
     StringVariable, DiscreteVariable, ContinuousVariable, TimeVariable,
@@ -181,9 +183,36 @@ def summarize_(data: Table):
 
 
 @summarize.register
-def summarize_(matrix: DistMatrix):  # pylint: disable=function-redefined
-    n, m = matrix.shape
-    return PartialSummary(f"{n}×{m}", _nobr(f"{n}×{m} distance matrix"))
+def summarize_(matrix: DistMatrix):
+    def previewer():
+        view = DistMatrixView(selectionMode=TableView.NoSelection)
+        model = DistMatrixModel()
+        model.set_data(matrix)
+        col_labels = matrix.get_labels(matrix.col_items)
+        row_labels = matrix.get_labels(matrix.row_items)
+        if matrix.is_symmetric() and (
+                (col_labels is None) is not (row_labels is None)):
+            if col_labels is None:
+                col_labels = row_labels
+            else:
+                row_labels = col_labels
+        if col_labels is None:
+            col_labels = [str(x) for x in range(w)]
+        if row_labels is None:
+            row_labels = [str(x) for x in range(h)]
+        model.set_labels(Qt.Horizontal, col_labels)
+        model.set_labels(Qt.Vertical, row_labels)
+        view.setModel(model)
+
+        return view
+
+    # pylint: disable=function-redefined
+    h, w = matrix.shape
+    return PartialSummary(
+        f"{w}×{h}",
+        _nobr(f"{w}×{h} distance matrix"),
+        previewer
+    )
 
 
 @summarize.register

--- a/Orange/widgets/utils/tests/test_distmatrixmodel.py
+++ b/Orange/widgets/utils/tests/test_distmatrixmodel.py
@@ -1,0 +1,85 @@
+import unittest
+
+import numpy as np
+from AnyQt.QtCore import Qt
+from AnyQt.QtGui import QColor
+
+from orangewidget.tests.base import GuiTest
+
+from Orange.misc import DistMatrix
+from Orange.widgets.utils.itemdelegates import FixedFormatNumericColumnDelegate
+from Orange.widgets.utils.distmatrixmodel import DistMatrixModel
+
+
+class TestModel(GuiTest):
+    def assert_brush_value(self, brush, value):
+        self.assert_brush_color(brush, QColor.fromHsv(120, int(value), 255))
+
+    def assert_brush_color(self, brush, color):
+        self.assertEqual(brush.color().getRgb()[:3], color.getRgb()[:3])
+
+    def test_data(self):
+        model = DistMatrixModel()
+
+        dist = DistMatrix(np.array([[1.0, 2, 3], [0, 10, 5]]))
+        model.set_data(dist)
+
+        self.assertEqual(model.rowCount(), 2)
+        self.assertEqual(model.columnCount(), 3)
+        index = model.index(0, 1)
+        self.assertEqual(
+            index.data(FixedFormatNumericColumnDelegate.ColumnDataSpanRole),
+            (0, 10))
+        self.assertEqual(index.data(Qt.DisplayRole), 2)
+        self.assert_brush_value(index.data(Qt.BackgroundRole), 2 / 10 * 170)
+
+    def test_header_data(self):
+        model = DistMatrixModel()
+
+        dist = DistMatrix(np.array([[1.0, 2, 3], [0, 10, 5]]))
+        model.set_data(dist)
+
+        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.DisplayRole))
+        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.BackgroundRole))
+        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.ForegroundRole))
+        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.DisplayRole))
+        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.BackgroundRole))
+        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.ForegroundRole))
+
+        model.set_labels(Qt.Horizontal, list("abc"))
+        self.assertEqual(model.headerData(1, Qt.Horizontal, Qt.DisplayRole), "b")
+        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.DisplayRole))
+        # These shouldn't fail; what they return ... we don't care here
+        model.headerData(1, Qt.Horizontal, Qt.BackgroundRole)
+        model.headerData(1, Qt.Horizontal, Qt.ForegroundRole)
+        model.headerData(1, Qt.Vertical, Qt.BackgroundRole)
+        model.headerData(1, Qt.Vertical, Qt.ForegroundRole)
+
+        model.set_labels(Qt.Vertical, list("de"))
+        self.assertEqual(model.headerData(1, Qt.Horizontal, Qt.DisplayRole), "b")
+        self.assertEqual(model.headerData(1, Qt.Vertical, Qt.DisplayRole), "e")
+
+        model.set_labels(Qt.Horizontal, None)
+        self.assertIsNone(model.headerData(1, Qt.Horizontal, Qt.DisplayRole))
+        self.assertEqual(model.headerData(1, Qt.Vertical, Qt.DisplayRole), "e")
+
+        colors = np.array([QColor(1, 2, 3), QColor(4, 5, 6), QColor(7, 8, 9)])
+        model.set_labels(Qt.Horizontal, list("abc"), colors)
+
+        self.assert_brush_color(
+            model.headerData(1, Qt.Horizontal, Qt.BackgroundRole),
+            colors[1].lighter(150))
+        self.assertIsNone(model.headerData(1, Qt.Vertical, Qt.BackgroundRole))
+
+        vcolors = np.array([QColor(12, 13, 14), QColor(9, 10, 11)])
+        model.set_labels(Qt.Vertical, list("de"), vcolors)
+        self.assert_brush_color(
+            model.headerData(1, Qt.Horizontal, Qt.BackgroundRole),
+            colors[1].lighter(150))
+        self.assert_brush_color(
+            model.headerData(1, Qt.Vertical, Qt.BackgroundRole),
+            vcolors[1].lighter(150))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/bench_datadelegate.py
+++ b/benchmark/bench_datadelegate.py
@@ -6,8 +6,7 @@ import Orange
 from Orange.data import Table
 from Orange.widgets.data.owtable import RichTableModel, TableBarItemDelegate, \
     TableDataDelegate
-from Orange.widgets.unsupervised.owdistancematrix import DistanceMatrixModel, \
-    TableBorderItem
+from Orange.widgets.utils.distmatrixmodel import DistMatrixModel
 from Orange.widgets.utils.tableview import TableView
 
 from .base import benchmark, Benchmark
@@ -77,16 +76,13 @@ class BenchDistanceDelegate(BaseBenchTableView):
         super().setUp()
         data = Table("iris")
         dist = Orange.distance.Euclidean(data)
-        self.model = DistanceMatrixModel()
+        self.model = DistMatrixModel()
         self.model.set_data(dist)
-        self.delegate = TableBorderItem()
-        self.view.setItemDelegate(self.delegate)
         self.view.setModel(self.model)
 
     def tearDown(self) -> None:
         super().tearDown()
         del self.model
-        del self.delegate
 
     @benchmark(number=3, warmup=1, repeat=10)
     def bench_paint(self):


### PR DESCRIPTION
##### Issue

The issue was basically to add summary previews for distance matrix outputs ... and as usual this small change resulted in major rewrite of a widget.

This included support for non-square matrices and visual changes.

**Based on #6245.**

##### Description of changes

- Widget can now show non-square matrices (not that we really need this)
- Horizontal and vertical header are no longer necessary the same
- Detection of default labels is now more flexible
- Model and view are extracted into a separate file
- ... where they are used by summary previewer
- Colored borders around cells were awful and are removed.

##### Includes
- [X] Code changes
- [X] Tests
