### PR TITLE
[FIX] listfilter: Fix dragDropActionDidComplete signal type

### DIFF
--- a/Orange/widgets/utils/listfilter.py
+++ b/Orange/widgets/utils/listfilter.py
@@ -42,7 +42,7 @@ class VariablesListItemView(QListView):
     """
     #: Emitted with a Qt.DropAction when a drag/drop (originating from this
     #: view) completed successfully
-    dragDropActionDidComplete = Signal(int)
+    dragDropActionDidComplete = Signal(Qt.DropAction)
 
     def __init__(self, parent=None, acceptedType=Orange.data.Variable):
         super().__init__(parent)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes: https://github.com/biolab/orange3/issues/6287

In PyQt6 Qt.DropAction is not an integer.

##### Description of changes

*  Change dragDropActionDidComplete signal type (in PyQt6 Qt.DropAction is not an integer)

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
