### PR TITLE
Data Sets: Remember selected language

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -204,6 +204,7 @@ class OWDataSets(OWWidget):
 
     #: Selected dataset id
     selected_id = settings.Setting(None)   # type: Optional[str]
+    language = settings.Setting(DEFAULT_LANG)
 
     #: main area splitter state
     splitter_state = settings.Setting(b'')  # type: bytes
@@ -236,7 +237,11 @@ class OWDataSets(OWWidget):
         layout.addSpacing(20)
         layout.addWidget(QLabel("Show data sets in "))
         lang_combo = self.language_combo = QComboBox()
-        lang_combo.addItems([self.DEFAULT_LANG, self.ALL_LANGUAGES])
+        languages = [self.DEFAULT_LANG, self.ALL_LANGUAGES]
+        if self.language is not None and self.language not in languages:
+            languages.insert(1, self.language)
+        lang_combo.addItems(languages)
+        lang_combo.setCurrentText(self.language)
         lang_combo.activated.connect(self._on_language_changed)
         layout.addWidget(lang_combo)
         self.mainArea.layout().addLayout(layout)
@@ -353,7 +358,10 @@ class OWDataSets(OWWidget):
         combo = self.language_combo
         current_language = combo.currentText()
         allkeys = set(self.allinfo_local) | set(self.allinfo_remote)
-        languages = sorted({self._parse_info(key).language for key in allkeys})
+        languages = {self._parse_info(key).language for key in allkeys}
+        if self.language is not None:
+            languages.add(self.language)
+        languages = sorted(languages)
         combo.clear()
         if self.DEFAULT_LANG not in languages:
             combo.addItem(self.DEFAULT_LANG)
@@ -408,10 +416,10 @@ class OWDataSets(OWWidget):
     def _on_language_changed(self):
         combo = self.language_combo
         if combo.currentIndex() == combo.count() - 1:
-            language = None
+            self.language = None
         else:
-            language = combo.currentText()
-        self.view.model().setLanguage(language)
+            self.language = combo.currentText()
+        self.view.model().setLanguage(self.language)
 
     @Slot(object)
     def __set_index(self, f):

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -63,6 +63,27 @@ class TestOWDataSets(WidgetTest):
         self.assertEqual(model.rowCount(), 2)
 
     @patch("Orange.widgets.data.owdatasets.list_remote",
+           Mock(return_value={('core', 'foo.tab'): {"language": "English"},
+                              ('core', 'bar.tab'): {"language": "Slovenščina"}}))
+    @patch("Orange.widgets.data.owdatasets.list_local",
+           Mock(return_value={}))
+    def test_remember_language(self):
+        w = self.create_widget(OWDataSets)  # type: OWDataSets
+        self.wait_until_stop_blocking(w)
+        w.language_combo.setCurrentText("Slovenščina")
+        w.language_combo.activated.emit(w.language_combo.currentIndex())
+        settings = w.settingsHandler.pack_data(w)
+
+        w2 = self.create_widget(OWDataSets, stored_settings=settings)
+        self.wait_until_stop_blocking(w2)
+        self.assertEqual(w2.language_combo.currentText(), "Slovenščina")
+
+        settings["language"] = "Klingon"
+        w2 = self.create_widget(OWDataSets, stored_settings=settings)
+        self.wait_until_stop_blocking(w2)
+        self.assertEqual(w2.language_combo.currentText(), "Klingon")
+
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(return_value={('core', 'iris.tab'): {}}))
     @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={}))


### PR DESCRIPTION
##### Issue

Fixes #6461.

##### Description of changes

- Language setting is now stored.
- The selected language is always added to combo, even if no data sets with that language exist (which should never happen, but let's play it safe), resulting in an empty list of data sets.

##### Includes
- [X] Code changes
- [X] Tests
