### PR TITLE
InteractiveViewBox: Don't suspend_jittering for graphs that don't support it

### DIFF
--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -220,13 +220,15 @@ class InteractiveViewBox(pg.ViewBox):
                 self.safe_update_scale_box(ev.buttonDownPos(), ev.pos())
                 if ev.isFinish():
                     self._updateDragtipShown(False)
-                    self.graph.unsuspend_jittering()
+                    if hasattr(self.graph, "unsuspend_jittering"):
+                        self.graph.unsuspend_jittering()
                     self.rbScaleBox.hide()
                     value_rect = get_mapped_rect()
                     self.graph.select_by_rectangle(value_rect)
                 else:
                     self._updateDragtipShown(True)
-                    self.graph.suspend_jittering()
+                    if hasattr(self.graph, "suspend_jittering"):
+                        self.graph.suspend_jittering()
                     self.safe_update_scale_box(ev.buttonDownPos(), ev.pos())
 
         def zoom():


### PR DESCRIPTION
##### Issue

Selection by dragging a rectangle crashes in Choropleth.

Choropleth is not a projection and doesn't "jitter" anything, yet it uses `InteractiveViewBox`. Drag event therefore crashes when it tries to suspend jittering.

##### Description of changes

Call (`un`)`suspend_jittering` only if such method exists.

No tests. I'm not creating drag events to check this single if with an obvious test. :)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
