### PR TITLE
owhierarchicalclustering: Use GraphicsWidgetView for layout

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -147,6 +147,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         annotated = self.get_output(self.widget.Outputs.annotated_data)
         self.assertIsNotNone(annotated)
 
+        self.widget.grab()  # Force layout
         # selecting clusters with cutoff should select all data
         QTest.mousePress(
             self.widget.view.headerView().viewport(),


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Reuse GraphicsWidgetView in OWHierarchicalclustering instead of custom layouting.

Maybe fixes https://github.com/biolab/orange3/issues/6236

##### Description of changes

 Use GraphicsWidgetView for layout

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
