### PR TITLE
Hierarhical Clustering: Narrower combos

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -276,6 +276,7 @@ class OWHierarchicalClustering(widget.OWWidget):
             minimumContentsLength=14,
             sizeAdjustPolicy=QComboBox.AdjustToMinimumContentsLengthWithIcon
         )
+        cb.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
         cb.setModel(model)
         cb.setCurrentIndex(cb.findData(self.annotation, Qt.EditRole))
 
@@ -305,7 +306,9 @@ class OWHierarchicalClustering(widget.OWWidget):
             model=model, callback=self._update_labels,
             sizePolicy=QSizePolicy(QSizePolicy.MinimumExpanding,
                                    QSizePolicy.Fixed))
+        cb.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
         self.color_by_label = QLabel("Color by:")
+        self.color_by_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         grid.addWidget(self.color_by_label, 2, 0)
         grid.addWidget(cb, 2, 1)
 


### PR DESCRIPTION
##### Issue

Fixes #7035.


##### Description of changes

The current change resolves the problem with the combo for colors, but not for annotation, which uses our own combo with reimplemented showPopup. showPopup is copied from Qt, but apparently without the code at https://github.com/radekp/qt/blob/master/src/gui/widgets/qcombobox.cpp#L2380.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
