### PR TITLE
[FIX] tableview: Fix errors with sparse basket columns

### DIFF
--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -155,6 +155,24 @@ class TestOWTable(WidgetTest, WidgetOutputsTestMixin):
         output = self.get_output(self.widget.Outputs.selected_data)
         self.assertIs(output, self.data)
 
+    def test_sort_basket_column(self):
+        data = self.data.to_sparse()
+        self.send_signal(self.widget.Inputs.data, data)
+        self.widget.view.sortByColumn(0, Qt.AscendingOrder)
+        self.assertEqual(self.widget.stored_sort, [("iris", 1)])
+        self.widget.view.sortByColumn(1, Qt.AscendingOrder)
+        self.assertEqual(self.widget.stored_sort,
+                         [("iris", 1), ("\\BASKET(FEATURES)", 1)])
+        # test restore
+        w = self.create_widget(OWTable, stored_settings={
+            "stored_sort": self.widget.stored_sort
+        })
+        self.send_signal(w.Inputs.data, data)
+        self.assertEqual(w.stored_sort, self.widget.stored_sort)
+        output_a = self.get_output(self.widget.Outputs.selected_data)
+        output_b = self.get_output(w.Outputs.selected_data)
+        self.assertEqual(output_a.ids.tolist(), output_b.ids.tolist())
+
     def test_info(self):
         info_text = self.widget.info_text
         no_input = "No data."

--- a/Orange/widgets/data/utils/models.py
+++ b/Orange/widgets/data/utils/models.py
@@ -72,7 +72,7 @@ class RichTableModel(TableModel):
             var = super().headerData(
                 section, orientation, TableModel.VariableRole)
             if var is None:
-                return super().headerData(section, orientation, Qt.DisplayRole)
+                return []
             return [(label, var.attributes.get(label))
                     for label in self._labels]
         elif orientation == Qt.Horizontal and role == Qt.DecorationRole and \

--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -112,9 +112,7 @@ def is_table_sortable(table):
     if isinstance(table, Orange.data.sql.table.SqlTable):
         return False
     elif isinstance(table, Orange.data.Table):
-        # Dense only (due to sparse basket column).
-        return all(d == Orange.data.Table.DENSE for d in
-                   (table.X_density(), table.Y_density(), table.metas_density()))
+        return True
     else:
         return False
 

--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -112,7 +112,9 @@ def is_table_sortable(table):
     if isinstance(table, Orange.data.sql.table.SqlTable):
         return False
     elif isinstance(table, Orange.data.Table):
-        return True
+        # Dense only (due to sparse basket column).
+        return all(d == Orange.data.Table.DENSE for d in
+                   (table.X_density(), table.Y_density(), table.metas_density()))
     else:
         return False
 

--- a/Orange/widgets/data/utils/tests/test_tableview.py
+++ b/Orange/widgets/data/utils/tests/test_tableview.py
@@ -58,3 +58,12 @@ class TableViewTest(GuiTest):
         sel = [(idx.row(), idx.column()) for idx in view.selectedIndexes()]
         self.assertEqual(sorted(sel), [(0, 2), (0, 3), (1, 2), (1, 3)])
         self.assertEqual(view.blockSelection(), ([1, 2], [2, 3]))
+
+    def test_basket_column(self):
+        model = RichTableModel(self.data.to_sparse())
+        view = RichTableView()
+        view.setModel(model)
+        self.assertFalse(view.isSortingEnabled())
+        view.grab()
+        model.setRichHeaderFlags(RichTableModel.Name | RichTableModel.Labels)
+        view.grab()

--- a/Orange/widgets/data/utils/tests/test_tableview.py
+++ b/Orange/widgets/data/utils/tests/test_tableview.py
@@ -63,7 +63,5 @@ class TableViewTest(GuiTest):
         model = RichTableModel(self.data.to_sparse())
         view = RichTableView()
         view.setModel(model)
-        self.assertFalse(view.isSortingEnabled())
-        view.grab()
         model.setRichHeaderFlags(RichTableModel.Name | RichTableModel.Labels)
         view.grab()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Since #6370 errors appear in data table when a sparse basket column in on input.

When clicking 'Show variable labels':
```
Traceback (most recent call last):
  File "/home/ales/devel/orange3/Orange/widgets/data/utils/tableview.py", line 175, in __headerDataChanged
    text += "\n".join(key for key, _ in items)
  File "/home/ales/devel/orange3/Orange/widgets/data/utils/tableview.py", line 175, in <genexpr>
    text += "\n".join(key for key, _ in items)
ValueError: not enough values to unpack (expected 2, got 1)
```

When trying to sort a basket column:
````
Traceback (most recent call last):
  File "/home/ales/devel/orange3/Orange/widgets/data/owtable.py", line 341, in _on_sort_indicator_changed
    self.stored_sort.append((var.name, order))
AttributeError: 'NoneType' object has no attribute 'name'

````

##### Description of changes

Fix errors in handling sparse basket column in tableview.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
