### PR TITLE
[FIX] SOM: Store selection Settings in list instead of np.ndarray

### DIFF
--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -543,24 +543,29 @@ class TestOWSOM(WidgetTest):
         m = selm((0, 0)).astype(int)
         widget.on_selection_change(selm((0, 0)))
         np.testing.assert_equal(widget.selection, m)
+        self.assertIsInstance(widget.selection, list)
         widget.redraw_selection.assert_called_once()
         widget.update_output.assert_called_once()
 
         m = selm((0, 1)).astype(int)
         widget.on_selection_change(selm((0, 1)))
         np.testing.assert_equal(widget.selection, m)
+        self.assertIsInstance(widget.selection, list)
 
         m[0, 0] = 1
         widget.on_selection_change(selm((0, 0)), SomView.SelectionAddToGroup)
         np.testing.assert_equal(widget.selection, m)
+        self.assertIsInstance(widget.selection, list)
 
         m[0, 0] = 0
         widget.on_selection_change(selm((0, 0)), SomView.SelectionRemove)
         np.testing.assert_equal(widget.selection, m)
+        self.assertIsInstance(widget.selection, list)
 
         m[0, 0] = 2
         widget.on_selection_change(selm((0, 0)), SomView.SelectionNewGroup)
         np.testing.assert_equal(widget.selection, m)
+        self.assertIsInstance(widget.selection, list)
 
     @_patch_recompute_som
     def test_on_selection_change_on_empty(self):


### PR DESCRIPTION
##### Issue
The orange widget base does not support settings with type `np.ndarrray`

```
Traceback (most recent call last):
  File "../orange-canvas-core/orangecanvas/application/canvasmain.py", line 1612, in save_swp
    if not document.isModifiedStrict() and undoStack.isClean():
  File "../orange-canvas-core/orangecanvas/document/schemeedit.py", line 664, in isModifiedStrict
    node_properties(self.__scheme)
  File "../orange-canvas-core/orangecanvas/document/schemeedit.py", line 2538, in node_properties
    scheme.sync_node_properties()
  File "../orange-widget-base/orangewidget/workflow/widgetsscheme.py", line 99, in sync_node_properties
    if settings != node.properties:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

##### Description of changes
Store SOM's settings in a list instead. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
