### PR TITLE
Lint: Disable duplicate-code

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,8 @@ disable=
     no-name-in-module, no-member,  # too many false positives from Qt
     import-error,       # false positives, and we don't expect any true positives
     too-many-ancestors, # I don't think this is a problem
-    no-else-return      # else's may actually improve readability
+    no-else-return,     # else's may actually improve readability
+    duplicate-code      # too strict; we're disciplined and don't do this by mistake
 
 
 [REPORTS]


### PR DESCRIPTION
##### Issue

Pylint introduced a check for duplicated code.

As we discussed, lint should warn us against things we do accidentally. Duplicated code is not on the list of our common sins, and we can safely assume (and can also already observe) that in our code these issue will be false positives.