### PR TITLE
[FIX] Concatenate - preserve table names when compute value ignored

### DIFF
--- a/Orange/widgets/data/owconcatenate.py
+++ b/Orange/widgets/data/owconcatenate.py
@@ -263,6 +263,7 @@ class OWConcatenate(widget.OWWidget):
                 dumb_domain,
                 table.X, table.Y, table.metas, table.W,
                 table.attributes, table.ids)
+            dumb_table.name = table.name
             dumb_tables.append(dumb_table)
         return dumb_tables
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Coconcate widget does not preserve table names when compute value is ignored, so `unknown` appears in the `Source ID` column instead of the correct name.

##### Description of changes
Preserve table name also when ignore compute value is ticked. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
