### PR TITLE
Translation test fixes

### DIFF
--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -541,7 +541,7 @@ class TestOWCreateClass(WidgetTest):
         def assertError(class_name, class_name_empty, class_name_duplicated, is_out):
             widget.class_name = class_name
             widget.apply()
-            output = self.get_output("Data")
+            output = self.get_output()
             self.assertEqual(widget.Error.class_name_empty.is_shown(), class_name_empty)
             self.assertEqual(widget.Error.class_name_duplicated.is_shown(), class_name_duplicated)
             self.assertEqual(output is not None, is_out)

--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -112,7 +112,7 @@ class TestOWCSVFileImport(WidgetTest):
         item = w.current_item()
         self.assertTrue(samepath(item.path(), path))
         self.assertEqual(item.options(), self.data_regions_options)
-        out = self.get_output("Data", w)
+        out = self.get_output(w.Outputs.data)
         self._check_data_regions(out)
         self.assertEqual(out.name, "data-regions")
 
@@ -144,7 +144,7 @@ class TestOWCSVFileImport(WidgetTest):
             "local settings item must be recorded in _session_items_v2 when "
             "activated",
         )
-        self._check_data_regions(self.get_output("Data", w))
+        self._check_data_regions(self.get_output(w.Outputs.data))
 
     data_csv_types_options = owcsvimport.Options(
         encoding="ascii", dialect=csv.excel_tab(),
@@ -168,7 +168,7 @@ class TestOWCSVFileImport(WidgetTest):
         )
         widget.commit()
         self.wait_until_finished(widget)
-        output = self.get_output("Data", widget)
+        output = self.get_output(widget.Outputs.data)
         domain = output.domain
 
         self.assertIsInstance(domain["time"], TimeVariable)
@@ -201,7 +201,7 @@ class TestOWCSVFileImport(WidgetTest):
         )
         widget.commit()
         self.wait_until_finished(widget)
-        output = self.get_output("Data", widget)
+        output = self.get_output(widget.Outputs.data)
         self.assertTupleEqual(('1', '3', '4', '5', '12'), output.domain.attributes[1].values)
 
     def test_backward_compatibility(self):
@@ -221,7 +221,7 @@ class TestOWCSVFileImport(WidgetTest):
         )
         widget.commit()
         self.wait_until_finished(widget)
-        output = self.get_output("Data", widget)
+        output = self.get_output(widget.Outputs.data)
         domain = output.domain
 
         self.assertIsInstance(domain["time"], StringVariable)

--- a/Orange/widgets/data/tests/test_owdatasampler.py
+++ b/Orange/widgets/data/tests/test_owdatasampler.py
@@ -21,31 +21,32 @@ class TestOWDataSampler(WidgetTest):
         """ Check if error message appears and then disappears when
         data is removed from input"""
         self.widget.controls.sampling_type.buttons[2].click()
-        self.send_signal("Data", self.iris)
+        self.send_signal(self.iris)
         self.assertFalse(self.widget.Error.too_many_folds.is_shown())
-        self.send_signal("Data", self.iris[:5])
+        self.send_signal(self.iris[:5])
         self.assertTrue(self.widget.Error.too_many_folds.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(None)
         self.assertFalse(self.widget.Error.too_many_folds.is_shown())
-        self.send_signal("Data", Table.from_domain(self.iris.domain))
+        self.send_signal(Table.from_domain(self.iris.domain))
         self.assertTrue(self.widget.Error.no_data.is_shown())
 
     def test_stratified_on_unbalanced_data(self):
         unbalanced_data = self.iris[:51]
 
         self.widget.controls.stratify.setChecked(True)
-        self.send_signal("Data", unbalanced_data)
+        self.send_signal(unbalanced_data)
         self.assertTrue(self.widget.Warning.could_not_stratify.is_shown())
 
     def test_bootstrap(self):
         self.select_sampling_type(self.widget.Bootstrap)
 
-        self.send_signal("Data", self.iris)
+        self.send_signal(self.iris)
 
         in_input = set(self.iris.ids)
-        sample = self.get_output("Data Sample")
+        sample = self.get_output(self.widget.Outputs.data_sample)
         in_sample = set(sample.ids)
-        in_remaining = set(self.get_output("Remaining Data").ids)
+        in_remaining = set(
+            self.get_output(self.widget.Outputs.remaining_data).ids)
 
         # Bootstrap should sample len(input) instances
         self.assertEqual(len(sample), len(self.iris))
@@ -66,7 +67,7 @@ class TestOWDataSampler(WidgetTest):
     def test_no_intersection_in_outputs(self):
         """ Check whether outputs intersect and whether length of outputs sums
         to length of original data"""
-        self.send_signal("Data", self.iris)
+        self.send_signal(self.iris)
         w = self.widget
         sampling_types = [w.FixedProportion, w.FixedSize, w.CrossValidation]
 
@@ -78,43 +79,43 @@ class TestOWDataSampler(WidgetTest):
                     self.select_sampling_type(sampling_type)
                     self.widget.commit()
 
-                    sample = self.get_output("Data Sample")
-                    other = self.get_output("Remaining Data")
+                    sample = self.get_output(self.widget.Outputs.data_sample)
+                    other = self.get_output(self.widget.Outputs.remaining_data)
                     self.assertEqual(len(self.iris), len(sample) + len(other))
                     self.assertNoIntersection(sample, other)
 
     def test_bigger_size_with_replacement(self):
         """Allow bigger output without replacement."""
-        self.send_signal('Data', self.iris[:2])
+        self.send_signal(self.iris[:2])
         sample_size = self.set_fixed_sample_size(3, with_replacement=True)
         self.assertEqual(3, sample_size, 'Should be able to set a bigger size '
                          'with replacement')
 
     def test_bigger_size_without_replacement(self):
         """Lower output samples to match input's without replacement."""
-        self.send_signal('Data', self.iris[:2])
+        self.send_signal(self.iris[:2])
         sample_size = self.set_fixed_sample_size(3)
         self.assertEqual(2, sample_size)
 
     def test_bigger_output_warning(self):
         """Should warn when sample size is bigger than input."""
-        self.send_signal('Data', self.iris[:2])
+        self.send_signal(self.iris[:2])
         self.set_fixed_sample_size(3, with_replacement=True)
         self.assertTrue(self.widget.Warning.bigger_sample.is_shown())
 
     def test_shuffling(self):
-        self.send_signal('Data', self.iris)
+        self.send_signal(self.iris)
 
         self.set_fixed_sample_size(150)
         self.assertFalse(self.widget.Warning.bigger_sample.is_shown())
-        sample = self.get_output("Data Sample")
+        sample = self.get_output(self.widget.Outputs.data_sample)
         self.assertTrue((self.iris.ids != sample.ids).any())
         self.assertEqual(set(self.iris.ids), set(sample.ids))
 
         self.select_sampling_type(self.widget.FixedProportion)
         self.widget.sampleSizePercentage = 100
         self.widget.commit()
-        sample = self.get_output("Data Sample")
+        sample = self.get_output(self.widget.Outputs.data_sample)
         self.assertTrue((self.iris.ids != sample.ids).any())
         self.assertEqual(set(self.iris.ids), set(sample.ids))
 

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -25,6 +25,7 @@ class TestOWDataSets(WidgetTest):
     @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={('core', 'foo.tab'): {}}))
     @patch("Orange.widgets.data.owdatasets.log", Mock())
+    @WidgetTest.skipNonEnglish
     def test_only_local(self):
         w = self.create_widget(OWDataSets)  # type: OWDataSets
         self.wait_until_stop_blocking(w)
@@ -67,6 +68,7 @@ class TestOWDataSets(WidgetTest):
            Mock(return_value={}))
     @patch("Orange.widgets.data.owdatasets.ensure_local",
            Mock(return_value="iris.tab"))
+    @WidgetTest.skipNonEnglish
     def test_download_iris(self):
         w = self.create_widget(OWDataSets)  # type: OWDataSets
         self.wait_until_stop_blocking(w)
@@ -83,6 +85,7 @@ class TestOWDataSets(WidgetTest):
            Mock(return_value={('dir1', 'dir2', 'foo.tab'): {},
                               ('bar.tab',): {}}))
     @patch("Orange.widgets.data.owdatasets.log", Mock())
+    @WidgetTest.skipNonEnglish
     def test_dir_depth(self):
         w = self.create_widget(OWDataSets)  # type: OWDataSets
         self.wait_until_stop_blocking(w)

--- a/Orange/widgets/data/tests/test_owdiscretize.py
+++ b/Orange/widgets/data/tests/test_owdiscretize.py
@@ -519,7 +519,7 @@ class TestModels(WidgetTest, DataMixin):
         model = w.varview.model()
         display = model.index(0).data()
         self.assertIn("x", display)
-        self.assertIn("equal", display)
+        self.assertIn("freq", display)
         self.assertIn("3", display)
         self.assertIn(
             str(w.discretized_vars[("x", False)].compute_value.points[0])[:3],
@@ -542,7 +542,7 @@ class TestModels(WidgetTest, DataMixin):
         w._update_discretizations()
         display = model.index(0).data()
         self.assertIn("x", display)
-        self.assertIn("equal", display)
+        self.assertIn("width", display)
         self.assertIn("3", display)
         self.assertIn(
             str(w.discretized_vars[("x", False)].compute_value.points[0])[:3],

--- a/Orange/widgets/data/tests/test_oweditdomain.py
+++ b/Orange/widgets/data/tests/test_oweditdomain.py
@@ -179,14 +179,14 @@ class TestOWEditDomain(WidgetTest):
     def test_input_from_owcolor(self):
         """Check widget's data sent from OWColor widget"""
         owcolor = self.create_widget(OWColor)
-        self.send_signal("Data", self.iris, widget=owcolor)
+        self.send_signal(owcolor.Inputs.data, self.iris)
         disc_model = owcolor.disc_model
         disc_model.setData(disc_model.index(0, 1), (1, 2, 3), ColorRole)
         cont_model = owcolor.cont_model
         palette = list(colorpalettes.ContinuousPalettes.values())[-1]
         cont_model.setData(cont_model.index(1, 1), palette, ColorRole)
-        owcolor_output = self.get_output("Data", owcolor)
-        self.send_signal("Data", owcolor_output)
+        owcolor_output = self.get_output(owcolor.Outputs.data)
+        self.send_signal(owcolor_output)
         self.assertEqual(self.widget.data, owcolor_output)
         np.testing.assert_equal(self.widget.data.domain.class_var.colors[0],
                                 (1, 2, 3))

--- a/Orange/widgets/data/tests/test_owimpute.py
+++ b/Orange/widgets/data/tests/test_owimpute.py
@@ -58,8 +58,8 @@ class TestOWImpute(WidgetTest):
 
         # only meta columns
         data = data.transform(Domain([], [], data.domain.attributes))
-        self.send_signal("Data", data, wait=1000)
-        imp_data = self.get_output("Data")
+        self.send_signal(self.widget.Inputs.data, data, wait=1000)
+        imp_data = self.get_output()
         self.assertEqual(len(imp_data), len(data))
         self.assertEqual(imp_data.domain, data.domain)
         np.testing.assert_equal(imp_data.metas, data.metas)

--- a/Orange/widgets/data/tests/test_owmergedata.py
+++ b/Orange/widgets/data/tests/test_owmergedata.py
@@ -770,15 +770,15 @@ class TestOWMergeData(WidgetTest):
         data = Table("iris")[::25]
         data_ed_dense = Table("titanic")[::300]
         data_ed_sparse = Table("titanic")[::300].to_sparse()
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
 
-        self.send_signal("Extra Data", data_ed_dense)
-        output_dense = self.get_output("Data")
+        self.send_signal(self.widget.Inputs.extra_data, data_ed_dense)
+        output_dense = self.get_output()
         self.assertFalse(sp.issparse(output_dense.X))
         self.assertFalse(output_dense.is_sparse())
 
-        self.send_signal("Extra Data", data_ed_sparse)
-        output_sparse = self.get_output("Data")
+        self.send_signal(self.widget.Inputs.extra_data, data_ed_sparse)
+        output_sparse = self.get_output()
         self.assertTrue(sp.issparse(output_sparse.X))
         self.assertTrue(output_sparse.is_sparse())
 

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -46,17 +46,17 @@ class TestOWNeighbors(WidgetTest):
         self.send_signal(widget.Inputs.reference, None)
         self.assertEqual(widget.reference, None)
         widget.apply_button.button.click()
-        self.assertIsNone(self.get_output("Neighbors"))
+        self.assertIsNone(self.get_output())
 
     def test_output_neighbors(self):
         """Check if neighbors are on the output after apply"""
         widget = self.widget
-        self.assertIsNone(self.get_output("Neighbors"))
+        self.assertIsNone(self.get_output())
         self.send_signals(((widget.Inputs.data, self.iris),
                            (widget.Inputs.reference, self.iris[:10])))
         widget.apply_button.button.click()
-        self.assertIsNotNone(self.get_output("Neighbors"))
-        self.assertIsInstance(self.get_output("Neighbors"), Table)
+        self.assertIsNotNone(self.get_output())
+        self.assertIsInstance(self.get_output(), Table)
         self.assertTrue(all([i in self.iris.ids for i in
                              self.get_output(widget.Outputs.data).ids])
                         )
@@ -75,7 +75,7 @@ class TestOWNeighbors(WidgetTest):
                 widget.apply_button.button.click()
                 if METRICS[widget.distance_index][0] != "Jaccard" \
                         and widget.n_neighbors != 0:
-                    self.assertIsNotNone(self.get_output("Neighbors"))
+                    self.assertIsNotNone(self.get_output())
 
     def test_exclude_reference(self):
         """Check neighbors when reference is excluded"""
@@ -95,7 +95,7 @@ class TestOWNeighbors(WidgetTest):
         self.send_signal(widget.Inputs.data, self.iris)
         self.send_signal(widget.Inputs.reference, reference)
         widget.apply_button.button.click()
-        neighbors = self.get_output("Neighbors")
+        neighbors = self.get_output()
         self.assertEqual(self.iris.domain.attributes,
                          neighbors.domain.attributes)
         self.assertEqual(self.iris.domain.class_vars,
@@ -112,7 +112,7 @@ class TestOWNeighbors(WidgetTest):
         self.send_signal(widget.Inputs.data, self.iris)
         self.send_signal(widget.Inputs.reference, reference)
         widget.apply_button.button.click()
-        self.assertIsNotNone(self.get_output("Neighbors"))
+        self.assertIsNotNone(self.get_output())
 
     def test_compute_distances_apply_called(self):
         """Check compute distances and apply are called when receiving signal"""

--- a/Orange/widgets/data/tests/test_owpivot.py
+++ b/Orange/widgets/data/tests/test_owpivot.py
@@ -160,8 +160,7 @@ class TestOWPivot(WidgetTest):
                                         self.iris.domain.class_var.name)
         self.assertFalse(self.widget.Warning.cannot_aggregate.is_shown())
         # agg: Count, Majority, feature: None
-        simulate.combobox_activate_item(self.widget.controls.val_feature,
-                                        "(None)")
+        simulate.combobox_activate_index(self.widget.controls.val_feature, 0)
         self.assertTrue(self.widget.Warning.cannot_aggregate.is_shown())
         # agg: Count, Majority, feature: None, row: Continuous
         simulate.combobox_activate_item(self.widget.controls.row_feature,

--- a/Orange/widgets/data/tests/test_owpythonscript.py
+++ b/Orange/widgets/data/tests/test_owpythonscript.py
@@ -39,6 +39,7 @@ class TestOWPythonScript(WidgetTest):
         sys.last_type = sys.last_value = sys.last_traceback = None
         super().tearDown()
 
+    @WidgetTest.skipNonEnglish
     def test_inputs(self):
         """Check widget's inputs"""
         for input_, data in (("Data", self.iris),
@@ -53,6 +54,7 @@ class TestOWPythonScript(WidgetTest):
             self.send_signal(input_, Input.Closed, 1)
             self.assertEqual(getattr(self.widget, input_.lower()), [])
 
+    @WidgetTest.skipNonEnglish
     def test_outputs(self):
         """Check widget's outputs"""
         for signal, data in (
@@ -104,6 +106,7 @@ class TestOWPythonScript(WidgetTest):
     def test_owns_errors(self):
         self.assertIsNot(self.widget.Error, OWWidget.Error)
 
+    @WidgetTest.skipNonEnglish
     def test_multiple_signals(self):
         click = self.widget.execute_button.click
         console_locals = self.widget.console.locals

--- a/Orange/widgets/data/tests/test_owrank.py
+++ b/Orange/widgets/data/tests/test_owrank.py
@@ -140,12 +140,12 @@ class TestOWRank(WidgetTest):
             with self.subTest(fitter=fitter),\
                     warnings.catch_warnings():
                 warnings.filterwarnings("ignore", ".*", ConvergenceWarning)
-                self.send_signal("Scorer", fitter, 1)
+                self.send_signal(self.widget.Inputs.scorer, fitter, 1)
 
                 for data in (self.housing,
                              heart_disease):
                     with self.subTest(data=data.name):
-                        self.send_signal('Data', data)
+                        self.send_signal(self.widget.Inputs.data, data)
                         self.wait_until_finished()
                         scores = [model.data(model.index(row, model.columnCount() - 1))
                                   for row in range(model.rowCount())]
@@ -156,7 +156,7 @@ class TestOWRank(WidgetTest):
                             model.columnCount() - 1, Qt.Horizontal).lower()
                         self.assertIn(name, last_column)
 
-                self.send_signal("Scorer", None, 1)
+                self.send_signal(self.widget.Inputs.scorer, None, 1)
                 self.assertEqual(self.widget.scorers, [])
 
     def test_input_scorer_disconnect(self):

--- a/Orange/widgets/data/tests/test_owsave.py
+++ b/Orange/widgets/data/tests/test_owsave.py
@@ -315,6 +315,7 @@ class TestOWSave(OWSaveTestBase):
                 else:
                     self.assertFalse(items["Type annotations"], msg=msg)
 
+    @WidgetTest.skipNonEnglish
     def test_migration_to_version_2(self):
         const_settings = {
             'add_type_annotations': True, 'auto_save': False,

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -356,9 +356,10 @@ class TestOWSelectRows(WidgetTest):
 
         self.enterFilter(data.domain["c2"], "is defined")
         self.assertFalse(self.widget.Error.parsing_error.is_shown())
-        self.assertEqual(len(self.get_output("Matching Data")), 3)
-        self.assertEqual(len(self.get_output("Unmatched Data")), 1)
-        self.assertEqual(len(self.get_output("Data")), len(data))
+        outputs = self.widget.Outputs
+        self.assertEqual(len(self.get_output(outputs.matching_data)), 3)
+        self.assertEqual(len(self.get_output(outputs.unmatched_data)), 1)
+        self.assertEqual(len(self.get_output(outputs.annotated_data)), len(data))
 
         # Test saving of settings
         self.widget.settingsHandler.pack_data(self.widget)
@@ -373,14 +374,15 @@ class TestOWSelectRows(WidgetTest):
         self.send_signal(self.widget.Inputs.data, data)
 
         self.enterFilter(data.domain[0], "is below", "-1")
-        self.assertIsNone(self.get_output("Matching Data"))
-        self.assertEqual(len(self.get_output("Unmatched Data")), len_data)
-        self.assertEqual(len(self.get_output("Data")), len_data)
+        outputs = self.widget.Outputs
+        self.assertIsNone(self.get_output(outputs.matching_data))
+        self.assertEqual(len(self.get_output(outputs.unmatched_data)), len_data)
+        self.assertEqual(len(self.get_output(outputs.annotated_data)), len_data)
         self.widget.remove_all_button.click()
         self.enterFilter(data.domain[0], "is below", "10")
-        self.assertIsNone(self.get_output("Unmatched Data"))
-        self.assertEqual(len(self.get_output("Matching Data")), len_data)
-        self.assertEqual(len(self.get_output("Data")), len_data)
+        self.assertIsNone(self.get_output(outputs.unmatched_data))
+        self.assertEqual(len(self.get_output(outputs.matching_data)), len_data)
+        self.assertEqual(len(self.get_output(outputs.annotated_data)), len_data)
 
     def test_annotated_data(self):
         iris = Table("iris")
@@ -441,14 +443,15 @@ class TestOWSelectRows(WidgetTest):
 
         # first displayed date is min date
         self.assertEqual(value_combo.date(), QDate(2014, 1, 23))
-        self.assertEqual(len(self.get_output("Matching Data")), 691)
+        outputs = self.widget.Outputs
+        self.assertEqual(len(self.get_output(outputs.matching_data)), 691)
         self.widget.remove_all_button.click()
         self.enterFilter("Date_Posted_or_Updated", "is below",
                          QDate(2014, 4, 17))
-        self.assertEqual(len(self.get_output("Matching Data")), 840)
+        self.assertEqual(len(self.get_output(outputs.matching_data)), 840)
         self.enterFilter("Date_Posted_or_Updated", "is greater than",
                          QDate(2014, 6, 30))
-        self.assertIsNone(self.get_output("Matching Data"))
+        self.assertIsNone(self.get_output(outputs.matching_data))
         self.widget.remove_all_button.click()
         # date is in range min-max date
         self.enterFilter("Date_Posted_or_Updated", "equals", QDate(2013, 1, 1))
@@ -464,7 +467,7 @@ class TestOWSelectRows(WidgetTest):
         self.widget.remove_all_button.click()
         self.enterFilter("Date_Posted_or_Updated", "is between",
                          QDate(2014, 4, 17), QDate(2014, 4, 30))
-        self.assertEqual(len(self.get_output("Matching Data")), 58)
+        self.assertEqual(len(self.get_output(outputs.matching_data)), 58)
 
     @patch.object(owselectrows.QMessageBox, "question",
                   return_value=owselectrows.QMessageBox.Ok)

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -23,7 +23,7 @@ class TestOWDataTable(WidgetTest, WidgetOutputsTestMixin):
         WidgetOutputsTestMixin.init(cls,
                                     output_all_on_no_selection=True)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWDataTable.Inputs.data
         cls.signal_data = cls.data  # pylint: disable=no-member
 
     def setUp(self):

--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -16,7 +16,7 @@ from AnyQt.QtCore import (
     QModelIndex, pyqtSignal, QTimer,
     QItemSelectionModel, QItemSelection)
 
-from orangewidget.report import plural
+from orangecanvas.utils.localization import pl
 from orangewidget.utils.itemmodels import AbstractSortTableModel
 
 import Orange
@@ -517,7 +517,7 @@ class OWPredictions(OWWidget):
         n_predictors = len(self.predictors)
         if n_predictors:
             n_valid = len(self._non_errored_predictors())
-            details += plural("Model: {number} model{s}", n_predictors)
+            details += f"Model: {n_predictors} {pl(n_predictors, 'model')}"
             if n_valid != n_predictors:
                 details += f" ({n_predictors - n_valid} failed)"
             details += "<ul>"

--- a/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
+++ b/Orange/widgets/evaluate/tests/test_owconfusionmatrix.py
@@ -28,7 +28,7 @@ class TestOWConfusionMatrix(WidgetTest, WidgetOutputsTestMixin):
         cls.results_2_iris = cv(cls.iris, [bayes, tree])
         cls.results_2_titanic = cv(titanic, [bayes, tree])
 
-        cls.signal_name = "Evaluation Results"
+        cls.signal_name = OWConfusionMatrix.Inputs.evaluation_results
         cls.signal_data = cls.results_1_iris
         cls.same_input_output_domain = False
 

--- a/Orange/widgets/evaluate/tests/test_owliftcurve.py
+++ b/Orange/widgets/evaluate/tests/test_owliftcurve.py
@@ -167,6 +167,7 @@ class TestOWLiftCurve(WidgetTest, EvaluateTest):
         self.assertEqual(model.threshold, 0.6)
         self.assertFalse(self.widget.Information.no_output.is_shown())
 
+    @WidgetTest.skipNonEnglish
     def test_visual_settings(self):
         graph = self.widget.plot
 

--- a/Orange/widgets/evaluate/tests/test_owtestandscore.py
+++ b/Orange/widgets/evaluate/tests/test_owtestandscore.py
@@ -190,15 +190,15 @@ class TestOWTestAndScore(WidgetTest):
         )
         self.widget.n_folds = 0
         self.assertFalse(self.widget.Error.train_data_error.is_shown())
-        self.send_signal("Data", table)
-        self.send_signal("Learner", MajorityLearner(), 0, wait=1000)
+        self.send_signal(self.widget.Inputs.train_data, table)
+        self.send_signal(self.widget.Inputs.learner, MajorityLearner(), 0, wait=1000)
         self.assertTrue(self.widget.Error.train_data_error.is_shown())
 
     def test_data_errors(self):
         """ Test all data_errors """
 
         def assertErrorShown(data, is_shown, message):
-            self.send_signal("Data", data)
+            self.send_signal(self.widget.Inputs.train_data, data)
             self.assertEqual(is_shown, self.widget.Error.train_data_error.is_shown())
             self.assertEqual(message, str(self.widget.Error.train_data_error))
 

--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -552,7 +552,7 @@ class CallFrontListView(ControlledCallFront):
         for value in values:
             index = None
             if not isinstance(value, int):
-                if isinstance(value, Variable):
+                if value is None or isinstance(value, Variable):
                     search_role = TableVariable
                 else:
                     search_role = Qt.DisplayRole

--- a/Orange/widgets/model/owrules.py
+++ b/Orange/widgets/model/owrules.py
@@ -267,7 +267,7 @@ class OWRuleLearner(OWBaseLearner):
             widget=insert_gamma_box, master=self, value="gamma", minv=0.0,
             maxv=1.0, step=0.01, label="γ:", orientation=Qt.Horizontal,
             callback=self.settings_changed, alignment=Qt.AlignRight,
-            enabled=self.storage_covers[self.covering_algorithm] == "weighted")
+            enabled=self.covering_algorithm == 1)
 
         # bottom-level search procedure (search bias)
         middle_box = gui.vBox(widget=self.controlArea, box="Rule search")
@@ -314,8 +314,7 @@ class OWRuleLearner(OWBaseLearner):
             checked="checked_parent_alpha")
 
     def settings_changed(self, *args, **kwargs):
-        self.gamma_spin.setDisabled(
-            self.storage_covers[self.covering_algorithm] != "weighted")
+        self.gamma_spin.setDisabled(self.covering_algorithm == 0)
         super().settings_changed(*args, **kwargs)
 
     def update_model(self):

--- a/Orange/widgets/model/tests/test_owcalibratedlearner.py
+++ b/Orange/widgets/model/tests/test_owcalibratedlearner.py
@@ -29,10 +29,10 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
     def test_output_learner(self):
         """Check if learner is on output after apply"""
         # Overridden to change the output type in the last test
-        initial = self.get_output("Learner")
+        initial = self.get_output(self.widget.Outputs.learner)
         self.assertIsNotNone(initial, "Does not initialize the learner output")
         self.click_apply()
-        newlearner = self.get_output("Learner")
+        newlearner = self.get_output(self.widget.Outputs.learner)
         self.assertIsNot(initial, newlearner,
                          "Does not send a new learner instance on `Apply`.")
         self.assertIsNotNone(newlearner)
@@ -46,7 +46,7 @@ class TestOWCalibratedLearner(WidgetTest, WidgetLearnerTestMixin):
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.click_apply()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.send_signal('Data', self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.click_apply()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)

--- a/Orange/widgets/model/tests/test_owlogisticregression.py
+++ b/Orange/widgets/model/tests/test_owlogisticregression.py
@@ -57,7 +57,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
     def test_output_coefficients(self):
         """Check if coefficients are on output after apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.coefficients))
-        self.send_signal("Data", self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.click_apply()
         self.assertIsInstance(self.get_output(self.widget.Outputs.coefficients), Table)
 
@@ -73,7 +73,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
                             np.arange(120, 140, dtype=int)))]
         for case in cases:
             data = table[case, :]
-            self.send_signal("Data", data)
+            self.send_signal(self.widget.Inputs.data, data)
             self.click_apply()
 
     def test_coefficients_one_value(self):
@@ -93,7 +93,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
                 [0., 1.],
                 ["yes", "no"]))
         )
-        self.send_signal("Data", table)
+        self.send_signal(self.widget.Inputs.data, table)
         self.click_apply()
         coef = self.get_output(self.widget.Outputs.coefficients)
         self.assertEqual(coef.domain[0].name, "no")
@@ -107,16 +107,16 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         table = Table("iris")
         with table.unlocked():
             table.Y[:5] = np.NaN
-        self.send_signal("Data", table)
-        coef1 = self.get_output("Coefficients")
+        self.send_signal(self.widget.Inputs.data, table)
+        coef1 = self.get_output(self.widget.Outputs.coefficients)
         table = table[5:]
-        self.send_signal("Data", table)
-        coef2 = self.get_output("Coefficients")
+        self.send_signal(self.widget.Inputs.data, table)
+        coef2 = self.get_output(self.widget.Outputs.coefficients)
         self.assertTrue(np.array_equal(coef1, coef2))
 
     def test_class_weights(self):
         table = Table("iris")
-        self.send_signal("Data", table)
+        self.send_signal(self.widget.Inputs.data, table)
         self.assertFalse(self.widget.class_weight)
         self.widget.controls.class_weight.setChecked(True)
         self.assertTrue(self.widget.class_weight)

--- a/Orange/widgets/model/tests/test_owrandomforest.py
+++ b/Orange/widgets/model/tests/test_owrandomforest.py
@@ -51,7 +51,7 @@ class TestOWRandomForest(WidgetTest, WidgetLearnerTestMixin):
 
     def test_class_weights(self):
         table = Table("iris")
-        self.send_signal("Data", table)
+        self.send_signal(self.widget.Inputs.data, table)
         self.assertFalse(self.widget.class_weight)
         self.widget.controls.class_weight.setChecked(True)
         self.assertTrue(self.widget.class_weight)

--- a/Orange/widgets/model/tests/test_owrulesclassification.py
+++ b/Orange/widgets/model/tests/test_owrulesclassification.py
@@ -113,10 +113,10 @@ class TestOWRulesClassification(WidgetTest, WidgetLearnerTestMixin):
         with data.unlocked():
             data.X = sparse.csr_matrix(data.X)
         self.assertTrue(sparse.issparse(data.X))
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         self.click_apply()
         self.assertTrue(self.widget.Error.sparse_not_supported.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.click_apply()
         self.assertFalse(self.widget.Error.sparse_not_supported.is_shown())
 
@@ -130,13 +130,13 @@ class TestOWRulesClassification(WidgetTest, WidgetLearnerTestMixin):
         with unittest.mock.patch(
             "Orange.widgets.model.owrules.CustomRuleLearner.__call__",
             side_effect=MemoryError):
-            self.send_signal("Data", data)
+            self.send_signal(self.widget.Inputs.data, data)
             self.assertTrue(self.widget.Error.out_of_memory.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.out_of_memory.is_shown())
 
     def test_default_rule(self):
         data = Table("zoo")
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         self.click_apply()
         self.assertEqual(sum(self.widget.model.rule_list[-1].curr_class_dist.tolist()), len(data))

--- a/Orange/widgets/model/tests/test_owstack.py
+++ b/Orange/widgets/model/tests/test_owstack.py
@@ -15,19 +15,19 @@ class TestOWStackedLearner(WidgetTest):
     def test_input_data(self):
         """Check widget's data with data on the input"""
         self.assertEqual(self.widget.data, None)
-        self.send_signal("Data", self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.assertEqual(self.widget.data, self.data)
         self.wait_until_stop_blocking()
 
     def test_output_learner(self):
         """Check if learner is on output after apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.send_signal("Learners", LogisticRegressionLearner(), 0)
+        self.send_signal(self.widget.Inputs.learners, LogisticRegressionLearner(), 0)
         self.widget.apply_button.button.clicked.emit()
-        initial = self.get_output("Learner")
+        initial = self.get_output(self.widget.Outputs.learner)
         self.assertIsNotNone(initial, "Does not initialize the learner output")
         self.widget.apply_button.button.clicked.emit()
-        newlearner = self.get_output("Learner")
+        newlearner = self.get_output(self.widget.Outputs.learner)
         self.assertIsNot(initial, newlearner,
                          "Does not send a new learner instance on `Apply`.")
         self.assertIsNotNone(newlearner)
@@ -36,10 +36,10 @@ class TestOWStackedLearner(WidgetTest):
     def test_output_model(self):
         """Check if model is on output after sending data and apply"""
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.send_signal("Learners", LogisticRegressionLearner(), 0)
+        self.send_signal(self.widget.Inputs.learners, LogisticRegressionLearner(), 0)
         self.widget.apply_button.button.clicked.emit()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.send_signal('Data', self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.widget.apply_button.button.clicked.emit()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)

--- a/Orange/widgets/model/tests/test_owsvm.py
+++ b/Orange/widgets/model/tests/test_owsvm.py
@@ -95,10 +95,10 @@ class TestOWSVMClassification(WidgetTest, WidgetLearnerTestMixin):
     def test_sparse_warning(self):
         """Check if the user is warned about sparse input"""
         data = Table("iris")
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         self.assertFalse(self.widget.Warning.sparse_data.is_shown())
 
         with data.unlocked():
             data.X = csr_matrix(data.X)
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         self.assertTrue(self.widget.Warning.sparse_data.is_shown())

--- a/Orange/widgets/model/tests/test_tree.py
+++ b/Orange/widgets/model/tests/test_tree.py
@@ -47,11 +47,11 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         GH-2430
         """
         table1 = Table("iris")
-        self.send_signal("Data", table1)
-        model_dense = self.get_output("Model")
+        self.send_signal(self.widget.Inputs.data, table1)
+        model_dense = self.get_output(self.widget.Outputs.model)
         table2 = Table("iris").to_sparse()
-        self.send_signal("Data", table2)
-        model_sparse = self.get_output("Model")
+        self.send_signal(self.widget.Inputs.data, table2)
+        model_sparse = self.get_output(self.widget.Outputs.model)
         self.assertTrue(np.array_equal(model_dense._code, model_sparse._code))
         self.assertTrue(np.array_equal(model_dense._values, model_sparse._values))
 
@@ -61,10 +61,10 @@ class TestOWClassificationTree(WidgetTest, WidgetLearnerTestMixin):
         GH-2497
         """
         table1 = Table("housing")
-        self.send_signal("Data", table1)
-        model_dense = self.get_output("Model")
+        self.send_signal(self.widget.Inputs.data, table1)
+        model_dense = self.get_output(self.widget.Outputs.model)
         table2 = Table("housing").to_sparse()
-        self.send_signal("Data", table2)
-        model_sparse = self.get_output("Model")
+        self.send_signal(self.widget.Inputs.data, table2)
+        model_sparse = self.get_output(self.widget.Outputs.model)
         self.assertTrue(np.array_equal(model_dense._code, model_sparse._code))
         self.assertTrue(np.array_equal(model_dense._values, model_sparse._values))

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -771,6 +771,7 @@ class ProjectionWidgetTestMixin:
         self.wait_until_finished(timeout=timeout)
         self.send_signal(self.widget.Inputs.data, table)
 
+    @WidgetTest.skipNonEnglish
     def test_visual_settings(self, timeout=DEFAULT_TIMEOUT):
         graph = self.widget.graph
         font = QFont()

--- a/Orange/widgets/tests/base.py
+++ b/Orange/widgets/tests/base.py
@@ -257,17 +257,17 @@ class WidgetLearnerTestMixin:
     def test_input_data(self):
         """Check widget's data with data on the input"""
         self.assertEqual(self.widget.data, None)
-        self.send_signal("Data", self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.assertEqual(self.widget.data, self.data)
         self.wait_until_stop_blocking()
 
     def test_input_data_disconnect(self):
         """Check widget's data and model after disconnecting data from input"""
-        self.send_signal("Data", self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.assertEqual(self.widget.data, self.data)
         self.click_apply()
         self.wait_until_stop_blocking()
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.wait_until_stop_blocking()
         self.assertEqual(self.widget.data, None)
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
@@ -275,19 +275,19 @@ class WidgetLearnerTestMixin:
     def test_input_data_learner_adequacy(self):
         """Check if error message is shown with inadequate data on input"""
         for inadequate in self.inadequate_dataset:
-            self.send_signal("Data", inadequate)
+            self.send_signal(self.widget.Inputs.data, inadequate)
             self.click_apply()
             self.wait_until_stop_blocking()
             self.assertTrue(self.widget.Error.data_error.is_shown())
         for valid in self.valid_datasets:
-            self.send_signal("Data", valid)
+            self.send_signal(self.widget.Inputs.data, valid)
             self.wait_until_stop_blocking()
             self.assertFalse(self.widget.Error.data_error.is_shown())
 
     def test_input_preprocessor(self):
         """Check learner's preprocessors with an extra pp on input"""
         randomize = Randomize()
-        self.send_signal("Preprocessor", randomize)
+        self.send_signal(self.widget.Inputs.preprocessor, randomize)
         self.assertEqual(
             randomize, self.widget.preprocessors,
             'Preprocessor not added to widget preprocessors')
@@ -300,7 +300,7 @@ class WidgetLearnerTestMixin:
     def test_input_preprocessors(self):
         """Check multiple preprocessors on input"""
         pp_list = PreprocessorList([Randomize(), RemoveNaNColumns()])
-        self.send_signal("Preprocessor", pp_list)
+        self.send_signal(self.widget.Inputs.preprocessor, pp_list)
         self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(
@@ -310,12 +310,12 @@ class WidgetLearnerTestMixin:
     def test_input_preprocessor_disconnect(self):
         """Check learner's preprocessors after disconnecting pp from input"""
         randomize = Randomize()
-        self.send_signal("Preprocessor", randomize)
+        self.send_signal(self.widget.Inputs.preprocessor, randomize)
         self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(randomize, self.widget.preprocessors)
 
-        self.send_signal("Preprocessor", None)
+        self.send_signal(self.widget.Inputs.preprocessor, None)
         self.click_apply()
         self.wait_until_stop_blocking()
         self.assertIsNone(self.widget.preprocessors,
@@ -323,10 +323,10 @@ class WidgetLearnerTestMixin:
 
     def test_output_learner(self):
         """Check if learner is on output after apply"""
-        initial = self.get_output("Learner")
+        initial = self.get_output(self.widget.Outputs.learner)
         self.assertIsNotNone(initial, "Does not initialize the learner output")
         self.click_apply()
-        newlearner = self.get_output("Learner")
+        newlearner = self.get_output(self.widget.Outputs.learner)
         self.assertIsNot(initial, newlearner,
                          "Does not send a new learner instance on `Apply`.")
         self.assertIsNotNone(newlearner)
@@ -337,7 +337,7 @@ class WidgetLearnerTestMixin:
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
         self.click_apply()
         self.assertIsNone(self.get_output(self.widget.Outputs.model))
-        self.send_signal('Data', self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.click_apply()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
@@ -355,20 +355,21 @@ class WidgetLearnerTestMixin:
         self.widget.name_line_edit.setText(new_name)
         self.click_apply()
         self.wait_until_stop_blocking()
-        self.assertEqual(self.get_output("Learner").name, new_name)
+        self.assertEqual(self.get_output(self.widget.Outputs.learner).name,
+                         new_name)
 
     def test_output_model_name(self):
         """Check if model's name properly changes"""
         new_name = "Model Name"
         self.widget.name_line_edit.setText(new_name)
-        self.send_signal("Data", self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.click_apply()
         self.wait_until_stop_blocking()
         self.assertEqual(self.get_output(self.widget.Outputs.model).name, new_name)
 
     def test_output_model_picklable(self):
         """Check if model can be pickled"""
-        self.send_signal("Data", self.data)
+        self.send_signal(self.widget.Inputs.data, self.data)
         self.click_apply()
         self.wait_until_stop_blocking()
         model = self.get_output(self.widget.Outputs.model)
@@ -392,7 +393,7 @@ class WidgetLearnerTestMixin:
         """Check if learner's parameters are set to default (widget's) values
         """
         for dataset in self.valid_datasets:
-            self.send_signal("Data", dataset)
+            self.send_signal(self.widget.Inputs.data, dataset)
             self.click_apply()
             self.wait_until_stop_blocking()
             for parameter in self.parameters:
@@ -407,7 +408,7 @@ class WidgetLearnerTestMixin:
         # Test params on every valid dataset, since some attributes may apply
         # to only certain problem types
         for dataset in self.valid_datasets:
-            self.send_signal("Data", dataset)
+            self.send_signal(self.widget.Inputs.data, dataset)
             self.wait_until_stop_blocking()
 
             for parameter in self.parameters:
@@ -428,7 +429,9 @@ class WidgetLearnerTestMixin:
                     self.assertEqual(
                         param, value,
                         "Mismatching setting for parameter '%s'" % parameter)
-                    param = self._get_param_value(self.get_output("Learner"), parameter)
+                    param = self._get_param_value(
+                        self.get_output(self.widget.Outputs.learner),
+                        parameter)
                     self.assertEqual(
                         param, value,
                         "Mismatching setting for parameter '%s'" % parameter)
@@ -444,7 +447,7 @@ class WidgetLearnerTestMixin:
     def test_params_trigger_settings_changed(self):
         """Check that the learner gets updated whenever a param is changed."""
         for dataset in self.valid_datasets:
-            self.send_signal("Data", dataset)
+            self.send_signal(self.widget.Inputs.data, dataset)
             self.wait_until_stop_blocking()
 
             for parameter in self.parameters:
@@ -517,7 +520,7 @@ class WidgetOutputsTestMixin:
         self.wait_until_finished(timeout=timeout)
 
         # check selected data output
-        output = self.get_output("Selected Data")
+        output = self.get_output(self.widget.Outputs.selected_data)
         if self.output_all_on_no_selection:
             self.assertEqual(output, self.signal_data)
         else:
@@ -532,7 +535,7 @@ class WidgetOutputsTestMixin:
         selected_indices = self._select_data()
 
         # check selected data output
-        selected = self.get_output("Selected Data")
+        selected = self.get_output(self.widget.Outputs.selected_data)
         n_sel, n_attr = len(selected), len(self.data.domain.attributes)
         self.assertGreater(n_sel, 0)
         self.assertEqual(selected.domain == self.data.domain,
@@ -553,7 +556,7 @@ class WidgetOutputsTestMixin:
 
         # check output when data is removed
         self.send_signal(self.signal_name, None)
-        self.assertIsNone(self.get_output("Selected Data"))
+        self.assertIsNone(self.get_output(self.widget.Outputs.selected_data))
         self.assertIsNone(self.get_output(ANNOTATED_DATA_SIGNAL_NAME))
 
     def _select_data(self):

--- a/Orange/widgets/unsupervised/tests/test_owdistancemap.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancemap.py
@@ -16,7 +16,7 @@ class TestOWDistanceMap(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Distances"
+        cls.signal_name = OWDistanceMap.Inputs.distances
         cls.signal_data = Euclidean(cls.data)
 
     def setUp(self):

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -190,6 +190,7 @@ class TestOWDistanceMatrix(WidgetTest):
         self.assertEqual(header(1, Qt.Horizontal), "dd")
         self.assertEqual(header(1, Qt.Vertical), "bb")
 
+    @WidgetTest.skipNonEnglish
     def test_migrate_settings_v1_and_use_them(self):
         ind = [1, 2, 5, 6, 7, 8]
         context = Context(

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -23,7 +23,7 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         WidgetOutputsTestMixin.init(cls)
 
         cls.distances = Euclidean(cls.data)
-        cls.signal_name = "Distances"
+        cls.signal_name = OWHierarchicalClustering.Inputs.distances
         cls.signal_data = cls.distances
         cls.same_input_output_domain = False
 

--- a/Orange/widgets/unsupervised/tests/test_owmds.py
+++ b/Orange/widgets/unsupervised/tests/test_owmds.py
@@ -26,7 +26,7 @@ class TestOWMDS(WidgetTest, ProjectionWidgetTestMixin,
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Distances"
+        cls.signal_name = OWMDS.Inputs.distances
         cls.signal_data = Euclidean(cls.data)
         cls.same_input_output_domain = False
 
@@ -136,7 +136,7 @@ class TestOWMDS(WidgetTest, ProjectionWidgetTestMixin,
         """
         signal_data = Euclidean(self.data, axis=0)
         signal_data.row_items = None
-        self.send_signal("Distances", signal_data)
+        self.send_signal(self.widget.Inputs.distances, signal_data)
 
     def test_distances_without_data_1(self):
         """
@@ -145,7 +145,7 @@ class TestOWMDS(WidgetTest, ProjectionWidgetTestMixin,
         """
         signal_data = Euclidean(self.data, axis=1)
         signal_data.row_items = None
-        self.send_signal("Distances", signal_data)
+        self.send_signal(self.widget.Inputs.distances, signal_data)
 
     def test_small_data(self):
         data = self.data[:1]

--- a/Orange/widgets/unsupervised/tests/test_owmds.py
+++ b/Orange/widgets/unsupervised/tests/test_owmds.py
@@ -159,6 +159,7 @@ class TestOWMDS(WidgetTest, ProjectionWidgetTestMixin,
         self.widget.initialization = 0
         self.widget._OWMDS__invalidate_embedding()  # pylint: disable=protected-access
 
+    @WidgetTest.skipNonEnglish
     def test_migrate_settings_from_version_1(self):
         context_settings = [
             Context(attributes={'iris': 1,

--- a/Orange/widgets/unsupervised/tests/test_owtsne.py
+++ b/Orange/widgets/unsupervised/tests/test_owtsne.py
@@ -33,7 +33,7 @@ class TestOWtSNE(WidgetTest, ProjectionWidgetTestMixin, WidgetOutputsTestMixin):
         WidgetOutputsTestMixin.init(cls)
         cls.same_input_output_domain = False
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWtSNE.Inputs.data
         cls.signal_data = cls.data
 
     def setUp(self):

--- a/Orange/widgets/utils/tests/test_concurrent_example.py
+++ b/Orange/widgets/utils/tests/test_concurrent_example.py
@@ -19,7 +19,7 @@ class TestOWConcurrentWidget(WidgetTest, ProjectionWidgetTestMixin,
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWConcurrentWidget.Inputs.data
         cls.signal_data = cls.data
         cls.same_input_output_domain = False
 

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -39,9 +39,9 @@ class TestOWBaseLearner(WidgetTest):
             auto_apply = True
 
         self.widget = self.create_widget(OWFailingLearner)
-        self.send_signal("Data", self.iris)
+        self.send_signal(self.widget.Inputs.data, self.iris)
         self.assertTrue(self.widget.Error.fitting_failed.is_shown())
-        self.send_signal("Data", None)
+        self.send_signal(self.widget.Inputs.data, None)
         self.assertFalse(self.widget.Error.fitting_failed.is_shown())
 
     def test_subclasses_do_not_share_outputs(self):

--- a/Orange/widgets/utils/tests/test_owlearnerwidget.py
+++ b/Orange/widgets/utils/tests/test_owlearnerwidget.py
@@ -68,6 +68,7 @@ class TestOWBaseLearner(WidgetTest):
         self.assertEqual(WidgetA.Outputs.learner.type, KNNLearner)
         self.assertFalse(hasattr(WidgetA.Outputs, "test"))
 
+    @WidgetTest.skipNonEnglish
     def test_send_backward_compatibility(self):
         class WidgetA(OWBaseLearner):
             name = "A"

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from Orange.data import Table, Domain, StringVariable, ContinuousVariable, \
     DiscreteVariable, TimeVariable
+from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.state_summary import format_summary_details, \
     format_multiple_summaries
 
@@ -102,6 +103,7 @@ def make_table(attributes, target=None, metas=None):
 
 
 class TestUtils(unittest.TestCase):
+    @WidgetTest.skipNonEnglish
     def test_details(self):
         """Check if details part of the summary is formatted correctly"""
         data = Table('zoo')
@@ -196,6 +198,7 @@ class TestUtils(unittest.TestCase):
         data = None
         self.assertEqual('', format_summary_details(data))
 
+    @WidgetTest.skipNonEnglish
     def test_multiple_summaries(self):
         data = Table('zoo')
         extra_data = Table('zoo')[20:]

--- a/Orange/widgets/visualize/tests/test_owbarplot.py
+++ b/Orange/widgets/visualize/tests/test_owbarplot.py
@@ -308,6 +308,7 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, None)
         self.widget.report_button.click()
 
+    @WidgetTest.skipNonEnglish
     def test_visual_settings(self):
         graph = self.widget.graph
         font = QFont()

--- a/Orange/widgets/visualize/tests/test_owbarplot.py
+++ b/Orange/widgets/visualize/tests/test_owbarplot.py
@@ -21,7 +21,7 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWBarPlot.Inputs.data
         cls.signal_data = cls.data
         cls.titanic = Table("titanic")
         cls.housing = Table("housing")

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -26,7 +26,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         cls.titanic = Table("titanic")
         cls.heart = Table("heart_disease")
         cls.data = cls.iris
-        cls.signal_name = "Data"
+        cls.signal_name = OWBoxPlot.Inputs.data
         cls.signal_data = cls.data
 
     def setUp(self):
@@ -86,7 +86,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         # This is a test and does it at its own risk:
         # pylint: disable=protected-access
         data.domain.attributes[1]._values = []
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         self.widget.controls.order_by_importance.setChecked(True)
         self._select_list_items(self.widget.attr_list)
         self._select_list_items(self.widget.group_list)
@@ -100,7 +100,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         # This is a test and does it at its own risk:
         # pylint: disable=protected-access
         data.domain.attributes[1]._values = []
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         self._select_list_items(self.widget.attr_list)
         self._select_list_items(self.widget.group_list)
 
@@ -131,7 +131,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
 
 
         data = self.titanic
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
 
         select_group(2)  # First attribute
 
@@ -149,7 +149,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
                          ['sex', 'status', 'age', 'survived'])
 
         data = self.heart
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         select_group(1)  # Class
         order_check.setChecked(True)
         self.assertEqual(self.model_order(model),
@@ -182,7 +182,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
                 attr_selection.ClearAndSelect)
 
         data = self.titanic
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
 
         select_attr(1)  # First attribute
 
@@ -202,7 +202,7 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
                          ['None', 'sex', 'status', 'age', 'survived'])
 
         data = self.heart
-        self.send_signal("Data", data)
+        self.send_signal(self.widget.Inputs.data, data)
         select_attr(0)  # Class
         self.assertIsNone(groups[0])
         self.assertEqual(self.model_order(model),

--- a/Orange/widgets/visualize/tests/test_owfreeviz.py
+++ b/Orange/widgets/visualize/tests/test_owfreeviz.py
@@ -22,7 +22,7 @@ class TestOWFreeViz(WidgetTest, AnchorProjectionWidgetTestMixin,
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWFreeViz.Inputs.data
         cls.signal_data = cls.data
         cls.same_input_output_domain = False
         cls.heart_disease = Table("heart_disease")

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -29,7 +29,7 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWHeatMap.Inputs.data
         cls.signal_data = cls.data
 
     def setUp(self):

--- a/Orange/widgets/visualize/tests/test_owlinearprojection.py
+++ b/Orange/widgets/visualize/tests/test_owlinearprojection.py
@@ -25,7 +25,7 @@ class TestOWLinearProjection(WidgetTest, AnchorProjectionWidgetTestMixin,
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWLinearProjection.Inputs.data
         cls.signal_data = cls.data
         cls.same_input_output_domain = False
 

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -327,6 +327,7 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
             self.send_signal(self.widget.Inputs.data, self.titanic)
             commit.assert_called()
 
+    @WidgetTest.skipNonEnglish
     def test_visual_settings(self, timeout=DEFAULT_TIMEOUT):
         graph = self.widget.graph
         font = QFont()

--- a/Orange/widgets/visualize/tests/test_owlineplot.py
+++ b/Orange/widgets/visualize/tests/test_owlineplot.py
@@ -70,7 +70,7 @@ class TestOWLinePLot(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWLinePlot.Inputs.data
         cls.signal_data = cls.data
 
     def setUp(self):

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -20,7 +20,7 @@ class TestOWMosaicDisplay(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWMosaicDisplay.Inputs.data
         cls.signal_data = cls.data
 
     def setUp(self):
@@ -451,7 +451,7 @@ class MosaicVizRankTests(WidgetTest):
             else:
                 self.assertEqual(color, str(discrete_data.domain.class_var))
 
-            output = self.get_output("Data")
+            output = self.get_output(self.widget.Outputs.annotated_data)
             self.assertEqual(output.domain.class_var, table.domain.class_var)
 
             for ma in range(i == 0, 7):

--- a/Orange/widgets/visualize/tests/test_owprojectionwidget.py
+++ b/Orange/widgets/visualize/tests/test_owprojectionwidget.py
@@ -169,7 +169,7 @@ class TestOWDataProjectionWidget(WidgetTest, ProjectionWidgetTestMixin,
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = TestableDataProjectionWidget.Inputs.data
         cls.signal_data = cls.data
         cls.same_input_output_domain = False
 

--- a/Orange/widgets/visualize/tests/test_owpythagorastree.py
+++ b/Orange/widgets/visualize/tests/test_owpythagorastree.py
@@ -104,7 +104,7 @@ class TestOWPythagorasTree(WidgetTest, WidgetOutputsTestMixin):
         cls.model = tree(cls.data)
         cls.model.instances = cls.data
 
-        cls.signal_name = "Tree"
+        cls.signal_name = OWPythagorasTree.Inputs.tree
         cls.signal_data = cls.model
 
         # Set up for widget tests

--- a/Orange/widgets/visualize/tests/test_owradviz.py
+++ b/Orange/widgets/visualize/tests/test_owradviz.py
@@ -19,7 +19,7 @@ class TestOWRadviz(WidgetTest, AnchorProjectionWidgetTestMixin,
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWRadviz.Inputs.data
         cls.signal_data = cls.data
         cls.same_input_output_domain = False
         cls.heart_disease = Table("heart_disease")

--- a/Orange/widgets/visualize/tests/test_owruleviewer.py
+++ b/Orange/widgets/visualize/tests/test_owruleviewer.py
@@ -21,7 +21,7 @@ class TestOWRuleViewer(WidgetTest, WidgetOutputsTestMixin):
         # the Rules widget does. We simulate the model we get from the widget.
         cls.classifier.instances = cls.titanic
 
-        cls.signal_name = "Classifier"
+        cls.signal_name = OWRuleViewer.Inputs.classifier
         cls.signal_data = cls.classifier
         cls.data = cls.titanic
 

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -30,7 +30,7 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         WidgetOutputsTestMixin.init(cls)
         cls.same_input_output_domain = False
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWScatterPlot.Inputs.data
         cls.signal_data = cls.data
 
     def setUp(self):

--- a/Orange/widgets/visualize/tests/test_owsieve.py
+++ b/Orange/widgets/visualize/tests/test_owsieve.py
@@ -24,7 +24,7 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWSieveDiagram.Inputs.data
         cls.signal_data = cls.data
         cls.titanic = Table("titanic")
         cls.iris = Table("iris")
@@ -142,13 +142,13 @@ class TestOWSieveDiagram(WidgetTest, WidgetOutputsTestMixin):
         self.send_signal(self.widget.Inputs.data, self.iris)
         self.assertEqual(len(self.widget.discrete_data.domain.variables),
                          len(self.iris.domain.variables))
-        output = self.get_output("Data")
+        output = self.get_output(self.widget.Inputs.data)
         self.assertFalse(output.is_sparse())
 
         table = self.iris.to_sparse()
         self.send_signal(self.widget.Inputs.data, table)
         self.assertEqual(len(self.widget.discrete_data.domain.variables), 2)
-        output = self.get_output("Data")
+        output = self.get_output(self.widget.Inputs.data)
         self.assertTrue(output.is_sparse())
 
     @patch('Orange.widgets.visualize.owsieve.SieveRank.on_manual_change')

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -26,7 +26,7 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         WidgetOutputsTestMixin.init(cls)
         cls.same_input_output_domain = False
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWSilhouettePlot.Inputs.data
         cls.signal_data = cls.data
         cls.scorename = "Silhouette ({})".format(cls.data.domain.class_var.name)
 

--- a/Orange/widgets/visualize/tests/test_owtreegraph.py
+++ b/Orange/widgets/visualize/tests/test_owtreegraph.py
@@ -23,7 +23,7 @@ class TestOWTreeGraph(WidgetTest, WidgetOutputsTestMixin):
         cls.model = tree(cls.data)
         cls.model.instances = cls.data
 
-        cls.signal_name = "Tree"
+        cls.signal_name = OWTreeGraph.Inputs.tree
         cls.signal_data = cls.model
 
         # Load a dataset that contains two variables with the same entropy

--- a/Orange/widgets/visualize/tests/test_owviolinplot.py
+++ b/Orange/widgets/visualize/tests/test_owviolinplot.py
@@ -318,6 +318,7 @@ class TestOWViolinPlot(WidgetTest, WidgetOutputsTestMixin):
                                     widget=widget)
         self.assert_table_equal(selected2, selected3)
 
+    @WidgetTest.skipNonEnglish
     def test_visual_settings(self):
         graph = self.widget.graph
 

--- a/Orange/widgets/visualize/tests/test_owviolinplot.py
+++ b/Orange/widgets/visualize/tests/test_owviolinplot.py
@@ -31,7 +31,7 @@ class TestOWViolinPlot(WidgetTest, WidgetOutputsTestMixin):
         super().setUpClass()
         WidgetOutputsTestMixin.init(cls)
 
-        cls.signal_name = "Data"
+        cls.signal_name = OWViolinPlot.Inputs.data
         cls.signal_data = cls.data
         cls.housing = Table("housing")
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - chardet >=3.0.2
     - xlrd >=1.2.0
     - xlsxwriter
-    - anyqt >=0.1.0
+    - anyqt >=0.2.0
     - pyqt >=5.12,!=5.15.1,<6.0
     - pyqtgraph >=0.13.1
     - joblib >=1.0.0
@@ -60,8 +60,8 @@ requirements:
     - openTSNE >=0.6.1,!=0.7.0
     - pandas >=1.4.0,!=1.5.0
     - pyyaml
-    - orange-canvas-core >=0.1.28,<0.2a
-    - orange-widget-base >=4.19.0
+    - orange-canvas-core >=0.1.30,<0.2a
+    - orange-widget-base >=4.20.0
     - openpyxl
     - httpx >=0.21
     - baycomp >=1.0.2

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,7 +1,7 @@
-orange-canvas-core>=0.1.28,<0.2a
-orange-widget-base>=4.19.0
+orange-canvas-core>=0.1.30,<0.2a
+orange-widget-base>=4.20.0
 
-AnyQt>=0.1.0
+AnyQt>=0.2.0
 
 pyqtgraph>=0.13.1
 matplotlib>=3.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -40,9 +40,9 @@ deps =
     latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
-    oldest: orange-canvas-core==0.1.28
-    oldest: orange-widget-base==4.19.0
-    oldest: AnyQt==0.1.0
+    oldest: orange-canvas-core==0.1.30
+    oldest: orange-widget-base==4.20.0
+    oldest: AnyQt==0.2.0
     oldest: pyqtgraph>=0.13.1
     oldest: matplotlib==3.2.0
     oldest: qtconsole==4.7.2


### PR DESCRIPTION
##### Issue

Tests on translated Orange fail.

##### Description of changes

- Don't refer to signals by their user-readable names (e.g. `"Data"`); use the more "modern" form, (e.g. `widget.Inputs.data`).
- Decorate tests that are too difficult to translate with `skipNonEnglish`

There was also a bug in listview's callfront that would bite us eventually: placeholder was handled correctly only if it was named "None".

##### Includes
- [X] Code changes
- [X] Test changes
