### PR TITLE
[FIX] tableview: Remove toggle selection on corner widget click

### DIFF
--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -62,8 +62,6 @@ class DataTableView(TableView):
         self.__cornerButton = btn = self.findChild(QAbstractButton)
         self.__cornerButtonFilter = DataTableView.__CornerPainter(self)
         btn.installEventFilter(self.__cornerButtonFilter)
-        btn.clicked.disconnect(self.selectAll)
-        btn.clicked.connect(self.cornerButtonClicked)
         if sys.platform == "darwin":
             btn.setAttribute(Qt.WA_MacSmallSize)
 
@@ -85,21 +83,6 @@ class DataTableView(TableView):
     def cornerText(self):
         """Return the corner text."""
         return self.__cornerText
-
-    def cornerButtonClicked(self):
-        model = self.model()
-        selection = self.selectionModel()
-        selection = selection.selection()
-        if len(selection) == 1:
-            srange = selection[0]
-            if srange.top() == 0 and srange.left() == 0 \
-                    and srange.right() == model.columnCount() - 1 \
-                    and srange.bottom() == model.rowCount() - 1:
-                self.clearSelection()
-            else:
-                self.selectAll()
-        else:
-            self.selectAll()
 
 
 def source_model(model: QAbstractItemModel) -> Optional[QAbstractItemModel]:

--- a/Orange/widgets/data/utils/tests/test_tableview.py
+++ b/Orange/widgets/data/utils/tests/test_tableview.py
@@ -44,17 +44,6 @@ class TableViewTest(GuiTest):
                                  RichTableModel.Icon)
         view.grab()
 
-    def test_tableview_toggle_select_all(self):
-        view = RichTableView()
-        model = RichTableModel(self.data)
-        view.setModel(model)
-        b = view.findChild(QAbstractButton)
-        b.click()
-        self.assertEqual(len(view.selectionModel().selectedRows(0)),
-                         model.rowCount())
-        b.click()
-        self.assertEqual(len(view.selectionModel().selectedRows(0)), 0)
-
     def test_selection(self):
         view = RichTableView()
         model = RichTableModel(self.data)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

With Qt 6.7.0
```
Traceback (most recent call last):
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/scheme/widgetmanager.py", line 404, in __process_init_queue
    self.ensure_created(node)
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/scheme/widgetmanager.py", line 350, in ensure_created
    self.__add_widget_for_node(node)
  File "/Users/aleserjavec/workspace/orange-canvas/orangecanvas/scheme/widgetmanager.py", line 243, in __add_widget_for_node
    w = self.create_widget_for_node(node)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/virtual/py312/lib/python3.12/site-packages/orangewidget/workflow/widgetsscheme.py", line 300, in create_widget_for_node
    widget = self.create_widget_instance(node)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/virtual/py312/lib/python3.12/site-packages/orangewidget/workflow/widgetsscheme.py", line 413, in create_widget_instance
    widget.__init__()
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owtable.py", line 255, in __init__
    view = DataTableView(sortingEnabled=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/owtable.py", line 90, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/gui.py", line 669, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/tableview.py", line 127, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/aleserjavec/workspace/orange3/Orange/widgets/data/utils/tableview.py", line 65, in __init__
    btn.clicked.disconnect(self.selectAll)
TypeError: disconnect() failed between 'clicked' and 'selectAll'
-------------------------------------------------------------------------------
```

On Qt 6.7.0 a wrong signal is connected meaning we get an exception trying to disconnect the selectAll slot (QTBUG-124267). 
Still even that fixed the implementation has changed such that it is using explicit disconnect in the widget's destructor (using explicit stored established QObject::Connection) so it will fail there. 

Out of abundance of caution simply remove the behavior override.


##### Description of changes

* Remove toggle selection on corner widget click

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
