### PR TITLE
torgerson: Replace deprecated parameter

### DIFF
--- a/Orange/projection/manifold.py
+++ b/Orange/projection/manifold.py
@@ -85,7 +85,7 @@ def torgerson(distances, n_components=2, eigen_solver="auto"):
         U, L = v[:, ::-1], w[::-1]
     elif eigen_solver == "lapack":  # lapack (d|s)syevr
         w, v = lapack_eigh(B, overwrite_a=True,
-                           eigvals=(max(N - n_components, 0), N - 1))
+                           subset_by_index=(max(N - n_components, 0), N - 1))
         assert np.all(np.diff(w) >= 0), "w was not in ascending order"
         U, L = v[:, ::-1], w[::-1]
     else:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Parameter eigvals is deprecated and will be removed in scipy==1.12.0

##### Description of changes
Replace the parameter with subset_by_index parameter.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
