### PR TITLE
[FIX] Rank - make sorting setting PyQt6 compatible

### DIFF
--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -230,7 +230,7 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
     sorting = Setting((0, enum2int(Qt.DescendingOrder)))
     selected_methods = Setting(set())
 
-    settings_version = 3
+    settings_version = 4
     settingsHandler = DomainContextHandler()
     selected_attrs = ContextSetting([], schema_only=True)
     selectionMethod = ContextSetting(SelectNBest)

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -29,6 +29,7 @@ from Orange.widgets.settings import (
     ContextSetting, DomainContextHandler, Setting
 )
 from Orange.widgets.unsupervised.owdistances import InterruptException
+from Orange.widgets.utils import enum2int
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.utils.itemmodels import VariableListModel
@@ -226,7 +227,7 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
     nSelected = ContextSetting(5)
     auto_apply = Setting(True)
 
-    sorting = Setting((0, Qt.DescendingOrder))
+    sorting = Setting((0, enum2int(Qt.DescendingOrder)))
     selected_methods = Setting(set())
 
     settings_version = 3
@@ -496,9 +497,11 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
             sort_column, sort_order = self.sorting
             if sort_column < len(labels):
                 # adds 2 to skip the first two columns
-                self.ranksModel.sort(sort_column + 2, sort_order)
+                # Qt.SortOrder is Enum in PyQt6 and int-like object in PyQt5
+                # in both cases Qt.SortOrder transforms int sort_order to required type
+                self.ranksModel.sort(sort_column + 2, Qt.SortOrder(sort_order))
                 self.ranksView.horizontalHeader().setSortIndicator(
-                    sort_column + 2, sort_order
+                    sort_column + 2, Qt.SortOrder(sort_order)
                 )
         except ValueError:
             pass
@@ -561,7 +564,7 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
             self.autoSelection()
 
         # Store the header states
-        sort_order = self.ranksModel.sortOrder()
+        sort_order = enum2int(self.ranksModel.sortOrder())
         sort_column = self.ranksModel.sortColumn() - 2  # -2 for name and '#' columns
         self.sorting = (sort_column, sort_order)
 
@@ -639,6 +642,12 @@ class OWRank(OWWidget, ConcurrentWidgetMixin):
                 hview.restoreState(headerState)
                 column, order = hview.sortIndicatorSection() - 1, hview.sortIndicatorOrder()
             settings["sorting"] = (column, order)
+
+        # before we saved sort order as Qt.SortOrder object, now it is integer
+        # help users with SortOrder as setting migrate to int setting
+        if "sorting" in settings:
+            column, order = settings["sorting"]
+            settings["sorting"] = (column, enum2int(order))
 
     @classmethod
     def migrate_context(cls, context, version):

--- a/Orange/widgets/utils/__init__.py
+++ b/Orange/widgets/utils/__init__.py
@@ -1,7 +1,7 @@
-import enum
 import inspect
 import sys
 from collections import deque
+from enum import Enum, IntEnum
 from typing import (
     TypeVar, Callable, Any, Iterable, Optional, Hashable, Type, Union, Tuple
 )
@@ -91,7 +91,7 @@ def qname(type_: type) -> str:
 
 
 _T1 = TypeVar("_T1")  # pylint: disable=invalid-name
-_E = TypeVar("_E", bound=enum.Enum)  # pylint: disable=invalid-name
+_E = TypeVar("_E", bound=Enum)  # pylint: disable=invalid-name
 _A = TypeVar("_A")  # pylint: disable=invalid-name
 _B = TypeVar("_B")  # pylint: disable=invalid-name
 
@@ -176,3 +176,21 @@ def instance_tooltip(domain, row, skip_attrs=()):
              ("Meta", "Metas", 4, domain.metas),
              ("Feature", "Features", 10, domain.attributes))
     return "<br/>".join(show_part(row, *columns) for columns in parts)
+
+
+def enum2int(enum: Union[Enum, IntEnum]) -> int:
+    """
+    PyQt5 uses IntEnum like object for settings, for example SortOrder while
+    PyQt6 uses Enum. PyQt5's IntEnum also does not support value attribute.
+    This function transform both settings objects to int.
+
+    Parameters
+    ----------
+    enum
+        IntEnum like object or Enum object with Qt's settings
+
+    Returns
+    -------
+    Settings transformed to int
+    """
+    return int(enum) if isinstance(enum, int) else enum.value


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Probably fixes https://github.com/biolab/orange3/issues/6229


##### Description of changes
Store the sorting setting as an integer and transform it to Qt.SortOrder when passed to model/wiev

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
