### PR TITLE
[FIX] Scatter Plot - Handle input features that are hidden in data

### DIFF
--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -526,6 +526,7 @@ class OWScatterPlot(OWDataProjectionWidget):
     def can_draw_regresssion_line(self):
         return self.data is not None and \
                self.data.domain is not None and \
+               self.attr_x is not None and self.attr_y is not None and \
                self.attr_x.is_continuous and \
                self.attr_y.is_continuous
 
@@ -571,12 +572,13 @@ class OWScatterPlot(OWDataProjectionWidget):
         self.attr_box.setEnabled(True)
         self.vizrank.setEnabled(True)
         if self.attribute_selection_list and self.data is not None and \
-                self.data.domain is not None and \
-                all(attr in self.data.domain for attr
-                        in self.attribute_selection_list):
-            self.attr_x, self.attr_y = self.attribute_selection_list[:2]
+                self.data.domain is not None:
             self.attr_box.setEnabled(False)
             self.vizrank.setEnabled(False)
+            if all(attr in self.xy_model for attr in self.attribute_selection_list):
+                self.attr_x, self.attr_y = self.attribute_selection_list
+            else:
+                self.attr_x, self.attr_y = None, None
         self._invalidated = self._invalidated or self._xy_invalidated
         self._xy_invalidated = False
         super().handleNewSignals()
@@ -593,6 +595,10 @@ class OWScatterPlot(OWDataProjectionWidget):
                 or self.attr_x != attributes[0] \
                 or self.attr_y != attributes[1]
         else:
+            if self.attr_x is None or self.attr_y is None:
+                # scenario happens when features input removed and features
+                # were invalid or hidden and those attr_x and attr_h were None
+                self.init_attr_values()
             self.attribute_selection_list = None
 
     def set_attr(self, attr_x, attr_y):

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -349,6 +349,38 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         self.assertTrue(self.widget.attr_box.isEnabled())
         self.assertTrue(self.widget.vizrank.isEnabled())
 
+    def test_features_and_hidden_data(self):
+        new_domain = self.data.domain.copy()
+        new_domain.attributes[0].attributes["hidden"] = True
+        data = self.data.transform(new_domain)
+
+        self.send_signal(self.widget.Inputs.data, data)
+        self.send_signal(self.widget.Inputs.features, AttributeList(data.domain[:2]))
+        self.assertIsNone(self.widget.attr_x)
+        self.assertIsNone(self.widget.attr_y)
+        self.assertFalse(self.widget.attr_box.isEnabled())
+        self.assertFalse(self.widget.vizrank.isEnabled())
+
+        self.send_signal(self.widget.Inputs.features, None)
+        self.assertEqual(self.widget.attr_x, self.data.domain[1])
+        self.assertEqual(self.widget.attr_y, self.data.domain[2])
+        self.assertTrue(self.widget.attr_box.isEnabled())
+        self.assertTrue(self.widget.vizrank.isEnabled())
+
+        # try with features not in data
+        bad_feat = AttributeList([ContinuousVariable("a"), ContinuousVariable("b")])
+        self.send_signal(self.widget.Inputs.features, bad_feat)
+        self.assertIsNone(self.widget.attr_x)
+        self.assertIsNone(self.widget.attr_y)
+        self.assertFalse(self.widget.attr_box.isEnabled())
+        self.assertFalse(self.widget.vizrank.isEnabled())
+
+        self.send_signal(self.widget.Inputs.features, None)
+        self.assertEqual(self.widget.attr_x, self.data.domain[1])
+        self.assertEqual(self.widget.attr_y, self.data.domain[2])
+        self.assertTrue(self.widget.attr_box.isEnabled())
+        self.assertTrue(self.widget.vizrank.isEnabled())
+
     def test_output_features(self):
         data = Table("iris")
         self.send_signal(self.widget.Inputs.data, data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Connected to #6367 
When some features are hidden in the data, and those features are present on Scatter Plot's feature input widget fails.

##### Description of changes
Handle describe scenario and do not plot anyting

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
