### PR TITLE
[ENH] Improve scorer selection in Test and Score and predictions

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -66,6 +66,9 @@ class Score(metaclass=ScoreMetaType):
     name = None
     long_name = None  #: A short user-readable name (e.g. a few words)
 
+    default_visible = True
+    priority = 100
+
     def __new__(cls, results=None, **kwargs):
         self = super().__new__(cls)
         if results is not None:
@@ -137,6 +140,7 @@ class RegressionScore(Score, abstract=True):
 class CA(ClassificationScore):
     __wraps__ = skl_metrics.accuracy_score
     long_name = "Classification accuracy"
+    priority = 20
 
 
 class PrecisionRecallFSupport(ClassificationScore):
@@ -185,14 +189,17 @@ class TargetScore(ClassificationScore):
 
 class Precision(TargetScore):
     __wraps__ = skl_metrics.precision_score
+    priority = 40
 
 
 class Recall(TargetScore):
     __wraps__ = skl_metrics.recall_score
+    priority = 50
 
 
 class F1(TargetScore):
     __wraps__ = skl_metrics.f1_score
+    priority = 30
 
 
 class AUC(ClassificationScore):
@@ -211,6 +218,7 @@ class AUC(ClassificationScore):
     separate_folds = True
     is_binary = True
     long_name = "Area under ROC curve"
+    priority = 10
 
     @staticmethod
     def calculate_weights(results):
@@ -282,6 +290,8 @@ class LogLoss(ClassificationScore):
 
     """
     __wraps__ = skl_metrics.log_loss
+    priority = 120
+    default_visible = False
 
     def compute_score(self, results, eps=1e-15, normalize=True,
                       sample_weight=None):
@@ -297,6 +307,8 @@ class LogLoss(ClassificationScore):
 
 class Specificity(ClassificationScore):
     is_binary = True
+    priority = 110
+    default_visible = False
 
     @staticmethod
     def calculate_weights(results):
@@ -350,6 +362,7 @@ class Specificity(ClassificationScore):
 class MSE(RegressionScore):
     __wraps__ = skl_metrics.mean_squared_error
     long_name = "Mean square error"
+    priority = 20
 
 
 class RMSE(RegressionScore):
@@ -357,21 +370,26 @@ class RMSE(RegressionScore):
 
     def compute_score(self, results):
         return np.sqrt(MSE(results))
+    priority = 30
 
 
 class MAE(RegressionScore):
     __wraps__ = skl_metrics.mean_absolute_error
     long_name = "Mean absolute error"
+    priority = 40
 
 
 # pylint: disable=invalid-name
 class R2(RegressionScore):
     __wraps__ = skl_metrics.r2_score
     long_name = "Coefficient of determination"
+    priority = 50
 
 
 class CVRMSE(RegressionScore):
     long_name = "Coefficient of variation of the RMSE"
+    priority = 110
+    default_visible = False
 
     def compute_score(self, results):
         mean = np.nanmean(results.actual)

--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -37,6 +37,7 @@ class ScoreMetaType(WrapperMeta):
             if not kwargs.get("abstract"):
                 # Don't use inherited names, look into dict_
                 cls.name = dict_.get("name", name)
+                cls.long_name = dict_.get("long_name", cls.name)
                 cls.registry[name] = cls
         else:
             cls.registry = {}
@@ -139,6 +140,7 @@ class RegressionScore(Score, abstract=True):
 # pylint: disable=invalid-name
 class CA(ClassificationScore):
     __wraps__ = skl_metrics.accuracy_score
+    name = "CA"
     long_name = "Classification accuracy"
     priority = 20
 
@@ -189,16 +191,20 @@ class TargetScore(ClassificationScore):
 
 class Precision(TargetScore):
     __wraps__ = skl_metrics.precision_score
+    name = "Prec"
+    long_name = "Precision"
     priority = 40
 
 
 class Recall(TargetScore):
     __wraps__ = skl_metrics.recall_score
+    name = long_name = "Recall"
     priority = 50
 
 
 class F1(TargetScore):
     __wraps__ = skl_metrics.f1_score
+    name = long_name = "F1"
     priority = 30
 
 
@@ -217,6 +223,7 @@ class AUC(ClassificationScore):
     __wraps__ = skl_metrics.roc_auc_score
     separate_folds = True
     is_binary = True
+    name = "AUC"
     long_name = "Area under ROC curve"
     priority = 10
 
@@ -291,6 +298,8 @@ class LogLoss(ClassificationScore):
     """
     __wraps__ = skl_metrics.log_loss
     priority = 120
+    name = "LogLoss"
+    long_name = "Logistic loss"
     default_visible = False
 
     def compute_score(self, results, eps=1e-15, normalize=True,
@@ -308,6 +317,8 @@ class LogLoss(ClassificationScore):
 class Specificity(ClassificationScore):
     is_binary = True
     priority = 110
+    name = "Spec"
+    long_name = "Specificity"
     default_visible = False
 
     @staticmethod
@@ -361,11 +372,13 @@ class Specificity(ClassificationScore):
 
 class MSE(RegressionScore):
     __wraps__ = skl_metrics.mean_squared_error
+    name = "MSE"
     long_name = "Mean square error"
     priority = 20
 
 
 class RMSE(RegressionScore):
+    name = "RMSE"
     long_name = "Root mean square error"
 
     def compute_score(self, results):
@@ -375,6 +388,7 @@ class RMSE(RegressionScore):
 
 class MAE(RegressionScore):
     __wraps__ = skl_metrics.mean_absolute_error
+    name = "MAE"
     long_name = "Mean absolute error"
     priority = 40
 
@@ -382,11 +396,13 @@ class MAE(RegressionScore):
 # pylint: disable=invalid-name
 class R2(RegressionScore):
     __wraps__ = skl_metrics.r2_score
+    name = "R2"
     long_name = "Coefficient of determination"
     priority = 50
 
 
 class CVRMSE(RegressionScore):
+    name = "CVRMSE"
     long_name = "Coefficient of variation of the RMSE"
     priority = 110
     default_visible = False

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -63,6 +63,8 @@ class OWPredictions(OWWidget):
     description = "Display predictions of models for an input dataset."
     keywords = []
 
+    settings_version = 2
+
     want_control_area = False
 
     class Inputs:
@@ -940,6 +942,12 @@ class OWPredictions(OWWidget):
     def showEvent(self, event):
         super().showEvent(event)
         QTimer.singleShot(0, self._update_splitter)
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        if version < 2:
+            if "score_table" in settings:
+                ScoreTable.migrate_to_show_scores_hints(settings["score_table"])
 
 
 class ItemDelegate(TableDataDelegate):

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -152,10 +152,6 @@ class OWTestAndScore(OWWidget):
 
     settings_version = 4
     buttons_area_orientation = None
-    UserAdviceMessages = [
-        widget.Message(
-            "Click on the table header to select shown columns",
-            "click_header")]
 
     settingsHandler = settings.PerfectDomainContextHandler()
     score_table = settings.SettingProvider(ScoreTable)

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -655,6 +655,7 @@ class OWTestAndScore(OWWidget):
                         item.setData(float(stat.value[0]), Qt.DisplayRole)
                     else:
                         item.setToolTip(str(stat.exception))
+                        # pylint: disable=unsubscriptable-object
                         if self.score_table.show_score_hints[scorer.__name__]:
                             has_missing_scores = True
                     row.append(item)

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -150,7 +150,7 @@ class OWTestAndScore(OWWidget):
         predictions = Output("Predictions", Table)
         evaluations_results = Output("Evaluation Results", Results)
 
-    settings_version = 3
+    settings_version = 4
     buttons_area_orientation = None
     UserAdviceMessages = [
         widget.Message(
@@ -655,7 +655,7 @@ class OWTestAndScore(OWWidget):
                         item.setData(float(stat.value[0]), Qt.DisplayRole)
                     else:
                         item.setToolTip(str(stat.exception))
-                        if scorer.name in self.score_table.shown_scores:
+                        if self.score_table.show_score_hints[scorer.__name__]:
                             has_missing_scores = True
                     row.append(item)
 
@@ -899,6 +899,9 @@ class OWTestAndScore(OWWidget):
             settings_["context_settings"] = [
                 c for c in settings_.get("context_settings", ())
                 if not hasattr(c, 'classes')]
+        if version < 4:
+            if "score_table" in settings_:
+                ScoreTable.migrate_to_show_scores_hints(settings_["score_table"])
 
     @Slot(float)
     def setProgressValue(self, value):

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1168,6 +1168,11 @@ class TestOWPredictions(WidgetTest):
             widget.send_report()
             self.assertIn(value, widget.report_paragraph.call_args[0][1])
 
+    def test_migrate_shown_scores(self):
+        settings = {"score_table": {"shown_scores": {"Sensitivity"}}}
+        self.widget.migrate_settings(settings, 1)
+        self.assertTrue(settings["score_table"]["show_score_hints"]["Sensitivity"])
+
 
 class SelectionModelTest(unittest.TestCase):
     def setUp(self):

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -325,7 +325,7 @@ class TestOWTestAndScore(WidgetTest):
         header = view.horizontalHeader()
         p = header.rect().center()
         # second visible header section (after 'Model')
-        _, idx, *_ = (i for i in range(header.count())
+        _, _, idx, *_ = (i for i in range(header.count())
                       if not header.isSectionHidden(i))
         p.setX(header.sectionPosition(idx) + 5)
         QTest.mouseClick(header.viewport(), Qt.LeftButton, pos=p)
@@ -723,11 +723,13 @@ class TestOWTestAndScore(WidgetTest):
         selection_model = view.selectionModel()
         selection_model.select(model.index(0, 0),
                                selection_model.Select | selection_model.Rows)
-
         self.widget.copy_to_clipboard()
         clipboard_text = QApplication.clipboard().text()
+        # Tests appear to register additional scorers, so we clip the list
+        # to what we know to be there and visible
+        clipboard_text = "\t".join(clipboard_text.split("\t")[:6]).strip()
         view_text = "\t".join([str(model.data(model.index(0, i)))
-                               for i in (0, 3, 4, 5, 6, 7)]) + "\r\n"
+                               for i in (0, 3, 4, 5, 6, 7)]).strip()
         self.assertEqual(clipboard_text, view_text)
 
     def test_multi_target_input(self):

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -21,7 +21,6 @@ from Orange.modelling import ConstantLearner
 from Orange.regression import MeanLearner
 from Orange.widgets.evaluate.owtestandscore import (
     OWTestAndScore, results_one_vs_rest)
-from Orange.widgets.evaluate.utils import BUILTIN_SCORERS_ORDER
 from Orange.widgets.settings import (
     ClassValuesContextHandler, PerfectDomainContextHandler)
 from Orange.widgets.tests.base import WidgetTest
@@ -154,6 +153,11 @@ class TestOWTestAndScore(WidgetTest):
         self.widget.migrate_settings(settings, 2)
         self.assertEqual(settings['context_settings'], [context_valid])
 
+    def test_migrate_shown_scores(self):
+        settings = {"score_table": {"shown_scores": {"Sensitivity"}}}
+        self.widget.migrate_settings(settings, 3)
+        self.assertTrue(settings["score_table"]["show_score_hints"]["Sensitivity"])
+
     def test_memory_error(self):
         """
         Handling memory error.
@@ -225,38 +229,39 @@ class TestOWTestAndScore(WidgetTest):
             # These classes are registered, pylint: disable=unused-variable
             class NewScore(Score):
                 class_types = (DiscreteVariable, ContinuousVariable)
+                name = "new scorer"
 
                 @staticmethod
                 def is_compatible(domain: Domain) -> bool:
                     return True
 
             class NewClassificationScore(ClassificationScore):
-                pass
+                name = "new classification scorer"
+                default_visible = False
 
             class NewRegressionScore(RegressionScore):
                 pass
 
-            builtins = BUILTIN_SCORERS_ORDER
-            self.send_signal("Data", Table("iris"))
-            scorer_names = [scorer.name for scorer in self.widget.scorers]
-            self.assertEqual(
-                tuple(scorer_names[:len(builtins[DiscreteVariable])]),
-                builtins[DiscreteVariable])
-            self.assertIn("NewScore", scorer_names)
-            self.assertIn("NewClassificationScore", scorer_names)
+            widget = self.create_widget(OWTestAndScore)
+            header = widget.score_table.view.horizontalHeader()
+            self.send_signal(widget.Inputs.train_data, Table("iris"))
+            scorer_names = [scorer.name for scorer in widget.scorers]
+            self.assertIn("new scorer", scorer_names)
+            self.assertFalse(header.isSectionHidden(3 + scorer_names.index("new scorer")))
+            self.assertIn("new classification scorer", scorer_names)
+            self.assertTrue(header.isSectionHidden(3 + scorer_names.index("new classification scorer")))
             self.assertNotIn("NewRegressionScore", scorer_names)
+            model = widget.score_table.model
 
-            self.send_signal("Data", Table("housing"))
-            scorer_names = [scorer.name for scorer in self.widget.scorers]
-            self.assertEqual(
-                tuple(scorer_names[:len(builtins[ContinuousVariable])]),
-                builtins[ContinuousVariable])
-            self.assertIn("NewScore", scorer_names)
-            self.assertNotIn("NewClassificationScore", scorer_names)
+
+            self.send_signal(widget.Inputs.train_data, Table("housing"))
+            scorer_names = [scorer.name for scorer in widget.scorers]
+            self.assertIn("new scorer", scorer_names)
+            self.assertNotIn("new classification scorer", scorer_names)
             self.assertIn("NewRegressionScore", scorer_names)
 
-            self.send_signal("Data", None)
-            self.assertEqual(self.widget.scorers, [])
+            self.send_signal(widget.Inputs.train_data, None)
+            self.assertEqual(widget.scorers, [])
         finally:
             del Score.registry["NewScore"]  # pylint: disable=no-member
             del Score.registry["NewClassificationScore"]  # pylint: disable=no-member
@@ -752,14 +757,15 @@ class TestOWTestAndScore(WidgetTest):
         mock_learner = Mock(spec=Learner, return_value=mock_model)
         mock_learner.name = 'Mockery'
 
-        self.widget.resampling = OWTestAndScore.TestOnTrain
-        self.send_signal(self.widget.Inputs.train_data, data)
-        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0)
-        self.send_signal(self.widget.Inputs.learner, mock_learner, 1)
-        _ = self.get_output(self.widget.Outputs.evaluations_results, wait=5000)
-        self.assertTrue(len(self.widget.scorers) == 1)
-        self.assertTrue(NewScorer in self.widget.scorers)
-        self.assertTrue(len(self.widget._successful_slots()) == 1)
+        widget = self.create_widget(OWTestAndScore)
+        widget.resampling = OWTestAndScore.TestOnTrain
+        self.send_signal(widget.Inputs.train_data, data)
+        self.send_signal(widget.Inputs.learner, MajorityLearner(), 0)
+        self.send_signal(widget.Inputs.learner, mock_learner, 1)
+        _ = self.get_output(widget.Outputs.evaluations_results, wait=5000)
+        self.assertTrue(len(widget.scorers) == 1)
+        self.assertTrue(NewScorer in widget.scorers)
+        self.assertTrue(len(widget._successful_slots()) == 1)
 
 
 class TestHelpers(unittest.TestCase):

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -3,6 +3,7 @@
 import unittest
 import collections
 from distutils.version import LooseVersion
+from unittest.mock import patch
 
 import numpy as np
 
@@ -11,7 +12,8 @@ from AnyQt.QtGui import QStandardItem
 from AnyQt.QtCore import QPoint, Qt
 
 import Orange
-from Orange.widgets.evaluate.utils import ScoreTable, usable_scorers, BUILTIN_SCORERS_ORDER
+from Orange.evaluation.scoring import Score, RMSE, AUC, CA, F1, Specificity
+from Orange.widgets.evaluate.utils import ScoreTable, usable_scorers
 from Orange.widgets.tests.base import GuiTest
 from Orange.data import Table, DiscreteVariable, ContinuousVariable
 from Orange.evaluation import scoring
@@ -41,15 +43,26 @@ class TestUsableScorers(unittest.TestCase):
 
 
 class TestScoreTable(GuiTest):
-    def test_show_column_chooser(self):
-        score_table = ScoreTable(None)
-        view = score_table.view
-        all, shown = "MABDEFG", "ABDF"
-        header = view.horizontalHeader()
-        score_table.shown_scores = set(shown)
-        score_table.model.setHorizontalHeaderLabels(list(all))
-        score_table._update_shown_columns()
+    def setUp(self):
+        class NewScore(Score):
+            name = "new score"
 
+        self.orig_hints = ScoreTable.show_score_hints
+        hints = ScoreTable.show_score_hints = self.orig_hints.default.copy()
+        hints.update(dict(F1=True, CA=False, AUC=True, Recall=True,
+                          Specificity=False, NewScore=True))
+        self.name_to_qualname = {score.name: score.__name__
+                            for score in Score.registry.values()}
+        self.score_table = ScoreTable(None)
+        self.score_table.update_header([F1, CA, AUC, Specificity, NewScore])
+        self.score_table._update_shown_columns()
+
+    def tearDown(self):
+        ScoreTable.show_score_hints = self.orig_hints
+        del Score.registry["NewScore"]
+
+    def test_show_column_chooser(self):
+        hints = ScoreTable.show_score_hints
         actions = collections.OrderedDict()
         menu_add_action = QMenu.addAction
 
@@ -59,17 +72,27 @@ class TestScoreTable(GuiTest):
             return action
 
         def execmenu(*_):
-            self.assertEqual(list(actions), list(all)[1:])
-            for name, action in actions.items():
-                self.assertEqual(action.isChecked(), name in shown)
-            actions["E"].triggered.emit(True)
-            self.assertEqual(score_table.shown_scores, set("ABDEF"))
-            actions["B"].triggered.emit(False)
-            self.assertEqual(score_table.shown_scores, set("ADEF"))
-            for i, name in enumerate(all):
-                self.assertEqual(name == "M" or name in "ADEF",
-                                 not header.isSectionHidden(i),
-                                 msg="error in section {}({})".format(i, name))
+            scores = ["F1", "CA", "AUC", "Specificity", "new score"]
+            self.assertEqual(list(actions)[2:], scores)
+            header = self.score_table.view.horizontalHeader()
+            for i, (name, action) in enumerate(actions.items()):
+                if i >= 2:
+                    self.assertEqual(action.isChecked(),
+                                     hints[self.name_to_qualname[name]],
+                                     msg=f"error in section {name}")
+                    self.assertEqual(header.isSectionHidden(i),
+                                    hints[self.name_to_qualname[name]],
+                                    msg=f"error in section {name}")
+            actions["CA"].triggered.emit(True)
+            hints["CA"] = True
+            for k, v in hints.items():
+                self.assertEqual(self.score_table.show_score_hints[k], v,
+                                 msg=f"error at {k}")
+            actions["AUC"].triggered.emit(False)
+            hints["AUC"] = False
+            for k, v in hints.items():
+                self.assertEqual(self.score_table.show_score_hints[k], v,
+                                 msg=f"error at {k}")
 
         # We must patch `QMenu.exec` because the Qt would otherwise (invisibly)
         # show the popup and wait for the user.
@@ -78,27 +101,7 @@ class TestScoreTable(GuiTest):
         # `menuexec` finishes.
         with unittest.mock.patch("AnyQt.QtWidgets.QMenu.addAction", addAction), \
              unittest.mock.patch("AnyQt.QtWidgets.QMenu.exec", execmenu):
-            score_table.show_column_chooser(QPoint(0, 0))
-
-    def test_update_shown_columns(self):
-        score_table = ScoreTable(None)
-        view = score_table.view
-        all, shown = "MABDEFG", "ABDF"
-        header = view.horizontalHeader()
-        score_table.shown_scores = set(shown)
-        score_table.model.setHorizontalHeaderLabels(list(all))
-        score_table._update_shown_columns()
-        for i, name in enumerate(all):
-            self.assertEqual(name == "M" or name in shown,
-                             not header.isSectionHidden(i),
-                             msg="error in section {}({})".format(i, name))
-
-        score_table.shown_scores = set()
-        score_table._update_shown_columns()
-        for i, name in enumerate(all):
-            self.assertEqual(i == 0,
-                             not header.isSectionHidden(i),
-                             msg="error in section {}({})".format(i, name))
+            self.score_table.show_column_chooser(QPoint(0, 0))
 
     def test_sorting(self):
         def order(n=5):
@@ -141,6 +144,15 @@ class TestScoreTable(GuiTest):
 
         model.sort(2, Qt.DescendingOrder)
         self.assertEqual(order(3), "DEC")
+
+    def test_shown_scores_backward_compatibility(self):
+        self.assertEqual(self.score_table.shown_scores,
+                         {"F1", "AUC", "new score"})
+
+    def test_migration(self):
+        settings = dict(foo=False, shown_scores={"Sensitivity"})
+        ScoreTable.migrate_to_show_scores_hints(settings)
+        self.assertTrue(settings["show_score_hints"]["Sensitivity"])
 
     def test_column_settings_reminder(self):
         if LooseVersion(Orange.__version__) >= LooseVersion("3.37"):

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -158,13 +158,6 @@ class TestScoreTable(GuiTest):
         ScoreTable.migrate_to_show_scores_hints(settings)
         self.assertTrue(settings["show_score_hints"]["Sensitivity"])
 
-    def test_column_settings_reminder(self):
-        if LooseVersion(Orange.__version__) >= LooseVersion("3.37"):
-            self.fail(
-                "Orange 3.32 added a workaround to show C-Index into ScoreTable.__init__. "
-                "This should have been properly fixed long ago."
-            )
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -3,6 +3,7 @@
 import unittest
 import collections
 from distutils.version import LooseVersion
+from itertools import count
 from unittest.mock import patch
 
 import numpy as np
@@ -12,7 +13,7 @@ from AnyQt.QtGui import QStandardItem
 from AnyQt.QtCore import QPoint, Qt
 
 import Orange
-from Orange.evaluation.scoring import Score, RMSE, AUC, CA, F1, Specificity
+from Orange.evaluation.scoring import Score, AUC, CA, F1, Specificity
 from Orange.widgets.evaluate.utils import ScoreTable, usable_scorers
 from Orange.widgets.tests.base import GuiTest
 from Orange.data import Table, DiscreteVariable, ContinuousVariable
@@ -47,12 +48,12 @@ class TestScoreTable(GuiTest):
         class NewScore(Score):
             name = "new score"
 
+        self.NewScore = NewScore  # pylint: disable=invalid-name
+
         self.orig_hints = ScoreTable.show_score_hints
         hints = ScoreTable.show_score_hints = self.orig_hints.default.copy()
         hints.update(dict(F1=True, CA=False, AUC=True, Recall=True,
                           Specificity=False, NewScore=True))
-        self.name_to_qualname = {score.name: score.__name__
-                            for score in Score.registry.values()}
         self.score_table = ScoreTable(None)
         self.score_table.update_header([F1, CA, AUC, Specificity, NewScore])
         self.score_table._update_shown_columns()
@@ -72,23 +73,28 @@ class TestScoreTable(GuiTest):
             return action
 
         def execmenu(*_):
-            scores = ["F1", "CA", "AUC", "Specificity", "new score"]
-            self.assertEqual(list(actions)[2:], scores)
+            # pylint: disable=unsubscriptable-object,unsupported-assignment-operation
+            scorers = [F1, CA, AUC, Specificity, self.NewScore]
+            self.assertEqual(list(actions)[2:], ['F1',
+                                                 'Classification accuracy (CA)',
+                                                 'Area under ROC curve (AUC)',
+                                                 'Specificity (Spec)',
+                                                 'new score'])
             header = self.score_table.view.horizontalHeader()
-            for i, (name, action) in enumerate(actions.items()):
+            for i, action, scorer in zip(count(), actions.values(), scorers):
                 if i >= 2:
                     self.assertEqual(action.isChecked(),
-                                     hints[self.name_to_qualname[name]],
-                                     msg=f"error in section {name}")
+                                     hints[scorer.__name__],
+                                     msg=f"error in section {scorer.name}")
                     self.assertEqual(header.isSectionHidden(i),
-                                    hints[self.name_to_qualname[name]],
-                                    msg=f"error in section {name}")
-            actions["CA"].triggered.emit(True)
+                                    hints[scorer.__name__],
+                                    msg=f"error in section {scorer.name}")
+            actions["Classification accuracy (CA)"].triggered.emit(True)
             hints["CA"] = True
             for k, v in hints.items():
                 self.assertEqual(self.score_table.show_score_hints[k], v,
                                  msg=f"error at {k}")
-            actions["AUC"].triggered.emit(False)
+            actions["Area under ROC curve (AUC)"].triggered.emit(False)
             hints["AUC"] = False
             for k, v in hints.items():
                 self.assertEqual(self.score_table.show_score_hints[k], v,
@@ -99,8 +105,8 @@ class TestScoreTable(GuiTest):
         # Assertions are made within `menuexec` since they check the
         # instances of `QAction`, which are invalid (destroyed by Qt?) after
         # `menuexec` finishes.
-        with unittest.mock.patch("AnyQt.QtWidgets.QMenu.addAction", addAction), \
-             unittest.mock.patch("AnyQt.QtWidgets.QMenu.exec", execmenu):
+        with patch("AnyQt.QtWidgets.QMenu.addAction", addAction), \
+             patch("AnyQt.QtWidgets.QMenu.exec", execmenu):
             self.score_table.show_column_chooser(QPoint(0, 0))
 
     def test_sorting(self):

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -56,7 +56,6 @@ class TestScoreTable(GuiTest):
                           Specificity=False, NewScore=True))
         self.score_table = ScoreTable(None)
         self.score_table.update_header([F1, CA, AUC, Specificity, NewScore])
-        self.score_table._update_shown_columns()
 
     def tearDown(self):
         ScoreTable.show_score_hints = self.orig_hints
@@ -75,20 +74,19 @@ class TestScoreTable(GuiTest):
         def execmenu(*_):
             # pylint: disable=unsubscriptable-object,unsupported-assignment-operation
             scorers = [F1, CA, AUC, Specificity, self.NewScore]
-            self.assertEqual(list(actions)[2:], ['F1',
+            self.assertEqual(list(actions)[3:], ['F1',
                                                  'Classification accuracy (CA)',
                                                  'Area under ROC curve (AUC)',
                                                  'Specificity (Spec)',
                                                  'new score'])
             header = self.score_table.view.horizontalHeader()
-            for i, action, scorer in zip(count(), actions.values(), scorers):
-                if i >= 2:
-                    self.assertEqual(action.isChecked(),
-                                     hints[scorer.__name__],
-                                     msg=f"error in section {scorer.name}")
-                    self.assertEqual(header.isSectionHidden(i),
-                                    hints[scorer.__name__],
-                                    msg=f"error in section {scorer.name}")
+            for i, action, scorer in zip(count(), list(actions.values())[3:], scorers):
+                self.assertEqual(action.isChecked(),
+                                 hints[scorer.__name__],
+                                 msg=f"error in section {scorer.name}")
+                self.assertEqual(header.isSectionHidden(3 + i),
+                                 not hints[scorer.__name__],
+                                 msg=f"error in section {scorer.name}")
             actions["Classification accuracy (CA)"].triggered.emit(True)
             hints["CA"] = True
             for k, v in hints.items():
@@ -107,7 +105,7 @@ class TestScoreTable(GuiTest):
         # `menuexec` finishes.
         with patch("AnyQt.QtWidgets.QMenu.addAction", addAction), \
              patch("AnyQt.QtWidgets.QMenu.exec", execmenu):
-            self.score_table.show_column_chooser(QPoint(0, 0))
+            self.score_table.view.horizontalHeader().show_column_chooser(QPoint(0, 0))
 
     def test_sorting(self):
         def order(n=5):

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -184,9 +184,16 @@ class ScoreTable(OWComponent, QObject):
         header = self.view.horizontalHeader()
         for col in range(1, self.model.columnCount()):
             item = self.model.horizontalHeaderItem(col)
-            action = menu.addAction(item.data(Qt.DisplayRole))
-            action.setCheckable(True)
             qualname = item.data(Qt.UserRole)
+            if col < 3:
+                option = item.data(Qt.DisplayRole)
+            else:
+                score = Score.registry[qualname]
+                option = score.long_name
+                if score.name != score.long_name:
+                    option += f" ({score.name})"
+            action = menu.addAction(option)
+            action.setCheckable(True)
             action.setChecked(self.show_score_hints[qualname])
 
             @action.triggered.connect


### PR DESCRIPTION
##### Issue

- `ScoreTable`, which is used in Test and Score, and in Predictions, has a hard coded list of scorers, which defines the (default) visibility and the order. New scores are thus invisible by default.
- The names of classes are used for names of columns. It is thus impossible to translate them. A `name` attribute exists, but is not defined and defaults to class name.
- The user may not be aware that (s)he can choose additional scores by right-clicking the header.

##### Description of changes

- Scorers define default visibility and priority as class attributes.
- Visibility settings are stored as "hints", so new scorers (e.g. from add-ons) may be visible if they that's their default.
- The `name` attribute is now defined, but in settings the scorers are referred to by their class names, so settings "survive" the change of language.
- Add an indicator that can be clicked and opens a popup for selection of scores (fixes #6131).

    Although currently in `Orange.widgets.evaluate.utils`, the class `SelectableColumnsHeader` is general and can be moved somewhere else and used, e.g. in `OWRanks`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
