### PR TITLE
[ENH] Select Columns: Accept partially correct drops

### DIFF
--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -63,7 +63,7 @@ class VariablesListItemModel(VariableListModel):
         return flags
 
     @staticmethod
-    def supportedDropActions():
+    def supportedDropActions():  # pylint: disable=arguments-differ
         return Qt.MoveAction  # pragma: no cover
 
     @staticmethod
@@ -177,7 +177,10 @@ class PrimitivesView(SelectedVarsView):
         return True
 
 
+# It is, what it is (and should be), pylint: disable=invalid-name
 class SelectAttributesDomainContextHandler(DomainContextHandler):
+    # Context handler's methods have variable arguments,
+    # pylint: disable=arguments-differ,keyword-arg-before-vararg
     def encode_setting(self, context, setting, value):
         if setting.name == 'domain_role_hints':
             value = {(var.name, vartype(var)): role_i

--- a/Orange/widgets/data/tests/test_owselectcolumns.py
+++ b/Orange/widgets/data/tests/test_owselectcolumns.py
@@ -26,6 +26,7 @@ Continuous = vartype(ContinuousVariable("c"))
 Discrete = vartype(DiscreteVariable("d"))
 
 
+# It is, what it is (and should be), pylint: disable=invalid-name
 class TestSelectAttributesDomainContextHandler(TestCase):
     def setUp(self):
         self.domain = Domain(
@@ -45,6 +46,7 @@ class TestSelectAttributesDomainContextHandler(TestCase):
         self.handler.read_defaults = lambda: None
 
     def test_open_context(self):
+        # Why not? pylint: disable=use-dict-literal
         self.handler.bind(SimpleWidget)
         context = Mock(
             attributes=self.args[1], metas=self.args[2], values=dict(
@@ -72,6 +74,7 @@ class TestSelectAttributesDomainContextHandler(TestCase):
                           domain['c2']: ('class', 0)})
 
     def test_open_context_with_imperfect_match(self):
+        # Why not? pylint: disable=use-dict-literal
         self.handler.bind(SimpleWidget)
         context1 = Mock(values=dict(
             domain_role_hints=({('d1', Discrete): ('attribute', 0),


### PR DESCRIPTION
##### Issue

Fixes #5897.

Drag & Drop between VariablesListViews rejects drops that contain any variables of unacceptable type.

##### Description of changes

- Reimplement drag procedure to accept partially correct drops.
- Same for buttons: the are enabled if there is anything to move, and move only what they may

##### Includes
- [X] Code changes
- [x] Tests
- N/A: Documentation
