### PR TITLE
[CI] tox.ini: Skip pymssql dependency on MacOS with py<3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pyqtwebengine==5.15.*;platform_system!="Windows" or python_version>='3.10'
     coverage
     psycopg2-binary
-    pymssql<3.0
+    pymssql;platform_system!="Darwin" or python_version>="3.11"
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
     # GUI requirements


### PR DESCRIPTION
##### Issue
Tests fail on arm macs with Python<3.11 because the pymssql library cannot be installed.


##### Description of changes
Skip this dependency on systems for which it is not available.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
