### PR TITLE
Tox - remove catboost pin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,6 @@ deps =
     pyqt5==5.15.*;platform_system!="Windows" or python_version>='3.10'
     pyqtwebengine==5.12.*;platform_system=="Windows" and python_version<'3.10'
     pyqtwebengine==5.15.*;platform_system!="Windows" or python_version>='3.10'
-    # https://github.com/catboost/catboost/issues/2371#issuecomment-1536253780
-    # todo: remove when issue resolved
-    catboost<1.2;platform_system=="Darwin" and python_version=="3.8"
     -r {toxinidir}/requirements-opt.txt
     coverage
     psycopg2-binary


### PR DESCRIPTION
##### Description of changes
According to https://github.com/catboost/catboost/issues/2371#issuecomment-1594282255 universal wheel for catbost >= 1.2 will now install on Python 3.8, so it is time to revert https://github.com/biolab/orange3/pull/6440

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
