### PR TITLE
[ENH] Dask: Logistic Regression

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -141,7 +141,7 @@ class Learner(ReprableWithPreprocessors):
 
         progress_callback(0.1, "Fitting...")
         model = self._fit_model(data)
-        model.used_vals = [np.unique(y).astype(int) for y in data.Y[:, None].T]
+        model.used_vals = [np.asarray(np.unique(y), dtype=int) for y in data.Y[:, None].T]
         if not hasattr(model, "domain") or model.domain is None:
             # some models set domain themself and it should be respected
             # e.g. calibration learners set the base_learner's domain which

--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -1,10 +1,19 @@
+import warnings
+
 import numpy as np
+import dask.array as da
 import sklearn.linear_model as skl_linear_model
+
+try:
+    import dask_ml.linear_model as dask_linear_model
+except ImportError:
+    dask_linear_model = skl_linear_model
 
 from Orange.classification import SklLearner, SklModel
 from Orange.preprocess import Normalize
 from Orange.preprocess.score import LearnerScorer
 from Orange.data import Variable, DiscreteVariable
+
 
 __all__ = ["LogisticRegressionLearner"]
 
@@ -22,11 +31,11 @@ class _FeatureScorerMixin(LearnerScorer):
 class LogisticRegressionClassifier(SklModel):
     @property
     def intercept(self):
-        return self.skl_model.intercept_
+        return np.atleast_1d(self.skl_model.intercept_)
 
     @property
     def coefficients(self):
-        return self.skl_model.coef_
+        return np.atleast_2d(self.skl_model.coef_)
 
 
 class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
@@ -43,9 +52,23 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
 
     def _initialize_wrapped(self, X=None, Y=None):
         params = self.params.copy()
+        solver = params.pop("solver")
+        penalty = params.get("penalty") or "none"
+
+        if isinstance(X, da.Array) or isinstance(Y, da.Array):
+            if dask_linear_model is skl_linear_model:
+                warnings.warn("dask_ml is not installed, using sklearn instead.")
+            else:
+                if solver == "auto":
+                    if penalty in "none":
+                        solver = "gradient_descent"
+                    else:
+                        solver = "admm"
+                params["solver"], params["penalty"] = solver, penalty
+                return dask_linear_model.LogisticRegression(**params)
+
         # The default scikit-learn solver `lbfgs` (v0.22) does not support the
         # l1 penalty.
-        solver, penalty = params.pop("solver"), params.get("penalty")
         if solver == "auto":
             if penalty == "l1":
                 solver = "liblinear"

--- a/Orange/widgets/evaluate/owtestandscore.py
+++ b/Orange/widgets/evaluate/owtestandscore.py
@@ -950,7 +950,7 @@ class OWTestAndScore(OWWidget):
                     do_stratify = False
                 elif self.data.domain.class_var.is_discrete:
                     least = min(filter(None,
-                                       np.bincount(self.data.Y.astype(int))))
+                                       np.bincount(np.asarray(self.data.Y, dtype=int))))
                     if least < k:
                         self.Warning.cant_stratify(k, least)
                         do_stratify = False


### PR DESCRIPTION
LogisticRegressionLearner and the corresponding widget now support DaskTables. Currently only for binary problems (*filtering rows doesn't work, because it doesn't update the target variable's list of possible values, to fix this we would need to check the contents the table instead).

Changes:
- LogisticRegressionLearner imports dask_ml which we may not want to add to the requirements
- _initialized_wrapped method of SklLearner now takes two arguments
- DaskTable overrides _filter_has_class method to avoid using bottleneck on dask (assumes DaskTables are never sparse)
- added np.asarray in a number of places to compute values when it seemed reasonable (statistics, predictions, test & score)