### PR TITLE
Handle a numpy's deprecation

### DIFF
--- a/Orange/misc/distmatrix.py
+++ b/Orange/misc/distmatrix.py
@@ -51,9 +51,10 @@ class DistMatrix(np.ndarray):
         self.col_items = getattr(obj, 'col_items', None)
         self.axis = getattr(obj, 'axis', 1)
 
-    def __array_wrap__(self, out_arr, context=None):
+    def __array_wrap__(self, out_arr, context=None, return_scalar=False):
         if out_arr.ndim == 0:  # a single scalar
             return out_arr[()]
+        del return_scalar  # added support for the argument due to a deprecation warning
         return np.ndarray.__array_wrap__(self, out_arr, context)
 
     # __reduce__() and __setstate__() ensure DistMatrix is picklable.


### PR DESCRIPTION
##### Issue
DeprecationWarning: __array_wrap__ must accept context and return_scalar arguments (positionally) in the future. (Deprecated NumPy 2.0)

#### Solution
I just added an argument which keeps being unused. I have no idea how it changes behaviour, and most importantly, how pre-2.0 numpy handles it. Thus, I just ignore it.