### PR TITLE
Fix for bug in SOM when receiving one row of data

### DIFF
--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -220,7 +220,7 @@ class OWSOM(OWWidget):
 
     class Error(OWWidget.Error):
         no_numeric_variables = Msg("Data contains no numeric columns.")
-        no_defined_rows = Msg("All rows contain at least one undefined value.")
+        not_enough_data = Msg("SOM needs at least two data rows without missing values.")
 
     def __init__(self):
         super().__init__()
@@ -318,8 +318,8 @@ class OWSOM(OWWidget):
                 self.cont_x = x.tocsr()
             else:
                 mask = np.all(np.isfinite(x), axis=1)
-                if not np.any(mask):
-                    self.Error.no_defined_rows()
+                if np.sum(mask) <= 1:
+                    self.Error.not_enough_data()
                 else:
                     if np.all(mask):
                         self.data = data

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -121,7 +121,7 @@ class TestOWSOM(WidgetTest):
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(widget.Warning.missing_values.is_shown())
 
-    def test_missing_all_but_one_row_data(self):
+    def test_single_row_data(self):
         widget = self.widget
         with self.iris.unlocked():
             self.iris.X[:-1] = np.nan
@@ -131,9 +131,11 @@ class TestOWSOM(WidgetTest):
 
         self.send_signal(widget.Inputs.data, Table("heart_disease"))
         self.assertFalse(widget.Error.not_enough_data.is_shown())
+        self.assertTrue(widget.Warning.ignoring_disc_variables.is_shown())
 
         self.send_signal(widget.Inputs.data, self.iris)
         self.assertTrue(widget.Error.not_enough_data.is_shown())
+        self.assertFalse(widget.Warning.ignoring_disc_variables.is_shown())
 
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(widget.Error.not_enough_data.is_shown())

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -86,7 +86,7 @@ class TestOWSOM(WidgetTest):
                 self.iris.X[i, i % 4] = np.nan
 
         self.send_signal(widget.Inputs.data, self.iris)
-        self.assertTrue(widget.Error.no_defined_rows.is_shown())
+        self.assertTrue(widget.Error.not_enough_data.is_shown())
         self.assertFalse(widget.Warning.ignoring_disc_variables.is_shown())
         self.assertIsNone(widget.data)
         self.assertIsNone(widget.cont_x)
@@ -100,7 +100,7 @@ class TestOWSOM(WidgetTest):
             self.iris.X[:50, 0] = np.nan
 
         self.send_signal(widget.Inputs.data, self.iris)
-        self.assertFalse(widget.Error.no_defined_rows.is_shown())
+        self.assertFalse(widget.Error.not_enough_data.is_shown())
         self.assertTrue(widget.Warning.missing_values.is_shown())
         np.testing.assert_almost_equal(
             widget.data.Y.flatten(), [1] * 50 + [2] * 50)
@@ -115,11 +115,28 @@ class TestOWSOM(WidgetTest):
             self.iris.X[5, 0] = np.nan
 
         self.send_signal(widget.Inputs.data, self.iris)
-        self.assertFalse(widget.Error.no_defined_rows.is_shown())
+        self.assertFalse(widget.Error.not_enough_data.is_shown())
         self.assertTrue(widget.Warning.missing_values.is_shown())
 
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(widget.Warning.missing_values.is_shown())
+
+    def test_missing_all_but_one_row_data(self):
+        widget = self.widget
+        with self.iris.unlocked():
+            self.iris.X[:-1] = np.nan
+
+        self.send_signal(widget.Inputs.data, self.iris)
+        self.assertTrue(widget.Error.not_enough_data.is_shown())
+
+        self.send_signal(widget.Inputs.data, Table("heart_disease"))
+        self.assertFalse(widget.Error.not_enough_data.is_shown())
+
+        self.send_signal(widget.Inputs.data, self.iris)
+        self.assertTrue(widget.Error.not_enough_data.is_shown())
+
+        self.send_signal(widget.Inputs.data, None)
+        self.assertFalse(widget.Error.not_enough_data.is_shown())
 
     @_patch_recompute_som
     def test_sparse_data(self):

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -121,6 +121,7 @@ class TestOWSOM(WidgetTest):
         self.send_signal(widget.Inputs.data, None)
         self.assertFalse(widget.Warning.missing_values.is_shown())
 
+    @_patch_recompute_som
     def test_single_row_data(self):
         widget = self.widget
         with self.iris.unlocked():


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #6254 

##### Description of changes
SOM throws error when receiving only one row, added tests for receiving only one row of data.


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
