### PR TITLE
[FIX] Order available PostgreSQL tables

### DIFF
--- a/Orange/data/sql/backend/postgres.py
+++ b/Orange/data/sql/backend/postgres.py
@@ -111,7 +111,7 @@ class Psycopg2Backend(Backend):
                         AND n.nspname !~ '^pg_toast'
                         {}
                         AND NOT c.relname LIKE '\\_\\_%'
-                   ORDER BY 1;""".format(schema_clause)
+                   ORDER BY 1,2;""".format(schema_clause)
 
     def create_variable(self, field_name, field_metadata,
                         type_hints, inspect_table=None):


### PR DESCRIPTION
The list of available PostgreSQL tables should by ordered by both schema_name and relation_name

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->
I noticed that the table list in the SQL Table widget is not ordered.
This simple patch add the relation name to the ORDER BY

##### Description of changes
Added the order by for the second column too

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
