### PR TITLE
[FIX] Silhouette Plot: Fix needless eliding

### DIFF
--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -209,7 +209,7 @@ class TextListBase(QGraphicsWidget):
         fm = QFontMetrics(self.font())
         spacing = self.__spacing
         N = self.count()
-        width = self.__width_for_font(self.font())
+        width = self.__width_for_font(self.font()) + 1
         if self.has_color_strip():
             width += int(round((fm.height() + spacing) * 1.3))
         height = N * fm.height() + max(N - 1, 0) * spacing


### PR DESCRIPTION
##### Issue

Fixes #6285.

Silhouette seemed to often elide the longest label; "Proteas" also became "Prote..." without an obvious reason.

##### Description of changes

I added a single pixel to label width and can no longer reproduce this. I assume it could had been some rounding issue.

@larazupan, if you know how to checkout a pull request, please try whether this works for you, too.

##### Includes
- [X] Code changes
