### PR TITLE
[ENH] Tree Viewer: correctly show the first category (escape class values)

### DIFF
--- a/Orange/widgets/visualize/owtreeviewer.py
+++ b/Orange/widgets/visualize/owtreeviewer.py
@@ -488,7 +488,7 @@ class OWTreeGraph(OWTreeViewer2D):
         else:
             modus = np.argmax(distr)
             tabs = distr[modus]
-            text = f"<b>{self.domain.class_vars[0].values[int(modus)]}</b><br/>"
+            text = f"<b>{escape(self.domain.class_vars[0].values[int(modus)])}</b><br/>"
         if tabs > 0.999:
             text += f"100%, {total}/{total}"
         else:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -15138,7 +15138,7 @@ widgets/visualize/owtreeviewer.py:
             , …: true
             '<p style="line-height: 120%; margin-bottom: 0">{text}</p>': false
         def `node_content_cls`:
-            <b>{self.domain.class_vars[0].values[int(modus)]}</b><br/>: false
+            <b>{escape(self.domain.class_vars[0].values[int(modus)])}</b><br/>: false
             100%, {total}/{total}: false
             {100 * tabs:2.1f}%, {int(total * tabs)}/{total}: false
         def `node_content_reg`:


### PR DESCRIPTION
##### Issue

Fixes #7004.

@wvdvegte noticed that "Tree viewer doesn't show first category of discretized numeric variable", which is true, and also interestingly misleading. :) I assumed that it has something to do with the index 0 being falsy, while in fact the problem was that the label of the first value of categorized variable starts with a character `<`, and we output this as HTML.

##### Description of changes

Escape the label.

##### Includes
- [X] Code changes
- [ ] Tests
