### PR TITLE
[FIX] Predictions: allow loading of workflows saved in a localized version (target class setting fix)

### DIFF
--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -9363,6 +9363,8 @@ widgets/evaluate/owpredictions.py:
             Target class: Ciljni razred
         def `migrate_settings`:
             score_table: false
+        def `migrate_context`:
+            target_class: false
     class `ClassificationItemDelegate`:
         def `__init__`:
             ' : ': false


### PR DESCRIPTION
##### Issue

Fixes #7015.

When a workflow is opened with Orange set to a different language, it crashed because the setting for target classes was saved as literal, e.g. `(Average over classes)`.

##### Description of changes

This is the only literal value, other possible values of the setting are class values. I replaced it with an empty string. `None` would be better, but `gui.combobox` allows setting a display value for an empty string.

Migrations replace the setting with an empty string if
- it matches the literal *for the current language*, or
- if the value of the setting doesn't appear in the list of classes.

The second patches the bug for existing workflows. The second condition also covers the first, but let us keep the first for clarity.

##### Includes
- [X] Code changes
- [X] Tests
