### PR TITLE
Hierarchical clustering: Allow more than 20 clusters in Top n spin

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -240,6 +240,9 @@ class OWHierarchicalClustering(widget.OWWidget):
             Msg("Subset data refers to a different table")
         pruning_disables_colors = \
             Msg("Pruned cluster doesn't show colors and indicate subset")
+        many_clusters = \
+            Msg("Variables with too many values may "
+                "degrade the performance of downstream widgets.")
 
     #: Stored (manual) selection state (from a saved workflow) to restore.
     __pending_selection_restore = None  # type: Optional[SelectionState]
@@ -361,7 +364,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             2, 0
         )
         self.top_n_spin = gui.spin(
-            self.selection_box, self, "top_n", 1, 20,
+            self.selection_box, self, "top_n", 1, 1000,
             controlWidth=spin_width, alignment=Qt.AlignRight,
             callback=self._top_n_changed, addToLayout=False)
         self.top_n_spin.lineEdit().returnPressed.connect(self._top_n_return)
@@ -766,6 +769,7 @@ class OWHierarchicalClustering(widget.OWWidget):
     @gui.deferred
     def commit(self):
         items = getattr(self.matrix, "items", self.items)
+        self.Warning.many_clusters.clear()
         if not items:
             self.Outputs.selected_data.send(None)
             self.Outputs.annotated_data.send(None)
@@ -778,6 +782,8 @@ class OWHierarchicalClustering(widget.OWWidget):
 
         maps = [indices[node.value.first:node.value.last]
                 for node in selection]
+        if len(maps) > 20:
+            self.Warning.many_clusters()
 
         selected_indices = list(chain(*maps))
 

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -207,3 +207,22 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         annotated = [(a.name, a.attributes['cluster']) for a in o.domain.attributes]
         self.assertEqual(annotated, [('sepal length', 1), ('petal width', 2),
                                      ('sepal width', 3), ('petal length', 3)])
+
+    def test_many_values_warning(self):
+        w = self.widget
+
+        self.send_signal(self.widget.Inputs.distances, self.distances)
+        w.top_n = 21
+        w.selection_box.buttons[2].click()
+        self.assertTrue(w.Warning.many_clusters.is_shown())
+
+        w.top_n = 20
+        w.selection_box.buttons[2].click()
+        self.assertFalse(w.Warning.many_clusters.is_shown())
+
+        w.top_n = 21
+        w.selection_box.buttons[2].click()
+        self.assertTrue(w.Warning.many_clusters.is_shown())
+
+        self.send_signal(self.widget.Inputs.distances, None)
+        self.assertFalse(w.Warning.many_clusters.is_shown())


### PR DESCRIPTION
##### Issue

Fixes #6883.

##### Description of changes

The spin box expects some maximum value; Qt's default is 99. I set it to 1000, but the widget will show a warning if the value is above 20.

The warning checks the final number of clusters. It won't be shown if Top N setting is too high, but there are not enough data instances for so many clusters. And the warning is also shown when >20 clusters are obtained in some other way, either manually or via treshold.

##### Includes
- [X] Code changes
- [X] Tests
