### PR TITLE
[MNT] CI: Update/replace obsolete ubuntu-18.04 runners

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: False
       matrix:
         python: [3.9]
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
             python-version: '3.10'
             tox_env: orange-latest
             name: Latest
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
             tox_env: orange-oldest
             name: Oldest dependencies


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

ubuntu-18.04 actions runners are deprecated

##### Description of changes

replace obsolete ubuntu-18.04 runners

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
