### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/Orange/preprocess/_relieff.pyx
+++ b/Orange/preprocess/_relieff.pyx
@@ -354,7 +354,7 @@ cdef void contingency_tables(np.ndarray X,
 
 cdef tuple prepare(X, y, is_discrete, contingencies):
     X = np.array(X, dtype=np.float64, order='C')
-    is_discrete = np.asarray(is_discrete, dtype=np.bool8)
+    is_discrete = np.asarray(is_discrete, dtype=np.bool_)
     is_continuous = ~is_discrete
     if is_continuous.any():
         row_min = np.nanmin(X, 0)

--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -372,7 +372,7 @@ class ReliefF(Scorer):
         from Orange.preprocess._relieff import relieff
         weights = np.asarray(relieff(data.X, data.Y,
                                      self.n_iterations, self.k_nearest,
-                                     np.array([a.is_discrete for a in data.domain.attributes]),
+                                     np.array([a.is_discrete for a in data.domain.attributes], dtype=bool),
                                      rstate))
         if feature:
             return weights[0]

--- a/Orange/widgets/unsupervised/tests/test_owdbscan.py
+++ b/Orange/widgets/unsupervised/tests/test_owdbscan.py
@@ -6,7 +6,6 @@ from scipy.sparse import csr_matrix, csc_matrix
 
 from Orange.data import Table
 from Orange.clustering import DBSCAN
-from Orange.distance import Euclidean
 from Orange.preprocess import Normalize, Continuize, SklImpute
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import simulate, possible_duplicate_table
@@ -169,12 +168,6 @@ class TestOWDBSCAN(WidgetTest):
 
     def test_get_kth_distances(self):
         dists = get_kth_distances(self.iris, "euclidean", k=5)
-        self.assertEqual(len(self.iris), len(dists))
-        # dists must be sorted
-        np.testing.assert_array_equal(dists, np.sort(dists)[::-1])
-
-        # test with different distance - e.g. Orange distance
-        dists = get_kth_distances(self.iris, Euclidean, k=5)
         self.assertEqual(len(self.iris), len(dists))
         # dists must be sorted
         np.testing.assert_array_equal(dists, np.sort(dists)[::-1])

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -89,7 +89,7 @@ class OWFreeVizGraph(OWGraphWithAnchors):
             self.anchor_items = []
             for point, label in zip(points, labels):
                 anchor = AnchorItem(line=QLineF(0, 0, *point), text=label)
-                anchor.setVisible(np.linalg.norm(point) > r)
+                anchor.setVisible(bool(np.linalg.norm(point) > r))
                 anchor.setPen(pg.mkPen((100, 100, 100)))
                 anchor.setFont(self.parameter_setter.anchor_font)
                 self.plot_widget.addItem(anchor)
@@ -98,7 +98,7 @@ class OWFreeVizGraph(OWGraphWithAnchors):
             for anchor, point, label in zip(self.anchor_items, points, labels):
                 anchor.setLine(QLineF(0, 0, *point))
                 anchor.setText(label)
-                anchor.setVisible(np.linalg.norm(point) > r)
+                anchor.setVisible(bool(np.linalg.norm(point) > r))
                 anchor.setFont(self.parameter_setter.anchor_font)
 
     def update_circle(self):

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -229,7 +229,7 @@ class OWLinProjGraph(OWGraphWithAnchors):
                 anchor.setFont(self.parameter_setter.anchor_font)
 
                 visible = self.always_show_axes or np.linalg.norm(point) > r
-                anchor.setVisible(visible)
+                anchor.setVisible(bool(visible))
                 anchor.setPen(pg.mkPen((100, 100, 100)))
                 self.plot_widget.addItem(anchor)
                 self.anchor_items.append(anchor)
@@ -237,7 +237,7 @@ class OWLinProjGraph(OWGraphWithAnchors):
             for anchor, point, label in zip(self.anchor_items, points, labels):
                 anchor.setLine(QLineF(0, 0, *point))
                 visible = self.always_show_axes or np.linalg.norm(point) > r
-                anchor.setVisible(visible)
+                anchor.setVisible(bool(visible))
                 anchor.setFont(self.parameter_setter.anchor_font)
 
     def update_circle(self):

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -960,7 +960,7 @@ class OWNomogram(OWWidget):
                 coef = self.log_reg_coeffs[i]
                 self.log_reg_coeffs[i] = np.hstack((coef * min_t, coef * max_t))
                 self.log_reg_cont_data_extremes.append(
-                    [sorted([min_t, max_t], reverse=(c < 0)) for c in coef.flat])
+                    [sorted([min_t, max_t], reverse=bool(c < 0)) for c in coef.flat])
             else:
                 self.log_reg_cont_data_extremes.append([None])
 

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -395,7 +395,7 @@ class OWRadviz(OWAnchorProjectionWidget):
             not np.isnan(self.data.get_column(self.attr_color)).all() and \
             np.sum(np.all(np.isfinite(self.data.X), axis=1)) > 1 and \
             np.all(np.nan_to_num(np.nanstd(self.data.X, 0)) != 0)
-        self.btn_vizrank.setEnabled(is_enabled)
+        self.btn_vizrank.setEnabled(bool(is_enabled))
         if is_enabled:
             self.vizrank.initialize()
 

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -293,8 +293,8 @@ class AxisItem(AxisItem):
         # Remove ticks that will later be removed in AxisItem.generateDrawSpecs
         # because they are out of range. Removing them here is needed so that
         # they do not affect spaces and label format
-        ticks = ticks[(ticks[0] < minVal)
-                      :len(ticks) - (ticks[-1] > maxVal)]
+        ticks = ticks[int((ticks[0] < minVal))
+                      :len(ticks) - int((ticks[-1] > maxVal))]
 
         max_steps = max(int(size / self._label_width), 1)
         if len(ticks) > max_steps:
@@ -1269,7 +1269,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
                 mask = None
 
         self._signal_too_many_labels(
-            mask is not None and mask.sum() > self.MAX_VISIBLE_LABELS)
+            bool(mask is not None and mask.sum() > self.MAX_VISIBLE_LABELS))
         if self._too_many_labels or mask is None or not np.any(mask):
             return
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix various numpy DeprecationWarnings 

##### Description of changes

* Replace deprecated np.bool8 alias with np.bool_ 
* Replace use of np.bool_ use as bool argument to PyQt methods
* test_owdbscan: Remove test for `get_kth_distances` with orange distances.

   This is never used except in tests and raises/spams deprecation warnings with numpy 1.25. This in turn results in significant test runtime of 40+ seconds for this test.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
