### PR TITLE
[FIX] owtable: Remove multiple connections to 'selectionFinished'

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -115,6 +115,7 @@ class OWTable(OWWidget):
         )
         view.setSortingEnabled(True)
         view.setItemDelegate(TableDataDelegate(view))
+        view.selectionFinished.connect(self.update_selection)
 
         if self.select_rows:
             view.setSelectionBehavior(QTableView.SelectRows)
@@ -225,7 +226,6 @@ class OWTable(OWWidget):
 
         # update the header (attribute names)
         self._update_variable_labels()
-        view.selectionFinished.connect(self.update_selection)
 
     def _update_input_summary(self):
         def format_summary(summary):


### PR DESCRIPTION


##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Due to bad refactoring multiple connections to selectedFinished signal were established (on each input change) leading to multiple calls to commit.

##### Description of changes

Remove multiple connections to 'selectionFinished'

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
