### PR TITLE
Avoid openTSNE 0.7.0 due to segfaults

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,7 @@ requirements:
     - python-louvain >=0.13
     - requests
     - matplotlib-base >=3.2.0
-    - openTSNE >=0.6.1
+    - openTSNE >=0.6.1,!=0.7.0
     - pandas >=1.4.0,!=1.5.0
     - pyyaml
     - orange-canvas-core >=0.1.28,<0.2a

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -20,7 +20,7 @@ serverfiles		# for Data Sets synchronization
 networkx
 python-louvain>=0.13
 requests
-openTSNE>=0.6.1
+openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
 baycomp>=1.0.2
 pandas>=1.4.0,!=1.5.0
 pyyaml


### PR DESCRIPTION
##### Issue
Tests fail after the new openTSNE release.