### PR TITLE
[CI] Test with Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install Tox
         run: |
@@ -37,12 +37,12 @@ jobs:
       fail-fast: False
       matrix:
         os: [ubuntu-22.04]
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: ubuntu-22.04
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: orange-latest
             name: Latest
           - os: ubuntu-20.04
@@ -54,7 +54,7 @@ jobs:
             tox_env: pyqt6
             name: PyQt6
           - os: ubuntu-22.04
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: beta
             name: "Scientific Python nightly wheels"
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Skip testing workflows at coverage
         if: |
-          matrix.python-version == '3.11' && matrix.tox_env == 'orange-released'
+          matrix.python-version == '3.12' && matrix.tox_env == 'orange-released'
         run: |
           echo 'SKIP_EXAMPLE_WORKFLOWS=1' >> $GITHUB_ENV
 
@@ -111,7 +111,7 @@ jobs:
           ORANGE_TEST_DB_URI: postgres://postgres_user:postgres_password@localhost:5432/postgres_db|mssql://SA:sqlServerPassw0rd@localhost:1433
 
       - name: Upload code coverage
-        if: matrix.python-version == '3.11' && matrix.tox_env == 'orange-released'
+        if: matrix.python-version == '3.12' && matrix.tox_env == 'orange-released'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
@@ -125,16 +125,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: orange-latest
             name: Latest
           - os: macos-latest
-            python-version: '3.11'
+            python-version: '3.12'
             tox_env: orange-latest
             name: Latest
           - os: windows-latest

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -2,9 +2,9 @@
 # pylint: disable=missing-docstring
 
 import unittest
-from distutils.version import LooseVersion
 
 import numpy as np
+from packaging.version import Version
 
 import Orange
 from Orange.data import Table
@@ -110,7 +110,7 @@ class TestSklAdaBoostLearner(unittest.TestCase):
         self.assertRaises(ValueError, learner, self.iris)
 
     def test_remove_deprecation(self):
-        if LooseVersion(Orange.__version__) >= LooseVersion("3.39"):
+        if Version(Orange.__version__) >= Version("3.39"):
             self.fail(
                 "`base_estimator` was deprecated in "
                 "version 3.37. Please remove everything related to it."

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -2,7 +2,8 @@
 # pylint: disable=missing-docstring
 import pickle
 import unittest
-from distutils.version import LooseVersion
+
+from packaging.version import Version
 
 import Orange
 
@@ -137,7 +138,7 @@ class TestSklLearner(unittest.TestCase):
     def test_supports_weights_property(self):
         """This test is to be included in the 3.37 release and will fail in
         version 3.39. This serves as a reminder."""
-        if LooseVersion(Orange.__version__) >= LooseVersion("3.39"):
+        if Version(Orange.__version__) >= Version("3.39"):
             self.fail(
                 "`SklLearner.supports_weights` as a property that parses fit() "
                 "was deprecated in 3.37. Replace it with `supports_weights = False`"

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -633,9 +633,8 @@ class TestOWPredictions(WidgetTest):
         self.send_signal(self.widget.Inputs.predictors, log_reg_iris)
         self.send_signal(self.widget.Inputs.data, self.iris)
         self.widget.selection_store.unregister = Mock()
-        prev_model = self.widget.predictionsview.model()
         self.send_signal(self.widget.Inputs.predictors, log_reg_iris)
-        self.widget.selection_store.unregister.called_with(prev_model)
+        self.widget.selection_store.unregister.assert_called_once()
 
     def test_multi_inputs(self):
         w = self.widget


### PR DESCRIPTION
##### Description of changes
- Test Orange on Python 3.12, which has been out for some time now.
- Replace `distutils`, which was deprecated and removed in Python 3.12 form tests.
- Replace wrongly used called_with (should be assert_called_with) in test_owpredictions. Since it was not even a valid check (selection model change when the model is set to None in the widget), I replaced it with just assert_called_once, which checks that `unregister` was called.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
