### PR TITLE
[MNT] CI: Add Python 3.13 to test matrices drop 3.9

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        python: [3.9]
+        python: ['3.10']
         os: [ubuntu-22.04]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,24 +37,24 @@ jobs:
       fail-fast: False
       matrix:
         os: [ubuntu-22.04]
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: ubuntu-22.04
-            python-version: '3.12'
+            python-version: '3.13'
             tox_env: orange-latest
             name: Latest
           - os: ubuntu-20.04
-            python-version: 3.9
+            python-version: '3.10'
             tox_env: orange-oldest
             name: Oldest dependencies
           - os: ubuntu-22.04
-            python-version: '3.10'
+            python-version: '3.12'
             tox_env: pyqt6
             name: PyQt6
           - os: ubuntu-22.04
-            python-version: '3.12'
+            python-version: '3.13'
             tox_env: beta
             name: "Scientific Python nightly wheels"
 
@@ -125,24 +125,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         tox_env: [orange-released]
         name: [Released]
         include:
           - os: windows-latest
-            python-version: '3.12'
+            python-version: '3.13'
             tox_env: orange-latest
             name: Latest
           - os: macos-latest
-            python-version: '3.12'
+            python-version: '3.13'
             tox_env: orange-latest
             name: Latest
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.12'
             tox_env: pyqt6
             name: PyQt6
           - os: macos-latest
-            python-version: 3.9
+            python-version: '3.12'
             tox_env: pyqt6
             name: PyQt6
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - keyring
     - keyrings.alt
     - networkx
-    - numpy >=1.20.0
+    - numpy >=1.21.0
     - openpyxl >=3.1.3
     - openTSNE >=0.6.1,!=0.7.0
     - pandas >=1.4.0,!=1.5.0,!=2.0.0

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - networkx
     - numpy >=1.21.0
     - openpyxl >=3.1.3
-    - openTSNE >=0.6.1,!=0.7.0
+    - openTSNE >=0.6.2,!=0.7.0
     - pandas >=1.4.0,!=1.5.0,!=2.0.0
     - packaging
     - pip >=19.3

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -8,7 +8,7 @@ joblib>=1.2.0
 keyring
 keyrings.alt    # for alternative keyring implementations
 networkx
-numpy>=1.20.0
+numpy>=1.21.0
 openpyxl>=3.1.3
 openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
 packaging

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -10,7 +10,7 @@ keyrings.alt    # for alternative keyring implementations
 networkx
 numpy>=1.21.0
 openpyxl>=3.1.3
-openTSNE>=0.6.1,!=0.7.0  # 0.7.0 segfaults
+openTSNE>=0.6.2,!=0.7.0  # 0.7.0 segfaults
 packaging
 pandas>=1.4.0,!=1.5.0,!=2.0.0
 pip>=19.3

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
 ]
 
-PYTHON_REQUIRES = ">=3.9"
+PYTHON_REQUIRES = ">=3.10"
 
 
 requirements = ['requirements-core.txt', 'requirements-gui.txt']

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     # oldest: keyring
     # oldest: keyrings.alt
     # oldest: networkx
-    oldest: numpy==1.20
+    oldest: numpy==1.21
     oldest: openpyxl==3.1.3
     oldest: openTSNE==0.6.1
     oldest: pandas==1.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
     # oldest: networkx
     oldest: numpy==1.21
     oldest: openpyxl==3.1.3
-    oldest: openTSNE==0.6.1
+    oldest: openTSNE==0.6.2
     oldest: pandas==1.4.0
     oldest: pip==19.3
     oldest: python-louvain==0.13


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Add Python 3.13 to test matrix, drop 3.9

This needs https://github.com/biolab/orange3/pull/6850 merged first to remove catboost as dependency because it does not support 3.13

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
