### PR TITLE
[FIX] _simple_tree.c: Fix compilation error with gcc 14

### DIFF
--- a/Orange/classification/_simple_tree.c
+++ b/Orange/classification/_simple_tree.c
@@ -1,3 +1,6 @@
+#if (defined __GLIBC__ || defined __GNU__ || defined __linux__)
+#define _GNU_SOURCE
+#endif
 #include <math.h>
 #include <float.h>
 #include <assert.h>


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Non standard `qsort_r` is not defined unless _GNU_SOURCE is defined or `--std=gnu99` flag is used.

##### Description of changes

Fix compilation error with gcc 14

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
