### PR TITLE
[FIX] Naive Bayes: fix predictions with unknown values

### DIFF
--- a/Orange/classification/naive_bayes.py
+++ b/Orange/classification/naive_bayes.py
@@ -113,6 +113,7 @@ class NaiveBayesModel(Model):
             p0 = p.T[0].copy()
             probs[:] += p0
             log_prob[i, :p.shape[1]] = p.T - p0
+            log_prob[i, n_vals-1] = -p0
 
         dat = data.data.copy()
         dat[np.isnan(dat)] = n_vals - 1

--- a/Orange/classification/naive_bayes.py
+++ b/Orange/classification/naive_bayes.py
@@ -98,7 +98,7 @@ class NaiveBayesModel(Model):
         zeros = np.zeros((1, probs.shape[1]))
         for col, attr_prob in zip(data.T, self.log_cont_prob):
             col = col.copy()
-            col[np.isnan(col)] = attr_prob.shape[1] - 1
+            col[np.isnan(col)] = attr_prob.shape[1]
             col = col.astype(int)
             probs0 = np.vstack((attr_prob.T, zeros))
             probs += probs0[col]

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -311,6 +311,32 @@ class TestNaiveBayesLearner(unittest.TestCase):
         np.testing.assert_almost_equal(exp_probs, probs)
         np.testing.assert_equal(values, np.argmax(exp_probs, axis=1))
 
+    def test_predict_missing_attributes(self):
+        x = np.array([
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 0],
+            [0, 1, 0],
+            [1, 1, 0],
+            [1, 2, 0],
+            [1, 2, np.nan]])
+        y = np.array([1,0,0,0,1,1,1])
+        domain = Domain(
+            [DiscreteVariable("a", values="ab"),
+             DiscreteVariable("b", values="abc"),
+             DiscreteVariable("c", values="a")],
+            DiscreteVariable("y", values="AB"))
+        data = Table.from_numpy(domain, x, y)
+
+        model = self.learner(data)
+        test_x = np.array([[np.nan, np.nan, np.nan],
+                           [np.nan, 0, np.nan],
+                           [0, np.nan, np.nan]])
+        probs = model(test_x, ret=model.Probs)
+        np.testing.assert_almost_equal(probs, [[(3+1)/(7+2), (4+1)/(7+2)],
+                                               [(1+1)/(2+2), (1+1)/(2+2)],
+                                               [(3+1)/(3+2), (0+1)/(3+2)]])
+
     def test_no_attributes(self):
         y = np.array([0, 0, 0, 1, 1, 1, 2, 2])
         domain = Domain([], DiscreteVariable("y", values="abc"))

--- a/Orange/tests/test_naive_bayes.py
+++ b/Orange/tests/test_naive_bayes.py
@@ -101,14 +101,17 @@ class TestNaiveBayesLearner(unittest.TestCase):
     def test_predictions(self):
         self._test_predictions(sparse=None)
         self._test_predictions_with_absent_class(sparse=None)
+        self._test_predict_missing_attributes(sparse=None)
 
     def test_predictions_csr_matrix(self):
         self._test_predictions(sparse=sp.csr_matrix)
         self._test_predictions_with_absent_class(sparse=sp.csr_matrix)
+        self._test_predict_missing_attributes(sparse=sp.csr_matrix)
 
     def test_predictions_csc_matrix(self):
         self._test_predictions(sparse=sp.csc_matrix)
         self._test_predictions_with_absent_class(sparse=sp.csc_matrix)
+        self._test_predict_missing_attributes(sparse=sp.csc_matrix)
 
     def _test_predictions(self, sparse):
         x = np.array([
@@ -311,7 +314,7 @@ class TestNaiveBayesLearner(unittest.TestCase):
         np.testing.assert_almost_equal(exp_probs, probs)
         np.testing.assert_equal(values, np.argmax(exp_probs, axis=1))
 
-    def test_predict_missing_attributes(self):
+    def _test_predict_missing_attributes(self, sparse):
         x = np.array([
             [1, 0, 0],
             [0, 1, 0],
@@ -320,6 +323,8 @@ class TestNaiveBayesLearner(unittest.TestCase):
             [1, 1, 0],
             [1, 2, 0],
             [1, 2, np.nan]])
+        if sparse is not None:
+            x = sparse(x)
         y = np.array([1,0,0,0,1,1,1])
         domain = Domain(
             [DiscreteVariable("a", values="ab"),
@@ -332,6 +337,8 @@ class TestNaiveBayesLearner(unittest.TestCase):
         test_x = np.array([[np.nan, np.nan, np.nan],
                            [np.nan, 0, np.nan],
                            [0, np.nan, np.nan]])
+        if sparse is not None and sparse is not sp.csc_matrix:
+            test_x = sparse(test_x)
         probs = model(test_x, ret=model.Probs)
         np.testing.assert_almost_equal(probs, [[(3+1)/(7+2), (4+1)/(7+2)],
                                                [(1+1)/(2+2), (1+1)/(2+2)],


### PR DESCRIPTION
##### Issue

Partially addresses #6553.

##### Description of changes

There was an off-by-one error in the Naive Bayes classifier, which resulted in treating unknown feature values as the largest values instead of a separate unknown value (which doesn't contribute towards either class).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
