### PR TITLE
setup: Import trubar locally

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ from distutils.command.build_ext import build_ext
 from distutils.command import config, build
 from distutils.core import Extension
 
-from trubar import translate
-
 try:
     import numpy
     have_numpy = True
@@ -488,6 +486,10 @@ class InstallMultilingualCommand(install):
         self.compile_to_multilingual()
 
     def compile_to_multilingual(self):
+        # Import locally so that editable install won't require trubar
+        # pylint: disable=import-outside-toplevel
+        from trubar import translate
+
         package_dir = os.path.dirname(os.path.abspath(__file__))
         translate(
             "msgs.jaml",


### PR DESCRIPTION
##### Issue

Fixes #6992.

##### Description of changes

Editable install (pip install -e, python setup.py develop) does not run trubar. This PR imports it locally to avoid the unnecessary dependency.

Add-ons already do so. We made a mistake only here.