### PR TITLE
Rule Viewer: Remove learner params from report

### DIFF
--- a/Orange/widgets/visualize/owruleviewer.py
+++ b/Orange/widgets/visualize/owruleviewer.py
@@ -174,7 +174,6 @@ class OWRuleViewer(widget.OWWidget):
     def send_report(self):
         if self.classifier is not None:
             self.report_domain("Data domain", self.classifier.original_domain)
-            self.report_items("Rule induction algorithm", self.classifier.params)
             self.report_table("Induced rules", self.view)
 
     def sizeHint(self):


### PR DESCRIPTION
##### Issue

Fixes #6299.

##### Description of changes

I removed learner parameters from report. They should be reported in learner, not here.

##### Includes
- [X] Code changes
