### PR TITLE
[FIX] Logistic regression: fix penalty argument for no regularization

### DIFF
--- a/Orange/widgets/model/owlogisticregression.py
+++ b/Orange/widgets/model/owlogisticregression.py
@@ -49,7 +49,7 @@ class OWLogisticRegression(OWBaseLearner):
     max_iter = 10000
 
     penalty_types = ("Lasso (L1)", "Ridge (L2)", "None")
-    penalty_types_short = ["l1", "l2", "none"]
+    penalty_types_short = ["l1", "l2", None]
 
     class Warning(OWBaseLearner.Warning):
         class_weights_used = Msg("Weighting by class may decrease performance.")
@@ -86,7 +86,7 @@ class OWLogisticRegression(OWBaseLearner):
     def set_c(self):
         self.strength_C = self.C_s[self.C_index]
         penalty = self.penalty_types_short[self.penalty_type]
-        enable_c = penalty != "none"
+        enable_c = penalty is not None
         self.c_box.setEnabled(enable_c)
         if enable_c:
             fmt = "C={}" if self.strength_C >= 1 else "C={:.3f}"
@@ -110,7 +110,7 @@ class OWLogisticRegression(OWBaseLearner):
             self.Warning.class_weights_used()
         else:
             class_weight = None
-        if penalty == "none":
+        if penalty is None:
             C = 1.0
         else:
             C = self.strength_C

--- a/Orange/widgets/model/tests/test_owlogisticregression.py
+++ b/Orange/widgets/model/tests/test_owlogisticregression.py
@@ -125,10 +125,10 @@ class TestOWLogisticRegression(WidgetTest, WidgetLearnerTestMixin):
         self.assertTrue(self.widget.Warning.class_weights_used.is_shown())
 
     def test_no_penalty(self):
-        self.widget.set_penalty("none")
+        self.widget.set_penalty(None)
         self.click_apply()
         lr = self.get_output(self.widget.Outputs.learner)
-        self.assertEqual(lr.penalty, "none")
+        self.assertEqual(lr.penalty, None)
         self.assertEqual(lr.C, 1.0)
         self.assertEqual(self.widget.c_label.text(), "N/A")
         self.assertFalse(self.widget.c_slider.isEnabledTo(self.widget))


### PR DESCRIPTION
##### Issue

Fixes #6885.

As of 1.3.2, Scikit used to accept `'none'` as penalty. In 1.5.1 it expects `None`.

I unsuccessfully tried to find where, when and why it changed, but it doesn't really matter, I guess.

##### Description of changes

Replace `'none'` with `None`.

##### Includes
- [X] Code changes
- [X] Tests
