### PR TITLE
Table: Assure unique table.ids when unpickling

### DIFF
--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -1,6 +1,7 @@
 """
 Support for example tables wrapping data stored on a PostgreSQL server.
 """
+import contextlib
 import functools
 import logging
 import threading
@@ -669,3 +670,21 @@ class SqlTable(Table):
 
     def get_nan_frequency_class(self):
         return self.__get_nan_frequency(self.domain.class_vars)
+
+    def __getstate__(self):
+        # avoids locking magic in Table.__getstate__
+        return self.__dict__
+
+    def __setstate__(self, state):
+        # avoid locking magic in Table.__setstate__
+        self.__dict__.update(state)
+
+    # pylint: disable=unused-argument
+    def _update_locks(self, *args, **kwargs):
+        # avoid locking inherited from Table
+        return
+
+    # pylint: disable=unused-argument
+    def unlocked(self, *parts):
+        # avoid locking inherited from Table
+        return contextlib.nullcontext()

--- a/Orange/data/sql/table.py
+++ b/Orange/data/sql/table.py
@@ -679,6 +679,11 @@ class SqlTable(Table):
         # avoid locking magic in Table.__setstate__
         self.__dict__.update(state)
 
+        # if X is defined then it was already downloaded
+        # thus ids exist to, rewrite them
+        if self._X is not None:
+            self._init_ids(self)
+
     # pylint: disable=unused-argument
     def _update_locks(self, *args, **kwargs):
         # avoid locking inherited from Table

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -553,6 +553,8 @@ class Table(Sequence, Storage):
                 setattr(self, "Y", no_view(state.pop("_Y")))  # state["_Y"] is a 2d array
             self.__dict__.update(state)
 
+        self._init_ids(self)
+
     def __getstate__(self):
         # Compatibility with pickles before table locking:
         # return the same state as before table lock

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1010,8 +1010,9 @@ class Table(Sequence, Storage):
     @classmethod
     def _init_ids(cls, obj):
         with cls._next_instance_lock:
-            obj.ids = np.array(range(cls._next_instance_id, cls._next_instance_id + obj.X.shape[0]))
+            nid = cls._next_instance_id
             cls._next_instance_id += obj.X.shape[0]
+        obj.ids = np.arange(nid, nid + obj.X.shape[0], dtype=int)
 
     @classmethod
     def new_id(cls):

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1009,10 +1009,11 @@ class Table(Sequence, Storage):
 
     @classmethod
     def _init_ids(cls, obj):
+        length = int(obj.X.shape[0])
         with cls._next_instance_lock:
             nid = cls._next_instance_id
-            cls._next_instance_id += obj.X.shape[0]
-        obj.ids = np.arange(nid, nid + obj.X.shape[0], dtype=int)
+            cls._next_instance_id += length
+        obj.ids = np.arange(nid, nid + length, dtype=int)
 
     @classmethod
     def new_id(cls):

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -753,6 +753,25 @@ class TestSqlTable(unittest.TestCase, dbt):
         self.assertEqual(iris[0], iris2[0])
 
     @dbt.run_on(["postgres"])
+    def test_pickling_respects_downloaded_state(self):
+        iris = SqlTable(self.conn, self.iris, inspect_values=True)
+        iris2 = pickle.loads(pickle.dumps(iris))
+        # pylint: disable=protected-access
+        self.assertIsNone(iris._X)
+        self.assertIsNone(iris2._X)
+        self.assertIsNone(iris._ids)
+        self.assertIsNone(iris2._ids)
+
+        # trigger download into X, Y, metas
+        iris.X.shape[0]  # pylint: disable=pointless-statement
+        self.assertIsNotNone(iris._X)
+        self.assertIsNotNone(iris._ids)
+        iris2 = pickle.loads(pickle.dumps(iris))
+        self.assertIsNotNone(iris2._X)
+        self.assertIsNotNone(iris2._ids)
+        np.testing.assert_equal(iris._X, iris2._X)
+
+    @dbt.run_on(["postgres"])
     def test_list_tables_with_schema(self):
         with self.backend.execute_sql_query("DROP SCHEMA IF EXISTS orange_tests CASCADE") as cur:
             cur.execute("CREATE SCHEMA orange_tests")

--- a/Orange/tests/sql/test_sql_table.py
+++ b/Orange/tests/sql/test_sql_table.py
@@ -769,7 +769,8 @@ class TestSqlTable(unittest.TestCase, dbt):
         iris2 = pickle.loads(pickle.dumps(iris))
         self.assertIsNotNone(iris2._X)
         self.assertIsNotNone(iris2._ids)
-        np.testing.assert_equal(iris._X, iris2._X)
+        np.testing.assert_equal(iris.X, iris2.X)
+        self.assertEqual(len(set(iris.ids) | set(iris2.ids)), 300)
 
     @dbt.run_on(["postgres"])
     def test_list_tables_with_schema(self):

--- a/Orange/tests/test_table.py
+++ b/Orange/tests/test_table.py
@@ -723,6 +723,16 @@ class TableTestCase(unittest.TestCase):
         finally:
             os.remove("iris.pickle")
 
+    def test_read_pickle_ids(self):
+        table = data.Table("iris")
+        try:
+            table.save("iris.pickle")
+            table1 = data.Table.from_file("iris.pickle")
+            table2 = data.Table.from_file("iris.pickle")
+            self.assertEqual(len(set(table1.ids) | set(table2.ids)), 300)
+        finally:
+            os.remove("iris.pickle")
+
     def test_from_numpy(self):
         a = np.arange(20, dtype="d").reshape((4, 5)).copy()
         m = np.arange(4, dtype="d").reshape((4, 1)).copy()

--- a/Orange/widgets/visualize/tests/test_owvenndiagram.py
+++ b/Orange/widgets/visualize/tests/test_owvenndiagram.py
@@ -3,7 +3,6 @@
 
 import unittest
 from unittest.mock import patch
-from copy import deepcopy
 
 import numpy as np
 
@@ -36,7 +35,7 @@ class TestOWVennDiagram(WidgetTest, WidgetOutputsTestMixin):
 
     def test_rows_id(self):
         data = Table('zoo')
-        data1 = deepcopy(data)
+        data1 = data.copy()
         with data1.unlocked():
             data1[:, 1] = 1
         self.widget.rowwise = True


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Different Tables could have the same ids when unpickled.

##### Description of changes
Create new table.ids in `__setstate__`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
