### PR TITLE
[FIX] Bar Plot: Fix annotation by enumeration

### DIFF
--- a/Orange/widgets/visualize/owbarplot.py
+++ b/Orange/widgets/visualize/owbarplot.py
@@ -572,7 +572,10 @@ class OWBarPlot(OWWidget):
         elif not self.annot_var:
             return []
         elif self.annot_var == self.enumeration:
-            return np.arange(1, len(self.data) + 1)[self.grouped_indices]
+            return [
+                str(x)
+                for x in np.arange(1, len(self.data) + 1)[self.grouped_indices]
+            ]
         else:
             return [self.annot_var.str_val(row[self.annot_var])
                     for row in self.grouped_data]

--- a/Orange/widgets/visualize/tests/test_owbarplot.py
+++ b/Orange/widgets/visualize/tests/test_owbarplot.py
@@ -137,6 +137,21 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertFalse(group_axis.isVisible())
         self.assertFalse(annot_axis.isVisible())
 
+    def test_annotate_by_enumeration(self):
+        widget = self.widget
+
+        self.send_signal(widget.Inputs.data, self.data)
+        combo = widget.controls.annot_var
+        for i in range(combo.count()):
+            try:
+                simulate.combobox_activate_index(combo, i)
+            except AssertionError:  # skip disabled items
+                pass
+            else:
+                labels = widget.get_labels()
+                self.assertTrue(not labels
+                                or all(isinstance(x, str) for x in labels))
+
     def test_datasets(self):
         controls = self.widget.controls
         for ds in datasets.datasets():


### PR DESCRIPTION
##### Issue

Bar Plot fails when we select to annotate by Enumeration.

`get_labels` returns a `np.array` of type `int64` instead of list or array of `str`.

##### Description of changes

Change numbers into strings.

##### Includes
- [X] Code changes
- [X] Tests