### PR TITLE
adaboost: adapt to scikit-learn's 1.4 deprecation of base_estimator

### DIFF
--- a/Orange/ensembles/ada_boost.py
+++ b/Orange/ensembles/ada_boost.py
@@ -1,3 +1,5 @@
+import warnings
+
 import sklearn.ensemble as skl_ensemble
 
 from Orange.base import SklLearner
@@ -7,6 +9,8 @@ from Orange.classification.base_classification import (
 from Orange.regression.base_regression import (
     SklLearnerRegression, SklModelRegression
 )
+from Orange.util import OrangeDeprecationWarning
+
 
 __all__ = ['SklAdaBoostClassificationLearner', 'SklAdaBoostRegressionLearner']
 
@@ -15,21 +19,32 @@ class SklAdaBoostClassifier(SklModelClassification):
     pass
 
 
+def base_estimator_deprecation():
+    warnings.warn(
+        "`base_estimator` is deprecated (to be removed in 3.39): use `estimator` instead.",
+        OrangeDeprecationWarning, stacklevel=3)
+
+
 class SklAdaBoostClassificationLearner(SklLearnerClassification):
     __wraps__ = skl_ensemble.AdaBoostClassifier
     __returns__ = SklAdaBoostClassifier
     supports_weights = True
 
-    def __init__(self, base_estimator=None, n_estimators=50, learning_rate=1.,
-                 algorithm='SAMME.R', random_state=None, preprocessors=None):
+    def __init__(self, estimator=None, n_estimators=50, learning_rate=1.,
+                 algorithm='SAMME.R', random_state=None, preprocessors=None,
+                 base_estimator="deprecated"):
+        if base_estimator != "deprecated":
+            base_estimator_deprecation()
+            estimator = base_estimator
+        del base_estimator
         from Orange.modelling import Fitter
         # If fitter, get the appropriate Learner instance
-        if isinstance(base_estimator, Fitter):
-            base_estimator = base_estimator.get_learner(
-                base_estimator.CLASSIFICATION)
+        if isinstance(estimator, Fitter):
+            estimator = estimator.get_learner(
+                estimator.CLASSIFICATION)
         # If sklearn learner, get the underlying sklearn representation
-        if isinstance(base_estimator, SklLearner):
-            base_estimator = base_estimator.__wraps__(**base_estimator.params)
+        if isinstance(estimator, SklLearner):
+            estimator = estimator.__wraps__(**estimator.params)
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
 
@@ -43,15 +58,20 @@ class SklAdaBoostRegressionLearner(SklLearnerRegression):
     __returns__ = SklAdaBoostRegressor
     supports_weights = True
 
-    def __init__(self, base_estimator=None, n_estimators=50, learning_rate=1.,
-                 loss='linear', random_state=None, preprocessors=None):
+    def __init__(self, estimator=None, n_estimators=50, learning_rate=1.,
+                 loss='linear', random_state=None, preprocessors=None,
+                 base_estimator="deprecated"):
+        if base_estimator != "deprecated":
+            base_estimator_deprecation()
+            estimator = base_estimator
+        del base_estimator
         from Orange.modelling import Fitter
         # If fitter, get the appropriate Learner instance
-        if isinstance(base_estimator, Fitter):
-            base_estimator = base_estimator.get_learner(
-                base_estimator.REGRESSION)
+        if isinstance(estimator, Fitter):
+            estimator = estimator.get_learner(
+                estimator.REGRESSION)
         # If sklearn learner, get the underlying sklearn representation
-        if isinstance(base_estimator, SklLearner):
-            base_estimator = base_estimator.__wraps__(**base_estimator.params)
+        if isinstance(estimator, SklLearner):
+            estimator = estimator.__wraps__(**estimator.params)
         super().__init__(preprocessors=preprocessors)
         self.params = vars()

--- a/Orange/tests/test_pca.py
+++ b/Orange/tests/test_pca.py
@@ -5,7 +5,6 @@ import unittest
 from unittest.mock import MagicMock
 
 import numpy as np
-from sklearn import __version__ as sklearn_version
 from sklearn.utils import check_random_state
 
 from Orange.data import Table, Domain
@@ -155,8 +154,6 @@ class TestPCA(unittest.TestCase):
             pca.singular_values_, rpca.singular_values_, decimal=8
         )
 
-    @unittest.skipIf(sklearn_version.startswith('0.20'),
-                     "https://github.com/scikit-learn/scikit-learn/issues/12234")
     def test_incremental_pca(self):
         data = self.ionosphere
         self.__ipca_test_helper(data, n_com=3, min_xpl_var=0.49)

--- a/Orange/widgets/evaluate/tests/test_owliftcurve.py
+++ b/Orange/widgets/evaluate/tests/test_owliftcurve.py
@@ -1,11 +1,9 @@
 # pylint: disable=protected-access,duplicate-code
 import copy
-import pkg_resources
 import unittest
 from unittest.mock import Mock
 
 import numpy as np
-import sklearn
 
 from AnyQt.QtGui import QFont, QPen
 
@@ -21,14 +19,6 @@ from Orange.widgets.evaluate.owliftcurve import OWLiftCurve, cumulative_gains, \
     cumulative_gains_from_results, CurveTypes, precision_recall_from_results, \
     points_from_results, compute_area
 from Orange.tests import test_filename
-
-
-# scikit-learn==1.1.1 does not support read the docs, therefore
-# we can not make it a requirement for now. When the minimum required
-# version is >=1.1.1, delete these exceptions.
-OK_SKLEARN = pkg_resources.parse_version(sklearn.__version__) >= \
-             pkg_resources.parse_version("1.1.1")
-SKIP_REASON = "Only test precision-recall with scikit-learn>=1.1.1"
 
 
 class TestOWLiftCurve(EvaluateTest):
@@ -304,7 +294,6 @@ class UtilsTest(unittest.TestCase):
         assert_almost_equal(thresholds, [])
 
     @staticmethod
-    @unittest.skipUnless(OK_SKLEARN, SKIP_REASON)
     def test_precision_recall_from_results():
         y_true = np.array([1, 0, 1, 0, 0, 1])
         y_scores = np.array([0.6, 0.5, 0.9, 0.4, 0.2, 0.4])
@@ -324,7 +313,6 @@ class UtilsTest(unittest.TestCase):
                                 np.array([0.2, 0.4, 0.5, 0.6, 0.9, 1]))
 
     @staticmethod
-    @unittest.skipUnless(OK_SKLEARN, SKIP_REASON)
     def test_precision_recall_from_results_one():
         y_true = np.array([1, 0, 1, 0, 0, 1])
         y_scores = np.array([0.6, 0.5, 1, 0.4, 0.2, 0.4])
@@ -344,7 +332,6 @@ class UtilsTest(unittest.TestCase):
                                 np.array([0.2, 0.4, 0.5, 0.6, 1]))
 
     @staticmethod
-    @unittest.skipUnless(OK_SKLEARN, SKIP_REASON)
     def test_precision_recall_from_results_multiclass():
         y_true = np.array([1, 0, 1, 0, 2, 2])
         y_scores = np.array([[0.3, 0.3, 0.4],

--- a/Orange/widgets/model/owadaboost.py
+++ b/Orange/widgets/model/owadaboost.py
@@ -80,7 +80,7 @@ class OWAdaBoost(OWBaseLearner):
         if self.base_estimator is None:
             return None
         return self.LEARNER(
-            base_estimator=self.base_estimator,
+            estimator=self.base_estimator,
             n_estimators=self.n_estimators,
             learning_rate=self.learning_rate,
             random_state=self.random_seed,

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - catboost >=1.0.1
     - chardet >=3.0.2
     - httpx >=0.21
-    - joblib >=1.0.0
+    - joblib >=1.1.1
     - keyring
     - keyrings.alt
     - networkx
@@ -64,7 +64,7 @@ requirements:
     - python-louvain >=0.13
     - pyyaml
     - requests
-    - scikit-learn >=1.1.0,!=1.2.*,<1.4   # ignoring 1.2.*: scikit-learn/issues/26241
+    - scikit-learn >=1.3.0
     - scipy >=1.9
     - serverfiles
     - setuptools >=51.0.0

--- a/i18n/si.jaml
+++ b/i18n/si.jaml
@@ -2010,14 +2010,18 @@ distance/distance.py:
         def `compute_distances`:
             hamming: false
 ensembles/ada_boost.py:
+    def `base_estimator_deprecation`:
+        '`base_estimator` is deprecated (to be removed in 3.39): use `estimator` instead.': false
     SklAdaBoostClassificationLearner: false
     SklAdaBoostRegressionLearner: false
     class `SklAdaBoostClassificationLearner`:
         def `__init__`:
             SAMME.R: false
+            deprecated: false
     class `SklAdaBoostRegressionLearner`:
         def `__init__`:
             linear: false
+            deprecated: false
 ensembles/stack.py:
     StackedLearner: false
     StackedClassificationLearner: false

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -5,7 +5,7 @@ catboost>=1.0.1
 chardet>=3.0.2
 httpx>=0.21.0
 # Multiprocessing abstraction
-joblib>=1.0.0
+joblib>=1.1.1
 keyring
 keyrings.alt    # for alternative keyring implementations
 networkx
@@ -17,7 +17,7 @@ pip>=18.0
 python-louvain>=0.13
 pyyaml
 requests
-scikit-learn>=1.1.0,!=1.2.*,<1.4  # ignoring 1.2.*: scikit-learn/issues/26241
+scikit-learn>=1.3.0
 scipy>=1.9
 serverfiles		# for Data Sets synchronization
 setuptools>=51.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     oldest: catboost==1.0.1
     oldest: chardet==3.0.2
     oldest: httpx==0.21.0
-    oldest: joblib==1.0.0
+    oldest: joblib==1.1.1
     # oldest: keyring
     # oldest: keyrings.alt
     # oldest: networkx
@@ -62,7 +62,7 @@ deps =
     oldest: python-louvain==0.13
     # oldest: pyyaml
     # oldest: requests
-    oldest: scikit-learn==1.1.0
+    oldest: scikit-learn==1.3.0
     oldest: scipy==1.9
     # oldest: serverfiles
     oldest: setuptools==51.0.0


### PR DESCRIPTION
##### Issue
/home/runner/work/orange3/orange3/.tox/orange-latest/lib/python3.11/site-packages/sklearn/ensemble/_base.py:156: FutureWarning: `base_estimator` was renamed to `estimator` in version 1.2 and will be removed in 1.4.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
