### PR TITLE
CI: Remove pymssql tests on macOS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ deps =
     pyqtwebengine==5.15.*;platform_system!="Windows" or python_version>='3.10'
     coverage
     psycopg2-binary
-    pymssql;platform_system!="Darwin" or python_version>="3.11"
+    pymssql;platform_system!="Darwin"
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
     # GUI requirements


### PR DESCRIPTION
##### Issue

These tests fail because pymssql on macOS fails to install on CI. I tried hard to build them, but failed.

##### Description of changes

Don't install pymssql and tests are skipped.

Our code that uses it is tested on Windows and Linux. Our releases include a properly built pymssql on macOS: according to @markotoplak, tests of releases would detect any problems.
