### PR TITLE
SharedComputeValue: Allow inheriting __eq__ and __hash__

### DIFF
--- a/Orange/data/util.py
+++ b/Orange/data/util.py
@@ -77,7 +77,8 @@ class SharedComputeValue:
         if compute_shared is not None \
                 and not isinstance(compute_shared, (types.BuiltinFunctionType,
                                                    types.FunctionType)) \
-                and not redefines_eq_and_hash(compute_shared):
+                and not redefines_eq_and_hash(compute_shared) \
+                and not type(compute_shared).__dict__.get("InheritEq", False):
             warnings.warn(f"{type(compute_shared).__name__} should define "
                           f"__eq__ and __hash__ to be used for compute_shared",
                           stacklevel=2)

--- a/Orange/tests/test_data_util.py
+++ b/Orange/tests/test_data_util.py
@@ -145,3 +145,20 @@ class TestSharedComputeValue(unittest.TestCase):
 
         self.assertNotEqual(c1, e)
         self.assertNotEqual(hash(c1), hash(e))
+
+    def test_eq_hash_inheritance(self):
+        class NoFlag:
+            pass
+
+        class WithFlag:
+            InheritEq = True
+
+        x = Orange.data.ContinuousVariable("x")
+        self.assertWarnsRegex(
+            UserWarning, ".*define __eq__ and __hash__.*",
+            SharedComputeValue, NoFlag(), x)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            SharedComputeValue(WithFlag(), x)
+            self.assertEqual(len(w), 0)

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1546,6 +1546,7 @@ data/util.py:
         dim must be greater than max(values): false
     class `SharedComputeValue`:
         def `__init__`:
+            InheritEq: false
             '{type(compute_shared).__name__} should define ': false
             __eq__ and __hash__ to be used for compute_shared: false
     def `get_unique_names`:


### PR DESCRIPTION
##### Issue

`SharedComputeValue` doesn't allow inheriting (or, rather, disabling the warning about inheriting) `__eq__` and `__hash__` in classes that compute values.

##### Description of changes

I added a check for the flag.

##### Includes
- [X] Code changes
- [X] Tests