### PR TITLE
WidgetLearnerTestMixin: Fix for clicks of disabled buttons

### DIFF
--- a/Orange/widgets/model/tests/test_owcalibratedlearner.py
+++ b/Orange/widgets/model/tests/test_owcalibratedlearner.py
@@ -31,7 +31,7 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
         # Overridden to change the output type in the last test
         initial = self.get_output("Learner")
         self.assertIsNotNone(initial, "Does not initialize the learner output")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         newlearner = self.get_output("Learner")
         self.assertIsNot(initial, newlearner,
                          "Does not send a new learner instance on `Apply`.")
@@ -44,10 +44,10 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
         """Check if model is on output after sending data and apply"""
         # Overridden to change the output type in the last two test
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.send_signal('Data', self.data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
         self.assertIsNotNone(model)

--- a/Orange/widgets/model/tests/test_owcurvefit.py
+++ b/Orange/widgets/model/tests/test_owcurvefit.py
@@ -219,7 +219,7 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
 
     def test_output_model(self):  # overwritten
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
 
         self.__init_widget()
@@ -358,7 +358,7 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
                 insert("2")
             else:
                 simulate.combobox_activate_index(feature_combo, 1)
-            self.widget.apply_button.button.click()
+            self.click_apply()
 
             self.assertIsNotNone(self.get_output(self.widget.Outputs.learner))
             self.assertFalse(self.widget.Error.no_parameter.is_shown())
@@ -402,13 +402,13 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         self.__init_widget()
         self.assertFalse(self.widget.Error.invalid_exp.is_shown())
         self.widget._OWCurveFit__insert_into_expression(" + ")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Error.invalid_exp.is_shown())
         self.widget._OWCurveFit__insert_into_expression(" 2 ")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertFalse(self.widget.Error.invalid_exp.is_shown())
         self.widget._OWCurveFit__insert_into_expression(" + ")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Error.invalid_exp.is_shown())
         self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.invalid_exp.is_shown())
@@ -443,10 +443,10 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
     def test_no_parameter(self):
         self.send_signal(self.widget.Inputs.data, self.housing)
         self.widget._OWCurveFit__expression_edit.setText("LSTAT + 1")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Error.no_parameter.is_shown())
         self.widget._OWCurveFit__expression_edit.setText("LSTAT + a")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertFalse(self.widget.Error.no_parameter.is_shown())
 
     def test_unused_parameter(self):
@@ -456,11 +456,11 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         self.assertFalse(self.widget.Warning.unused_parameter.is_shown())
 
         self.widget._OWCurveFit__expression_edit.setText("p1 + LSTAT + p2")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertFalse(self.widget.Warning.unused_parameter.is_shown())
 
         self.widget._OWCurveFit__expression_edit.setText("p1 + LSTAT")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Warning.unused_parameter.is_shown())
 
         self.send_signal(self.widget.Inputs.data, None)
@@ -471,11 +471,11 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
         self.__add_button.click()
 
         self.widget._OWCurveFit__expression_edit.setText("p1 + LSTAT")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertFalse(self.widget.Error.unknown_parameter.is_shown())
 
         self.widget._OWCurveFit__expression_edit.setText("p2 + LSTAT")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Error.unknown_parameter.is_shown())
 
         self.send_signal(self.widget.Inputs.data, None)
@@ -528,7 +528,7 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
             self.__add_button.click()
         exp = "p1 * exp(-p2 * LSTAT) + p3"
         self.widget._OWCurveFit__expression_edit.setText(exp)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         learner = self.get_output(self.widget.Outputs.learner)
         self.assertIsInstance(learner, CurveFitLearner)
         model = self.get_output(self.widget.Outputs.model)

--- a/Orange/widgets/model/tests/test_owgradientboosting.py
+++ b/Orange/widgets/model/tests/test_owgradientboosting.py
@@ -354,7 +354,7 @@ class TestOWGradientBoosting(WidgetTest, WidgetLearnerTestMixin):
             if cls is None:
                 continue
             simulate.combobox_activate_index(method_cb, i)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.assertIsInstance(self.widget.learner, cls)
 
     def test_missing_lib(self):

--- a/Orange/widgets/model/tests/test_owlogisticregression.py
+++ b/Orange/widgets/model/tests/test_owlogisticregression.py
@@ -58,7 +58,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         """Check if coefficients are on output after apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.coefficients))
         self.send_signal("Data", self.data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertIsInstance(self.get_output(self.widget.Outputs.coefficients), Table)
 
     def test_domain_with_more_values_than_table(self):
@@ -74,7 +74,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         for case in cases:
             data = table[case, :]
             self.send_signal("Data", data)
-            self.widget.apply_button.button.click()
+            self.click_apply()
 
     def test_coefficients_one_value(self):
         """
@@ -94,7 +94,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
                 ["yes", "no"]))
         )
         self.send_signal("Data", table)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         coef = self.get_output(self.widget.Outputs.coefficients)
         self.assertEqual(coef.domain[0].name, "no")
         self.assertGreater(coef[2][0], 0.)
@@ -120,13 +120,13 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         self.assertFalse(self.widget.class_weight)
         self.widget.controls.class_weight.setChecked(True)
         self.assertTrue(self.widget.class_weight)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertEqual(self.widget.model.skl_model.class_weight, "balanced")
         self.assertTrue(self.widget.Warning.class_weights_used.is_shown())
 
     def test_no_penalty(self):
         self.widget.set_penalty("none")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         lr = self.get_output(self.widget.Outputs.learner)
         self.assertEqual(lr.penalty, "none")
         self.assertEqual(lr.C, 1.0)
@@ -134,7 +134,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         self.assertFalse(self.widget.c_slider.isEnabledTo(self.widget))
 
         self.widget.set_penalty("l2")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         lr = self.get_output(self.widget.Outputs.learner)
         self.assertEqual(lr.penalty, "l2")
         self.assertEqual(self.widget.c_label.text(), "C=1")

--- a/Orange/widgets/model/tests/test_owneuralnetwork.py
+++ b/Orange/widgets/model/tests/test_owneuralnetwork.py
@@ -30,9 +30,9 @@ class TestOWNeuralNetwork(WidgetTest, WidgetLearnerTestMixin):
         self.assertFalse(self.widget.Warning.no_layers.is_shown())
 
         self.widget.hidden_layers_input = ""
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Warning.no_layers.is_shown())
 
         self.widget.hidden_layers_input = "10,"
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertFalse(self.widget.Warning.no_layers.is_shown())

--- a/Orange/widgets/model/tests/test_owrandomforest.py
+++ b/Orange/widgets/model/tests/test_owrandomforest.py
@@ -55,7 +55,7 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
         self.assertFalse(self.widget.class_weight)
         self.widget.controls.class_weight.setChecked(True)
         self.assertTrue(self.widget.class_weight)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertEqual(self.widget.model.skl_model.class_weight, "balanced")
         self.assertTrue(self.widget.Warning.class_weights_used.is_shown())
 

--- a/Orange/widgets/model/tests/test_owrulesclassification.py
+++ b/Orange/widgets/model/tests/test_owrulesclassification.py
@@ -114,10 +114,10 @@ class TestOWRulesClassification(WidgetTest, WidgetLearnerTestMixin):
             data.X = sparse.csr_matrix(data.X)
         self.assertTrue(sparse.issparse(data.X))
         self.send_signal("Data", data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Error.sparse_not_supported.is_shown())
         self.send_signal("Data", None)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertFalse(self.widget.Error.sparse_not_supported.is_shown())
 
     def test_out_of_memory(self):
@@ -138,5 +138,5 @@ class TestOWRulesClassification(WidgetTest, WidgetLearnerTestMixin):
     def test_default_rule(self):
         data = Table("zoo")
         self.send_signal("Data", data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertEqual(sum(self.widget.model.rule_list[-1].curr_class_dist.tolist()), len(data))

--- a/Orange/widgets/model/tests/test_owstack.py
+++ b/Orange/widgets/model/tests/test_owstack.py
@@ -23,10 +23,10 @@ class TestOWStackedLearner(WidgetTest):
         """Check if learner is on output after apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.send_signal("Learners", LogisticRegressionLearner(), 0)
-        self.widget.apply_button.button.click()
+        self.widget.apply_button.button.clicked.emit()
         initial = self.get_output("Learner")
         self.assertIsNotNone(initial, "Does not initialize the learner output")
-        self.widget.apply_button.button.click()
+        self.widget.apply_button.button.clicked.emit()
         newlearner = self.get_output("Learner")
         self.assertIsNot(initial, newlearner,
                          "Does not send a new learner instance on `Apply`.")
@@ -37,10 +37,10 @@ class TestOWStackedLearner(WidgetTest):
         """Check if model is on output after sending data and apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.send_signal("Learners", LogisticRegressionLearner(), 0)
-        self.widget.apply_button.button.click()
+        self.widget.apply_button.button.clicked.emit()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.send_signal('Data', self.data)
-        self.widget.apply_button.button.click()
+        self.widget.apply_button.button.clicked.emit()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
         self.assertIsNotNone(model)

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -248,6 +248,9 @@ class WidgetLearnerTestMixin:
 
         self.parameters = []
 
+    def click_apply(self):
+        self.widget.apply_button.button.clicked.emit()
+
     def test_has_unconditional_apply(self):
         self.assertTrue(hasattr(self.widget, "unconditional_apply"))
 
@@ -262,7 +265,7 @@ class WidgetLearnerTestMixin:
         """Check widget's data and model after disconnecting data from input"""
         self.send_signal("Data", self.data)
         self.assertEqual(self.widget.data, self.data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.send_signal("Data", None)
         self.wait_until_stop_blocking()
@@ -273,7 +276,7 @@ class WidgetLearnerTestMixin:
         """Check if error message is shown with inadequate data on input"""
         for inadequate in self.inadequate_dataset:
             self.send_signal("Data", inadequate)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.wait_until_stop_blocking()
             self.assertTrue(self.widget.Error.data_error.is_shown())
         for valid in self.valid_datasets:
@@ -288,7 +291,7 @@ class WidgetLearnerTestMixin:
         self.assertEqual(
             randomize, self.widget.preprocessors,
             'Preprocessor not added to widget preprocessors')
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(
             (randomize,), self.widget.learner.preprocessors,
@@ -298,7 +301,7 @@ class WidgetLearnerTestMixin:
         """Check multiple preprocessors on input"""
         pp_list = PreprocessorList([Randomize(), RemoveNaNColumns()])
         self.send_signal("Preprocessor", pp_list)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(
             (pp_list,), self.widget.learner.preprocessors,
@@ -308,12 +311,12 @@ class WidgetLearnerTestMixin:
         """Check learner's preprocessors after disconnecting pp from input"""
         randomize = Randomize()
         self.send_signal("Preprocessor", randomize)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(randomize, self.widget.preprocessors)
 
         self.send_signal("Preprocessor", None)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.assertIsNone(self.widget.preprocessors,
                           'Preprocessors not removed on disconnect.')
@@ -322,7 +325,7 @@ class WidgetLearnerTestMixin:
         """Check if learner is on output after apply"""
         initial = self.get_output("Learner")
         self.assertIsNotNone(initial, "Does not initialize the learner output")
-        self.widget.apply_button.button.click()
+        self.click_apply()
         newlearner = self.get_output("Learner")
         self.assertIsNot(initial, newlearner,
                          "Does not send a new learner instance on `Apply`.")
@@ -332,10 +335,10 @@ class WidgetLearnerTestMixin:
     def test_output_model(self):
         """Check if model is on output after sending data and apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.send_signal('Data', self.data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
         self.assertIsNotNone(model)
@@ -345,12 +348,12 @@ class WidgetLearnerTestMixin:
     def test_output_learner_name(self):
         """Check if learner's name properly changes"""
         new_name = "Learner Name"
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertEqual(self.widget.learner.name,
                          self.widget.name_line_edit.text()
                          or self.widget.name_line_edit.placeholderText())
         self.widget.name_line_edit.setText(new_name)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(self.get_output("Learner").name, new_name)
 
@@ -359,14 +362,14 @@ class WidgetLearnerTestMixin:
         new_name = "Model Name"
         self.widget.name_line_edit.setText(new_name)
         self.send_signal("Data", self.data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(self.get_output(self.widget.Outputs.model).name, new_name)
 
     def test_output_model_picklable(self):
         """Check if model can be pickled"""
         self.send_signal("Data", self.data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
         self.assertIsNotNone(model)
@@ -390,7 +393,7 @@ class WidgetLearnerTestMixin:
         """
         for dataset in self.valid_datasets:
             self.send_signal("Data", dataset)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.wait_until_stop_blocking()
             for parameter in self.parameters:
                 # Skip if the param isn't used for the given data type
@@ -416,7 +419,7 @@ class WidgetLearnerTestMixin:
 
                 for value in parameter.values:
                     parameter.set_value(value)
-                    self.widget.apply_button.button.click()
+                    self.click_apply()
                     self.wait_until_stop_blocking()
                     param = self._get_param_value(self.widget.learner, parameter)
                     self.assertEqual(

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -22,6 +22,9 @@ class TestOWManifoldLearning(WidgetTest):
         self.widget = self.create_widget(
             OWManifoldLearning, stored_settings={"auto_apply": False})  # type: OWManifoldLearning
 
+    def click_apply(self):
+        self.widget.apply_button.button.clicked.emit()
+
     def test_input_data(self):
         """Check widget's data"""
         self.assertEqual(self.widget.data, None)
@@ -34,10 +37,10 @@ class TestOWManifoldLearning(WidgetTest):
         """Check if data is on output after apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.transformed_data))
         self.send_signal(self.widget.Inputs.data, self.iris)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertIsInstance(self.get_output(self.widget.Outputs.transformed_data), Table)
         self.send_signal(self.widget.Inputs.data, None)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertIsNone(self.get_output(self.widget.Outputs.transformed_data))
 
     def test_n_components(self):
@@ -48,7 +51,7 @@ class TestOWManifoldLearning(WidgetTest):
             self.assertEqual(self.widget.data, self.iris)
             self.widget.n_components_spin.setValue(i)
             self.widget.n_components_spin.onEnter()
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self._compare_tables(self.get_output(self.widget.Outputs.transformed_data), i)
 
     def test_manifold_methods(self):
@@ -58,7 +61,7 @@ class TestOWManifoldLearning(WidgetTest):
         for i in range(len(self.widget.MANIFOLD_METHODS)):
             self.assertEqual(self.widget.data, self.iris)
             self.widget.manifold_methods_combo.activated.emit(i)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self._compare_tables(self.get_output(self.widget.Outputs.transformed_data), n_comp)
 
     def _compare_tables(self, _output, n_components):
@@ -74,11 +77,11 @@ class TestOWManifoldLearning(WidgetTest):
         def __callback():
             # Send sparse data to input
             self.send_signal(self.widget.Inputs.data, data)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.assertTrue(self.widget.Error.sparse_not_supported.is_shown())
             # Clear input
             self.send_signal(self.widget.Inputs.data, None)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.assertFalse(self.widget.Error.sparse_not_supported.is_shown())
 
         simulate.combobox_run_through_all(
@@ -92,12 +95,12 @@ class TestOWManifoldLearning(WidgetTest):
         def __callback():
             # Send data to input
             self.send_signal(self.widget.Inputs.data, self.iris)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.assertFalse(self.widget.Error.manifold_error.is_shown())
 
             # Clear input
             self.send_signal(self.widget.Inputs.data, None)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.assertFalse(self.widget.Error.manifold_error.is_shown())
 
         simulate.combobox_run_through_all(
@@ -108,7 +111,7 @@ class TestOWManifoldLearning(WidgetTest):
         simulate.combobox_activate_item(self.widget.manifold_methods_combo, "MDS")
         data = possible_duplicate_table('C0', class_var=True)
         self.send_signal(self.widget.Inputs.data, data)
-        self.widget.apply_button.button.click()
+        self.click_apply()
         out = self.get_output(self.widget.Outputs.transformed_data)
         self.assertTrue(out.domain.attributes[0], 'C0 (1)')
 
@@ -136,7 +139,7 @@ class TestOWManifoldLearning(WidgetTest):
         self.widget.manifold_methods_combo.activated.emit(0)  # t-SNE
         self.widget.tsne_editor.metric_combo.activated.emit(4)  # Mahalanobis
         self.assertFalse(self.widget.Error.manifold_error.is_shown())
-        self.widget.apply_button.button.click()
+        self.click_apply()
         self.assertTrue(self.widget.Error.manifold_error.is_shown())
 
     def test_out_of_memory(self):
@@ -149,7 +152,7 @@ class TestOWManifoldLearning(WidgetTest):
             mock.side_effect = MemoryError
             self.send_signal("Data", table)
             self.widget.manifold_methods_combo.activated.emit(1)
-            self.widget.apply_button.button.click()
+            self.click_apply()
             self.assertTrue(self.widget.Error.out_of_memory.is_shown())
 
     def test_unconditional_commit_on_new_signal(self):


### PR DESCRIPTION
##### Issue

Tests fail after https://github.com/biolab/orange-widget-base/pull/228 because they click disable buttons.

##### Description of changes

Call `clicked.emit()` directly.
