### PR TITLE
Feature Statitics: Rename to Variable Statistics

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -119,7 +119,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         @property
         def name(self):
             return {self.ICON: '',
-                    self.NAME: 'Name',
+                    self.NAME: 'Variable',
                     self.DISTRIBUTION: 'Distribution',
                     self.CENTER: 'Mean',
                     self.MODE: 'Mode',
@@ -330,11 +330,11 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
         modes = [var.str_val(val)
                  for var, val in zip(self.variables, self._mode)]
         metas = np.vstack((names, modes)).T
-        meta_attrs = [StringVariable('Feature'), StringVariable('Mode')]
+        meta_attrs = [StringVariable('Variable'), StringVariable('Mode')]
 
         domain = Domain(attributes=attrs, metas=meta_attrs)
         statistics = Table.from_numpy(domain, x, metas=metas)
-        statistics.name = f'{self.table.name} (Feature Statistics)'
+        statistics.name = f'{self.table.name} (Variable Statistics)'
         return statistics
 
     def __compute_stat(self, matrices, discrete_f=None, continuous_f=None,
@@ -733,9 +733,10 @@ class DistributionDelegate(NoFocusRectDelegate):
 
 
 class OWFeatureStatistics(widget.OWWidget):
-    name = 'Feature Statistics'
+    name = 'Variable Statistics'
     description = 'Show basic statistics for data features.'
     icon = 'icons/FeatureStatistics.svg'
+    keywords = 'feature statistics'
 
     class Inputs:
         data = Input('Data', Table, default=True)

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -4744,7 +4744,7 @@ widgets/data/owcreateclass.py:
         class `Error`:
             Class name duplicated.: Spremenljivka s tem imenom že obstaja.
             Class name should not be empty.: Ime razreda ne more biti prazno.
-            'Invalid regular expression: {}': 'Napačen regularni izraz: {}'
+            'Invalid regular expression: {}': Napačen regularni izraz: {}
         def `__init__`:
             class_name: false
             New Class Name: Ime novega razreda
@@ -6115,7 +6115,7 @@ widgets/data/owfeaturestatistics.py:
     class `FeatureStatisticsTableModel`:
         class `Columns`:
             def `name`:
-                Name: Ime
+                Variable: Spremenljivka
                 Distribution: Porazdelitev
                 Mean: Srednja vrednost
                 Mode: Najpogostejša
@@ -6129,9 +6129,9 @@ widgets/data/owfeaturestatistics.py:
                 C: false
         def `get_statistics_table`:
             Entropy: Entropija
-            Feature: Spremenljivka
+            Variable: Spremenljivka
             Mode: Najpogostejša
-            {self.table.name} (Feature Statistics): {self.table.name} (Statistika spremenljivk)
+            {self.table.name} (Variable Statistics): {self.table.name} (Statistika spremenljivk)
         def `_sortColumnData`:
             Data should be at most 2-dimensional: false
         def `_argsortData`:
@@ -6149,9 +6149,10 @@ widgets/data/owfeaturestatistics.py:
                 {self._dispersion[row]:.3g}: false
                 {missing} ({perc} %): false
     class `OWFeatureStatistics`:
-        Feature Statistics: Statistika spremenljivk
+        Variable Statistics: Statistika spremenljivk
         Show basic statistics for data features.: Pokaže osnovno statistiko spremenljivk.
         icons/FeatureStatistics.svg: false
+        feature statistics: true
         class `Inputs`:
             Data: Podatki
         class `Outputs`:


### PR DESCRIPTION
##### Issue

Closes #7084.

##### Description of changes

- Rename Feature Statistics to Variable Statistics.
- Rename the column from "Name" to "Variable" in the Variable Statistics table.
- Rename the output variable from "Feature" to "Variable".

Backward compatibility (non-)issues:

- Renaming the output variable will break existing workflows that ... huh, that ... filtered by this variable?! Such workflows are unlikely, and the fix would introduce some ugly code, so let us not worry about it.
- Since only the name (and not the qualified name) has changed, existing workflows won't be affected.
- I added a keyword so that typing "feature" still finds the widget.

##### Includes
- [X] Code changes
- [ ] Documentation
