### PR TITLE
Table: Fix ensure_copy to also check ids

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1475,6 +1475,8 @@ class Table(Sequence, Storage):
             self._metas = self._metas.copy()
         if is_view(self._W):
             self._W = self._W.copy()
+        if is_view(self.ids):
+            self.ids = self.ids.copy()
 
     def copy(self):
         """

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -253,6 +253,25 @@ class TestTableInit(unittest.TestCase):
             tabw.metas,
             np.hstack((tab.metas, np.array(list("abcde")).reshape(5, -1))))
 
+    def test_copy(self):
+        domain = Domain([ContinuousVariable("x")],
+                        ContinuousVariable("y"),
+                        [ContinuousVariable("z")])
+        data1 = Table.from_list(domain, [[1, 2, 3]], weights=[4])
+        data1.ids[0]= 5
+        data2 = data1.copy()
+        with data2.unlocked():
+            data2.X += 1
+            data2.Y += 1
+            data2.metas += 1
+            data2.W += 1
+            data2.ids += 1
+        self.assertEqual(data1.X, [[1]])
+        self.assertEqual(data1.Y, [[2]])
+        self.assertEqual(data1.metas, [[3]])
+        self.assertEqual(data1.W, [[4]])
+        self.assertEqual(data1.ids, [[5]])
+
 
 class TestTableLocking(unittest.TestCase):
     @classmethod

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -10,7 +10,6 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import QColor, QBrush, QPen, QFontMetrics
 from AnyQt.QtCore import Qt, QPointF, QSizeF, QRectF
 
-from orangecanvas.utils.localization import pl
 from orangewidget.utils.combobox import ComboBoxSearch
 
 from Orange.base import TreeModel, SklModel
@@ -20,6 +19,7 @@ from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.owtreeviewer2d import \
     GraphicsNode, GraphicsEdge, OWTreeViewer2D
 from Orange.widgets.utils import to_html
+from Orange.widgets.utils.localization import pl
 from Orange.data import Table
 from Orange.util import color_to_hex
 


### PR DESCRIPTION
##### Issue

`Table.copy()` does not copy ids, but uses a reference to existing ids, as detected by tests in Image Analytics (https://github.com/biolab/orange3-imageanalytics/actions/runs/4314962156/jobs/7529016431).

##### Includes
- [X] Code changes
- [X] Tests
