### PR TITLE
owpredictions: Fix an exception when switching regression error in gui

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -325,7 +325,9 @@ class OWPredictions(OWWidget):
         self.score_opt_box.setVisible(bool(self.class_var))
 
     def _reg_error_changed(self):
-        self.predictionsview.model().setRegErrorType(self.show_reg_errors)
+        model = self.predictionsview.model()
+        if model is not None:
+            model.setRegErrorType(self.show_reg_errors)
         self._update_prediction_delegate()
 
     def _update_errors_visibility(self):

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1157,6 +1157,13 @@ class TestOWPredictions(WidgetTest):
         self.assertEqual(delegate.span, max(3 / 2, 6 / 11))
         self.assertFalse(delegate.centered)
 
+    def test_regression_error_no_model(self):
+        data = self.housing[:5]
+        self.send_signal(self.widget.Inputs.data, data)
+        combo = self.widget.controls.show_reg_errors
+        with excepthook_catch(raise_on_exit=True):
+            simulate.combobox_activate_index(combo, 1)
+
     def test_report(self):
         widget = self.widget
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

An error is raised when there is a regression dataset on input but no model and the user changes the 'Show regression error:'
```
-------------------------- AttributeError Exception ---------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange-widget-base/orangewidget/gui.py", line 2261, in __call__
    self.func(**kwds)
  File "/home/ales/devel/orange3/Orange/widgets/evaluate/owpredictions.py", line 328, in _reg_error_changed
    self.predictionsview.model().setRegErrorType(self.show_reg_errors)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'setRegErrorType'
-------------------------------------------------------------------------------
```


##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
