### PR TITLE
[NO-MERGE] Try fixing documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,3 +45,5 @@ multiproject_projects = {
         "path": "visual-programming/source/"
     },
 }
+
+html_theme = "alabaster"


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
RTD started to complain that the theme was not defined in the config. 

##### Description of changes
The theme is not defined in the main config but in configs for subprojects. This PR was just a trial if it is a problem.

Edit: After some research, I found out it should be already fixed: https://github.com/readthedocs/readthedocs.org/issues/10662 and the release is today, so it should start working. So lets just wait and close when it starts to work.


##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
