### PR TITLE
Reorder requirements alphabetically

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,50 +27,50 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
-    - setuptools
-    - numpy
-    - cython
     - pip
-    - wheel
-    - sphinx >=4.2.0
-    - docutils <0.17  # docutils changed html template in 0.17
+    - cython
+    - numpy
     - recommonmark
+    - setuptools
+    - sphinx >=4.2.0
+    - wheel
   run:
     - python
-    - setuptools >=51.0.0
-    - numpy >=1.20.0
-    - scipy >=1.9
-    - scikit-learn >=1.1.0,<1.2.0
-    - bottleneck >=1.3.4
-    - chardet >=3.0.2
-    - xlrd >=1.2.0
-    - xlsxwriter
+    # GUI requirements
+    - orange-canvas-core >=0.1.30,<0.2a
+    - orange-widget-base >=4.22.0
     - anyqt >=0.2.0
     - pyqt >=5.12,!=5.15.1,<6.0
+    - matplotlib-base >=3.2.0
+    - pygments >=2.8.0
     - pyqtgraph >=0.13.1
+    - qtconsole >=4.7.2
+    # core requirements
+    - baycomp >=1.0.2
+    - bottleneck >=1.3.4
+    - catboost >=1.0.1
+    - chardet >=3.0.2
+    - httpx >=0.21
     - joblib >=1.0.0
     - keyring
     - keyrings.alt
-    - pip >=18.0
-    - python.app  # [osx]
-    - serverfiles
-    - python-louvain >=0.13
-    - requests
-    - matplotlib-base >=3.2.0
+    - networkx
+    - numpy >=1.20.0
+    - openpyxl
     - openTSNE >=0.6.1,!=0.7.0
     - pandas >=1.4.0,!=1.5.0,!=2.0.0
+    - pip >=18.0
+    - python.app  # [osx]
+    - python-louvain >=0.13
     - pyyaml
-    - orange-canvas-core >=0.1.30,<0.2a
-    - orange-widget-base >=4.22.0
-    - openpyxl
-    - httpx >=0.21
-    - baycomp >=1.0.2
-    # cachecontrol (required by canvas core) <0.12.5 is incompatible with msgpack 1.0
-    - cachecontrol >=0.12.6
-    - qtconsole >=4.7.2
-    - pygments >=2.8.0
-    - catboost >=1.0.1
+    - requests
+    - scikit-learn >=1.1.0,<1.2.0
+    - scipy >=1.9
+    - serverfiles
+    - setuptools >=51.0.0
     - xgboost >=1.7.4
+    - xlsxwriter
+    - xlrd >=1.2.0
 
 test:
   # Python imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
 requires = [
-    "setuptools>=51.0",
-    "wheel",
     "cython>=3.0",
     "oldest-supported-numpy",
-    "sphinx",
     "recommonmark",
+    "setuptools>=51.0",
+    "sphinx",
+    "wheel",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,30 +1,28 @@
-pip>=18.0
-numpy>=1.20.0
-scipy>=1.9
-# scikit-learn version 1.0.0 includes problematic libomp 12 which breaks xgboost
-# https://github.com/scikit-learn/scikit-learn/pull/21227
-scikit-learn>=1.1.0,<1.2.0
+baycomp>=1.0.2
 bottleneck>=1.3.4
-# Reading Excel files
-xlrd>=1.2.0
-# Writing Excel Files
-xlsxwriter
+catboost>=1.0.1
 # Encoding detection
 chardet>=3.0.2
+httpx>=0.21.0
 # Multiprocessing abstraction
 joblib>=1.0.0
 keyring
 keyrings.alt    # for alternative keyring implementations
-setuptools>=51.0.0
-serverfiles		# for Data Sets synchronization
 networkx
-python-louvain>=0.13
-requests
-openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
-baycomp>=1.0.2
-pandas>=1.4.0,!=1.5.0,!=2.0.0
-pyyaml
+numpy>=1.20.0
 openpyxl
-httpx>=0.21.0
-catboost>=1.0.1
+openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
+pandas>=1.4.0,!=1.5.0,!=2.0.0
+pip>=18.0
+python-louvain>=0.13
+pyyaml
+requests
+scikit-learn>=1.1.0,<1.2.0
+scipy>=1.9
+serverfiles		# for Data Sets synchronization
+setuptools>=51.0.0
 xgboost>=1.7.4
+# Reading Excel files
+xlrd>=1.2.0
+# Writing Excel Files
+xlsxwriter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pylint
 radon
+recommonmark
 # for build_htmlhelp command
 sphinx>=1.5
-recommonmark

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,3 @@
-# docutils changed html template in version 0.17; fixing to 0.16 until parser is not fixed
-# todo: remove docutils requirement when parser fixed in widget-base and released
-docutils<0.17
-Sphinx>=4.2.0
 recommonmark
+Sphinx>=4.2.0
 sphinx-multiproject

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -3,7 +3,7 @@ orange-widget-base>=4.22.0
 
 AnyQt>=0.2.0
 
-pyqtgraph>=0.13.1
 matplotlib>=3.2.0
-qtconsole>=4.7.2
 pygments>=2.8.0
+pyqtgraph>=0.13.1
+qtconsole>=4.7.2

--- a/tox.ini
+++ b/tox.ini
@@ -36,37 +36,39 @@ deps =
     latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
+    # GUI requirements
     oldest: orange-canvas-core==0.1.30
     oldest: orange-widget-base==4.22.0
     oldest: AnyQt==0.2.0
-    oldest: pyqtgraph>=0.13.1
     oldest: matplotlib==3.2.0
-    oldest: qtconsole==4.7.2
     oldest: pygments==2.8.0
-    oldest: pip==18.0
-    oldest: numpy==1.20
-    oldest: scipy==1.9
-    oldest: scikit-learn==1.1.0
+    oldest: pyqtgraph>=0.13.1
+    oldest: qtconsole==4.7.2
+    # core requirements
+    oldest: baycomp==1.0.2
     oldest: bottleneck==1.3.4
-    oldest: xlrd==1.2.0
-    # oldest: xlsxwriter
+    oldest: catboost==1.0.1
     oldest: chardet==3.0.2
+    oldest: httpx==0.21.0
     oldest: joblib==1.0.0
     # oldest: keyring
     # oldest: keyrings.alt
-    oldest: setuptools==51.0.0
-    # oldest: serverfiles
     # oldest: networkx
-    oldest: python-louvain==0.13
-    # oldest: requests
-    oldest: openTSNE==0.6.1
-    oldest: baycomp==1.0.2
-    oldest: pandas==1.4.0
-    # oldest: pyyaml
+    oldest: numpy==1.20
     # oldest: openpyxl
-    oldest: httpx==0.21.0
+    oldest: openTSNE==0.6.1
+    oldest: pandas==1.4.0
+    oldest: pip==18.0
+    oldest: python-louvain==0.13
+    # oldest: pyyaml
+    # oldest: requests
+    oldest: scikit-learn==1.1.0
+    oldest: scipy==1.9
+    # oldest: serverfiles
+    oldest: setuptools==51.0.0
     oldest: xgboost==1.7.4
-    oldest: catboost==1.0.1
+    oldest: xlrd==1.2.0
+    # oldest: xlsxwriter
 
 commands_pre =
     # Verify installed packages have compatible dependencies


### PR DESCRIPTION
##### Issue
Every time I make a release, I have difficulty checking requirements versions between Orange and conda-forge because of different orders in configuration files.

##### Description of changes
With this PR, I propose to order requirements alphabetically so they can be matched more easily.

I also remove `docutils` constraint that is not required anymore due to fix in https://github.com/biolab/orange-canvas-core/pull/224

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
