### PR TITLE
[ENH] Neighbours - Sort resulting instances in order according to distance

### DIFF
--- a/Orange/widgets/data/owneighbors.py
+++ b/Orange/widgets/data/owneighbors.py
@@ -153,7 +153,12 @@ class OWNeighbors(OWWidget):
         up_to = len(dist) - np.sum(inrefs)
         if self.limit_neighbors and self.n_neighbors < up_to:
             up_to = self.n_neighbors
-        return np.argpartition(dist, up_to - 1)[:up_to]
+        # get indexes of N neighbours in unsorted order - faster than argsort
+        idx = np.argpartition(dist, up_to - 1)[:up_to]
+        # sort selected N neighbours according to distances
+        sorted_subset_idx = np.argsort(dist[idx])
+        # map sorted indexes back to original index space
+        return idx[sorted_subset_idx]
 
     def _data_with_similarity(self, indices):
         domain = self.data.domain

--- a/Orange/widgets/data/tests/test_owneighbors.py
+++ b/Orange/widgets/data/tests/test_owneighbors.py
@@ -452,6 +452,25 @@ class TestOWNeighbors(WidgetTest):
         self.send_signal(self.widget.Inputs.reference, data[0:1])
         self.assertIsInstance(self.get_output(self.widget.Outputs.data), Table2)
 
+    def test_order_by_distance(self):
+        domain = Domain([ContinuousVariable(x) for x in "ab"])
+        reference = Table.from_numpy(domain, [[1, 0]])
+        data = Table.from_numpy(domain, [[1, 0.1], [2, 0], [1, 0], [0, 0.1], [0.1, 0]])
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.reference, reference)
+
+        output = self.get_output(self.widget.Outputs.data)
+        expected = [[1, 0], [1, 0.1], [0.1, 0], [2, 0], [0, 0.1]]
+        np.testing.assert_array_equal(output.X, expected)
+        dst = output.get_column("distance").tolist()
+        self.assertTrue(dst == sorted(dst))  # check distance in ascending order
+
+        # test on bigger set
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        self.send_signal(self.widget.Inputs.reference, self.iris[:1])
+        dst = self.get_output(self.widget.Outputs.data).get_column("distance").tolist()
+        self.assertTrue(dst == sorted(dst))  # check distance in ascending order
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
The resulting instances in the Neighbour widget are in the original order. It would be better to sort them according to distance.

##### Description of changes
Sort neighbours according to distance in ascending order.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
