### PR TITLE
Test on Pandas 2

### DIFF
--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -1,6 +1,7 @@
 # pylint: disable=import-outside-toplevel
 import unittest
 from datetime import date, datetime, timezone, timedelta
+from unittest import skipIf
 
 import numpy as np
 import pandas as pd
@@ -199,6 +200,11 @@ class TestPandasCompat(unittest.TestCase):
         self.assertEqual(table.domain.variables[0].have_time, 0)
         self.assertEqual(table.domain.variables[0].have_date, 1)
 
+    @skipIf(
+        datetime.today() < datetime(2023, 8, 1),
+        "Temporarily skipping because of pandas issue",
+    )
+    # https://github.com/pandas-dev/pandas/issues/53134#issuecomment-1546011517
     def test_table_from_frame_time(self):
         df = pd.DataFrame(
             [[pd.Timestamp("00:00:00.25")], [pd.Timestamp("20:20:20.30")], [np.nan]]
@@ -412,6 +418,11 @@ class TestPandasCompat(unittest.TestCase):
         )
         self.assertTrue(all(isinstance(v, StringVariable) for v in table.domain.metas))
 
+    @skipIf(
+        datetime.today() < datetime(2023, 8, 1),
+        "Temporarily skipping because of pandas issue",
+    )
+    # https://github.com/pandas-dev/pandas/issues/53134#issuecomment-1546011517
     def test_time_variable_compatible(self):
         def to_df(val):
             return pd.DataFrame([[pd.Timestamp(val)]])

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,6 @@ deps =
     -r {toxinidir}/requirements-opt.txt
     coverage
     psycopg2-binary
-    # we should unpin this someday, but must fix backward incompatibilities first
-    pandas<2
     # no wheels for mac
     pymssql<3.0;platform_system!='Darwin' and python_version<'3.8'
     latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph


### PR DESCRIPTION
##### Issue
Currently, we do not test Orange on Pandas 2.

##### Description of changes
Remove the constraint and test on Pandas 2. Two tests are still affected by Pandas 2 changes/[bugs](https://github.com/pandas-dev/pandas/issues/53134#issuecomment-1546011517), so I suggest skipping them temporarily. I think it is safe since the problem appears in the tests and not in the Orange code (the Pandas module is unaffected by the issue).

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
