### PR TITLE
Test with Qt 6.8.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -111,10 +111,10 @@ setenv =
     QT_API=PyQt6
     ANYQT_HOOK_DENY=pyqt5
 deps =
-    PyQt6==6.5.*
-    PyQt6-Qt6==6.5.*
-    PyQt6-WebEngine==6.5.*
-    PyQt6-WebEngine-Qt6==6.5.*
+    PyQt6==6.8.*
+    PyQt6-Qt6==6.8.*
+    PyQt6-WebEngine==6.8.*
+    PyQt6-WebEngine-Qt6==6.8.*
 
 commands =
     python -m unittest -v Orange.widgets.tests


### PR DESCRIPTION
##### Issue

Trying to find out the reason for this fail on Windows:

```======================================================================
FAIL: test_sorting (Orange.widgets.obsolete.tests.test_owtable.TestOWDataTable.test_sorting)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\test-install\Lib\site-packages\Orange\widgets\obsolete\tests\test_owtable.py", line 109, in test_sorting
    self.assertTrue(output_original != output_sorted)
AssertionError: False is not true```
