### PR TITLE
[ENH] Datasets: Let the filter override domain and language

### DIFF
--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -639,13 +639,10 @@ class OWDataSets(OWWidget):
             di = current.data(Qt.UserRole)
             text = description_html(di)
             self.descriptionlabel.setText(text)
-            # for settings do not use os.path.join (Windows separator is different)
-            self.selected_id = di.file_path[-1]
             # do not clear a dataset once you select it if it was unlisted
             di.publication_status = Namespace.PUBLISHED
         else:
             self.descriptionlabel.setText("")
-            self.selected_id = None
 
     def commit(self):
         """
@@ -658,6 +655,7 @@ class OWDataSets(OWWidget):
         di = self.selected_dataset()
         if di is not None:
             self.Error.clear()
+            self.selected_id = di.file_path[-1]
 
             if self.__awaiting_state is not None:
                 # disconnect from the __commit_complete
@@ -692,6 +690,7 @@ class OWDataSets(OWWidget):
                 self.setBlocking(False)
                 self.commit_cached(di.file_path)
         else:
+            self.selected_id = None
             self.load_and_output(None)
 
     @Slot(object)

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -278,7 +278,10 @@ class OWDataSets(OWWidget):
         if self.language is not None and self.language not in languages:
             languages.insert(1, self.language)
         lang_combo.addItems(languages)
-        lang_combo.setCurrentText(self.language)
+        if self.language is None:
+            lang_combo.setCurrentIndex(lang_combo.count() - 1)
+        else:
+            lang_combo.setCurrentText(self.language)
         lang_combo.activated.connect(self._on_language_changed)
         layout.addWidget(lang_combo)
 
@@ -428,7 +431,7 @@ class OWDataSets(OWWidget):
         if self.DEFAULT_LANG not in languages:
             combo.addItem(self.DEFAULT_LANG)
         combo.addItems(languages + [self.ALL_LANGUAGES])
-        if current_language in languages:
+        if current_language in languages or current_language == self.ALL_LANGUAGES:
             combo.setCurrentText(current_language)
         elif self.DEFAULT_LANG in languages:
             combo.setCurrentText(self.DEFAULT_LANG)

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -490,8 +490,6 @@ class OWDataSets(OWWidget):
             # for settings do not use os.path.join (Windows separator is different)
             if file_path[-1] == self.selected_id:
                 current_index = i
-                # for selected_id, set publication status so that unlisted data load correctly
-                datainfo.publication_status = Namespace.PUBLISHED
                 if self.core_widget:
                     self.domain = datainfo.domain
                     if self.domain == "sc":  # domain from the list of ignored domain
@@ -639,8 +637,6 @@ class OWDataSets(OWWidget):
             di = current.data(Qt.UserRole)
             text = description_html(di)
             self.descriptionlabel.setText(text)
-            # do not clear a dataset once you select it if it was unlisted
-            di.publication_status = Namespace.PUBLISHED
         else:
             self.descriptionlabel.setText("")
 

--- a/Orange/widgets/data/owdatasets.py
+++ b/Orange/widgets/data/owdatasets.py
@@ -298,15 +298,14 @@ class OWDataSets(OWWidget):
         layout.addWidget(lang_combo)
         self.combo_elements.append(lang_combo)
 
-        layout.addSpacing(20)
-        label = QLabel("Domain:")
-        layout.addWidget(label)
-        self.combo_elements.append(label)
-
         domain_combo = self.domain_combo = QComboBox()
         domain_combo.addItem(self.GENERAL_DOMAIN_LABEL)
         domain_combo.activated.connect(self._on_domain_changed)
         if self.core_widget:
+            layout.addSpacing(20)
+            label = QLabel("Domain:")
+            layout.addWidget(label)
+            self.combo_elements.append(label)
             layout.addWidget(domain_combo)
         self.combo_elements.append(domain_combo)
 

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -184,6 +184,22 @@ class TestOWDataSets(WidgetTest):
         self.assertEqual(w2.language_combo.currentText(), "Klingon")
 
     @patch("Orange.widgets.data.owdatasets.list_remote",
+           Mock(return_value={('core', 'foo.tab'): {"language": "English"},
+                              ('core', 'bar.tab'): {"language": "Slovenščina"}}))
+    @patch("Orange.widgets.data.owdatasets.list_local",
+           Mock(return_value={}))
+    def test_remember_all_languages(self):
+        w = self.create_widget(OWDataSets)  # type: OWDataSets
+        self.wait_until_stop_blocking(w)
+        w.language_combo.setCurrentText(w.ALL_LANGUAGES)
+        w.language_combo.activated.emit(w.language_combo.currentIndex())
+        settings = w.settingsHandler.pack_data(w)
+
+        w2 = self.create_widget(OWDataSets, stored_settings=settings)
+        self.wait_until_stop_blocking(w2)
+        self.assertEqual(w2.language_combo.currentText(), w2.ALL_LANGUAGES)
+
+    @patch("Orange.widgets.data.owdatasets.list_remote",
            Mock(return_value={('core', 'iris.tab'): {}}))
     @patch("Orange.widgets.data.owdatasets.list_local",
            Mock(return_value={}))

--- a/Orange/widgets/data/tests/test_owdatasets.py
+++ b/Orange/widgets/data/tests/test_owdatasets.py
@@ -182,6 +182,8 @@ class TestOWDataSets(WidgetTest):
         self.wait_until_stop_blocking(w)
         w.language_combo.setCurrentText("Slovenščina")
         w.language_combo.activated.emit(w.language_combo.currentIndex())
+        w.domain_combo.setCurrentText(w.GENERAL_DOMAIN_LABEL)
+        w.domain_combo.activated.emit(w.domain_combo.currentIndex())
 
         self.assertEqual(self.__titles(w), {"Bax data set"})
 
@@ -189,6 +191,18 @@ class TestOWDataSets(WidgetTest):
         self.assertEqual(self.__titles(w), {"Foo data set",
                                             "Bar data set",
                                             "Bax data set"})
+        self.assertEqual(w.language_combo.currentText(), w.ALL_LANGUAGES)
+        self.assertFalse(w.language_combo.isEnabled())
+        self.assertEqual(w.domain_combo.currentText(), w.ALL_DOMAINS_LABEL)
+        self.assertFalse(w.domain_combo.isEnabled())
+
+        w.filterLineEdit.setText("da")
+        self.assertEqual(self.__titles(w), {"Bax data set"})
+        self.assertEqual(w.language_combo.currentText(), "Slovenščina")
+        self.assertTrue(w.language_combo.isEnabled())
+        self.assertEqual(w.domain_combo.currentText(), w.GENERAL_DOMAIN_LABEL)
+        self.assertTrue(w.domain_combo.isEnabled())
+
 
         w.filterLineEdit.setText("bar d")
         self.assertEqual(self.__titles(w), {"Bar data set"})
@@ -211,7 +225,8 @@ class TestOWDataSets(WidgetTest):
         settings = w.settingsHandler.pack_data(w)
         w2 = self.create_widget(OWDataSets, stored_settings=settings)
         self.wait_until_stop_blocking(w2)
-        self.assertEqual(w2.language_combo.currentText(), "English")
+        self.assertEqual(w2.language_combo.currentText(), w2.ALL_LANGUAGES)
+        self.assertFalse(w2.language_combo.isEnabled())
         self.assertEqual(w2.filterLineEdit.text(), "bax d")
         self.assertEqual(self.__titles(w2), {"Bax data set"})
 
@@ -266,8 +281,8 @@ class TestOWDataSets(WidgetTest):
         # select the only dataset
         sel_type = QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows
         w.view.selectionModel().select(w.view.model().index(0, 0), sel_type)
-        self.assertEqual(w.selected_id, "iris.tab")
         w.commit()
+        self.assertEqual(w.selected_id, "iris.tab")
         iris = self.get_output(w.Outputs.data, w)
         self.assertEqual(len(iris), 150)
 

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -594,10 +594,6 @@ classification/random_forest.py:
         def `__init__`:
             gini: false
             sqrt: false
-        def `fitted_parameters`:
-            n_estimators: false
-            Number of trees: Število dreves
-            Trees: Dreves
 classification/rules.py:
     CN2Learner: false
     CN2UnorderedLearner: false
@@ -2562,6 +2558,9 @@ modelling/randomforest.py:
         random forest: false
         classification: false
         regression: false
+        def `fitted_parameters`:
+            n_estimators: false
+            Number of trees: Število dreves
 modelling/svm.py:
     SVMLearner: false
     LinearSVMLearner: false
@@ -3269,8 +3268,7 @@ regression/pls.py:
             Only numeric target variables expected.: Metoda deluje le za številčne ciljne spremenljivke.
         def `fitted_parameters`:
             n_components: false
-            Number of components: Število komponent
-            Comp: Komp
+            Components: Komponent
     __main__: false
     housing: false
     'learner: {learner}\nRMSE: {ca}\n': false
@@ -3284,10 +3282,6 @@ regression/random_forest.py:
     class `RandomForestRegressionLearner`:
         def `__init__`:
             squared_error: false
-        def `fitted_parameters`:
-            n_estimators: false
-            Number of trees: Število dreves
-            Trees: Dreves
 regression/simple_random_forest.py:
     SimpleRandomForestLearner: false
     class `SimpleRandomForestLearner`:
@@ -5293,6 +5287,7 @@ widgets/data/owdatasets.py:
             label: false
             _header_index: false
             Search for data set ...: Poišči podatke ...
+            Typing four letters or more overrides domain and language filters: Vpišite vsaj štiri črke, da prekličete filtre po področju in jeziku
             'Show data sets in ': 'Prikaži zbirke podatkov v jeziku '
             Domain:: Področje:
             Press Return or double-click to send: Pritisni Enter ali dvoklikni za izbor
@@ -9020,8 +9015,8 @@ widgets/evaluate/owparameterfitter.py:
             item: false
     class `FitterPlot`:
         def `clear_all`:
-            left: false
             bottom: false
+            left: false
         def `set_data`:
             bottom: false
             left: false
@@ -9064,6 +9059,7 @@ widgets/evaluate/owparameterfitter.py:
             At least {N_FOLD} instances are needed.: Potrebujemo vsaj {N_FOLD} primerov.
             "Invalid values for '{}': {}": Neveljavne vrednosti za '{}': {}
             Minimum must be less than maximum.: Minimum mora biti manjši od maksimuma.
+            Data has no target.: Podatki nimajo ciljne spremenljivke.
         class `Warning`:
             {} has no parameters to fit.: {} nima parametrov za umerjanje.
         def `_add_controls`:
@@ -9079,6 +9075,8 @@ widgets/evaluate/owparameterfitter.py:
             manual_steps: false
             e.g. 10, 20, ..., 50: npr. 10, 20, ..., 50
             auto_commit: false
+        def `initial_parameters`:
+            classification: false
         def `_steps_from_manual`:
             ...: false
             ', ': false


### PR DESCRIPTION
##### Issue

Adding the domain and language combo made it more difficult to load educational data sets.

Also fixes #6931.

##### Description of changes

Make the filter override the domain (and language) setting. The number of data sets is large, so users always filter them anyway.

The fix may also provide an alternative to 16bbfdfeecff0bb6fc6de562014d1faca1e8905d? @markotoplak 

##### Includes
- [X] Code changes
- [X] Tests
