### PR TITLE
[FIX] owdiscretize: Fix formatting display string when user role is undefined

### DIFF
--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -330,6 +330,8 @@ class DiscDomainModel(DomainModel):
         if role == Qt.ToolTipRole:
             var = self[index.row()]
             data = index.data(Qt.UserRole)
+            if not isinstance(data, DiscDesc):
+                return super().data(index, role)
             tip = f"<b>{var.name}: </b>"
             values = map(html.escape, data.values)
             if not data.values:
@@ -342,8 +344,12 @@ class DiscDomainModel(DomainModel):
                     + "".join(f"- {value}<br/>" for value in values)
         value = super().data(index, role)
         if role == Qt.DisplayRole:
-            hint, points, values = index.data(Qt.UserRole)
-            value += f" ({format_desc(hint)}){points}"
+            try:
+                hint, points, values = index.data(Qt.UserRole)
+            except TypeError:
+                pass  # don't have user role (yet)
+            else:
+                value += f" ({format_desc(hint)}){points}"
         return value
 
 

--- a/Orange/widgets/data/tests/test_owdiscretize.py
+++ b/Orange/widgets/data/tests/test_owdiscretize.py
@@ -18,7 +18,8 @@ from Orange.widgets.data.owdiscretize import OWDiscretize, \
     IncreasingNumbersListValidator, VarHint, Methods, DefaultKey, \
     _fixed_width_discretization, _fixed_time_width_discretization, \
     _custom_discretization, variable_key, Options, DefaultHint, \
-    _mdl_discretization, ListViewSearch, format_desc, DefaultDiscModel
+    _mdl_discretization, ListViewSearch, format_desc, DefaultDiscModel, \
+    DiscDomainModel, DiscDesc
 from Orange.widgets.tests.base import WidgetTest, GuiTest
 from Orange.widgets.utils.itemmodels import select_rows
 
@@ -547,6 +548,27 @@ class TestModels(WidgetTest, DataMixin):
         self.assertIn(
             str(w.discretized_vars[("x", False)].compute_value.points[0])[:3],
             display)
+
+
+class TestDiscModel(GuiTest, DataMixin):
+    def setUp(self) -> None:
+        super().setUp()
+        self.prepare_data()
+
+    def test_model(self):
+        model = DiscDomainModel()
+        model.set_domain(self.domain)
+        index = model.index(0)
+        self.assertEqual(index.data(Qt.DisplayRole), "x")
+        self.assertIn("x", index.data(Qt.ToolTipRole), "x")
+        model.setData(
+            index,
+            DiscDesc(
+                VarHint(Methods.EqualFreq, (3, )), "1, 2", ("1", "2")),
+            Qt.UserRole
+        )
+        self.assertTrue(index.data(Qt.DisplayRole).startswith("x "))
+        self.assertIn("2", index.data(Qt.ToolTipRole))
 
 
 class TestDefaultDiscModel(GuiTest):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix an error in display string formatting when updating widget input while a filter/search string is entered in the list view. I.e. 
* `File -> Discretize`, 
* Enter some text in the filter edit line
* Reload the file.

```
----------------------------- TypeError Exception -----------------------------
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owdiscretize.py", line 345, in data
    hint, points, values = index.data(Qt.UserRole)
    ^^^^^^^^^^^^^^^^^^^^
TypeError: cannot unpack non-iterable NoneType object
-------------------------------------------------------------------------------
```

##### Description of changes

Fix formatting display string when user role is undefined

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
