### PR TITLE
Start Vizrank when opened, pause when closed

### DIFF
--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -12,7 +12,7 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.metrics import r2_score
 
 from AnyQt.QtGui import QStandardItem, QPalette
-from AnyQt.QtCore import Qt, QRectF, QLineF, pyqtSignal as Signal
+from AnyQt.QtCore import QRectF, QLineF
 
 import pyqtgraph as pg
 
@@ -22,13 +22,13 @@ from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.projection import PCA, LDA, LinearProjector
 from Orange.util import Enum
 from Orange.widgets import gui, report
-from Orange.widgets.gui import OWComponent
 from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
 from Orange.widgets.utils.localization import pl
 from Orange.widgets.utils.plot import variables_selection
 from Orange.widgets.utils.plot.owplotgui import VariableSelectionModel
 from Orange.widgets.utils.widgetpreview import WidgetPreview
-from Orange.widgets.visualize.utils import VizRankDialog
+from Orange.widgets.visualize.utils import VizRankDialogNAttrs, \
+    CloseVizrankMixin
 from Orange.widgets.visualize.utils.component import OWGraphWithAnchors
 from Orange.widgets.visualize.utils.plotutils import AnchorItem
 from Orange.widgets.visualize.utils.widget import OWAnchorProjectionWidget
@@ -38,54 +38,13 @@ from Orange.widgets.widget import Msg
 MAX_LABEL_LEN = 20
 
 
-class LinearProjectionVizRank(VizRankDialog, OWComponent):
+class LinearProjectionVizRank(VizRankDialogNAttrs):
     captionTitle = "Score Plots"
-    n_attrs = Setting(3)
     minK = 10
 
-    attrsSelected = Signal([])
-    _AttrRole = next(gui.OrangeUserRole)
-
-    def __init__(self, master):
-        # Add the spin box for a number of attributes to take into account.
-        VizRankDialog.__init__(self, master)
-        OWComponent.__init__(self, master)
-
-        box = gui.hBox(self)
-        self.n_attrs_spin = gui.spin(
-            box, self, None, 3, 8, label="Number of variables: ",
-            controlWidth=50, alignment=Qt.AlignRight,
-            callback=self.on_attrs_changed)
-        gui.rubber(box)
-
-        self.last_run_n_attrs = None
-        self.attr_color = master.attr_color
-        self.attrs = []
-
-    def initialize(self):
-        super().initialize()
-        self.attr_color = self.master.attr_color
-        n_cont = sum(v is not self.attr_color
-                     for v in self.master.continuous_variables)
-        self.n_attrs_spin.setValue(min(self.n_attrs, n_cont))
-        self.n_attrs_spin.setMaximum(n_cont)
-
-    def before_running(self):
-        """
-        If the number of attributes is different than
-        in the last run, reset the saved state (if it was paused).
-        """
-        if self.n_attrs != self.last_run_n_attrs:
-            self.saved_state = None
-            self.saved_progress = 0
-        if self.saved_state is None:
-            self.scores = []
-            self.rank_model.clear()
-        self.last_run_n_attrs = self.n_attrs
-
-    def check_preconditions(self):
-        return super().check_preconditions() \
-               and self.master.btn_vizrank.isEnabled()
+    def max_attrs(self):
+        return sum(v is not self.attr_color
+                   for v in self.master.continuous_variables)
 
     def state_count(self):
         n_all_attrs = len(self.attrs)
@@ -173,36 +132,6 @@ class LinearProjectionVizRank(VizRankDialog, OWComponent):
         attrs = selected.indexes()[0].data(self._AttrRole)
         self.selectionChanged.emit([attrs])
 
-    def on_attrs_changed(self):
-        if self.keep_running:
-            self.pause_computation()
-        if self.rank_model.rowCount() == 0:
-            self.button.setText("Start")
-            self.button.setDisabled(False)
-        elif (new_attrs := self.n_attrs_spin.value()) != self.n_attrs:
-            self.button.setText(f"Restart with {new_attrs} variables")
-            self.button.setDisabled(False)
-        else:
-            self.button.setText("Continue" if not self.done else "Finished")
-            self.button.setDisabled(self.done)
-
-    def start_computation(self):
-        self.n_attrs_spin.setValue(self.n_attrs)
-        self.n_attrs_spin.lineEdit().deselect()
-        self.rank_table.setFocus(Qt.FocusReason.OtherFocusReason)
-        super().start_computation()
-
-    def toggle(self):
-        if self.n_attrs != self.n_attrs_spin.value():
-            self.n_attrs = self.n_attrs_spin.value()
-            self.initialize()
-        super().toggle()
-
-    def closeEvent(self, event):
-        self.pause_computation()
-        self.n_attrs_spin.setValue(self.n_attrs)
-        super().closeEvent(event)
-
 
 class OWLinProjGraph(OWGraphWithAnchors):
     hide_radius = Setting(0)
@@ -283,7 +212,7 @@ Placement = Enum("Placement", dict(Circular=0, LDA=1, PCA=2), type=int,
                  qualname="Placement")
 
 
-class OWLinearProjection(OWAnchorProjectionWidget):
+class OWLinearProjection(OWAnchorProjectionWidget, CloseVizrankMixin):
     name = "Linear Projection"
     description = "A multi-axis projection of data onto " \
                   "a two-dimensional plane."
@@ -326,8 +255,8 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         self.model_selected.selection_changed.connect(
             self.__model_selected_changed)
         self.vizrank, self.btn_vizrank = LinearProjectionVizRank.add_vizrank(
-            None, self, "Suggest Features", self.__vizrank_set_attrs)
-        self.btn_vizrank.pressed.connect(self.start_vizrank)
+            None, self, "Suggest Features", self.__vizrank_set_attrs,
+            auto_start=True)
         box.layout().addWidget(self.btn_vizrank)
 
     def _add_controls_placement(self, box):
@@ -451,9 +380,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         if is_enabled:
             self.vizrank.initialize()
 
-    def start_vizrank(self):
-        self.vizrank.start_computation()
-
     def check_data(self):
         def error(err):
             err()
@@ -493,22 +419,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         norm_emb = normalized(embedding[self.valid_data])
         return (norm_emb.ravel(), np.zeros(len(norm_emb), dtype=float)) \
             if embedding.shape[1] == 1 else norm_emb.T
-
-    def closeEvent(self, event):
-        if self.vizrank is not None:
-            self.vizrank.close()
-        super().closeEvent(event)
-
-    def hideEvent(self, event):
-        if self.vizrank is not None:
-            self.vizrank.hide()
-        super().hideEvent(event)
-
-    def deleteEvent(self):
-        if self.vizrank is not None:
-            self.vizrank.keep_running = False
-            self.vizrank.shutdown()
-        super().deleteEvent()
 
     def _get_send_report_caption(self):
         def projection_name():

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import cross_val_score
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
 from AnyQt.QtGui import QStandardItem, QColor, QPalette
-from AnyQt.QtCore import Qt, QRectF, QPoint, pyqtSignal as Signal
+from AnyQt.QtCore import Qt, QRectF, QPoint
 
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ScatterPlotItem import ScatterPlotItem
@@ -17,12 +17,12 @@ from Orange.data import Table, Domain
 from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.projection import RadViz
 from Orange.widgets import widget, gui
-from Orange.widgets.gui import OWComponent
-from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
+from Orange.widgets.settings import ContextSetting, SettingProvider
 from Orange.widgets.utils.plot.owplotgui import VariableSelectionModel, \
     variables_selection
 from Orange.widgets.utils.widgetpreview import WidgetPreview
-from Orange.widgets.visualize.utils import VizRankDialog
+from Orange.widgets.visualize.utils import VizRankDialogNAttrs, \
+    CloseVizrankMixin
 from Orange.widgets.visualize.utils.component import OWGraphWithAnchors
 from Orange.widgets.visualize.utils.plotutils import TextItem
 from Orange.widgets.visualize.utils.widget import OWAnchorProjectionWidget
@@ -32,32 +32,14 @@ MAX_DISPLAYED_VARS = 20
 MAX_LABEL_LEN = 16
 
 
-class RadvizVizRank(VizRankDialog, OWComponent):
+class RadvizVizRank(VizRankDialogNAttrs):
     captionTitle = "Score Plots"
-    n_attrs = Setting(3)
     minK = 10
 
-    attrsSelected = Signal([])
-    _AttrRole = next(gui.OrangeUserRole)
-
-    percent_data_used = Setting(100)
-
     def __init__(self, master):
-        """Add the spin box for maximal number of attributes"""
-        VizRankDialog.__init__(self, master)
-        OWComponent.__init__(self, master)
-
-        self.master = master
+        super().__init__(master)
         self.n_neighbors = 10
 
-        box = gui.hBox(self)
-        max_n_attrs = min(MAX_DISPLAYED_VARS, len(master.model_selected))
-        self.n_attrs_spin = gui.spin(
-            box, self, "n_attrs", 3, max_n_attrs, label="Maximum number of variables: ",
-            controlWidth=50, alignment=Qt.AlignRight, callback=self._n_attrs_changed)
-        gui.rubber(box)
-        self.last_run_n_attrs = None
-        self.attr_color = master.attr_color
         self.attr_ordering = None
         self.data = None
         self.valid_data = None
@@ -66,9 +48,9 @@ class RadvizVizRank(VizRankDialog, OWComponent):
         self.rank_table.verticalHeader().sectionClicked.connect(
             self.on_header_clicked)
 
-    def initialize(self):
-        super().initialize()
-        self.attr_color = self.master.attr_color
+    def max_attrs(self):
+        return sum(v is not self.attr_color
+                   for v in self.master.primitive_variables)
 
     def _compute_attr_order(self):
         """
@@ -88,53 +70,23 @@ class RadvizVizRank(VizRankDialog, OWComponent):
 
     def _evaluate_projection(self, x, y):
         """
-        kNNEvaluate - evaluate class separation in the given projection using a k-NN method
-        Parameters
-        ----------
-        x - variables to evaluate
-        y - class
-
-        Returns
-        -------
-        scores
+        kNNEvaluate - evaluate class separation in the given projection with k-NN
         """
-        if self.percent_data_used != 100:
-            rand = np.random.choice(len(x), int(len(x) * self.percent_data_used / 100),
-                                    replace=False)
-            x = x[rand]
-            y = y[rand]
-        neigh = KNeighborsClassifier(n_neighbors=3) if self.attr_color.is_discrete else \
-            KNeighborsRegressor(n_neighbors=3)
-        assert ~(np.isnan(x).any(axis=None) | np.isnan(x).any(axis=None))
+        assert not np.any(np.isnan(x)) and not np.any(np.isnan(y))
+        neigh = (KNeighborsClassifier if self.attr_color.is_discrete else
+                 KNeighborsRegressor)(n_neighbors=3)
         neigh.fit(x, y)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             scores = cross_val_score(neigh, x, y, cv=3)
         return scores.mean()
 
-    def _n_attrs_changed(self):
-        """
-        Change the button label when the number of attributes changes. The method does not reset
-        anything so the user can still see the results until actually restarting the search.
-        """
-        if self.n_attrs != self.last_run_n_attrs or self.saved_state is None:
-            self.button.setText("Start")
-        else:
-            self.button.setText("Continue")
-        self.button.setEnabled(self.check_preconditions())
-
-    def progressBarSet(self, value):
-        self.setWindowTitle(self.captionTitle + " Evaluated {} permutations".format(value))
-
-    def check_preconditions(self):
-        master = self.master
-        if not super().check_preconditions():
-            return False
-        elif not master.btn_vizrank.isEnabled():
-            return False
-        self.n_attrs_spin.setMaximum(min(MAX_DISPLAYED_VARS,
-                                         len(master.model_selected)))
-        return True
+    def state_count(self):
+        n_all_attrs = len(self.attrs)
+        if not n_all_attrs:
+            return 0
+        n_attrs = self.n_attrs
+        return factorial(n_all_attrs) // (2 * factorial(n_all_attrs - n_attrs) * n_attrs)
 
     def on_selection_changed(self, selected, _):
         self.on_row_clicked(selected.indexes()[0])
@@ -185,30 +137,12 @@ class RadvizVizRank(VizRankDialog, OWComponent):
 
     def row_for_state(self, score, state):
         attrs = [self.attrs[s] for s in state]
-        item = QStandardItem("[{:0.6f}] ".format(-score) + ", ".join(a.name for a in attrs))
+        item = QStandardItem(', '.join(a.name for a in attrs))
         item.setData(attrs, self._AttrRole)
         return [item]
 
     def _update_progress(self):
         self.progressBarSet(int(self.saved_progress))
-
-    def before_running(self):
-        """
-        Disable the spin for number of attributes before running and
-        enable afterwards. Also, if the number of attributes is different than
-        in the last run, reset the saved state (if it was paused).
-        """
-        if self.n_attrs != self.last_run_n_attrs:
-            self.saved_state = None
-            self.saved_progress = 0
-        if self.saved_state is None:
-            self.scores = []
-            self.rank_model.clear()
-        self.last_run_n_attrs = self.n_attrs
-        self.n_attrs_spin.setDisabled(True)
-
-    def stopped(self):
-        self.n_attrs_spin.setDisabled(False)
 
 
 class OWRadvizGraph(OWGraphWithAnchors):
@@ -309,7 +243,7 @@ class OWRadvizGraph(OWGraphWithAnchors):
         self.plot_widget.addItem(self.indicator_item)
 
 
-class OWRadviz(OWAnchorProjectionWidget):
+class OWRadviz(OWAnchorProjectionWidget, CloseVizrankMixin):
     name = "Radviz"
     description = "Display Radviz projection"
     icon = "icons/Radviz.svg"
@@ -337,7 +271,8 @@ class OWRadviz(OWAnchorProjectionWidget):
         self.model_selected.selection_changed.connect(
             self.__model_selected_changed)
         self.vizrank, self.btn_vizrank = RadvizVizRank.add_vizrank(
-            None, self, "Suggest features", self.vizrank_set_attrs)
+            None, self, "Suggest features", self.vizrank_set_attrs,
+            auto_start=True)
         box.layout().addWidget(self.btn_vizrank)
         super()._add_controls()
 

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -409,7 +409,8 @@ class OWScatterPlot(OWDataProjectionWidget):
         )
         vizrank_box = gui.hBox(self.attr_box)
         self.vizrank, self.vizrank_button = ScatterPlotVizRank.add_vizrank(
-            vizrank_box, self, "Find Informative Projections", self.set_attr)
+            vizrank_box, self, "Find Informative Projections", self.set_attr,
+            auto_start=True)
 
     def _add_controls_sampling(self):
         self.sampling = gui.auto_commit(

--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -119,7 +119,8 @@ class OWSieveDiagram(OWWidget):
         gui.widgetLabel(self.attr_box, "\u2717", sizePolicy=fixed_size)
         gui.comboBox(value="attr_y", **combo_args)
         self.vizrank, self.vizrank_button = SieveRank.add_vizrank(
-            self.attr_box, self, "Score Combinations", self.set_attr)
+            self.attr_box, self, "Score Combinations", self.set_attr,
+            auto_start=True)
         self.vizrank_button.setSizePolicy(*fixed_size)
 
         self.canvas = QGraphicsScene(self)

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -363,7 +363,7 @@ class MosaicVizRankTests(WidgetTest):
     def test_max_attr_combo_1_disabling(self):
         widget = self.widget
         vizrank = widget.vizrank
-        combo = vizrank.max_attr_combo
+        combo = vizrank.attrs_combo
         model = combo.model()
         enabled = Qt.ItemIsSelectable | Qt.ItemIsEnabled
 

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -115,6 +115,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.keep_running = False
         self.scheduled_call = None
         self.saved_state = None
+        self.done = False
         self.saved_progress = 0
         self.scores = []
         self.add_to_model = Queue()
@@ -224,6 +225,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.keep_running = False
         self.scheduled_call = None
         self.saved_state = None
+        self.done = False
         self.saved_progress = 0
         self.progressBarFinished()
         self.scores = []
@@ -329,6 +331,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.button.setEnabled(False)
         self.keep_running = False
         self.saved_state = None
+        self.done = True
         self._stopped()
 
     def _stopped(self):
@@ -361,20 +364,27 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
 
     def toggle(self):
         """Start or pause the computation."""
-        self.keep_running = not self.keep_running
-        if self.keep_running:
-            self.button.setText("Pause")
-            self.button.repaint()
-            self.progressBarInit()
-            self.before_running()
-            self.start(run_vizrank, self.compute_score,
-                       self.iterate_states, self.saved_state, self.scores,
-                       self.saved_progress, self.state_count())
+        if not self.keep_running:
+            self.start_computation()
         else:
-            self.button.setText("Continue")
-            self.button.repaint()
-            self.cancel()
-            self._stopped()
+            self.pause_computation()
+
+    def start_computation(self):
+        self.keep_running = True
+        self.button.setText("Pause")
+        self.button.repaint()
+        self.progressBarInit()
+        self.before_running()
+        self.start(run_vizrank, self.compute_score,
+                   self.iterate_states, self.saved_state, self.scores,
+                   self.saved_progress, self.state_count())
+
+    def pause_computation(self):
+        self.keep_running = False
+        self.button.setText("Continue")
+        self.button.repaint()
+        self.cancel()
+        self._stopped()
 
     def before_running(self):
         """Code that is run before running vizrank in its own thread"""

--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,8 @@ disable=
     no-name-in-module, no-member,  # too many false positives from Qt
     import-error,       # false positives, and we don't expect any true positives
     too-many-ancestors, # I don't think this is a problem
-    no-else-return      # else's may actually improve readability
+    no-else-return,     # else's may actually improve readability
+    duplicate-code      # too strict; we're disciplined and don't do this by mistake
 
 
 [REPORTS]


### PR DESCRIPTION
##### Issue

Fixes #6504. Also fixes #6624.

##### Description of changes

- Vizrank starts immediately, as the user presses "Suggest Features", and closing it **pauses** it. 
- Re-opening after closing restarts it.
- Changing the settings (number of attributes) also pauses it. The user can restart with the new setting or continue with the old.

(Rather) unrelated, I disabled `duplicate-code` issue in pylint, as we discussed a few weeks ago. This is a new test, it is too strict, and also unnecessary in our context: duplicated code was never an issue for us, so we will get just plenty of pointless issues. Including here, which is why I've had enough in this PR.

List of commits:

- Commit 1: Auto-start/pause for Linear Projection.
- Commit 2: Fixes #6624.
- Commit 3: Minor change in the runner. I think this is cleaner, plus it reduce the block enclosed in try-except .
- Commit 4: Refactoring: 
    - `VizRankDialogNAttrs`, a VizRank dialog in which user sets the number of variables, with functionality shared between Linear projection and Radviz
    - `CloseVizrankMixin` that should be mixed into all widgets with vizranks so that they stop vizrank when they are closed
    - `auto_start: bool` argument for `VizRankDialog.add_vizrank`, which causes computation to start when the vizrank button is pressed, and pauses it when dialog is closed.
- Commit 5: Auto-start/pause for Radviz.
- Commit 6: Auto-start/pause for Mosaic.
- Commit 7: Sieve and Scatter plot.
- Commit 8: Disable `duplicate-code` in pylintrc

##### Includes
- [X] Code changes
- [X] Some tests
