### PR TITLE
Update owselectrows.py fix error QLayout: Attempting to add QLayout and error unexpected type 'QDate'

### DIFF
--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -878,8 +878,6 @@ class DateTimeWidget(QDateTimeEdit):
                     self.setDateTime(date_time)
                 elif isinstance(date_time, QDate):
                     self.setDate(date_time)
-                elif isinstance(date_time, QTime):
-                    self.setTime(date_time)
         elif self.have_date and not self.have_time:
             self.setDate(date_time)
         elif not self.have_date and self.have_time:

--- a/Orange/widgets/data/owselectrows.py
+++ b/Orange/widgets/data/owselectrows.py
@@ -470,7 +470,7 @@ class OWSelectRows(widget.OWWidget):
                 self.cond_list.setCellWidget(oper_combo.row, 2, combo)
                 combo.currentIndexChanged.connect(self.conditions_changed)
         else:
-            box = gui.hBox(self, addToLayout=False)
+            box = gui.hBox(self.cond_list, addToLayout=False)
             box.var_type = vtype
             self.cond_list.setCellWidget(oper_combo.row, 2, box)
             if vtype == 2:  # continuous:
@@ -874,7 +874,12 @@ class DateTimeWidget(QDateTimeEdit):
                 self.setDateTime(
                     QDateTime(self.date(), self.calendarWidget.timeedit.time()))
             else:
-                self.setDateTime(date_time)
+                if isinstance(date_time, QDateTime):
+                    self.setDateTime(date_time)
+                elif isinstance(date_time, QDate):
+                    self.setDate(date_time)
+                elif isinstance(date_time, QTime):
+                    self.setTime(date_time)
         elif self.have_date and not self.have_time:
             self.setDate(date_time)
         elif not self.have_date and self.have_time:

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -217,12 +217,12 @@ class TestOWSelectRows(WidgetTest):
         dtw.set_datetime(QTime(12, 0))
         self.assertEqual(dtw.time(), QTime(12, 0))
 
-    def test_set_datetime_with_only_date(self):
-        dt = QDateTime.fromString("2024-01-01T00:00:00", Qt.ISODate)
+    def test_set_datetime_sets_date_with_qdate(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
         dt.setTimeSpec(Qt.UTC)
         column = np.array([dt.toSecsSinceEpoch()])
 
-        dtw = DateTimeWidget(None, column, (1, 0))  # solo fecha
+        dtw = DateTimeWidget(None, column, (1, 1))  # tiene fecha y hora
         test_date = QDate(2024, 1, 1)
 
         dtw.set_datetime(test_date)

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 import numpy as np
 
-from AnyQt.QtCore import QLocale, Qt, QDate
+from AnyQt.QtCore import QLocale, Qt, QDate, QDateTime, QTime
 from AnyQt.QtTest import QTest
 from AnyQt.QtWidgets import QLineEdit, QComboBox
 
@@ -182,6 +182,32 @@ class TestOWSelectRows(WidgetTest):
             test_dt = QDateTime(QDate(2014, 6, 2), QTime(16, 0))
             date_widget.set_datetime(test_dt)
             self.assertEqual(date_widget.dateTime(), test_dt)
+            
+    def test_set_datetime_with_qdatetime(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+        dtw = DateTimeWidget(None, column, (1, 1))
+        dtw.set_datetime(dt)
+        self.assertEqual(dtw.dateTime().time().hour(), 12)
+        self.assertEqual(dtw.dateTime().date(), QDate(2024, 1, 1))
+
+    def test_set_datetime_with_qdate(self):
+        dt = QDateTime(QDate(2024, 1, 1), QTime(0, 0), Qt.UTC)
+        timestamp = dt.toSecsSinceEpoch()
+        column = np.array([timestamp])
+        dtw = DateTimeWidget(None, column, (1, 0))
+        dtw.set_datetime(QDate(2024, 1, 1))
+        self.assertEqual(dtw.date(), QDate(2024, 1, 1))
+
+    def test_set_datetime_with_qtime(self):
+        # Use a fixed day (2000-01-01) and desired time
+        dt = QDateTime(QDate(2000, 1, 1), QTime(12, 0), Qt.UTC)
+        timestamp = dt.toSecsSinceEpoch()
+        column = np.array([timestamp])
+        dtw = DateTimeWidget(None, column, (0, 1))
+        dtw.set_datetime(QTime(12, 0))
+        self.assertEqual(dtw.time(), QTime(12, 0))
 
     @override_locale(QLocale.C)  # Locale with decimal point
     def test_continuous_filter_with_c_locale(self):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -208,6 +208,24 @@ class TestOWSelectRows(WidgetTest):
         dtw = DateTimeWidget(None, column, (0, 1))
         dtw.set_datetime(QTime(12, 0))
         self.assertEqual(dtw.time(), QTime(12, 0))
+        
+    def test_set_datetime_dispatch_qdate(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+        dtw = DateTimeWidget(None, column, (1, 0))  # solo fecha
+        date = QDate(2024, 1, 1)
+        dtw.set_datetime(date)
+        self.assertEqual(dtw.date(), date)
+
+    def test_set_datetime_dispatch_qtime(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+        dtw = DateTimeWidget(None, column, (0, 1))  # solo hora
+        time = QTime(12, 0)
+        dtw.set_datetime(time)
+        self.assertEqual(dtw.time(), time)
 
     @override_locale(QLocale.C)  # Locale with decimal point
     def test_continuous_filter_with_c_locale(self):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -209,24 +209,6 @@ class TestOWSelectRows(WidgetTest):
         dtw.set_datetime(QTime(12, 0))
         self.assertEqual(dtw.time(), QTime(12, 0))
         
-    def test_set_datetime_dispatch_qdate(self):
-        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
-        dt.setTimeSpec(Qt.UTC)
-        column = np.array([dt.toSecsSinceEpoch()])
-        dtw = DateTimeWidget(None, column, (1, 0))  # solo fecha
-        date = QDate(2024, 1, 1)
-        dtw.set_datetime(date)
-        self.assertEqual(dtw.date(), date)
-
-    def test_set_datetime_dispatch_qtime(self):
-        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
-        dt.setTimeSpec(Qt.UTC)
-        column = np.array([dt.toSecsSinceEpoch()])
-        dtw = DateTimeWidget(None, column, (0, 1))  # solo hora
-        time = QTime(12, 0)
-        dtw.set_datetime(time)
-        self.assertEqual(dtw.time(), time)
-        
     def test_set_datetime_with_qtime_when_have_both(self):
         dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
         dt.setTimeSpec(Qt.UTC)
@@ -234,28 +216,6 @@ class TestOWSelectRows(WidgetTest):
         dtw = DateTimeWidget(None, column, (1, 1))  # fecha y hora
         dtw.set_datetime(QTime(12, 0))
         self.assertEqual(dtw.time(), QTime(12, 0))
-
-    def test_set_datetime_sets_date_with_qdate(self):
-        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
-        dt.setTimeSpec(Qt.UTC)
-        column = np.array([dt.toSecsSinceEpoch()])
-
-        dtw = DateTimeWidget(None, column, (1, 1))  # tiene fecha y hora
-        test_date = QDate(2024, 1, 1)
-
-        dtw.set_datetime(test_date)
-        self.assertEqual(dtw.date(), test_date)
-
-    def test_set_datetime_sets_time_with_qtime(self):
-        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
-        dt.setTimeSpec(Qt.UTC)
-        column = np.array([dt.toSecsSinceEpoch()])
-
-        dtw = DateTimeWidget(None, column, (1, 1))  # tiene fecha y hora
-        test_time = QTime(12, 0)
-
-        dtw.set_datetime(test_time)
-        self.assertEqual(dtw.time(), test_time)
 
     def test_set_datetime_with_only_date(self):
         dt = QDateTime.fromString("2024-01-01T00:00:00", Qt.ISODate)

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -282,6 +282,20 @@ class TestOWSelectRows(WidgetTest):
         self.widget.remove_all_button.click()
         self.enterFilter(iris.domain[2], "is below", "5,2")
         self.assertEqual(self.widget.conditions[0][2], ("52",))
+        
+    def test_set_datetime_sets_time_when_only_time_enabled(self):
+        # We prepare a QDateTime with only time (the date is irrelevant)
+        dt = QDateTime.fromString("2000-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+
+        # We create a widget that has only time, not date.
+        dtw = DateTimeWidget(None, column, (0, 1))  # have_date=False, have_time=True
+
+        test_time = QTime(12, 0)
+        dtw.set_datetime(test_time)
+
+        self.assertEqual(dtw.time(), test_time)
 
     @override_locale(QLocale.Slovenian)  # Locale with decimal comma
     def test_continuous_filter_with_sl_SI_locale(self):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -226,6 +226,47 @@ class TestOWSelectRows(WidgetTest):
         time = QTime(12, 0)
         dtw.set_datetime(time)
         self.assertEqual(dtw.time(), time)
+        
+    def test_set_datetime_with_qtime_when_have_both(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+        dtw = DateTimeWidget(None, column, (1, 1))  # fecha y hora
+        dtw.set_datetime(QTime(12, 0))
+        self.assertEqual(dtw.time(), QTime(12, 0))
+
+    def test_set_datetime_sets_date_with_qdate(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+
+        dtw = DateTimeWidget(None, column, (1, 1))  # tiene fecha y hora
+        test_date = QDate(2024, 1, 1)
+
+        dtw.set_datetime(test_date)
+        assert dtw.date() == test_date
+
+    def test_set_datetime_sets_time_with_qtime(self):
+        dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+
+        dtw = DateTimeWidget(None, column, (1, 1))  # tiene fecha y hora
+        test_time = QTime(12, 0)
+
+        dtw.set_datetime(test_time)
+        assert dtw.time() == test_time
+
+    def test_set_datetime_with_only_date(self):
+        dt = QDateTime.fromString("2024-01-01T00:00:00", Qt.ISODate)
+        dt.setTimeSpec(Qt.UTC)
+        column = np.array([dt.toSecsSinceEpoch()])
+
+        dtw = DateTimeWidget(None, column, (1, 0))  # solo fecha
+        test_date = QDate(2024, 1, 1)
+
+        dtw.set_datetime(test_date)
+        assert dtw.date() == test_date
 
     @override_locale(QLocale.C)  # Locale with decimal point
     def test_continuous_filter_with_c_locale(self):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -244,7 +244,7 @@ class TestOWSelectRows(WidgetTest):
         test_date = QDate(2024, 1, 1)
 
         dtw.set_datetime(test_date)
-        assert dtw.date() == test_date
+        self.assertEqual(dtw.date(), test_date)
 
     def test_set_datetime_sets_time_with_qtime(self):
         dt = QDateTime.fromString("2024-01-01T12:00:00", Qt.ISODate)
@@ -255,7 +255,7 @@ class TestOWSelectRows(WidgetTest):
         test_time = QTime(12, 0)
 
         dtw.set_datetime(test_time)
-        assert dtw.time() == test_time
+        self.assertEqual(dtw.time(), test_time)
 
     def test_set_datetime_with_only_date(self):
         dt = QDateTime.fromString("2024-01-01T00:00:00", Qt.ISODate)
@@ -266,7 +266,7 @@ class TestOWSelectRows(WidgetTest):
         test_date = QDate(2024, 1, 1)
 
         dtw.set_datetime(test_date)
-        assert dtw.date() == test_date
+        self.assertEqual(dtw.date(), test_date)
 
     @override_locale(QLocale.C)  # Locale with decimal point
     def test_continuous_filter_with_c_locale(self):

--- a/Orange/widgets/data/tests/test_owselectrows.py
+++ b/Orange/widgets/data/tests/test_owselectrows.py
@@ -156,6 +156,33 @@ class TestOWSelectRows(WidgetTest):
             self.widget.conditions_changed()
             self.widget.commit.now()
 
+        self.widget.remove_all()
+        self.enterFilter("breach_start", "equals", QDate(2014, 6, 2))
+
+        container = self.widget.cond_list.cellWidget(0, 2)
+        date_widget = container.findChild(DateTimeWidget)
+        self.assertIsNotNone(date_widget)
+
+        fmt = date_widget.format  # Tuple: (have_date, have_time)
+
+        # Test with QDate if the widget supports date
+        if fmt[0]:
+            test_date = QDate(2014, 6, 2)
+            date_widget.set_datetime(test_date)
+            self.assertEqual(date_widget.date(), test_date)
+
+        # Test with QTime if the widget supports time
+        if fmt[1]:
+            test_time = QTime(16, 0)
+            date_widget.set_datetime(test_time)
+            self.assertEqual(date_widget.time(), test_time)
+
+        # Test with QDateTime if the widget supports both
+        if fmt == (1, 1):
+            test_dt = QDateTime(QDate(2014, 6, 2), QTime(16, 0))
+            date_widget.set_datetime(test_dt)
+            self.assertEqual(date_widget.dateTime(), test_dt)
+
     @override_locale(QLocale.C)  # Locale with decimal point
     def test_continuous_filter_with_c_locale(self):
         iris = Table("iris")[:5]


### PR DESCRIPTION
…nd error unexpected type 'QDate'

Fix error: QLayout: Attempting to add QLayout "" to ErrorReporting "", which already has a layout
Fix error: TypeError: setDateTime(self, dateTime: Union[QDateTime, datetime.datetime]): argument 1 has unexpected type 'QDate'

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
