### PR TITLE
[FIX] ListView - empty variable when all values unselected

### DIFF
--- a/Orange/widgets/gui.py
+++ b/Orange/widgets/gui.py
@@ -503,14 +503,14 @@ class CallBackListView(ControlledCallback):
         if isinstance(self.view.model(), QSortFilterProxyModel):
             selection = self.view.model().mapSelectionToSource(selection)
         values = [i.row() for i in selection.indexes()]
-        if values:
-            # FIXME: irrespective of PyListModel check, this might/should always
-            # callback with values!
-            if isinstance(self.model, PyListModel):
-                values = [self.model[i] for i in values]
-            if self.view.selectionMode() == self.view.SingleSelection:
-                values = values[0]
-            self.acyclic_setattr(values)
+
+        # set attribute's values
+        if isinstance(self.model, PyListModel):
+            values = [self.model[i] for i in values]
+        if self.view.selectionMode() == self.view.SingleSelection:
+            assert len(values) <= 1
+            values = values[0] if values else None
+        self.acyclic_setattr(values)
 
 
 class CallBackListBox:

--- a/Orange/widgets/tests/test_gui.py
+++ b/Orange/widgets/tests/test_gui.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest.mock import patch
 
 import numpy as np
@@ -54,6 +55,10 @@ class TestListModel(GuiTest):
         sel_model.clear()
         view.setCurrentIndex(self.attrs.index(1, 0))
         self.assertEqual(widget.foo, [b])
+
+        # unselect all
+        sel_model.clear()
+        self.assertEqual(widget.foo, [])
 
     def test_select_callfront(self):
         widget = self.widget
@@ -129,3 +134,7 @@ class TestRankModel(GuiTest):
         test_array = np.array(["Bertha", "daniela", "ann", "Cecilia"])
         assert_equal(func(test_array, Qt.AscendingOrder), [2, 0, 3, 1])
         assert_equal(func(test_array, Qt.DescendingOrder), [1, 3, 0, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description if the issue does not exist. -->
When using `ExtendedSelection` or `MultiSelection` and all values are unselected, the setting attribute still keeps the old selection.

##### Description of changes
Set the setting attribute to the empty list when all values are unselected. 

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
