### PR TITLE
[FIX] Fix unpickling domains: do not pickle indices (which can cause problems)

### DIFF
--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -272,6 +272,9 @@ class ModelTest(unittest.TestCase):
         data = Table("heart_disease")
         for learner in all_learners():
             with self.subTest(learner.__name__):
+                # Skip slow tests
+                if issubclass(learner, _RuleLearner):
+                    continue
                 if learner in (ThresholdLearner, CalibratedLearner):
                     model = learner(LogisticRegressionLearner())(data)
                 else:
@@ -415,7 +418,7 @@ class LearnerAccessibility(unittest.TestCase):
             if learner in (ThresholdLearner, CalibratedLearner):
                 continue
             # Skip slow tests
-            if isinstance(learner, _RuleLearner):
+            if issubclass(learner, _RuleLearner):
                 continue
             with self.subTest(learner.__name__):
                 learner = learner()
@@ -439,7 +442,7 @@ class LearnerAccessibility(unittest.TestCase):
             if learner in (ThresholdLearner, CalibratedLearner):
                 continue
             # Skip slow tests
-            if isinstance(learner, _RuleLearner):
+            if issubclass(learner, _RuleLearner):
                 continue
             with self.subTest(learner.__name__):
                 learner = learner()

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -419,8 +419,6 @@ class LearnerAccessibility(unittest.TestCase):
             if isinstance(learner, _RuleLearner):
                 continue
             with self.subTest(learner.__name__):
-                if "RandomForest" not in learner.__name__:
-                    continue
                 learner = learner()
                 for ds in datasets:
                     model = learner(ds)

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -5,7 +5,6 @@ import pickle
 import pkgutil
 import unittest
 
-import traceback
 import warnings
 
 import numpy as np

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -539,6 +539,7 @@ class TestDomainInit(unittest.TestCase):
             metas=[var1, var2]
         )
         # pylint: disable=protected-access
+        domain._ensure_indices()
         self.assertDictEqual(
             {-1: -1, -2: -2, var1: -1, var2: -2, var1.name: -1, var2.name: -2},
             domain._indices


### PR DESCRIPTION
##### Issue

Fixes  #6202, where the domain could not be unpickled if data included something based on SharedComputeValue (that redefined `__hash__`) and was further preprocessed before learning (thus only scikit-based learners failed but TreeLearner did not).

Unpickling dictionaries that include objects that redefine `__hash__` as keys is sometimes problematic (when said objects do not have `__dict__` filled-in yet in but are used as keys in a restored dictionary).

See the following for a problem description. https://petrounias.org/articles/2014/09/16/pickling-python-collections-with-non-built-in-type-keys-and-cycles/

##### Description of changes

Orange's `Domain` includes `_indices` for name-based or var-based indexing. That is a dictionary with `Variables` as keys, and these can cause problems during unpickling. Because `_indices` can be recreated, I decided not to pickle it and therefore managed to avoid this specific problem.

This will makes new pickled domain incompatible with older Orange versions.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
