### PR TITLE
[ENH] Open draged files on CSV Import, Load Model and Distance File widgets

### DIFF
--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 from numpy.testing import assert_array_equal
 
-from AnyQt.QtCore import QSettings, Qt
+from AnyQt.QtCore import QSettings, Qt, QUrl
 from AnyQt.QtGui import QIcon
 from AnyQt.QtWidgets import QFileDialog
 from AnyQt.QtTest import QSignalSpy
@@ -28,7 +28,7 @@ from Orange.tests import named_file
 from Orange.widgets.tests.base import WidgetTest, GuiTest
 from Orange.widgets.data import owcsvimport
 from Orange.widgets.data.owcsvimport import (
-    OWCSVFileImport, pandas_to_table, ColumnType, RowSpec,
+    OWCSVFileImport, pandas_to_table, ColumnType, RowSpec, ImportItem,
 )
 from Orange.widgets.utils.pathutils import PathItem, samepath
 from Orange.widgets.utils.settings import QSettings_writeArray
@@ -373,6 +373,41 @@ class TestOWCSVFileImport(WidgetTest):
             cur = widget.current_item()
             self.assertEqual(item[0], cur.varPath())
             self.assertEqual(item[1].as_dict(), cur.options().as_dict())
+
+    def test_activate_import_dialog(self):
+        path = self.data_regions_path
+        item = ImportItem.fromPath(path)
+        self.widget.import_items_model.appendRow(ImportItem.fromPath(path))
+        opts = item.options()
+        self.assertIsNone(opts)
+        with mock.patch.object(owcsvimport.CSVImportDialog, "show"):
+            self.widget.import_options_button.click()
+            dlg = self.widget.findChild(owcsvimport.CSVImportDialog)
+            dlg.accept()
+        item_ = self.widget.current_item()
+        self.assertEqual(item.path(), item_.path())
+        self.assertIsNotNone(item_.options())
+
+    def test_drop_file(self):
+        self.assertFalse(self.widget.canDropUrl(QUrl("https://aa-bb.com")))
+        url = QUrl.fromLocalFile(self.data_regions_path)
+        self.assertTrue(self.widget.canDropUrl(url))
+
+        with mock.patch.object(owcsvimport.CSVImportDialog, "show"):
+            self.widget.handleDroppedUrl(url)
+            dlg = self.widget.findChild(owcsvimport.CSVImportDialog)
+            dlg.reject()
+        item = self.widget.current_item()
+        self.assertIsNone(item, "Rejecting the dialog should not record the recent file")
+
+        with mock.patch.object(owcsvimport.CSVImportDialog, "show"):
+            self.widget.handleDroppedUrl(url)
+            dlg = self.widget.findChild(owcsvimport.CSVImportDialog)
+            dlg.accept()
+        item = self.widget.current_item()
+        self.assertEqual(item.path(), url.toLocalFile())
+        out = self.get_output(self.widget.Outputs.data)
+        self.assertEqual(len(out.domain), 3)
 
     def test_long_data(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-self-use,protected-access,invalid-name,arguments-differ
+# pylint: disable=protected-access,invalid-name,arguments-differ
 import tempfile
 import unittest
 from unittest import mock

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -95,11 +95,6 @@ class TestOWFile(WidgetTest):
         self.widget.dragEnterEvent(event)
         self.assertTrue(event.isAccepted())
 
-    def test_dragEnterEvent_skips_osx_file_references(self):
-        event = self._drag_enter_event(QUrl.fromLocalFile('/.file/id=12345'))
-        self.widget.dragEnterEvent(event)
-        self.assertFalse(event.isAccepted())
-
     def test_dragEnterEvent_skips_usupported_files(self):
         event = self._drag_enter_event(QUrl.fromLocalFile('file.unsupported'))
         self.widget.dragEnterEvent(event)

--- a/Orange/widgets/data/tests/test_owfile.py
+++ b/Orange/widgets/data/tests/test_owfile.py
@@ -71,11 +71,13 @@ class TestOWFile(WidgetTest):
     event_data = None
 
     def setUp(self):
+        super().setUp()
         self.widget = self.create_widget(OWFile)  # type: OWFile
         dataset_dirs.append(dirname(__file__))
 
     def tearDown(self):
         dataset_dirs.pop()
+        super().tearDown()
 
     def test_describe_call_get_nans(self):
         table = Table("iris")
@@ -120,6 +122,12 @@ class TestOWFile(WidgetTest):
 
         self.assertEqual(self.widget.source, OWFile.LOCAL_FILE)
         self.assertTrue(path.samefile(self.widget.last_path(), TITANIC_PATH))
+        self.widget.load_data.assert_called_with()
+
+        event = self._drop_event(QUrl("https://example.com/aa.csv"))
+        self.widget.load_data.reset_mock()
+        self.widget.dropEvent(event)
+        self.assertEqual(self.widget.source, OWFile.URL)
         self.widget.load_data.assert_called_with()
 
     def _drop_event(self, url):

--- a/Orange/widgets/model/owloadmodel.py
+++ b/Orange/widgets/model/owloadmodel.py
@@ -3,7 +3,7 @@ import pickle
 from typing import Any, Dict
 
 from AnyQt.QtWidgets import QSizePolicy, QStyle, QFileDialog
-from AnyQt.QtCore import QTimer
+from AnyQt.QtCore import QTimer, QUrl
 
 from orangewidget.workflow.drophandler import SingleFileDropHandler
 
@@ -11,13 +11,13 @@ from Orange.base import Model
 from Orange.widgets import widget, gui
 from Orange.widgets.model import owsavemodel
 from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin, RecentPath, \
-    stored_recent_paths_prepend
+    stored_recent_paths_prepend, OWUrlDropBase
 from Orange.widgets.utils import stdpaths
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Msg, Output
 
 
-class OWLoadModel(widget.OWWidget, RecentPathsWComboMixin):
+class OWLoadModel(OWUrlDropBase, RecentPathsWComboMixin):
     name = "Load Model"
     description = "Load a model from an input file."
     priority = 3050
@@ -90,6 +90,17 @@ class OWLoadModel(widget.OWWidget, RecentPathsWComboMixin):
             self.Outputs.model.send(None)
         else:
             self.Outputs.model.send(model)
+
+    def canDropUrl(self, url: QUrl) -> bool:
+        if url.isLocalFile():
+            return OWLoadModelDropHandler().canDropFile(url.toLocalFile())
+        else:
+            return False
+
+    def handleDroppedUrl(self, url: QUrl) -> None:
+        if url.isLocalFile():
+            self.add_path(url.toLocalFile())
+            self.open_file()
 
 
 class OWLoadModelDropHandler(SingleFileDropHandler):

--- a/Orange/widgets/tests/utils.py
+++ b/Orange/widgets/tests/utils.py
@@ -5,6 +5,7 @@ from AnyQt.QtTest import QTest
 from AnyQt.QtGui import QContextMenuEvent
 from AnyQt.QtWidgets import QApplication, QWidget, QButtonGroup
 
+from orangecanvas.gui.test import dragDrop
 from orangewidget.tests.utils import (
     simulate, excepthook_catch, EventSpy, mouseMove
 )
@@ -16,6 +17,7 @@ EventSpy = EventSpy
 excepthook_catch = excepthook_catch
 simulate = simulate
 mouseMove = mouseMove
+dragDrop = dragDrop
 
 
 def qbuttongroup_emit_clicked(bg: QButtonGroup, id_: int):

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -79,9 +79,6 @@ class OWDistanceFile(OWUrlDropBase, RecentPathsWComboMixin):
         self.set_file_list()
         QTimer.singleShot(0, self.open_file)
 
-    def set_file_list(self):
-        super().set_file_list()
-
     def reload(self):
         return self.open_file()
 

--- a/Orange/widgets/unsupervised/owdistancefile.py
+++ b/Orange/widgets/unsupervised/owdistancefile.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 
 from AnyQt.QtWidgets import QSizePolicy, QStyle, QMessageBox, QFileDialog
-from AnyQt.QtCore import QTimer
+from AnyQt.QtCore import QTimer, QUrl
 
 from orangewidget.settings import Setting
 from orangewidget.widget import Msg
@@ -13,12 +13,12 @@ from Orange.misc import DistMatrix
 from Orange.widgets import widget, gui
 from Orange.data import get_sample_datasets_dir
 from Orange.widgets.utils.filedialogs import RecentPathsWComboMixin, RecentPath, \
-    stored_recent_paths_prepend
+    stored_recent_paths_prepend, OWUrlDropBase
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import Output
 
 
-class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
+class OWDistanceFile(OWUrlDropBase, RecentPathsWComboMixin):
     name = "Distance File"
     id = "orange.widgets.unsupervised.distancefile"
     description = "Read distances from a file."
@@ -147,6 +147,17 @@ class OWDistanceFile(widget.OWWidget, RecentPathsWComboMixin):
             self.report_paragraph("No data was loaded.")
         else:
             self.report_items([("File name", self.distances.name)])
+
+    def canDropUrl(self, url: QUrl) -> bool:
+        if url.isLocalFile():
+            return OWDistanceFileDropHandler().canDropFile(url.toLocalFile())
+        else:
+            return False
+
+    def handleDroppedUrl(self, url: QUrl) -> None:
+        if url.isLocalFile():
+            self.add_path(url.toLocalFile())
+            self.open_file()
 
 
 class OWDistanceFileDropHandler(SingleFileDropHandler):

--- a/Orange/widgets/utils/tests/test_filedialogs.py
+++ b/Orange/widgets/utils/tests/test_filedialogs.py
@@ -1,0 +1,28 @@
+from AnyQt.QtCore import QUrl, QMimeData
+
+from Orange.widgets.tests.base import WidgetTest
+from Orange.widgets.tests.utils import dragDrop
+from Orange.widgets.utils.filedialogs import OWUrlDropBase
+
+
+class TestOWUrlDropBase(WidgetTest):
+    def test_drop(self):
+        class TestW(OWUrlDropBase):
+            path = None
+
+            def canDropUrl(self, url: QUrl) -> bool:
+                return url.toLocalFile().endswith(".foo")
+
+            def handleDroppedUrl(self, url: QUrl) -> None:
+                self.path = url.toLocalFile()
+
+        w = self.create_widget(TestW)
+        url = QUrl("file:///bar.foo")
+        mime = QMimeData()
+        mime.setUrls([url])
+        self.assertTrue(dragDrop(w, mime))
+        self.assertEqual(w.path, url.toLocalFile())
+        url = QUrl("file:///bar.baz")
+        mime.setUrls([url])
+        self.assertFalse(dragDrop(w, mime))
+        self.assertNotEqual(w.path, url.toLocalFile())


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Open dragged files on CSV Import, Load Model and Distance File widgets similar to how existing File works.

##### Description of changes

* owcsvimport.py Handle drops on the widget. Implement common OWUrlDropBase abstract class.
* Use OWUrlDropBase in File, LoadMode, Distance File widgets.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
