### PR TITLE
[FIX] MDS: Remove repeated updates at the end of optimization

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -400,10 +400,7 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
     def on_done(self, result: Result):
         assert isinstance(result.embedding, np.ndarray)
         assert len(result.embedding) == len(self.effective_matrix)
-        self.embedding = result.embedding
-        self.graph.update_coordinates()
-        self.graph.update_density()
-        self.update_stress()
+        # embedding, graph and stress are already updated in on_partial_result
         self.run_button.setText("Start")
         self.step_button.setEnabled(True)
         self.commit.deferred()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Graph and stress were updated twice in a row - in last call of `on_partial_result` and in `on_done`

##### Description of changes
Remove updates in `on_done` - @VesnaT , @janezd please check and confirm that they were indeed unnecessary and that `on_partial_result` is always already called before it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
