### PR TITLE
[FIX] owpredicttions: Remove special magic value 2

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -915,7 +915,6 @@ class OWPredictions(OWWidget):
             name = f"{slot.predictor.name} (error)"
             newmetas.append(ContinuousVariable(name=name))
             err = self.predictionsview.model().errorColumn(index)
-            err[err == 2] = numpy.nan
             newcolumns.append(err)
 
     def send_report(self):
@@ -1383,8 +1382,7 @@ class PredictionsModel(AbstractSortTableModel):
             nans = numpy.isnan(actuals)
             actuals[nans] = 0
             errors = 1 - numpy.choose(actuals.astype(int), self._probs[column].T)
-            errors[nans] = 2
-            errors[numpy.isnan(errors)] = 2
+            errors[nans] = numpy.nan
             return errors
         else:
             actual = self._actual

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1,6 +1,7 @@
 """Tests for OWPredictions"""
 # pylint: disable=protected-access,too-many-lines,too-many-public-methods
 import os
+import random
 import unittest
 from functools import partial
 from tempfile import NamedTemporaryFile
@@ -1765,6 +1766,16 @@ class PredictionsModelTest(unittest.TestCase):
         np.testing.assert_almost_equal(
             [model.data(model.index(row, 3)) for row in range(5)],
             1 - np.array(sorted([80, 5, 20, 60, 50])) / 100)
+
+        # Numpy's sort puts nan's at the end, and the widget counts on it
+        # because we want to show them last. If this test fails, this
+        # (undocumented) numpy's behavior has changed, and the widget needs
+        # to be updated.
+        data = list(range(10)) + [np.nan] * 10
+        copy = data.copy()
+        for _ in range(10):
+            random.shuffle(data)
+            np.testing.assert_equal(np.sort(data), copy)
 
     def test_sorting_classification_different(self):
         model = PredictionsModel(self.values, self.probs, self.actual)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes gh-6911

@janezd what was the point of using 2 as invalid value. I cannot find any place where it would be used/checked, 
except where it is replaced with NaN on output.

##### Description of changes

Remove special magic value 2. Just use NaN.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
