### PR TITLE
RemoveNaNColumns - compute nans in advance

### DIFF
--- a/Orange/preprocess/preprocess.py
+++ b/Orange/preprocess/preprocess.py
@@ -307,7 +307,8 @@ class RemoveNaNColumns(Preprocess):
                         self.threshold
         if isinstance(threshold, float):
             threshold = threshold * data.X.shape[0]
-        nans = np.sum(np.isnan(data.X), axis=0)
+        # compute nans in advance, otherwise dask will do it for every attribute
+        nans = np.asarray(np.sum(np.isnan(data.X), axis=0))
         att = [a for a, n in zip(data.domain.attributes, nans) if n < threshold]
         domain = Orange.data.Domain(att, data.domain.class_vars,
                                     data.domain.metas)


### PR DESCRIPTION
Current implementation works fine for numpy, but because dask is lazy it will iterate over the entire table multiple times (once for each attribute).
On a 3000 by 3000 example dataset this reduced the performance of logistic regression by a factor of 10. Without preprocessing it runs in ~500 msec, with preprocessing it took ~5 sec.

solution: compute nans once in advance and store them in memory.