### PR TITLE
[FIX] Sql - Fix comparison with values trailing spaces

### DIFF
--- a/Orange/data/sql/backend/mssql.py
+++ b/Orange/data/sql/backend/mssql.py
@@ -158,10 +158,12 @@ class PymssqlBackend(Backend):
         return self.create_sql_query(
             table_name,
             [field],
-            # workaround for collations that are not case sensitive and
-            # UTF characters sensitive - in the domain we still want to
-            # have all values (collation independent)
-            group_by=[f"{field}, Cast({field} as binary)"],
+            # Cast - workaround for collations that are not case-sensitive and
+            # UTF characters sensitive
+            # DATALENGTH - workaround for string comparison that ignore trailing
+            # spaces, two strings that differ only in space in the end would
+            # group together if DATALENGTH wouldn't be used
+            group_by=[f"{field}, Cast({field} as binary), DATALENGTH({field})"],
             order_by=[field],
             limit=21,
         )


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Loading table fails when values of the column in the table have trailing spaces, and the column interprets as DiscreteVariable since MSSQl ignore trailing spaces while comparing string values.

##### Description of changes
Add `DATALENGTH` to `groupby` comparison to ensure trailing spaces are not ignored while grouping.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
