### PR TITLE
Context handler that respects position in Domain

### DIFF
--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -76,7 +76,154 @@ class ContextSetting(WBContextSetting):
         self.required = required
 
 
-class DomainContextHandler(ContextHandler):
+class StructuredVariableSettingMixin:
+
+    def filter_value(self, setting, data, *args):
+        value = data.get(setting.name, None)
+        if isinstance(value, list):
+            new_value = [item for item in value
+                         if self.is_valid_item(setting, item,  *args)]
+            data[setting.name] = new_value
+        elif isinstance(value, dict):
+            new_value = {item: val for item, val in value.items()
+                         if self.is_valid_item(setting, item,  *args)}
+            data[setting.name] = new_value
+        elif self.is_encoded_var(value) \
+                and not self.match_variable(setting, value,  *args):
+            del data[setting.name]
+
+    def encode_setting(self, context, setting, value):
+        if isinstance(value, list):
+            if all(e is None or isinstance(e, Variable) for e in value) \
+                    and any(e is not None for e in value):
+                return ([None if e is None else self.encode_variable(e)
+                         for e in value],
+                        -3)
+            else:
+                return copy.copy(value)
+
+        elif isinstance(value, dict) \
+                and all(isinstance(e, Variable) for e in value):
+            return ({self.encode_variable(e): val for e, val in value.items()},
+                    -4)
+
+        if isinstance(value, Variable):
+            if isinstance(setting, WBContextSetting):
+                return self.encode_variable(value)
+            else:
+                raise ValueError("Variables must be stored as ContextSettings; "
+                                 f"change {setting.name} to ContextSetting.")
+
+        return copy.copy(value), -2
+
+    # backward compatibility, pylint: disable=keyword-arg-before-vararg
+    def decode_setting(self, setting, value, domain=None, *args):
+        def get_var(name):
+            if domain is None:
+                raise ValueError("Cannot decode variable without domain")
+            return domain[name]
+
+        if isinstance(value, tuple):
+            data, dtype = value
+            if dtype == -3:
+                return[None if name_type is None else get_var(name_type[0])
+                       for name_type in data]
+            if dtype == -4:
+                return {get_var(name): val for (name, _), val in data.items()}
+            if dtype >= 100:
+                return get_var(data)
+            return value[0]
+        else:
+            return value
+
+    def match(self, context, *args):
+        matches = []
+        try:
+            for setting, data, _ in \
+                    self.provider.traverse_settings(data=context.values):
+                if not isinstance(setting, WBContextSetting):
+                    continue
+                value = data.get(setting.name, None)
+
+                if isinstance(value, list):
+                    matches.append(
+                        self.match_list(setting, value, context, *args))
+                # type check is a (not foolproof) check in case of a pair that
+                # would, by conincidence, have -3 or -4 as the second element
+                elif isinstance(value, tuple) and len(value) == 2 \
+                       and (value[1] == -3 and isinstance(value[0], list)
+                            or (value[1] == -4 and isinstance(value[0], dict))):
+                    matches.append(self.match_list(setting, value[0], context,
+                                                   *args))
+                elif value is not None:
+                    matches.append(
+                        self.match_value(setting, value, *args))
+        except IncompatibleContext:
+            return self.NO_MATCH
+
+        if self.first_match and matches and sum(m[0] for m in matches):
+            return self.MATCH
+
+        matches.append((0, 0))
+        matched, available = [sum(m) for m in zip(*matches)]
+        return matched / available if available else 0.1
+
+    def match_list(self, setting, value, context, *args):
+        """Match a list of values with the given context.
+        returns a tuple containing number of matched and all values.
+        """
+        matched = 0
+        for item in value:
+            if self.is_valid_item(setting, item, *args):
+                matched += 1
+            elif setting.required == WBContextSetting.REQUIRED:
+                raise IncompatibleContext()
+        return matched, len(value)
+
+    def match_value(self, setting, value, *args):
+        """Match a single value """
+        if value[1] < 0:
+            return 0, 0
+
+        if self.match_variable(setting, value, *args):
+            return 1, 1
+        elif setting.required == setting.OPTIONAL:
+            return 0, 1
+        else:
+            raise IncompatibleContext()
+
+    def is_valid_item(self, setting, item, *args):
+        """Return True if given item can be used with attrs and metas
+
+        Subclasses can override this method to checks data in alternative
+        representations.
+        """
+        if not isinstance(item, tuple):
+            return True
+        return self.match_variable(setting, item, *args)
+
+    @classmethod
+    def match_variable(cls, setting, value, *args):
+        """ Return if variable described with value can be matched to *args. """
+        raise NotImplementedError
+
+
+class VariableEncoderMixin:
+
+    @staticmethod
+    def encode_variable(var):
+        return var.name, 100 + vartype(var)
+
+    @staticmethod
+    def is_encoded_var(value):
+        return isinstance(value, tuple) \
+            and len(value) == 2 \
+            and isinstance(value[0], str) and isinstance(value[1], int) \
+            and value[1] >= 0
+
+
+class DomainContextHandler(ContextHandler, StructuredVariableSettingMixin,
+                           VariableEncoderMixin):
     """Context handler for widgets with settings that depend on
     the input dataset. Suitable settings are selected based on the
     data domain."""
@@ -138,75 +285,20 @@ class DomainContextHandler(ContextHandler):
             domain = domain.domain
         super().open_context(widget, domain, *self.encode_domain(domain))
 
-    def _filter_value(self, setting, data, *args):
-        value = data.get(setting.name, None)
-        if isinstance(value, list):
-            new_value = [item for item in value
-                         if self.is_valid_item(setting, item,  *args)]
-            data[setting.name] = new_value
-        elif isinstance(value, dict):
-            new_value = {item: val for item, val in value.items()
-                         if self.is_valid_item(setting, item,  *args)}
-            data[setting.name] = new_value
-        elif self.is_encoded_var(value) \
-                and not self._var_exists(setting, value,  *args):
-            del data[setting.name]
-
     def filter_value(self, setting, data, domain, *args):
-        self._filter_value(setting, data, *args)
+        StructuredVariableSettingMixin.filter_value(self, setting, data, *args)
 
-    @staticmethod
-    def encode_variable(var):
-        return var.name, 100 + vartype(var)
-
-    @classmethod
-    def encode_setting(cls, context, setting, value):
-        if isinstance(value, list):
-            if all(e is None or isinstance(e, Variable) for e in value) \
-                    and any(e is not None for e in value):
-                return ([None if e is None else cls.encode_variable(e)
-                         for e in value],
-                        -3)
-            else:
-                return copy.copy(value)
-
-        elif isinstance(value, dict) \
-                and all(isinstance(e, Variable) for e in value):
-            return ({cls.encode_variable(e): val for e, val in value.items()},
-                    -4)
-
-        if isinstance(value, Variable):
-            if isinstance(setting, WBContextSetting):
-                return cls.encode_variable(value)
-            else:
-                raise ValueError("Variables must be stored as ContextSettings; "
-                                 f"change {setting.name} to ContextSetting.")
-
-        return copy.copy(value), -2
+    def encode_setting(self, context, setting, value):
+        return StructuredVariableSettingMixin.encode_setting(
+            self, context, setting, value)
 
     # backward compatibility, pylint: disable=keyword-arg-before-vararg
     def decode_setting(self, setting, value, domain=None, *args):
-        def get_var(name):
-            if domain is None:
-                raise ValueError("Cannot decode variable without domain")
-            return domain[name]
+        return StructuredVariableSettingMixin.decode_setting(
+            self, setting, value, domain, *args)
 
-        if isinstance(value, tuple):
-            data, dtype = value
-            if dtype == -3:
-                return[None if name_type is None else get_var(name_type[0])
-                       for name_type in data]
-            if dtype == -4:
-                return {get_var(name): val for (name, _), val in data.items()}
-            if dtype >= 100:
-                return get_var(data)
-            return value[0]
-        else:
-            return value
-
-    @classmethod
-    def _var_exists(cls, setting, value, attributes, metas):
-        if not cls.is_encoded_var(value):
+    def match_variable(self, setting, value, attributes, metas):
+        if not self.is_encoded_var(value):
             return False
 
         attr_name, attr_type = value
@@ -222,80 +314,7 @@ class DomainContextHandler(ContextHandler):
     def match(self, context, domain, attrs, metas):
         if context.attributes == attrs and context.metas == metas:
             return self.PERFECT_MATCH
-        return self._match(context, attrs, metas)
-
-    def _match(self, context, *args):
-        matches = []
-        try:
-            for setting, data, _ in \
-                    self.provider.traverse_settings(data=context.values):
-                if not isinstance(setting, WBContextSetting):
-                    continue
-                value = data.get(setting.name, None)
-
-                if isinstance(value, list):
-                    matches.append(
-                        self.match_list(setting, value, context, *args))
-                # type check is a (not foolproof) check in case of a pair that
-                # would, by conincidence, have -3 or -4 as the second element
-                elif isinstance(value, tuple) and len(value) == 2 \
-                       and (value[1] == -3 and isinstance(value[0], list)
-                            or (value[1] == -4 and isinstance(value[0], dict))):
-                    matches.append(self.match_list(setting, value[0], context,
-                                                   *args))
-                elif value is not None:
-                    matches.append(
-                        self.match_value(setting, value, *args))
-        except IncompatibleContext:
-            return self.NO_MATCH
-
-        if self.first_match and matches and sum(m[0] for m in matches):
-            return self.MATCH
-
-        matches.append((0, 0))
-        matched, available = [sum(m) for m in zip(*matches)]
-        return matched / available if available else 0.1
-
-    def match_list(self, setting, value, context, *args):
-        """Match a list of values with the given context.
-        returns a tuple containing number of matched and all values.
-        """
-        matched = 0
-        for item in value:
-            if self.is_valid_item(setting, item, *args):
-                matched += 1
-            elif setting.required == WBContextSetting.REQUIRED:
-                raise IncompatibleContext()
-        return matched, len(value)
-
-    def match_value(self, setting, value, *args):
-        """Match a single value """
-        if value[1] < 0:
-            return 0, 0
-
-        if self._var_exists(setting, value, *args):
-            return 1, 1
-        elif setting.required == setting.OPTIONAL:
-            return 0, 1
-        else:
-            raise IncompatibleContext()
-
-    def is_valid_item(self, setting, item, *args):
-        """Return True if given item can be used with attrs and metas
-
-        Subclasses can override this method to checks data in alternative
-        representations.
-        """
-        if not isinstance(item, tuple):
-            return True
-        return self._var_exists(setting, item, *args)
-
-    @staticmethod
-    def is_encoded_var(value):
-        return isinstance(value, tuple) \
-            and len(value) == 2 \
-            and isinstance(value[0], str) and isinstance(value[1], int) \
-            and value[1] >= 0
+        return StructuredVariableSettingMixin.match(self, context, attrs, metas)
 
 
 class SimpleDomainContextHandler(DomainContextHandler):
@@ -305,11 +324,10 @@ class SimpleDomainContextHandler(DomainContextHandler):
 
     new_context = ContextHandler.new_context
 
-    @classmethod
-    def _var_exists(cls, setting, value, domain):
+    def match_variable(self, setting, value, domain):
         assert isinstance(setting, ContextSetting)
 
-        if not cls.is_encoded_var(value):
+        if not self.is_encoded_var(value):
             return False
 
         attr_name, attr_type = value
@@ -324,13 +342,13 @@ class SimpleDomainContextHandler(DomainContextHandler):
                 or idx < 0 and setting.exclude_metas):
             return False
 
-        return cls.encode_variable(candidate)[1] == attr_type
+        return self.encode_variable(candidate)[1] == attr_type
 
     def filter_value(self, setting, data, domain):
-        self._filter_value(setting, data, domain)
+        StructuredVariableSettingMixin.filter_value(self, setting, data, domain)
 
     def match(self, context, domain):
-        return self._match(context, domain)
+        return StructuredVariableSettingMixin.match(self, context, domain)
 
 
 class ClassValuesContextHandler(ContextHandler):

--- a/Orange/widgets/settings.py
+++ b/Orange/widgets/settings.py
@@ -317,12 +317,29 @@ class DomainContextHandler(ContextHandler, StructuredVariableSettingMixin,
         return StructuredVariableSettingMixin.match(self, context, attrs, metas)
 
 
-class SimpleDomainContextHandler(DomainContextHandler):
+class SimpleDomainContextHandler(ContextHandler, StructuredVariableSettingMixin,
+                                 VariableEncoderMixin):
+    def __init__(self):
+        super().__init__()
+        self.first_match = True
 
-    def encode_domain(self, domain):
-        return tuple()
+    def open_context(self, widget, domain):
+        if domain is None:
+            return
+        if not isinstance(domain, Domain):
+            domain = domain.domain
+        super().open_context(widget, domain)
 
-    new_context = ContextHandler.new_context
+    def filter_value(self, setting, data, domain, *args):
+        StructuredVariableSettingMixin.filter_value(self, setting, data, *args)
+
+    def encode_setting(self, context, setting, value):
+        return StructuredVariableSettingMixin.encode_setting(
+            self, context, setting, value)
+
+    def decode_setting(self, setting, value, domain, *args):
+        return StructuredVariableSettingMixin.decode_setting(
+            self, setting, value, domain, *args)
 
     def match_variable(self, setting, value, domain):
         assert isinstance(setting, ContextSetting)

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -148,7 +148,7 @@ class OWHeatMap(widget.OWWidget):
 
     settings_version = 4
 
-    settingsHandler = settings.DomainContextHandlerPosition()
+    settingsHandler = settings.SimpleDomainContextHandler()
 
     # Disable clustering for inputs bigger than this
     MaxClustering = 25000

--- a/Orange/widgets/visualize/owheatmap.py
+++ b/Orange/widgets/visualize/owheatmap.py
@@ -146,9 +146,9 @@ class OWHeatMap(widget.OWWidget):
         selected_data = Output("Selected Data", Table, default=True)
         annotated_data = Output(ANNOTATED_DATA_SIGNAL_NAME, Table)
 
-    settings_version = 3
+    settings_version = 4
 
-    settingsHandler = settings.DomainContextHandler()
+    settingsHandler = settings.DomainContextHandlerPosition()
 
     # Disable clustering for inputs bigger than this
     MaxClustering = 25000
@@ -170,7 +170,7 @@ class OWHeatMap(widget.OWWidget):
     #: text row annotation (row names)
     annotation_var = settings.ContextSetting(None)
     #: color row annotation
-    annotation_color_var = settings.ContextSetting(None)
+    annotation_color_var = settings.ContextSetting(None, exclude_attributes=True)
     column_annotation_color_key: Optional[Tuple[str, str]] = settings.ContextSetting(None)
 
     # Discrete variable used to split that data/heatmaps (vertically)

--- a/Orange/widgets/visualize/tests/test_owheatmap.py
+++ b/Orange/widgets/visualize/tests/test_owheatmap.py
@@ -365,6 +365,20 @@ class TestOWHeatMap(WidgetTest, WidgetOutputsTestMixin):
         widget.set_annotation_color_var(None)
         self.assertFalse(widget.scene.widget.right_side_colors[0].isVisible())
 
+    def test_row_color_annotations_invalid_context(self):
+        widget = self.widget
+        data = self.brown_selected[::5]
+        self.send_signal(widget.Inputs.data, data, widget=widget)
+        widget.set_annotation_color_var(data.domain["function"])
+        self.assertTrue(widget.scene.widget.right_side_colors[0].isVisible())
+        # attributes are ignored in for annotation_color_var, so the following
+        # data should not match any context
+        data_attributes = self.brown_selected.transform(
+            Domain(data.domain.attributes + data.domain.class_vars))
+        self.send_signal(widget.Inputs.data, data_attributes, widget=widget)
+        self.assertEqual(widget.row_side_color_cb.currentText(), "(None)")
+        self.assertFalse(widget.scene.widget.right_side_colors[0].isVisible())
+
     def test_col_color_annotations(self):
         widget = self.widget
         data = self._brown_selected_10()


### PR DESCRIPTION
##### Issue

Resolves #6721

##### Description of changes

Added a new context handler that respects context settings' attributes `exclude_attributes`, `exclude_metas` and `exclude_class_vars`.  This context handler avoids storing the whole domain into settings and thus perfect matches do not work.

I searched for possible instances of #6721 in this repo and found only 3 cases where a limited `DomainModel` was used for a context settings, out of which only 1 was problematic:
1. owcorrelations, `feature_model`: not a problem, because it is applied to a processed data set where every possible feature is moved into `.attributes`.
2. owtestandscore, `feature_model` (for CV by Feature): not the same problem, because it uses `PerfectDomainHandler`.
3. owheatmap, `row_side_color_model`: finally, a bug. It this case, because of heavy customization, there were no crashes but UI was in an inconsistent state.

In Heat Map, a combo box for choosing row annotation color is limited to metas and class vars, and thus, when a selected feature was moved from metas to attributes, an incompatible context would match. That did not trigger any crashes because the combo box was updated through special functions, but it did leave the UI in an inconsistent state: an element with index of -1 was selected in the combo (""), and, the saved color was still shown in the map. Fixed by using the proposed ContextHandler.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
