### PR TITLE
[CI] Test with scientific python nightly wheels 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,10 @@ jobs:
             python-version: '3.10'
             tox_env: pyqt6
             name: PyQt6
+          - os: ubuntu-22.04
+            python-version: '3.11'
+            tox_env: beta
+            name: "Scientific Python nightly wheels"
 
     services:
       postgres:

--- a/Orange/tests/sql/base.py
+++ b/Orange/tests/sql/base.py
@@ -332,24 +332,13 @@ class DataBaseTest:
 
     @classmethod
     def _check_db(cls, db):
+        ver = None
         if ">" in db:
             i = db.find(">")
-            if db[:i] in cls.db_conn and \
-                    cls.db_conn[db[:i]].version <= int(db[i + 1:]):
-                raise unittest.SkipTest(
-                    "This test is only run database version higher then {}"
-                    .format(db[i + 1:]))
-            else:
-                db = db[:i]
+            db, ver = db[:i], db[i:]
         elif "<" in db:
             i = db.find("<")
-            if db[:i] in cls.db_conn and \
-                    cls.db_conn[db[:i]].version >= int(db[i + 1:]):
-                raise unittest.SkipTest(
-                    "This test is only run on database version lower then {}"
-                    .format(db[i + 1:]))
-            else:
-                db = db[:i]
+            db, ver = db[:i], db[i:]
 
         if db in cls.db_conn:
             if not cls.db_conn[db].is_module:
@@ -364,6 +353,16 @@ class DataBaseTest:
                 raise unittest.SkipTest("No connection provided for {}".format(db))
             else:
                 raise Exception("Unsupported database")
+
+        if ver is not None:
+            if ver[0] == ">" and cls.db_conn[db].version <= int(ver[1:]):
+                raise unittest.SkipTest(
+                    "This test is only run database version higher then {}"
+                    .format(ver[1:]))
+            if ver[0] == "<" and cls.db_conn[db].version >= int(ver[1:]):
+                raise unittest.SkipTest(
+                    "This test is only run on database version lower then {}"
+                    .format(ver[1:]))
 
         return db
 

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,30 @@ commands =
     # codecov-actions wants xml report
     coverage xml -o {toxinidir}/coverage.xml
 
+[testenv:beta]
+changedir =
+    {envsitepackagesdir}
+setenv =
+    QT_API=PyQt6
+    ANYQT_HOOK_DENY=pyqt5
+    PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    PIP_PRE=1
+deps =
+    latest: https://github.com/pyqtgraph/pyqtgraph/archive/refs/heads/master.zip#egg=pyqtgraph
+    latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
+    latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
+    PyQt6==6.5.*
+    PyQt6-Qt6==6.5.*
+    PyQt6-WebEngine==6.5.*
+    PyQt6-WebEngine-Qt6==6.5.*
+commands_pre =
+    # Verify installed packages have compatible dependencies
+    pip check
+    # freeze environment
+    pip freeze
+commands =
+    python -m unittest -v Orange.tests Orange.widgets.tests
+
 [testenv:pyqt6]
 changedir =
     {envsitepackagesdir}


### PR DESCRIPTION
##### Issue
Sometimes Orange starts crashing when newer scikit-learn & company get released. We could at least anticipate that.

~~Needs #6637 to be merged first.~~ I remembered doing something like this when I was removing `scikit-learn<1.4` limit in #6637.

##### Description of changes
Adds a nightly build repository to one of our tests. 
