### PR TITLE
[FIX] Only deepcopy the .attributes for the outermost Table transformation

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -835,8 +835,9 @@ class Table(Sequence, Storage):
                 self.W = source.W[row_indices]
                 self.name = getattr(source, 'name', '')
                 self.ids = source.ids[row_indices]
+                self.attributes = getattr(source, 'attributes', {})
                 if new_cache:  # only deepcopy attributes for the outermost transformation
-                    self.attributes = deepcopy(getattr(source, 'attributes', {}))
+                    self.attributes = deepcopy(self.attributes)
                 _idcache_save(_thread_local.conversion_cache, (domain, source), self)
             return self
         finally:
@@ -895,8 +896,9 @@ class Table(Sequence, Storage):
             self.W = source.W[row_indices]
             self.name = getattr(source, 'name', '')
             self.ids = source.ids[row_indices]
+            self.attributes = getattr(source, 'attributes', {})
             if is_outermost_transformation:
-                self.attributes = deepcopy(getattr(source, 'attributes', {}))
+                self.attributes = deepcopy(self.attributes)
         return self
 
     @classmethod

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -881,6 +881,7 @@ class Table(Sequence, Storage):
         :return: a new table
         :rtype: Orange.data.Table
         """
+        is_outermost_transformation = _thread_local.conversion_cache is None
         self = cls()
         self.domain = source.domain
         with self.unlocked_reference():
@@ -894,7 +895,8 @@ class Table(Sequence, Storage):
             self.W = source.W[row_indices]
             self.name = getattr(source, 'name', '')
             self.ids = source.ids[row_indices]
-            self.attributes = deepcopy(getattr(source, 'attributes', {}))
+            if is_outermost_transformation:
+                self.attributes = deepcopy(getattr(source, 'attributes', {}))
         return self
 
     @classmethod

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -835,7 +835,8 @@ class Table(Sequence, Storage):
                 self.W = source.W[row_indices]
                 self.name = getattr(source, 'name', '')
                 self.ids = source.ids[row_indices]
-                self.attributes = deepcopy(getattr(source, 'attributes', {}))
+                if new_cache:  # only deepcopy attributes for the outermost transformation
+                    self.attributes = deepcopy(getattr(source, 'attributes', {}))
                 _idcache_save(_thread_local.conversion_cache, (domain, source), self)
             return self
         finally:

--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -792,6 +792,16 @@ class Table(Sequence, Storage):
         :return: a new table
         :rtype: Orange.data.Table
         """
+        if domain is source.domain:
+            table = cls.from_table_rows(source, row_indices)
+            # assure resulting domain is the instance passed on input
+            table.domain = domain
+            # since sparse flags are not considered when checking for
+            # domain equality, fix manually.
+            with table.unlocked_reference():
+                table = assure_domain_conversion_sparsity(table, source)
+            return table
+
         new_cache = _thread_local.conversion_cache is None
         try:
             if new_cache:
@@ -801,15 +811,6 @@ class Table(Sequence, Storage):
                 cached = _idcache_restore(_thread_local.conversion_cache, (domain, source))
                 if cached is not None:
                     return cached
-            if domain is source.domain:
-                table = cls.from_table_rows(source, row_indices)
-                # assure resulting domain is the instance passed on input
-                table.domain = domain
-                # since sparse flags are not considered when checking for
-                # domain equality, fix manually.
-                with table.unlocked_reference():
-                    table = assure_domain_conversion_sparsity(table, source)
-                return table
 
             # avoid boolean indices; also convert to slices if possible
             row_indices = _optimize_indices(row_indices, len(source))


### PR DESCRIPTION
##### Issue
#6189 introduced deep-copying of the dictionary `Table.attributes` at table transformations. Because table transformations often happen withing table transformation, this can lead to wasting computation and memory. An example of the bug that can happen is Quasars/orange-spectroscopy/pull/726.

For illustration, here is a small example:
```python
import numpy as np
import Orange
from Orange.projection import PCA
from mem_use import MemUse

mem = MemUse()
mem.start()

data = Orange.data.Table(np.random.random((1000, 1000)))
data.attributes["big"] = [ i for i in range(100000) ]
mem.wait_gc("loaded data")

p = PCA(n_components=10)(data)

mem.wait_gc("pca")
mem.draw()
````

The memory use/time graphs below (first master, then this branch) show big differences (~30 seconds vs 1 second) that all stem from the wasteful use of deepcopy:

![master](https://github.com/biolab/orange3/assets/552182/1fbc307d-371c-4983-a174-74ca63f63857)
![this-branch](https://github.com/biolab/orange3/assets/552182/7d5e401d-bf7d-4b0a-8d6e-c108a5629fe2)


##### Description of changes
The code now only copies `.attributes` only for the outermost transformations.

~~**And the thing that should be discussed.**~~ ~~This PR~~ The previous version of the PR would introduce problems if deeper internal transformations wanted to read `table.attributes`. I intentionally left it so just to see if there are any problems. I could add support for them by just referencing that dict for non internal transformations, but if any were naughty and actually modified `table.attributes`, we'd have problems.

I discussed above with myself and noticed that there are no mechanisms for compute_values to set output `table.attributes` and that even before this PR, if any compute_value was particularly naughty, there were problems. The following test fails on master.

```python
def test_attributes_with_naughty_compute_values(self):
    self.table.attributes["A"] = "Original"
    orig = copy.deepcopy(self.table.attributes)

    def changes_attributes(data: Table):
        self.table.attributes["A"] = "Changed"
        return data.get_column(data.domain.attributes[0])

    ndom = Domain([ContinuousVariable("naughty", compute_value=changes_attributes)])
    new_table = self.table.from_table(ndom, self.table)

    self.assertEqual(orig, new_table.attributes)
```

The last commit therefore ensures that `.attributes` are always set, but yes, as before, they should not be modified within the `compute_value`.
 
##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
