### PR TITLE
CSVWriter: Write numeric variables via repr_val

### DIFF
--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -654,7 +654,7 @@ class _FileWriter:
         if var.is_time:
             return var.repr_val
         elif var.is_continuous:
-            return lambda value: "" if isnan(value) else value
+            return lambda value: "" if isnan(value) else var.repr_val(value)
         elif var.is_discrete:
             return lambda value: "" if isnan(value) else var.values[int(value)]
         elif var.is_string:

--- a/Orange/data/tests/test_io.py
+++ b/Orange/data/tests/test_io.py
@@ -135,9 +135,9 @@ class TestWriters(unittest.TestCase):
 c\td\ta\tb
 continuous\tstring\tx y z\tcontinuous
 class\tmeta\t\t
-3.0\tfoo\ty\t0.5
-1.0\tbar\tz\t
-7.0\tbaz\t\t1.0625""".strip())
+3\tfoo\ty\t0.500
+1\tbar\tz\t
+7\tbaz\t\t1.06250""".strip())
         finally:
             os.remove(fname)
 


### PR DESCRIPTION
##### Issue

Fixes #6456. Numeric variables ignored the number of decimals when writing.

##### Description of changes

Convert to strings via `repr_val`. This will be slower, though.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
