### PR TITLE
[FIX] CSV Import: Add explicit datetime conversion

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1532,11 +1532,6 @@ def load_csv(path, opts, progress_callback=None, compatibility_mode=False):
         numbers_format_kwds["thousands"] = opts.group_separator
 
     if numbers_format_kwds:
-        # float_precision = "round_trip" cannot handle non c-locale decimal and
-        # thousands sep (https://github.com/pandas-dev/pandas/issues/35365).
-        # Fallback to 'high'.
-        numbers_format_kwds["float_precision"] = "high"
-    else:
         numbers_format_kwds["float_precision"] = "round_trip"
 
     with ExitStack() as stack:

--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1554,7 +1554,12 @@ def load_csv(path, opts, progress_callback=None, compatibility_mode=False):
             na_values=na_values, keep_default_na=False,
             **numbers_format_kwds
         )
-
+        if parse_dates:
+            for date_col in parse_dates:
+                if df.dtypes[date_col] == "object":
+                    df[df.columns[date_col]] = pd.to_datetime(
+                        df.iloc[:, date_col], errors="coerce"
+                    )
         if prefix:
             df.columns = [f"{prefix}{column}" for column in df.columns]
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes an error with dev version of pandas as seen on CI i.e.
```
FAIL: test_load_csv (Orange.widgets.data.tests.test_owcsvimport.TestUtils.test_load_csv)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/orange3/orange3/.tox/beta/lib/python3.11/site-packages/Orange/widgets/data/tests/test_owcsvimport.py", line 449, in test_load_csv
    self.assertSequenceEqual(
AssertionError: Sequences differ: [dtype('O'), dtype('float64'), dtype('O'), Catego[100 chars]64')] != [dtype('<M8[ns]'), dtype('float64'), dtype('O'), [24 chars]64')]

First differing element 0:
dtype('O')
dtype('<M8[ns]')

+ [dtype('<M8[ns]'), dtype('float64'), dtype('O'), 'category', dtype('float64')]
- [dtype('O'),
-  dtype('float64'),
-  dtype('O'),
-  CategoricalDtype(categories=['one', 'three', 'two'], ordered=False, categories_dtype=object),
-  dtype('float64')]
```

##### Description of changes

Add explicit to_datetime conversion for requested datetime columns when read_csv failed to convert all values.
Also remove obsolete workaround float precision parsing. 

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
