### PR TITLE
owpreprocess: fix potential crash at destruction

### DIFF
--- a/Orange/widgets/data/owpreprocess.py
+++ b/Orange/widgets/data/owpreprocess.py
@@ -1178,6 +1178,10 @@ class OWPreprocess(widget.OWWidget, openclass=True):
 
         gui.auto_apply(self.buttonsArea, self, "autocommit")
 
+        self.__update_size_constraint_timer = QTimer(
+            self, singleShot=True, interval=0,
+        )
+        self.__update_size_constraint_timer.timeout.connect(self.__update_size_constraint)
         self._initialize()
 
     def _initialize(self):
@@ -1367,8 +1371,7 @@ class OWPreprocess(widget.OWWidget, openclass=True):
 
     def eventFilter(self, receiver, event):
         if receiver is self.flow_view and event.type() == QEvent.LayoutRequest:
-            QTimer.singleShot(0, self.__update_size_constraint)
-
+            self.__update_size_constraint_timer.start()
         return super().eventFilter(receiver, event)
 
     def storeSpecificSettings(self):


### PR DESCRIPTION
##### Issue
When signals are handled when objects are being destroyed we can bugs as in #6136.

The test in https://github.com/biolab/orange3-single-cell/actions/runs/6010124237/job/16300932397?pr=395 failed with 
```
 test_editor_normalize_groups (tests.test_owscpreprocess.TestNormalizeEditor) ... Traceback (most recent call last):
  File "/Users/runner/work/orange3-single-cell/orange3-single-cell/.tox/orange-oldest/lib/python3.9/site-packages/Orange/widgets/data/owpreprocess.py", line 1412, in __update_size_constraint
    sh = self.flow_view.minimumSizeHint()
AttributeError: 'OWscPreprocess' object has no attribute 'flow_view'
```

Thanks to @elapraznik for the crash. :)

##### Description of changes
Check if the object is still live. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
