### PR TITLE
[ENH] OWSilhouettePlot: displays average silhouette

### DIFF
--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -177,6 +177,11 @@ class OWSilhouettePlot(widget.OWWidget):
         ibox.setFixedWidth(ibox.sizeHint().width())
         warning.setVisible(False)
 
+        # box displaying the average silhouette score
+        avg_box = gui.vBox(self.controlArea, "Average Silhouette Score")
+        self.avg_silhouette_label = gui.widgetLabel(avg_box, "")
+        self._update_avg_silhouette()
+
         gui.rubber(self.controlArea)
 
         gui.auto_send(self.buttonsArea, self, "auto_commit")
@@ -292,6 +297,7 @@ class OWSilhouettePlot(widget.OWWidget):
         self._clear_scene()
         self.Error.clear()
         self.Warning.clear()
+        self._update_avg_silhouette()  # Update the average silhouette display
 
     def _clear_scene(self):
         # Clear the graphics scene and associated objects
@@ -340,6 +346,15 @@ class OWSilhouettePlot(widget.OWWidget):
             else:
                 assert False, "invalid state"
 
+    def _update_avg_silhouette(self):
+        # update the average silhouette score
+        if self._silhouette is not None and len(self._silhouette) > 0:
+            avg_score = np.mean(self._silhouette)
+            self.avg_silhouette_label.setText(
+                f"<b>Silhouette:</b> {avg_score:.4f}")
+        else:
+            self.avg_silhouette_label.setText("<b>Silhouette:</b> N/A")
+
     def _update(self):
         # Update/recompute the effective distances and scores as required.
         self._clear_messages()
@@ -383,6 +398,8 @@ class OWSilhouettePlot(widget.OWWidget):
             if count_nandist:
                 self.Warning.nan_distances(
                     count_nandist, s="s" if count_nandist > 1 else "")
+
+        self._update_avg_silhouette()  # Update the average silhouette display
 
     def _reset_all(self):
         self._mask = None

--- a/Orange/widgets/visualize/owsilhouetteplot.py
+++ b/Orange/widgets/visualize/owsilhouetteplot.py
@@ -136,16 +136,17 @@ class OWSilhouettePlot(widget.OWWidget):
         self._silhouette = None  # type: Optional[np.ndarray]
         self._silplot = None     # type: Optional[SilhouettePlot]
 
-        controllayout = self.controlArea.layout()
-        assert isinstance(controllayout, QVBoxLayout)
+        info_box = gui.vBox(self.controlArea, "Info")
+        self.avg_silhouette_label = gui.widgetLabel(info_box, "")
+        self._update_avg_silhouette()
+
         self._distances_gui_box = distbox = gui.widgetBox(
-            None, "Distance"
+            self.controlArea, "Distance"
         )
         self._distances_gui_cb = gui.comboBox(
             distbox, self, "distance_idx",
             items=[name for name, _ in OWSilhouettePlot.Distances],
             orientation=Qt.Horizontal, callback=self._invalidate_distances)
-        controllayout.addWidget(distbox)
 
         box = gui.vBox(self.controlArea, "Grouping")
         self.cluster_var_model = itemmodels.VariableListModel(
@@ -177,10 +178,6 @@ class OWSilhouettePlot(widget.OWWidget):
         ibox.setFixedWidth(ibox.sizeHint().width())
         warning.setVisible(False)
 
-        # box displaying the average silhouette score
-        avg_box = gui.vBox(self.controlArea, "Average Silhouette Score")
-        self.avg_silhouette_label = gui.widgetLabel(avg_box, "")
-        self._update_avg_silhouette()
 
         gui.rubber(self.controlArea)
 
@@ -347,13 +344,12 @@ class OWSilhouettePlot(widget.OWWidget):
                 assert False, "invalid state"
 
     def _update_avg_silhouette(self):
-        # update the average silhouette score
         if self._silhouette is not None and len(self._silhouette) > 0:
             avg_score = np.mean(self._silhouette)
             self.avg_silhouette_label.setText(
-                f"<b>Silhouette:</b> {avg_score:.4f}")
+                f"Average Silhouette: {avg_score:.4f}")
         else:
-            self.avg_silhouette_label.setText("<b>Silhouette:</b> N/A")
+            self.avg_silhouette_label.setText("Average Silhouette: N/A")
 
     def _update(self):
         # Update/recompute the effective distances and scores as required.

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -303,26 +303,14 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertNotIn("annotation_var_idx", values)
 
     def test_average_silhouette_score(self):
-        """Test the average silhouette score display"""
-        # Load brown-selected data
         data = Table("brown-selected")
         self.send_signal(self.widget.Inputs.data, data)
-
-        # Check if the score is displayed correctly
         self.assertEqual(self.widget.avg_silhouette_label.text(),
                         "<b>Silhouette:</b> 0.4692")
-
-        # Remove data
         self.send_signal(self.widget.Inputs.data, None)
-
-        # Check if N/A is displayed
         self.assertEqual(self.widget.avg_silhouette_label.text(),
                         "<b>Silhouette:</b> N/A")
-
-        # Load data again
         self.send_signal(self.widget.Inputs.data, data)
-
-        # Check if the score is displayed correctly again
         self.assertEqual(self.widget.avg_silhouette_label.text(), 
                         "<b>Silhouette:</b> 0.4692")
 

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -302,6 +302,30 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(context.values["cluster_var"], ("cfoo", 101))
         self.assertNotIn("annotation_var_idx", values)
 
+    def test_average_silhouette_score(self):
+        """Test the average silhouette score display"""
+        # Load brown-selected data
+        data = Table("brown-selected")
+        self.send_signal(self.widget.Inputs.data, data)
+
+        # Check if the score is displayed correctly
+        self.assertEqual(self.widget.avg_silhouette_label.text(),
+                        "<b>Silhouette:</b> 0.4692")
+
+        # Remove data
+        self.send_signal(self.widget.Inputs.data, None)
+
+        # Check if N/A is displayed
+        self.assertEqual(self.widget.avg_silhouette_label.text(),
+                        "<b>Silhouette:</b> N/A")
+
+        # Load data again
+        self.send_signal(self.widget.Inputs.data, data)
+
+        # Check if the score is displayed correctly again
+        self.assertEqual(self.widget.avg_silhouette_label.text(), 
+                        "<b>Silhouette:</b> 0.4692")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
+++ b/Orange/widgets/visualize/tests/test_owsilhouetteplot.py
@@ -306,13 +306,13 @@ class TestOWSilhouettePlot(WidgetTest, WidgetOutputsTestMixin):
         data = Table("brown-selected")
         self.send_signal(self.widget.Inputs.data, data)
         self.assertEqual(self.widget.avg_silhouette_label.text(),
-                        "<b>Silhouette:</b> 0.4692")
+                        "Average Silhouette: 0.4692")
         self.send_signal(self.widget.Inputs.data, None)
         self.assertEqual(self.widget.avg_silhouette_label.text(),
-                        "<b>Silhouette:</b> N/A")
+                        "Average Silhouette: N/A")
         self.send_signal(self.widget.Inputs.data, data)
         self.assertEqual(self.widget.avg_silhouette_label.text(), 
-                        "<b>Silhouette:</b> 0.4692")
+                        "Average Silhouette: 0.4692")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Silhouette Plot would display silhouette score per group, but not the average silhouette score which may serve as a reference to judge if the group is below or above the average.

<img width="722" alt="image" src="https://github.com/user-attachments/assets/78423129-4e8c-40af-93b1-36e21c726a14" />

Also, learning about average silhouette score may be beneficial when judging on the quality of some clustering that precedes Silhouette Plot widget, say, a Hierarchical Clustering or DBSCAN and Silhouette Plot combination.

##### Description of changes

This pull request introduces an info box that reports on the average silhouette score:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/e511ae42-6a92-45cc-9557-b90ad84d587a" />

The style of reporting (the label in bold and the number in normal text) follows that of an Info widget. When input data is missing, the box displays N/A.

Unit tests should most likely be added. I have currently tested the widget by coupling it in the workflow with k-means, that also reports on the average silhouette:

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/486bd010-0a3e-44f3-bc01-99e02a98c118" />

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
