### PR TITLE
[FIX] tableview: Fix index error when displaying dataset with zero columns

### DIFF
--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -168,7 +168,8 @@ class RichTableView(DataTableView):
             model = self.model()
             model = source_model(model)
             if isinstance(model, RichTableModel) and \
-                    model.richHeaderFlags() & RichTableModel.Labels:
+                    model.richHeaderFlags() & RichTableModel.Labels and \
+                    model.columnCount() > 0:
                 items = model.headerData(
                     0, Qt.Horizontal, RichTableModel.LabelsItemsRole
                 )

--- a/Orange/widgets/data/utils/tests/test_tableview.py
+++ b/Orange/widgets/data/utils/tests/test_tableview.py
@@ -31,6 +31,19 @@ class TableViewTest(GuiTest):
         model.setRichHeaderFlags(RichTableModel.Name)
         self.assertEqual(view.cornerText(), "")
 
+    def test_tableview_empty_model(self):
+        data = Orange.data.Table.from_list(
+            Orange.data.Domain([], None),
+            [],
+        )
+        view = RichTableView()
+        model = RichTableModel(data)
+        view.setModel(model)
+        self.assertIsInstance(view.selectionModel(), BlockSelectionModel)
+        model.setRichHeaderFlags(RichTableModel.Name | RichTableModel.Labels |
+                                 RichTableModel.Icon)
+        view.grab()
+
     def test_tableview_toggle_select_all(self):
         view = RichTableView()
         model = RichTableModel(self.data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

An error occurs when displaying a zero columns dataset in RichTableView
```python
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/tableview.py", line 173, in __headerDataChanged
    items = model.headerData(
            ^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/models.py", line 72, in headerData
    var = super().headerData(
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/utils/itemmodels.py", line 1050, in headerData
    coldesc = self.columns[section]
              ~~~~~~~~~~~~^^^^^^^^^
IndexError: list index out of range
```
Example workflow *Python Script -> Table* with 
```python
import Orange

out_data = Orange.data.Table.from_list(
    Orange.data.Domain([], None),
    [[],
     [],
     []]
)
```
script, *Show variable labels (if present)* must be checked.
##### Description of changes


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
