### PR TITLE
widgets.data.utils.tableview: Fix failing test when disconnecting corner button

### DIFF
--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -62,6 +62,10 @@ class DataTableView(TableView):
         self.__cornerButton = btn = self.findChild(QAbstractButton)
         self.__cornerButtonFilter = DataTableView.__CornerPainter(self)
         btn.installEventFilter(self.__cornerButtonFilter)
+        # Remove default connection for corner button.
+        # Sometimes no signal is connected, so we first add a dummy connection
+        # to prevent disconnect from failing.
+        btn.clicked.connect(lambda _: None)
         btn.disconnect()
         btn.clicked.connect(self.cornerButtonClicked)
         if sys.platform == "darwin":

--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -62,11 +62,7 @@ class DataTableView(TableView):
         self.__cornerButton = btn = self.findChild(QAbstractButton)
         self.__cornerButtonFilter = DataTableView.__CornerPainter(self)
         btn.installEventFilter(self.__cornerButtonFilter)
-        # Remove default connection for corner button.
-        # Sometimes no signal is connected, so we first add a dummy connection
-        # to prevent disconnect from failing.
-        btn.clicked.connect(lambda _: None)
-        btn.disconnect()
+        btn.clicked.disconnect(self.selectAll)
         btn.clicked.connect(self.cornerButtonClicked)
         if sys.platform == "darwin":
             btn.setAttribute(Qt.WA_MacSmallSize)


### PR DESCRIPTION
##### Issue

After merging #6346, tests sometimes fail with
https://github.com/biolab/orange3/actions/runs/4577138548/jobs/8085131305#step:8:7161 - if they get this far. In #6346, we haven't seen this because they crashed earlier. I've seen this on all OSs, and on PyQt5 and 6.

`QObject.disconnect()` (https://github.com/baoboa/pyqt5/blob/11d5f43bc6f213d9d60272f3954a0048569cfc7c/qpy/QtCore/qpycore_pyqtboundsignal.cpp#L535)  is failing on `false` result from `QObject::disconnect()`. The latter returns `false` for wrong combinations of argument (https://github.com/qt/qtbase/blob/46b483ace0248bec349e3c2e87736f717510d400/src/corelib/kernel/qobject.cpp#L3104), which should not be the case here, or when no signals were disconnected (https://github.com/qt/qtbase/blob/46b483ace0248bec349e3c2e87736f717510d400/src/corelib/kernel/qobject.cpp#L3149). 

Based on this, I assume that button is not connected. I don't know why; `QTableView`'s constructor connects it (https://github.com/openwebos/qt/blob/master/src/gui/itemviews/qtableview.cpp#L632). I haven't seen any `disconnect`.

##### Description of changes

Connect a dummy signal, so disconnect does not fail when no signals are connected.