### PR TITLE
Annotate graph_name with graph's types

### DIFF
--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -765,7 +765,7 @@ class OWPaintData(OWWidget):
     labels = Setting(["C1", "C2"], schema_only=True)
 
     buttons_area_orientation = Qt.Vertical
-    graph_name = "plot"
+    graph_name = "plot"  # pg.GraphicsItem (pg.PlotItem)
 
     class Warning(OWWidget.Warning):
         no_input_variables = Msg("Input data has no variables")

--- a/Orange/widgets/evaluate/owcalibrationplot.py
+++ b/Orange/widgets/evaluate/owcalibrationplot.py
@@ -137,7 +137,7 @@ class OWCalibrationPlot(widget.OWWidget):
     visual_settings = settings.Setting({}, schema_only=True)
     auto_commit = settings.Setting(True)
 
-    graph_name = "plot"
+    graph_name = "plot"  # pg.GraphicsItem (pg.PlotItem)
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -158,7 +158,7 @@ class OWLiftCurve(widget.OWWidget):
     auto_commit = settings.Setting(True)
     visual_settings = settings.Setting({}, schema_only=True)
 
-    graph_name = "plot"
+    graph_name = "plot"  # pg.GraphicsItem (pg.PlotItem)
 
     XLabels = ("P Rate", "P Rate", "Recall")
     YLabels = ("Lift", "TP Rate", "Precision")

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -324,7 +324,7 @@ class OWROCAnalysis(widget.OWWidget):
     display_convex_hull = settings.Setting(False)
     display_convex_curve = settings.Setting(False)
 
-    graph_name = "plot"
+    graph_name = "plot"  # pg.GraphicsItem (pg.PlotItem)
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/unsupervised/owcorrespondence.py
+++ b/Orange/widgets/unsupervised/owcorrespondence.py
@@ -48,7 +48,7 @@ class OWCorrespondenceAnalysis(widget.OWWidget):
     selected_var_indices = settings.ContextSetting([])
     auto_commit = Setting(True)
 
-    graph_name = "plot.plotItem"
+    graph_name = "plot.plotItem"  # QGraphicsView (pg.PlotWidget)
 
     class Error(widget.OWWidget.Error):
         empty_data = widget.Msg("Empty dataset")

--- a/Orange/widgets/unsupervised/owdistancemap.py
+++ b/Orange/widgets/unsupervised/owdistancemap.py
@@ -296,7 +296,7 @@ class OWDistanceMap(widget.OWWidget):
 
     autocommit = settings.Setting(True)
 
-    graph_name = "grid_widget"
+    graph_name = "grid_widget" # pg.GraphicsItem (pg.GraphicsWidget)
 
     # Disable clustering for inputs bigger than this
     _MaxClustering = 25000

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -217,7 +217,7 @@ class OWHierarchicalClustering(widget.OWWidget):
 
     autocommit = settings.Setting(True)
 
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene
 
     basic_annotations = [None, "Enumeration"]
 

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -43,7 +43,7 @@ class OWPCA(widget.OWWidget):
     maxp = settings.Setting(20)
     axis_labels = settings.Setting(10)
 
-    graph_name = "plot.plotItem"
+    graph_name = "plot.plotItem"  # QGraphicsView (pg.PlotWidget -> SliderGraph)
 
     class Warning(widget.OWWidget.Warning):
         trivial_components = widget.Msg(

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -199,7 +199,7 @@ class OWSOM(OWWidget):
     pie_charts = Setting(False)
     selection = Setting(None, schema_only=True)
 
-    graph_name = "view"
+    graph_name = "view"  # QGraphicsView
 
     _grid_pen = QPen(QBrush(QColor(224, 224, 224)), 2)
     _grid_pen.setCosmetic(True)

--- a/Orange/widgets/visualize/owbarplot.py
+++ b/Orange/widgets/visualize/owbarplot.py
@@ -391,7 +391,7 @@ class OWBarPlot(OWWidget):
     visual_settings = Setting({}, schema_only=True)
 
     graph = SettingProvider(BarPlotGraph)
-    graph_name = "graph.plotItem"
+    graph_name = "graph.plotItem"  # QGraphicsView (pg.PlotWidget -> BarPlotGraph)
 
     class Error(OWWidget.Error):
         no_cont_features = Msg("Plotting requires a numeric feature.")

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -200,7 +200,7 @@ class OWBoxPlot(widget.OWWidget):
     _box_brush = QBrush(QColor(0x33, 0x88, 0xff, 0xc0))
     _attr_brush = QBrush(QColor(0x33, 0x00, 0xff))
 
-    graph_name = "box_scene"
+    graph_name = "box_scene"  # QGraphicsScene
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -287,7 +287,7 @@ class OWDistributions(OWWidget):
 
     auto_apply = settings.Setting(True)
 
-    graph_name = "plot"
+    graph_name = "plot"  # pg.GraphicsItem (pg.ViewBox)
 
     Fitters = (
         ("None", None, (), ()),

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -187,7 +187,7 @@ class OWHeatMap(widget.OWWidget):
 
     auto_commit = settings.Setting(True)
 
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene (HeatmapScene)
 
     class Information(widget.OWWidget.Information):
         sampled = Msg("Data has been sampled")

--- a/Orange/widgets/visualize/owlineplot.py
+++ b/Orange/widgets/visualize/owlineplot.py
@@ -735,7 +735,7 @@ class OWLinePlot(OWWidget):
     selection = Setting(None, schema_only=True)
     visual_settings = Setting({}, schema_only=True)
 
-    graph_name = "graph.plotItem"
+    graph_name = "graph.plotItem"  # QGraphicsScene (pg.PlotWidget -> LinePlotGraph)
 
     class Error(OWWidget.Error):
         not_enough_attrs = Msg("Need at least one numeric feature.")

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -568,7 +568,7 @@ class OWMosaicDisplay(OWWidget):
             create_annotated_table(self.data, sel_idx))
 
     def send_report(self):
-        self.report_plot(self.canvas)
+        self.report_plot()
 
     def update_graph(self):
         spacing = self.SPACING

--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -321,7 +321,7 @@ class OWMosaicDisplay(OWWidget):
                    QColor(110, 110, 255), QColor(0, 0, 255)]
     RED_COLORS = [QColor(255, 255, 255), QColor(255, 200, 200),
                   QColor(255, 100, 100), QColor(255, 0, 0)]
-    graph_name = "canvas"
+    graph_name = "canvas"  # QGraphicsScene
 
     attrs_changed_manually = Signal(list)
 

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -674,7 +674,7 @@ class OWNomogram(OWWidget):
     sort_index = Setting(SortBy.ABSOLUTE)
     cont_feature_dim_index = Setting(0)
 
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene
 
     class Error(OWWidget.Error):
         invalid_classifier = Msg("Nomogram accepts only Naive Bayes and "

--- a/Orange/widgets/visualize/owpythagorastree.py
+++ b/Orange/widgets/visualize/owpythagorastree.py
@@ -54,7 +54,7 @@ class OWPythagorasTree(OWWidget):
         annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Table)
 
     # Enable the save as feature
-    graph_name = 'scene'
+    graph_name = 'scene'  # QGraphicsScene (TreeGraphicsScene)
 
     # Settings
     settingsHandler = settings.ClassValuesContextHandler()

--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -219,9 +219,6 @@ class OWPythagoreanForest(OWWidget):
     class Outputs:
         tree = Output("Tree", TreeModel)
 
-    # Enable the save as feature
-    graph_name = 'scene'
-
     # Settings
     settingsHandler = settings.ClassValuesContextHandler()
 

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -85,7 +85,7 @@ class OWSieveDiagram(OWWidget):
         selected_data = Output("Selected Data", Table, default=True)
         annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Table)
 
-    graph_name = "canvas"
+    graph_name = "canvas"  # QGraphicsScene
 
     want_control_area = False
 

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -100,7 +100,7 @@ class OWSilhouettePlot(widget.OWWidget):
                  ("Manhattan", Orange.distance.Manhattan),
                  ("Cosine", Orange.distance.Cosine)]
 
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene
 
     class Error(widget.OWWidget.Error):
         need_two_clusters = Msg("Need at least two non-empty clusters")

--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -392,7 +392,7 @@ class OWTreeGraph(OWTreeViewer2D):
         elif self.regression_colors != self.COL_DEFAULT:
             items.append(("Color by", self.COL_OPTIONS[self.regression_colors]))
         self.report_items(items)
-        self.report_plot(self.scene)
+        self.report_plot()
 
     def update_node_info(self, node):
         if self.tree_adapter.has_children(node.node_inst) and not self.show_intermediate:

--- a/Orange/widgets/visualize/owtreeviewer2d.py
+++ b/Orange/widgets/visualize/owtreeviewer2d.py
@@ -369,7 +369,7 @@ class OWTreeViewer2D(OWWidget, openclass=True):
     _DEF_NODE_WIDTH = 24
     _DEF_NODE_HEIGHT = 20
 
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene (TreeGraphicsScene)
 
     def __init__(self):
         super().__init__()

--- a/Orange/widgets/visualize/owvenndiagram.py
+++ b/Orange/widgets/visualize/owvenndiagram.py
@@ -97,7 +97,7 @@ class OWVennDiagram(widget.OWWidget):
     selected_feature = ContextSetting(IDENTITY_STR)
 
     want_main_area = False
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene
     atr_types = ['attributes', 'metas', 'class_vars']
     atr_vals = {'metas': 'metas', 'attributes': 'X', 'class_vars': 'Y'}
     row_vals = {'attributes': 'x', 'class_vars': 'y', 'metas': 'metas'}

--- a/Orange/widgets/visualize/owviolinplot.py
+++ b/Orange/widgets/visualize/owviolinplot.py
@@ -763,7 +763,7 @@ class OWViolinPlot(OWWidget):
     selection_ranges = Setting([], schema_only=True)
     visual_settings = Setting({}, schema_only=True)
 
-    graph_name = "graph.plotItem"
+    graph_name = "graph.plotItem"  # QGraphicsView (pg.PlotWidget -> ViolinPlot)
     buttons_area_orientation = None
 
     def __init__(self):

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -387,7 +387,7 @@ class OWDataProjectionWidget(OWProjectionWidgetBase, openclass=True):
 
     GRAPH_CLASS = OWScatterPlotBase
     graph = SettingProvider(OWScatterPlotBase)
-    graph_name = "graph.plot_widget.plotItem"
+    graph_name = "graph.plot_widget.plotItem"  # pg.GraphicsItem  (pg.PlotItem)
     embedding_variables_names = ("proj-x", "proj-y")
     buttons_area_orientation = Qt.Vertical
 


### PR DESCRIPTION
##### Issue

We don't know which object types are passed to methods for reporting, saving charts and copying to clipboard.

##### Description of changes

- Added comments with one of the four types handled by `ImgFormat` (`pg.GraphicsItem`, `QGraphicsScene`, `QGraphicsView`, `QWidget`), and the actual derived type, if applicable.
- Mosaic and Tree Viewer passed the object to be plotted as an argument to `report_plot`. If `graph_name` is given, it's better to use if for `report_plot` to avoid ambiguity.