### PR TITLE
[FIX] Projections: When the number of colors equals the limit, do not introduce 'other'

### DIFF
--- a/Orange/widgets/visualize/tests/test_owprojectionwidget.py
+++ b/Orange/widgets/visualize/tests/test_owprojectionwidget.py
@@ -100,6 +100,11 @@ class TestOWProjectionWidget(WidgetTest):
         self.assertEqual(
             get_column(disc2, return_labels=True, max_categories=4),
             disc2.values)
+        np.testing.assert_almost_equal(
+            get_column(disc2, max_categories=3), y)
+        self.assertEqual(
+            get_column(disc2, return_labels=True, max_categories=3),
+            disc2.values)
 
         # Test that get_columns modify a copy of the data and not the data
         np.testing.assert_almost_equal(get_column(disc), x)

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -139,7 +139,7 @@ class OWProjectionWidgetBase(OWWidget, openclass=True):
 
         needs_merging = attr.is_discrete \
                         and max_categories is not None \
-                        and len(attr.values) >= max_categories
+                        and len(attr.values) > max_categories
         if return_labels and not needs_merging:
             assert attr.is_discrete
             return attr.values


### PR DESCRIPTION
##### Issue

Fixes #7089.

##### Description of changes

@wvdvegte, this was indeed the most snackish snack. If I haven't overlooked something, it only required changing `>=` to `>`. Plus adding a test, but changing a `4` into a `3` in the existing test would also suffice.

##### Includes
- [X] Code changes
- [X] Tests