### PR TITLE
Use pre-3.0 cython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=41.0.0,<50.0",
     "wheel",
-    "cython",
+    "cython<3.0",
     "oldest-supported-numpy",
     "sphinx",
     "recommonmark",


### PR DESCRIPTION
##### Issue
Cython 3.0 was released. Thus our tests fail.

##### Description of changes
As a temporary change use the older cython version.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
