### PR TITLE
Resolve Edit Domain (datetime to epoch) timebomb

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install system dependencies on MacOS
         run: brew install libomp
-        if: matrix.os == 'macos-10.15' || matrix.os == 'macos-11' || matrix.os == 'macos-12'
+        if: runner.os == 'macOS'
 
       - name: Install dependencies
         run: |

--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -2837,11 +2837,6 @@ def datetime_to_epoch(dti: pd.DatetimeIndex, only_time) -> np.ndarray:
     # when dti has timezone info also the subtracted timestamp must have it
     # otherwise subtracting fails
     initial_ts = pd.Timestamp("1970-01-01", tz=None if dti.tz is None else "UTC")
-    # pandas in versions before 1.4 don't support subtracting different timezones
-    # remove next two lines when read-the-docs start supporting config files
-    # for subprojects, or they change default python version to 3.8
-    if dti.tz is not None:
-        dti = dti.tz_convert("UTC")
     delta = dti - (dti.normalize() if only_time else initial_ts)
     return (delta / pd.Timedelta("1s")).values
 

--- a/Orange/widgets/data/owgroupby.py
+++ b/Orange/widgets/data/owgroupby.py
@@ -77,8 +77,6 @@ def var(s):
     """
     if is_datetime64_any_dtype(s):
         initial_ts = pd.Timestamp("1970-01-01", tz=None if s.dt.tz is None else "UTC")
-        if s.dt.tz is not None:
-            s = s.tz_convert("UTC")
         s = (s - initial_ts) / pd.Timedelta("1s")
     var_ = s.var()
     return var_.total_seconds() if isinstance(var_, pd.Timedelta) else var_

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -957,17 +957,6 @@ class TestReinterpretTransforms(TestCase):
             np.array(list(chain(expected, expected)), dtype=float).transpose()
         )
 
-    def test_raise_pandas_version(self):
-        """
-        When this test start to fail:
-        - remove this test
-        - remove if clause in datetime_to_epoch function and supporting comments
-        - remove same if clause in var function in owgroupby (line 77, 78)
-        - set pandas dependency version to pandas>=1.4
-        """
-        from datetime import datetime
-        self.assertLess(datetime.today(), datetime(2023, 1, 1))
-
     def test_reinterpret_string(self):
         table = self.data_str
         domain = table.domain

--- a/Orange/widgets/model/tests/test_owgradientboosting.py
+++ b/Orange/widgets/model/tests/test_owgradientboosting.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import sys
 from typing import Type
@@ -157,18 +158,19 @@ class TestXGBLearnerEditor(BaseEditorTest):
         booster = XGBClassifier()
         model = booster(data)
         params = model.skl_model.get_params()
+        booster_params = json.loads(model.skl_model.get_booster().save_config())
+        updater = booster_params["learner"]["gradient_booster"]["updater"]
+        tp = updater["grow_colmaker"]["train_param"]
         self.assertEqual(params["n_estimators"], self.editor.n_estimators)
-        self.assertEqual(round(params["learning_rate"], 1),
-                         self.editor.learning_rate)
-        self.assertEqual(params["max_depth"], self.editor.max_depth)
-        self.assertEqual(params["reg_lambda"], self.editor.lambda_)
-        self.assertEqual(params["subsample"], self.editor.subsample)
-        self.assertEqual(params["colsample_bytree"],
-                         self.editor.colsample_bytree)
-        self.assertEqual(params["colsample_bylevel"],
-                         self.editor.colsample_bylevel)
-        self.assertEqual(params["colsample_bynode"],
-                         self.editor.colsample_bynode)
+        self.assertEqual(
+            round(float(tp["learning_rate"]), 1), self.editor.learning_rate
+        )
+        self.assertEqual(int(tp["max_depth"]), self.editor.max_depth)
+        self.assertEqual(float(tp["reg_lambda"]), self.editor.lambda_)
+        self.assertEqual(int(tp["subsample"]), self.editor.subsample)
+        self.assertEqual(int(tp["colsample_bytree"]), self.editor.colsample_bytree)
+        self.assertEqual(int(tp["colsample_bylevel"]), self.editor.colsample_bylevel)
+        self.assertEqual(int(tp["colsample_bynode"]), self.editor.colsample_bynode)
 
     @unittest.skipIf(XGBRegressor is None, "Missing 'xgboost' package")
     def test_default_parameters_reg(self):
@@ -176,18 +178,19 @@ class TestXGBLearnerEditor(BaseEditorTest):
         booster = XGBRegressor()
         model = booster(data)
         params = model.skl_model.get_params()
+        booster_params = json.loads(model.skl_model.get_booster().save_config())
+        updater = booster_params["learner"]["gradient_booster"]["updater"]
+        tp = updater["grow_colmaker"]["train_param"]
         self.assertEqual(params["n_estimators"], self.editor.n_estimators)
-        self.assertEqual(round(params["learning_rate"], 1),
-                         self.editor.learning_rate)
-        self.assertEqual(params["max_depth"], self.editor.max_depth)
-        self.assertEqual(params["reg_lambda"], self.editor.lambda_)
-        self.assertEqual(params["subsample"], self.editor.subsample)
-        self.assertEqual(params["colsample_bytree"],
-                         self.editor.colsample_bytree)
-        self.assertEqual(params["colsample_bylevel"],
-                         self.editor.colsample_bylevel)
-        self.assertEqual(params["colsample_bynode"],
-                         self.editor.colsample_bynode)
+        self.assertEqual(
+            round(float(tp["learning_rate"]), 1), self.editor.learning_rate
+        )
+        self.assertEqual(int(tp["max_depth"]), self.editor.max_depth)
+        self.assertEqual(float(tp["reg_lambda"]), self.editor.lambda_)
+        self.assertEqual(int(tp["subsample"]), self.editor.subsample)
+        self.assertEqual(int(tp["colsample_bytree"]), self.editor.colsample_bytree)
+        self.assertEqual(int(tp["colsample_bylevel"]), self.editor.colsample_bylevel)
+        self.assertEqual(int(tp["colsample_bynode"]), self.editor.colsample_bynode)
 
 
 class TestXGBRFLearnerEditor(BaseEditorTest):
@@ -220,18 +223,19 @@ class TestXGBRFLearnerEditor(BaseEditorTest):
         booster = XGBRFClassifier()
         model = booster(data)
         params = model.skl_model.get_params()
+        booster_params = json.loads(model.skl_model.get_booster().save_config())
+        updater = booster_params["learner"]["gradient_booster"]["updater"]
+        tp = updater["grow_colmaker"]["train_param"]
         self.assertEqual(params["n_estimators"], self.editor.n_estimators)
-        self.assertEqual(round(params["learning_rate"], 1),
-                         self.editor.learning_rate)
-        self.assertEqual(params["max_depth"], self.editor.max_depth)
-        self.assertEqual(params["reg_lambda"], self.editor.lambda_)
-        self.assertEqual(params["subsample"], self.editor.subsample)
-        self.assertEqual(params["colsample_bytree"],
-                         self.editor.colsample_bytree)
-        self.assertEqual(params["colsample_bylevel"],
-                         self.editor.colsample_bylevel)
-        self.assertEqual(params["colsample_bynode"],
-                         self.editor.colsample_bynode)
+        self.assertEqual(
+            round(float(tp["learning_rate"]), 1), self.editor.learning_rate
+        )
+        self.assertEqual(int(tp["max_depth"]), self.editor.max_depth)
+        self.assertEqual(float(tp["reg_lambda"]), self.editor.lambda_)
+        self.assertEqual(int(tp["subsample"]), self.editor.subsample)
+        self.assertEqual(int(tp["colsample_bytree"]), self.editor.colsample_bytree)
+        self.assertEqual(int(tp["colsample_bylevel"]), self.editor.colsample_bylevel)
+        self.assertEqual(int(tp["colsample_bynode"]), self.editor.colsample_bynode)
 
     @unittest.skipIf(XGBRFRegressor is None, "Missing 'xgboost' package")
     def test_default_parameters_reg(self):
@@ -239,18 +243,19 @@ class TestXGBRFLearnerEditor(BaseEditorTest):
         booster = XGBRFRegressor()
         model = booster(data)
         params = model.skl_model.get_params()
+        booster_params = json.loads(model.skl_model.get_booster().save_config())
+        updater = booster_params["learner"]["gradient_booster"]["updater"]
+        tp = updater["grow_colmaker"]["train_param"]
         self.assertEqual(params["n_estimators"], self.editor.n_estimators)
-        self.assertEqual(round(params["learning_rate"], 1),
-                         self.editor.learning_rate)
-        self.assertEqual(params["max_depth"], self.editor.max_depth)
-        self.assertEqual(params["reg_lambda"], self.editor.lambda_)
-        self.assertEqual(params["subsample"], self.editor.subsample)
-        self.assertEqual(params["colsample_bytree"],
-                         self.editor.colsample_bytree)
-        self.assertEqual(params["colsample_bylevel"],
-                         self.editor.colsample_bylevel)
-        self.assertEqual(params["colsample_bynode"],
-                         self.editor.colsample_bynode)
+        self.assertEqual(
+            round(float(tp["learning_rate"]), 1), self.editor.learning_rate
+        )
+        self.assertEqual(int(tp["max_depth"]), self.editor.max_depth)
+        self.assertEqual(float(tp["reg_lambda"]), self.editor.lambda_)
+        self.assertEqual(int(tp["subsample"]), self.editor.subsample)
+        self.assertEqual(int(tp["colsample_bytree"]), self.editor.colsample_bytree)
+        self.assertEqual(int(tp["colsample_bylevel"]), self.editor.colsample_bylevel)
+        self.assertEqual(int(tp["colsample_bynode"]), self.editor.colsample_bynode)
 
 
 class TestCatGBLearnerEditor(BaseEditorTest):

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - requests
     - matplotlib-base >=3.2.0
     - openTSNE >=0.6.1
-    - pandas >=1.3.0,!=1.5.0
+    - pandas >=1.4.0,!=1.5.0
     - pyyaml
     - orange-canvas-core >=0.1.28,<0.2a
     - orange-widget-base >=4.19.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -22,7 +22,7 @@ python-louvain>=0.13
 requests
 openTSNE>=0.6.1
 baycomp>=1.0.2
-pandas>=1.3.0,!=1.5.0
+pandas>=1.4.0,!=1.5.0
 pyyaml
 openpyxl
 httpx>=0.21.0

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,2 +1,2 @@
 catboost!=1.0.0  # 1.0.0 segfaults on Macs
-xgboost
+xgboost>=1.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ deps =
     # oldest: requests
     oldest: openTSNE==0.6.1
     oldest: baycomp==1.0.2
-    oldest: pandas==1.3.0
+    oldest: pandas==1.4.0
     # oldest: pyyaml
     # oldest: openpyxl
     oldest: httpx==0.21.0

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ deps =
     # oldest: pyyaml
     # oldest: openpyxl
     oldest: httpx==0.21.0
+    oldest: xgboost==1.5.0
 
 commands_pre =
     # Verify installed packages have compatible dependencies


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In Edit Domain has a timebomb suggesting increasing the minimum version of Pandas and removing a workaround for features not supported in older versions.

##### Description of changes
- Removing timebomb
- Removing extra code in the Edit domain and the Group By widgets that changed time to UTC is no longer required since Pandas from version 1.4 supports subtracting different timezones.
- Fix XGB test since `get_params` changed https://github.com/dmlc/xgboost/pull/8634

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
