### PR TITLE
[FIX] 1 line headers: only allow single-letter types and flags

### DIFF
--- a/Orange/data/io_base.py
+++ b/Orange/data/io_base.py
@@ -174,11 +174,11 @@ class _TableHeader:
                                             for vartype in Variable.registry.values())
                          if len(t) == 1]).upper()  # CNDST
 
-        res = ('^(?:('
+        res = ('^((?P<flags>'
                f'[{roles}{types}]|'
-               f'(?:[{roles}][{types}])|'
-               f'(?:[{types}][{roles}])'
-               ')#)?(.*)')
+               f'([{roles}][{types}])|'
+               f'([{types}][{roles}])'
+               ')#)?(?P<name>.*)')
 
         header1_re = re.compile(res)
 
@@ -186,7 +186,7 @@ class _TableHeader:
         names = []
         for i in headers[0]:
             m = header1_re.match(i)
-            f, n = m.group(1), m.group(2)
+            f, n = m.group("flags", "name")
             flags.append('' if f is None else f)
             names.append(n)
 

--- a/Orange/data/tests/test_io_base.py
+++ b/Orange/data/tests/test_io_base.py
@@ -70,6 +70,16 @@ class TestTableHeader(InitTestData):
         self.assertListEqual(types, types_)
         self.assertListEqual(flags, flags_)
 
+    def test_get_header_data_1_hashes(self):
+        names, types, flags = _TableHeader.create_header_data(
+            [["Some long text#and here", "vd#Invalid spec", "C#Valid spec"]])
+        names_ = ["Some long text#and here", "vd#Invalid spec", "Valid spec"]
+        types_ = ["", "", "c"]
+        flags_ = ["", "", ""]
+        self.assertListEqual(names, names_)
+        self.assertListEqual(types, types_)
+        self.assertListEqual(flags, flags_)
+
     def test_get_header_data_3(self):
         names, types, flags = _TableHeader.create_header_data(self.header3[:3])
         self.assertListEqual(names, ["a", "b", "c", "d", "w", "e", "f", "g"])

--- a/Orange/data/tests/test_io_base.py
+++ b/Orange/data/tests/test_io_base.py
@@ -72,10 +72,12 @@ class TestTableHeader(InitTestData):
 
     def test_get_header_data_1_hashes(self):
         names, types, flags = _TableHeader.create_header_data(
-            [["Some long text#and here", "vd#Invalid spec", "C#Valid spec"]])
-        names_ = ["Some long text#and here", "vd#Invalid spec", "Valid spec"]
-        types_ = ["", "", "c"]
-        flags_ = ["", "", ""]
+            [["Some long text#and here", "vd#Invalid spec", "C#Valid spec",
+              "m#Meta", "cD#Discrete class", "Si#Ignored string"]])
+        names_ = ["Some long text#and here", "vd#Invalid spec", "Valid spec",
+                  "Meta", "Discrete class", "Ignored string"]
+        types_ = ["", "", "c", "", "d", "s"]
+        flags_ = ["", "", "", "m", "c", "i"]
         self.assertListEqual(names, names_)
         self.assertListEqual(types, types_)
         self.assertListEqual(flags, flags_)

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1155,6 +1155,15 @@ data/io_base.py:
     ^\s*( |{}|)*\s*$: false
     class `_TableHeader`:
         '#': false
+        def `_header1`:
+            TYPE_HEADERS: false
+            ^((?P<flags>: false
+            [{roles}{types}]|: false
+            ([{roles}][{types}])|: false
+            ([{types}][{roles}]): false
+            )#)?(?P<name>.*): false
+            flags: false
+            name: false
     class `_TableBuilder`:
         def `__init__`:
             'Feature ': false


### PR DESCRIPTION
##### Issue
Fixes #6945

##### Description of changes
This fix creates specific 1-line header matching rules (does not reuse the 3-line header ones).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
