### PR TITLE
FIX: create Values from strings

### DIFF
--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -160,6 +160,8 @@ class Value(float):
         :param value: value
         """
         if variable.is_primitive():
+            if isinstance(variable, DiscreteVariable) and isinstance(value, str):
+                value = variable.to_val(value)
             self = super().__new__(cls, value)
             self.variable = variable
             self._value = None

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -209,6 +209,9 @@ class TestSqlTable(unittest.TestCase, dbt):
     def test_getitem_single_value(self):
         table = SqlTable(self.conn, self.iris, inspect_values=True)
         self.assertAlmostEqual(table[0, 0], 5.1)
+        self.assertAlmostEqual(table[0, table.domain[0]], 5.1)
+        self.assertEqual(table[0, 4], "Iris-setosa")
+        self.assertEqual(table[0, table.domain[4]], "Iris-setosa")
 
     @dbt.run_on(["postgres", "mssql"])
     def test_type_hints(self):


### PR DESCRIPTION
##### Issue
Cannot create a discrete `Value` from it's string representation. This means indexing into SQLTable like `table[row, variable]` doesn't work.

##### Description of changes
add special case for `DiscreteVariable` in Values `__new__` method as well as extending sqltable tests.