### PR TITLE
OWScoringSheetViewer test: Fix random fails

### DIFF
--- a/Orange/widgets/visualize/tests/test_owscoringsheetviewer.py
+++ b/Orange/widgets/visualize/tests/test_owscoringsheetviewer.py
@@ -99,6 +99,8 @@ class TestOWScoringSheetViewer(WidgetTest):
     def test_target_class_change(self):
         self.send_signal(self.widget.Inputs.classifier, self.scoring_sheet_model)
         self.class_combo = self.widget.class_combo
+        self.class_combo.setCurrentIndex(0)
+        self.widget._class_combo_changed()
 
         # Check if the values of the combobox "match" the domain
         self.assertEqual(


### PR DESCRIPTION
##### Issue

Tests occasionally fail.

The test tests that coefficients change when the user changes the combo (with `assertNotEqual`). Sometimes they don't.

##### Description of changes

One guess would be that a combo is set from context to a wrong initial value. I'm setting it explicitly. This may or may not fix the problem.

If tests still fail, they may indicate a real problem. `_class_combo_changed` (https://github.com/biolab/orange3/blob/master/Orange/widgets/visualize/owscoringsheetviewer.py#L446C9-L446C29) checks whether the class indeed changed and if so, they (indirectly) call https://github.com/biolab/orange3/blob/master/Orange/widgets/visualize/owscoringsheetviewer.py#L459, which just negates some coefficients and subtracts risks from `100 -`. I don't think this is very safe. The widget should remember the values for one target and use them to compute that values for the shown target. Switching back and forth can easily go wrong.

