### PR TITLE
[FIX] Avoid slowdowns by caching Domain.__eq__

### DIFF
--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -170,7 +170,7 @@ class Domain:
         self.anonymous = False
 
         self._hash = None  # cache for __hash__()
-        self._eq_cache = IDWeakrefCache({})  # cache for __eq__()
+        self._eq_cache = IDWeakrefCache(_LRS10Dict())  # cache for __eq__()
 
     def _ensure_indices(self):
         if self._indices is None:
@@ -536,3 +536,12 @@ class Domain:
         if self._hash is None:
             self._hash = hash(self.attributes) ^ hash(self.class_vars) ^ hash(self.metas)
         return self._hash
+
+
+class _LRS10Dict(dict):
+    """ A small "least recently stored" (not LRU) dict """
+
+    def __setitem__(self, key, value):
+        if len(self) >= 10:
+            del self[next(iter(self))]
+        super().__setitem__(key, value)

--- a/Orange/data/domain.py
+++ b/Orange/data/domain.py
@@ -11,6 +11,7 @@ import numpy as np
 from Orange.data import (
     Unknown, Variable, ContinuousVariable, DiscreteVariable, StringVariable
 )
+from Orange.misc.cache import IDWeakrefCache
 from Orange.util import deprecated, OrangeDeprecationWarning
 
 __all__ = ["DomainConversion", "Domain"]
@@ -169,6 +170,7 @@ class Domain:
         self.anonymous = False
 
         self._hash = None  # cache for __hash__()
+        self._eq_cache = IDWeakrefCache({})  # cache for __eq__()
 
     def _ensure_indices(self):
         if self._indices is None:
@@ -185,6 +187,7 @@ class Domain:
         self._variables = self.attributes + self.class_vars
         self._indices = None
         self._hash = None
+        self._eq_cache = {}
 
     def __getstate__(self):
         # Do not pickle dictionaries because unpickling dictionaries that
@@ -195,6 +198,7 @@ class Domain:
         del state["_variables"]
         del state["_indices"]
         del state["_hash"]
+        del state["_eq_cache"]
         return state
 
     # noinspection PyPep8Naming
@@ -518,9 +522,15 @@ class Domain:
         if not isinstance(other, Domain):
             return False
 
-        return (self.attributes == other.attributes and
-                self.class_vars == other.class_vars and
-                self.metas == other.metas)
+        try:
+            eq = self._eq_cache[(other,)]
+        except KeyError:
+            eq = (self.attributes == other.attributes and
+                  self.class_vars == other.class_vars and
+                  self.metas == other.metas)
+            self._eq_cache[(other,)] = eq
+
+        return eq
 
     def __hash__(self):
         if self._hash is None:

--- a/Orange/regression/tests/test_pls.py
+++ b/Orange/regression/tests/test_pls.py
@@ -124,6 +124,14 @@ class TestPLSRegressionLearner(unittest.TestCase):
         self.assertNotEqual(hash(proj1), hash(proj2))
         self.assertNotEqual(hash(proj1.domain), hash(proj2.domain))
 
+    def test_eq_hash_fake_same_model(self):
+        data = Table("housing")
+        pls1 = PLSRegressionLearner()(data)
+        pls2 = PLSRegressionLearner()(data)
+
+        proj1 = pls1.project(data)
+        proj2 = pls2.project(data)
+
         proj2.domain[0].compute_value.compute_shared.pls_model = \
             proj1.domain[0].compute_value.compute_shared.pls_model
         # reset hash caches because object were hacked

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -441,22 +441,24 @@ class TestDomainInit(unittest.TestCase):
         self.assertEqual(domain1, domain2)
 
         var1 = ContinuousVariable('var1')
-        domain1.attributes = (var1,)
+        domain1 = Domain([var1])
         self.assertNotEqual(domain1, domain2)
 
-        domain2.attributes = (var1,)
+        domain2 = Domain([var1])
         self.assertEqual(domain1, domain2)
 
-        domain1.class_vars = (var1,)
+        var2 = ContinuousVariable('var2')
+        domain1 = Domain([var1], [var2])
         self.assertNotEqual(domain1, domain2)
 
-        domain2.class_vars = (var1,)
+        domain2 = Domain([var1], [var2])
         self.assertEqual(domain1, domain2)
 
-        domain1._metas = (var1,)
+        var3 = ContinuousVariable('var3')
+        domain1 = Domain([var1], [var2], [var3])
         self.assertNotEqual(domain1, domain2)
 
-        domain2._metas = (var1,)
+        domain2 = Domain([var1], [var2], [var3])
         self.assertEqual(domain1, domain2)
 
     def test_domain_conversion_is_fast_enough(self):

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -488,6 +488,27 @@ class TestDomainInit(unittest.TestCase):
         domain1._eq_cache[(domain2,)] = False  # pylint: disable=protected-access
         self.assertFalse(domain1 == domain2)
 
+    def test_eq_cache_not_grow(self):
+        var = ContinuousVariable('var')
+        domain = Domain([var])
+        domains = [Domain([var]) for _ in range(10)]
+        for d in domains:
+            self.assertTrue(domain == d)
+
+        # pylint: disable=protected-access,pointless-statement
+
+        # __eq__ results to all ten domains should be cached
+        for d in domains:
+            domain._eq_cache[(d,)]
+
+        dn = Domain([var])
+        self.assertTrue(domain == dn)
+        # the last compared domain should be cached
+        domain._eq_cache[(dn,)]
+        # but the first compared should be lost in cache
+        with self.assertRaises(KeyError):
+            domain._eq_cache[(domains[0],)]
+
     def test_domain_conversion_is_fast_enough(self):
         attrs = [ContinuousVariable("f%i" % i) for i in range(10000)]
         class_vars = [ContinuousVariable("c%i" % i) for i in range(10)]

--- a/Orange/tests/test_pca.py
+++ b/Orange/tests/test_pca.py
@@ -178,6 +178,12 @@ class TestPCA(unittest.TestCase):
         self.assertNotEqual(hash(p1), hash(p2))
         self.assertNotEqual(hash(p1.domain), hash(p2.domain))
 
+    def test_eq_hash_fake_same_projection(self):
+        d = np.random.RandomState(0).rand(20, 20)
+        data = Table.from_numpy(None, d)
+        p1 = PCA()(data)
+        p2 = PCA()(data)
+
         # copy projection
         p2.domain[0].compute_value.compute_shared.projection = \
             p1.domain[0].compute_value.compute_shared.projection


### PR DESCRIPTION
##### Issue

Per quasars/orange-spectroscopy#713 domain comparison can be so slow that it seems that Orange crashed. They are slow especially when multiple domain transformations are chained and if there are many attributes.

A demo to reproduce the issue follows. This `__eq__` implementation follows how we implemented `__eq__` for PCA and PLS, but there, fortunately, because scikit-learn does not properly implement `__eq__`s we do not see this issue. 

What follows is the simplest `SharedComputeValue` with `__eq__` that ensures that the input domain is the same (as all our domain transformations).

```python
import time
import numpy as np

from Orange.data import Domain, Table
from Orange.data.util import SharedComputeValue


class SelectColumn(SharedComputeValue):

    def __init__(self, feature, commonfn):
        super().__init__(commonfn)
        self.feature = feature

    def compute(self, data, common):
        return common[:, self.feature]

    def __eq__(self, other):
        return super().__eq__(other) and self.feature == other.feature

    def __hash__(self):
        return hash((super().__hash__(), self.feature))


class IncrementAll:

    def __init__(self, domain):
        self.domain = domain

    def __call__(self, data):
        if data.domain != self.domain:
            data = data.transform(self.domain)
        return data.X + 1

    def __eq__(self, other):
        return type(self) is type(other) and self.domain == other.domain

    def __hash__(self):
        return hash((type(self), self.domain))


def increment(data):
    common = IncrementAll(data.domain)
    atts = [a.copy(compute_value=SelectColumn(i, common))
            for i, a in enumerate(data.domain.attributes)]
    domain = Domain(atts, data.domain.class_vars,
                                data.domain.metas)
    return data.transform(domain

d = Table.from_numpy(None, X=np.random.random((10, 100)))
d1 = d2 = d

for i in range(5):
    t = time.time()
    d1 = increment(d1)
    d2 = increment(d2)
    assert d1.domain == d2.domain
    print("depth:", i+1, "  time:", time.time() - t)
```

On this branch, I see:
```
depth: 1   time: 0.09512972831726074
depth: 2   time: 0.006474971771240234
depth: 3   time: 0.006785392761230469
depth: 4   time: 0.006263017654418945
depth: 5   time: 0.006262540817260742
```

While on master I get (each increase in depth makes it 100 times slower):

```
depth: 1   time: 0.09968352317810059
depth: 2   time: 0.04008889198303223
depth: 3   time: 3.431462526321411
depth: 4   time: 356.5397837162018
depth: 5   I STOPPED IT
```

##### Description of changes

I implemented caching in `Domain.__eq__`. We deem domains read-only and already cache `__hash__`, so why not this one too?

The first commit refactors id-based caching used in `table.py` for use elsewhere.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
