### PR TITLE
[FIX] owhierarchicalclustering: Fix IndexError

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -149,7 +149,10 @@ class SelectedLabelsModel(PyListModel):
             return font
         if role == Qt.BackgroundRole:
             if self.__colors is not None:
-                return self.__colors[index.row()]
+                if index.row() < len(self.__colors):
+                    return self.__colors[index.row()]
+                else:
+                    return QColor()
             elif not any(self) and self.subset:  # no labels, no color, but subset
                 return QColor(0, 0, 0)
         if role == Qt.UserRole and self.subset:

--- a/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/tests/test_owhierarchicalclustering.py
@@ -1,10 +1,12 @@
 # Test methods with long descriptive names can omit docstrings
 # pylint: disable=missing-docstring, protected-access
+import unittest
 import warnings
 
 import numpy as np
 
 from AnyQt.QtCore import QPoint, Qt
+from AnyQt.QtGui import QColor
 from AnyQt.QtTest import QTest
 
 import Orange.misc
@@ -13,7 +15,7 @@ from Orange.distance import Euclidean
 from Orange.misc import DistMatrix
 from Orange.widgets.tests.base import WidgetTest, WidgetOutputsTestMixin
 from Orange.widgets.unsupervised.owhierarchicalclustering import \
-    OWHierarchicalClustering
+    OWHierarchicalClustering, SelectedLabelsModel
 
 
 class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
@@ -207,3 +209,15 @@ class TestOWHierarchicalClustering(WidgetTest, WidgetOutputsTestMixin):
         annotated = [(a.name, a.attributes['cluster']) for a in o.domain.attributes]
         self.assertEqual(annotated, [('sepal length', 1), ('petal width', 2),
                                      ('sepal width', 3), ('petal length', 3)])
+
+class TestSelectedLabelsModel(unittest.TestCase):
+    def test_model_extend(self):
+        model = SelectedLabelsModel()
+        model[:] = ["1"]
+        model.set_colors([QColor(Qt.blue)])
+        index = model.index(0)
+        self.assertEqual(index.data(Qt.DisplayRole), "1")
+        self.assertEqual(index.data(Qt.BackgroundRole), QColor(Qt.blue))
+        model[:]= ["1", "2"]
+        index1 = model.index(1)
+        self.assertEqual(index1.data(Qt.BackgroundRole), QColor()) # should be invalid color


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

File -> Table -> Distances -> Hierarchical Clustering

Select some rows in *Table*, color by some variable in *Hierarchical Clustering* now extend the selection in *Table* (<kbd>cmd + click</kbd>) with new instances (must output more data then before).

 Raises
```
---------------------------- IndexError Exception -----------------------------
Traceback (most recent call last):
  File "/home/ales/devel/orange3/Orange/widgets/unsupervised/owhierarchicalclustering.py", line 152, in data
    return self.__colors[index.row()]
           ~~~~~~~~~~~~~^^^^^^^^^^^^^
IndexError: index 12 is out of bounds for axis 0 with size 12
-------------------------------------------------------------------------------
```
and then it segfaults.

##### Description of changes

Fix IndexError

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
