### PR TITLE
Nomogram: Fix reporting, saving image, copying to clipboard

### DIFF
--- a/Orange/widgets/visualize/tests/test_ownomogram.py
+++ b/Orange/widgets/visualize/tests/test_ownomogram.py
@@ -350,6 +350,15 @@ class TestOWNomogram(WidgetTest):
         lr = LogisticRegressionLearner()(data)
         self.send_signal(self.widget.Inputs.classifier, lr)
 
+    def test_report_copy_save_graph(self):
+        # Test that reporting, copying to clipboard, and saving graph don't crash
+        self.send_signal(self.widget.Inputs.classifier, self.nb_cls)
+        self.widget.send_report()
+        self.widget.copy_to_clipboard()
+        with patch("orangewidget.utils.filedialogs.open_filename_dialog_save") as m:
+            m.return_value = (None, None, None)
+            self.widget.save_graph()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #7114.

##### Description of changes

If a scene has multiple views, `graph_name` should not specify a scene but a view.

In this case, we have tree views that need to be stitched together.
- Report now "reports" three (separate) scenes.
- Copying to clipboard and saving to an image file (which also didn't work) instead construct a new view that contains the entire scene save it. Reporting could do the same, but the resulting image in the report wouldn't be properly scaled (at list on my retina screen).
  
##### Includes
- [X] Code changes
- [X] Tests
