### PR TITLE
[FIX] Make ReliefF and RReliefF results replicable

### DIFF
--- a/Orange/preprocess/score.py
+++ b/Orange/preprocess/score.py
@@ -351,7 +351,7 @@ class ReliefF(Scorer):
     friendly_name = "ReliefF"
     preprocessors = Scorer.preprocessors + [RemoveNaNColumns()]
 
-    def __init__(self, n_iterations=50, k_nearest=10, random_state=None):
+    def __init__(self, n_iterations=50, k_nearest=10, random_state=0):
         self.n_iterations = n_iterations
         self.k_nearest = k_nearest
         self.random_state = random_state
@@ -386,7 +386,7 @@ class RReliefF(Scorer):
     friendly_name = "RReliefF"
     preprocessors = Scorer.preprocessors + [RemoveNaNColumns()]
 
-    def __init__(self, n_iterations=50, k_nearest=50, random_state=None):
+    def __init__(self, n_iterations=50, k_nearest=50, random_state=0):
         self.n_iterations = n_iterations
         self.k_nearest = k_nearest
         self.random_state = random_state

--- a/Orange/tests/test_score_feature.py
+++ b/Orange/tests/test_score_feature.py
@@ -119,8 +119,8 @@ class FeatureScoringTest(unittest.TestCase):
         weights = ReliefF()(old_breast, None)
 
         np.testing.assert_array_equal(
-            ReliefF(random_state=1)(self.breast, None),
-            ReliefF(random_state=1)(self.breast, None)
+            ReliefF()(self.breast, None),
+            ReliefF()(self.breast, None)
         )
 
     def test_rrelieff(self):


### PR DESCRIPTION
##### Issue
ReliefF and RReliefF had default random_seed set to `None`. Therefore their results in Rank and Preprocess widgets could differ. I became aware of this when reviewing #7023.

##### Description of changes
I just changed the default random_seed, so now ReliefF is replicable unless explicitly specified not to be.

It would be trivial to add random_seed arguments in some places, but the Rank and Preprocess would need slightly bigger refactoring, because the current code there does not allow easy adding of arguments to various scorers.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
