### PR TITLE
[ENH] Faster TableModel for Dask tables (through caching)

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -787,6 +787,7 @@ class ModelActionsWidget(QWidget):
         return self.insertAction(-1, action, *args)
 
 
+# pylint: disable=abstract-method
 class ModelCache(QObject, ConcurrentMixin):
     def __init__(self, model):
         super().__init__()
@@ -800,7 +801,7 @@ class ModelCache(QObject, ConcurrentMixin):
                      "height": 60,
                      "width": 15}
 
-        self.delayed_request = QTimer()
+        self.delayed_request = QTimer(self)
         self.delayed_request.timeout.connect(self.update)
         self.last_cache_time = 0
 
@@ -860,9 +861,6 @@ class ModelCache(QObject, ConcurrentMixin):
             self.update_view(item)
             self.fetch_data()
             return None
-
-    def on_partial_result(self, result):
-        pass  # can dask report progress?
 
     def on_done(self, result):
         top, left, bottom, right = result

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -1,3 +1,4 @@
+from time import perf_counter
 from numbers import Number, Integral
 from math import isnan, isinf
 
@@ -12,7 +13,7 @@ from xml.sax.saxutils import escape
 
 from AnyQt.QtCore import (
     Qt, QObject, QAbstractListModel, QModelIndex,
-    QItemSelectionModel, QItemSelection)
+    QItemSelectionModel, QItemSelection, QTimer)
 from AnyQt.QtCore import pyqtSignal as Signal
 from AnyQt.QtGui import QColor, QBrush
 from AnyQt.QtWidgets import (
@@ -21,6 +22,7 @@ from AnyQt.QtWidgets import (
 
 import numpy
 
+from orangewidget.utils.cache import LRUCache
 from orangewidget.utils.itemmodels import (
     PyListModel, AbstractSortTableModel as _AbstractSortTableModel,
     LabelledSeparator, SeparatorItem
@@ -29,8 +31,10 @@ from orangewidget.utils.itemmodels import (
 from Orange.widgets.utils.colorpalettes import ContinuousPalettes, ContinuousPalette
 from Orange.data import Value, Variable, Storage, DiscreteVariable, ContinuousVariable
 from Orange.data.domain import filter_visible
+from Orange.data.dask import DaskTable
 from Orange.widgets import gui
 from Orange.widgets.utils import datacaching
+from Orange.widgets.utils.concurrent import ConcurrentMixin
 from Orange.statistics import basic_stats
 from Orange.util import deprecated
 
@@ -783,6 +787,89 @@ class ModelActionsWidget(QWidget):
         return self.insertAction(-1, action, *args)
 
 
+class ModelCache(QObject, ConcurrentMixin):
+    def __init__(self, model):
+        super().__init__()
+        self.model: TableModel = model
+
+        self.source = self.model.source
+
+        self.data = LRUCache(10000)
+        self.view = {"top": 0,
+                     "left": 0,
+                     "height": 60,
+                     "width": 15}
+
+        self.delayed_request = QTimer()
+        self.delayed_request.timeout.connect(self.update)
+        self.last_cache_time = 0
+
+    def update_view(self, item):
+        row, col = item
+        if row < self.view["top"]:
+            self.view["top"] = row
+        elif row > self.view["top"] + self.view["height"]:
+            self.view["top"] = row - self.view["height"]
+        if col < self.view["left"]:
+            self.view["left"] = col
+        elif col > self.view["left"] + self.view["width"]:
+            self.view["left"] = col - self.view["width"]
+
+    def apply_view(self):
+        buffer = 20  # completely arbitrary
+        max_h, max_w = len(self.source), len(self.source.domain)
+        top = max(self.view["top"] - buffer, 0)
+        left = max(self.view["left"] - buffer, 0)
+        bottom = min(self.view["top"] + self.view["height"] + buffer, max_h)
+        right = min(self.view["left"] + self.view["width"] + buffer, max_w)
+        return top, left, bottom, right
+
+    def update_cache(self, _task):
+        top, left, bottom, right = self.apply_view()
+
+        _vars = [self.model.columns[c].var for c in range(left, right)]
+
+        chunk = self.source[self.model.mapToSourceRows(range(top, bottom)),
+                            _vars].compute()
+
+        for c_row, v_row in enumerate(range(top, bottom)):
+            for c_col, v_col in enumerate(range(left, right)):
+                self.data[(v_row, v_col)] = chunk[c_row, _vars[c_col]]
+
+        return top, left, bottom, right
+
+    def update(self):
+        self.last_cache_time = perf_counter()
+        self.delayed_request.stop()
+        self.start(self.update_cache)
+
+    def reset(self):
+        self.data.clear()
+        self.update()
+
+    def fetch_data(self):
+        cache_interval = 0.02  # minimum time in seconds before requesting new data
+        elapsed = perf_counter() - self.last_cache_time
+        self.delayed_request.stop()
+        self.delayed_request.start(max(1, int(1000 * (cache_interval - elapsed))))
+
+    def __getitem__(self, item):
+        try:
+            return self.data[item]
+        except KeyError:
+            self.update_view(item)
+            self.fetch_data()
+            return None
+
+    def on_partial_result(self, result):
+        pass  # can dask report progress?
+
+    def on_done(self, result):
+        top, left, bottom, right = result
+        self.model.dataChanged.emit(self.model.index(top, left),
+                                    self.model.index(bottom, right))
+
+
 class TableModel(AbstractSortTableModel):
     """
     An adapter for using Orange.data.Table within Qt's Item View Framework.
@@ -910,7 +997,17 @@ class TableModel(AbstractSortTableModel):
         if self.__rowCount > (2 ** 31 - 1):
             raise ValueError("len(sourcedata) > 2 ** 31 - 1")
 
-    def _get_source_item(self, row, coldesc):
+        self.lazy_loading = isinstance(self.source, DaskTable)
+        if self.lazy_loading:
+            self.cache = ModelCache(model=self)
+            self.layoutChanged.connect(self.cache.reset)
+
+    def _get_source_item(self, row, col):
+        if self.lazy_loading:
+            return self.cache[row, col]
+
+        row = self.mapToSourceRows(row)
+        coldesc = self.columns[col]
         if isinstance(coldesc, self.Basket):
             # `self.source[row:row + 1]` returns Table
             # `self.source[row]` returns RowInstance
@@ -979,12 +1076,13 @@ class TableModel(AbstractSortTableModel):
         if not 0 <= row <= self.__rowCount:
             return None
 
-        row = self.mapToSourceRows(row)
         col = 0 if role is _ClassValueRole else index.column()
 
         try:
             coldesc = self.columns[col]
-            instance = self._get_source_item(row, coldesc)
+            instance = self._get_source_item(row, col)
+            if instance is None:
+                return None
         except IndexError:
             self.layoutAboutToBeChanged.emit()
             self.beginRemoveRows(self.parent(), row, max(self.rowCount(), row))

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -1,5 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import time
 import unittest
 from unittest.mock import patch
 
@@ -22,6 +23,7 @@ from Orange.widgets.utils.itemmodels import \
     TableModel, _as_contiguous_range
 from Orange.widgets.gui import TableVariable
 from Orange.tests import test_filename
+from Orange.tests.test_dasktable import temp_dasktable
 from Orange.tests.sql.base import DataBaseTest as dbt
 from Orange.data.sql.table import SqlTable
 
@@ -555,6 +557,20 @@ class TestTableModel(unittest.TestCase, dbt):
     def test_local_dense_data(self):
         table = Table("iris.tab")
         model = TableModel(table)
+
+        self._dense_data(table, model.data, model.index)
+
+    def test_dask_dense_data(self):
+        table = temp_dasktable("iris.tab")
+        model = TableModel(table)
+
+        # table is empty until cache is filled
+        self.assertIsNone(model.data(model.index(0, 0), Qt.DisplayRole))
+
+        # for some reason timeout must be manually triggered...
+        model.cache.delayed_request.stop()
+        model.cache.delayed_request.timeout.emit()
+        time.sleep(1)
 
         self._dense_data(table, model.data, model.index)
 


### PR DESCRIPTION
##### Issue
Currently the data is read one row at a time, which causes issues when the dataset is very wide.

##### Description of changes
Updated `RichTableModel` with a new mechanism to read only the data currently in view and cache it. This only gets used for `DaskTables`. Otherwise if the data is stored in `numpy` arrays it reads each element from them directly, and if the data is sparse it will default to the old behaviour of using `RowInstance`. This is done because the entire row must be read in order for the "basket_formatter" to work. I haven't tested or considered what should happen for `SQLTable`, but I'm thinking we also default to the old behaviour?

also a small change in `test_owtable` because the sorting test was failing.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
