### PR TITLE
[FIX] CSV Import - Fix categorical parsing for "mixed-type" column

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -1773,14 +1773,10 @@ def pandas_to_table(df):
     for header, series in df.items():  # type: (Any, pd.Series)
         if isinstance(series.dtype, CategoricalDtype):
             coldata = series.values  # type: pd.Categorical
-            categories = natural_sorted(str(c) for c in coldata.categories)
-            var = Orange.data.DiscreteVariable.make(
-                str(header), values=categories
-            )
+            categories = natural_sorted(set(str(c) for c in coldata.categories))
+            var = Orange.data.DiscreteVariable.make(str(header), values=categories)
             # Remap the coldata into the var.values order/set
-            coldata = pd.Categorical(
-                coldata.astype("str"), categories=var.values
-            )
+            coldata = pd.Categorical(coldata.astype("str"), categories=var.values)
             codes = coldata.codes
             assert np.issubdtype(codes.dtype, np.integer)
             orangecol = np.array(codes, dtype=float)


### PR DESCRIPTION
##### Issue
The CSV widget fails to parse the data in some cases, such as columns with many numbers, one string, and more numbers. Pandas seem to parse that column as categorical with categories as integers first, and from the string on categories, they are stored as strings (and therefore duplicated).

Before creating a table, the CSV widget transforms all categories to strings so it gets duplicated categories for each category (categories were repeated initially when Pandas read them, but the exact value was both string and int, so it didn't seem to be duplicates).

For the exact scenario, check the newly added test.

##### Description of changes
Fixing the issue by ensuring unique categories after conversion to string.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
