### PR TITLE
Saving Distance Matrices: Handle NaNs in Excel #6766

### DIFF
--- a/Orange/misc/_distmatrix_xlsx.py
+++ b/Orange/misc/_distmatrix_xlsx.py
@@ -134,6 +134,6 @@ def write_matrix(matrix: "DistMatrix", filename):
         for x in range(y + has_diagonal if symmetric else matrix.shape[1]):
             value = matrix[y, x]
             if not np.isnan(value):
-                 sheet.cell(y + row_off, x + col_off).value = value
+                sheet.cell(y + row_off, x + col_off).value = value
 
     wb.save(filename)

--- a/Orange/misc/_distmatrix_xlsx.py
+++ b/Orange/misc/_distmatrix_xlsx.py
@@ -132,6 +132,8 @@ def write_matrix(matrix: "DistMatrix", filename):
     has_diagonal = int(np.any(np.diag(matrix) != 0))
     for y in range(matrix.shape[0]):
         for x in range(y + has_diagonal if symmetric else matrix.shape[1]):
-            sheet.cell(y + row_off, x + col_off).value = matrix[y, x]
+            value = matrix[y, x]
+            if not np.isnan(value):
+                 sheet.call(y + row_off, x + col_off).value = value
 
     wb.save(filename)

--- a/Orange/misc/_distmatrix_xlsx.py
+++ b/Orange/misc/_distmatrix_xlsx.py
@@ -134,6 +134,6 @@ def write_matrix(matrix: "DistMatrix", filename):
         for x in range(y + has_diagonal if symmetric else matrix.shape[1]):
             value = matrix[y, x]
             if not np.isnan(value):
-                 sheet.call(y + row_off, x + col_off).value = value
+                 sheet.cell(y + row_off, x + col_off).value = value
 
     wb.save(filename)

--- a/Orange/misc/tests/test_distmatrix_xlsx.py
+++ b/Orange/misc/tests/test_distmatrix_xlsx.py
@@ -245,6 +245,19 @@ class FunctionsTest(unittest.TestCase):
             self.assertIsNone(row_items)
             self.assertEqual(col_items, mcol_items)
 
+    def test_nan_values(self):
+        with named_file("", suffix=".xlsx") as fname:
+            matrix = DistMatrix([[np.nan, 2, 3], [4, np.nan, np.nan]])
+            write_matrix(matrix, fname)
+
+    def test_read_matrix_with_nan_values(self):
+        with named_file("", suffix=".xlsx") as fname:
+            matrix = DistMatrix([[np.nan, 2, 3], [4, np.nan, np.nan]])
+            write_matrix(matrix, fname)
+            matrix, row_labels, col_labels, _ = read_matrix(fname)
+        self.assertTrue(np.isnan(matrix[0, 0]))
+        self.assertTrue(np.isnan(matrix[1, 1]))
+        self.assertTrue(np.isnan(matrix[1, 2]))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/misc/tests/test_distmatrix_xlsx.py
+++ b/Orange/misc/tests/test_distmatrix_xlsx.py
@@ -254,7 +254,7 @@ class FunctionsTest(unittest.TestCase):
         with named_file("", suffix=".xlsx") as fname:
             matrix = DistMatrix([[np.nan, 2, 3], [4, np.nan, np.nan]])
             write_matrix(matrix, fname)
-            matrix, row_labels, col_labels, _ = read_matrix(fname)
+            matrix, _, _, _ = read_matrix(fname)
         self.assertTrue(np.isnan(matrix[0, 0]))
         self.assertTrue(np.isnan(matrix[1, 1]))
         self.assertTrue(np.isnan(matrix[1, 2]))


### PR DESCRIPTION
##### Issue
Resolves https://github.com/biolab/orange3/issues/6599

Description of changes
Added handling for NaN (Not a Number) values - implemented handling cells with NaN values by leaving them empty when writing to the file and interpreting them as NaN when reading from the file.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
