### PR TITLE
Minor fixes in Mosaic and Sieve vizrank

### DIFF
--- a/Orange/widgets/visualize/owsieve.py
+++ b/Orange/widgets/visualize/owsieve.py
@@ -56,7 +56,6 @@ class ChiSqStats:
 
 
 class SieveRank(VizRankDialogAttrPair):
-    caption_title = "Sieve Rank"
     sort_names_in_row = True
 
     def compute_score(self, state):

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -356,6 +356,30 @@ class MosaicVizRankTests(WidgetTest):
         model = combo.model()
         self.assertEqual(model.item(0).flags() & enabled, enabled)
 
+    def test_disable_combo_3_4(self):
+        def assert_enabled(*args, sel=1):
+            enabled = Qt.ItemIsSelectable | Qt.ItemIsEnabled
+            vizrank = widget.vizrank_dialog
+            combo = vizrank.attrs_combo
+            model = combo.model()
+            for opt in (2, 3):
+                self.assertEqual(model.item(opt).flags() & enabled,
+                                 enabled if opt + 1 in args else Qt.NoItemFlags)
+            self.assertEqual(combo.currentIndex(), sel)
+
+        widget = self.widget
+
+        data = Table("iris.tab")
+        widget.vizrank_attr_range_index = 3
+        self.send_signal(self.widget.Inputs.data, data)
+        assert_enabled(3, 4, sel=3)
+
+        self.send_signal(self.widget.Inputs.data, data[:, :3])
+        assert_enabled(3, sel=2)
+
+        self.send_signal(self.widget.Inputs.data, data[:, :2])
+        assert_enabled(sel=1)
+
     def test_attr_range(self):
         data = Table("iris.tab")
         domain = data.domain

--- a/i18n/si.jaml
+++ b/i18n/si.jaml
@@ -14346,8 +14346,6 @@ widgets/visualize/owsieve.py:
     class `ChiSqStats`:
         def `__init__`:
             ignore: false
-    class `SieveRank`:
-        Sieve Rank: Rangiranje
     class `OWSieveDiagram`:
         Sieve Diagram: Sievov diagram
         'Visualize the observed and expected frequencies ': 'Prikaz pričakovanih in opaženih pogostosti '


### PR DESCRIPTION
##### Issue

Minor improvements over #6661.

##### Description of changes

**Mosaic:**
- Mosaic: disable vizrank for less than two variables
- Mosaic: disable the option to select three or four variables when the number of variables is smaller than that.
- Mosaic: don't declare vizrank dialog as setting provider because it no longer is, and can't be.

**Sieve:**

- Remove unused `caption_title`.

##### Includes
- [X] Code changes
- [X] Tests
