### PR TITLE
Require orange-widget-base>=4.22

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - pandas >=1.4.0,!=1.5.0,!=2.0.0
     - pyyaml
     - orange-canvas-core >=0.1.30,<0.2a
-    - orange-widget-base >=4.21.0
+    - orange-widget-base >=4.22.0
     - openpyxl
     - httpx >=0.21
     - baycomp >=1.0.2

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,5 +1,5 @@
 orange-canvas-core>=0.1.30,<0.2a
-orange-widget-base>=4.21.0
+orange-widget-base>=4.22.0
 
 AnyQt>=0.2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
     oldest: orange-canvas-core==0.1.30
-    oldest: orange-widget-base==4.21.0
+    oldest: orange-widget-base==4.22.0
     oldest: AnyQt==0.2.0
     oldest: pyqtgraph>=0.13.1
     oldest: matplotlib==3.2.0


### PR DESCRIPTION
##### Issue
After https://github.com/biolab/orange-widget-base/pull/253, we may request users to have the newest orange-widget-base.

While building the Miniconda installer, I noticed it didn't take the newest version (4.21 instead). Since it can happen to any other user, I propose requiring 4.22 by Orange. I think it doesn't hurt.

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
