### PR TITLE
[FIX] Adapt to newly released pandas 2.1

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -2,11 +2,11 @@
 from unittest.mock import patch
 
 import numpy as np
+from pandas import SparseDtype
 from scipy import sparse as sp
 from scipy.sparse import csr_matrix
 import pandas as pd
 from pandas.core.arrays import SparseArray
-from pandas.core.arrays.sparse.dtype import SparseDtype
 from pandas.api.types import (
     is_categorical_dtype, is_object_dtype,
     is_datetime64_any_dtype, is_numeric_dtype, is_integer_dtype

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -200,11 +200,6 @@ class TestPandasCompat(unittest.TestCase):
         self.assertEqual(table.domain.variables[0].have_time, 0)
         self.assertEqual(table.domain.variables[0].have_date, 1)
 
-    @skipIf(
-        datetime.today() < datetime(2023, 10, 1),
-        "Temporarily skipping because of pandas issue",
-    )
-    # https://github.com/pandas-dev/pandas/issues/53134#issuecomment-1546011517
     def test_table_from_frame_time(self):
         df = pd.DataFrame(
             [[pd.Timestamp("00:00:00.25")], [pd.Timestamp("20:20:20.30")], [np.nan]]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
pandas_compat imports `SparseDtype` from `pandas.core.arrays.sparse.dtype`, which is no longer valid.

##### Description of changes
Fix SparseDtype import

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
