### PR TITLE
Remove the eps argument from LogLoss

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -11,6 +11,7 @@ Examples
 """
 
 import math
+import warnings
 
 import numpy as np
 import sklearn.metrics as skl_metrics
@@ -18,6 +19,8 @@ from sklearn.metrics import confusion_matrix
 
 from Orange.data import DiscreteVariable, ContinuousVariable, Domain
 from Orange.misc.wrapper_meta import WrapperMeta
+from Orange.util import OrangeDeprecationWarning
+
 
 __all__ = ["CA", "Precision", "Recall", "F1", "PrecisionRecallFSupport", "AUC",
            "MSE", "RMSE", "MAE", "MAPE", "R2", "LogLoss", "MatthewsCorrCoefficient"]
@@ -302,12 +305,20 @@ class LogLoss(ClassificationScore):
     long_name = "Logistic loss"
     default_visible = False
 
-    def compute_score(self, results, eps=1e-15, normalize=True,
+    def compute_score(self, results, eps="auto", normalize=True,
                       sample_weight=None):
+        if eps != "auto":
+            # eps argument will be removed in scikit-learn 1.5
+            warnings.warn(
+                (
+                    "`LogLoss.compute_score`: eps parameter is unused. "
+                    "It will always have value of `np.finfo(y_pred.dtype).eps`."
+                ),
+                OrangeDeprecationWarning,
+            )
         return np.fromiter(
             (skl_metrics.log_loss(results.actual,
                                   probabilities,
-                                  eps=eps,
                                   normalize=normalize,
                                   sample_weight=sample_weight)
              for probabilities in results.probabilities),

--- a/i18n/si.jaml
+++ b/i18n/si.jaml
@@ -2100,6 +2100,10 @@ evaluation/scoring.py:
     class `LogLoss`:
         LogLoss: Log Izguba
         Logistic loss: Logistična izguba
+        def `compute_score`:
+            auto: False
+            '`LogLoss.compute_score`: eps parameter is unused. ': False
+            It will always have value of `np.finfo(y_pred.dtype).eps`.: False
     class `Specificity`:
         Spec: true
         Specificity: Specifičnost


### PR DESCRIPTION
It is deprecated and will be removed in scikit-learn 1.5. Our tests are full of these:

/home/runner/work/orange3/orange3/.tox/orange-latest/lib/python3.11/site-packages/sklearn/metrics/_classification.py:2851:
FutureWarning: Setting the eps parameter is deprecated and will be removed in 1.5. Instead eps will always have a default value of `np.finfo(y_pred.dtype).eps`

