### PR TITLE
Fix CI to work with tox 4.9.0 (released Aug 16)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py-orange-{latest, released}
+    orange-{oldest, latest, released}
     pylint-ci
     build_doc
     add-ons


### PR DESCRIPTION
##### Issue
Tox fails saying it can not find the environment
