### PR TITLE
[FIX] Domain Editor - Adapt to dark mode

### DIFF
--- a/Orange/widgets/utils/domaineditor.py
+++ b/Orange/widgets/utils/domaineditor.py
@@ -81,9 +81,10 @@ class VarTableModel(QAbstractTableModel):
             if col == Column.tpe:
                 return gui.attributeIconDict[self.vartypes.index(val) + 1]
         if role == Qt.ForegroundRole:
-            if self.variables[row][Column.place] == Place.skip \
-                    and col != Column.place:
+            if self.variables[row][Column.place] == Place.skip and col != Column.place:
                 return QColor(160, 160, 160)
+            # The background is light-ish, force dark text color - same as data table
+            return self.data(index, Qt.BackgroundRole) and QColor(0, 0, 0, 200)
         if role == Qt.BackgroundRole:
             place = self.variables[row][Column.place]
             mapping = [Place.meta, Place.feature, Place.class_var, None]


### PR DESCRIPTION
##### Issue

Metas and class attributes are poorly visible in the domain editor in dark mode.

##### Description of changes

Use dark colours for a light background in the dark mode. It is exactly the same implementation as in the Data Table.

Before:

![Screenshot 2024-02-07 at 16 58 38](https://github.com/biolab/orange3/assets/6421558/f18f309d-975a-4e04-b046-d68335a77d68)

After:

![Screenshot 2024-02-07 at 16 56 57](https://github.com/biolab/orange3/assets/6421558/9d120c61-ab74-4b42-a1ae-c8b202bf9a5c)

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
