### PR TITLE
Pin pandas to <2

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -58,7 +58,7 @@ requirements:
     - requests
     - matplotlib-base >=3.2.0
     - openTSNE >=0.6.1,!=0.7.0
-    - pandas >=1.4.0,!=1.5.0
+    - pandas >=1.4.0,!=1.5.0,<2
     - pyyaml
     - orange-canvas-core >=0.1.30,<0.2a
     - orange-widget-base >=4.20.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -22,7 +22,7 @@ python-louvain>=0.13
 requests
 openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
 baycomp>=1.0.2
-pandas>=1.4.0,!=1.5.0
+pandas>=1.4.0,!=1.5.0,<2
 pyyaml
 openpyxl
 httpx>=0.21.0

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,8 @@ deps =
     -r {toxinidir}/requirements-opt.txt
     coverage
     psycopg2-binary
+    # we should unpin this someday, but must fix backward incompatibilities first
+    pandas<2
     # no wheels for mac
     pymssql<3.0;platform_system!='Darwin' and python_version<'3.8'
     latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph


### PR DESCRIPTION
##### Issue

Temporary alternative to #6395.

Pandas 2 includes too many backward incompatibilities, in particular related to datetime, which we use heavily. Hence it'd be wise to pin in at least before release.
