### PR TITLE
Remove deprecated SklLearner.support_weights detection

### DIFF
--- a/Orange/base.py
+++ b/Orange/base.py
@@ -603,20 +603,6 @@ class SklLearner(Learner, metaclass=WrapperMeta):
             return self.__returns__(clf.fit(X, Y))
         return self.__returns__(clf.fit(X, Y, sample_weight=W.reshape(-1)))
 
-    @property
-    def supports_weights(self):
-        """Indicates whether this learner supports weighted instances.
-        """
-        warnings.warn('SklLearner.supports_weights property is deprecated. All '
-                      'subclasses should redefine the supports_weights attribute. '
-                      'The property will be removed in 3.39.',
-                      OrangeDeprecationWarning)
-        varnames = self.__wraps__.fit.__code__.co_varnames
-        # scikit-learn often uses decorators on fit()
-        if hasattr(self.__wraps__.fit, "__wrapped__"):
-            varnames = varnames + self.__wraps__.fit.__wrapped__.__code__.co_varnames
-        return 'sample_weight' in varnames
-
     def __getattr__(self, item):
         try:
             return self.params[item]

--- a/Orange/tests/test_base.py
+++ b/Orange/tests/test_base.py
@@ -3,15 +3,10 @@
 import pickle
 import unittest
 
-from packaging.version import Version
-
-import Orange
-
 from Orange.base import SklLearner, Learner, Model
 from Orange.data import Domain, Table
 from Orange.preprocess import Discretize, Randomize, Continuize
 from Orange.regression import LinearRegressionLearner
-from Orange.util import OrangeDeprecationWarning
 
 
 class DummyLearner(Learner):
@@ -96,29 +91,6 @@ class TestLearner(unittest.TestCase):
 
 
 class TestSklLearner(unittest.TestCase):
-    def test_sklearn_supports_weights(self):
-        """Check that the SklLearner correctly infers whether or not the
-        learner supports weights"""
-
-        class DummySklLearner:
-            def fit(self, X, y, sample_weight=None):
-                pass
-
-        class DummyLearner(SklLearner):
-            __wraps__ = DummySklLearner
-
-        with self.assertWarns(OrangeDeprecationWarning):
-            self.assertTrue(DummyLearner().supports_weights)
-
-        class DummySklLearner:
-            def fit(self, X, y):
-                pass
-
-        class DummyLearner(SklLearner):
-            __wraps__ = DummySklLearner
-
-        with self.assertWarns(OrangeDeprecationWarning):
-            self.assertFalse(DummyLearner().supports_weights)
 
     def test_linreg(self):
         self.assertTrue(
@@ -134,16 +106,6 @@ class TestSklLearner(unittest.TestCase):
         self.assertEqual(min(args), 0)
         self.assertEqual(max(args), 1)
         self.assertListEqual(args, sorted(args))
-
-    def test_supports_weights_property(self):
-        """This test is to be included in the 3.37 release and will fail in
-        version 3.39. This serves as a reminder."""
-        if (Version(Orange.__version__).is_prerelease and
-                Version(Orange.__version__) >= Version("3.40")):
-            self.fail(
-                "`SklLearner.supports_weights` as a property that parses fit() "
-                "was deprecated in 3.37. Replace it with `supports_weights = False`"
-            )
 
 
 class TestModel(unittest.TestCase):


### PR DESCRIPTION
##### Issue
Test failing

##### Description of changes
Removed the properly. The default value `False` is taken from the superclass.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
