### PR TITLE
Remove use of deprecated distutils

### DIFF
--- a/Orange/canvas/config.py
+++ b/Orange/canvas/config.py
@@ -5,11 +5,8 @@ Orange Canvas Configuration
 import random
 import uuid
 import warnings
-
 import os
 import sys
-import itertools
-from distutils.version import LooseVersion
 
 from typing import Dict, Any, Optional, Iterable, List
 
@@ -112,7 +109,7 @@ class Config(config.Config):
 
         version = Config.ApplicationVersion
         if version:
-            version_parsed = LooseVersion(version)
+            version_parsed = pkg_resources.parse_version(version)
             version_comp = version_parsed.version
             version = ".".join(map(str, version_comp[:2]))
         size = 13

--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -5,7 +5,7 @@ Examples
 --------
 >>> import Orange
 >>> data = Orange.data.Table('iris')
->>> learner = Orange.classification.LogisticRegressionLearner()
+>>> learner = Orange.classification.LogisticRegressionLearner(solver="liblinear")
 >>> results = Orange.evaluation.TestOnTrainingData(data, [learner])
 
 """
@@ -293,7 +293,7 @@ class LogLoss(ClassificationScore):
     Examples
     --------
     >>> Orange.evaluation.LogLoss(results)
-    array([ 0.3...])
+    array([0.3...])
 
     """
     __wraps__ = skl_metrics.log_loss

--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -116,9 +116,9 @@ def bincount(x, weights=None, max_val=None, minlength=0):
     values as well, even if they do not appear in the data. However, this will
     not truncate the bincount if values larger than `max_count` are found.
     >>> bincount([0, 0, 1, 1, 2], max_val=4)
-    (array([ 2.,  2.,  1.,  0.,  0.]), 0.0)
+    (array([2., 2., 1., 0., 0.]), 0.0)
     >>> bincount([0, 1, 2, 3, 4], max_val=2)
-    (array([ 1.,  1.,  1.,  1.,  1.]), 0.0)
+    (array([1., 1., 1., 1., 1.]), 0.0)
 
     """
     # Store the original matrix before any manipulation to check for sparse

--- a/Orange/tests/test_doctest.py
+++ b/Orange/tests/test_doctest.py
@@ -1,10 +1,6 @@
 import sys
 import os
-import unittest
 from doctest import DocTestSuite, ELLIPSIS, NORMALIZE_WHITESPACE
-
-import pkg_resources
-import numpy
 
 SKIP_DIRS = (
     # Skip modules which import and initialize stuff that require QApplication
@@ -55,24 +51,12 @@ class Context(dict):
 def suite(package):
     """Assemble test suite for doctests in path (recursively)"""
     from importlib import import_module
-    # numpy 1.14 changed array str/repr (NORMALIZE_WHITESPACE does not
-    # handle this). When 1.15 is released update all docstrings and skip the
-    # tests for < 1.14.
-    npversion = pkg_resources.parse_version(numpy.__version__)
-    if npversion >= pkg_resources.parse_version("1.14"):
-        def setUp(test):
-            raise unittest.SkipTest("Skip doctest on numpy >= 1.14.0")
-    else:
-        def setUp(test):
-            pass
-
     for module in find_modules(package.__file__):
         try:
             module = import_module(module)
             yield DocTestSuite(module,
                                globs=Context(module.__dict__.copy()),
-                               optionflags=ELLIPSIS | NORMALIZE_WHITESPACE,
-                               setUp=setUp)
+                               optionflags=ELLIPSIS | NORMALIZE_WHITESPACE)
         except ValueError:
             pass  # No doctests in module
         except ImportError:

--- a/Orange/tests/test_doctest.py
+++ b/Orange/tests/test_doctest.py
@@ -2,8 +2,8 @@ import sys
 import os
 import unittest
 from doctest import DocTestSuite, ELLIPSIS, NORMALIZE_WHITESPACE
-from distutils.version import LooseVersion
 
+import pkg_resources
 import numpy
 
 SKIP_DIRS = (
@@ -58,8 +58,8 @@ def suite(package):
     # numpy 1.14 changed array str/repr (NORMALIZE_WHITESPACE does not
     # handle this). When 1.15 is released update all docstrings and skip the
     # tests for < 1.14.
-    npversion = LooseVersion(numpy.__version__)
-    if npversion >= LooseVersion("1.14"):
+    npversion = pkg_resources.parse_version(numpy.__version__)
+    if npversion >= pkg_resources.parse_version("1.14"):
         def setUp(test):
             raise unittest.SkipTest("Skip doctest on numpy >= 1.14.0")
     else:

--- a/Orange/widgets/evaluate/tests/test_owliftcurve.py
+++ b/Orange/widgets/evaluate/tests/test_owliftcurve.py
@@ -1,7 +1,7 @@
 # pylint: disable=protected-access,duplicate-code
 import copy
+import pkg_resources
 import unittest
-from distutils.version import LooseVersion
 from unittest.mock import Mock
 
 import numpy as np
@@ -26,7 +26,8 @@ from Orange.tests import test_filename
 # scikit-learn==1.1.1 does not support read the docs, therefore
 # we can not make it a requirement for now. When the minimum required
 # version is >=1.1.1, delete these exceptions.
-OK_SKLEARN = LooseVersion(sklearn.__version__) >= LooseVersion("1.1.1")
+OK_SKLEARN = pkg_resources.parse_version(sklearn.__version__) >= \
+             pkg_resources.parse_version("1.1.1")
 SKIP_REASON = "Only test precision-recall with scikit-learn>=1.1.1"
 
 

--- a/Orange/widgets/evaluate/tests/test_utils.py
+++ b/Orange/widgets/evaluate/tests/test_utils.py
@@ -2,7 +2,6 @@
 
 import unittest
 import collections
-from distutils.version import LooseVersion
 from itertools import count
 from unittest.mock import patch
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Distutils stdlib is [deprecated](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated)

##### Description of changes

Remove import and use of distutils except in setup.py where setuptools provides it.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
