### PR TITLE
Replace pip's codecov with codecov-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,11 +103,10 @@ jobs:
           ORANGE_TEST_DB_URI: postgres://postgres_user:postgres_password@localhost:5432/postgres_db|mssql://SA:sqlServerPassw0rd@localhost:1433
 
       - name: Upload code coverage
-        if: |
-          matrix.python-version == '3.8' && matrix.tox_env == 'orange-released'
-        run: |
-          pip install codecov
-          codecov
+        if: matrix.python-version == '3.8' && matrix.tox_env == 'orange-released'
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
 
   test_on_macos_and_windows:
     runs-on: ${{ matrix.os }}

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,8 @@ commands =
     coverage run -m unittest -v Orange.tests Orange.widgets.tests
     coverage combine
     coverage report
+    # codecov-actions wants xml report
+    coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:pyqt6]
 changedir =


### PR DESCRIPTION
##### Issue
Codecov is not available at pyp anymore

##### Description of changes
Use codecov-actions instead

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
