### PR TITLE
[FIX] Update check and notifications: avoid compression

### DIFF
--- a/Orange/canvas/__main__.py
+++ b/Orange/canvas/__main__.py
@@ -90,7 +90,7 @@ def check_for_updates():
                     request = Request('https://orange.biolab.si/version/',
                                       headers={
                                           'Accept': 'text/plain',
-                                          'Accept-Encoding': 'gzip, deflate',
+                                          'Accept-Encoding': 'identity',
                                           'Connection': 'close',
                                           'User-Agent': ua_string()})
                     contents = urlopen(request, timeout=10).read().decode()
@@ -209,6 +209,7 @@ def pull_notifications():
                 request = Request('https://orange.biolab.si/notification-feed',
                                   headers={
                                       'Accept': 'text/plain',
+                                      'Accept-Encoding': 'identity',
                                       'Connection': 'close',
                                       'User-Agent': ua_string(),
                                       'Cache-Control': 'no-cache',

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -227,7 +227,7 @@ canvas/__main__.py:
                 Accept: false
                 text/plain: false
                 Accept-Encoding: false
-                gzip, deflate: false
+                identity: false
                 Connection: false
                 close: false
                 User-Agent: false
@@ -259,6 +259,8 @@ canvas/__main__.py:
                 https://orange.biolab.si/notification-feed: false
                 Accept: false
                 text/plain: false
+                Accept-Encoding: false
+                identity: false
                 Connection: false
                 close: false
                 User-Agent: false


### PR DESCRIPTION
##### Issue

Update check failed for me because the response was compresses, and `urllib` (if I understand it) does not decompress it automatically.

```
2025-06-02 13:30:08,020:ERROR:Orange.canvas.__main__: Failed to check for updates Traceback (most recent call last):
  File "/home/marko/dev/orange3/Orange/canvas/__main__.py", line 97, in run
    contents = urlopen(request, timeout=10).read().decode()
````

##### Description of changes

Force `identity` encoding.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
