### PR TITLE
Mosaic VizRank: Start when opened, pause when closed

### DIFF
--- a/Orange/widgets/visualize/owmosaic.py
+++ b/Orange/widgets/visualize/owmosaic.py
@@ -10,7 +10,7 @@ from scipy.special import comb
 from AnyQt.QtCore import Qt, QSize, pyqtSignal as Signal
 from AnyQt.QtGui import QColor, QPainter, QPen, QStandardItem
 from AnyQt.QtWidgets import (
-    QGraphicsScene, QGraphicsLineItem, QGraphicsItemGroup)
+    QGraphicsScene, QGraphicsLineItem, QGraphicsItemGroup, QLabel, QComboBox)
 
 from Orange.data import Table, filter, Variable, Domain, DiscreteVariable
 from Orange.data.sql.table import SqlTable, LARGE_TABLE, DEFAULT_SAMPLE_TIME
@@ -28,7 +28,8 @@ from Orange.widgets.utils.annotated_data import (create_annotated_table,
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.utils import (
-    CanvasText, CanvasRectangle, ViewWithPress, VizRankDialog)
+    CanvasText, CanvasRectangle, ViewWithPress, VizRankDialog,
+    CloseVizrankMixin)
 from Orange.widgets.visualize.utils.plotutils import wrap_legend_items
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 
@@ -42,17 +43,28 @@ class MosaicVizRank(VizRankDialog, OWComponent):
     _AttrRole = next(gui.OrangeUserRole)
 
     def __init__(self, master):
-        """Add the spin box for maximal number of attributes"""
-        VizRankDialog.__init__(self, master)
+        VizRankDialog.__init__(self, master, pause_on_close=True)
         OWComponent.__init__(self, master)
 
         box = gui.hBox(self)
-        self.max_attr_combo = gui.comboBox(
-            box, self, "max_attrs",
-            label="Number of variables:", orientation=Qt.Horizontal,
-            items=["one", "two", "three", "four",
-                   "at most two", "at most three", "at most four"],
-            callback=self.max_attr_changed)
+        label = QLabel("Score combinations of")
+
+        def update_combo_label():
+            label.setText(
+                "Score Mosaics with" if self.attrs_combo.currentIndex() == 0
+                else "Score combinations of")
+
+        self.attrs_combo = QComboBox()
+        self.attrs_combo.addItems(
+            ["a single variable", "two variables", "three variables",
+             "four variables", "at most two variables",
+             "at most three variables", "at most four variables"])
+        self.attrs_combo.activated.connect(self.on_attrs_changed)
+        self.attrs_combo.currentIndexChanged.connect(update_combo_label)
+        self.attrs_combo.setCurrentIndex(self.max_attrs)
+        update_combo_label()
+        box.layout().addWidget(label)
+        box.layout().addWidget(self.attrs_combo)
         gui.rubber(box)
         self.layout().addWidget(self.button)
         self.attr_ordering = None
@@ -60,9 +72,6 @@ class MosaicVizRank(VizRankDialog, OWComponent):
         self.last_run_max_attr = None
 
         self.master.attrs_changed_manually.connect(self.on_manual_change)
-
-    def sizeHint(self):
-        return QSize(400, 512)
 
     def initialize(self):
         """Clear the ordering to trigger recomputation when needed"""
@@ -75,9 +84,8 @@ class MosaicVizRank(VizRankDialog, OWComponent):
 
     def before_running(self):
         """
-        Disable the spin for maximal number of attributes before running and
-        enable afterwards. Also, if the number of attributes is different than
-        in the last run, reset the saved state (if it was paused).
+        If the number of attributes is different from before,
+        reset the saved state (if it was paused).
         """
         if self.max_attrs != self.last_run_max_attr:
             self.saved_state = None
@@ -87,26 +95,22 @@ class MosaicVizRank(VizRankDialog, OWComponent):
             self.rank_model.clear()
         self.compute_attr_order()
         self.last_run_max_attr = self.max_attrs
-        self.max_attr_combo.setDisabled(True)
 
-    def stopped(self):
-        self.max_attr_combo.setDisabled(False)
-
-    def max_attr_changed(self):
-        """
-        Change the button label when the maximal number of attributes changes.
-
-        The method does not reset anything so the user can still see the
-        results until actually restarting the search.
-        """
-        if self.max_attrs != self.last_run_max_attr or self.saved_state is None:
+    def on_attrs_changed(self):
+        if self.keep_running:
+            self.pause_computation()
+        if self.rank_model.rowCount() == 0:
             self.button.setText("Start")
+            self.button.setDisabled(False)
+        elif self.attrs_combo.currentIndex() != self.max_attrs:
+            self.button.setText(f"Restart with new settings")
+            self.button.setDisabled(False)
         else:
-            self.button.setText("Continue")
-        self.button.setEnabled(self.check_preconditions())
+            self.button.setText("Continue" if not self.done else "Finished")
+            self.button.setDisabled(self.done)
 
     def coloring_changed(self):
-        item = self.max_attr_combo.model().item(0)
+        item = self.attrs_combo.model().item(0)
         actflags = Qt.ItemIsSelectable | Qt.ItemIsEnabled
         if self._compute_class_dists():
             item.setFlags(item.flags() | actflags)
@@ -128,6 +132,17 @@ class MosaicVizRank(VizRankDialog, OWComponent):
             self.Information.no_attributes()
             return False
         return True
+
+    def start_computation(self):
+        self.attrs_combo.setCurrentIndex(self.max_attrs)
+        self.rank_table.setFocus(Qt.FocusReason.OtherFocusReason)
+        super().start_computation()
+
+    def toggle(self):
+        if self.max_attrs != self.attrs_combo.currentIndex():
+            self.max_attrs = self.attrs_combo.currentIndex()
+            self.initialize()
+        super().toggle()
 
     def compute_attr_order(self):
         """
@@ -286,8 +301,12 @@ class MosaicVizRank(VizRankDialog, OWComponent):
         item.setData(attrs, self._AttrRole)
         return [item]
 
+    def closeEvent(self, event):
+        super().closeEvent(event)
+        self.attrs_combo.setCurrentIndex(self.max_attrs)
 
-class OWMosaicDisplay(OWWidget):
+
+class OWMosaicDisplay(OWWidget, CloseVizrankMixin):
     name = "Mosaic Display"
     description = "Display data in a mosaic plot."
     icon = "icons/MosaicDisplay.svg"
@@ -369,6 +388,7 @@ class OWMosaicDisplay(OWWidget):
             for i in range(1, 5)]
         self.vizrank, self.vizrank_button = MosaicVizRank.add_vizrank(
             box, self, "Find Informative Mosaics", self.set_attr)
+        self.vizrank_button.pressed.connect(self.start_vizrank)
 
         box2 = gui.vBox(self.controlArea, box="Interior Coloring")
         self.color_model = DomainModel(
@@ -425,6 +445,9 @@ class OWMosaicDisplay(OWWidget):
             self.variable2 = self.model_1[min(1, len(self.model_1) - 1)]
         self.variable3 = self.variable4 = None
         self.variable_color = self.data.domain.class_var  # None is OK, too
+
+    def start_vizrank(self):
+        self.vizrank.start_computation()
 
     def get_disc_attr_list(self):
         return [self.discrete_data.domain[var.name]

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -363,7 +363,7 @@ class MosaicVizRankTests(WidgetTest):
     def test_max_attr_combo_1_disabling(self):
         widget = self.widget
         vizrank = widget.vizrank
-        combo = vizrank.max_attr_combo
+        combo = vizrank.attrs_combo
         model = combo.model()
         enabled = Qt.ItemIsSelectable | Qt.ItemIsEnabled
 

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -115,6 +115,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.keep_running = False
         self.scheduled_call = None
         self.saved_state = None
+        self.done = False
         self.saved_progress = 0
         self.scores = []
         self.add_to_model = Queue()
@@ -224,6 +225,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.keep_running = False
         self.scheduled_call = None
         self.saved_state = None
+        self.done = False
         self.saved_progress = 0
         self.progressBarFinished()
         self.scores = []
@@ -329,6 +331,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.button.setEnabled(False)
         self.keep_running = False
         self.saved_state = None
+        self.done = True
         self._stopped()
 
     def _stopped(self):
@@ -361,20 +364,27 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
 
     def toggle(self):
         """Start or pause the computation."""
-        self.keep_running = not self.keep_running
-        if self.keep_running:
-            self.button.setText("Pause")
-            self.button.repaint()
-            self.progressBarInit()
-            self.before_running()
-            self.start(run_vizrank, self.compute_score,
-                       self.iterate_states, self.saved_state, self.scores,
-                       self.saved_progress, self.state_count())
+        if not self.keep_running:
+            self.start_computation()
         else:
-            self.button.setText("Continue")
-            self.button.repaint()
-            self.cancel()
-            self._stopped()
+            self.pause_computation()
+
+    def start_computation(self):
+        self.keep_running = True
+        self.button.setText("Pause")
+        self.button.repaint()
+        self.progressBarInit()
+        self.before_running()
+        self.start(run_vizrank, self.compute_score,
+                   self.iterate_states, self.saved_state, self.scores,
+                   self.saved_progress, self.state_count())
+
+    def pause_computation(self):
+        self.keep_running = False
+        self.button.setText("Continue")
+        self.button.repaint()
+        self.cancel()
+        self._stopped()
 
     def before_running(self):
         """Code that is run before running vizrank in its own thread"""

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -15,13 +15,15 @@ from AnyQt.QtWidgets import (
     QTableView, QGraphicsTextItem, QGraphicsRectItem, QGraphicsView, QDialog,
     QVBoxLayout, QLineEdit
 )
+
 from Orange.data import Variable
 from Orange.widgets import gui
 from Orange.widgets.gui import HorizontalGridDelegate, TableBarItem
 from Orange.widgets.utils.concurrent import ConcurrentMixin, TaskState
 from Orange.widgets.utils.messages import WidgetMessagesMixin
 from Orange.widgets.utils.progressbar import ProgressBarMixin
-from Orange.widgets.widget import Msg
+from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
+from Orange.widgets.widget import Msg, OWComponent
 
 
 class Result(namespace):
@@ -101,7 +103,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
     class Information(WidgetMessagesMixin.Information):
         nothing_to_rank = Msg("There is nothing to rank.")
 
-    def __init__(self, master):
+    def __init__(self, master, *, pause_on_close=False):
         """Initialize the attributes and set up the interface"""
         QDialog.__init__(self, master, windowTitle=self.captionTitle)
         WidgetMessagesMixin.__init__(self)
@@ -116,6 +118,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.scheduled_call = None
         self.saved_state = None
         self.done = False
+        self.pause_on_close = pause_on_close
         self.saved_progress = 0
         self.scores = []
         self.add_to_model = Queue()
@@ -394,6 +397,10 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         """Code that is run after stopping the vizrank thread"""
         pass
 
+    def closeEvent(self, event):
+        if self.pause_on_close:
+            self.pause_computation()
+        super().closeEvent(event)
 
 def run_vizrank(compute_score: Callable, iterate_states: Callable,
                 saved_state: Optional[Iterable], scores: List,
@@ -568,6 +575,105 @@ class VizRankDialogAttrPair(VizRankDialog):
         item = QStandardItem(", ".join(a.name for a in attrs))
         item.setData(attrs, self._AttrRole)
         return [item]
+
+
+class VizRankDialogNAttrs(VizRankDialog):
+    n_attrs = Setting(3)
+
+    attrsSelected = Signal([])
+    _AttrRole = next(gui.OrangeUserRole)
+
+    def __init__(self, master):
+        # Add the spin box for a number of attributes to take into account.
+        VizRankDialog.__init__(self, master, pause_on_close=True)
+        OWComponent.__init__(self, master)
+
+        box = gui.hBox(self)
+        self.n_attrs_spin = gui.spin(
+            box, self, None, 3, 8, label="Number of variables: ",
+            controlWidth=50, alignment=Qt.AlignRight,
+            callback=self.on_attrs_changed)
+        gui.rubber(box)
+
+        self.last_run_n_attrs = None
+        self.attr_color = master.attr_color
+        self.attrs = []
+
+    @staticmethod
+    def max_attrs():
+        return 8
+
+    def initialize(self):
+        super().initialize()
+        self.attr_color = self.master.attr_color
+        n_cont = self.max_attrs()
+        self.n_attrs_spin.setValue(min(self.n_attrs, n_cont))
+        self.n_attrs_spin.setMaximum(n_cont)
+
+    def check_preconditions(self):
+        return super().check_preconditions() \
+               and self.master.btn_vizrank.isEnabled()
+
+    def before_running(self):
+        """
+        If the number of attributes is different than
+        in the last run, reset the saved state (if it was paused).
+        """
+        if self.n_attrs != self.last_run_n_attrs:
+            self.saved_state = None
+            self.saved_progress = 0
+        if self.saved_state is None:
+            self.scores = []
+            self.rank_model.clear()
+        self.last_run_n_attrs = self.n_attrs
+
+    def on_attrs_changed(self):
+        if self.keep_running:
+            self.pause_computation()
+        if self.rank_model.rowCount() == 0:
+            self.button.setText("Start")
+            self.button.setDisabled(False)
+        elif (new_attrs := self.n_attrs_spin.value()) != self.n_attrs:
+            self.button.setText(f"Restart with {new_attrs} variables")
+            self.button.setDisabled(False)
+        else:
+            self.button.setText("Continue" if not self.done else "Finished")
+            self.button.setDisabled(self.done)
+
+    def start_computation(self):
+        self.n_attrs_spin.setValue(self.n_attrs)
+        self.n_attrs_spin.lineEdit().deselect()
+        self.rank_table.setFocus(Qt.FocusReason.OtherFocusReason)
+        super().start_computation()
+
+    def toggle(self):
+        if self.n_attrs != self.n_attrs_spin.value():
+            self.n_attrs = self.n_attrs_spin.value()
+            self.initialize()
+        super().toggle()
+
+    def closeEvent(self, event):
+        super().closeEvent(event)
+        self.n_attrs_spin.setValue(self.n_attrs)
+
+
+class CloseVizrankMixin:
+    def closeEvent(self, event):
+        if self.vizrank is not None:
+            self.vizrank.close()
+        super().closeEvent(event)
+
+    def hideEvent(self, event):
+        if self.vizrank is not None:
+            self.vizrank.hide()
+        super().hideEvent(event)
+
+    def deleteEvent(self):
+        if self.vizrank is not None:
+            self.vizrank.keep_running = False
+            self.vizrank.shutdown()
+        super().deleteEvent()
+
 
 
 class CanvasText(QGraphicsTextItem):


### PR DESCRIPTION
##### Issue

Ref. #6504. I also strongly suspect

Based on #6614 (for `pause_when_closed` flag, and for `CloseVizrankMixin`). Only the last commit is new.

@processo was totally right in #6504. I knew that closing VizRank doesn't stop it, but I expected that closing the widget would. Of course it doesn't, and in case of Mosaic, which rapidly fills the table model and fires signals, it blocks the main thread, making Orange basically unresponsive even after the widget is closed and everything should have been silent.

When #6612 or alike is merged, we should prevent vizranks from sending such frequent updates.

##### Description of changes

Changes are similar to those made to vizranks in #6614.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
