### PR TITLE
Visual settings Updater: Retain axis color

### DIFF
--- a/Orange/widgets/visualize/utils/customizableplot.py
+++ b/Orange/widgets/visualize/utils/customizableplot.py
@@ -123,10 +123,12 @@ class Updater:
                                 **settings: _SettingType):
         for item in items:
             font = Updater.change_font(item.label.font(), settings)
+            default_color = pg.mkPen(pg.getConfigOption("foreground"))
             item.label.setFont(font)
             fstyle = ["normal", "italic"][font.italic()]
             style = {"font-size": f"{font.pointSize()}pt",
                      "font-family": f"{font.family()}",
+                     "color": item.labelStyle.get("color", default_color),
                      "font-style": f"{fstyle}"}
             item.setLabel(item.labelText, item.labelUnits,
                           item.labelUnitPrefix, **style)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Changing the axis font (using a Visual Settings dialog) on the following plot

![image](https://github.com/biolab/orange3/assets/11465003/eeb5cb94-18b4-41f9-bf49-0ed5c26bfc20)

results in a changed color:

![image](https://github.com/biolab/orange3/assets/11465003/b7a5af51-33e0-4c1c-b89e-11d24ace1cb5)


##### Description of changes
Retain original color when changing the axis font.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
