### PR TITLE
TableModel avoid RowInstance

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -844,7 +844,7 @@ class TableModel(AbstractSortTableModel):
 
         def make_basket(vars, density, role):
             return TableModel.Basket(
-                vars, TableModel.Attribute, brush_for_role[role], density,
+                vars, role, brush_for_role[role], density,
                 make_basket_formatter(vars, density)
             )
 
@@ -903,8 +903,7 @@ class TableModel(AbstractSortTableModel):
         if isinstance(coldesc, self.Basket):
             # `self.source[row:row + 1]` returns Table
             # `self.source[row]` returns RowInstance
-            if coldesc.role is self.ClassVar:
-                return self.source[row:row + 1].Y
+            # We only worry about X and metas, as Y cannot be sparse
             if coldesc.role is self.Meta:
                 return self.source[row:row + 1].metas
             if coldesc.role is self.Attribute:

--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -5,7 +5,7 @@ import operator
 from collections import namedtuple, defaultdict
 from collections.abc import Sequence
 from contextlib import contextmanager
-from functools import reduce, partial, lru_cache, wraps
+from functools import reduce, partial, wraps
 from itertools import chain
 from warnings import warn
 from xml.sax.saxutils import escape
@@ -26,7 +26,7 @@ from orangewidget.utils.itemmodels import (
 )
 
 from Orange.widgets.utils.colorpalettes import ContinuousPalettes, ContinuousPalette
-from Orange.data import Variable, Storage, DiscreteVariable, ContinuousVariable
+from Orange.data import Value, Variable, Storage, DiscreteVariable, ContinuousVariable
 from Orange.data.domain import filter_visible
 from Orange.widgets import gui
 from Orange.widgets.utils import datacaching
@@ -819,39 +819,35 @@ class TableModel(AbstractSortTableModel):
         self.X_density = sourcedata.X_density()
         self.Y_density = sourcedata.Y_density()
         self.M_density = sourcedata.metas_density()
+        self.Y_len = len(domain.class_vars)
+        self.M_len = len(domain.metas)
 
         brush_for_role = {
             role: QBrush(c) if c is not None else None
             for role, c in self.ColorForRole.items()
         }
 
-        def format_sparse(vars, datagetter, instance):
-            data = datagetter(instance)
-            return ", ".join("{}={}".format(vars[i].name, vars[i].repr_val(v))
-                             for i, v in zip(data.indices, data.data))
+        def format_sparse(vars, row):
+            row = row.tocsr()
+            return ", ".join("{}={}".format(vars[i].name, vars[i].str_val(v))
+                             for i, v in zip(row.indices, row.data))
 
-        def format_sparse_bool(vars, datagetter, instance):
-            data = datagetter(instance)
-            return ", ".join(vars[i].name for i in data.indices)
+        def format_sparse_bool(vars, row):
+            row = row.tocsr()
+            return ", ".join(vars[i].name for i in row.indices)
 
-        def format_dense(var, instance):
-            return str(instance[var])
+        def format_dense(var, val):
+            return var.str_val(val)
 
-        def make_basket_formater(vars, density, role):
-            formater = (format_sparse if density == Storage.SPARSE
-                        else format_sparse_bool)
-            if role == TableModel.Attribute:
-                getter = operator.attrgetter("sparse_x")
-            elif role == TableModel.ClassVar:
-                getter = operator.attrgetter("sparse_y")
-            elif role == TableModel.Meta:
-                getter = operator.attrgetter("sparse_metas")
-            return partial(formater, vars, getter)
+        def make_basket_formatter(vars, density):
+            formatter = (format_sparse if density == Storage.SPARSE
+                         else format_sparse_bool)
+            return partial(formatter, vars)
 
         def make_basket(vars, density, role):
             return TableModel.Basket(
                 vars, TableModel.Attribute, brush_for_role[role], density,
-                make_basket_formater(vars, density, role)
+                make_basket_formatter(vars, density)
             )
 
         def make_column(var, role):
@@ -896,11 +892,6 @@ class TableModel(AbstractSortTableModel):
                    [set(var.attributes) for var in self.vars],
                    set()))
 
-        @lru_cache(maxsize=1000)
-        def row_instance(index):
-            return self.source[int(index)]
-        self._row_instance = row_instance
-
         # column basic statistics (VariableStatsRole), computed when
         # first needed.
         self.__stats = None
@@ -909,6 +900,25 @@ class TableModel(AbstractSortTableModel):
 
         if self.__rowCount > (2 ** 31 - 1):
             raise ValueError("len(sourcedata) > 2 ** 31 - 1")
+
+    def _get_source_item(self, row, col):
+        if col < self.Y_len:
+            if self.source.Y.ndim == 1:
+                return self.source.Y[row]
+            elif self.Y_density == Storage.DENSE:
+                return self.source.Y[row, col]
+            else:
+                return self.source.Y[row]
+        elif self.Y_len <= col < self.Y_len + self.M_len:
+            if self.M_density == Storage.DENSE:
+                return self.source.metas[row, col - self.Y_len]
+            else:
+                return self.source.metas[row]
+        else:
+            if self.X_density == Storage.DENSE:
+                return self.source.X[row, col - self.Y_len - self.M_len]
+            else:
+                return self.source.X[row]
 
     def sortColumnData(self, column):
         return self._columnSortKeyData(column, TableModel.ValueRole)
@@ -964,14 +974,15 @@ class TableModel(AbstractSortTableModel):
         if role not in _recognizedRoles:
             return None
 
-        row, col = index.row(), index.column()
-        if  not 0 <= row <= self.__rowCount:
+        row = index.row()
+        if not 0 <= row <= self.__rowCount:
             return None
 
         row = self.mapToSourceRows(row)
+        col = 0 if role is _ClassValueRole else index.column()
 
         try:
-            instance = self._row_instance(row)
+            instance = self._get_source_item(row, col)
         except IndexError:
             self.layoutAboutToBeChanged.emit()
             self.beginRemoveRows(self.parent(), row, max(self.rowCount(), row))
@@ -983,23 +994,17 @@ class TableModel(AbstractSortTableModel):
 
         if role == _Qt_DisplayRole:
             return coldesc.format(instance)
-        elif role == _Qt_EditRole and isinstance(coldesc, TableModel.Column):
-            return instance[coldesc.var]
+        elif role in (_Qt_EditRole, _ValueRole) and isinstance(coldesc, TableModel.Column):
+            return Value(coldesc.var, instance)
         elif role == _Qt_BackgroundRole:
             return coldesc.background
         elif role == _Qt_ForegroundRole:
-            if coldesc.background is not None:
-                # The background is light-ish, force dark text color
-                return QColor(0, 0, 0, 200)
-            else:
-                return None
-        elif role == _ValueRole and isinstance(coldesc, TableModel.Column):
-            return instance[coldesc.var]
-        elif role == _ClassValueRole:
-            try:
-                return instance.get_class()
-            except TypeError:
-                return None
+            # The background is light-ish, force dark text color
+            return coldesc.background and QColor(0, 0, 0, 200)
+        elif role == _ClassValueRole \
+                and isinstance(coldesc, TableModel.Column) \
+                and len(self.domain.class_vars) == 1:
+            return Value(coldesc.var, instance)
         elif role == _VariableRole and isinstance(coldesc, TableModel.Column):
             return coldesc.var
         elif role == _DomainRole:

--- a/Orange/widgets/utils/tests/test_itemmodels.py
+++ b/Orange/widgets/utils/tests/test_itemmodels.py
@@ -3,6 +3,8 @@
 import unittest
 from unittest.mock import patch
 
+from scipy.sparse import csr_matrix
+
 from AnyQt.QtCore import Qt, QModelIndex
 from AnyQt.QtTest import QSignalSpy
 from AnyQt.QtGui import QBrush, QColor
@@ -599,7 +601,7 @@ class TestTableModel(unittest.TestCase, dbt):
         self.assertEqual(table.domain[4], data(index(0, 0), TableModel.VariableRole))
         self.assertIsInstance(data(index(0, 0), TableModel.VariableStatsRole), BasicStats)
 
-        # X: basket
+        # X: sparse
         self.assertEqual("sepal_length=1.5, sepal_width=5.3, petal_length=4.1, petal_width=2",
                          data(index(0, 3), Qt.DisplayRole))
         self.assertIsNone(data(index(0, 3), Qt.EditRole))
@@ -609,6 +611,20 @@ class TestTableModel(unittest.TestCase, dbt):
         self.assertIsNone(data(index(0, 3), TableModel.ClassValueRole))
         self.assertIsNone(data(index(0, 3), TableModel.VariableRole))
         self.assertIsNone(data(index(0, 3), TableModel.VariableStatsRole))
+
+        # X: sparse_bool
+        table = Table.from_numpy(Domain(table.domain.class_vars, metas=table.domain.attributes),
+                                 csr_matrix(table.Y), metas=table.X)
+        model = TableModel(table)
+        data, index = model.data, model.index
+
+        self.assertEqual("Iris-setosa", data(index(0, 1), Qt.DisplayRole))
+
+        # metas: sparse
+        self.assertEqual("sepal_length=1.5, sepal_width=5.3, petal_length=4.1, petal_width=2",
+                         data(index(0, 0), Qt.DisplayRole))
+        self.assertIsInstance(data(index(0, 0), Qt.BackgroundRole), QBrush)
+        self.assertIsInstance(data(index(0, 0), Qt.ForegroundRole), QColor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Description of changes
Trying to avoid the use of `RowInstance` in anticipation of upcoming dask integration (see #6267).
Includes preliminary tests.
