### PR TITLE
ROC: Output a model with a new operating threshold

### DIFF
--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -20,7 +20,8 @@ from Orange.classification import ThresholdClassifier
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.evaluate.contexthandlers import \
     EvaluationResultsContextHandler
-from Orange.widgets.evaluate.utils import check_results_adequacy
+from Orange.widgets.evaluate.utils import check_results_adequacy, \
+    check_can_calibrate
 from Orange.widgets.utils import colorpalettes
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.utils.customizableplot import Updater, \
@@ -493,23 +494,10 @@ class OWLiftCurve(widget.OWWidget):
         wrapped = None
         results = self.results
         if results is not None:
-            problems = [
-                msg for condition, msg in (
-                    (results.folds is not None and len(results.folds) > 1,
-                     "each training data sample produces a different model"),
-                    (results.models is None,
-                     "test results do not contain stored models - try testing "
-                     "on separate data or on training data"),
-                    (len(self.selected_classifiers) != 1,
-                     "select a single model - the widget can output only one"),
-                    (len(results.domain.class_var.values) != 2,
-                     "cannot calibrate non-binary classes"))
-                if condition]
-            if len(problems) == 1:
-                self.Information.no_output(problems[0])
-            elif problems:
-                self.Information.no_output(
-                    "".join(f"\n - {problem}" for problem in problems))
+            problems = check_can_calibrate(
+                self.results, self.selected_classifiers)
+            if problems:
+                self.Information.no_output(problems)
             else:
                 clsf_idx = self.selected_classifiers[0]
                 model = results.models[0, clsf_idx]

--- a/Orange/widgets/evaluate/owliftcurve.py
+++ b/Orange/widgets/evaluate/owliftcurve.py
@@ -268,7 +268,7 @@ class OWLiftCurve(widget.OWWidget):
             item = self.classifiers_list_box.item(i)
             item.setIcon(colorpalettes.ColorIcon(color))
 
-        class_values = results.data.domain.class_var.values
+        class_values = results.domain.class_var.values
         self.target_cb.addItems(class_values)
         if class_values:
             self.target_index = 0

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -466,7 +466,7 @@ class OWROCAnalysis(widget.OWWidget):
             listitem = self.classifiers_list_box.item(i)
             listitem.setIcon(colorpalettes.ColorIcon(self.colors[i]))
 
-        class_var = results.data.domain.class_var
+        class_var = results.domain.class_var
         self.target_cb.addItems(class_var.values)
         self.target_index = 0
         self._set_target_prior()

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -13,18 +13,21 @@ from AnyQt.QtCore import Qt, QSize
 import pyqtgraph as pg
 
 import Orange
+from Orange.base import Model
+from Orange.classification import ThresholdClassifier
+from Orange.evaluation.testing import Results
 from Orange.widgets import widget, gui, settings
 from Orange.widgets.evaluate.contexthandlers import \
     EvaluationResultsContextHandler
-from Orange.widgets.evaluate.utils import check_results_adequacy
+from Orange.widgets.evaluate.utils import check_results_adequacy, \
+    check_can_calibrate
 from Orange.widgets.utils import colorpalettes
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.utils.plotutils import GraphicsView, PlotItem
-from Orange.widgets.widget import Input
+from Orange.widgets.widget import Input, Output, Msg
 from Orange.widgets import report
 
 from Orange.widgets.evaluate.utils import results_for_preview
-from Orange.evaluation.testing import Results
 
 
 #: Points on a ROC curve
@@ -304,6 +307,12 @@ class OWROCAnalysis(widget.OWWidget):
 
     class Inputs:
         evaluation_results = Input("Evaluation Results", Orange.evaluation.Results)
+
+    class Outputs:
+        calibrated_model = Output("Calibrated Model", Model)
+
+    class Information(widget.OWWidget.Information):
+        no_output = Msg("Can't output a model: {}")
 
     buttons_area_orientation = None
     settingsHandler = EvaluationResultsContextHandler()
@@ -620,8 +629,7 @@ class OWROCAnalysis(widget.OWWidget):
         pen.setCosmetic(True)
         self.plot.plot([0, 1], [0, 1], pen=pen, antialias=True)
 
-        if self.roc_averaging == OWROCAnalysis.Merge:
-            self._update_perf_line()
+        self._update_perf_line()
 
         self._update_axes_ticks()
 
@@ -730,8 +738,7 @@ class OWROCAnalysis(widget.OWWidget):
         self._on_display_perf_line_changed()
 
     def _on_display_perf_line_changed(self):
-        if self.roc_averaging == OWROCAnalysis.Merge:
-            self._update_perf_line()
+        self._update_perf_line()
 
         if self.perf_line is not None:
             self.perf_line.setVisible(self.display_perf_line)
@@ -745,9 +752,12 @@ class OWROCAnalysis(widget.OWWidget):
             self._setup_plot()
 
     def _update_perf_line(self):
-        if self._perf_line is None:
+
+        if self._perf_line is None or self.roc_averaging != OWROCAnalysis.Merge:
+            self._update_output(None)
             return
 
+        ind = None
         self._perf_line.setVisible(self.display_perf_line)
         if self.display_perf_line:
             m = roc_iso_performance_slope(
@@ -761,6 +771,26 @@ class OWROCAnalysis(widget.OWWidget):
                 self._perf_line.setPos((hull.fpr[ind[0]], hull.tpr[ind[0]]))
             else:
                 self._perf_line.setVisible(False)
+
+        self._update_output(None if ind is None else hull.thresholds[ind[0]])
+
+    def _update_output(self, threshold):
+        self.Information.no_output.clear()
+
+        if threshold is None:
+            self.Outputs.calibrated_model.send(None)
+            return
+
+        problems = check_can_calibrate(self.results, self.selected_classifiers)
+        if problems:
+            self.Information.no_output(problems)
+            self.Outputs.calibrated_model.send(None)
+            return
+
+        model = ThresholdClassifier(
+            self.results.models[0][self.selected_classifiers[0]],
+            threshold)
+        self.Outputs.calibrated_model.send(model)
 
     def onDeleteWidget(self):
         self.clear()

--- a/Orange/widgets/evaluate/tests/base.py
+++ b/Orange/widgets/evaluate/tests/base.py
@@ -1,9 +1,59 @@
+from unittest.mock import Mock
+
+import numpy as np
+
 from Orange import classification, evaluation
-from Orange.data import Table
+from Orange.data import Table, Domain, DiscreteVariable
+from Orange.evaluation import Results
+from Orange.evaluation.performance_curves import Curves
+from Orange.tests import test_filename
+
+from Orange.widgets.tests.base import WidgetTest
 
 
-class EvaluateTest:
+class EvaluateTest(WidgetTest):
+    def setUp(self):
+        super().setUp()
+
+        n, p = (0, 1)
+        actual, probs = np.array([
+            (p, .8), (n, .7), (p, .6), (p, .55), (p, .54), (n, .53), (n, .52),
+            (p, .51), (n, .505), (p, .4), (n, .39), (p, .38), (n, .37),
+            (n, .36), (n, .35), (p, .34), (n, .33), (p, .30), (n, .1)]).T
+        self.curves = Curves(actual, probs)
+        probs2 = (probs + 1) / 2
+        self.curves2 = Curves(actual, probs2)
+        pred = probs > 0.5
+        pred2 = probs2 > 0.5
+        probs = np.vstack((1 - probs, probs)).T
+        probs2 = np.vstack((1 - probs2, probs2)).T
+        domain = Domain([], DiscreteVariable("y", values=("a", "b")))
+        self.results = Results(
+            domain=domain,
+            actual=actual,
+            folds=np.array([Ellipsis]),
+            models=np.array([[Mock(), Mock()]]),
+            row_indices=np.arange(19),
+            predicted=np.array((pred, pred2)),
+            probabilities=np.array([probs, probs2]))
+
+        self.lenses = data = Table(test_filename("datasets/lenses.tab"))
+        majority = classification.MajorityLearner()
+        majority.name = "majority"
+        knn3 = classification.KNNLearner(n_neighbors=3)
+        knn3.name = "knn-3"
+        knn1 = classification.KNNLearner(n_neighbors=1)
+        knn1.name = "knn-1"
+        self.lenses_results = evaluation.TestOnTestData(
+            store_data=True, store_models=True)(
+                data=data[::2], test_data=data[1::2],
+                learners=[majority, knn3, knn1])
+        self.lenses_results.learner_names = ["majority", "knn-3", "knn-1"]
+
     def test_many_evaluation_results(self):
+        if not hasattr(self, "widget"):
+            return
+
         data = Table("iris")
         learners = [
             classification.MajorityLearner(),

--- a/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
+++ b/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
@@ -11,56 +11,15 @@ from sklearn.exceptions import ConvergenceWarning
 
 from orangewidget.utils.combobox import qcombobox_emit_activated
 
-from Orange.data import Table, DiscreteVariable, Domain, ContinuousVariable
-import Orange.evaluation
-import Orange.classification
-from Orange.evaluation import Results
+from Orange.data import Domain, ContinuousVariable
 from Orange.evaluation.performance_curves import Curves
 from Orange.widgets.evaluate.tests.base import EvaluateTest
 from Orange.widgets.evaluate.owcalibrationplot import OWCalibrationPlot
-from Orange.widgets.tests.base import WidgetTest
-from Orange.tests import test_filename
 
 
-class TestOWCalibrationPlot(WidgetTest, EvaluateTest):
+class TestOWCalibrationPlot(EvaluateTest):
     def setUp(self):
         super().setUp()
-
-        n, p = (0, 1)
-        actual, probs = np.array([
-            (p, .8), (n, .7), (p, .6), (p, .55), (p, .54), (n, .53), (n, .52),
-            (p, .51), (n, .505), (p, .4), (n, .39), (p, .38), (n, .37),
-            (n, .36), (n, .35), (p, .34), (n, .33), (p, .30), (n, .1)]).T
-        self.curves = Curves(actual, probs)
-        probs2 = (probs + 0.5) / 2 + 1
-        self.curves2 = Curves(actual, probs2)
-        pred = probs > 0.5
-        pred2 = probs2 > 0.5
-        probs = np.vstack((1 - probs, probs)).T
-        probs2 = np.vstack((1 - probs2, probs2)).T
-        domain = Domain([], DiscreteVariable("y", values=("a", "b")))
-        self.results = Results(
-            domain=domain,
-            actual=actual,
-            folds=np.array([Ellipsis]),
-            models=np.array([[Mock(), Mock()]]),
-            row_indices=np.arange(19),
-            predicted=np.array((pred, pred2)),
-            probabilities=np.array([probs, probs2]))
-
-        self.lenses = data = Table(test_filename("datasets/lenses.tab"))
-        majority = Orange.classification.MajorityLearner()
-        majority.name = "majority"
-        knn3 = Orange.classification.KNNLearner(n_neighbors=3)
-        knn3.name = "knn-3"
-        knn1 = Orange.classification.KNNLearner(n_neighbors=1)
-        knn1.name = "knn-1"
-        self.lenses_results = Orange.evaluation.TestOnTestData(
-            store_data=True, store_models=True)(
-                data=data[::2], test_data=data[1::2],
-                learners=[majority, knn3, knn1])
-        self.lenses_results.learner_names = ["majority", "knn-3", "knn-1"]
-
         self.widget = self.create_widget(OWCalibrationPlot)  # type: OWCalibrationPlot
         warnings.filterwarnings("ignore", ".*", ConvergenceWarning)
 
@@ -382,6 +341,8 @@ class TestOWCalibrationPlot(WidgetTest, EvaluateTest):
     @patch("Orange.widgets.evaluate.owcalibrationplot.CalibratedLearner")
     def test_apply_no_output(self, *_):
         """Test no output warnings"""
+        # Similar to test_owcalibrationplot, but just a little different, hence
+        # pylint: disable=duplicate-code
         widget = self.widget
         model_list = widget.controls.selected_classifiers
 

--- a/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
+++ b/Orange/widgets/evaluate/tests/test_owcalibrationplot.py
@@ -395,7 +395,7 @@ class TestOWCalibrationPlot(WidgetTest, EvaluateTest):
             multiple_selected:
                 "select a single model - the widget can output only one",
             non_binary_class:
-                "cannot calibrate non-binary classes"}
+                "cannot calibrate non-binary models"}
 
         def test_shown(shown):
             widget_msg = widget.Information.no_output

--- a/Orange/widgets/evaluate/tests/test_owliftcurve.py
+++ b/Orange/widgets/evaluate/tests/test_owliftcurve.py
@@ -31,7 +31,7 @@ OK_SKLEARN = pkg_resources.parse_version(sklearn.__version__) >= \
 SKIP_REASON = "Only test precision-recall with scikit-learn>=1.1.1"
 
 
-class TestOWLiftCurve(WidgetTest, EvaluateTest):
+class TestOWLiftCurve(EvaluateTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/Orange/widgets/evaluate/tests/test_owrocanalysis.py
+++ b/Orange/widgets/evaluate/tests/test_owrocanalysis.py
@@ -1,11 +1,12 @@
 # pylint: disable=protected-access
-
-import unittest
-from unittest.mock import patch
 import copy
+import unittest
+from unittest.mock import patch, Mock
+
 import numpy as np
 import pyqtgraph as pg
 from AnyQt.QtWidgets import QToolTip
+from AnyQt.QtCore import QItemSelection
 
 from Orange.data import Table
 import Orange.evaluation
@@ -15,7 +16,6 @@ from Orange.evaluation import Results
 from Orange.widgets.evaluate import owrocanalysis
 from Orange.widgets.evaluate.owrocanalysis import OWROCAnalysis
 from Orange.widgets.evaluate.tests.base import EvaluateTest
-from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.tests.utils import mouseMove, simulate
 from Orange.tests import test_filename
 
@@ -75,7 +75,7 @@ class TestROC(unittest.TestCase):
                 self.assertFalse(rocdata.avg_threshold.is_valid)
 
 
-class TestOWROCAnalysis(WidgetTest, EvaluateTest):
+class TestOWROCAnalysis(EvaluateTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -111,6 +111,15 @@ class TestOWROCAnalysis(WidgetTest, EvaluateTest):
         self.widget.onDeleteWidget()
         self.widgets.remove(self.widget)
         self.widget = None
+
+    @staticmethod
+    def _set_list_selection(listview, selection):
+        model = listview.model()
+        selectionmodel = listview.selectionModel()
+        itemselection = QItemSelection()
+        for item in selection:
+            itemselection.select(model.index(item, 0), model.index(item, 0))
+        selectionmodel.select(itemselection, selectionmodel.ClearAndSelect)
 
     def test_basic(self):
         res = self.res
@@ -268,6 +277,95 @@ class TestOWROCAnalysis(WidgetTest, EvaluateTest):
 
         simulate.combobox_activate_item(w.controls.target_index, "soft")
         self.assertEqual(np.round(5/12 * 100), w.target_prior)
+
+    @patch("Orange.widgets.evaluate.owrocanalysis.ThresholdClassifier")
+    def test_apply_no_output(self, *_):
+        """Test no output warnings"""
+        # Similar to test_owcalibrationplot, but just a little different, hence
+        # pylint: disable=duplicate-code
+        widget = self.widget
+        model_list = widget.controls.selected_classifiers
+
+        multiple_folds, multiple_selected, no_models, non_binary_class = "abcd"
+        messages = {
+            multiple_folds:
+                "each training data sample produces a different model",
+            no_models:
+                "test results do not contain stored models - try testing on "
+                "separate data or on training data",
+            multiple_selected:
+                "select a single model - the widget can output only one",
+            non_binary_class:
+                "cannot calibrate non-binary models"}
+
+        def test_shown(shown):
+            widget_msg = widget.Information.no_output
+            output = self.get_output(widget.Outputs.calibrated_model)
+            if not shown:
+                self.assertFalse(widget_msg.is_shown())
+                self.assertIsNotNone(output)
+            else:
+                self.assertTrue(widget_msg.is_shown())
+                self.assertIsNone(output)
+                for msg_id in shown:
+                    msg = messages[msg_id]
+                    self.assertIn(msg, widget_msg.formatted,
+                                  f"{msg} not included in the message")
+
+        self.send_signal(widget.Inputs.evaluation_results, self.results)
+        test_shown({multiple_selected})
+
+        self._set_list_selection(model_list, [0])
+        test_shown(())
+        widget.controls.display_perf_line.click()
+        output = self.get_output(widget.Outputs.calibrated_model)
+        self.assertIsNone(output)
+        widget.controls.display_perf_line.click()
+        output = self.get_output(widget.Outputs.calibrated_model)
+        self.assertIsNotNone(output)
+
+        self._set_list_selection(model_list, [0, 1])
+
+        self.results.models = None
+        self.send_signal(widget.Inputs.evaluation_results, self.results)
+        test_shown({multiple_selected, no_models})
+
+        self.send_signal(widget.Inputs.evaluation_results, self.lenses_results)
+        test_shown({multiple_selected, non_binary_class})
+
+        self._set_list_selection(model_list, [0])
+        test_shown({non_binary_class})
+
+        self.results.folds = [slice(0, 5), slice(5, 10), slice(10, 19)]
+        self.results.models = np.array([[Mock(), Mock()]] * 3)
+
+        self.send_signal(widget.Inputs.evaluation_results, self.results)
+        test_shown({multiple_selected, multiple_folds})
+
+        self._set_list_selection(model_list, [0])
+        test_shown({multiple_folds})
+
+    @patch("Orange.widgets.evaluate.owrocanalysis.ThresholdClassifier")
+    def test_calibrated_output(self, tc):
+        widget = self.widget
+        model_list = widget.controls.selected_classifiers
+
+        self.send_signal(widget.Inputs.evaluation_results, self.results)
+        self._set_list_selection(model_list, [0])
+
+        model, threshold = tc.call_args[0]
+        self.assertIs(model, self.results.models[0][0])
+        self.assertAlmostEqual(threshold, 0.47)
+
+        widget.controls.fp_cost.setValue(1000)
+        model, threshold = tc.call_args[0]
+        self.assertIs(model, self.results.models[0][0])
+        self.assertAlmostEqual(threshold, 0.9)
+
+        self._set_list_selection(model_list, [1])
+        model, threshold = tc.call_args[0]
+        self.assertIs(model, self.results.models[0][1])
+        self.assertAlmostEqual(threshold, 0.45)
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -50,6 +50,28 @@ def check_results_adequacy(results, error_group, check_nan=True):
         return results
 
 
+def check_can_calibrate(results, selection, require_binary=True):
+    assert results is not None
+
+    problems = [
+        msg for condition, msg in (
+            (results.folds is not None and len(results.folds) > 1,
+             "each training data sample produces a different model"),
+            (results.models is None,
+             "test results do not contain stored models - try testing "
+             "on separate data or on training data"),
+            (len(selection) != 1,
+             "select a single model - the widget can output only one"),
+            (require_binary and len(results.domain.class_var.values) != 2,
+             "cannot calibrate non-binary models"))
+        if condition]
+
+    if len(problems) == 1:
+        return problems[0]
+    else:
+        return "".join(f"\n - {problem}" for problem in problems)
+
+
 def results_for_preview(data_name=""):
     from Orange.data import Table
     from Orange.evaluation import CrossValidation

--- a/Orange/widgets/evaluate/utils.py
+++ b/Orange/widgets/evaluate/utils.py
@@ -31,10 +31,7 @@ def check_results_adequacy(results, error_group, check_nan=True):
 
     if results is None:
         return None
-    if results.data is None:
-        error_group.invalid_results(
-            "Results do not include information on test data.")
-    elif not results.data.domain.has_discrete_class:
+    elif not results.domain.has_discrete_class:
         error_group.invalid_results(
             "Categorical target variable is required.")
     elif not results.actual.size:

--- a/doc/visual-programming/source/widgets/evaluate/rocanalysis.md
+++ b/doc/visual-programming/source/widgets/evaluate/rocanalysis.md
@@ -37,6 +37,12 @@ The diagonal dotted line represents the behavior of a random classifier. The ful
     computer in a .svg or .png format.
 7. Produce a report.
 
+The widget will output a model with a new operating threshold if
+
+- input results come from testing on a single data set and not in some type of cross validation (which produces multiple potentially different models),
+- only a single curve is shown,
+- and the widget shows the performance line, which indicates the new operating threshold - the one that corresponds to the point at which the line touches the curve.
+
 Example
 -------
 


### PR DESCRIPTION
##### Issue

Fixes #6437.

##### Description of changes

Output a model when the widget shows the threshold line (and a single model is selected). The official reason (but to some extent an excuse) that it's tied to the line is that otherwise the widget doesn't clearly indicate what the output would be.

The widget is too graph-centric. The optimized threshold is computed in passing, while drawing the line. This PR (supposedly) works and it doesn't significantly degrade the quality of the existing code. We can improve this code if/when we rewrite the whole widget.

As a small step toward this goal, I've done a small refactoring of code that is repeated in Lift Curve, Calibration plot and (now) the ROC Analysis widget, and in the corresponding tests.

##### Includes
- [X] Code changes
- [X] Tests
- [X] Documentation