### PR TITLE
Add message `Table length` and `Limit`

### DIFF
--- a/Orange/widgets/data/owsql.py
+++ b/Orange/widgets/data/owsql.py
@@ -296,7 +296,8 @@ class OWSql(OWBaseSql):
                     confirm = QMessageBox(self)
                     confirm.setIcon(QMessageBox.Warning)
                     confirm.setText("Data appears to be big. Do you really "
-                                    "want to download it to local memory?")
+                                    "want to download it to local memory?\n"
+                                    "Table length: {:,}. Limit {:,}".format(table.approx_len(), MAX_DL_LIMIT))
 
                     if table.approx_len() <= MAX_DL_LIMIT:
                         confirm.addButton("Yes", QMessageBox.YesRole)


### PR DESCRIPTION
##### Issue #6046

##### Description of changes

Made a message about the limit. Database table length and actual limit

Now the message looks like this:
```
Data appears to be big. Do you really want to download it to local memory?
Table length: 1,000,100. Limit 1,000,000
```

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
