### PR TITLE
[FIX] SVM: degree has to be an integer

### DIFF
--- a/Orange/widgets/model/owsvm.py
+++ b/Orange/widgets/model/owsvm.py
@@ -35,6 +35,8 @@ class OWSVM(OWBaseLearner):
     class Warning(OWBaseLearner.Warning):
         sparse_data = Msg('Input data is sparse, default preprocessing is to scale it.')
 
+    settings_version = 2
+
     #: Different types of SVMs
     SVM, Nu_SVM = range(2)
     #: SVM type
@@ -156,8 +158,8 @@ class OWSVM(OWBaseLearner):
         gamma.setSpecialValueText(self._default_gamma)
         coef0 = gui.doubleSpin(
             inbox, self, "coef0", 0.0, 10.0, 0.01, label=" c: ", **common)
-        degree = gui.doubleSpin(
-            inbox, self, "degree", 0.0, 10.0, 0.5, label=" d: ", **common)
+        degree = gui.spin(
+            inbox, self, "degree", 0, 10, 1, label=" d: ", **common)
         self._kernel_params = [gamma, coef0, degree]
         gui.rubber(parambox)
 
@@ -254,6 +256,12 @@ class OWSVM(OWBaseLearner):
         else:
             items["Kernel"] = "Sigmoid, tanh({g:.4} x⋅y + {c:.4})".format(
                 g=gamma, c=self.coef0)
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        if version < 2:
+            if "degree" in settings:
+                settings["degree"] = int(settings["degree"])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/model/tests/test_owsvm.py
+++ b/Orange/widgets/model/tests/test_owsvm.py
@@ -102,3 +102,22 @@ class TestOWSVMClassification(WidgetTest, WidgetLearnerTestMixin):
             data.X = csr_matrix(data.X)
         self.send_signal(self.widget.Inputs.data, data)
         self.assertTrue(self.widget.Warning.sparse_data.is_shown())
+
+    def test_change_degree(self):
+        data = Table("iris")
+        self.send_signal(self.widget.Inputs.data, data)
+        self.widget.kernel_box.buttons[1].click()
+        degree_spin = self.widget._kernel_params[2]  # pylint: disable=protected-access
+        degree_spin.stepUp()
+        self.assertEqual(self.widget.degree, 4)
+        self.click_apply()
+        self.wait_until_stop_blocking()
+        self.assertFalse(self.widget.Error.fitting_failed.is_shown())
+
+    def test_migrate_degree(self):
+        settings = {}
+        OWSVM.migrate_settings(settings, 1)
+
+        settings = {"degree": 4.0}
+        OWSVM.migrate_settings(settings, 1)
+        self.assertIsInstance(settings["degree"], int)


### PR DESCRIPTION
##### Issue
Fixed #6853

##### Description of changes
A spin for doubles was used for degrees - now it is not anymore. I also took care of transitioning saved settings.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
