### PR TITLE
OWPythagoreanForest: Cast QPoint to QPointF

### DIFF
--- a/Orange/widgets/visualize/owpythagoreanforest.py
+++ b/Orange/widgets/visualize/owpythagoreanforest.py
@@ -186,7 +186,7 @@ class PythagorasTreeDelegate(QStyledItemDelegate):
         # be painted in the centre of the rect
         offset_w = (option.rect.width() - scene_w) / 2
         offset_h = (option.rect.height() - scene_h) / 2
-        offset = option.rect.topLeft() + QPointF(offset_w, offset_h)
+        offset = QPointF(option.rect.topLeft()) + QPointF(offset_w, offset_h)
         # Finally, we have all the data for the new rect in which to render
         target_rect = QRectF(offset, QSizeF(scene_w, scene_h))
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Can't compute QPoint and QPointF since PyQt6.

##### Description of changes
Cast QPoint to QPointF.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
