### PR TITLE
requirements-pyqt.txt: use PyQt6

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ conda install orange3-<addon name>
 
 We recommend using our [standalone installer](https://orange.biolab.si/download) or conda, but Orange is also installable with pip. You will need a C/C++ compiler (on Windows we suggest using Microsoft Visual Studio Build Tools).
 Orange needs PyQt to run. Install either:
-- PyQt5 and PyQtWebEngine: `pip install -r requirements-pyqt.txt` 
-- PyQt6 and PyQt6-WebEngine: `pip install PyQt6 PyQt6-WebEngine`
+- PyQt6 and PyQt6-WebEngine: `pip install PyQt6 PyQt6-WebEngine` (suggested)
+- PyQt5 and PyQtWebEngine: `pip install PyQt5 PyQtWebEngine`
 
 ### Installing with winget (Windows only)
 
@@ -139,7 +139,7 @@ conda activate orange3
 
 git clone ssh://git@github.com/$MY_GITHUB_USERNAME/orange3
 
-# Install PyQT and PyQtWebEngine. You can also use PyQt6
+# Install PyQt. This will install PyQt6; you can also use PyQt5
 pip install -r orange3/requirements-pyqt.txt
 pip install -e orange3
 ```

--- a/requirements-pyqt.txt
+++ b/requirements-pyqt.txt
@@ -1,2 +1,6 @@
-PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
-PyQtWebEngine>=5.12
+PyQt6>=6.5
+PyQt6-WebEngine>=6.5
+
+# Alternatively, for PyQt5
+# PyQt5>=5.12,!=5.15.1  # 5.15.1 skipped because of QTBUG-87057 - affects select columns
+# PyQtWebEngine>=5.12


### PR DESCRIPTION
PyQt5, for example, does not work well with Wayland: biolab/orange3/issues/7168

requirements-pyqt.txt is referenced in README.md, this is why it may lead new users into something that is likely stale