### PR TITLE
Orange.utils: Add decorator 'allot'

### DIFF
--- a/Orange/tests/test_util.py
+++ b/Orange/tests/test_util.py
@@ -2,7 +2,7 @@ from itertools import count
 import time
 import os
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import warnings
 
 import numpy as np
@@ -245,6 +245,14 @@ class TestUtil(unittest.TestCase):
 
 class TestAllot(unittest.TestCase):
     # names of functions within tests don't matter, pylint: disable=invalid-name
+
+    def setUp(self):
+        # patch the object to user perf_counter, which will include the time
+        # when tests `sleep`
+        patcher = patch.object(allot, "_allot__timer", new=time.perf_counter)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_duration(self):
         @allot
         def f(x, y):

--- a/i18n/si.jaml
+++ b/i18n/si.jaml
@@ -142,6 +142,9 @@ util.py:
                 __self__: false
                 {func.__self__.__class__}.{name}: false
                 Call to deprecated {name}{alternative}: false
+    class `allot`:
+        def `call`:
+            skippable function cannot return a result: false
     def `literal_eval`:
         set(): false
     ==: false


### PR DESCRIPTION
##### Issue

When animating an optimization like laying out a network (and supposedly also MDS, tSNE, freeviz) frequent updates of the graph can make the gui unresponsive.

In particular, when optimizing a network layout in the network add-on, the user can temporarily decrease the gravity and then increase it again, using a slider. The slider is unresponsive when the network has a lot of connections.

##### Changes

Decorator `allot(p)` allocates a given proportion of time to the function. I tried it in the Network Explorer, decorating `on_partial_result` with `allot(0.02)` makes the widget responsive on graphs with 10000 nodes and edges.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation
