### PR TITLE
[FIX] OWSom: Fix crash for data without class variable

### DIFF
--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -1018,7 +1018,6 @@ class OWSOM(OWWidget):
                 compute_value=GetGroups(id_to_group, default_grp, offset))
 
             if not self.data.domain.class_vars:
-                self.data.domain.class_vars = ()
                 class_vars, metas = (grp_var,), som_attrs
             else:
                 class_vars, metas = (), (grp_var,) + som_attrs

--- a/Orange/widgets/unsupervised/owsom.py
+++ b/Orange/widgets/unsupervised/owsom.py
@@ -1018,7 +1018,8 @@ class OWSOM(OWWidget):
                 compute_value=GetGroups(id_to_group, default_grp, offset))
 
             if not self.data.domain.class_vars:
-                class_vars, metas = grp_var, som_attrs
+                self.data.domain.class_vars = ()
+                class_vars, metas = (grp_var,), som_attrs
             else:
                 class_vars, metas = (), (grp_var,) + som_attrs
             return add_columns(self.data.domain, (), class_vars, metas)

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -723,6 +723,13 @@ class TestOWSOM(WidgetTest):
         restart_button.click()
         self.assertFalse(w.Information.modified.is_shown())
 
+    def test_make_domain_without_class_vars(self):
+        widget = self.widget
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        widget.data.domain.class_vars = None
+        widget.update_output()
+        self.assertIsNotNone(self.get_output(widget.Outputs.annotated_data))
+
 
 class TestComputeValues(unittest.TestCase):
     def test_eq_hash(self):

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -723,7 +723,7 @@ class TestOWSOM(WidgetTest):
         restart_button.click()
         self.assertFalse(w.Information.modified.is_shown())
 
-        def test_make_domain_without_class_vars(self):
+    def test_make_domain_without_class_vars(self):
         widget = self.widget
         data = self.iris.transform(Domain(self.iris.domain.attributes))
         self.send_signal(self.widget.Inputs.data, data)

--- a/Orange/widgets/unsupervised/tests/test_owsom.py
+++ b/Orange/widgets/unsupervised/tests/test_owsom.py
@@ -723,12 +723,17 @@ class TestOWSOM(WidgetTest):
         restart_button.click()
         self.assertFalse(w.Information.modified.is_shown())
 
-    def test_make_domain_without_class_vars(self):
+        def test_make_domain_without_class_vars(self):
         widget = self.widget
-        self.send_signal(self.widget.Inputs.data, self.iris)
-        widget.data.domain.class_vars = None
-        widget.update_output()
-        self.assertIsNotNone(self.get_output(widget.Outputs.annotated_data))
+        data = self.iris.transform(Domain(self.iris.domain.attributes))
+        self.send_signal(self.widget.Inputs.data, data)
+
+        domain = self.get_output((widget.Outputs.annotated_data)).domain
+        self.assertEqual(domain.attributes, data.domain.attributes)
+        self.assertEqual(domain.class_var.name, ANNOTATED_DATA_FEATURE_NAME)
+        self.assertEqual([var.name for var in domain.metas],
+                         ["som_cell", "som_row", "som_col", "som_error"])
+
 
 
 class TestComputeValues(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Fixes #6750

##### Description of changes
Fixed TypeError: 'DiscreteVariable' object is not iterable.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
