### PR TITLE
[ENH] owsavebase: Display a warning when auto save is disabled

### DIFF
--- a/Orange/canvas/run.py
+++ b/Orange/canvas/run.py
@@ -14,6 +14,14 @@ from orangecanvas.scheme import signalmanager
 # Imported to make webwidget addons work
 from Orange.widgets.utils.webview import WebviewWidget  # pylint: disable=unused-import
 
+LOG_LEVELS = [
+    logging.CRITICAL + 10,
+    logging.CRITICAL,
+    logging.ERROR,
+    logging.WARN,
+    logging.INFO,
+    logging.DEBUG
+]
 
 def main(argv=None):
     app = QApplication(list(argv) if argv else [])
@@ -28,13 +36,13 @@ def main(argv=None):
         )
     )
     parser.add_argument("--log-level", "-l", metavar="LEVEL", type=int,
-                        default=logging.CRITICAL, dest="log_level")
+                        default=3, dest="log_level")
     parser.add_argument("--config", default="Orange.canvas.config.Config",
                         type=str)
     parser.add_argument("file")
     args = parser.parse_args(argv[1:])
 
-    log_level = args.log_level
+    log_level = LOG_LEVELS[args.log_level]
     filename = args.file
     logging.basicConfig(level=log_level)
 
@@ -71,6 +79,9 @@ def main(argv=None):
                 if msg.contents and msg.severity == msg.Error:
                     print(msg.contents, msg.message_id, file=sys.stderr)
                     severity = msg.Error
+                elif msg.contents and msg.severity == msg.Warning and \
+                        log_level <= logging.WARNING:
+                    print(msg.contents, file=sys.stderr)
         if severity == UserMessage.Error:
             app.exit(1)
         else:

--- a/Orange/widgets/utils/save/tests/test_owsavebase.py
+++ b/Orange/widgets/utils/save/tests/test_owsavebase.py
@@ -157,6 +157,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             self.assertPathEqual(w.last_dir, "/home/u/orange/a/b")
             self.assertPathEqual(w.filename, "/home/u/orange/a/b/c.foo")
             self.assertTrue(w.auto_save)
+            self.assertFalse(w.Warning.auto_save_disabled.is_shown())
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -166,6 +167,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             self.assertPathEqual(w.last_dir, "/home/u/orange/a/b")
             self.assertPathEqual(w.filename, "/home/u/orange/a/b/c.foo")
             self.assertFalse(w.auto_save)
+            self.assertFalse(w.Warning.auto_save_disabled.is_shown())
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -175,6 +177,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             self.assertPathEqual(w.last_dir, "/home/u/orange/a/d")
             self.assertPathEqual(w.filename, "/home/u/orange/a/d/c.foo")
             self.assertTrue(w.auto_save)
+            self.assertFalse(w.Warning.auto_save_disabled.is_shown())
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -184,6 +187,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             self.assertPathEqual(w.last_dir, "/home/u/orange/")
             self.assertPathEqual(w.filename, "/home/u/orange/c.foo")
             self.assertFalse(w.auto_save)
+            self.assertFalse(w.Warning.auto_save_disabled.is_shown())
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -193,6 +197,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             self.assertPathEqual(w.last_dir, "/home/u/orange/")
             self.assertPathEqual(w.filename, "/home/u/orange/c.foo")
             self.assertTrue(w.auto_save)
+            self.assertFalse(w.Warning.auto_save_disabled.is_shown())
 
             w = self.create_widget(
                 self.OWSaveMockWriter,
@@ -202,6 +207,7 @@ class TestOWSaveBaseWithWriters(WidgetTest):
             self.assertPathEqual(w.last_dir, "/home/u/orange/")
             self.assertPathEqual(w.filename, "/home/u/orange/c.foo")
             self.assertTrue(w.auto_save)
+            self.assertFalse(w.Warning.auto_save_disabled.is_shown())
 
     def test_move_workflow(self):
         """Widget correctly stores relative paths"""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Ref: https://github.com/biolab/orange3/issues/6449#issuecomment-1559709448

##### Description of changes

Display a warning when auto save is disabled in a loaded workflow. 
Also change auto save to be a schema only setting.
Also print out warning widget messages in run.py

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
