### PR TITLE
[FIX] Adapt tests to pandas 2.1 and fix deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Tox
         run: |
@@ -37,20 +37,20 @@ jobs:
       fail-fast: False
       matrix:
         os: [ubuntu-22.04]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: ubuntu-22.04
-            python-version: '3.10'
+            python-version: '3.11'
             tox_env: orange-latest
             name: Latest
           - os: ubuntu-20.04
-            python-version: 3.8
+            python-version: 3.9
             tox_env: orange-oldest
             name: Oldest dependencies
           - os: ubuntu-22.04
-            python-version: 3.9
+            python-version: '3.10'
             tox_env: pyqt6
             name: PyQt6
 
@@ -120,16 +120,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.11'
             tox_env: orange-latest
             name: Latest
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.11'
             tox_env: orange-latest
             name: Latest
           - os: windows-latest

--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -2,7 +2,6 @@
 from unittest.mock import patch
 
 import numpy as np
-from pandas import SparseDtype
 from scipy import sparse as sp
 from scipy.sparse import csr_matrix
 import pandas as pd
@@ -301,7 +300,7 @@ def vars_from_df(df, role=None, force_nominal=False):
         elif not any(a_expr):
             # if all c in columns table will share memory with dataframe
             a_df = df if all(c in a_cols for c in df.columns) else df[a_cols]
-            if all(isinstance(a, SparseDtype) for a in a_df.dtypes):
+            if all(isinstance(a, pd.SparseDtype) for a in a_df.dtypes):
                 arr = csr_matrix(a_df.sparse.to_coo())
             else:
                 arr = np.asarray(a_df)

--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -8,8 +8,10 @@ from scipy.sparse import csr_matrix
 import pandas as pd
 from pandas.core.arrays import SparseArray
 from pandas.api.types import (
-    is_categorical_dtype, is_object_dtype,
-    is_datetime64_any_dtype, is_numeric_dtype, is_integer_dtype
+    is_object_dtype,
+    is_datetime64_any_dtype,
+    is_numeric_dtype,
+    is_integer_dtype,
 )
 
 from Orange.data import (
@@ -166,9 +168,11 @@ def _reset_index(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _is_discrete(s, force_nominal):
-    return (is_categorical_dtype(s) or
-            is_object_dtype(s) and (force_nominal or
-                                    s.nunique() < s.size ** .666))
+    return (
+        isinstance(s.dtype, pd.CategoricalDtype)
+        or is_object_dtype(s)
+        and (force_nominal or s.nunique() < s.size**0.666)
+    )
 
 
 def _is_datetime(s):

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -795,7 +795,7 @@ class TestDenseTablePandas(TestTablePandas):
     def test_amend(self):
         with self.table.unlocked():
             df = self.table.X_df
-            df.iloc[0][0] = 0
+            df.iloc[0, 0] = 0
         X = self.table.X
         with self.table.unlocked():
             self.table.X_df = df

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -200,6 +200,11 @@ class TestPandasCompat(unittest.TestCase):
         self.assertEqual(table.domain.variables[0].have_time, 0)
         self.assertEqual(table.domain.variables[0].have_date, 1)
 
+    @skipIf(
+        pd.__version__.split(".")[:2] == ["2", "0"],
+        "Skipping because of pandas issue in version 2.0.*",
+    )
+    # https://github.com/pandas-dev/pandas/issues/53134#issuecomment-1546011517
     def test_table_from_frame_time(self):
         df = pd.DataFrame(
             [[pd.Timestamp("00:00:00.25")], [pd.Timestamp("20:20:20.30")], [np.nan]]
@@ -414,8 +419,8 @@ class TestPandasCompat(unittest.TestCase):
         self.assertTrue(all(isinstance(v, StringVariable) for v in table.domain.metas))
 
     @skipIf(
-        datetime.today() < datetime(2023, 10, 1),
-        "Temporarily skipping because of pandas issue",
+        pd.__version__.split(".")[:2] == ["2", "0"],
+        "Skipping because of pandas issue in version 2.0.*",
     )
     # https://github.com/pandas-dev/pandas/issues/53134#issuecomment-1546011517
     def test_time_variable_compatible(self):
@@ -423,6 +428,10 @@ class TestPandasCompat(unittest.TestCase):
             return pd.DataFrame([[pd.Timestamp(val)]])
 
         for datestr, timestamp, outstr in TestTimeVariable.TESTS:
+            if datestr == "010101.01":
+                # 010101.01 parses as Jan 1 year 1 which isn't wrong since we do
+                # not provide format (and pandas does as it does in this case)
+                continue
             var = TimeVariable("time")
             var_parse = var.to_val(datestr)
             try:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - recommonmark
   run:
     - python
-    - setuptools >=41.0.0
+    - setuptools >=51.0.0
     - numpy >=1.20.0
     - scipy >=1.9
     - scikit-learn >=1.1.0,<1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=41.0.0,<50.0",
+    "setuptools>=51.0",
     "wheel",
     "cython>=3.0",
     "oldest-supported-numpy",

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -15,7 +15,7 @@ chardet>=3.0.2
 joblib>=1.0.0
 keyring
 keyrings.alt    # for alternative keyring implementations
-setuptools>=41.0.0
+setuptools>=51.0.0
 serverfiles		# for Data Sets synchronization
 networkx
 python-louvain>=0.13

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     oldest: joblib==1.0.0
     # oldest: keyring
     # oldest: keyrings.alt
-    oldest: setuptools==41.0.0
+    oldest: setuptools==51.0.0
     # oldest: serverfiles
     # oldest: networkx
     oldest: python-louvain==0.13


### PR DESCRIPTION
##### Description of changes
- CI - Stop testing Python 3.8 since it isn't recommended to support it anymore, according to [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). Pandas, Numpy, and Scipy dropped support already (after reading skip in the second point of this PR, it is unnecessary to drop those tests anymore, but I would go further with this anyway).
- Re-add skip to pandas test that was removed as part of #6559 (since, at some point, we will probably run the oldest supported workflow with Pandas 2.0.*). It was updating the skipp that was still present and a minor update of the test.
- Handle some deprecations in the Pandas module (is_categorical_dtype and setting value by index without `iloc`).
- Reupdate import from #6559 

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
