### PR TITLE
Remove deprecated `base_estimator` from AdaBoost learners

### DIFF
--- a/Orange/ensembles/ada_boost.py
+++ b/Orange/ensembles/ada_boost.py
@@ -1,5 +1,3 @@
-import warnings
-
 import sklearn.ensemble as skl_ensemble
 
 from Orange.base import SklLearner
@@ -9,7 +7,6 @@ from Orange.classification.base_classification import (
 from Orange.regression.base_regression import (
     SklLearnerRegression, SklModelRegression
 )
-from Orange.util import OrangeDeprecationWarning
 
 
 __all__ = ['SklAdaBoostClassificationLearner', 'SklAdaBoostRegressionLearner']
@@ -19,24 +16,13 @@ class SklAdaBoostClassifier(SklModelClassification):
     pass
 
 
-def base_estimator_deprecation():
-    warnings.warn(
-        "`base_estimator` is deprecated (to be removed in 3.39): use `estimator` instead.",
-        OrangeDeprecationWarning, stacklevel=3)
-
-
 class SklAdaBoostClassificationLearner(SklLearnerClassification):
     __wraps__ = skl_ensemble.AdaBoostClassifier
     __returns__ = SklAdaBoostClassifier
     supports_weights = True
 
     def __init__(self, estimator=None, n_estimators=50, learning_rate=1.,
-                 algorithm='SAMME', random_state=None, preprocessors=None,
-                 base_estimator="deprecated"):
-        if base_estimator != "deprecated":
-            base_estimator_deprecation()
-            estimator = base_estimator
-        del base_estimator
+                 algorithm='SAMME', random_state=None, preprocessors=None):
         from Orange.modelling import Fitter
         # If fitter, get the appropriate Learner instance
         if isinstance(estimator, Fitter):
@@ -59,12 +45,7 @@ class SklAdaBoostRegressionLearner(SklLearnerRegression):
     supports_weights = True
 
     def __init__(self, estimator=None, n_estimators=50, learning_rate=1.,
-                 loss='linear', random_state=None, preprocessors=None,
-                 base_estimator="deprecated"):
-        if base_estimator != "deprecated":
-            base_estimator_deprecation()
-            estimator = base_estimator
-        del base_estimator
+                 loss='linear', random_state=None, preprocessors=None):
         from Orange.modelling import Fitter
         # If fitter, get the appropriate Learner instance
         if isinstance(estimator, Fitter):

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -4,9 +4,7 @@
 import unittest
 
 import numpy as np
-from packaging.version import Version
 
-import Orange
 from Orange.data import Table
 from Orange.classification import SklTreeLearner
 from Orange.regression import SklTreeRegressionLearner
@@ -15,7 +13,6 @@ from Orange.ensembles import (
     SklAdaBoostRegressionLearner,
 )
 from Orange.evaluation import CrossValidation, CA, RMSE
-from Orange.util import OrangeDeprecationWarning
 
 
 class TestSklAdaBoostLearner(unittest.TestCase):
@@ -108,16 +105,3 @@ class TestSklAdaBoostLearner(unittest.TestCase):
     def test_adaboost_adequacy_reg(self):
         learner = SklAdaBoostRegressionLearner()
         self.assertRaises(ValueError, learner, self.iris)
-
-    def test_remove_deprecation(self):
-        if (Version(Orange.__version__).is_prerelease
-                and Version(Orange.__version__) >= Version("3.40")):
-            self.fail(
-                "`base_estimator` was deprecated in "
-                "version 3.37. Please remove everything related to it."
-            )
-        stump_estimator = SklTreeLearner(max_depth=1)
-        with self.assertWarns(OrangeDeprecationWarning):
-            SklAdaBoostClassificationLearner(base_estimator=stump_estimator)
-        with self.assertWarns(OrangeDeprecationWarning):
-            SklAdaBoostClassificationLearner(base_estimator=stump_estimator)


### PR DESCRIPTION
##### Issue
Failing time bomb.

##### Description of changes
Removed.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
