### PR TITLE
[FIX] Table.add_column - Do not try to insert data in locked empty array

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -1722,7 +1722,12 @@ class Table(Sequence, Storage):
                 raise ValueError(f"cannot set data for variable {index.name} "
                                  "with different encoding")
             index = self.domain.index(index)
-        self._get_column_view(index)[:] = data
+        # Zero-sized arrays cannot be made writeable, yet the below
+        # assignment would fail despite doing nothing.
+        if len(self) > 0:
+            self._get_column_view(index)[:] = data
+        else:
+            assert len(self) == len(data)
 
     def _filter_is_defined(self, columns=None, negate=False):
         # structure of function is obvious; pylint: disable=too-many-branches

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -263,6 +263,22 @@ class TestTableInit(unittest.TestCase):
             tabw.metas,
             np.hstack((tab.metas, np.array(list("abcde")).reshape(5, -1))))
 
+    def test_add_column_empty(self):
+        a, b = ContinuousVariable("a"), ContinuousVariable("b")
+        table = Table.from_list(Domain([a]), [])
+
+        new_table = table.add_column(b, [], to_metas=True)
+        self.assertTupleEqual(new_table.domain.attributes, (a,))
+        self.assertTupleEqual(new_table.domain.metas, (b,))
+        self.assertTupleEqual((0, 1), new_table.X.shape)
+        self.assertTupleEqual((0, 1), new_table.metas.shape)
+
+        new_table = table.add_column(ContinuousVariable("b"), [], to_metas=False)
+        self.assertTupleEqual(new_table.domain.attributes, (a, b))
+        self.assertTupleEqual(new_table.domain.metas, ())
+        self.assertTupleEqual((0, 2), new_table.X.shape)
+        self.assertTupleEqual((0, 0), new_table.metas.shape)
+
     def test_copy(self):
         domain = Domain([ContinuousVariable("x")],
                         ContinuousVariable("y"),


### PR DESCRIPTION
##### Issue
When a table has no rows add_column still tries to insert (empty) data to the table's array. In case the table's array is empty Orange doesn't unlock it and so inserting fails.

##### Description of changes
Skip inserting empty data when the array is empty

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
