### PR TITLE
Feature Statistics: Add a legend

### DIFF
--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -572,6 +572,39 @@ class TestFeatureStatisticsUI(WidgetTest):
         self.assertIn("<table>", report_text)
         self.assertEqual(6, report_text.count("<tr>"))  # header + 5 rows
 
+    def test_color_legend(self):
+        w = self.widget
+        data = Table("heart_disease")
+        self.send_signal(self.widget.Inputs.data, data)
+
+        self.assertIs(w.color_var, data.domain.class_var)
+        self.assertEqual(len(w.legend_items), 2)
+        self.assertFalse(w.legend_view.isHidden())
+
+        w.cb_color_var.setCurrentIndex(4)  # age (numeric, no legend)
+        w.cb_color_var.activated.emit(4)
+        self.assertEqual(len(w.legend_items), 0)
+        self.assertTrue(w.legend_view.isHidden())
+
+        w.cb_color_var.setCurrentIndex(6)  # chest pain
+        w.cb_color_var.activated.emit(6)
+        self.assertEqual(len(w.legend_items), 4)
+        self.assertFalse(w.legend_view.isHidden())
+
+        w.cb_color_var.setCurrentIndex(0)  # None
+        w.cb_color_var.activated.emit(0)
+        self.assertEqual(len(w.legend_items), 0)
+        self.assertTrue(w.legend_view.isHidden())
+
+        # Show
+        w.cb_color_var.setCurrentIndex(6)  # chest pain
+        w.cb_color_var.activated.emit(6)
+
+        # to check that the legend is hidden when the data is removed
+        self.send_signal(self.widget.Inputs.data, None)
+        self.assertEqual(len(w.legend_items), 0)
+        self.assertTrue(w.legend_view.isHidden())
+
 
 class TestSummary(WidgetTest):
     def setUp(self):


### PR DESCRIPTION
##### Issue

Fixes #6730.

##### Description of changes

Adds a legend below the table.

<img width="1001" alt="Screenshot 2024-09-13 at 20 09 45" src="https://github.com/user-attachments/assets/527172a1-cfb5-4b22-ab48-1fb09bdb9e28">

The legend is present only when showing the color attribute is categorical, not numeric.

The upper part scrolls; the legend stays in place. If the widget is to narrow, the legend wraps.

<img width="466" alt="Screenshot 2024-09-13 at 20 09 53" src="https://github.com/user-attachments/assets/1e54f3b2-1487-44cd-83bc-6b831a592961">

#6730 proposed putting the legend next the to color combo. This would indeed make it more obvious what the legend refers to, but it wouldn't look bad, especially when wrapped (which would soon happen). Since these are the only colors in the table, the current position of the legend shouldn't be too confusing.

##### Includes
- [X] Code changes
- [X] Tests
