### PR TITLE
Tree Viewer: Replace format with f-string

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -10,6 +10,7 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import QColor, QBrush, QPen, QFontMetrics
 from AnyQt.QtCore import Qt, QPointF, QSizeF, QRectF
 
+from orangecanvas.utils.localization import pl
 from orangewidget.utils.combobox import ComboBoxSearch
 
 from Orange.base import TreeModel, SklModel
@@ -307,9 +308,9 @@ class OWTreeGraph(OWTreeViewer2D):
             self.openContext(self.domain.class_var)
             # self.root_node = self.walkcreate(model.root, None)
             self.root_node = self.walkcreate(self.tree_adapter.root)
-            self.infolabel.setText('{} nodes, {} leaves'.format(
-                self.tree_adapter.num_nodes,
-                len(self.tree_adapter.leaves(self.tree_adapter.root))))
+            nodes = self.tree_adapter.num_nodes
+            leaves = len(self.tree_adapter.leaves(self.tree_adapter.root))
+            self.infolabel.setText(f'{nodes} {pl(nodes, "node")}, {leaves} {pl(leaves, "leaf|leaves")}')
         self.setup_scene()
         self.Outputs.selected_data.send(None)
         self.Outputs.annotated_data.send(create_annotated_table(self.dataset, []))

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -403,7 +403,7 @@ class OWTreeViewer2D(OWWidget, openclass=True):
             "Depth: ",
             gui.comboBox(box, self, 'max_tree_depth',
                          items=["Unlimited"] + [
-                             "{} levels".format(x) for x in range(2, 10)],
+                             f"{x} levels" for x in range(2, 10)],
                          addToLayout=False, sendSelectedValue=False,
                          callback=self.toggle_tree_depth, sizePolicy=policy))
         layout.addRow(


### PR DESCRIPTION
##### Issue

Some labels were created using f-strings and thus impossible to translate

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
