### PR TITLE
test_owcurvefit: fix testing failure on conda

### DIFF
--- a/Orange/widgets/model/tests/test_owcurvefit.py
+++ b/Orange/widgets/model/tests/test_owcurvefit.py
@@ -365,6 +365,15 @@ class TestOWCurveFit(WidgetTest, WidgetLearnerTestMixin):
             self.assertFalse(self.widget.Error.invalid_exp.is_shown())
             model = self.get_output(self.widget.Outputs.model)
             coefficients = self.get_output(self.widget.Outputs.coefficients)
+            if f in ["inf", "nan", "arccos", "arccosh", "arcsin", "arctanh"]:
+                # These functions produce objective function values with NaN.
+                # Different implementations of optimization that scipy uses get
+                # different results: one stops optimization immediately with some
+                # results, the other stops when maximum number of iterations
+                # (and errors with fitting_failed). The optimization implementation
+                # can be different even with same scipy version (in my case, between
+                # pypi and conda-forge package). Thus, we skip these.
+                continue
             if f == "gcd":
                 self.assertTrue(self.widget.Error.fitting_failed.is_shown())
                 self.assertIsNone(model)


### PR DESCRIPTION
##### Issue

I saw the follwing with conda scipy from conda (first noticed in https://github.com/biolab/orange3-installers/pull/55#issuecomment-2154271242):

```
======================================================================
FAIL: test_expression (Orange.widgets.model.tests.test_owcurvefit.TestOWCurveFit.test_expression)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\test-install\Lib\site-packages\Orange\widgets\model\tests\test_owcurvefit.py", line 373, in test_expression
    self.assertIsNotNone(model)
AssertionError: unexpectedly None
```

##### Description of changes

`test_expression` looped through all possible functions, and some of them produce objective function values with NaNs.

Different implementations of optimization that scipy uses get different results: one stops optimization immediately with some results, the other stops when maximum number of iterations (and errors with fitting_failed). The optimization implementation can be different even with the same scipy version (in my case, between pypi and conda-forge package). Thus, we skip these.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
