### PR TITLE
[FIX] owpredictions: Fix a type error in report when using NoopDelegate

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -9,7 +9,7 @@ from typing import Set, Sequence, Union, Optional, List, NamedTuple
 import numpy
 from AnyQt.QtWidgets import (
     QTableView, QSplitter, QToolTip, QStyle, QApplication, QSizePolicy,
-    QPushButton, QAbstractItemDelegate)
+    QPushButton, QStyledItemDelegate)
 from AnyQt.QtGui import QPainter, QStandardItem, QPen, QColor, QBrush
 from AnyQt.QtCore import (
     Qt, QSize, QRect, QRectF, QPoint, QPointF, QLocale,
@@ -1117,13 +1117,15 @@ class ErrorDelegate(PredictionsBarItemDelegate):
         return cls.__size_hint
 
 
-class NoopItemDelegate(QAbstractItemDelegate):
+class NoopItemDelegate(QStyledItemDelegate):
     def paint(self, *_):
         pass
 
-    @staticmethod
-    def sizeHint(*_):
+    def sizeHint(self, *_):
         return QSize(0, 0)
+
+    def displayText(self, *_):
+        return ""
 
 
 class ClassificationErrorDelegate(ErrorDelegate):

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -152,6 +152,14 @@ class TestOWPredictions(WidgetTest):
             predmodel.data(predmodel.index(0, 0), Qt.UserRole)))
         self.assertIn(predmodel.data(predmodel.index(0, 0))[0],
                       titanic.domain.class_var.values)
+        self.widget.send_report()
+
+        housing = self.housing[::5]
+        mean_housing = ConstantLearner()(housing)
+        no_target = housing.transform(Domain(housing.domain.attributes, None))
+        self.send_signal(self.widget.Inputs.data, no_target)
+        self.send_signal(self.widget.Inputs.predictors, mean_housing, 1)
+        self.widget.send_report()
 
     def test_invalid_regression_target(self):
         widget = self.widget


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix an error when reporting regression model with data that does not have the target column:

```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange-widget-base/orangewidget/report/report.py", line 59, in show_report
    self.create_report_html()
  File "/home/ales/devel/orange-widget-base/orangewidget/report/report.py", line 98, in create_report_html
    self.send_report()
  File "/home/ales/devel/orange3/Orange/widgets/evaluate/owpredictions.py", line 930, in send_report
    self.report_table("Data & Predictions", merge_data_with_predictions(),
  File "/home/ales/devel/orange-widget-base/orangewidget/report/report.py", line 340, in report_table
    body = report_list(table, header_rows, header_columns)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ales/devel/orange-widget-base/orangewidget/report/report.py", line 324, in report_list
    return join("  <tr>\n    {}</tr>\n".format(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ales/devel/orange-widget-base/orangewidget/report/report.py", line 324, in <genexpr>
    return join("  <tr>\n    {}</tr>\n".format(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ales/devel/orange3/Orange/widgets/evaluate/owpredictions.py", line 907, in merge_data_with_predictions
    [delegate.displayText(
  File "/home/ales/devel/orange3/Orange/widgets/evaluate/owpredictions.py", line 907, in <listcomp>
    [delegate.displayText(
     ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoopItemDelegate' object has no attribute 'displayText'
-------------------------------------------------------------------------------
```

##### Description of changes

Fix type of NoopDelegate

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
