### PR TITLE
[FIX] tableview: Avoid unnecessary calls to setSortingEnabled

### DIFF
--- a/Orange/widgets/data/utils/tableview.py
+++ b/Orange/widgets/data/utils/tableview.py
@@ -125,7 +125,12 @@ class RichTableView(DataTableView):
             self.horizontalHeader().setSortIndicator(-1, Qt.AscendingOrder)
 
             sortable = self.isModelSortable(model)
-            self.setSortingEnabled(sortable)
+            if sortable != self.isSortingEnabled():
+                # setSortingEnabled disconnects/reconnects Qt's internal
+                # connections to model.sort(), causing client
+                # sortIndicatorChange connections to trigger before the model
+                # is actually sorted. Avoid unnecessary calls.
+                self.setSortingEnabled(sortable)
             header = self.horizontalHeader()
             header.setSectionsClickable(sortable)
             header.setSortIndicatorShown(sortable)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes: https://github.com/biolab/orange3/pull/7103

##### Description of changes

setSortingEnabled disconnects/reconnects Qt's internal connections to model.sort(), causing client
sortIndicatorChange connections to trigger before the model is actually sorted. Avoid unnecessary calls.

The strange thing is this should have been happening also on Qt < 6.8.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
