### PR TITLE
[Fix] DBSCAN #7111, Change a way of checking eps.

### DIFF
--- a/Orange/widgets/unsupervised/owdbscan.py
+++ b/Orange/widgets/unsupervised/owdbscan.py
@@ -167,9 +167,9 @@ class OWDBSCAN(widget.OWWidget):
         self.cut_point = int(DEFAULT_CUT_POINT * len(self.k_distances))
         self.eps = self.k_distances[self.cut_point]
 
-        mask = self.k_distances >= EPS_BOTTOM_LIMIT
-        if self.eps < EPS_BOTTOM_LIMIT and sum(mask):
-            self.eps = np.min(self.k_distances[mask])
+        if self.eps < EPS_BOTTOM_LIMIT:
+            mask = self.k_distances >= EPS_BOTTOM_LIMIT
+            self.eps = sum(mask) and np.min(self.k_distances[mask]) or EPS_BOTTOM_LIMIT
             self.cut_point = self._find_nearest_dist(self.eps)
 
     @Inputs.data

--- a/Orange/widgets/unsupervised/tests/test_owdbscan.py
+++ b/Orange/widgets/unsupervised/tests/test_owdbscan.py
@@ -37,6 +37,21 @@ class TestOWDBSCAN(WidgetTest):
         self.assertEqual("Cluster", str(output.domain.metas[0]))
         self.assertEqual("DBSCAN Core", str(output.domain.metas[1]))
 
+        # one feature only
+        np_array = np.round(np.random.random((20, 1)), 0)
+        one_feature_table = Table.from_numpy(None, X=np_array)
+
+        self.send_signal(w.Inputs.data, one_feature_table)
+        output = self.get_output(w.Outputs.annotated_data)
+
+        self.assertIsNotNone(output)
+        self.assertEqual(len(one_feature_table), len(output))
+        self.assertTupleEqual(one_feature_table.X.shape, output.X.shape)
+        self.assertEqual(2, output.metas.shape[1])
+        self.assertEqual("Cluster", str(output.domain.metas[0]))
+        self.assertEqual("DBSCAN Core", str(output.domain.metas[1]))
+
+
     def test_unique_domain(self):
         w = self.widget
         data = possible_duplicate_table("Cluster")


### PR DESCRIPTION
[Q] Why not skip second checks by using elseif in line 180?

##### Issue
Fixes #7111

##### Description of changes
Change a way of checking epsilon after assign it from `k_distances` at default cut point.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
