### PR TITLE
[ENH] Naive Bayes for Dask

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -444,7 +444,7 @@ class Model(Reprable):
         # Call the predictor
         backmappers = None
         n_values = []
-        if isinstance(data, (np.ndarray, scipy.sparse.csr_matrix)):
+        if isinstance(data, (np.ndarray, scipy.sparse.csr_matrix, da.Array)):
             prediction = self.predict(data)
         elif isinstance(data, Table):
             backmappers, n_values = self.get_backmappers(data)

--- a/Orange/data/dask.py
+++ b/Orange/data/dask.py
@@ -12,6 +12,7 @@ from os import path
 
 from Orange.data import Table, RowInstance
 from Orange.data.table import _FromTableConversion, _ArrayConversion
+from Orange.statistics.util import contingency
 
 
 class DaskRowInstance(RowInstance):
@@ -263,6 +264,51 @@ class DaskTable(Table):
         if not negate:
             retain = np.logical_not(retain)
         return self.from_table_rows(self, np.asarray(retain))
+
+    def _compute_contingency(self, col_vars=None, row_var=None):
+        if row_var is None:
+            row_var = self.domain.class_var
+            if row_var is None:
+                raise ValueError("No row variable")
+
+        row_indi = self.domain.index(row_var)
+        row_var = self.domain[row_indi]
+
+        if not row_var.is_discrete:
+            raise TypeError("Row variable must be discrete")
+
+        if col_vars is None:
+            col_indi = range(len(self.domain.variables))
+        else:
+            col_indi = [self.domain.index(var) for var in col_vars]
+        col_vars = [self.domain[ind] for ind in col_indi]
+
+        if any(not var.is_discrete for var in col_vars):
+            raise NotImplementedError("Contingency can only be computed for categorical values.")
+
+        @dask.delayed
+        def delayed_contingency(*args, **kwargs):
+            return contingency(*args, **kwargs)
+
+        n_atts = self.X.shape[1]
+        contingencies = [None] * len(col_vars)
+        for arr, f_cond, f_ind in (
+                (self.X, lambda i: 0 <= i < n_atts, lambda i: i),
+                (self._Y, lambda i: i >= n_atts, lambda i: i - n_atts),
+                (self.metas, lambda i: i < 0, lambda i: -1 - i)):
+
+            for e, ind in enumerate(col_indi):
+                if f_cond(ind):
+                    col_i, arr_i, var = e, f_ind(col_indi[e]), col_vars[e]
+                    col = arr if arr.ndim == 1 else arr[:, arr_i]
+                    contingencies[col_i] = delayed_contingency(
+                        col.astype(float),
+                        self._get_column_view(row_indi),
+                        max_X=len(var.values) - 1,
+                        max_y=len(row_var.values) - 1,
+                        weights=self.W if self.has_weights() else None)
+
+        return dask.compute(contingencies)[0]
 
 
 def dask_stats(X, compute_variance=False):

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -6,11 +6,13 @@ from unittest.mock import Mock
 
 import numpy as np
 import scipy.sparse as sp
+import dask.array as da
 
 from Orange.classification import NaiveBayesLearner
 from Orange.data import Table, Domain, DiscreteVariable, ContinuousVariable
 from Orange.evaluation import CrossValidation, CA
 from Orange.tests import test_filename
+from Orange.tests.test_dasktable import temp_dasktable
 
 
 # This class is used to force predict_storage to fall back to the slower
@@ -52,6 +54,8 @@ class TestNaiveBayesLearner(unittest.TestCase):
         cls.data = data = Table('titanic')
         cls.learner = NaiveBayesLearner()
         cls.table = data[::20]
+        cls.iris = Table("iris")
+        cls.lenses = Table(test_filename("datasets/lenses.tab"))
 
     def setUp(self):
         self.model = self.learner(self.data)
@@ -64,16 +68,20 @@ class TestNaiveBayesLearner(unittest.TestCase):
         self.assertLess(ca, 0.9)
 
         cv = CrossValidation(k=10)
-        results = cv(Table("iris"), [self.learner])
+        results = cv(self.iris, [self.learner])
         ca = CA(results)
         self.assertGreater(ca, 0.7)
 
-    def test_degenerate(self):
-        d = Domain((ContinuousVariable(name="A"),
+    @staticmethod
+    def _create_degenerate():
+        d = Domain([ContinuousVariable(name="A"),
                     ContinuousVariable(name="B"),
-                    ContinuousVariable(name="C")),
+                    ContinuousVariable(name="C")],
                    DiscreteVariable(name="CLASS", values=("M", "F")))
-        t = Table.from_list(d, [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 1]])
+        return Table.from_list(d, [[0, 1, 0, 0], [0, 1, 0, 1], [0, 1, 0, 1]])
+
+    def test_degenerate(self):
+        t = self._create_degenerate()
         nb = NaiveBayesLearner()
         model = nb(t)
         self.assertEqual(model.domain.attributes, ())
@@ -82,14 +90,13 @@ class TestNaiveBayesLearner(unittest.TestCase):
 
     def test_allnan_cv(self):
         # GH 2740
-        data = Table(test_filename('datasets/lenses.tab'))
         cv = CrossValidation(stratified=False)
-        results = cv(data, [self.learner])
+        results = cv(self.lenses, [self.learner])
         self.assertFalse(any(results.failed))
 
     def test_prediction_routing(self):
         data = self.data
-        predict = self.model.predict = Mock(return_value=(data.Y, None))
+        predict = self.model.predict = Mock(return_value=(np.asarray(data.Y), None))
 
         self.model(data)
         predict.assert_called()
@@ -258,23 +265,76 @@ class TestNaiveBayesLearner(unittest.TestCase):
         probs = model(test_x, ret=model.Probs)
         np.testing.assert_almost_equal(probs, exp_probs)
 
-    def test_no_attributes(self):
+    @staticmethod
+    def _create_no_attributes():
         y = np.array([0, 0, 0, 1, 1, 1, 2, 2])
         domain = Domain([], DiscreteVariable("y", values="abc"))
-        data = Table.from_numpy(domain, np.zeros((len(y), 0)), y.T)
+        return Table.from_numpy(domain, np.zeros((len(y), 0)), y.T)
+
+    def test_no_attributes(self):
+        data = self._create_no_attributes()
         model = self.learner(data)
         np.testing.assert_almost_equal(
             model.predict_storage(np.zeros((5, 0)))[1],
             [[4/11, 4/11, 3/11]] * 5
         )
 
-    def test_no_targets(self):
+    @staticmethod
+    def _create_no_targets():
         x = np.array([[0], [1], [2]])
         y = np.full(3, np.nan)
         domain = Domain([DiscreteVariable("x", values="abc")],
                         DiscreteVariable("y", values="abc"))
-        data = Table.from_numpy(domain, x, y)
+        return Table.from_numpy(domain, x, y)
+
+    def test_no_targets(self):
+        data = self._create_no_targets()
         self.assertRaises(ValueError, self.learner, data)
+
+
+class TestNaivebayesLearnerOnDask(TestNaiveBayesLearner):
+    @classmethod
+    def setUpClass(cls):
+        data = Table('titanic')
+        cls.learner = NaiveBayesLearner()
+        cls.data = temp_dasktable(data)
+        cls.table = temp_dasktable(data[::20])
+
+    @unittest.skip("sparse matrices not supported")
+    def test_predictions_csr_matrix(self):
+        super().test_predictions_csr_matrix()
+
+    @unittest.skip("sparse matrices not supported")
+    def test_predictions_csc_matrix(self):
+        super().test_predictions_csc_matrix()
+
+    def _test_predictions(self, sparse, absent_class=False):
+        (data, domain, results,
+         test_x, test_y, exp_probs) = self._create_prediction_data(sparse, absent_class)
+        self.assertIsNone(sparse)
+        model = self.learner(temp_dasktable(data))
+        assert_model_equal(model, results)
+        test_data = temp_dasktable(Table.from_numpy(domain, test_x, test_y))
+        assert_predictions_equal(test_data, model, exp_probs)
+
+    def _test_predict_missing_attributes(self, sparse):
+        data, test_x, exp_probs = self._create_missing_attributes(sparse)
+        self.assertIsNone(sparse)
+        model = self.learner(temp_dasktable(data))
+        probs = model(da.from_array(test_x), ret=model.Probs)
+        np.testing.assert_almost_equal(probs, exp_probs)
+
+    @staticmethod
+    def _create_degenerate():
+        return temp_dasktable(TestNaiveBayesLearner._create_degenerate())
+
+    @staticmethod
+    def _create_no_targets():
+        return temp_dasktable(TestNaiveBayesLearner._create_no_targets())
+
+    @staticmethod
+    def _create_no_attributes():
+        return temp_dasktable(TestNaiveBayesLearner._create_no_attributes())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reimplement `_compute_contingency` on `DaskTable` to enable the naive Bayes learner (other uses of this function have not been tested and instead raise an error).
