### PR TITLE
Distance File: Don't accept dropped .xlsx files

### DIFF
--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -124,6 +124,8 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
                 err = str(exc)
                 self.Error.invalid_file(" \n"[len(err) > 40] + err)
             else:
+                # If you add any other checks before accepting the file,
+                # you should probably mirror them in canDropFile
                 if distances.shape[0] != distances.shape[1]:
                     self.Error.non_square_matrix()
                 else:
@@ -158,7 +160,14 @@ class OWDistanceFileDropHandler(SingleFileDropHandler):
         return {"recent_paths": stored_recent_paths_prepend(self.WIDGET, r)}
 
     def canDropFile(self, path: str) -> bool:
-        return os.path.splitext(path)[1].lower() in (".dst", ".xlsx")
+        if os.path.splitext(path)[0] == ".dst":
+            return True
+        try:
+            distances = DistMatrix.from_file(path)
+        except Exception:  # pylint: disable=broad-except
+            return False
+        else:
+            return distances.shape[0] == distances.shape[1]
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/unsupervised/tests/test_owdistancefile.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancefile.py
@@ -35,9 +35,13 @@ class TestOWDistanceFile(WidgetTest):
 
 class TestOWDistanceFileDropHandler(unittest.TestCase):
     def test_canDropFile(self):
+        def ren(name):
+            return os.path.join(os.path.split(Orange.tests.__file__)[0], name)
+
         handler = OWDistanceFileDropHandler()
-        self.assertTrue(handler.canDropFile("test.dst"))
-        self.assertTrue(handler.canDropFile("test.xlsx"))
+        self.assertTrue(handler.canDropFile(ren("xlsx_files/distances_with_nans.xlsx")))
+        self.assertFalse(handler.canDropFile(ren("xlsx_files/distances_nonsquare.xlsx")))
+        self.assertFalse(handler.canDropFile(ren("datasets/lenses.tab")))
         self.assertFalse(handler.canDropFile("test.bin"))
 
     def test_parametersFromFile(self):


### PR DESCRIPTION
##### Issue

When dropping an .xlsx file onto canvas, the user has to choose between Distance File and File, which is confusing (because these are widget names). The user almost always wants to load an .xlsx with File.

##### Description of changes

Distance File's functionality now no longer accepts .xlsx files.

##### Includes
- [X] Code changes
- [X] Tests
