### PR TITLE
Delay failing tests due to deprecations to 3.40

### DIFF
--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -110,7 +110,8 @@ class TestSklAdaBoostLearner(unittest.TestCase):
         self.assertRaises(ValueError, learner, self.iris)
 
     def test_remove_deprecation(self):
-        if Version(Orange.__version__) >= Version("3.39"):
+        if (Version(Orange.__version__).is_prerelease
+                and Version(Orange.__version__) >= Version("3.39")):
             self.fail(
                 "`base_estimator` was deprecated in "
                 "version 3.37. Please remove everything related to it."

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -111,7 +111,7 @@ class TestSklAdaBoostLearner(unittest.TestCase):
 
     def test_remove_deprecation(self):
         if (Version(Orange.__version__).is_prerelease
-                and Version(Orange.__version__) >= Version("3.39")):
+                and Version(Orange.__version__) >= Version("3.40")):
             self.fail(
                 "`base_estimator` was deprecated in "
                 "version 3.37. Please remove everything related to it."

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -139,7 +139,7 @@ class TestSklLearner(unittest.TestCase):
         """This test is to be included in the 3.37 release and will fail in
         version 3.39. This serves as a reminder."""
         if (Version(Orange.__version__).is_prerelease and
-                Version(Orange.__version__) >= Version("3.39")):
+                Version(Orange.__version__) >= Version("3.40")):
             self.fail(
                 "`SklLearner.supports_weights` as a property that parses fit() "
                 "was deprecated in 3.37. Replace it with `supports_weights = False`"

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -138,7 +138,8 @@ class TestSklLearner(unittest.TestCase):
     def test_supports_weights_property(self):
         """This test is to be included in the 3.37 release and will fail in
         version 3.39. This serves as a reminder."""
-        if Version(Orange.__version__) >= Version("3.39"):
+        if (Version(Orange.__version__).is_prerelease and
+                Version(Orange.__version__) >= Version("3.39")):
             self.fail(
                 "`SklLearner.supports_weights` as a property that parses fit() "
                 "was deprecated in 3.37. Replace it with `supports_weights = False`"


### PR DESCRIPTION
##### Issue
Two tests fail.


##### Description of changes
This PR delays failing deprecations to 3.40. I am doing this separately so that we have additional flexibility when doing a patch release.