### PR TITLE
Change setup.py to work with Cython 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=41.0.0,<50.0",
     "wheel",
-    "cython<3.0",
+    "cython>=3.0",
     "oldest-supported-numpy",
     "sphinx",
     "recommonmark",

--- a/setup.py
+++ b/setup.py
@@ -481,16 +481,14 @@ def setup_package():
         # numpy.distutils insist all data files are installed in site-packages
         'install_data': install_data.install_data
     }
-    if have_numpy and have_cython:
-        extra_args = {}
-    else:
+    if not (have_numpy and have_cython):
         # substitute a build_ext command with one that raises an error when
         # building. In order to fully support `pip install` we need to
         # survive a `./setup egg_info` without numpy so pip can properly
         # query our install dependencies
-        extra_args = {}
         cmdclass["build_ext"] = build_ext_error
 
+    extra_args = {}
     setup(
         name=NAME,
         version=FULLVERSION,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ except ImportError:
     have_sphinx = False
 
 try:
-    from Cython.Distutils.build_ext import new_build_ext as build_ext
     from Cython.Build import cythonize
     have_cython = True
 except ImportError:
@@ -484,7 +483,6 @@ def setup_package():
     }
     if have_numpy and have_cython:
         extra_args = {}
-        cmdclass["build_ext"] = build_ext
     else:
         # substitute a build_ext command with one that raises an error when
         # building. In order to fully support `pip install` we need to

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ except ImportError:
 
 try:
     from Cython.Distutils.build_ext import new_build_ext as build_ext
+    from Cython.Build import cythonize
     have_cython = True
 except ImportError:
     have_cython = False
@@ -434,14 +435,7 @@ def ext_modules():
     if os.name == 'posix':
         libraries.append("m")
 
-    return [
-        # Cython extensions. Will be automatically cythonized.
-        Extension(
-            "*",
-            ["Orange/*/*.pyx"],
-            include_dirs=includes,
-            libraries=libraries,
-        ),
+    modules = [
         Extension(
             "Orange.classification._simple_tree",
             sources=[
@@ -463,6 +457,16 @@ def ext_modules():
             export_symbols=["compute_density"],
         ),
     ]
+
+    if have_cython:
+        modules += cythonize(Extension(
+            "*",
+            ["Orange/*/*.pyx"],
+            include_dirs=includes,
+            libraries=libraries,
+        ))
+
+    return modules
 
 
 def setup_package():


### PR DESCRIPTION
##### Issue

Fixes #6519.

Cython 3.0 with current setup.py cythonizes pyx -> c, but doesn't call compiler.

##### Description of changes

Call `cythonize`. Whyever.

I checked that there should be no problems with new default behaviour of `/` ("true division", producing floats). In most pyx files we specifiy `cdivision=True` anyway, so the behaviour of Cython remained the same).

If this is OK, we need to
- [ ] also merge https://github.com/biolab/orange3-network/pull/253
- [ ] check other officially supported extensions that use Cython; I checked those I have have installed)

Interestingly, with addon Associate we distribute .cpp. When was the last time anybody touched that add-on?