### PR TITLE
[FIX] Edit Domain - set have_time and have_date to time variables

### DIFF
--- a/Orange/widgets/data/oweditdomain.py
+++ b/Orange/widgets/data/oweditdomain.py
@@ -1547,7 +1547,7 @@ class TimeVariableEditor(VariableEditor):
 
     def set_data(self, var, transform=()):
         super().set_data(var, transform)
-        if self.parent() is not None and isinstance(self.parent().var, Time):
+        if self.parent() is not None and isinstance(self.parent().var, (Time, Real)):
             # when transforming from time to time disable format selection combo
             self.format_cb.setEnabled(False)
         else:
@@ -2730,11 +2730,13 @@ def apply_reinterpret_c(var, tr, data: MArray):
     elif isinstance(tr, AsContinuous):
         return var
     elif isinstance(tr, AsString):
-        # TimeVar will be interpreted by StrpTime later
         tstr = ToStringTransform(var)
         rvar = Orange.data.StringVariable(name=var.name, compute_value=tstr)
     elif isinstance(tr, AsTime):
-        rvar = Orange.data.TimeVariable(name=var.name, compute_value=Identity(var))
+        # continuous variable is always transformed to time as UNIX epoch
+        rvar = Orange.data.TimeVariable(
+            name=var.name, compute_value=Identity(var), have_time=1, have_date=1
+        )
     else:
         assert False
     return copy_attributes(rvar, var)

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -1015,6 +1015,20 @@ class TestReinterpretTransforms(TestCase):
         v = apply_transform(domain.metas[0],table, [])
         self.assertIs(v, domain.metas[0])
 
+    def test_to_time_variable(self):
+        table = self.data
+        tr = AsTime()
+        dtr = []
+        for v in table.domain:
+            strp = StrpTime("Detect automatically", None, 1, 1)
+            vtr = apply_transform_var(
+                apply_reinterpret(v, tr, table_column_data(table, v)), [strp]
+            )
+            dtr.append(vtr)
+        ttable = table.transform(Domain([], metas=dtr))
+        for var in ttable.domain:
+            self.assertTrue(var.have_date or var.have_time)
+
 
 class TestUtils(TestCase):
     def test_mapper(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
When transforming continuous variable to time, Edit Domain does not set `have_time` and `have_date` attributes.
Fixes https://github.com/biolab/orange3/issues/5648

##### Description of changes
Set to mentioned attributes when transforming Continuous to TimeVariable

Additionally, when implementing #5819, it was agreed that CountinousVariable always transforms to Time as UNIX epoch (seconds from 1970-01-01). Still format selection dropdown remained active, which can confuse the user. In this PR, I lock the format selection dropdown when transforming ContinousVariable (and TimeVariable - which was done already before).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
