### PR TITLE
Fixes for tests on nightly builds of numpy/scipy/pandas

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -210,7 +210,7 @@ def _convert_datetime(series, var):
     def col_type(dt):
         """Test if is date, time or datetime"""
         dt_nonnat = dt[~pd.isnull(dt)]  # nat == nat is False
-        if (dt_nonnat.dt.floor("d") == dt_nonnat).all():
+        if (dt_nonnat.dt.floor("D") == dt_nonnat).all():
             # all times are 00:00:00.0 - pure date
             return 1, 0
         elif (dt_nonnat.dt.date == pd.Timestamp("now").date()).all():

--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -1,11 +1,12 @@
 """Pandas DataFrame↔Table conversion helpers"""
-from unittest.mock import patch
+from functools import partial
 
 import numpy as np
 from scipy import sparse as sp
 from scipy.sparse import csr_matrix
 import pandas as pd
 from pandas.core.arrays import SparseArray
+import pandas.core.arrays.sparse.accessor
 from pandas.api.types import (
     is_object_dtype,
     is_datetime64_any_dtype,
@@ -20,6 +21,19 @@ from Orange.data import (
 from Orange.data.table import Role
 
 __all__ = ['table_from_frame', 'table_to_frame']
+
+
+# Patch a bug in pandas SparseFrameAccessor.to_dense
+# As of pandas=3.0.0.dev0+1524.g23c497bb2f, to_dense ignores _constructor
+# and alwats returns DataFrame.
+if pd.__version__ < "3":
+    def to_dense(self):
+        # pylint: disable=protected-access
+        data = {k: v.array.to_dense() for k, v in self._parent.items()}
+        constr = self._parent._constructor
+        return constr(data, index=self._parent.index, columns=self._parent.columns)
+
+    pandas.core.arrays.sparse.accessor.SparseFrameAccessor.to_dense = to_dense
 
 
 class OrangeDataFrame(pd.DataFrame):
@@ -74,8 +88,6 @@ class OrangeDataFrame(pd.DataFrame):
             data = dict(enumerate(sparrays))
             super().__init__(data, index=index, **kwargs)
             self.columns = columns
-            # a hack to keep Orange df _metadata in sparse->dense conversion
-            self.sparse.to_dense = self.__patch_constructor(self.sparse.to_dense)
         else:
             copy = kwargs.pop("copy", False)
             super().__init__(
@@ -88,21 +100,15 @@ class OrangeDataFrame(pd.DataFrame):
                                if table.W.size > 0 else {})
         self.orange_attributes = table.attributes
 
-    def __patch_constructor(self, method):
-        def new_method(*args, **kwargs):
-            with patch(
-                    'pandas.DataFrame',
-                    OrangeDataFrame
-            ):
-                df = method(*args, **kwargs)
-            df.__finalize__(self)
-            return df
-
-        return new_method
-
     @property
     def _constructor(self):
-        return OrangeDataFrame
+        return partial(self.from_existing, self)
+
+    @staticmethod
+    def from_existing(existing, *args, **kwargs):
+        self = type(existing)(*args, **kwargs)
+        self.__finalize__(existing)
+        return self
 
     def to_orange_table(self):
         return table_from_frame(self)

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -19,6 +19,11 @@ else:
     pytz = None
 
 class TestPandasCompat(unittest.TestCase):
+    def test_patch_for_to_dense(self):
+        if pd.__version__ >= "3" and "dev" not in pd.__version__:
+            self.fail("Try removing the patch for to_dense in pandas_compat.\n"
+                      "If successful, remove this test.")
+
     def test_table_from_frame(self):
         nan = np.nan
         df = pd.DataFrame([['a', 1, pd.Timestamp('2017-12-19')],

--- a/Orange/data/tests/test_pandas.py
+++ b/Orange/data/tests/test_pandas.py
@@ -5,7 +5,6 @@ from unittest import skipIf
 
 import numpy as np
 import pandas as pd
-import pytz
 from scipy.sparse import csr_matrix
 import scipy.sparse as sp
 
@@ -14,6 +13,10 @@ from Orange.data import ContinuousVariable, DiscreteVariable, TimeVariable, Tabl
 from Orange.data.pandas_compat import OrangeDataFrame, table_from_frame
 from Orange.data.tests.test_variable import TestTimeVariable
 
+if pd.__version__ < "2":
+    import pytz
+else:
+    pytz = None
 
 class TestPandasCompat(unittest.TestCase):
     def test_table_from_frame(self):
@@ -307,7 +310,7 @@ class TestPandasCompat(unittest.TestCase):
             ]
         )
         table = table_from_frame(df)
-        tz = pytz.utc if pd.__version__ < "2" else timezone.utc
+        tz = pytz.utc if pytz is not None else timezone.utc
         self.assertEqual(tz, table.domain.variables[0].timezone)
         np.testing.assert_equal(
             table.X,
@@ -326,7 +329,7 @@ class TestPandasCompat(unittest.TestCase):
             ]
         )
         table = table_from_frame(df)
-        tz = pytz.FixedOffset(60) if pd.__version__ < "2" else \
+        tz = pytz.FixedOffset(60) if pytz is not None else \
             timezone(timedelta(seconds=3600))
         self.assertEqual(tz, table.domain.variables[0].timezone)
         np.testing.assert_equal(
@@ -345,12 +348,6 @@ class TestPandasCompat(unittest.TestCase):
                 [np.nan],
             ]
         )
-        table = table_from_frame(df)
-        self.assertEqual(pytz.timezone("CET"), table.domain.variables[0].timezone)
-        # Testing the table was removed because a change in pytz broke it:
-        # treatment of DST has changed, so test were off by an hour,
-        # while time zones before ~1930 seem to be off by 42 minutes
-        # We could fix this, but prefer not to test pytz regressions.
 
         df = pd.DataFrame(
             [
@@ -360,7 +357,7 @@ class TestPandasCompat(unittest.TestCase):
             ]
         )
         table = table_from_frame(df)
-        tz = pytz.utc if pd.__version__ < "2" else timezone.utc
+        tz = pytz.utc if pytz is not None else timezone.utc
         self.assertEqual(tz, table.domain.variables[0].timezone)
         np.testing.assert_equal(
             table.X,

--- a/Orange/preprocess/_relieff.pyx
+++ b/Orange/preprocess/_relieff.pyx
@@ -26,7 +26,7 @@ from libcpp.algorithm cimport make_heap, pop_heap
 # Import C99 features from numpy's npy_math (MSVC 2010)
 # Note we cannot import isnan due to mixing C++ and C
 # (at least on OSX the <cmath> undefines the isnan macro)
-from numpy.math cimport INFINITY, NAN
+from libc.math cimport INFINITY, NAN
 
 ctypedef np.float64_t   double
 ctypedef np.int8_t[:]   arr_i1_t

--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -510,9 +510,10 @@ class TestUtils(unittest.TestCase):
         )
         df = owcsvimport.load_csv(io.BytesIO(contents), opts)
         self.assertEqual(df.shape, (3, 5))
+        resolution = "ns" if pd.__version__ < "3.0" else "s"
         self.assertSequenceEqual(
             list(df.dtypes),
-            [np.dtype("M8[ns]"), np.dtype(float), np.dtype(object),
+            [np.dtype(f"M8[{resolution}]"), np.dtype(float), np.dtype(object),
              "category", np.dtype(float)],
         )
         opts = owcsvimport.Options(

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -27,7 +27,7 @@ class TestOWNomogram(WidgetTest):
         super().setUpClass()
         cls.data = Table("heart_disease")
         cls.nb_cls = NaiveBayesLearner()(cls.data)
-        cls.lr_cls = LogisticRegressionLearner()(cls.data)
+        cls.lr_cls = LogisticRegressionLearner(max_iter=1000)(cls.data)
         cls.titanic = Table("titanic")
         cls.lenses = Table(test_filename("datasets/lenses.tab"))
 
@@ -86,7 +86,7 @@ class TestOWNomogram(WidgetTest):
     def test_nomogram_lr(self):
         """Check probabilities for logistic regression classifier for various
         values of classes and radio buttons"""
-        self._test_helper(self.lr_cls, [61, 39])
+        self._test_helper(self.lr_cls, [57, 43])
 
     def test_nomogram_nb_multiclass(self):
         """Check probabilities for naive bayes classifier for various values


### PR DESCRIPTION
##### Issue

*Scientific Python nightly wheels* fails.

##### Description of changes

- **Cython code in Relief**: Import `NAN` and `INFTY` from `libc.math` instead of from `numpy.math`. This caused an error in cythonizing.
- **Importin pytz**: In `test_pandas`, do not import `pytz`. We do not (directly) depend on it, and pandas removes it in 3.0.
- **Indices in sparse matrices**: Index-out-of-range error is a bug in scipy and was fixed in https://github.com/scipy/scipy/pull/21616.
- **Different result in nomograms:** scipy changed the optimizer that is used for fitting logistic regression. @markotoplak fixed this by increasing the number of iterations
- **Time resolution in pandas**: Pandas can now import time in 1 s resolution, where it previously used 1 ns, and the resulting type is `<M8[s]` instead of `<M8[ns]`. We convert this to floats containing seconds from epoch, so it doesn't affect us. A test failed just because it expected to see `<M8[ns]`, so I changed the test.
- **Subclassing in pandas (#6902)**: is caused by an old bug in pandas, now fixed in https://github.com/pandas-dev/pandas/pull/59967. Our workaround stopped working in pandas 3. This PR correctly defines `OrangeDataFrame`, but for pandas < 3 it dynamically patches the bug in pandas. The patch can be removed when we raise pandas requirements to 3.0.

##### To be fixed elsewhere

- **Variable type guessing in Group By**: The test that fails on Group by is a result of pandas being able to parse more date formats. This is a problem in Group By's design and is being fixed in #6906.