### PR TITLE
Pin sphinx to <8

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,3 +1,3 @@
 recommonmark
-Sphinx>=4.2.0
+Sphinx>=4.2.0,<8
 sphinx-multiproject


### PR DESCRIPTION
##### Issue

Readthedocs fails with 

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/orange3/envs/6894/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 795, in copy_download_files
    copyfile(self.srcdir / src, dest, force=True)
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

The direct cause of the problem is a recent change in Sphinx: https://github.com/sphinx-doc/sphinx/commit/0897b5948b933af38e86ab623770b2ece035c7c2#diff-be839d87d39d93093003a0a4ce40cf9610d0a9445e5e0aeb1cdc6bab527bfbbcR786

The Sphinx code is correct, though, because `self.srcdir` must be an instance of `pathlib.Path`, which defines `/` as a path-concatenating operator. The actual problem is in extension sphinx-multiproject, here: https://github.com/readthedocs/sphinx-multiproject/blob/main/multiproject/extension.py#L37. Changing `app.srcdir = str(new_srcdir.resolve())` to `app.srcdir = new_srcdir.resolve()` fixes the problem.

##### Description of changes

Pin sphinx to an earlier version until they fix the bug.

I see it's already reported in https://github.com/readthedocs/sphinx-multiproject/issues/9.