### PR TITLE
LogisticRegressionLearner: Remove deprecated argument 'multi_class'

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import sklearn.linear_model as skl_linear_model
 
@@ -5,6 +7,8 @@ from Orange.classification import SklLearner, SklModel
 from Orange.preprocess import Normalize
 from Orange.preprocess.score import LearnerScorer
 from Orange.data import Variable, DiscreteVariable
+from Orange.util import OrangeDeprecationWarning
+
 
 __all__ = ["LogisticRegressionLearner"]
 
@@ -38,12 +42,23 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
     def __init__(self, penalty="l2", dual=False, tol=0.0001, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,
                  random_state=None, solver="auto", max_iter=100,
-                 verbose=0, n_jobs=1, preprocessors=None):
+                 multi_class="deprecated", verbose=0, n_jobs=1, preprocessors=None):
+        if multi_class != "deprecated":
+            warnings.warn("The multi_class parameter was "
+                          "deprecated in scikit-learn 1.5. Using it with "
+                          "scikit-learn 1.7 will lead to a crash.",
+                          OrangeDeprecationWarning,
+                          stacklevel=2)
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
 
     def _initialize_wrapped(self):
         params = self.params.copy()
+
+        multi_class = params.pop("multi_class")
+        if multi_class != "deprecated":
+            params["multi_class"] = multi_class
+
         # The default scikit-learn solver `lbfgs` (v0.22) does not support the
         # l1 penalty.
         solver, penalty = params.pop("solver"), params.get("penalty")

--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -38,7 +38,7 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
     def __init__(self, penalty="l2", dual=False, tol=0.0001, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,
                  random_state=None, solver="auto", max_iter=100,
-                 multi_class="auto", verbose=0, n_jobs=1, preprocessors=None):
+                 verbose=0, n_jobs=1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
 
@@ -49,7 +49,7 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
         solver, penalty = params.pop("solver"), params.get("penalty")
         if solver == "auto":
             if penalty == "l1":
-                solver = "liblinear"
+                solver = "saga"
             else:
                 solver = "lbfgs"
         params["solver"] = solver

--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -5,7 +5,7 @@ Examples
 --------
 >>> import Orange
 >>> data = Orange.data.Table('iris')
->>> learner = Orange.classification.LogisticRegressionLearner(solver="liblinear")
+>>> learner = Orange.classification.LogisticRegressionLearner()
 >>> results = Orange.evaluation.TestOnTrainingData(data, [learner])
 
 """
@@ -296,7 +296,7 @@ class LogLoss(ClassificationScore):
     Examples
     --------
     >>> Orange.evaluation.LogLoss(results)
-    array([0.3...])
+    array([0.1...])
 
     """
     __wraps__ = skl_metrics.log_loss

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -1,6 +1,7 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring
 
+from datetime import datetime
 import unittest
 
 import numpy as np
@@ -9,6 +10,7 @@ import sklearn
 from Orange.data import Table, ContinuousVariable, Domain
 from Orange.classification import LogisticRegressionLearner, Model
 from Orange.evaluation import CrossValidation, CA
+from Orange.util import OrangeDeprecationWarning
 
 
 class TestLogisticRegressionLearner(unittest.TestCase):
@@ -149,8 +151,16 @@ class TestLogisticRegressionLearner(unittest.TestCase):
         # liblinear is default for l2 penalty
         lr = LogisticRegressionLearner(penalty="l1", solver="auto")
         skl_clf = lr._initialize_wrapped()
-        self.assertEqual(skl_clf.solver, "liblinear")
+        self.assertEqual(skl_clf.solver, "saga")
         self.assertEqual(skl_clf.penalty, "l1")
 
     def test_supports_weights(self):
         self.assertTrue(LogisticRegressionLearner().supports_weights)
+
+    def test_multi_class_deprecation(self):
+        with self.assertWarns(OrangeDeprecationWarning):
+            LogisticRegressionLearner(penalty="l1", multi_class="multinomial")
+        now = datetime.now()
+        if (now.year, now.month) >= (2026, 1):
+            raise Exception("If Orange depends on scikit-learn >= 1.7, remove this test "
+                            "and any mention of multi_class in LogisticRegressionLearner.")

--- a/Orange/widgets/evaluate/tests/test_owpredictions.py
+++ b/Orange/widgets/evaluate/tests/test_owpredictions.py
@@ -1304,7 +1304,7 @@ class TestOWPredictions(WidgetTest):
         log_reg = LogisticRegressionLearner()
         self.send_signal(self.widget.Inputs.predictors, log_reg(data), 0)
         self.send_signal(self.widget.Inputs.predictors,
-                         LogisticRegressionLearner(penalty="l1")(data), 1)
+                         LogisticRegressionLearner(penalty="l1", max_iter=1000)(data), 1)
         with data.unlocked(data.Y):
             data.Y[1] = np.nan
         self.send_signal(self.widget.Inputs.data, data)
@@ -1316,7 +1316,7 @@ class TestOWPredictions(WidgetTest):
         names = [f"{log_reg.name}{x}" for x in names]
         self.assertEqual(names, [m.name for m in pred.domain.metas])
         self.assertAlmostEqual(pred.metas[0, 4], 0.018, 3)
-        self.assertAlmostEqual(pred.metas[0, 9], 0.113, 3)
+        self.assertAlmostEqual(pred.metas[0, 9], 0.008, 3)
         self.assertTrue(np.isnan(pred.metas[1, 4]))
         self.assertTrue(np.isnan(pred.metas[1, 9]))
 

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -98,7 +98,7 @@ class TestOWNomogram(WidgetTest):
         """Check probabilities for logistic regression classifier for various
         values of classes and radio buttons for multiclass data"""
         cls = LogisticRegressionLearner(
-            multi_class="ovr", solver="liblinear"
+            solver="liblinear"
         )(self.lenses)
         self._test_helper(cls, [9, 45, 52])
 

--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -97,10 +97,8 @@ class TestOWNomogram(WidgetTest):
     def test_nomogram_lr_multiclass(self):
         """Check probabilities for logistic regression classifier for various
         values of classes and radio buttons for multiclass data"""
-        cls = LogisticRegressionLearner(
-            solver="liblinear"
-        )(self.lenses)
-        self._test_helper(cls, [9, 45, 52])
+        cls = LogisticRegressionLearner(max_iter=100)(self.lenses)
+        self._test_helper(cls, [18, 56, 78])
 
     def test_nomogram_with_instance_nb(self):
         """Check initialized marker values and feature sorting for naive bayes

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -521,12 +521,18 @@ classification/logistic_regression.py:
         def `__init__`:
             l2: false
             auto: false
+            deprecated: false
+            'The multi_class parameter was ': false
+            'deprecated in scikit-learn 1.5. Using it with ': false
+            scikit-learn 1.7 will lead to a crash.: false
         def `_initialize_wrapped`:
+            multi_class: false
+            deprecated: false
             solver: false
             penalty: false
             auto: false
             l1: false
-            liblinear: false
+            saga: false
             lbfgs: false
 classification/majority.py:
     MajorityLearner: false
@@ -3096,9 +3102,6 @@ projection/pca.py:
             auto: false
         def `fit`:
             n_components: false
-            svd_solver: false
-            auto: false
-            arpack: false
     class `SparsePCA`:
         Sparse PCA: false
         def `__init__`:
@@ -15437,7 +15440,6 @@ widgets/visualize/utils/error_bars_dialog.py:
             Upper:: Zgornje:
             Lower:: Spodnje:
     __main__: false
-    Error Bars: false
     Open: false
     iris: false
 widgets/visualize/utils/heatmap.py:


### PR DESCRIPTION
##### Issue

As per https://scikit-learn.org/1.5/modules/generated/sklearn.linear_model.LogisticRegression.html,

```
Deprecated since version 1.5: multi_class was deprecated in version 1.5 and will be
removed in 1.7. From then on, the recommended ‘multinomial’ will always be used
for n_classes >= 3. Solvers that do not support ‘multinomial’ will raise an error. Use
sklearn.multiclass.OneVsRestClassifier(LogisticRegression()) if you still want to use OvR.
```

##### Description of changes

Remove the argument.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
