### PR TITLE
[FIX] pythoneditor/editor: Change order in `terminate`

### DIFF
--- a/Orange/widgets/data/utils/pythoneditor/editor.py
+++ b/Orange/widgets/data/utils/pythoneditor/editor.py
@@ -968,12 +968,12 @@ class PythonEditor(QPlainTextEdit):
         some other interesting effects
         Call it on close to free memory and stop background highlighting
         """
-        self.text = ''
         if self._completer:
             self._completer.terminate()
 
         if self._vim is not None:
             self._vim.terminate()
+        self.text = ''
 
     def __enter__(self):
         """Context management method.


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Python editor tests (vim) frequently segfault.

##### Description of changes

Terminate subelements before clearing the text

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
