### PR TITLE
[FIX] Orange can be imported without Qt (fixed importing localization)

### DIFF
--- a/Orange/widgets/evaluate/owpredictions.py
+++ b/Orange/widgets/evaluate/owpredictions.py
@@ -16,7 +16,6 @@ from AnyQt.QtCore import (
     QModelIndex, pyqtSignal, QTimer,
     QItemSelectionModel, QItemSelection)
 
-from orangecanvas.utils.localization import pl
 from orangewidget.utils.itemmodels import AbstractSortTableModel
 from orangewidget.utils.signals import LazyValue
 
@@ -39,6 +38,7 @@ from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.utils.colorpalettes import LimitedDiscretePalette
 from Orange.widgets.utils.itemdelegates import TableDataDelegate
+from Orange.widgets.utils.localization import pl
 
 # Input slot for the Predictors channel
 PredictorSlot = NamedTuple(

--- a/Orange/widgets/utils/localization/__init__.py
+++ b/Orange/widgets/utils/localization/__init__.py
@@ -1,3 +1,3 @@
-from orangecanvas.utils.localization import pl
+from orangecanvas.localization import pl
 
 __all__ = ['pl']

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
   run:
     - python
     # GUI requirements
-    - orange-canvas-core >=0.2.4,<0.3a
+    - orange-canvas-core >=0.2.5,<0.3a
     - orange-widget-base >=4.25.0
     - anyqt >=0.2.0
     - pyqt >=5.12,!=5.15.1,<6.0

--- a/i18n/trubar-config.yaml
+++ b/i18n/trubar-config.yaml
@@ -5,9 +5,9 @@ languages:
   si:
     name: Slovenščina
     international-name: Slovenian
-    auto-import: from orangecanvas.utils.localization.si import plsi, plsi_sz, z_besedo  # pylint: disable=wrong-import-order
+    auto-import: from orangecanvas.localization.si import plsi, plsi_sz, z_besedo  # pylint: disable=wrong-import-order
 auto-import: |2
-  from orangecanvas.utils.localization import Translator  # pylint: disable=wrong-import-order
+  from orangecanvas.localization import Translator  # pylint: disable=wrong-import-order
   _tr = Translator("Orange", "biolab.si", "Orange")
   del Translator
 encoding: "utf-8"

--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,4 +1,4 @@
-orange-canvas-core>=0.2.4,<0.3a
+orange-canvas-core>=0.2.5,<0.3a
 orange-widget-base>=4.25.0
 
 AnyQt>=0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
     # GUI requirements
-    oldest: orange-canvas-core==0.2.4
+    oldest: orange-canvas-core==0.2.5
     oldest: orange-widget-base==4.25.0
     oldest: AnyQt==0.2.0
     oldest: matplotlib==3.2.0


### PR DESCRIPTION
##### Issue

Fixes #6952. Requires https://github.com/biolab/orange-canvas-core/pull/320 to be merged and released.

##### Description of changes

Import localization from a place that doesn't require Qt.

The most important change is the one in configuration of Trubar - this will allow running Orange without Qt.

The other two changes in `[Orange/widgets/utils/localization/__init__.py](https://github.com/biolab/orange3/compare/master...janezd:fix-headless-orange?expand=1#diff-3bf6fd4d089b6924794714d11768d90dbac35b1b370e9cfc788c6cd6f216eece)` are not strictly necessary, but  prevent a warning about importing localization from a deprecated module.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
