### PR TITLE
Random Forest, Gradient Boosting: Handle deprecated parameters

### DIFF
--- a/Orange/classification/gb.py
+++ b/Orange/classification/gb.py
@@ -25,7 +25,7 @@ class GBClassifier(SklLearner, _FeatureScorerMixin):
     __returns__ = SklModel
 
     def __init__(self,
-                 loss="deviance",
+                 loss="log_loss",
                  learning_rate=0.1,
                  n_estimators=100,
                  subsample=1.0,

--- a/Orange/classification/random_forest.py
+++ b/Orange/classification/random_forest.py
@@ -46,7 +46,7 @@ class RandomForestLearner(SklLearner, _FeatureScorerMixin):
                  min_samples_split=2,
                  min_samples_leaf=1,
                  min_weight_fraction_leaf=0.,
-                 max_features="auto",
+                 max_features="sqrt",
                  max_leaf_nodes=None,
                  bootstrap=True,
                  oob_score=False,

--- a/Orange/classification/xgb.py
+++ b/Orange/classification/xgb.py
@@ -82,7 +82,6 @@ class XGBClassifier(XGBBase, Learner, _FeatureScorerMixin):
                          importance_type=importance_type,
                          gpu_id=gpu_id,
                          validate_parameters=validate_parameters,
-                         use_label_encoder=False,
                          preprocessors=preprocessors)
 
 
@@ -146,5 +145,4 @@ class XGBRFClassifier(XGBBase, Learner, _FeatureScorerMixin):
                          importance_type=importance_type,
                          gpu_id=gpu_id,
                          validate_parameters=validate_parameters,
-                         use_label_encoder=False,
                          preprocessors=preprocessors)

--- a/Orange/regression/random_forest.py
+++ b/Orange/regression/random_forest.py
@@ -46,7 +46,7 @@ class RandomForestRegressionLearner(SklLearner, _FeatureScorerMixin):
                  min_samples_split=2,
                  min_samples_leaf=1,
                  min_weight_fraction_leaf=0.,
-                 max_features="auto",
+                 max_features=1.0,
                  max_leaf_nodes=None,
                  bootstrap=True,
                  oob_score=False,

--- a/Orange/tests/test_random_forest.py
+++ b/Orange/tests/test_random_forest.py
@@ -111,3 +111,28 @@ class RandomForestTest(unittest.TestCase):
         self.assertEqual(len(model.trees), n)
         tree = model.trees[0]
         tree(self.housing[0])
+
+    def test_max_features_cls(self):
+        data = Table("heart_disease")
+        forest_1 = RandomForestLearner(random_state=0, max_features=1)
+        model_1 = forest_1(data[1:])
+
+        forest_2 = RandomForestLearner(random_state=0, max_features=1.)
+        model_2 = forest_2(data[1:])
+        diff = np.sum(np.abs(model_1(data[:1], ret=model_2.Probs) -
+                             model_2(data[:1], ret=model_2.Probs)))
+        self.assertGreaterEqual(diff, 0.2)
+
+    def test_max_features_reg(self):
+        data = self.housing
+        forest_1 = RandomForestRegressionLearner(random_state=0, max_features=1)
+        model_1 = forest_1(data[1:])
+
+        forest_2 = RandomForestRegressionLearner(random_state=0, max_features=1.)
+        model_2 = forest_2(data[1:])
+        diff = np.sum(np.abs(model_1(data[:1]) - model_2(data[:1])))
+        self.assertGreater(diff, 1.2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -190,3 +190,7 @@ class FeatureScoringTest(unittest.TestCase):
         scores2 = learner.score_data(data)
 
         np.testing.assert_equal(scores1[0][:-1], scores2[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/model/owrandomforest.py
+++ b/Orange/widgets/model/owrandomforest.py
@@ -46,7 +46,7 @@ class OWRandomForest(OWBaseLearner):
             alignment=Qt.AlignRight, label="Number of trees: ",
             callback=self.settings_changed)
         self.max_features_spin = gui.spin(
-            box, self, "max_features", 2, 50, controlWidth=80,
+            box, self, "max_features", 1, 50, controlWidth=80,
             label="Number of attributes considered at each split: ",
             callback=self.settings_changed, checked="use_max_features",
             checkCallback=self.settings_changed, alignment=Qt.AlignRight,)

--- a/Orange/widgets/model/tests/test_owrandomforest.py
+++ b/Orange/widgets/model/tests/test_owrandomforest.py
@@ -1,5 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
+import unittest
+
 from AnyQt.QtCore import Qt
 from Orange.data import Table
 from Orange.widgets.model.owrandomforest import OWRandomForest
@@ -41,7 +43,7 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
         self.widget.min_samples_split_spin[0].setCheckState(Qt.Unchecked)
         self.parameters = self.parameters[:1]
         self.parameters.extend([
-            DefaultParameterMapping("max_features", "auto"),
+            DefaultParameterMapping("max_features", "sqrt"),
             DefaultParameterMapping("random_state", None),
             DefaultParameterMapping("max_depth", None),
             DefaultParameterMapping("min_samples_split", 2)])
@@ -56,3 +58,7 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
         self.widget.apply_button.button.click()
         self.assertEqual(self.widget.model.skl_model.class_weight, "balanced")
         self.assertTrue(self.widget.Warning.class_weights_used.is_shown())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - setuptools >=41.0.0
     - numpy >=1.19.5
     - scipy >=1.9
-    - scikit-learn >=1.0.1,<1.2.0
+    - scikit-learn >=1.1.0,<1.2.0
     - bottleneck >=1.3.4
     - chardet >=3.0.2
     - xlrd >=1.2.0
@@ -48,7 +48,7 @@ requirements:
     - anyqt >=0.1.0
     - pyqt >=5.12,!=5.15.1,<6.0
     - pyqtgraph >=0.12.2,!=0.12.4
-    - joblib >=0.11
+    - joblib >=1.0.0
     - keyring
     - keyrings.alt
     - pip >=18.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -3,7 +3,7 @@ numpy>=1.19.5
 scipy>=1.9
 # scikit-learn version 1.0.0 includes problematic libomp 12 which breaks xgboost
 # https://github.com/scikit-learn/scikit-learn/pull/21227
-scikit-learn>=1.0.1,<1.2.0
+scikit-learn>=1.1.0,<1.2.0
 bottleneck>=1.3.4
 # Reading Excel files
 xlrd>=1.2.0
@@ -12,7 +12,7 @@ xlsxwriter
 # Encoding detection
 chardet>=3.0.2
 # Multiprocessing abstraction
-joblib>=0.11
+joblib>=1.0.0
 keyring
 keyrings.alt    # for alternative keyring implementations
 setuptools>=41.0.0

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,2 +1,2 @@
-catboost!=1.0.0  # 1.0.0 segfaults on Macs
+catboost>=1.0.1
 xgboost>=1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ deps =
     # oldest: openpyxl
     oldest: httpx==0.21.0
     oldest: xgboost==1.5.0
+    oldest: catboost==1.0.1
 
 commands_pre =
     # Verify installed packages have compatible dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -50,12 +50,12 @@ deps =
     oldest: pip==18.0
     oldest: numpy==1.19.5
     oldest: scipy==1.9
-    oldest: scikit-learn==1.0.1
+    oldest: scikit-learn==1.1.0
     oldest: bottleneck==1.3.4
     oldest: xlrd==1.2.0
     # oldest: xlsxwriter
     oldest: chardet==3.0.2
-    oldest: joblib==0.11
+    oldest: joblib==1.0.0
     # oldest: keyring
     # oldest: keyrings.alt
     oldest: setuptools==41.0.0


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #6217, #6218, #6219

##### Description of changes
- set default RandomForestLearner.max_features to `sqrt`
- set default RandomForestRegressionLearner.max_features to `1.0`
- set default GBClassifier.loss to `log_loss`
- remove `use_label_encoder` parameter from XGBClassifier 
- remove `use_label_encoder` parameter from XGBRFClassifier
- set catboost minimum version

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
