### PR TITLE
Dask: compute Table chunks if unknown

### DIFF
--- a/Orange/data/dask.py
+++ b/Orange/data/dask.py
@@ -251,6 +251,11 @@ class DaskTable(Table):
         # table locking is currently disabled
         return contextlib.nullcontext()
 
+    def __len__(self):
+        if not isinstance(self.X.shape[0], int):
+            self.X.compute_chunk_sizes()
+        return self.X.shape[0]
+
 
 def dask_stats(X, compute_variance=False):
     is_numeric = np.issubdtype(X.dtype, np.number)

--- a/Orange/tests/test_dasktable.py
+++ b/Orange/tests/test_dasktable.py
@@ -189,3 +189,9 @@ class TableTestCase(unittest.TestCase):
         self.assertEqual(150, len(lines))
         self.assertEqual("[[5.1, 3.5, 1.4, 0.2 | Iris-setosa],", lines[0])
         self.assertEqual(" [5.9, 3.0, 5.1, 1.8 | Iris-virginica]]", lines[-1])
+
+    def test_table_len(self):
+        iris = temp_dasktable("iris")
+        iris = iris[iris.X[:, 0] > 6]
+        self.assertTrue(np.isnan(iris.X.shape[0]))
+        self.assertEqual(61, len(iris))


### PR DESCRIPTION
Calling len(Table) keeps causing trouble all over Orange, so maybe computing it would be reasonable to compute chunks. AFAIK it only needs to be done once.
