### PR TITLE
[FIX] Table.from_table works correctly with boolean indices

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -813,15 +813,9 @@ class Table(Sequence, Storage):
                         out = cparts if not array_conv.is_sparse else sp.vstack(cparts)
                         setattr(self, array_conv.target, out)
 
-                if source.has_weights():
-                    self.W = source.W[row_indices]
-                else:
-                    self.W = np.empty((n_rows, 0))
+                self.W = source.W[row_indices]
                 self.name = getattr(source, 'name', '')
-                if hasattr(source, 'ids'):
-                    self.ids = source.ids[row_indices]
-                else:
-                    cls._init_ids(self)
+                self.ids = source.ids[row_indices]
                 self.attributes = deepcopy(getattr(source, 'attributes', {}))
                 _idcache_save(_thread_local.conversion_cache, (domain, source), self)
             return self
@@ -879,7 +873,7 @@ class Table(Sequence, Storage):
                 self.metas = self.metas.reshape(-1, len(self.domain.metas))
             self.W = source.W[row_indices]
             self.name = getattr(source, 'name', '')
-            self.ids = np.array(source.ids[row_indices])
+            self.ids = source.ids[row_indices]
             self.attributes = deepcopy(getattr(source, 'attributes', {}))
         return self
 

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -2083,7 +2083,6 @@ class TableIndexingTests(TableTests):
                 np.testing.assert_almost_equal(table.metas,
                                                self.table.metas[r, metas])
 
-
     def test_optimize_indices(self):
         # ordinary conversion
         self.assertEqual(_optimize_indices([1, 2, 3], 4), slice(1, 4, 1))
@@ -2094,8 +2093,14 @@ class TableIndexingTests(TableTests):
         np.testing.assert_equal(_optimize_indices([1, 2, 4], 5), [1, 2, 4])
         np.testing.assert_equal(_optimize_indices((1, 2, 4), 5), [1, 2, 4])
 
-        # leave boolean arrays
-        np.testing.assert_equal(_optimize_indices([True, False, True], 3), [True, False, True])
+        # internally convert boolean arrays into indices
+        np.testing.assert_equal(_optimize_indices([False, False, False, False], 4), [])
+        np.testing.assert_equal(_optimize_indices([True, False, True, True], 4), [0, 2, 3])
+        np.testing.assert_equal(_optimize_indices([True, False, True], 3), slice(0, 4, 2))
+        with self.assertRaises(IndexError):
+            _optimize_indices([True, False, True], 2)
+        with self.assertRaises(IndexError):
+            _optimize_indices([True, False, True], 4)
 
         # do not convert if step is negative
         np.testing.assert_equal(_optimize_indices([4, 2, 0], 5), [4, 2, 0])


### PR DESCRIPTION
##### Issue
`Table.from_table` does not work correctly with boolean indices, but `from_table_rows` does. See the added test. 

##### Description of changes
Much of the code in `from_table` expects either slices or integer row indices, so boolean indices are converted to that.

The second last commit is a minor refactor of handling of `W` and `ids` in `from_table` so that it becomes equivalent to the `from_table_rows` implementation. Why did we handle them differently? `from_table` had some code from 2015 at that so I though it might not be needed anymore.

The last commit splits off two well-defined operations from `from_table` so that the code is a bit cleaner.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
