### PR TITLE
Update owboxplot.py add space for text below graph

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -734,7 +734,8 @@ class OWBoxPlot(widget.OWWidget):
 
         self.box_scene.setSceneRect(-self.label_width - 5,
                                     -30 - len(self.boxes) * 40,
-                                    self.scene_width, len(self.boxes * 40) + 90)
+                                    self.scene_width, len(self.boxes * 40) +
+                                    90 + self._axis_font.pixelSize() * 4)
         self._compute_tests_disc()
 
     def __draw_group_labels(self, y, row):

--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -675,7 +675,8 @@ class OWBoxPlot(widget.OWWidget):
                 label.show()
 
         r = QRectF(self.scene_min_x, -30 - len(self.stats) * heights,
-                   self.scene_width, len(self.stats) * heights + 90)
+                   self.scene_width, len(self.stats) * heights + 90 +
+                   self._axis_font.pixelSize() * 4)
         self.box_scene.setSceneRect(r)
 
         self._compute_tests_cont()


### PR DESCRIPTION
Add space below the Box Plot chart to accommodate the statistic text.

##### Issue
Fixes #7051


##### Description of changes
Add space for text.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
