### PR TITLE
Box Plot: Fix crash when attribute or group variable has no values

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -684,6 +684,15 @@ class OWBoxPlot(widget.OWWidget):
 
     def _display_changed_disc(self):
         self.clear_scene()
+
+        if self.group_var and self.conts is None or \
+                not self.group_var and self.dist is None:  # readability counts
+            # This happens if the attribute or group attribute don't have any
+            # values. See the condition in compute_box_data. This tests can't
+            # be moved to input data handler because it's user-choice specific.
+            self.stat_test = ""
+            return
+
         self.attr_labels = [QGraphicsSimpleTextItem(lab)
                             for lab in self.label_txts_all]
 
@@ -991,9 +1000,11 @@ class OWBoxPlot(widget.OWWidget):
             step = steps = 10
         else:
             if self.group_var:
+                assert self.conts is not None, "the callee must ensure this!"
                 max_box = max(float(np.sum(dist))
                               for dist in self.conts.array_with_unknowns)
             else:
+                assert self.dist is not None, "the callee must ensure this!"
                 max_box = float(np.sum(self.dist.array_with_unknowns))
             if max_box == 0:
                 self.scale_x = 1

--- a/Orange/widgets/visualize/tests/test_owboxplot.py
+++ b/Orange/widgets/visualize/tests/test_owboxplot.py
@@ -104,6 +104,19 @@ class TestOWBoxPlot(WidgetTest, WidgetOutputsTestMixin):
         self._select_list_items(self.widget.attr_list)
         self._select_list_items(self.widget.group_list)
 
+    def test_no_attribute_or_group_values(self):
+        attrs = [DiscreteVariable(n, values=tuple("xyz"[:i]))
+                 for i, n in enumerate("abc")]
+        n = np.nan
+        data = Table.from_numpy(Domain(attrs),
+                                [[n, n, n],
+                                 [n, n, 0],
+                                 [n, 0, 1]])
+        self.send_signal(data)
+        for self.widget.attribute in attrs:
+            for self.widget.group_var in attrs:
+                self.widget.update_graph()
+
     def test_attribute_combinations(self):
         self.send_signal(self.widget.Inputs.data, self.heart)
         group_list = self.widget.group_list


### PR DESCRIPTION
##### Issue

Fixes #7104.

The problem was not that there was no data: there was data, but the variable had no values (e.g. as in `values=()`).

##### Description of changes

Don't draw a graph when (categorical) variables have no values.

This is a nasty edge case that may also crash other widgets. It would be great if DBScan didn't produce such data.

##### Includes
- [X] Code changes
- [X] Tests
