### PR TITLE
SklAdaBoostClassificationLearner: deprecate `algorithm`

### DIFF
--- a/Orange/ensembles/ada_boost.py
+++ b/Orange/ensembles/ada_boost.py
@@ -1,3 +1,5 @@
+import warnings
+
 import sklearn.ensemble as skl_ensemble
 
 from Orange.base import SklLearner
@@ -7,6 +9,7 @@ from Orange.classification.base_classification import (
 from Orange.regression.base_regression import (
     SklLearnerRegression, SklModelRegression
 )
+from Orange.util import OrangeDeprecationWarning
 
 
 __all__ = ['SklAdaBoostClassificationLearner', 'SklAdaBoostRegressionLearner']
@@ -22,7 +25,12 @@ class SklAdaBoostClassificationLearner(SklLearnerClassification):
     supports_weights = True
 
     def __init__(self, estimator=None, n_estimators=50, learning_rate=1.,
-                 algorithm='SAMME', random_state=None, preprocessors=None):
+                 algorithm='deprecated', random_state=None, preprocessors=None):
+        if algorithm != "deprecated":
+            warnings.warn(
+                "`algorithm` is deprecated and has no effect (to be removed in 3.42).",
+                OrangeDeprecationWarning, stacklevel=2)
+        del algorithm
         from Orange.modelling import Fitter
         # If fitter, get the appropriate Learner instance
         if isinstance(estimator, Fitter):

--- a/Orange/tests/test_ada_boost.py
+++ b/Orange/tests/test_ada_boost.py
@@ -4,6 +4,9 @@
 import unittest
 
 import numpy as np
+from packaging.version import Version
+
+import Orange
 
 from Orange.data import Table
 from Orange.classification import SklTreeLearner
@@ -13,6 +16,7 @@ from Orange.ensembles import (
     SklAdaBoostRegressionLearner,
 )
 from Orange.evaluation import CrossValidation, CA, RMSE
+from Orange.util import OrangeDeprecationWarning
 
 
 class TestSklAdaBoostLearner(unittest.TestCase):
@@ -105,3 +109,13 @@ class TestSklAdaBoostLearner(unittest.TestCase):
     def test_adaboost_adequacy_reg(self):
         learner = SklAdaBoostRegressionLearner()
         self.assertRaises(ValueError, learner, self.iris)
+
+    def test_remove_deprecation(self):
+        if (Version(Orange.__version__).is_prerelease
+                and Version(Orange.__version__) >= Version("3.42")):
+            self.fail(
+                "SklAdaBoostClassificationLearner: `algorithm` was deprecated in "
+                "version 3.40. Please remove everything related to it."
+            )
+        with self.assertWarns(OrangeDeprecationWarning):
+            SklAdaBoostClassificationLearner(algorithm="invalid")(self.iris)

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -2101,7 +2101,8 @@ ensembles/ada_boost.py:
     SklAdaBoostRegressionLearner: false
     class `SklAdaBoostClassificationLearner`:
         def `__init__`:
-            SAMME: false
+            deprecated: false
+            `algorithm` is deprecated and has no effect (to be removed in 3.42).: false
     class `SklAdaBoostRegressionLearner`:
         def `__init__`:
             linear: false


### PR DESCRIPTION
##### Issue
Scikit-learn deprecated `algorithm` in 1.6 (to expire in 1.8).

Depends on #7117


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
