### PR TITLE
[ENH] IO - Change origin attribute when not find on system

### DIFF
--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -24,7 +24,7 @@ import xlrd
 import xlsxwriter
 import openpyxl
 
-from Orange.data import _io, Table, Domain, ContinuousVariable
+from Orange.data import _io, Table, Domain, ContinuousVariable, update_origin
 from Orange.data import Compression, open_compressed, detect_encoding, \
     isnastr, guess_data_type, sanitize_variable
 from Orange.data.io_base import FileFormatBase, Flags, DataTableMixin, PICKLE_PROTOCOL
@@ -179,6 +179,7 @@ class CSVReader(FileFormat, DataTableMixin):
                                                   ('-' + str(endpos)) if (endpos - pos) > 1 else '')
                         warnings.warn(warning)
                     self.set_table_metadata(self.filename, data)
+                    update_origin(data, self.filename)
                     return data
                 except Exception as e:
                     error = e
@@ -215,6 +216,7 @@ class PickleReader(FileFormat):
             if not isinstance(table, Table):
                 raise TypeError("file does not contain a data table")
             else:
+                update_origin(table, self.filename)
                 return table
 
     @classmethod
@@ -264,6 +266,7 @@ class _BaseExcelReader(FileFormat, DataTableMixin):
         try:
             cells = self.get_cells()
             table = self.data_table(cells)
+            update_origin(table, self.filename)
             table.name = path.splitext(path.split(self.filename)[-1])[0]
             if self.sheet and len(self.sheets) > 1:
                 table.name = '-'.join((table.name, self.sheet))

--- a/Orange/data/io.py
+++ b/Orange/data/io.py
@@ -164,14 +164,7 @@ class CSVReader(FileFormat, DataTableMixin):
                         skipinitialspace=True,
                     )
                     data = self.data_table(reader)
-
-                    # TODO: Name can be set unconditionally when/if
-                    # self.filename will always be a string with the file name.
-                    # Currently, some tests pass StringIO instead of
-                    # the file name to a reader.
-                    if isinstance(self.filename, str):
-                        data.name = path.splitext(
-                            path.split(self.filename)[-1])[0]
+                    data.name = path.splitext(path.split(self.filename)[-1])[0]
                     if error and isinstance(error, UnicodeDecodeError):
                         pos, endpos = error.args[2], error.args[3]
                         warning = ('Skipped invalid byte(s) in position '

--- a/Orange/data/tests/test_io_util.py
+++ b/Orange/data/tests/test_io_util.py
@@ -1,6 +1,18 @@
+import os.path
 import unittest
+from tempfile import TemporaryDirectory
 
-from Orange.data import ContinuousVariable, guess_data_type
+import numpy as np
+
+from Orange.data import (
+    ContinuousVariable,
+    guess_data_type,
+    Table,
+    Domain,
+    StringVariable,
+    DiscreteVariable,
+)
+from Orange.data.io_util import update_origin
 
 
 class TestIoUtil(unittest.TestCase):
@@ -8,6 +20,116 @@ class TestIoUtil(unittest.TestCase):
         self.assertIs(
             guess_data_type(["9", "", "98", "?", "98", "98", "98"])[2],
             ContinuousVariable)
+
+
+class TestUpdateOrigin(unittest.TestCase):
+    FILE_NAMES = ["file1.txt", "file2.txt", "file3.txt"]
+
+    def setUp(self) -> None:
+        self.alt_dir = TemporaryDirectory()  # pylint: disable=consider-using-with
+
+        self.var_string = var = StringVariable("Files")
+        files = self.FILE_NAMES + [var.Unknown]
+        self.table_string = Table.from_list(
+            Domain([], metas=[var]), np.array(files).reshape((-1, 1))
+        )
+        self.var_discrete = var = DiscreteVariable("Files", values=self.FILE_NAMES)
+        files = self.FILE_NAMES + [var.Unknown]
+        self.table_discrete = Table.from_list(
+            Domain([], metas=[var]), np.array(files).reshape((-1, 1))
+        )
+
+    def tearDown(self) -> None:
+        self.alt_dir.cleanup()
+
+    def __create_files(self):
+        for f in self.FILE_NAMES:
+            f = os.path.join(self.alt_dir.name, f)
+            with open(f, "w", encoding="utf8"):
+                pass
+            self.assertTrue(os.path.exists(f))
+
+    def test_origin_not_changed(self):
+        """
+        Origin exist; keep it unchanged, even though dataset path also includes
+        files from column.
+        """
+        with TemporaryDirectory() as dir_name:
+            self.var_string.attributes["origin"] = dir_name
+            update_origin(self.table_string, self.alt_dir.name)
+            self.assertEqual(
+                self.table_string.domain[self.var_string].attributes["origin"], dir_name
+            )
+
+    def test_origin_subdir(self):
+        """
+        Origin is wrong but last dir in origin exit in the dataset file's path
+        """
+        images_dir = os.path.join(self.alt_dir.name, "subdir")
+        os.mkdir(images_dir)
+
+        self.var_string.attributes["origin"] = "/a/b/subdir"
+        update_origin(self.table_string, os.path.join(self.alt_dir.name, "data.csv"))
+        self.assertEqual(
+            self.table_string.domain[self.var_string].attributes["origin"], images_dir
+        )
+
+    def test_origin_parents_subdir(self):
+        """
+        Origin is wrong but last dir in origin exit in the dataset file
+        parent's directory
+        """
+        # make the dir where dataset is placed
+        images_dir = os.path.join(self.alt_dir.name, "subdir")
+        os.mkdir(images_dir)
+
+        self.var_string.attributes["origin"] = "/a/b/subdir"
+        update_origin(self.table_string, os.path.join(images_dir, "data.csv"))
+        self.assertEqual(
+            self.table_string.domain[self.var_string].attributes["origin"], images_dir
+        )
+
+    def test_column_paths_subdir(self):
+        """
+        Origin dir not exiting but paths from column exist in dataset's dir
+        """
+        self.__create_files()
+
+        self.var_string.attributes["origin"] = "/a/b/non-exiting-dir"
+        update_origin(self.table_string, os.path.join(self.alt_dir.name, "data.csv"))
+        self.assertEqual(
+            self.table_string.domain[self.var_string].attributes["origin"],
+            self.alt_dir.name,
+        )
+
+        self.var_discrete.attributes["origin"] = "/a/b/non-exiting-dir"
+        update_origin(self.table_discrete, os.path.join(self.alt_dir.name, "data.csv"))
+        self.assertEqual(
+            self.table_discrete.domain[self.var_discrete].attributes["origin"],
+            self.alt_dir.name,
+        )
+
+    def test_column_paths_parents_subdir(self):
+        """
+        Origin dir not exiting but paths from column exist in dataset parent's dir
+        """
+        # make the dir where dataset is placed
+        dataset_dir = os.path.join(self.alt_dir.name, "subdir")
+        self.__create_files()
+
+        self.var_string.attributes["origin"] = "/a/b/non-exiting-dir"
+        update_origin(self.table_string, os.path.join(dataset_dir, "data.csv"))
+        self.assertEqual(
+            self.table_string.domain[self.var_string].attributes["origin"],
+            self.alt_dir.name,
+        )
+
+        self.var_discrete.attributes["origin"] = "/a/b/non-exiting-dir"
+        update_origin(self.table_discrete, os.path.join(dataset_dir, "data.csv"))
+        self.assertEqual(
+            self.table_discrete.domain[self.var_discrete].attributes["origin"],
+            self.alt_dir.name,
+        )
 
 
 if __name__ == '__main__':

--- a/Orange/tests/test_io.py
+++ b/Orange/tests/test_io.py
@@ -1,7 +1,5 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
-
-import io
 import os
 import pickle
 import shutil
@@ -124,12 +122,13 @@ class TestReader(unittest.TestCase):
         1, 0,
         1, 2,
         """
-        c = io.StringIO(samplefile)
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp:
+            tmp.write(samplefile)
         with self.assertWarns(UserWarning) as cm:
-            table = CSVReader(c).read()
+            table = CSVReader(tmp.name).read()
+        os.unlink(tmp.name)
         self.assertEqual(len(table.domain.attributes), 2)
-        self.assertEqual(cm.warning.args[0],
-                         "Columns with no headers were removed.")
+        self.assertEqual(cm.warning.args[0], "Columns with no headers were removed.")
 
     def test_type_annotations(self):
         class FooFormat(FileFormat):

--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -4,7 +4,6 @@ import sys
 import unittest
 from tempfile import NamedTemporaryFile
 import os
-import io
 import warnings
 
 from Orange.data import Table, ContinuousVariable, DiscreteVariable
@@ -80,8 +79,11 @@ class TestTabReader(unittest.TestCase):
         self.read_easy(csv_file_nh, "Feature ")
 
     def test_read_csv_with_na(self):
-        c = io.StringIO(csv_file_missing)
-        table = CSVReader(c).read()
+        with NamedTemporaryFile(mode="w", delete=False) as tmp:
+            tmp.write(csv_file_missing)
+
+        table = CSVReader(tmp.name).read()
+        os.unlink(tmp.name)
         f1, f2 = table.domain.variables
         self.assertIsInstance(f1, ContinuousVariable)
         self.assertIsInstance(f2, DiscreteVariable)
@@ -130,3 +132,7 @@ time
         data = reader.read()
         self.assertEqual(len(data), 8)
         self.assertEqual(len(data.domain.variables) + len(data.domain.metas), 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1,8 +1,9 @@
 """Tests for OWPredictions"""
 # pylint: disable=protected-access
-import io
+import os
 import unittest
 from functools import partial
+from tempfile import NamedTemporaryFile
 from typing import Optional
 from unittest.mock import Mock, patch
 
@@ -206,8 +207,10 @@ class TestOWPredictions(WidgetTest):
         child\tmale\tyes
         child\tfemale\tyes
         """
-        file1 = io.StringIO(filestr1)
-        table = TabReader(file1).read()
+        with NamedTemporaryFile(mode="w", delete=False) as tmp:
+            tmp.write(filestr1)
+        table = TabReader(tmp.name).read()
+        os.unlink(tmp.name)
         learner = TreeLearner()
         tree = learner(table)
 
@@ -220,9 +223,11 @@ class TestOWPredictions(WidgetTest):
         child\tmale\tyes
         child\tfemale\tunknown
         """
-        file2 = io.StringIO(filestr2)
-        bad_table = TabReader(file2).read()
+        with NamedTemporaryFile(mode="w", delete=False) as tmp:
+            tmp.write(filestr2)
 
+        bad_table = TabReader(tmp.name).read()
+        os.unlink(tmp.name)
         self.send_signal(self.widget.Inputs.predictors, tree, 1)
 
         with excepthook_catch():


### PR DESCRIPTION
##### Issue
For example, files that Orange loads (with the File widget) may contain paths in one or more columns—for example, the path to images for image analysis. One way to store paths may be to keep them as origin prefixes in attributes of attribute and the last part of the path as column values. Paths (origin + column values) are absolute paths. When the table is transferred to another computer, the path may not be valid anymore. 

##### Description of changes
If the dataset's author provides files besides the CSV file, they may be discovered, and the origin can be fixed.

Additionally, I replaced StringIO reader inputs with actual files in the test. The code should not be adapted to cases only possible in tests.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
