### PR TITLE
CI - Install catboost<1.2 on MacOS, python 3.8 runner (temporary solution)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,9 @@ deps =
     pyqt5==5.15.*;platform_system!="Windows" or python_version>='3.10'
     pyqtwebengine==5.12.*;platform_system=="Windows" and python_version<'3.10'
     pyqtwebengine==5.15.*;platform_system!="Windows" or python_version>='3.10'
+    # https://github.com/catboost/catboost/issues/2371#issuecomment-1536253780
+    # todo: remove when issue resolved
+    catboost<1.2;platform_system=="Darwin" and python_version=="3.8"
     -r {toxinidir}/requirements-opt.txt
     coverage
     psycopg2-binary


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
MacOS Python 3.8 run is failing on installing dependencies since Catboost increased the minimal OS version for wheels to 11 (which should work fine on macOS-latest). 

##### Description of changes
It is the GitHub action's issue. Read more here: https://github.com/catboost/catboost/issues/2371
I think. Currently, we have two options:
1. install the ninja package to enable building Catboost from the source
2. use Catboost<1.2

I first tried option 1, but it took too long to build on GH actions, so now I am considering option 2.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
