### PR TITLE
PCA: distinguish between PCA and IncrementalPCA

### DIFF
--- a/Orange/tests/test_pca.py
+++ b/Orange/tests/test_pca.py
@@ -159,8 +159,9 @@ class TestPCA(unittest.TestCase):
 
     @unittest.skipIf(sklearn_version.startswith('0.20'),
                      "https://github.com/scikit-learn/scikit-learn/issues/12234")
-    def test_incremental_pca(self):
-        data = self.ionosphere
+    @with_dasktable
+    def test_incremental_pca(self, prepare_table):
+        data = prepare_table(self.ionosphere)
         self.__ipca_test_helper(data, n_com=3, min_xpl_var=0.49)
         self.__ipca_test_helper(data, n_com=32, min_xpl_var=1)
 
@@ -172,7 +173,7 @@ class TestPCA(unittest.TestCase):
         self.assertEqual(n_com, pca_model.n_components)
         self.assertEqual((n_com, data.X.shape[1]), pca_model.components_.shape)
         proj = np.dot(data.X - pca_model.mean_, pca_model.components_.T)
-        np.testing.assert_almost_equal(pca_model(data).X, proj)
+        np.testing.assert_almost_equal(pca_model(data).X, np.asarray(proj))
         pc1_ipca = pca_model.components_[0]
         self.assertAlmostEqual(np.linalg.norm(pc1_ipca), 1)
         pc1_pca = PCA(n_components=n_com)(data).components_[0]


### PR DESCRIPTION
In the initial implementation of dask_ml into PCA I used IncrementalPCA instead due to memory concerns. This has now proven to be pointless, so it seems better to have each of the two projectors use the appropriate base class.

*IncrementalPCA is never actually used in Orange. If memory does end up being a concern though, I think the distinction between regular and incremental PCA should probably be made in the widget instead.