### PR TITLE
Improve stacklevel for warning about inherited eq for compute_value

### DIFF
--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -79,7 +79,8 @@ class SharedComputeValue:
                                                    types.FunctionType)) \
                 and not redefines_eq_and_hash(compute_shared):
             warnings.warn(f"{type(compute_shared).__name__} should define "
-                          f"__eq__ and __hash__ to be used for compute_shared")
+                          f"__eq__ and __hash__ to be used for compute_shared",
+                          stacklevel=2)
 
     def __call__(self, data, shared_data=None):
         """Fallback if common parts are not passed."""

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -379,7 +379,8 @@ class Variable(Reprable, metaclass=VariableMeta):
                 and not type(compute_value).__dict__.get("InheritEq", False):
             warnings.warn(f"{type(compute_value).__name__} should define "
                           "__eq__ and __hash__ to be used for compute_value\n"
-                          "or set InheritEq = True if inherited methods suffice")
+                          "or set InheritEq = True if inherited methods suffice",
+                          stacklevel=3)
 
         self._compute_value = compute_value
         self.unknown_str = MISSING_VALUES


### PR DESCRIPTION
##### Issue

The warning that classes used for `compute_value` need to define `__eq__` and `__hash__` (or signal that inherited methods are OK) do not set the stack level.

##### Description of changes

These warnings cannot point to the place where the error needs to be fixed (that is, the class definition), but this PR sets the stack level so that it will (usually) point to the place where the class is used, that is, to the line that contains `compute_value=AClassThatHasNoEqual()`. Imperfect, but better.

For string attributes, the level is incorrect because they have no `__init__`. This could be fixed by defining an `__init__`, but we seldom compute string variables, and defining an `__init__` just for this sound rather pointless.

##### Includes
- [X] Code changes
