### PR TITLE
[FIX] EmbedderCache - Handle cache persisting when no permissions

### DIFF
--- a/Orange/misc/tests/test_embedder_utils.py
+++ b/Orange/misc/tests/test_embedder_utils.py
@@ -1,7 +1,11 @@
 import os
+import shutil
+import stat
+import tempfile
 import unittest
+from unittest.mock import patch
 
-from Orange.misc.utils.embedder_utils import get_proxies
+from Orange.misc.utils.embedder_utils import get_proxies, EmbedderCache
 
 
 class TestProxies(unittest.TestCase):
@@ -61,6 +65,70 @@ class TestProxies(unittest.TestCase):
     def test_none(self):
         """ When no variable is set return None """
         self.assertIsNone(get_proxies())
+
+
+class TestEmbedderCache(unittest.TestCase):
+    # pylint: disable=protected-access
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        patcher = patch(
+            "Orange.misc.utils.embedder_utils.cache_dir", return_value=self.temp_dir
+        )
+        patcher.start()
+        self.addCleanup(patch.stopall)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_save_load_cache(self):
+        # open when cache file doesn't exist yet
+        cache = EmbedderCache("TestModel")
+        self.assertDictEqual({}, cache._cache_dict)
+
+        # add values and save to test opening with existing file
+        cache.add("abc", [1, 2, 3])
+        cache.persist_cache()
+
+        cache = EmbedderCache("TestModel")
+        self.assertDictEqual({"abc": [1, 2, 3]}, cache._cache_dict)
+
+    def test_save_cache_no_permission(self):
+        # prepare a file
+        cache = EmbedderCache("TestModel")
+        self.assertDictEqual({}, cache._cache_dict)
+        cache.add("abc", [1, 2, 3])
+        cache.persist_cache()
+
+        # set file to read-only and try to write
+        curr_permission = os.stat(cache._cache_file_path).st_mode
+        os.chmod(cache._cache_file_path, stat.S_IRUSR)
+        cache.add("abcd", [1, 2, 3])
+        # new values should be cached since file is readonly
+        cache.persist_cache()
+        cache = EmbedderCache("TestModel")
+        self.assertDictEqual({"abc": [1, 2, 3]}, cache._cache_dict)
+        os.chmod(cache._cache_file_path, curr_permission)
+
+    def test_load_cache_no_permission(self):
+        # prepare a file
+        cache = EmbedderCache("TestModel")
+        self.assertDictEqual({}, cache._cache_dict)
+        cache.add("abc", [1, 2, 3])
+        cache.persist_cache()
+
+        # no read permission - load no cache
+        if os.name == "nt":
+            with patch(
+                "Orange.misc.utils.embedder_utils.pickle.load",
+                side_effect=PermissionError,
+            ):
+                # it is difficult to change write permission on Windows using
+                # patch instead
+                cache = EmbedderCache("TestModel")
+        else:
+            os.chmod(cache._cache_file_path, stat.S_IWUSR)
+            cache = EmbedderCache("TestModel")
+        self.assertDictEqual({}, cache._cache_dict)
 
 
 if __name__ == "__main__":

--- a/Orange/misc/utils/embedder_utils.py
+++ b/Orange/misc/utils/embedder_utils.py
@@ -38,21 +38,25 @@ class EmbedderCache:
 
     def _init_cache(self):
         if isfile(self._cache_file_path):
-            try:
-                return self.load_pickle(self._cache_file_path)
-            except EOFError:
-                return {}
+            return self.load_pickle(self._cache_file_path)
         return {}
 
     @staticmethod
     def save_pickle(obj, file_name):
-        with open(file_name, 'wb') as f:
-            pickle.dump(obj, f)
+        try:
+            with open(file_name, 'wb') as f:
+                pickle.dump(obj, f)
+        except PermissionError:
+            # do not save cache if no right permission
+            pass
 
     @staticmethod
     def load_pickle(file_name):
-        with open(file_name, 'rb') as f:
-            return pickle.load(f)
+        try:
+            with open(file_name, 'rb') as f:
+                return pickle.load(f)
+        except (EOFError, PermissionError):
+            return {}
 
     @staticmethod
     def md5_hash(bytes_):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Issue described here: https://github.com/biolab/orange-canvas-core/pull/288

##### Description of changes
When no read or write permission, do not load or save embeddings to cache.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
