### PR TITLE
[ENH] Datasets: Add domain field; respect "Unlisted"

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -505,10 +505,10 @@ class OWDataSets(OWWidget):
 
     def _on_domain_changed(self):
         combo = self.domain_combo
-        if combo.currentIndex() == combo.count() - 1:
-            self.domain = ALL_DOMAINS
-        elif combo.currentIndex() == 0:
+        if combo.currentIndex() == 0:
             self.domain = GENERAL_DOMAIN
+        elif combo.currentIndex() == combo.count() - 1:
+            self.domain = ALL_DOMAINS
         else:
             self.domain = combo.currentText()
         self.view.model().setDomain(self.domain)

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -482,6 +482,8 @@ class OWDataSets(OWWidget):
             # for settings do not use os.path.join (Windows separator is different)
             if file_path[-1] == self.selected_id:
                 current_index = i
+                # for selected_id, set publication status so that unlisted data load correctly
+                datainfo.publication_status = Namespace.PUBLISHED
                 if self.core_widget:
                     self.domain = datainfo.domain
                     if self.domain == "sc":  # domain from the list of ignored domain
@@ -620,6 +622,8 @@ class OWDataSets(OWWidget):
             self.descriptionlabel.setText(text)
             # for settings do not use os.path.join (Windows separator is different)
             self.selected_id = di.file_path[-1]
+            # do not clear a dataset once you select it if it was unlisted
+            di.publication_status = Namespace.PUBLISHED
         else:
             self.descriptionlabel.setText("")
             self.selected_id = None

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -484,6 +484,8 @@ class OWDataSets(OWWidget):
                 current_index = i
                 if self.core_widget:
                     self.domain = datainfo.domain
+                    if self.domain == "sc":  # domain from the list of ignored domain
+                        self.domain = ALL_DOMAINS
                     combo = self.domain_combo
                     if self.domain == GENERAL_DOMAIN:
                         combo.setCurrentIndex(0)

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -12,6 +12,13 @@ from Orange.widgets.tests.base import WidgetTest
 
 
 class TestOWDataSets(WidgetTest):
+    def setUp(self):
+        # Most tests check the iniitialization of widget under different
+        # conditions, therefore mocks are needed prior to calling createWidget.
+        # Inherited methods will set self.widget; here we set it to None to
+        # avoid lint errors.
+        self.widget = None
+
     @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(side_effect=requests.exceptions.ConnectionError))
     @patch("Orange.widgets.data.owdatasets.list_local",

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -63,6 +63,27 @@ class TestOWDataSets(WidgetTest):
         self.assertEqual(model.rowCount(), 2)
 
     @patch("Orange.widgets.data.owdatasets.list_remote",
+           Mock(side_effect=requests.exceptions.ConnectionError))
+    @patch("Orange.widgets.data.owdatasets.list_local",
+           Mock(return_value={('core', 'foo.tab'): {"domain": "core"},
+                              ('core', 'bar.tab'): {"domain": "edu"}}))
+    @patch("Orange.widgets.data.owdatasets.log", Mock())
+    def test_filtering_by_domain(self):
+        w = self.create_widget(OWDataSets)  # type: OWDataSets
+        model = w.view.model()
+        model.setDomain(None)
+        self.wait_until_stop_blocking(w)
+        self.assertEqual(model.rowCount(), 2)
+
+        model.setDomain("edu")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.index(0, 0).data(Qt.UserRole).title, "bar.tab")
+
+        model.setDomain("core")
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.index(0, 0).data(Qt.UserRole).title, "foo.tab")
+
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(return_value={('core', 'foo.tab'): {"language": "English"},
                               ('core', 'bar.tab'): {"language": "Slovenščina"}}))
     @patch("Orange.widgets.data.owdatasets.list_local",

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -5237,6 +5237,7 @@ widgets/data/owdatasets.py:
     class `Namespace`:
         def `__init__`:
             English: false
+            core: false
     class `OWDataSets`:
         Datasets: Zbirke podatkov
         Load a dataset from an online repository: Naloži podatke s spletnega skladišča.
@@ -5247,6 +5248,7 @@ widgets/data/owdatasets.py:
         datasets: false
         English: Slovenščina
         All Languages: (Vsi jeziki)
+        (general): (splošno)
         islocal: false
         label: false
         title: false
@@ -5273,17 +5275,22 @@ widgets/data/owdatasets.py:
             _header_index: false
             Search for data set ...: Poišči podatke ...
             'Show data sets in ': 'Prikaži zbirke podatkov v jeziku '
+            'Domain: ': 'Področje: '
             Press Return or double-click to send: Pritisni Enter ali dvoklikni za izbor
             Description: Opis
             splitter_state: false
             Initializing: Zaganjam
         def `_parse_info`:
             version: false
+        def `update_domain_combo`:
+            core: false
         def `update_model`:
             ' ': false
             '  ': false
             ', ': false
             /: false
+        def `_on_domain_changed`:
+            core: false
         def `__set_index`:
             Error while fetching updated index: false
         def `set_model`:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -203,8 +203,8 @@ util.py:
             unsafe: false
 version.py:
     3.38.0: false
-    3.38.0.dev0+c767157: false
-    c7671579ac399d27a1b5fb21c31f870448db9ed8: false
+    3.38.0.dev0+b3dd2eb: false
+    b3dd2eba6a3cfa73ba06460226d6e16a8e25a23a: false
     .dev: false
 canvas/__main__.py:
     ORANGE_STATISTICS_API_URL: false
@@ -5314,13 +5314,13 @@ widgets/data/owdatasets.py:
     def `make_html_list`:
         '"margin: 5px; text-indent: -40px; margin-left: 40px;"': false
         def `format_item`:
-            <p style={}><small>{}</small></p>: false
+            <p style={style}><small>{i}</small></p>: false
         \n: false
     def `description_html`:
-        ' ({})': true
-        , from {}: , z {}
-        <b>{}</b>{}{}: true
-        <p>{}</p>: true
+        ' ({datainfo.year})': true
+        , from {datainfo.source}: , z {datainfo.source}
+        <b>{escape(datainfo.title)}</b>{year}{source}: true
+        <p>{datainfo.description}</p>: true
         <small><b>See Also</b>\n: <small><b>Glej tudi</b>\n
         </small>: true
         <small><b>References</b>\n: <small><b>Viri</b>\n

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -5237,7 +5237,6 @@ widgets/data/owdatasets.py:
     class `Namespace`:
         def `__init__`:
             English: false
-            core: false
     class `OWDataSets`:
         Datasets: Zbirke podatkov
         Load a dataset from an online repository: Naloži podatke s spletnega skladišča.
@@ -5248,7 +5247,8 @@ widgets/data/owdatasets.py:
         datasets: false
         English: Slovenščina
         All Languages: (Vsi jeziki)
-        (general): (splošno)
+        (General): (Splošno)
+        (Show all): (Prikaži vse)
         islocal: false
         label: false
         title: false
@@ -5275,7 +5275,7 @@ widgets/data/owdatasets.py:
             _header_index: false
             Search for data set ...: Poišči podatke ...
             'Show data sets in ': 'Prikaži zbirke podatkov v jeziku '
-            'Domain: ': 'Področje: '
+            Domain:: Področje:
             Press Return or double-click to send: Pritisni Enter ali dvoklikni za izbor
             Description: Opis
             splitter_state: false
@@ -5283,14 +5283,11 @@ widgets/data/owdatasets.py:
         def `_parse_info`:
             version: false
         def `update_domain_combo`:
-            core: false
+            sc: false
         def `update_model`:
             ' ': false
             '  ': false
             ', ': false
-            /: false
-        def `_on_domain_changed`:
-            core: false
         def `__set_index`:
             Error while fetching updated index: false
         def `set_model`:
@@ -5302,8 +5299,6 @@ widgets/data/owdatasets.py:
         def `__update_cached_state`:
             ' ': false
             '  ': false
-        def `__on_selection`:
-            /: false
         def `commit`:
             Fetching...: Pobiram...
         def `__commit_complete`:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -5288,6 +5288,7 @@ widgets/data/owdatasets.py:
             ' ': false
             '  ': false
             ', ': false
+            sc: false
         def `__set_index`:
             Error while fetching updated index: false
         def `set_model`:


### PR DESCRIPTION
##### Issue

- When reimplementing the repository of data sets, we added a field "Domain". Its current values are "core" and "sc", but the plan was to add (a very limited) number of others, such as "Education", and to allow the user to select a domain in the Data sets widget. Domains were not meant to be like tags but rather to allow the user select a single specific domain.

- With the new repository, the Datasets widget started showing single-cell data sets that were previously (if I remember correctly) accessible only in the single cell's widget. This PR reverts the behaviour to the more sensible original: by default, it only shows "core" data sets.

- With @BlazZupan we discussed that it would be handy if a data set could be unlisted - shown only if the user types the first five characters of the dataset's name into the filter. This would not be used to prevent the user from seeing the data set, but just to avoid polluting the list with data sets used at occasional workshops. The functionality has been implemented and deployed in the data sets editor (https://github.com/biolab/orada/commit/ccd980e5f05131a80ac33031d6d87009d80a2b21).

##### Description of changes

- Add a combo for selection of domains.
- Show the "core" domain as "(general)". It is the default and does not include sc data sets.
- Don't show data sets whose visibility is set as "unlisted" unless the user types the first five character into the filter.

To test the latter, try typing `luxem`.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
