### PR TITLE
[MNT] Cleanup python editor tests

### DIFF
--- a/Orange/widgets/data/utils/pythoneditor/tests/base.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/base.py
@@ -16,9 +16,9 @@ from AnyQt.QtCore import Qt, QCoreApplication
 
 from orangewidget.utils import enum_as_int
 
-from Orange.widgets import widget
 from Orange.widgets.data.utils.pythoneditor.editor import PythonEditor
 from Orange.widgets.data.utils.pythoneditor.vim import key_code
+from Orange.widgets.tests.base import GuiTest
 
 
 def _processPendingEvents(app):
@@ -57,13 +57,16 @@ def in_main_loop(func, *_):
     wrapper.__name__ = func.__name__  # for unittest test runner
     return wrapper
 
-class SimpleWidget(widget.OWWidget):
-    name = "Simple widget"
 
-    def __init__(self):
-        super().__init__()
-        self.qpart = PythonEditor(self)
-        self.mainArea.layout().addWidget(self.qpart)
+class EditorTest(GuiTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.qpart = PythonEditor()
+
+    def tearDown(self) -> None:
+        self.qpart.terminate()
+        del self.qpart
+        super().tearDown()
 
 
 def keySequenceClicks(widget_, keySequence, extraModifiers=Qt.NoModifier):

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_api.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_api.py
@@ -9,23 +9,14 @@ This is compatible with Orange3's GPL-3.0 license.
 """  # pylint: disable=duplicate-code
 import unittest
 
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 # pylint: disable=protected-access
 
-class _BaseTest(WidgetTest):
+
+class _BaseTest(EditorTest):
     """Base class for tests
     """
-
-    def setUp(self):
-        super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
-
-    def tearDown(self):
-        self.qpart.terminate()
-        super().tearDown()
 
 
 class Selection(_BaseTest):

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_bracket_highlighter.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_bracket_highlighter.py
@@ -10,23 +10,10 @@ This is compatible with Orange3's GPL-3.0 license.
 import unittest
 
 from Orange.widgets.data.utils.pythoneditor.brackethighlighter import BracketHighlighter
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 
-class Test(WidgetTest):
-    """Base class for tests
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
-
-    def tearDown(self):
-        self.qpart.terminate()
-        super().tearDown()
-
+class Test(EditorTest):
     def _verify(self, actual, expected):
         converted = []
         for item in actual:

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_draw_whitespace.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_draw_whitespace.py
@@ -9,23 +9,10 @@ This is compatible with Orange3's GPL-3.0 license.
 """  # pylint: disable=duplicate-code
 import unittest
 
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 
-class Test(WidgetTest):
-    """Base class for tests
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
-
-    def tearDown(self):
-        self.qpart.terminate()
-        super().tearDown()
-
+class Test(EditorTest):
     def _ws_test(self,
                  text,
                  expectedResult,

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_edit.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_edit.py
@@ -14,22 +14,10 @@ from AnyQt.QtGui import QKeySequence
 from AnyQt.QtTest import QTest
 
 from Orange.widgets.data.utils.pythoneditor.tests import base
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 
-class Test(WidgetTest):
-    """Base class for tests
-    """
-    def setUp(self):
-        super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
-
-    def tearDown(self):
-        self.qpart.terminate()
-        super().tearDown()
-
+class Test(EditorTest):
     def test_overwrite_edit(self):
         self.qpart.show()
         self.qpart.text = 'abcd'

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_indent.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_indent.py
@@ -12,23 +12,10 @@ import unittest
 from AnyQt.QtCore import Qt
 from AnyQt.QtTest import QTest
 
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 
-class Test(WidgetTest):
-    """Base class for tests
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
-
-    def tearDown(self):
-        self.qpart.terminate()
-        super().tearDown()
-
+class Test(EditorTest):
     def test_1(self):
         # Indent with Tab
         self.qpart.indentUseTabs = True

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_indenter/indenttest.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_indenter/indenttest.py
@@ -7,29 +7,21 @@ Originally licensed under the terms of GNU Lesser General Public License
 as published by the Free Software Foundation, version 2.1 of the license.
 This is compatible with Orange3's GPL-3.0 license.
 """  # pylint: disable=duplicate-code
-import sys
-import os
 
 from AnyQt.QtCore import Qt
 from AnyQt.QtTest import QTest
 
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 # pylint: disable=protected-access
 
-topLevelPath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-sys.path.insert(0, topLevelPath)
-sys.path.insert(0, os.path.join(topLevelPath, 'tests'))
 
-
-class IndentTest(WidgetTest):
+class IndentTest(EditorTest):
     """Base class for tests
     """
 
     def setUp(self):
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
+        super().setUp()
         if hasattr(self, 'INDENT_WIDTH'):
             self.qpart.indentWidth = self.INDENT_WIDTH
 

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_indenter/test_python.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_indenter/test_python.py
@@ -9,12 +9,7 @@ This is compatible with Orange3's GPL-3.0 license.
 """  # pylint: disable=duplicate-code
 import unittest
 
-import os.path
-import sys
-
 from Orange.widgets.data.utils.pythoneditor.tests.test_indenter.indenttest import IndentTest
-
-sys.path.append(os.path.abspath(os.path.join(__file__, '..')))
 
 
 class Test(IndentTest):

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_rectangular_selection.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_rectangular_selection.py
@@ -18,24 +18,10 @@ from AnyQt.QtTest import QTest
 from AnyQt.QtGui import QKeySequence
 
 from Orange.widgets.data.utils.pythoneditor.tests import base
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
-from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 
 
-class _Test(WidgetTest):
-    """Base class for tests
-    """
-
-    def setUp(self):
-        super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
-
-    def tearDown(self):
-        self.qpart.hide()
-        self.qpart.terminate()
-        super().tearDown()
-
+class _Test(EditorTest):
     def test_real_to_visible(self):
         self.qpart.text = 'abcdfg'
         self.assertEqual(0, self.qpart._rectangularSelection._realToVisibleColumn(self.qpart.text, 0))

--- a/Orange/widgets/data/utils/pythoneditor/tests/test_vim.py
+++ b/Orange/widgets/data/utils/pythoneditor/tests/test_vim.py
@@ -12,21 +12,18 @@ import unittest
 from AnyQt.QtCore import Qt
 from AnyQt.QtTest import QTest
 
-from Orange.widgets.data.utils.pythoneditor.tests.base import SimpleWidget
+from Orange.widgets.data.utils.pythoneditor.tests.base import EditorTest
 from Orange.widgets.data.utils.pythoneditor.vim import _globalClipboard
-from Orange.widgets.tests.base import WidgetTest
 
 # pylint: disable=too-many-lines
 
 
-class _Test(WidgetTest):
+class _Test(EditorTest):
     """Base class for tests
     """
 
     def setUp(self):
         super().setUp()
-        self.widget = self.create_widget(SimpleWidget)
-        self.qpart = self.widget.qpart
         self.qpart.lines = ['The quick brown fox',
                             'jumps over the',
                             'lazy dog',
@@ -38,8 +35,6 @@ class _Test(WidgetTest):
 
     def tearDown(self):
         self.qpart.hide()
-        self.qpart.terminate()
-        del self.qpart
         super().tearDown()
 
     def _onVimModeChanged(self, _, mode):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Cleanup teardown python editor tests

Maybe alleviates  segfaults in CI tests.

##### Description of changes

Do not use WidgetTest to test a non OWWidget component.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
