### PR TITLE
PLS: Loadings output

### DIFF
--- a/Orange/regression/pls.py
+++ b/Orange/regression/pls.py
@@ -131,15 +131,18 @@ class PLSModel(SklModelRegression):
 
         meta_vars = [StringVariable(name=meta_name)]
         metas = np.array(
-            [[f"Component {i + 1}" for i in range(n_components)]], dtype=object
+            [[f"Component {i + 1}" for i in range(n_components)] +
+             [f"Rotation {i + 1}" for i in range(n_components)]], dtype=object
         ).T
         dom = Domain(
             [ContinuousVariable(a.name) for a in orig_domain.attributes],
             [ContinuousVariable(a.name) for a in orig_domain.class_vars],
             metas=meta_vars)
         components = Table(dom,
-                           self.skl_model.x_loadings_.T,
-                           Y=self.skl_model.y_loadings_.T,
+                           np.vstack((self.skl_model.x_loadings_.T,
+                                      self.skl_model.x_rotations_.T)),
+                           Y=np.vstack((self.skl_model.y_loadings_.T,
+                                        self.skl_model.y_rotations_.T)),
                            metas=metas)
         components.name = 'components'
         return components

--- a/Orange/regression/tests/test_pls.py
+++ b/Orange/regression/tests/test_pls.py
@@ -81,9 +81,13 @@ class TestPLSRegressionLearner(unittest.TestCase):
             scikit_model = PLSRegression().fit(d.X, d.Y)
             components = orange_model.components()
             np.testing.assert_almost_equal(scikit_model.x_loadings_,
-                                           components.X.T)
+                                           components.X.T[:, :2])
             np.testing.assert_almost_equal(scikit_model.y_loadings_,
-                                           t2d(components.Y).T)
+                                           t2d(components.Y).T[:, :2])
+            np.testing.assert_almost_equal(scikit_model.x_rotations_,
+                                           components.X.T[:, 2:])
+            np.testing.assert_almost_equal(scikit_model.y_rotations_,
+                                           t2d(components.Y).T[:, 2:])
 
     def test_coefficients(self):
         for d in [table(10, 5, 1), table(10, 5, 3)]:

--- a/Orange/widgets/model/owpls.py
+++ b/Orange/widgets/model/owpls.py
@@ -1,7 +1,8 @@
-from AnyQt.QtCore import Qt
+import numpy as np
 import scipy.sparse as sp
+from AnyQt.QtCore import Qt
 
-from Orange.data import Table, Domain
+from Orange.data import Table, Domain, ContinuousVariable, StringVariable
 from Orange.regression import PLSRegressionLearner
 from Orange.widgets import gui
 from Orange.widgets.settings import Setting
@@ -24,6 +25,7 @@ class OWPLS(OWBaseLearner):
         coefsdata = Output("Coefficients", Table, explicit=True)
         data = Output("Data", Table)
         components = Output("Components", Table)
+        loadings = Output("Loadings", Table)
 
     class Warning(OWBaseLearner.Warning):
         sparse_data = Msg(
@@ -49,16 +51,16 @@ class OWPLS(OWBaseLearner):
 
     def update_model(self):
         super().update_model()
-        coef_table = None
-        data = None
-        components = None
+        coef_table = data = components = loadings = None
         if self.model is not None:
             coef_table = self.model.coefficients_table()
             data = self._create_output_data()
             components = self.model.components()
+            loadings = self._create_output_loadings()
         self.Outputs.coefsdata.send(coef_table)
         self.Outputs.data.send(data)
         self.Outputs.components.send(components)
+        self.Outputs.loadings.send(loadings)
 
     def _create_output_data(self) -> Table:
         projection = self.model.project(self.data)
@@ -67,6 +69,24 @@ class OWPLS(OWBaseLearner):
         metas = proj_domain.metas + proj_domain.attributes
         domain = Domain(data_domain.attributes, data_domain.class_vars, metas)
         return self.data.transform(domain)
+
+    def _create_output_loadings(self) -> Table:
+        components = self.model.components()
+        n_comp = len(components) // 2
+
+        names = [f"Loading {i + 1}" for i in range(n_comp)]
+        domain = Domain([ContinuousVariable(n) for n in names],
+                        metas=[StringVariable("Feature name")])
+
+        rotations = components[n_comp: n_comp * 2].X.T
+        loadings = components[:n_comp].Y.T
+        X = np.vstack([rotations, loadings])
+
+        M = np.array([[v.name] for v in components.domain.variables])
+
+        table = Table.from_numpy(domain, X, metas=M)
+        table.name = "Loadings"
+        return table
 
     @OWBaseLearner.Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/model/tests/test_owpls.py
+++ b/Orange/widgets/model/tests/test_owpls.py
@@ -60,16 +60,16 @@ class TestOWPLS(WidgetTest, WidgetLearnerTestMixin):
     def test_output_components(self):
         self.send_signal(self.widget.Inputs.data, self._data)
         components = self.get_output(self.widget.Outputs.components)
-        self.assertEqual(components.X.shape, (2, 13))
-        self.assertEqual(components.Y.shape, (2,))
-        self.assertEqual(components.metas.shape, (2, 1))
+        self.assertEqual(components.X.shape, (4, 13))
+        self.assertEqual(components.Y.shape, (4,))
+        self.assertEqual(components.metas.shape, (4, 1))
 
     def test_output_components_multi_target(self):
         self.send_signal(self.widget.Inputs.data, self._data_multi_target)
         components = self.get_output(self.widget.Outputs.components)
-        self.assertEqual(components.X.shape, (2, 12))
-        self.assertEqual(components.Y.shape, (2, 2))
-        self.assertEqual(components.metas.shape, (2, 1))
+        self.assertEqual(components.X.shape, (4, 12))
+        self.assertEqual(components.Y.shape, (4, 2))
+        self.assertEqual(components.metas.shape, (4, 1))
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/model/tests/test_owpls.py
+++ b/Orange/widgets/model/tests/test_owpls.py
@@ -71,6 +71,37 @@ class TestOWPLS(WidgetTest, WidgetLearnerTestMixin):
         self.assertEqual(components.Y.shape, (4, 2))
         self.assertEqual(components.metas.shape, (4, 1))
 
+    def test_output_loadings(self):
+        self.send_signal(self.widget.Inputs.data, self._data)
+        loadings = self.get_output(self.widget.Outputs.loadings)
+        self.assertEqual(loadings.name, "Loadings")
+        self.assertEqual(loadings.X.shape, (14, 2))
+        self.assertEqual(loadings.Y.shape, (14, 0,))
+        self.assertEqual(loadings.metas.shape, (14, 1))
+        self.assertEqual(["Loading 1", "Loading 2"],
+                         [v.name for v in loadings.domain.attributes])
+        self.assertEqual(["Feature name"],
+                         [v.name for v in loadings.domain.metas])
+        self.assertAlmostEqual(loadings.X[0, 0], 0.237, 3)
+        self.assertAlmostEqual(loadings.X[13, 0], -0.304, 3)
+
+    def test_output_loadings_multi_target(self):
+        self.send_signal(self.widget.Inputs.data, self._data_multi_target)
+        loadings = self.get_output(self.widget.Outputs.loadings)
+        self.assertEqual(loadings.name, "Loadings")
+        self.assertEqual(loadings.X.shape, (14, 2))
+        self.assertEqual(loadings.Y.shape, (14, 0))
+        self.assertEqual(loadings.metas.shape, (14, 1))
+        self.assertEqual(["Loading 1", "Loading 2"],
+                         [v.name for v in loadings.domain.attributes])
+        self.assertEqual(["Feature name"],
+                         [v.name for v in loadings.domain.metas])
+        metas = [[v.name] for v in self._data_multi_target.domain.variables]
+        self.assertTrue((loadings.metas == metas).all())
+        self.assertAlmostEqual(loadings.X[0, 0], -0.198, 3)
+        self.assertAlmostEqual(loadings.X[12, 0], -0.288, 3)
+        self.assertAlmostEqual(loadings.X[13, 0], 0.243, 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Addition to #6771.
To obtain the following plot from components, three additional widgets are needed

![image](https://github.com/biolab/orange3/assets/11465003/e76ff455-b641-4027-92d6-b58874d51c1c)

![image](https://github.com/biolab/orange3/assets/11465003/9f17e557-5425-41f1-b68e-404e1097f150)

Instead, add a new Output to simplify the procedure.

##### Description of changes
Add an additional output `Loadings`.
It consists of `pls_model.x_rotations_` and `pls_model.y_loadings_`. Variable names are also added to metas.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
