### PR TITLE
[FIX] io_util: Detect utf-8-sig when using `file` utility

### DIFF
--- a/Orange/tests/test_txt_reader.py
+++ b/Orange/tests/test_txt_reader.py
@@ -7,7 +7,7 @@ import warnings
 
 from Orange.data import Table, ContinuousVariable, DiscreteVariable
 from Orange.data.io import CSVReader
-from Orange.tests import test_filename
+from Orange.tests import test_filename, named_file
 
 tab_file = """\
 Feature 1\tFeature 2\tFeature 3
@@ -123,6 +123,12 @@ time
         data = reader.read()
         self.assertEqual(len(data), 8)
         self.assertEqual(len(data.domain.variables) + len(data.domain.metas), 15)
+
+    def test_utf_8_sig(self):
+        with named_file(csv_file, encoding="utf-8-sig") as f:
+            reader = CSVReader(f)
+            data = reader.read()
+            self.assertEqual(data.domain[0].name, "Feature 1")
 
 
 if __name__ == "__main__":

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1252,11 +1252,14 @@ data/io_util.py:
         .gz: false
         .bz2: false
         .xz: false
+    def `_is_utf8_sig`:
+        rb: false
     def `detect_encoding`:
         file: false
         --brief: false
         --mime-encoding: false
         utf-8: false
+        utf-8-sig: false
         us-ascii: false
         iso-8859-1: false
         utf-7: false


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Detect utf-8-sig when using file utility.

Fixes #7000

Note: An alternative would be to remove the [use of `file` utility](https://github.com/biolab/orange3/blob/091e88c53214e7adbfb367ee88f1ba98085a1ef3/Orange/data/io_util.py#L55-L70), chardet would recognize the BOM (and does so on windows where file is typically not available). 

##### Description of changes

Detect utf-8-sig when using file utility.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
