### PR TITLE
Adapt tests for the new setuptools version

### DIFF
--- a/Orange/tests/test_third_party.py
+++ b/Orange/tests/test_third_party.py
@@ -7,4 +7,5 @@ class TestPkgResources(TestCase):
     def test_parse_version(self):
         self.assertGreater(parse_version('3.4.1'), parse_version('3.4.0'))
         self.assertGreater(parse_version('3.4.1'), parse_version('3.4.dev'))
-        self.assertGreater(parse_version('3.4.0'), parse_version('3.4~1'))
+        self.assertGreater(parse_version('3.4.1'), parse_version('3.4.1.dev'))
+        self.assertLess(parse_version('3.4.1'), parse_version('3.4.2.dev'))


### PR DESCRIPTION
##### Issue
Setuptools 66.0.0 was released and one test does not run.

##### Description of changes
I removed the offending test and added 2 that make more sense for our repository.
