### PR TITLE
[CI] Add Python 3.11 to test matrices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: False
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
         tox_env: [orange-released]
         name: [Released]
         include:
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
         tox_env: [orange-released]
         name: [Released]
         include:

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -1,6 +1,6 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-
+import sys
 import unittest
 from tempfile import NamedTemporaryFile
 import os
@@ -86,15 +86,19 @@ class TestTabReader(unittest.TestCase):
         self.assertIsInstance(f1, ContinuousVariable)
         self.assertIsInstance(f2, DiscreteVariable)
 
-    def test_read_nonutf8_encoding(self):
+    @unittest.skipIf(
+        sys.version_info >= (3, 11), 'csv supports null bytes in 3.11'
+    )
+    def test_read_binary_blob(self):
         with self.assertRaises(ValueError) as cm:
-            data = Table(test_filename('datasets/binary-blob.tab'))
+            Table(test_filename('datasets/binary-blob.tab'))
         self.assertIn('NUL', cm.exception.args[0])
 
+    def test_read_nonutf8_encoding(self):
         with self.assertRaises(ValueError):
             with warnings.catch_warnings():
                 warnings.filterwarnings('error')
-                data = Table(test_filename('datasets/invalid_characters.tab'))
+                Table(test_filename('datasets/invalid_characters.tab'))
 
     def test_noncontinous_marked_continuous(self):
         file = NamedTemporaryFile("wt", delete=False)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Add Python 3.11 to test matrices

##### Description of changes

* Add Python 3.11 to test matrices
* Skip one test on Python 3.11 due to added support for null bytes in the csv module

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
