### PR TITLE
[ENH] Numpy 2.0 compatibility 

### DIFF
--- a/Orange/classification/__init__.py
+++ b/Orange/classification/__init__.py
@@ -1,5 +1,5 @@
 # Pull members from modules to Orange.classification namespace
-# pylint: disable=wildcard-import
+# pylint: disable=wildcard-import,broad-except
 
 from .base_classification import (ModelClassification as Model,
                                   LearnerClassification as Learner,
@@ -23,7 +23,7 @@ from .calibration import *
 from .scoringsheet import *
 try:
     from .catgb import *
-except ModuleNotFoundError:
+except Exception:
     pass
 from .gb import *
 try:

--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -381,7 +381,7 @@ class _TableBuilder:
                  (self.cols_W, float))
         X, Y, M, W = [self._list_into_ndarray(lst, dt) for lst, dt in lists]
         if X is None:
-            X = np.empty((self.data.shape[0], 0), dtype=np.float_)
+            X = np.empty((self.data.shape[0], 0), dtype=np.float64)
         return X, Y, M, W
 
     @staticmethod
@@ -393,7 +393,7 @@ class _TableBuilder:
         if dtype is not None:
             array.astype(dtype)
         else:
-            assert array.dtype == np.float_
+            assert array.dtype == np.float64
         return array
 
 

--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -50,7 +50,7 @@ def scale(values, min=0, max=1):
     """Return values scaled to [min, max]"""
     if len(values) == 0:
         return np.array([])
-    minval = np.float_(bn.nanmin(values))
+    minval = np.float64(bn.nanmin(values))
     ptp = bn.nanmax(values) - minval
     if ptp == 0:
         return np.clip(values, min, max)

--- a/Orange/preprocess/_relieff.pyx
+++ b/Orange/preprocess/_relieff.pyx
@@ -371,7 +371,7 @@ cdef tuple prepare(X, y, is_discrete, contingencies):
     is_defined = np.logical_not(np.isnan(y))
     X = X[is_defined]
     y = y[is_defined]
-    attr_stats = np.row_stack((np.nanmean(X, 0), np.nanstd(X, 0)))
+    attr_stats = np.vstack((np.nanmean(X, 0), np.nanstd(X, 0)))
     is_discrete = np.asarray(is_discrete, dtype=np.int8)
     contingency_tables(X, y, is_discrete, contingencies)
     return X, y, attr_stats, is_discrete

--- a/Orange/preprocess/discretize.py
+++ b/Orange/preprocess/discretize.py
@@ -44,7 +44,7 @@ class Discretizer(Transformation):
         if sp.issparse(c):
             return self.digitize(c, self.points)
         elif c.size:
-            return np.where(np.isnan(c), np.NaN, self.digitize(c, self.points))
+            return np.where(np.isnan(c), np.nan, self.digitize(c, self.points))
         else:
             return np.array([], dtype=int)
 

--- a/Orange/preprocess/remove.py
+++ b/Orange/preprocess/remove.py
@@ -233,7 +233,7 @@ def remove_unused_values(var, data):
     if len(unique) == len(var.values):
         return var
     used_values = [var.values[i] for i in unique]
-    translation_table = np.array([np.NaN] * len(var.values))
+    translation_table = np.array([np.nan] * len(var.values))
     translation_table[unique] = range(len(used_values))
     return DiscreteVariable(var.name, values=used_values, sparse=var.sparse,
                             compute_value=Lookup(var, translation_table))

--- a/Orange/regression/__init__.py
+++ b/Orange/regression/__init__.py
@@ -17,7 +17,7 @@ from .pls import *
 from ..classification.simple_tree import *
 try:
     from .catgb import *
-except ModuleNotFoundError:
+except Exception:
     pass
 from .gb import *
 try:

--- a/Orange/tests/test_classification.py
+++ b/Orange/tests/test_classification.py
@@ -347,7 +347,7 @@ class SklTest(unittest.TestCase):
     def test_nan_columns(self):
         data = Orange.data.Table("iris")
         with data.unlocked():
-            data.X[:, (1, 3)] = np.NaN
+            data.X[:, (1, 3)] = np.nan
         lr = LogisticRegressionLearner()
         cv = CrossValidation(k=2, store_models=True)
         res = cv(data, [lr])

--- a/Orange/tests/test_domain.py
+++ b/Orange/tests/test_domain.py
@@ -430,7 +430,7 @@ class TestDomainInit(unittest.TestCase):
         domain = Domain([DiscreteVariable("a", values="01"),
                          DiscreteVariable("b", values="01")],
                         DiscreteVariable("y", values="01"))
-        table = Table.from_list(domain, [[0, 1], [1, np.NaN]], [0, 1])
+        table = Table.from_list(domain, [[0, 1], [1, np.nan]], [0, 1])
         pre1 = Continuize()(Impute()(table))
         pre2 = table.transform(pre1.domain)
         np.testing.assert_almost_equal(pre1.X, pre2.X)

--- a/Orange/tests/test_preprocess.py
+++ b/Orange/tests/test_preprocess.py
@@ -80,7 +80,7 @@ class TestRemoveNaNColumns(unittest.TestCase):
     def test_column_filtering(self):
         data = Table("iris")
         with data.unlocked():
-            data.X[:, (1, 3)] = np.NaN
+            data.X[:, (1, 3)] = np.nan
 
         new_data = RemoveNaNColumns()(data)
         self.assertEqual(len(new_data.domain.attributes),
@@ -88,7 +88,7 @@ class TestRemoveNaNColumns(unittest.TestCase):
 
         data = Table("iris")
         with data.unlocked():
-            data.X[0, 0] = np.NaN
+            data.X[0, 0] = np.nan
         new_data = RemoveNaNColumns()(data)
         self.assertEqual(len(new_data.domain.attributes),
                          len(data.domain.attributes))

--- a/Orange/widgets/data/owselectbydataindex.py
+++ b/Orange/widgets/data/owselectbydataindex.py
@@ -83,7 +83,7 @@ that appear in Data Subset, based on row identity and not actual data.
             if self.data_subset and \
                     not np.intersect1d(subset_ids, self.data.ids).size:
                 self.Warning.instances_not_matching()
-            row_sel = np.in1d(self.data.ids, subset_ids)
+            row_sel = np.isin(self.data.ids, subset_ids)
             matching_output = self.data[row_sel]
             non_matching_output = self.data[~row_sel]
             annotated_output = create_annotated_table(self.data, row_sel)

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -652,7 +652,7 @@ class OWSelectRows(widget.OWWidget):
                 filters.negate = True
                 non_matching_output = filters(self.data)
 
-                row_sel = np.in1d(self.data.ids, matching_output.ids)
+                row_sel = np.isin(self.data.ids, matching_output.ids)
                 annotated_output = create_annotated_table(self.data, row_sel)
 
             # if hasattr(self.data, "name"):

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -56,7 +56,7 @@ class TestOWContinuize(WidgetTest):
     def test_one_column_nan_values_normalize_sd(self):
         table = Table("iris")
         with table.unlocked():
-            table[:, 2] = np.NaN
+            table[:, 2] = np.nan
         self.send_signal(self.widget.Inputs.data, table)
         # Normalize.NormalizeBySD
         self.widget.continuous_treatment = 2
@@ -64,14 +64,14 @@ class TestOWContinuize(WidgetTest):
 
         table = Table("iris")
         with table.unlocked():
-            table[1, 2] = np.NaN
+            table[1, 2] = np.nan
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.commit.now()
 
     def test_one_column_nan_values_normalize_span(self):
         table = Table("iris")
         with table.unlocked():
-            table[:, 2] = np.NaN
+            table[:, 2] = np.nan
         self.send_signal(self.widget.Inputs.data, table)
         # Normalize.NormalizeBySpan
         self.widget.continuous_treatment = 1
@@ -79,7 +79,7 @@ class TestOWContinuize(WidgetTest):
 
         table = Table("iris")
         with table.unlocked():
-            table[1, 2] = np.NaN
+            table[1, 2] = np.nan
         self.send_signal(self.widget.Inputs.data, table)
         self.widget.commit.now()
 

--- a/Orange/widgets/model/tests/test_owlogisticregression.py
+++ b/Orange/widgets/model/tests/test_owlogisticregression.py
@@ -106,7 +106,7 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         """
         table = Table("iris")
         with table.unlocked():
-            table.Y[:5] = np.NaN
+            table.Y[:5] = np.nan
         self.send_signal(self.widget.Inputs.data, table)
         coef1 = self.get_output(self.widget.Outputs.coefficients)
         table = table[5:]

--- a/Orange/widgets/tests/test_matplotlib_export.py
+++ b/Orange/widgets/tests/test_matplotlib_export.py
@@ -11,6 +11,7 @@ from Orange.widgets.visualize.owscatterplot import OWScatterPlot
 
 def add_intro(a):
     r = "import matplotlib.pyplot as plt\n" + \
+        "import numpy as np\n" + \
         "from numpy import array\n" + \
         "plt.clf()"
     return r + a

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -1180,7 +1180,7 @@ class OWBoxPlot(widget.OWWidget):
         conditions = self._gather_conditions()
         if conditions:
             selected = Values(conditions, conjunction=False)(self.dataset)
-            selection = np.in1d(
+            selection = np.isin(
                 self.dataset.ids, selected.ids, assume_unique=True).nonzero()[0]
         else:
             selected, selection = None, []

--- a/Orange/widgets/visualize/ownomogram.py
+++ b/Orange/widgets/visualize/ownomogram.py
@@ -1062,7 +1062,7 @@ class OWNomogram(OWWidget):
         names = list(chain.from_iterable(
             [_get_labels(a, lr and lr[i] and lr[i][0] and lr[i][cls_index],
                          OWNomogram.get_ruler_values(p.min(), p.max(),
-                                                     scale * p.ptp(), False))
+                                                     scale * np.ptp(p), False))
              for i, a, p in zip(attr_inds, attributes, points)]))
         points = list(chain.from_iterable(points))
 
@@ -1107,7 +1107,7 @@ class OWNomogram(OWWidget):
                 name_item, attr, self.log_reg_cont_data_extremes[i][cls_index],
                 self.get_ruler_values(
                     point.min(), point.max(),
-                    scale_x * point.ptp(), False),
+                    scale_x * np.ptp(point), False),
                 scale_x, name_offset, - scale_x * min_p)
             for i, attr, name_item, point in
             zip(attr_inds, attributes, name_items, points)]
@@ -1151,7 +1151,7 @@ class OWNomogram(OWWidget):
             def key(x):
                 i, attr = x
                 if attr.is_discrete:
-                    ptp = self.points[i][class_value].ptp()
+                    ptp = np.ptp(self.points[i][class_value])
                 else:
                     coef = np.abs(self.log_reg_coeffs_orig[i][class_value]).mean()
                     ptp = coef * np.ptp(self.log_reg_cont_data_extremes[i][class_value])

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -309,7 +309,7 @@ class OWRadviz(OWAnchorProjectionWidget, VizRankMixin(RadvizVizRank)):
     def _send_components_x(self):
         components_ = super()._send_components_x()
         angle = np.arctan2(*components_[::-1])
-        return np.row_stack((components_, angle))
+        return np.vstack((components_, angle))
 
     def _send_components_metas(self):
         return np.vstack((super()._send_components_metas(), ["angle"]))

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -1074,7 +1074,7 @@ class SilhouettePlot(QGraphicsWidget):
     def __selectionChanged(self, selected, deselected):
         for item, grp in zip(self.__plotItems(), self.__groups):
             select = np.flatnonzero(
-                np.in1d(grp.indices, selected, assume_unique=True))
+                np.isin(grp.indices, selected, assume_unique=True))
             items = item.items()
             if select.size:
                 for i in select:
@@ -1082,7 +1082,7 @@ class SilhouettePlot(QGraphicsWidget):
                     items[i].setBrush(QBrush(QColor(*color)))
 
             deselect = np.flatnonzero(
-                np.in1d(grp.indices, deselected, assume_unique=True))
+                np.isin(grp.indices, deselected, assume_unique=True))
             if deselect.size:
                 for i in deselect:
                     items[i].setBrush(QBrush(QColor(*grp.color)))

--- a/Orange/widgets/visualize/tests/test_owmosaic.py
+++ b/Orange/widgets/visualize/tests/test_owmosaic.py
@@ -421,9 +421,9 @@ class MosaicVizRankTests(WidgetTest):
             Domain(
                 [ContinuousVariable("a"), ContinuousVariable("b"), ContinuousVariable("c")]),
             np.array([
-                [0, np.NaN, 0],
-                [0, np.NaN, 0],
-                [0, np.NaN, 0]
+                [0, np.nan, 0],
+                [0, np.nan, 0],
+                [0, np.nan, 0]
             ])
         )
         self.send_signal(self.widget.Inputs.data, table)

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -158,7 +158,7 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         Silhouette Plot now sets axis range properly.
         GH-2377
         """
-        nan = np.NaN
+        nan = np.nan
         table = Table.from_list(
             Domain(
                 [ContinuousVariable("a"), ContinuousVariable("b"), ContinuousVariable("c")],

--- a/Orange/widgets/visualize/utils/heatmap.py
+++ b/Orange/widgets/visualize/utils/heatmap.py
@@ -1055,7 +1055,7 @@ class HeatmapGridWidget(QGraphicsWidget):
             indices = np.hstack([r.normalized_indices for r in self.parts.rows])
         else:
             indices = []
-        condition = np.in1d(indices, selection)
+        condition = np.isin(indices, selection)
         visual_indices = np.flatnonzero(condition)
         self.__selection_manager.select_rows(visual_indices.tolist())
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - pip
     - cython
-    - numpy
+    - numpy >= 2
     - recommonmark
     - setuptools
     - sphinx >=4.2.0,<8
@@ -43,14 +43,13 @@ requirements:
     # core requirements
     - baycomp >=1.0.2
     - bottleneck >=1.3.4
-    - catboost >=1.0.1
     - chardet >=3.0.2
     - httpx >=0.21
     - joblib >=1.2.0
     - keyring
     - keyrings.alt
     - networkx
-    - numpy >=1.20.0,<2
+    - numpy >=1.20.0
     - openpyxl >=3.1.3
     - openTSNE >=0.6.1,!=0.7.0
     - pandas >=1.4.0,!=1.5.0,!=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cython>=3.0",
-    "oldest-supported-numpy",
+    "numpy>=2.0",
     "recommonmark",
     "setuptools>=51.0",
     "sphinx",

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,6 +1,5 @@
 baycomp>=1.0.2
 bottleneck>=1.3.4
-catboost>=1.0.1
 # Encoding detection
 chardet>=3.0.2
 httpx>=0.21.0

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -9,7 +9,7 @@ joblib>=1.2.0
 keyring
 keyrings.alt    # for alternative keyring implementations
 networkx
-numpy>=1.20.0,<2
+numpy>=1.20.0
 openpyxl>=3.1.3
 openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
 packaging


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Numpy 2.0 compatibility

Currently numpy 2.0 support is still missing in catboost (https://github.com/catboost/catboost/issues/2671).
 
##### Description of changes

np.float_ -> np.float64
np.NaN -> np.nan
np.ndarray.ptp -> np.ptp
np.in1d -> np.isin
np.row_stack -> np.vstack

Replace oldest-supported-numpy with numpy>2.0 in the build dependencies. This is the [new preferred way](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice).

Remove catboost from requirements.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
