### PR TITLE
Display NaNs in StringVariable as "?"

### DIFF
--- a/Orange/data/tests/test_variable.py
+++ b/Orange/data/tests/test_variable.py
@@ -634,6 +634,8 @@ class TestStringVariable(VariableTest):
         self.assertEqual(a.str_val(""), "?")
         self.assertEqual(a.str_val(Value(a, "")), "?")
         self.assertEqual(a.repr_val(Value(a, "foo")), '"foo"')
+        self.assertEqual(a.str_val(np.nan), "?")
+        self.assertEqual(a.str_val(None), "?")
 
 
 @variabletest(TimeVariable)

--- a/Orange/data/variable.py
+++ b/Orange/data/variable.py
@@ -10,6 +10,7 @@ from math import isnan, floor
 from pickle import PickleError
 
 import numpy as np
+import pandas
 import scipy.sparse as sp
 
 from Orange.data import _variable
@@ -905,6 +906,8 @@ class StringVariable(Variable):
             if not val.value:
                 return "?"
             val = val.value
+        if pandas.isnull(val):
+            return "?"
         return str(val)
 
     def repr_val(self, val):


### PR DESCRIPTION
##### Issue
As @janezd noticed in #6670, "NaN" is displayed as it would have been a string in the DataTable.

##### Description of changes
Display "?" if pandas.isnull returns True.

Although we have been allowing None or NaN to appear in StringVariables for some time now, there are probably many bugs like this. As I was reading the code, it seems that we really assumed StringVariables to actually be, well, strings, when we wrote that code 10 years ago.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
