### PR TITLE
Distance Matrix: Crash on empty matrix

### DIFF
--- a/Orange/widgets/unsupervised/owdistancematrix.py
+++ b/Orange/widgets/unsupervised/owdistancematrix.py
@@ -72,6 +72,9 @@ class OWDistanceMatrix(widget.OWWidget):
         distances = Output("Distances", DistMatrix, dynamic=False)
         table = Output("Selected Data", Table, replaces=["Table"])
 
+    class Error(widget.OWWidget.Error):
+        empty_matrix = widget.Msg("Distance matrix is empty.")
+
     settingsHandler = DistanceMatrixContextHandler()
     settings_version = 2
     auto_commit = Setting(True)
@@ -107,7 +110,12 @@ class OWDistanceMatrix(widget.OWWidget):
 
     @Inputs.distances
     def set_distances(self, distances):
+        self.clear_messages()
         self.closeContext()
+        if distances is not None:
+            if len(distances) == 0:
+                distances = None
+                self.Error.empty_matrix()
         self.distances = distances
         self.tablemodel.set_data(self.distances)
         self.items = None

--- a/Orange/widgets/unsupervised/owdistances.py
+++ b/Orange/widgets/unsupervised/owdistances.py
@@ -127,6 +127,7 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
         unsupported_sparse = Msg("Some metrics don't support sparse data\n"
                                  "and were disabled: {}")
         imputing_data = Msg("Missing values were imputed")
+        no_features = Msg("Data has no features")
 
     def __init__(self):
         OWWidget.__init__(self)
@@ -242,11 +243,17 @@ class OWDistances(OWWidget, ConcurrentWidgetMixin):
                         return False
             return True
 
+        def _check_no_features():
+            if len(data.domain.attributes) == 0:
+                self.Warning.no_features()
+            return True
+
         metric_def = MetricDefs[self.metric_id]
         metric = metric_def.metric
         self.clear_messages()
         if data is not None:
             for check in (_check_sparse, _check_tractability,
+                          _check_no_features,
                           _fix_discrete, _fix_missing, _fix_nonbinary):
                 if not check():
                     data = None

--- a/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistancematrix.py
@@ -243,6 +243,13 @@ class TestOWDistanceMatrix(WidgetTest):
         self.assertEqual(widget._get_selection(), (([0], [0, 2]), False))
         self.assertEqual(widget.annotation_idx, 0)
 
+    def test_empty_matrix(self):
+        matrix = DistMatrix(np.empty((0, 0)))
+        self.send_signal(self.widget.Inputs.distances, matrix)
+        self.assertTrue(self.widget.Error.empty_matrix.is_shown())
+        self.send_signal(self.widget.Inputs.distances, None)
+        self.assertFalse(self.widget.Error.empty_matrix.is_shown())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/unsupervised/tests/test_owdistances.py
+++ b/Orange/widgets/unsupervised/tests/test_owdistances.py
@@ -265,6 +265,27 @@ class TestOWDistances(WidgetTest):
         out_domain = out.row_items.domain
         self.assertEqual(out_domain.metas, (domain["name"], domain["legs"]))
 
+    def test_no_features(self):
+        zoo = Table("zoo")[:5, 16:]
+
+        self.send_signal(self.widget.Inputs.data, zoo)
+        self.wait_until_finished()
+        out = self.get_output(self.widget.Outputs.distances)
+        self.assertEqual(out.shape, (5, 5))
+        self.assertTrue((out == 0).all())
+        self.assertTrue(self.widget.Warning.no_features.is_shown())
+
+        self.widget.controls.axis.buttons[1].click()
+        self.wait_until_finished()
+        out = self.get_output(self.widget.Outputs.distances)
+        self.assertEqual(out.shape, (0, 0))
+        self.assertTrue((out == 0).all())
+        self.assertTrue(self.widget.Warning.no_features.is_shown())
+
+        self.send_signal(self.widget.Inputs.data, None)
+        self.wait_until_finished()
+        self.assertFalse(self.widget.Warning.no_features.is_shown())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/utils/distmatrixmodel.py
+++ b/Orange/widgets/utils/distmatrixmodel.py
@@ -44,7 +44,7 @@ class DistMatrixModel(QAbstractTableModel):
         self.beginResetModel()
         self.distances = distances
         self.__header_data = dict.fromkeys(self.__header_data, LabelData())
-        if distances is None:
+        if distances is None or len(distances) == 0:
             self.__span = self.colors = self.brushes = None
             return
         minc = min(0, np.min(distances))

--- a/Orange/widgets/utils/tests/test_state_summary.py
+++ b/Orange/widgets/utils/tests/test_state_summary.py
@@ -6,15 +6,17 @@ from collections import namedtuple
 import numpy as np
 
 from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QTableView
 
 from orangecanvas.scheme.signalmanager import LazyValue
 from orangewidget.utils.signals import summarize
 
 from Orange.data import Table, Domain, StringVariable, ContinuousVariable, \
     DiscreteVariable, TimeVariable
+from Orange.misc import DistMatrix
 from Orange.widgets.tests.base import WidgetTest
 from Orange.widgets.utils.state_summary import format_summary_details, \
-    format_multiple_summaries
+    format_multiple_summaries, summarize_matrix
 
 VarDataPair = namedtuple('VarDataPair', ['variable', 'data'])
 
@@ -313,6 +315,24 @@ class TestSummarize(unittest.TestCase):
         previewer.assert_not_called()
         summary.preview_func()
         previewer.assert_called_with(data)
+
+
+class TestSummarizeMatrix(WidgetTest):
+    def test_summarize_matrix(self):
+        matrix = DistMatrix(np.arange(9).reshape(3, 3))
+        summary = summarize_matrix(matrix)
+        self.assertEqual(summary.summary, "3×3")
+        self.assertEqual(summary.details, "<nobr>3×3 distance matrix</nobr>")
+        view = summary.preview_func()
+        self.assertIsInstance(view, QTableView)
+
+    def test_summarize_matrix_empty(self):
+        matrix = DistMatrix(np.empty((0, 0)))
+        summary = summarize_matrix(matrix)
+        self.assertEqual(summary.summary, "0×0")
+        self.assertEqual(summary.details, "<nobr>0×0 distance matrix</nobr>")
+        view = summary.preview_func()
+        self.assertIsInstance(view, QTableView)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Distance Matrix crashes when 0×0 matrix appears on the input.

To reproduce:

![image](https://github.com/biolab/orange3/assets/11465003/68398ec6-322e-4d3f-a050-af85714cf6c6)

##### Description of changes
- Distance Matrix: handle empty matrix on the input
- Distances: warn when data on the input has no featues

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
