### PR TITLE
CI - Fix coverage 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Skip testing workflows at coverage
         if: |
-          matrix.python-version == '3.8' && matrix.tox_env == 'orange-released'
+          matrix.python-version == '3.11' && matrix.tox_env == 'orange-released'
         run: |
           echo 'SKIP_EXAMPLE_WORKFLOWS=1' >> $GITHUB_ENV
 
@@ -107,7 +107,7 @@ jobs:
           ORANGE_TEST_DB_URI: postgres://postgres_user:postgres_password@localhost:5432/postgres_db|mssql://SA:sqlServerPassw0rd@localhost:1433
 
       - name: Upload code coverage
-        if: matrix.python-version == '3.8' && matrix.tox_env == 'orange-released'
+        if: matrix.python-version == '3.11' && matrix.tox_env == 'orange-released'
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
##### Issue
Coverage is not reporting since reporting was done on Python 3.8, which is no longer used in CI.

##### Description of changes
Report on Python 3.11 that will be used until Apr 24, 2026, according to NEP https://numpy.org/neps/nep-0029-deprecation_policy.html
