### PR TITLE
Mosaic Vizrank: Start when opened, pause when closed

### DIFF
--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -12,7 +12,7 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.metrics import r2_score
 
 from AnyQt.QtGui import QStandardItem, QPalette
-from AnyQt.QtCore import Qt, QRectF, QLineF, pyqtSignal as Signal
+from AnyQt.QtCore import QRectF, QLineF
 
 import pyqtgraph as pg
 
@@ -22,13 +22,13 @@ from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.projection import PCA, LDA, LinearProjector
 from Orange.util import Enum
 from Orange.widgets import gui, report
-from Orange.widgets.gui import OWComponent
 from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
 from Orange.widgets.utils.localization import pl
 from Orange.widgets.utils.plot import variables_selection
 from Orange.widgets.utils.plot.owplotgui import VariableSelectionModel
 from Orange.widgets.utils.widgetpreview import WidgetPreview
-from Orange.widgets.visualize.utils import VizRankDialog
+from Orange.widgets.visualize.utils import VizRankDialogNAttrs, \
+    CloseVizrankMixin
 from Orange.widgets.visualize.utils.component import OWGraphWithAnchors
 from Orange.widgets.visualize.utils.plotutils import AnchorItem
 from Orange.widgets.visualize.utils.widget import OWAnchorProjectionWidget
@@ -38,54 +38,13 @@ from Orange.widgets.widget import Msg
 MAX_LABEL_LEN = 20
 
 
-class LinearProjectionVizRank(VizRankDialog, OWComponent):
+class LinearProjectionVizRank(VizRankDialogNAttrs):
     captionTitle = "Score Plots"
-    n_attrs = Setting(3)
     minK = 10
 
-    attrsSelected = Signal([])
-    _AttrRole = next(gui.OrangeUserRole)
-
-    def __init__(self, master):
-        # Add the spin box for a number of attributes to take into account.
-        VizRankDialog.__init__(self, master)
-        OWComponent.__init__(self, master)
-
-        box = gui.hBox(self)
-        self.n_attrs_spin = gui.spin(
-            box, self, None, 3, 8, label="Number of variables: ",
-            controlWidth=50, alignment=Qt.AlignRight,
-            callback=self.on_attrs_changed)
-        gui.rubber(box)
-
-        self.last_run_n_attrs = None
-        self.attr_color = master.attr_color
-        self.attrs = []
-
-    def initialize(self):
-        super().initialize()
-        self.attr_color = self.master.attr_color
-        n_cont = sum(v is not self.attr_color
-                     for v in self.master.continuous_variables)
-        self.n_attrs_spin.setValue(min(self.n_attrs, n_cont))
-        self.n_attrs_spin.setMaximum(n_cont)
-
-    def before_running(self):
-        """
-        If the number of attributes is different than
-        in the last run, reset the saved state (if it was paused).
-        """
-        if self.n_attrs != self.last_run_n_attrs:
-            self.saved_state = None
-            self.saved_progress = 0
-        if self.saved_state is None:
-            self.scores = []
-            self.rank_model.clear()
-        self.last_run_n_attrs = self.n_attrs
-
-    def check_preconditions(self):
-        return super().check_preconditions() \
-               and self.master.btn_vizrank.isEnabled()
+    def max_attrs(self):
+        return sum(v is not self.attr_color
+                   for v in self.master.continuous_variables)
 
     def state_count(self):
         n_all_attrs = len(self.attrs)
@@ -173,36 +132,6 @@ class LinearProjectionVizRank(VizRankDialog, OWComponent):
         attrs = selected.indexes()[0].data(self._AttrRole)
         self.selectionChanged.emit([attrs])
 
-    def on_attrs_changed(self):
-        if self.keep_running:
-            self.pause_computation()
-        if self.rank_model.rowCount() == 0:
-            self.button.setText("Start")
-            self.button.setDisabled(False)
-        elif (new_attrs := self.n_attrs_spin.value()) != self.n_attrs:
-            self.button.setText(f"Restart with {new_attrs} variables")
-            self.button.setDisabled(False)
-        else:
-            self.button.setText("Continue" if not self.done else "Finished")
-            self.button.setDisabled(self.done)
-
-    def start_computation(self):
-        self.n_attrs_spin.setValue(self.n_attrs)
-        self.n_attrs_spin.lineEdit().deselect()
-        self.rank_table.setFocus(Qt.FocusReason.OtherFocusReason)
-        super().start_computation()
-
-    def toggle(self):
-        if self.n_attrs != self.n_attrs_spin.value():
-            self.n_attrs = self.n_attrs_spin.value()
-            self.initialize()
-        super().toggle()
-
-    def closeEvent(self, event):
-        self.pause_computation()
-        self.n_attrs_spin.setValue(self.n_attrs)
-        super().closeEvent(event)
-
 
 class OWLinProjGraph(OWGraphWithAnchors):
     hide_radius = Setting(0)
@@ -283,7 +212,7 @@ Placement = Enum("Placement", dict(Circular=0, LDA=1, PCA=2), type=int,
                  qualname="Placement")
 
 
-class OWLinearProjection(OWAnchorProjectionWidget):
+class OWLinearProjection(OWAnchorProjectionWidget, CloseVizrankMixin):
     name = "Linear Projection"
     description = "A multi-axis projection of data onto " \
                   "a two-dimensional plane."
@@ -326,8 +255,8 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         self.model_selected.selection_changed.connect(
             self.__model_selected_changed)
         self.vizrank, self.btn_vizrank = LinearProjectionVizRank.add_vizrank(
-            None, self, "Suggest Features", self.__vizrank_set_attrs)
-        self.btn_vizrank.pressed.connect(self.start_vizrank)
+            None, self, "Suggest Features", self.__vizrank_set_attrs,
+            auto_start=True)
         box.layout().addWidget(self.btn_vizrank)
 
     def _add_controls_placement(self, box):
@@ -451,9 +380,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         if is_enabled:
             self.vizrank.initialize()
 
-    def start_vizrank(self):
-        self.vizrank.start_computation()
-
     def check_data(self):
         def error(err):
             err()
@@ -493,22 +419,6 @@ class OWLinearProjection(OWAnchorProjectionWidget):
         norm_emb = normalized(embedding[self.valid_data])
         return (norm_emb.ravel(), np.zeros(len(norm_emb), dtype=float)) \
             if embedding.shape[1] == 1 else norm_emb.T
-
-    def closeEvent(self, event):
-        if self.vizrank is not None:
-            self.vizrank.close()
-        super().closeEvent(event)
-
-    def hideEvent(self, event):
-        if self.vizrank is not None:
-            self.vizrank.hide()
-        super().hideEvent(event)
-
-    def deleteEvent(self):
-        if self.vizrank is not None:
-            self.vizrank.keep_running = False
-            self.vizrank.shutdown()
-        super().deleteEvent()
 
     def _get_send_report_caption(self):
         def projection_name():

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import cross_val_score
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
 from AnyQt.QtGui import QStandardItem, QColor, QPalette
-from AnyQt.QtCore import Qt, QRectF, QPoint, pyqtSignal as Signal
+from AnyQt.QtCore import Qt, QRectF, QPoint
 
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ScatterPlotItem import ScatterPlotItem
@@ -17,12 +17,12 @@ from Orange.data import Table, Domain
 from Orange.preprocess.score import ReliefF, RReliefF
 from Orange.projection import RadViz
 from Orange.widgets import widget, gui
-from Orange.widgets.gui import OWComponent
-from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
+from Orange.widgets.settings import ContextSetting, SettingProvider
 from Orange.widgets.utils.plot.owplotgui import VariableSelectionModel, \
     variables_selection
 from Orange.widgets.utils.widgetpreview import WidgetPreview
-from Orange.widgets.visualize.utils import VizRankDialog
+from Orange.widgets.visualize.utils import VizRankDialogNAttrs, \
+    CloseVizrankMixin
 from Orange.widgets.visualize.utils.component import OWGraphWithAnchors
 from Orange.widgets.visualize.utils.plotutils import TextItem
 from Orange.widgets.visualize.utils.widget import OWAnchorProjectionWidget
@@ -32,32 +32,14 @@ MAX_DISPLAYED_VARS = 20
 MAX_LABEL_LEN = 16
 
 
-class RadvizVizRank(VizRankDialog, OWComponent):
+class RadvizVizRank(VizRankDialogNAttrs):
     captionTitle = "Score Plots"
-    n_attrs = Setting(3)
     minK = 10
 
-    attrsSelected = Signal([])
-    _AttrRole = next(gui.OrangeUserRole)
-
-    percent_data_used = Setting(100)
-
     def __init__(self, master):
-        """Add the spin box for maximal number of attributes"""
-        VizRankDialog.__init__(self, master)
-        OWComponent.__init__(self, master)
-
-        self.master = master
+        super().__init__(master)
         self.n_neighbors = 10
 
-        box = gui.hBox(self)
-        max_n_attrs = min(MAX_DISPLAYED_VARS, len(master.model_selected))
-        self.n_attrs_spin = gui.spin(
-            box, self, "n_attrs", 3, max_n_attrs, label="Maximum number of variables: ",
-            controlWidth=50, alignment=Qt.AlignRight, callback=self._n_attrs_changed)
-        gui.rubber(box)
-        self.last_run_n_attrs = None
-        self.attr_color = master.attr_color
         self.attr_ordering = None
         self.data = None
         self.valid_data = None
@@ -66,9 +48,9 @@ class RadvizVizRank(VizRankDialog, OWComponent):
         self.rank_table.verticalHeader().sectionClicked.connect(
             self.on_header_clicked)
 
-    def initialize(self):
-        super().initialize()
-        self.attr_color = self.master.attr_color
+    def max_attrs(self):
+        return sum(v is not self.attr_color
+                   for v in self.master.primitive_variables)
 
     def _compute_attr_order(self):
         """
@@ -88,53 +70,23 @@ class RadvizVizRank(VizRankDialog, OWComponent):
 
     def _evaluate_projection(self, x, y):
         """
-        kNNEvaluate - evaluate class separation in the given projection using a k-NN method
-        Parameters
-        ----------
-        x - variables to evaluate
-        y - class
-
-        Returns
-        -------
-        scores
+        kNNEvaluate - evaluate class separation in the given projection with k-NN
         """
-        if self.percent_data_used != 100:
-            rand = np.random.choice(len(x), int(len(x) * self.percent_data_used / 100),
-                                    replace=False)
-            x = x[rand]
-            y = y[rand]
-        neigh = KNeighborsClassifier(n_neighbors=3) if self.attr_color.is_discrete else \
-            KNeighborsRegressor(n_neighbors=3)
-        assert ~(np.isnan(x).any(axis=None) | np.isnan(x).any(axis=None))
+        assert not np.any(np.isnan(x)) and not np.any(np.isnan(y))
+        neigh = (KNeighborsClassifier if self.attr_color.is_discrete else
+                 KNeighborsRegressor)(n_neighbors=3)
         neigh.fit(x, y)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             scores = cross_val_score(neigh, x, y, cv=3)
         return scores.mean()
 
-    def _n_attrs_changed(self):
-        """
-        Change the button label when the number of attributes changes. The method does not reset
-        anything so the user can still see the results until actually restarting the search.
-        """
-        if self.n_attrs != self.last_run_n_attrs or self.saved_state is None:
-            self.button.setText("Start")
-        else:
-            self.button.setText("Continue")
-        self.button.setEnabled(self.check_preconditions())
-
-    def progressBarSet(self, value):
-        self.setWindowTitle(self.captionTitle + " Evaluated {} permutations".format(value))
-
-    def check_preconditions(self):
-        master = self.master
-        if not super().check_preconditions():
-            return False
-        elif not master.btn_vizrank.isEnabled():
-            return False
-        self.n_attrs_spin.setMaximum(min(MAX_DISPLAYED_VARS,
-                                         len(master.model_selected)))
-        return True
+    def state_count(self):
+        n_all_attrs = len(self.attrs)
+        if not n_all_attrs:
+            return 0
+        n_attrs = self.n_attrs
+        return factorial(n_all_attrs) // (2 * factorial(n_all_attrs - n_attrs) * n_attrs)
 
     def on_selection_changed(self, selected, _):
         self.on_row_clicked(selected.indexes()[0])
@@ -185,30 +137,12 @@ class RadvizVizRank(VizRankDialog, OWComponent):
 
     def row_for_state(self, score, state):
         attrs = [self.attrs[s] for s in state]
-        item = QStandardItem("[{:0.6f}] ".format(-score) + ", ".join(a.name for a in attrs))
+        item = QStandardItem(', '.join(a.name for a in attrs))
         item.setData(attrs, self._AttrRole)
         return [item]
 
     def _update_progress(self):
         self.progressBarSet(int(self.saved_progress))
-
-    def before_running(self):
-        """
-        Disable the spin for number of attributes before running and
-        enable afterwards. Also, if the number of attributes is different than
-        in the last run, reset the saved state (if it was paused).
-        """
-        if self.n_attrs != self.last_run_n_attrs:
-            self.saved_state = None
-            self.saved_progress = 0
-        if self.saved_state is None:
-            self.scores = []
-            self.rank_model.clear()
-        self.last_run_n_attrs = self.n_attrs
-        self.n_attrs_spin.setDisabled(True)
-
-    def stopped(self):
-        self.n_attrs_spin.setDisabled(False)
 
 
 class OWRadvizGraph(OWGraphWithAnchors):
@@ -309,7 +243,7 @@ class OWRadvizGraph(OWGraphWithAnchors):
         self.plot_widget.addItem(self.indicator_item)
 
 
-class OWRadviz(OWAnchorProjectionWidget):
+class OWRadviz(OWAnchorProjectionWidget, CloseVizrankMixin):
     name = "Radviz"
     description = "Display Radviz projection"
     icon = "icons/Radviz.svg"
@@ -337,7 +271,8 @@ class OWRadviz(OWAnchorProjectionWidget):
         self.model_selected.selection_changed.connect(
             self.__model_selected_changed)
         self.vizrank, self.btn_vizrank = RadvizVizRank.add_vizrank(
-            None, self, "Suggest features", self.vizrank_set_attrs)
+            None, self, "Suggest features", self.vizrank_set_attrs,
+            auto_start=True)
         box.layout().addWidget(self.btn_vizrank)
         super()._add_controls()
 

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -363,7 +363,7 @@ class MosaicVizRankTests(WidgetTest):
     def test_max_attr_combo_1_disabling(self):
         widget = self.widget
         vizrank = widget.vizrank
-        combo = vizrank.max_attr_combo
+        combo = vizrank.attrs_combo
         model = combo.model()
         enabled = Qt.ItemIsSelectable | Qt.ItemIsEnabled
 

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -115,6 +115,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.keep_running = False
         self.scheduled_call = None
         self.saved_state = None
+        self.done = False
         self.saved_progress = 0
         self.scores = []
         self.add_to_model = Queue()
@@ -224,6 +225,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.keep_running = False
         self.scheduled_call = None
         self.saved_state = None
+        self.done = False
         self.saved_progress = 0
         self.progressBarFinished()
         self.scores = []
@@ -329,6 +331,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.button.setEnabled(False)
         self.keep_running = False
         self.saved_state = None
+        self.done = True
         self._stopped()
 
     def _stopped(self):
@@ -361,20 +364,27 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
 
     def toggle(self):
         """Start or pause the computation."""
-        self.keep_running = not self.keep_running
-        if self.keep_running:
-            self.button.setText("Pause")
-            self.button.repaint()
-            self.progressBarInit()
-            self.before_running()
-            self.start(run_vizrank, self.compute_score,
-                       self.iterate_states, self.saved_state, self.scores,
-                       self.saved_progress, self.state_count())
+        if not self.keep_running:
+            self.start_computation()
         else:
-            self.button.setText("Continue")
-            self.button.repaint()
-            self.cancel()
-            self._stopped()
+            self.pause_computation()
+
+    def start_computation(self):
+        self.keep_running = True
+        self.button.setText("Pause")
+        self.button.repaint()
+        self.progressBarInit()
+        self.before_running()
+        self.start(run_vizrank, self.compute_score,
+                   self.iterate_states, self.saved_state, self.scores,
+                   self.saved_progress, self.state_count())
+
+    def pause_computation(self):
+        self.keep_running = False
+        self.button.setText("Continue")
+        self.button.repaint()
+        self.cancel()
+        self._stopped()
 
     def before_running(self):
         """Code that is run before running vizrank in its own thread"""

--- a/Orange/widgets/visualize/utils/__init__.py
+++ b/Orange/widgets/visualize/utils/__init__.py
@@ -15,13 +15,15 @@ from AnyQt.QtWidgets import (
     QTableView, QGraphicsTextItem, QGraphicsRectItem, QGraphicsView, QDialog,
     QVBoxLayout, QLineEdit
 )
+
 from Orange.data import Variable
 from Orange.widgets import gui
 from Orange.widgets.gui import HorizontalGridDelegate, TableBarItem
 from Orange.widgets.utils.concurrent import ConcurrentMixin, TaskState
 from Orange.widgets.utils.messages import WidgetMessagesMixin
 from Orange.widgets.utils.progressbar import ProgressBarMixin
-from Orange.widgets.widget import Msg
+from Orange.widgets.settings import Setting, ContextSetting, SettingProvider
+from Orange.widgets.widget import Msg, OWComponent
 
 
 class Result(namespace):
@@ -116,6 +118,7 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.scheduled_call = None
         self.saved_state = None
         self.done = False
+        self.pause_on_close = False
         self.saved_progress = 0
         self.scores = []
         self.add_to_model = Queue()
@@ -151,12 +154,16 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         self.button = gui.button(
             self, self, "Start", callback=self.toggle, default=True)
 
+    def set_pause_on_close(self, state):
+        self.pause_on_close = state
+
     @property
     def _has_bars(self):
         return type(self).bar_length is not VizRankDialog.bar_length
 
     @classmethod
-    def add_vizrank(cls, widget, master, button_label, set_attr_callback):
+    def add_vizrank(cls, widget, master, button_label, set_attr_callback,
+                    *, auto_start=False):
         """
         Equip the widget with VizRank button and dialog, and monkey patch the
         widget's `closeEvent` and `hideEvent` to close/hide the vizrank, too.
@@ -178,9 +185,12 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         # want to mess with meta-classes either.
 
         vizrank = cls(master)
+        if auto_start:
+            vizrank.set_pause_on_close(True)
         button = gui.button(
             widget, master, button_label, callback=vizrank.reshow,
             enabled=False)
+        button.pressed.connect(vizrank.start_computation)
         vizrank.selectionChanged.connect(lambda args: set_attr_callback(*args))
 
         master_close_event = master.closeEvent
@@ -394,6 +404,10 @@ class VizRankDialog(QDialog, ProgressBarMixin, WidgetMessagesMixin,
         """Code that is run after stopping the vizrank thread"""
         pass
 
+    def closeEvent(self, event):
+        if self.pause_on_close:
+            self.pause_computation()
+        super().closeEvent(event)
 
 def run_vizrank(compute_score: Callable, iterate_states: Callable,
                 saved_state: Optional[Iterable], scores: List,
@@ -568,6 +582,105 @@ class VizRankDialogAttrPair(VizRankDialog):
         item = QStandardItem(", ".join(a.name for a in attrs))
         item.setData(attrs, self._AttrRole)
         return [item]
+
+
+class VizRankDialogNAttrs(VizRankDialog):
+    n_attrs = Setting(3)
+
+    attrsSelected = Signal([])
+    _AttrRole = next(gui.OrangeUserRole)
+
+    def __init__(self, master):
+        # Add the spin box for a number of attributes to take into account.
+        VizRankDialog.__init__(self, master)
+        OWComponent.__init__(self, master)
+
+        box = gui.hBox(self)
+        self.n_attrs_spin = gui.spin(
+            box, self, None, 3, 8, label="Number of variables: ",
+            controlWidth=50, alignment=Qt.AlignRight,
+            callback=self.on_attrs_changed)
+        gui.rubber(box)
+
+        self.last_run_n_attrs = None
+        self.attr_color = master.attr_color
+        self.attrs = []
+
+    @staticmethod
+    def max_attrs():
+        return 8
+
+    def initialize(self):
+        super().initialize()
+        self.attr_color = self.master.attr_color
+        n_cont = self.max_attrs()
+        self.n_attrs_spin.setValue(min(self.n_attrs, n_cont))
+        self.n_attrs_spin.setMaximum(n_cont)
+
+    def check_preconditions(self):
+        return super().check_preconditions() \
+               and self.master.btn_vizrank.isEnabled()
+
+    def before_running(self):
+        """
+        If the number of attributes is different than
+        in the last run, reset the saved state (if it was paused).
+        """
+        if self.n_attrs != self.last_run_n_attrs:
+            self.saved_state = None
+            self.saved_progress = 0
+        if self.saved_state is None:
+            self.scores = []
+            self.rank_model.clear()
+        self.last_run_n_attrs = self.n_attrs
+
+    def on_attrs_changed(self):
+        if self.keep_running:
+            self.pause_computation()
+        if self.rank_model.rowCount() == 0:
+            self.button.setText("Start")
+            self.button.setDisabled(False)
+        elif (new_attrs := self.n_attrs_spin.value()) != self.n_attrs:
+            self.button.setText(f"Restart with {new_attrs} variables")
+            self.button.setDisabled(False)
+        else:
+            self.button.setText("Continue" if not self.done else "Finished")
+            self.button.setDisabled(self.done)
+
+    def start_computation(self):
+        self.n_attrs_spin.setValue(self.n_attrs)
+        self.n_attrs_spin.lineEdit().deselect()
+        self.rank_table.setFocus(Qt.FocusReason.OtherFocusReason)
+        super().start_computation()
+
+    def toggle(self):
+        if self.n_attrs != self.n_attrs_spin.value():
+            self.n_attrs = self.n_attrs_spin.value()
+            self.initialize()
+        super().toggle()
+
+    def closeEvent(self, event):
+        super().closeEvent(event)
+        self.n_attrs_spin.setValue(self.n_attrs)
+
+
+class CloseVizrankMixin:
+    def closeEvent(self, event):
+        if self.vizrank is not None:
+            self.vizrank.close()
+        super().closeEvent(event)
+
+    def hideEvent(self, event):
+        if self.vizrank is not None:
+            self.vizrank.hide()
+        super().hideEvent(event)
+
+    def deleteEvent(self):
+        if self.vizrank is not None:
+            self.vizrank.keep_running = False
+            self.vizrank.shutdown()
+        super().deleteEvent()
+
 
 
 class CanvasText(QGraphicsTextItem):


### PR DESCRIPTION
##### Issue

Ref. #6504. I also strongly suspect

**Based on #6614 (for `auto_start` flag, and for `CloseVizrankMixin`). Only the last commit is new.**

@processo was totally right in #6504. I knew that closing VizRank doesn't stop it, but I expected that closing the widget would. Of course it doesn't, and in case of Mosaic, which rapidly fills the table model and fires signals, it blocks the main thread, making Orange basically unresponsive even after the widget is closed and everything should have been silent.

When #6612 or alike is merged, we should prevent vizranks from sending such frequent updates.

##### Description of changes

Changes are similar to those made to vizranks in #6614.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
