### PR TITLE
Stack: new table instead of transform

### DIFF
--- a/Orange/ensembles/stack.py
+++ b/Orange/ensembles/stack.py
@@ -81,7 +81,7 @@ class StackedLearner(Learner):
         dom = Domain([ContinuousVariable('f{}'.format(i + 1))
                       for i in range(X.shape[1])],
                      data.domain.class_var)
-        stacked_data = data.transform(dom).copy()
+        stacked_data = Table.from_table(dom, data)
         with stacked_data.unlocked_reference():
             stacked_data.X = X
             stacked_data.Y = res.actual

--- a/Orange/tests/test_stack.py
+++ b/Orange/tests/test_stack.py
@@ -1,7 +1,7 @@
 import unittest
 
 from Orange.data import Table
-from Orange.ensembles.stack import StackedFitter
+from Orange.ensembles.stack import StackedFitter, StackedLearner
 from Orange.evaluation import CA, CrossValidation, MSE
 from Orange.modelling import KNNLearner, TreeLearner
 
@@ -26,3 +26,16 @@ class TestStackedFitter(unittest.TestCase):
         mse = MSE()(results)
         self.assertLess(mse[0], mse[1])
         self.assertLess(mse[0], mse[2])
+
+    def test_timeseries(self):
+        def aggregate(data):
+            assert type(data) is Table
+
+        class CustomTable(Table):
+            pass
+
+        sl = StackedLearner([TreeLearner(), KNNLearner()],
+                             aggregate=aggregate)
+
+        data = CustomTable(self.iris)
+        sl(data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Fixes #6665.

##### Description of changes
Stacking transformed the data to the same data type as the input. However, Timeseries has an inbuilt assert for time variable, which was missing from stacked_data.

Tests will be added to Timeseries add-on.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
