### PR TITLE
Tox: use pre 23.2 for proper build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,9 @@ envlist =
     add-ons
 skip_missing_interpreters = true
 isolated_build = true
+requires =
+    pip==23.1.2
+
 
 [testenv]
 # https://tox.wiki/en/latest/config.html#download


### PR DESCRIPTION
##### Issue
Pip 23.2 was released on 15 Jul. Since then our tests fail.


##### Description of changes
Instruct tox to use older pip.


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
