### PR TITLE
[FIX] Writers: Store nans in StringVariable as empty strings instead of 'nan'

### DIFF
--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -15,6 +15,7 @@ from fnmatch import fnmatch
 from glob import glob
 
 import numpy as np
+import pandas
 
 from Orange.data import Table, Domain, Variable, DiscreteVariable, \
     StringVariable, ContinuousVariable, TimeVariable
@@ -665,7 +666,7 @@ class _FileWriter:
         elif var.is_discrete:
             return lambda value: "" if isnan(value) else var.values[int(value)]
         elif var.is_string:
-            return lambda value: value
+            return lambda value: "" if pandas.isnull(value) else value
         else:
             return var.repr_val
 

--- a/Orange/data/tests/test_io.py
+++ b/Orange/data/tests/test_io.py
@@ -122,7 +122,7 @@ class TestWriters(unittest.TestCase):
             self.domain,
             np.array([[1, 0.5], [2, np.nan], [np.nan, 1.0625]]),
             np.array([3, 1, 7]),
-            np.array(["foo bar baz".split()]).T
+            np.array([["foo", "bar", np.nan]], dtype=object).T
         )
 
     def test_write_tab(self):
@@ -137,7 +137,7 @@ continuous\tstring\tx y z\tcontinuous
 class\tmeta\t\t
 3\tfoo\ty\t0.500
 1\tbar\tz\t
-7\tbaz\t\t1.06250""".strip())
+7\t\t\t1.06250""".strip())
         finally:
             os.remove(fname)
 
@@ -149,7 +149,8 @@ class\tmeta\t\t
             data = ExcelReader(fname).read()
             np.testing.assert_equal(data.X, self.data.X)
             np.testing.assert_equal(data.Y, self.data.Y)
-            np.testing.assert_equal(data.metas, self.data.metas)
+            np.testing.assert_equal(data.metas[:2], self.data.metas[:2])
+            self.assertEqual(data.metas[2, 0], "")
             np.testing.assert_equal(data.domain, self.data.domain)
         finally:
             os.remove(fname)


### PR DESCRIPTION
##### Issue

Fixes #6527.

##### Description of changes

The function that creates a string representation for storing values in file didn't expect that a `StringVariable` can be `np.nan`. Now it does.

Our handling of StringVariable unknowns is a mess; the Table widget will apparently sometimes show `nan`. This must be solved in general. The present PR only fixes the crash in saving of Excel files.

##### Includes
- [X] Code changes
- [X] Tests
