### PR TITLE
Louvain Clustering: Enable Apply button on change

### DIFF
--- a/Orange/widgets/unsupervised/owlouvainclustering.py
+++ b/Orange/widgets/unsupervised/owlouvainclustering.py
@@ -141,7 +141,7 @@ class OWLouvainClustering(widget.OWWidget):
         self.apply_button = gui.auto_apply(
             self.buttonsArea, self, "auto_commit",
             commit=lambda: self.commit(), callback=lambda: self._on_auto_commit_changed()
-        )  # type: QWidget
+        ).button  # type: QWidget
 
     def _preprocess_data(self):
         if self.preprocessed_data is None:
@@ -202,6 +202,7 @@ class OWLouvainClustering(widget.OWWidget):
         elif self.auto_commit:
             # does not apply when auto commit is on
             state = False
+        self.apply_button.setEnabled(state)
         self.Information.modified(shown=state)
 
     def _on_auto_commit_changed(self):


### PR DESCRIPTION
##### Issue

After https://github.com/biolab/orange-widget-base/pull/228, Louvain's particular handling of deferred commit left the button disabled on change -- and at the same time telling the user to click it.

To test, disable auto commit and change the number of PCA components. Button remains disabled.

##### Description of changes

Explicitly enable the button.

No tests. In the longterm, we would refactor this widget to use deferred commit.

##### Includes
- [X] Code changes
