### PR TITLE
Table: Add 'Clear Selection', disable 'Restore order' when order is original

### DIFF
--- a/Orange/widgets/data/owtable.py
+++ b/Orange/widgets/data/owtable.py
@@ -239,17 +239,20 @@ class OWTable(OWWidget):
                      callback=self._on_distribution_color_changed)
 
         box = gui.vBox(self.controlArea, "Selection")
-
+        self.clear_button = gui.button(
+            box, self, "Clear Selection", callback=self.clear_selection,
+            autoDefault=False, enabled=False)
         gui.checkBox(box, self, "select_rows", "Select full rows",
                      callback=self._on_select_rows_changed)
 
         gui.rubber(self.controlArea)
 
-        gui.button(self.buttonsArea, self, "Restore Original Order",
-                   callback=self.restore_order,
-                   tooltip="Show rows in the original order",
-                   autoDefault=False,
-                   attribute=Qt.WA_LayoutUsesWidgetRect)
+        self.restore_button = gui.button(
+            self.buttonsArea, self, "Restore Original Order",
+            callback=self.restore_order,
+            tooltip="Show rows in the original order",
+            autoDefault=False, enabled=False,
+            attribute=Qt.WA_LayoutUsesWidgetRect)
         gui.auto_send(self.buttonsArea, self, "auto_commit")
 
         view = DataTableView(sortingEnabled=True)
@@ -308,6 +311,8 @@ class OWTable(OWWidget):
         self.__have_new_subset = True
 
     def handleNewSignals(self):
+        self.restore_button.setEnabled(False)
+        self.clear_button.setEnabled(False)
         super().handleNewSignals()
         self.Warning.non_sortable_input.clear()
         self.Warning.missing_sort_columns.clear()
@@ -464,6 +469,7 @@ class OWTable(OWWidget):
         self._update_input_summary()
 
     def _on_sort_indicator_changed(self, index: int, order: Qt.SortOrder) -> None:
+        self.restore_button.setEnabled(index != -1)
         if index == -1:
             self.stored_sort = []
         elif self.input is not None:
@@ -509,7 +515,7 @@ class OWTable(OWWidget):
         assert self.input is not None
         sort = self.__pending_sort
         self.__pending_sort = None
-        if sort is None:
+        if not sort:
             return  # pragma: no cover
         if not self.view.isSortingEnabled() and sort:
             self.Warning.non_sortable_input()
@@ -525,6 +531,7 @@ class OWTable(OWWidget):
             else:
                 missing_columns.append(self.__decode_column_id(colid))
         self.set_sort_columns(sort_)
+        self.restore_button.setEnabled(True)
         if missing_columns:
             self.Warning.missing_sort_columns(", ".join(missing_columns))
 
@@ -554,6 +561,10 @@ class OWTable(OWWidget):
         return [self.__encode_column_id(c) for c in self.input.model.columns]
 
     def update_selection(self, *_):
+        # Calling get_selection is expensive, so we consult selectionModel directly
+        sel_model = self.view.selectionModel()
+        selection = sel_model.selection()
+        self.clear_button.setEnabled(not selection.isEmpty())
         self.commit.deferred()
 
     def set_selection(self, rows: Sequence[int], columns: Sequence[int]) -> None:
@@ -569,6 +580,9 @@ class OWTable(OWWidget):
         Return the selected row and column indices of the selection in view.
         """
         return self.view.blockSelection()
+
+    def clear_selection(self):
+        self.set_selection([], [])
 
     @gui.deferred
     def commit(self):

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -52,6 +52,16 @@ class TestOWTable(WidgetTest, WidgetOutputsTestMixin):
         self.assertListEqual([], self.widget.stored_selection["columns"])
         self.assertListEqual([], self.widget.stored_selection["rows"])
 
+    def test_clear_selection(self):
+        self.send_signal(self.widget.Inputs.data, self.data)
+        self.assertFalse(self.widget.clear_button.isEnabled())
+        self._select_data()
+        self.assertTrue(self.widget.clear_button.isEnabled())
+        self.widget.clear_button.click()
+        self.assertListEqual([], self.widget.stored_selection["columns"])
+        self.assertListEqual([], self.widget.stored_selection["rows"])
+        self.assertFalse(self.widget.clear_button.isEnabled())
+
     def _select_data(self):
         self.widget.set_selection(
             list(range(0, len(self.data), 10)),
@@ -98,7 +108,9 @@ class TestOWTable(WidgetTest, WidgetOutputsTestMixin):
             "stored_sort": [("sepal length", 1), ("sepal width", -1)]
         })
         self.send_signal(widget.Inputs.data, None)
+        self.assertFalse(widget.restore_button.isEnabled())
         self.send_signal(widget.Inputs.data, self.data)
+        self.assertTrue(widget.restore_button.isEnabled())
         self.assertEqual(widget.view.horizontalHeader().sortIndicatorOrder(),
                          Qt.DescendingOrder)
         self.assertEqual(widget.view.horizontalHeader().sortIndicatorSection(), 2)
@@ -132,8 +144,10 @@ class TestOWTable(WidgetTest, WidgetOutputsTestMixin):
         output = self.get_output(self.widget.Outputs.selected_data)
         output = output.get_column(0)
         output_original = output.tolist()
+        self.assertFalse(self.widget.restore_button.isEnabled())
 
         self.widget.view.sortByColumn(1, Qt.AscendingOrder)
+        self.assertTrue(self.widget.restore_button.isEnabled())
         self.assertEqual(self.widget.stored_sort, [('sepal length', 1)])
         output = self.get_output(self.widget.Outputs.selected_data)
         output = output.get_column(0)
@@ -147,6 +161,7 @@ class TestOWTable(WidgetTest, WidgetOutputsTestMixin):
         self.assertTrue(sorted(output_sorted) == output_sorted)
 
         self.widget.restore_order()
+        self.assertFalse(self.widget.restore_button.isEnabled())
         output = self.get_output(self.widget.Outputs.selected_data)
         self.assertEqual(output.get_column(0).tolist(), output_original)
 

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -8212,6 +8212,7 @@ widgets/data/owtable.py:
             color_by_class: false
             Color by instance classes: Obarvaj primere glede na razred
             Selection: Izbor
+            Clear Selection: Počisti izbor
             select_rows: false
             Select full rows: Izbiraj cele vrstice
             Restore Original Order: Izvirni vrstni red


### PR DESCRIPTION
##### Issue

Closes #6969.

##### Description of changes

I think we agreed (in the core group meeting) that the title of the box stays Variables, because it is about variables. We also said that the behaviour of the output button is consistent with other widgets in Orange and that selection behaviour is consistent with common GUIs.

I thus fixed the second point, disabling of reorder button.

As a bonus, I added a button to clear selection (which is also disabled when there's no selection). We have enough space, but its placement doesn't look nice. Perhaps move it to next to "Restore Original Order"?

<img width="640" height="489" alt="Screenshot 2025-07-12 at 17 25 19" src="https://github.com/user-attachments/assets/82c67e26-3f71-4345-8279-f280e3ad2801" />

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
