### PR TITLE
Limit scikit-learn version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -64,7 +64,7 @@ requirements:
     - python-louvain >=0.13
     - pyyaml
     - requests
-    - scikit-learn >=1.3.0
+    - scikit-learn >= 1.3.0,<1.5.0
     - scipy >=1.9
     - setuptools >=51.0.0
     - xgboost >=1.7.4

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -18,7 +18,7 @@ pip>=19.3
 python-louvain>=0.13
 pyyaml
 requests
-scikit-learn>=1.3.0
+scikit-learn>=1.3.0,<1.5.0
 scipy>=1.9
 serverfiles		# for Data Sets synchronization
 xgboost>=1.7.4


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
PCA test are failing due to the latest scikit-learn release.

##### Description of changes
Limit the scikit-learn version as a temporary fix.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
