### PR TITLE
PLS: Add residual normal probability, distance to the model

### DIFF
--- a/Orange/regression/tests/test_pls.py
+++ b/Orange/regression/tests/test_pls.py
@@ -100,6 +100,12 @@ class TestPLSRegressionLearner(unittest.TestCase):
             n_target = len(d.domain.class_vars)
             self.assertEqual(res_table.X.shape, (len(d), 2 * n_target))
 
+    def test_dmodx(self):
+        for d in (table(10, 5, 1), table(10, 5, 3)):
+            orange_model = PLSRegressionLearner()(d)
+            dist_table = orange_model.dmodx(d)
+            self.assertEqual(dist_table.X.shape, (len(d), 1))
+
     def test_eq_hash(self):
         data = Table("housing")
         pls1 = PLSRegressionLearner()(data)

--- a/Orange/regression/tests/test_pls.py
+++ b/Orange/regression/tests/test_pls.py
@@ -93,6 +93,13 @@ class TestPLSRegressionLearner(unittest.TestCase):
             np.testing.assert_almost_equal(scikit_model.coef_.T,
                                            coef_table.X)
 
+    def test_residuals_normal_probability(self):
+        for d in [table(10, 5, 1), table(10, 5, 3)]:
+            orange_model = PLSRegressionLearner()(d)
+            res_table = orange_model.residuals_normal_probability(d)
+            n_target = len(d.domain.class_vars)
+            self.assertEqual(res_table.X.shape, (len(d), 2 * n_target))
+
     def test_eq_hash(self):
         data = Table("housing")
         pls1 = PLSRegressionLearner()(data)

--- a/Orange/widgets/model/owpls.py
+++ b/Orange/widgets/model/owpls.py
@@ -63,15 +63,19 @@ class OWPLS(OWBaseLearner):
     def _create_output_data(self) -> Table:
         projection = self.model.project(self.data)
         normal_probs = self.model.residuals_normal_probability(self.data)
+        dmodx = self.model.dmodx(self.data)
         data_domain = self.data.domain
         proj_domain = projection.domain
         nprobs_domain = normal_probs.domain
+        dmodx_domain = dmodx.domain
         metas = proj_domain.metas + proj_domain.attributes + \
-            nprobs_domain.attributes
+            nprobs_domain.attributes + dmodx_domain.attributes
         domain = Domain(data_domain.attributes, data_domain.class_vars, metas)
         data: Table = self.data.transform(domain)
         with data.unlocked(data.metas):
-            data.metas[:, -2 * len(self.data.domain.class_vars):] = normal_probs.X
+            data.metas[:, -2 * len(self.data.domain.class_vars) - 1: -1] = \
+                normal_probs.X
+            data.metas[:, -1] = dmodx.X[:, 0]
         return data
 
     @OWBaseLearner.Inputs.data

--- a/Orange/widgets/model/owpls.py
+++ b/Orange/widgets/model/owpls.py
@@ -62,11 +62,17 @@ class OWPLS(OWBaseLearner):
 
     def _create_output_data(self) -> Table:
         projection = self.model.project(self.data)
+        normal_probs = self.model.residuals_normal_probability(self.data)
         data_domain = self.data.domain
         proj_domain = projection.domain
-        metas = proj_domain.metas + proj_domain.attributes
+        nprobs_domain = normal_probs.domain
+        metas = proj_domain.metas + proj_domain.attributes + \
+            nprobs_domain.attributes
         domain = Domain(data_domain.attributes, data_domain.class_vars, metas)
-        return self.data.transform(domain)
+        data: Table = self.data.transform(domain)
+        with data.unlocked(data.metas):
+            data.metas[:, -2 * len(self.data.domain.class_vars):] = normal_probs.X
+        return data
 
     @OWBaseLearner.Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/model/tests/test_owpls.py
+++ b/Orange/widgets/model/tests/test_owpls.py
@@ -48,11 +48,12 @@ class TestOWPLS(WidgetTest, WidgetLearnerTestMixin):
         output = self.get_output(self.widget.Outputs.data)
         self.assertEqual(output.X.shape, (506, 13))
         self.assertEqual(output.Y.shape, (506,))
-        self.assertEqual(output.metas.shape, (506, 7))
+        self.assertEqual(output.metas.shape, (506, 8))
         self.assertEqual([v.name for v in self._data.domain.variables],
                          [v.name for v in output.domain.variables])
         metas = ["PLS U1", "PLS U2", "PLS T1", "PLS T2",
-                 "Sample Quantiles (MEDV)", "Theoretical Quantiles (MEDV)"]
+                 "Sample Quantiles (MEDV)", "Theoretical Quantiles (MEDV)",
+                 "DModX"]
         self.assertEqual([v.name for v in self._data.domain.metas] + metas,
                          [v.name for v in output.domain.metas])
 
@@ -61,16 +62,16 @@ class TestOWPLS(WidgetTest, WidgetLearnerTestMixin):
         output = self.get_output(self.widget.Outputs.data)
         self.assertEqual(output.X.shape, (506, 12))
         self.assertEqual(output.Y.shape, (506, 2))
-        self.assertEqual(output.metas.shape, (506, 9))
+        self.assertEqual(output.metas.shape, (506, 10))
         orig_domain = self._data_multi_target.domain
         self.assertEqual([v.name for v in orig_domain.variables],
                          [v.name for v in output.domain.variables])
         metas = ["PLS U1", "PLS U2", "PLS T1", "PLS T2",
                  "Sample Quantiles (MEDV)", "Theoretical Quantiles (MEDV)",
-                 "Sample Quantiles (CRIM)", "Theoretical Quantiles (CRIM)"]
+                 "Sample Quantiles (CRIM)", "Theoretical Quantiles (CRIM)",
+                 "DModX"]
         self.assertEqual([v.name for v in orig_domain.metas] + metas,
                          [v.name for v in output.domain.metas])
-
 
     def test_output_components(self):
         self.send_signal(self.widget.Inputs.data, self._data)

--- a/Orange/widgets/model/tests/test_owpls.py
+++ b/Orange/widgets/model/tests/test_owpls.py
@@ -48,14 +48,29 @@ class TestOWPLS(WidgetTest, WidgetLearnerTestMixin):
         output = self.get_output(self.widget.Outputs.data)
         self.assertEqual(output.X.shape, (506, 13))
         self.assertEqual(output.Y.shape, (506,))
-        self.assertEqual(output.metas.shape, (506, 5))
+        self.assertEqual(output.metas.shape, (506, 7))
+        self.assertEqual([v.name for v in self._data.domain.variables],
+                         [v.name for v in output.domain.variables])
+        metas = ["PLS U1", "PLS U2", "PLS T1", "PLS T2",
+                 "Sample Quantiles (MEDV)", "Theoretical Quantiles (MEDV)"]
+        self.assertEqual([v.name for v in self._data.domain.metas] + metas,
+                         [v.name for v in output.domain.metas])
 
     def test_output_data_multi_target(self):
         self.send_signal(self.widget.Inputs.data, self._data_multi_target)
         output = self.get_output(self.widget.Outputs.data)
         self.assertEqual(output.X.shape, (506, 12))
         self.assertEqual(output.Y.shape, (506, 2))
-        self.assertEqual(output.metas.shape, (506, 5))
+        self.assertEqual(output.metas.shape, (506, 9))
+        orig_domain = self._data_multi_target.domain
+        self.assertEqual([v.name for v in orig_domain.variables],
+                         [v.name for v in output.domain.variables])
+        metas = ["PLS U1", "PLS U2", "PLS T1", "PLS T2",
+                 "Sample Quantiles (MEDV)", "Theoretical Quantiles (MEDV)",
+                 "Sample Quantiles (CRIM)", "Theoretical Quantiles (CRIM)"]
+        self.assertEqual([v.name for v in orig_domain.metas] + metas,
+                         [v.name for v in output.domain.metas])
+
 
     def test_output_components(self):
         self.send_signal(self.widget.Inputs.data, self._data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Implement Residual normal probability plot.

##### Description of changes
Implement Residual normal probability plot by adding `Sample Quantiles` and `Theoretical Quantiles` for each target to output Data.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
