### PR TITLE
[ENH] PCA widget runs a separate thread

### DIFF
--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -158,8 +158,16 @@ class OWPCA(widget.OWWidget, ConcurrentWidgetMixin):
             self.start(self._call_projector, data, projector)
 
     @staticmethod
-    def _call_projector(data: Table, projector, _):
-        return projector(data)
+    def _call_projector(data: Table, projector, state):
+
+        def callback(i: float, status=""):
+            state.set_progress_value(i * 100)
+            if status:
+                state.set_status(status)
+            if state.is_interruption_requested():
+                raise Exception  # pylint: disable=broad-exception-raised
+
+        return projector(data, progress_callback=callback)
 
     def on_done(self, result):
         pca = result

--- a/Orange/widgets/unsupervised/owpca.py
+++ b/Orange/widgets/unsupervised/owpca.py
@@ -153,9 +153,9 @@ class OWPCA(widget.OWWidget):
 
         if self.normalize:
             self._pca_projector.preprocessors = \
-                self._pca_preprocessors + [preprocess.Normalize(center=False)]
+                PCA.preprocessors + [preprocess.Normalize(center=False)]
         else:
-            self._pca_projector.preprocessors = self._pca_preprocessors
+            self._pca_projector.preprocessors = PCA.preprocessors
 
         if not isinstance(data, SqlTable):
             pca = self._pca_projector(data)
@@ -254,7 +254,6 @@ class OWPCA(widget.OWWidget):
     def _init_projector(self):
         self._pca_projector = PCA(n_components=MAX_COMPONENTS, random_state=0)
         self._pca_projector.component = self.ncomponents
-        self._pca_preprocessors = PCA.preprocessors
 
     def _nselected_components(self):
         """Return the number of selected components."""

--- a/Orange/widgets/unsupervised/tests/test_owpca.py
+++ b/Orange/widgets/unsupervised/tests/test_owpca.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from Orange.data import Table, Domain, ContinuousVariable, TimeVariable
 from Orange.preprocess import preprocess
-from Orange.preprocess.preprocess import Normalize
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import table_dense_sparse, possible_duplicate_table
 from Orange.widgets.unsupervised.owpca import OWPCA
@@ -162,7 +161,7 @@ class TestOWPCA(WidgetTest):
         # Enable checkbox
         self.widget.controls.normalize.setChecked(True)
         self.assertTrue(self.widget.controls.normalize.isChecked())
-        with patch.object(preprocess, "Normalize", wraps=Normalize) as normalize:
+        with patch.object(preprocess.Normalize, "__call__", wraps=lambda x: x) as normalize:
             self.send_signal(self.widget.Inputs.data, data)
             self.wait_until_stop_blocking()
             self.assertTrue(self.widget.controls.normalize.isEnabled())
@@ -171,7 +170,7 @@ class TestOWPCA(WidgetTest):
         # Disable checkbox
         self.widget.controls.normalize.setChecked(False)
         self.assertFalse(self.widget.controls.normalize.isChecked())
-        with patch.object(preprocess, "Normalize", wraps=Normalize) as normalize:
+        with patch.object(preprocess.Normalize, "__call__", wraps=lambda x: x) as normalize:
             self.send_signal(self.widget.Inputs.data, data)
             self.wait_until_stop_blocking()
             self.assertTrue(self.widget.controls.normalize.isEnabled())


### PR DESCRIPTION
##### Issue
For larger data PCA takes longer. Moving computation to a separate thread allows canvas to still be responsive.

##### Description of changes
The first two commits only refactor the widget to lose some attributes.

This PR only improves the responsiveness of canvas. I did not find any easy ways to interrupt PCA so that is not done here. 
*Edit*: I added a commit that allows for cancelling within preprocessing. Code was stolen from owoutliers and the current implementation in `Learner`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
