### PR TITLE
setup.cfg: Remove dashes in options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [config]
 # applies to sdist and build commands
-with-htmlhelp=1
+with_htmlhelp=1
 
 [aliases]
 # build a sdist and a wheel release with included widget help


### PR DESCRIPTION
##### Issue

We've probably been bitten by https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals -- all tests fail in build.

##### Description of changes

Change `with-` with `with_`, i.e. `with-htmlhelp` to `with_htmlhelp`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
