### PR TITLE
owcsvimport: Replace use of deprecated np.float alias

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1837,7 +1837,7 @@ def pandas_to_table(df):
     if cols_x:
         X = np.column_stack([a for _, a in cols_x])
     else:
-        X = np.empty((df.shape[0], 0), dtype=np.float)
+        X = np.empty((df.shape[0], 0), dtype=np.float64)
     metas = [v for v, _ in cols_m]
     if cols_m:
         M = np.column_stack([a for _, a in cols_m])


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

owcsvimport (pandas_to_table) stil uses deprecated np.float alias

##### Description of changes

Replace use of deprecated np.float alias

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
