### PR TITLE
[FIX] Scatter Plot - Fix Vizrank for hidden attributes

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -1,4 +1,3 @@
-from itertools import chain
 from xml.sax.saxutils import escape
 
 import numpy as np
@@ -87,9 +86,11 @@ class ScatterPlotVizRank(VizRankDialogAttrPair):
 
     def score_heuristic(self):
         assert self.attr_color is not None
-        master_domain = self.master.data.domain
-        vars = [v for v in chain(master_domain.variables, master_domain.metas)
-                if v is not self.attr_color and v.is_primitive()]
+        vars = [
+            v
+            for v in self.master.xy_model  # same attributes that are in xy combos
+            if v is not self.attr_color and v.is_primitive()
+        ]
         domain = Domain(attributes=vars, class_vars=self.attr_color)
         data = self.master.data.transform(domain)
         relief = ReliefF if isinstance(domain.class_var, DiscreteVariable) \

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -472,6 +472,20 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         self.assertEqual(self.widget.vizrank_button.toolTip(),
                          "Color variable has no values")
 
+    def test_vizrank_hidden_attributes(self):
+        """
+        Test hidden attributes not considered in Find Informative Projections
+        """
+        new_domain = self.data.domain.copy()
+        new_domain.attributes[0].attributes["hidden"] = True
+        data = self.data.transform(new_domain)
+        self.send_signal(self.widget.Inputs.data, data)
+        vizrank = ScatterPlotVizRank(self.widget)
+        self.assertListEqual(
+            ["petal width", "petal length", "sepal width"],
+            [x.name for x in vizrank.score_heuristic()],
+        )
+
     def test_auto_send_selection(self):
         """
         Scatter Plot automatically sends selection only when the checkbox Send automatically


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes (partially) #6367 

##### Description of changes
Make Vizran consider only attributes that can be plotted (skipping hidden attributes).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
