### PR TITLE
Remove explicit pip requirement (oldest tests now force 20.3)

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -54,7 +54,6 @@ requirements:
     - openTSNE >=0.6.2,!=0.7.0
     - pandas >=1.4.0,!=1.5.0,!=2.0.0
     - packaging
-    - pip >=19.3
     - python.app  # [osx]
     - python-louvain >=0.13
     - pyyaml

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -13,7 +13,7 @@ openpyxl>=3.1.3
 openTSNE>=0.6.2,!=0.7.0  # 0.7.0 segfaults
 packaging
 pandas>=1.4.0,!=1.5.0,!=2.0.0
-pip>=19.3
+pip>=20.3
 python-louvain>=0.13
 pyyaml
 requests

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -13,7 +13,6 @@ openpyxl>=3.1.3
 openTSNE>=0.6.2,!=0.7.0  # 0.7.0 segfaults
 packaging
 pandas>=1.4.0,!=1.5.0,!=2.0.0
-pip>=20.3
 python-louvain>=0.13
 pyyaml
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,8 @@ setenv =
     COVERAGE_FILE = {toxinidir}/.coverage
     COVERAGE_RCFILE = {toxinidir}/.coveragerc
 deps =
-    pyqt5==5.12.*;platform_system=="Windows" and python_version<'3.10'
-    pyqt5==5.15.*;platform_system!="Windows" or python_version>='3.10'
-    pyqtwebengine==5.12.*;platform_system=="Windows" and python_version<'3.10'
-    pyqtwebengine==5.15.*;platform_system!="Windows" or python_version>='3.10'
+    pyqt5==5.15.*
+    pyqtwebengine==5.15.*
     coverage
     psycopg2-binary; platform_system=="Linux" # we only test this on Linux
     pymssql; platform_system=="Linux" # we only test this on Linux

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     oldest: openpyxl==3.1.3
     oldest: openTSNE==0.6.2
     oldest: pandas==1.4.0
-    oldest: pip==19.3
+    oldest: pip==20.3
     oldest: python-louvain==0.13
     # oldest: pyyaml
     # oldest: requests

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ deps =
     pymssql; platform_system=="Linux" # we only test this on Linux
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base
+    # pip is not in the requirements; here to see what happens with an old pip version
+    oldest: pip==20.3
     # GUI requirements
     oldest: orange-canvas-core==0.2.5
     oldest: orange-widget-base==4.25.0
@@ -57,7 +59,6 @@ deps =
     oldest: openpyxl==3.1.3
     oldest: openTSNE==0.6.2
     oldest: pandas==1.4.0
-    oldest: pip==20.3
     oldest: python-louvain==0.13
     # oldest: pyyaml
     # oldest: requests


### PR DESCRIPTION
##### Issue
Oldest test fails. Now they still fail (timeout when the tests are being executed), but at least they get past this:

```pip._vendor.pytoml.core.TomlError: /tmp/pip-install-x83ndwu_/libcst/pyproject.toml(51, 1): array-type-mismatch```

##### Description of changes
require pip>=20.3 (for manylinux_x_y packages like libcst)

See https://github.com/pypa/manylinux