### PR TITLE
German translation: Initial translation (draft)

### DIFF
--- a/i18n/de/msgs.jaml
+++ b/i18n/de/msgs.jaml
@@ -1,0 +1,5951 @@
+base.py:
+    class `Learner`:
+        def `__call__`:
+            Preprocessing...: Vorverarbeitung...
+            Fitting...: Anpassen...
+tree.py:
+    class `MappedDiscreteNode`:
+        def `_set_child_descriptions`:
+            (unreachable): (nicht erreichbar)
+            {} or {}: {} oder {}
+canvas/__main__.py:
+    def `check_for_updates`:
+        def `compare_versions`:
+            Orange Update Available: Orange-Update verfügbar
+            'Current version: <b>{}</b><br>': Aktuelle Version: <b>{}</b><br>
+            'Latest version: <b>{}</b>': Neueste Version: <b>{}</b>
+            Download: Herunterladen
+            Skip this Version: Diese Version überspringen
+canvas/config.py:
+    class `Config`:
+        Donate: "Spenden"
+        FAQ: "FAQ"
+canvas/mainwindow.py:
+    class `OUserSettingsDialog`:
+        def `__init__`:
+            Automatically check for updates: Automatisch nach Updates suchen
+            Updates: Updates
+            Reporting: Berichterstattung
+            Settings related to reporting: Einstellungen zur Berichterstattung
+            Machine ID:: Geräte-ID:
+            Share: Teilen
+            Share anonymous usage statistics to improve Orange: Anonyme Nutzungsstatistiken teilen, um Orange zu verbessern
+            Anonymous Statistics: Anonyme Statistiken
+            More info...: Mehr Informationen...
+            Notifications: Benachrichtigungen
+            Settings related to notifications: Einstellungen zu Benachrichtigungen
+            Enable notifications: Benachrichtigungen aktivieren
+            Pull and display a notification feed.: Benachrichtigungsfeed abrufen und anzeigen
+            On startup: Beim Start
+            Announcements: Ankündigungen
+            Show notifications about Biolab announcements.\n: Benachrichtigungen über Biolab-Ankündigungen anzeigen.\n
+            'This entails events and courses hosted by the developers of ': Dies betrifft Veranstaltungen und Kurse, die von den Entwicklern von
+            Orange.: Orange veranstaltet werden.
+            Blog posts: Blog-Beiträge
+            Show notifications about blog posts.\n: Benachrichtigungen über Blog-Beiträge anzeigen.\n
+            We'll only send you the highlights.: Wir zeigen nur die wichtigsten Beiträge an.
+            New features: Neue Funktionen
+            'Show notifications about new features in Orange when a new ': Benachrichtigungen über neue Funktionen in Orange anzeigen, wenn eine neue
+            version is downloaded and installed,\n: Version heruntergeladen und installiert wird,\n
+            should the new version entail notable updates.: sofern die neue Version wesentliche Änderungen enthält.
+            Show notifications about: Benachrichtigungen anzeigen über
+    class `MainWindow`:
+        def `open_canvas_settings`:
+            Preferences: Einstellungen
+classification/base_classification.py:
+    class `LearnerClassification`:
+        def `incompatibility_reason`:
+            Too many target variables.: Zu viele Zielvariablen.
+            Categorical class variable expected.: Kategoriale Klassenvariable erwartet.
+classification/calibration.py:
+    class `ThresholdClassifier`:
+        def `__init__`:
+            ThresholdClassifier requires a binary class: ThresholdClassifier erfordert eine binäre Klasse
+    class `ThresholdLearner`:
+        def `fit_storage`:
+            ThresholdLearner requires a binary class: ThresholdLearner erfordert eine binäre Klasse
+    class `CalibratedClassifier`:
+        def `__init__`:
+            CalibratedClassifier requires a discrete target: CalibratedClassifier erfordert ein diskretes Ziel
+classification/naive_bayes.py:
+    class `NaiveBayesLearner`:
+        def `fit_storage`:
+            'Only categorical variables are ': Nur kategoriale Variablen werden
+            supported.: unterstützt.
+            Data has no defined target values.: Die Daten enthalten keine definierten Zielwerte.
+classification/outlier_detection.py:
+    class `_OutlierModel`:
+        def `__call__`:
+            Predicting...: Vorhersage...
+    class `_OutlierLearner`:
+        def `_fit_model`:
+            Outlier: Ausreißer
+            Yes: Ja
+            No: Nein
+    class `OneClassSVMLearner`:
+        One class SVM: Ein-Klassen-SVM
+    class `LocalOutlierFactorLearner`:
+        Local Outlier Factor: Lokaler Ausreißerfaktor
+    class `IsolationForestLearner`:
+        Isolation Forest: Isolation Forest
+    class `EllipticEnvelopeLearner`:
+        Covariance Estimator: Kovarianzschätzer
+classification/random_forest.py:
+    class `RandomForestClassifier`:
+        def `trees`:
+            def `wrap`:
+                {} - tree {}: {} - Baum {}
+classification/rules.py:
+    class `Rule`:
+        def `__str__`:
+            ' AND ': ' UND '
+            TRUE: WAHR
+            'IF {} THEN {} ': 'WENN {} DANN {} '
+classification/scoringsheet.py:
+    class `ScoringSheetLearner`:
+        def `incompatibility_reason`:
+            Too many target variables.: Zu viele Zielvariablen.
+            Categorical class variable expected.: Kategoriale Klassenvariable erwartet.
+            Too many target variable values.: Zu viele Zielwertvariablen.
+        def `fit_storage`:
+            Class variable contains missing values.: Die Klassenvariable enthält fehlende Werte.
+        def `_optimize_decision_params_adjustment`:
+            The number of input features is too low for the current settings.: Die Anzahl der Eingabefeatures ist für die aktuellen Einstellungen zu gering.
+classification/simple_tree.py:
+    class `SimpleTreeModel`:
+        def `__init__`:
+            'Number of classes should be 1: {}': Die Anzahl der Klassen sollte 1 sein: {}
+            'Only Continuous and Discrete ': 'Nur kontinuierliche und diskrete '
+            variables are supported: Variablen werden unterstützt
+classification/softmax_regression.py:
+    class `SoftmaxRegressionLearner`:
+        def `fit`:
+            'Softmax regression does not support ': 'Softmax-Regression unterstützt keine '
+            multi-label classification: Mehrfachklassenklassifikation
+            unknown values: unbekannte Werte
+classification/tree.py:
+    class `TreeLearner`:
+        def `fit_storage`:
+            'Exhaustive binarization does not handle ': 'Exhaustive Binarisierung kann nicht umgehen mit '
+            attributes with more than {} values: Attributen mit mehr als {} Werten
+data/io.py:
+    class `CSVReader`:
+        Comma-separated values: Komma-getrennte Werte
+    class `TabReader`:
+        Tab-separated values: Tabulator-getrennte Werte
+    class `PickleReader`:
+        Pickled Orange data: Orange-Daten (gepickelt)
+        def `read`:
+            file does not contain a data table: Datei enthält keine Datentabelle
+    class `BasketReader`:
+        Basket file: Basket-Datei
+    class `_BaseExcelReader`:
+        def `read`:
+            "Couldn't load spreadsheet from ": 'Tabellenkalkulation konnte nicht geladen werden von '
+    class `ExcelReader`:
+        Microsoft Excel spreadsheet: Microsoft Excel-Tabellenkalkulation
+    class `XlsReader`:
+        Microsoft Excel 97-2004 spreadsheet: Microsoft Excel 97-2004-Tabellenkalkulation
+data/io_base.py:
+    class `FileFormatBase`:
+        def `locate`:
+            File "{}" was not found.: Datei "{}" wurde nicht gefunden.
+data/table.py:
+    class `Table`:
+        untitled: Unbenannt
+        def `concatenate`:
+            untitled: Unbenannt
+        def `transpose`:
+            Feature name: Merkmalsname
+data/variable.py:
+    class `TimeVariable`:
+        class `InvalidDateTimeFormatError`:
+            def `__init__`:
+                Invalid datetime format '{date_string}'. Only ISO 8601 supported.: Ungültiges Datums-/Zeitformat '{date_string}'. Nur ISO 8601 unterstützt.
+distance/base.py:
+    class `Distance`:
+        def `check_no_discrete`:
+            columns with discrete values are incommensurable: Spalten mit diskreten Werten sind nicht vergleichbar
+    class `DistanceModel`:
+        def `__call__`:
+            Two tables cannot be compared by columns: Zwei Tabellen können nicht spaltenweise verglichen werden
+distance/distance.py:
+    class `Euclidean`:
+        def `fit_cols`:
+            def `nowarn`:
+                some columns have no defined values: Einige Spalten haben keine definierten Werte
+            some columns are constant: Einige Spalten sind konstant
+    class `Manhattan`:
+        def `fit_cols`:
+            'some columns have zero absolute distance from median, ': 'Einige Spalten haben null absolute Differenz zum Median, '
+            or no values: oder keine Werte
+    class `Mahalanobis`:
+        def `fit`:
+            Covariance matrix is too large.: Kovarianzmatrix ist zu groß.
+            Computation of inverse covariance matrix failed.: Berechnung der inversen Kovarianzmatrix fehlgeschlagen.
+evaluation/scoring.py:
+    class `CA`:
+        CA: CA
+        Classification accuracy: Klassifikationsgenauigkeit
+    class `Precision`:
+        Prec: Präzision
+        Precision: Präzision
+    class `Recall`:
+        Recall: Trefferquote
+    class `F1`:
+        F1: F1
+    class `AUC`:
+        AUC: AUC
+        Area under ROC curve: Fläche unter der ROC-Kurve
+        def `calculate_weights`:
+            Class variable has less than two values: Die Klassenvariable hat weniger als zwei Werte
+        def `compute_score`:
+            Class variable has less than two values: Die Klassenvariable hat weniger als zwei Werte
+    class `LogLoss`:
+        LogLoss: LogLoss
+        Logistic loss: Logistischer Verlust
+        def `compute_score`:
+            auto: automatisch
+            '`LogLoss.compute_score`: eps parameter is unused. ': `LogLoss.compute_score`: eps-Parameter wird nicht verwendet.
+            It will always have value of `np.finfo(y_pred.dtype).eps`.: Er wird immer den Wert `np.finfo(y_pred.dtype).eps` haben.
+    class `Specificity`:
+        Spec: Spezifität
+        Specificity: Spezifität
+        def `compute_score`:
+            'Binary averaging needs two classes in data: ': 'Für binäres Mittelwertbild werden zwei Klassen in den Daten benötigt: '
+            'specify target class or use ': 'geben Sie die Zielklasse an oder verwenden Sie '
+            weighted averaging.: gewichtetes Mittelwertbild.
+    class `MatthewsCorrCoefficient`:
+        MCC: MCC
+        Matthews correlation coefficient: Matthews Korrelationskoeffizient
+    class `MSE`:
+        MSE: MSE
+        Mean square error: Mittlerer quadratischer Fehler
+    class `RMSE`:
+        RMSE: RMSE
+        Root mean square error: Quadratwurzel des mittleren quadratischen Fehlers
+    class `MAE`:
+        MAE: MAE
+        Mean absolute error: Mittlerer absoluter Fehler
+    class `MAPE`:
+        MAPE: MAPE
+        Mean absolute percentage error: Mittlerer absoluter prozentualer Fehler
+    class `R2`:
+        R2: R2
+        Coefficient of determination: Bestimmtheitsmaß
+    class `CVRMSE`:
+        CVRMSE: CVRMSE
+        Coefficient of variation of the RMSE: Variationskoeffizient des RMSE
+        def `compute_score`:
+            Mean value is too small: Mittelwert ist zu klein
+evaluation/testing.py:
+    class `Validation`:
+        def `_collect_part_results`:
+            Multiple targets are not supported.: Mehrere Zielvariablen werden nicht unterstützt
+misc/_distmatrix_xlsx.py:
+    def `_get_sheet`:
+        'No such sheet: {sheet_name}': Kein solches Tabellenblatt: {sheet_name}
+    def `_non_empty_cells`:
+        def `raise_empty`:
+            empty sheet: leeres Tabellenblatt
+    def `_matrix_from_cells`:
+        'invalid data in cell ': 'Ungültige Daten in Zelle '
+misc/distmatrix.py:
+    class `DistMatrix`:
+        def `_from_dst`:
+            empty file: leere Datei
+            distance file must begin with dimension: Distanzdatei muss mit Dimension beginnen
+            'mismatching number of column labels, ': 'Unterschiedliche Anzahl an Spaltenbeschriftungen, '
+            too many rows: zu viele Zeilen
+            'too many columns in matrix row ': 'Zu viele Spalten in Matrixzeile '
+            'invalid element at ': 'Ungültiges Element bei '
+            'row {num_or_lab(i, row_labels)}, ': 'Zeile {num_or_lab(i, row_labels)}, '
+            column {num_or_lab(j, col_labels)}: Spalte {num_or_lab(j, col_labels)}
+modelling/catgb.py:
+    class `CatGBLearner`:
+        Gradient Boosting (catboost): Gradient Boosting (CatBoost)
+modelling/column.py:
+    class `ColumnLearner`:
+        def `__init__`:
+            column '{column.name}': "Spalte '{column.name}'"
+    class `ColumnModel`:
+        def `__init__`:
+            column '{column.name}'{pars}: "Spalte '{column.name}'{pars}"
+modelling/gb.py:
+    class `GBLearner`:
+        Gradient Boosting (scikit-learn): Gradient Boosting (scikit-learn)
+modelling/randomforest.py:
+    class `RandomForestLearner`:
+        def `fitted_parameters`:
+            Number of trees: Anzahl der Bäume
+modelling/tree.py:
+    class `SklTreeLearner`:
+        tree: Baum
+    class `TreeLearner`:
+        tree: Baum
+modelling/xgb.py:
+    class `XGBLearner`:
+        Extreme Gradient Boosting (xgboost): Extreme Gradient Boosting (xgboost)
+    class `XGBRFLearner`:
+        Extreme Gradient Boosting Random Forest (xgboost): Extreme Gradient Boosting Random Forest (xgboost)
+preprocess/discretize.py:
+    class `Discretizer`:
+        def `_fmt_interval`:
+            < {highs}: < {highs}
+            ≥ {lows}: ≥ {lows}
+            {lows} - {highs}: {lows} - {highs}
+        def `_get_discretized_values`:
+            single_value: Einzelwert
+    def `_time_binnings`:
+        second: Sekunde
+        minute: Minute
+        hour: Stunde
+        day: Tag
+        week: Woche
+        month: Monat
+        year: Jahr
+        {step // 7} week{'s' * (step > 7)}: {step // 7} Woche{'n' * (step > 7)}
+        {step} {unit}{'s' * (step > 1)}: {step} {unit}{'n' * (step > 1)}
+    def `_simplified_labels`:
+        :: ::
+    sec: Sek
+    min: Min
+    hrs: Std
+    wks: Wo
+    mon: Mon
+    yrs: J
+preprocess/impute.py:
+    class `BaseImputeMethod`:
+        {var.name} -> {self.short_name}: {var.name} -> {self.short_name}
+    class `DoNotImpute`:
+        Don't impute: Nicht imputieren
+        leave: belassen
+    class `DropInstances`:
+        Remove instances with unknown values: Instanzen mit unbekannten Werten entfernen
+        drop: löschen
+    class `Average`:
+        Average/Most frequent: Mittelwert / Häufigster Wert
+        average: Durchschnitt
+        Replace with average/mode of the column: Mit Mittelwert/Modus der Spalte ersetzen
+        def `__call__`:
+            Variable must be numeric or categorical.: Variable muss numerisch oder kategorial sein
+    class `Default`:
+        Fixed value: Fester Wert
+        {var} -> {self.default}: {var} -> {self.default}
+    class `FixedValueByType`:
+        Fixed value: Fester Wert
+        Fixed Value: Fester Wert
+    class `Model`:
+        Model-based imputer: Modellbasierter Imputer
+        model: Modell
+        ' ({self.learner.name})': ' ({self.learner.name})'
+        def `name`:
+            {} ({}): {} ({})
+        def `__call__`:
+            `{}` doesn't support domain type: `{}` unterstützt diesen Domänentyp nicht
+    class `AsValue`:
+        As a distinct value: Als eigener Wert
+        new value: Neuer Wert
+        def `__call__`:
+            {var.name}: {var.name}
+            N/A: Nicht verfügbar
+            {var.name}_def: {var.name}_def
+            undef: undefiniert
+            def: definiert
+    class `ReplaceUnknownsRandom`:
+        def `__init__`:
+            'Only categorical and numeric ': 'Nur kategoriale und numerische '
+            variables are supported.: Variablen werden unterstützt
+    class `Random`:
+        Random values: Zufällige Werte
+        random: zufällig
+        Replace with a random value: Mit einem zufälligen Wert ersetzen
+preprocess/score.py:
+    class `Scorer`:
+        def `_friendly_vartype_name`:
+            categorical: Kategorial
+            numeric: Numerisch
+        def `__call__`:
+            {} requires data with a target variable.: {} benötigt Daten mit einer Zielvariablen
+            {} requires a {} target variable.: {} benötigt eine {} Zielvariable
+            {} cannot score {} variables.: {} kann {} Variablen nicht auswerten
+projection/base.py:
+    class `Projector`:
+        def `__call__`:
+            Preprocessing...: Vorverarbeitung...
+            Fitting...: Anpassung...
+projection/manifold.py:
+    class `MDS`:
+        MDS: MDS
+    class `Isomap`:
+        Isomap: Isomap
+    class `LocallyLinearEmbedding`:
+        Locally Linear Embedding: Lokal lineare Einbettung
+    class `SpectralEmbedding`:
+        Spectral Embedding: Spektrale Einbettung
+    class `TSNE`:
+        t-SNE: t-SNE
+        def `convert_embedding_to_model`:
+            t-SNE-{p}: t-SNE-{p}
+projection/radviz.py:
+    class `RadViz`:
+        def `__call__`:
+            Can not handle categorical variables: Kategoriale Variablen können nicht verarbeitet werden
+            ' with more than two values': ' mit mehr als zwei Werten'
+regression/base_regression.py:
+    class `LearnerRegression`:
+        def `incompatibility_reason`:
+            Too many target variables.: Zu viele Zielvariablen
+            Numeric target variable expected.: Numerische Zielvariable erwartet
+regression/pls.py:
+    class `PLSModel`:
+        def `components`:
+            components: Komponenten
+            Component {i + 1}: Komponente {i + 1}
+        def `coefficients_table`:
+            coef {i}: Koeffizient {i}
+            name: Name
+            coefficients: Koeffizienten
+        def `residuals_normal_probability`:
+            {name} ({var.name}): {name} ({var.name})
+            Sample Quantiles: Stichprobenquantile
+            Theoretical Quantiles: Theoretische Quantile
+            residuals normal probability: Normalwahrscheinlichkeit der Residuen
+    class `PLSRegressionLearner`:
+        def `incompatibility_reason`:
+            Numeric targets expected.: Numerische Zielvariablen erwartet
+            Only numeric target variables expected.: Es werden nur numerische Zielvariablen unterstützt
+        def `fitted_parameters`:
+            Components: Komponenten
+regression/random_forest.py:
+    class `RandomForestRegressor`:
+        def `trees`:
+            def `wrap`:
+                {} - tree {}: {} - Baum {}
+regression/tree.py:
+    class `TreeLearner`:
+        def `fit_storage`:
+            'Exhaustive binarization does not handle ': 'Exhaustive Binarisierung unterstützt nicht '
+            attributes with more than {} values: Attribute mit mehr als {} Werten
+widgets/__init__.py:
+    def `widget_discovery`:
+        Transform: Transformieren
+        Orange Obsolete: Orange veraltet
+widgets/data/__init__.py:
+    Data: Daten
+    Data manipulation: Datenbearbeitung
+widgets/data/owaggregatecolumns.py:
+    class `OWAggregateColumns`:
+        Aggregate Columns: Spalten aggregieren
+        Compute a sum, max, min ... of selected columns.: Summe, Maximum, Minimum ... ausgewählter Spalten berechnen
+        Transform: Transformieren
+        aggregate columns, aggregate, sum, product, max, min, mean, median, variance: aggregate columns, aggregate, sum, product, max, min, mean, median, variance, Spalten aggregieren, Aggregation, Summe, Produkt, Maximum, Minimum, Mittelwert, Median, Varianz
+        class `Inputs`:
+            Data: Daten
+            Features: Merkmale
+        class `Outputs`:
+            Data: Daten
+        class `Warning`:
+            Some input features are categorical:\n{}: Einige Eingabemerkmale sind kategorial:\n{}
+            Some input features are missing:\n{}: Einige Eingabemerkmale fehlen:\n{}
+        Sum: Summe
+        Product: Produkt
+        Minimal value: Minimalwert
+        Maximal value: Maximalwert
+        Mean value: Mittelwert
+        Variance: Varianz
+        Median: Median
+        def `__init__`:
+            Variable selection: Variablenauswahl
+            All: Alle
+            All, including meta attributes: Alle, einschließlich Metaattribute
+            Features from separate input signal: Merkmale aus separatem Eingangssignal
+            Selected variables: Ausgewählte Variablen
+            Operation: Operation
+            'Output variable name: ': 'Name der Ausgabewariable: '
+        def `send_report`:
+            Output:: Ausgabe:
+            "'{self._new_var_name()}' as {self.operation.lower()} of {var_list}": "'{self._new_var_name()}' als {self.operation.lower()} von {var_list}"
+        def `_and_others`:
+            "'{variables[0].name}'": "'{variables[0].name}'"
+            ', ': ', '
+            ' and {len(variables) - limit} more': ' und {len(variables) - limit} weitere'
+            " and '{variables[-1].name}'": " und '{variables[-1].name}'"
+widgets/data/owcolor.py:
+    class `DiscAttrDesc`:
+        def `from_dict`:
+            renaming of values ignored due to duplicate names: Umbenennung von Werten wegen doppelter Namen ignoriert
+    class `ContColorTableModel`:
+        def `data`:
+            def `_column2`:
+                Copy to all: Auf alle kopieren
+    class `OWColor`:
+        Color: Farbe
+        Set color legend for variables.: Farblegende für Variablen setzen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        def `__init__`:
+            Discrete Variables: Diskrete Variablen
+            Numeric Variables: Numerische Variablen
+            Save: Speichern
+            Load: Laden
+            Reset: Zurücksetzen
+        def `save`:
+            File name: Dateiname
+            Variable definitions (*.colors): Variablendefinitionen (*.colors)
+        def `load`:
+            File name: Dateiname
+            Variable definitions (*.colors): Variablendefinitionen (*.colors)
+            File error: Dateifehler
+            File cannot be opened.: Datei kann nicht geöffnet werden
+            Invalid file format.: Ungültiges Dateiformat
+        def `_parse_var_defs`:
+            Duplicated variable names: Doppelte Variablennamen
+            Variables will not be renamed due to duplicated names.: Variablen werden wegen doppelter Namen nicht umbenannt
+            'Definition for variable {names[0]}, which does not ': 'Definition für Variable {names[0]}, die nicht '
+            appear in the data, was ignored.\n: in den Daten vorkommt, wurde ignoriert.\n'
+            'Definitions for variables ': 'Definitionen für Variablen '
+            {", ".join(names[:-1])} and {names[-1]}: {", ".join(names[:-1])} und {names[-1]}
+            'Definitions for {", ".join(names[:4])} ': 'Definitionen für {", ".join(names[:4])} '
+            and {len(names) - 4} other variables: und {len(names) - 4} weitere Variablen
+            , which do not appear in the data, were ignored.\n: , die nicht in den Daten vorkommen, wurden ignoriert.\n'
+            Invalid definitions: Ungültige Definitionen
+        def `send_report`:
+            def `_report_variables`:
+                def `was`:
+                    '{n} (was: {o})': {n} (war: {o})
+            Features: Merkmale
+            {pl(len(dom.class_vars), "Outcome")}: {plde(len(dom.class_vars), "Ergebnis|Ergebnisse")}
+            Meta attributes: Metaattribute
+widgets/data/owconcatenate.py:
+    class `OWConcatenate`:
+        Concatenate: Zusammenfügen
+        Concatenate (append) two or more datasets.: Zwei oder mehr Datensätze zusammenfügen (anhängen)
+        Transform: Transformieren
+        concatenate, append, join, extend: concatenate, append, join, extend, zusammenfügen, anhängen, verbinden, erweitern
+        class `Inputs`:
+            Primary Data: Primäre Daten
+            Additional Data: Zusätzliche Daten
+        class `Outputs`:
+            Data: Daten
+        class `Error`:
+            Inputs must be of the same type.: Eingaben müssen denselben Typ haben
+            Ignoring column names requires matching column types: Ignorieren von Spaltennamen erfordert gleiche Spaltentypen
+        class `Warning`:
+            Variables with duplicated names have been renamed.: Variablen mit doppelten Namen wurden umbenannt
+            'Some variables may not be concatenated correctly due ': 'Einige Variablen konnten möglicherweise nicht korrekt zusammengefügt werden, da '
+            to attributes difference ({}).: Unterschiede bei den Attributen bestehen ({}).
+        Source ID: Quellen-ID
+        all variables that appear in input tables: Alle Variablen, die in den Eingangstabellen vorkommen
+        only variables that appear in all tables: Nur Variablen, die in allen Tabellen vorkommen
+        Class attribute: Klassenattribut
+        Attribute: Attribut
+        Meta attribute: Metaattribut
+        def `__init__`:
+            Variable Sets Merging: Zusammenführen von Variablensets
+            'When there is no primary table, ': 'Wenn keine Primärtabelle vorhanden ist, '
+            the output should contain: sollte die Ausgabe enthalten
+            merge_type: Zusammenführungsart
+            'The resulting table will have a class only if there ': 'Die resultierende Tabelle erhält eine Klasse nur, wenn '
+            is no conflict between input classes.: kein Konflikt zwischen den Eingangsklassen besteht
+            Variable matching: Variablenabgleich
+            Use column names from the primary table,\n: Spaltennamen aus der Primärtabelle verwenden,\n
+            and ignore names in other tables.: und Namen in anderen Tabellen ignorieren
+            Treat variables with the same name as the same variable,\n: Variablen mit demselben Namen als dieselbe Variable behandeln,\n
+            even if they are computed using different formulae.: selbst wenn sie mit unterschiedlichen Formeln berechnet wurden
+            Source Identification: Quellenidentifikation
+            Append data source IDs: Datenquellen-IDs anhängen
+            Feature name:: Merkmalname:
+            Place:: Platz:
+        def `commit`:
+            {} ({}): {} ({})
+        def `send_report`:
+            Domain: Domäne
+            from primary data: Aus primären Daten
+            Source data ID: Quellen-Daten-ID
+            {} (as {}): {} (als {})
+widgets/data/owcontinuize.py:
+    Use preset: Vorgabe verwenden
+    preset: Vorgabe
+    Treat the variable as defined in preset: Variable gemäß Vorgabe behandeln
+    Keep categorical: Kategorial beibehalten
+    keep as is: Belassen
+    Keep the variable discrete: Variable diskret belassen
+    First value as base: Erster Wert als Basis
+    first as base: Erster als Basis
+    One indicator variable for each value except the first: Eine Indikatorvariable für jeden Wert außer dem ersten
+    Most frequent as base: Häufigster Wert als Basis
+    frequent as base: Häufigster als Basis
+    One indicator variable for each value except the most frequent: Eine Indikatorvariable für jeden Wert außer dem häufigsten
+    One-hot encoding: One-Hot-Kodierung
+    one-hot: One-Hot
+    One indicator variable for each value: Eine Indikatorvariable für jeden Wert
+    Remove if more than 2 values: Entfernen, wenn mehr als 2 Werte
+    remove if >2: Entfernen, falls >2
+    Remove variables with more than two values; indicator otherwise: Variablen mit mehr als zwei Werten entfernen; sonst Indikator
+    Remove: Entfernen
+    remove: Entfernen
+    Remove variable: Variable entfernen
+    Treat as ordinal: Als ordinal behandeln
+    as ordinal: Als ordinal
+    Each value gets a consecutive number from 0 to number of values - 1: Jeder Wert erhält eine fortlaufende Nummer von 0 bis Anzahl der Werte - 1
+    Treat as normalized ordinal: Als normalisiertes Ordinal behandeln
+    as norm. ordinal: Als norm. Ordinal
+    Same as above, but scaled to [0, 1]: Wie oben, jedoch skaliert auf [0, 1]
+    Treat the variable as defined in 'default setting': Variable gemäß „Standard-Einstellung“ behandeln
+    Keep as it is: Belassen
+    no change: Keine Änderung
+    Keep the variable as it is: Variable unverändert belassen
+    Standardize to μ=0, σ²=1: Standardisieren auf μ=0, σ²=1
+    standardize: Standardisieren
+    Subtract the mean and divide by standard deviation: Mittelwert subtrahieren und durch Standardabweichung teilen
+    Center to μ=0: Auf μ=0 zentrieren
+    center: Zentrieren
+    Subtract the mean: Mittelwert subtrahieren
+    Scale to σ²=1: Auf σ²=1 skalieren
+    scale: Skalieren
+    Divide by standard deviation: Durch Standardabweichung teilen
+    Normalize to interval [-1, 1]: Auf Intervall [-1, 1] normalisieren
+    to [-1, 1]: Auf [-1, 1]
+    Linear transformation into interval [-1, 1]: Lineare Transformation ins Intervall [-1, 1]
+    Normalize to interval [0, 1]: Auf Intervall [0, 1] normalisieren
+    to [0, 1]: Auf [0, 1]
+    Linear transformation into interval [0, 1]: Lineare Transformation ins Intervall [0, 1]
+    class `ContDomainModel`:
+        def `__init__`:
+            Meta attributes: Metaattribute
+            Targets: Zielvariablen
+    class `DefaultContModel`:
+        def `data`:
+            'Preset: {self.method}': Vorgabe: {self.method}
+            Default for variables without specific settings: Standard für Variablen ohne spezifische Einstellungen
+    class `OWContinuize`:
+        Continuize: Numerisch machen
+        'Transform categorical attributes into numeric and, ': 'Kategoriale Attribute in numerische Attribute umwandeln und '
+        optionally, scale numeric values.: optional numerische Werte skalieren
+        Transform: Transformieren
+        continuize, encode, dummy, numeric, one-hot, binary, treatment, contrast: continuize, encode, dummy, numeric, one-hot, binary, treatment, contrast, numerisch machen, kodieren, Dummy, numerisch, One-Hot, binär, Treatment, Kontrast
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        class `Error`:
+            'Some chosen methods do not support sparse data: {}': Einige gewählte Methoden unterstützen keine spärlichen Daten: {}
+        def `__init__`:
+            Categorical Variables: Kategoriale Variablen
+            Numeric Variables: Numerische Variablen
+            Reset All: Alles zurücksetzen
+        def `send_report`:
+            Categorical variables: Kategoriale Variablen
+            Numeric variables: Numerische Variablen
+            Preset: Vorgabe
+            Unlisted: Nicht aufgelistet
+            'Any unlisted attributes default to preset option, and ': 'Nicht aufgelistete Attribute werden auf die Vorgabe gesetzt, und '
+            'unlisted meta attributes and target variables are kept ': 'nicht aufgelistete Metaattribute und Zielvariablen werden '
+            as they are: unverändert belassen
+widgets/data/owcorrelations.py:
+    class `CorrelationType`:
+        def `items`:
+            Pearson correlation: Pearson-Korrelation
+            Spearman correlation: Spearman-Korrelation
+    class `CorrelationRank`:
+        def `row_for_state`:
+            :: ::
+            N/A: k.A
+    class `OWCorrelations`:
+        Correlations: Korrelationen
+        Compute all pairwise attribute correlations.: Alle paarweisen Attributkorrelationen berechnen
+        Unsupervised: Unüberwacht
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+            Features: Merkmale
+            Correlations: Korrelationen
+        class `Information`:
+            Constant features have been removed.: Konstante Merkmale wurden entfernt
+        class `Error`:
+            At least two numeric features are needed.: Mindestens zwei numerische Merkmale erforderlich
+            At least two instances are needed.: Mindestens zwei Instanzen erforderlich
+        def `__init__`:
+            (All combinations): "(Alle Kombinationen)"
+            Impute missing values: "Fehlende Werte schätzen"
+            Replace missing values with means;\n: "Fehlende Werte durch Mittelwerte ersetzen;\n"
+            if disabled, rows with missing values for the corre: "Wenn deaktiviert, werden Zeilen mit fehlenden Werten für die entsprechenden "
+            sponding variables are ignored: "Variablen ignoriert"
+        def `commit`:
+            Correlation: Korrelation
+            uncorrected p: Unkorrigiertes p
+            FDR: FDR
+            Feature 1: Merkmal 1
+            Feature 2: Merkmal 2
+            Correlations: Korrelationen
+widgets/data/owcreateclass.py:
+    class `OWCreateClass`:
+        Create Class: Klasse erstellen
+        Create class attribute from a string attribute: Klassenattribut aus einem String-Attribut erstellen
+        Transform: Transformieren
+        create class: create class, Klasse erstellen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        class: Klasse
+        class `Warning`:
+            Data contains only numeric variables.: Die Daten enthalten nur numerische Variablen
+        class `Error`:
+            Class name duplicated.: Klassenname doppelt vergeben
+            Class name should not be empty.: Klassenname darf nicht leer sein
+            'Invalid regular expression: {}': "Ungültiger regulärer Ausdruck: {}"
+        def `__init__`:
+            New Class Name: Neuer Klassenname
+            Match by Substring: Nach Teilstring übereinstimmen
+            From column:: Aus Spalte:
+            Name: Name
+            Substring: Teilstring
+            Count: Anzahl
+            +: +
+            Options: Optionen
+            Use regular expressions: "Reguläre Ausdrücke verwenden"
+            Match only at the beginning: Nur am Anfang übereinstimmen
+            Case sensitive: Groß-/Kleinschreibung beachten
+            Apply: Anwenden
+        def `adjust_n_rule_rows`:
+            def `_add_line`:
+                ×: ×
+        def `class_labels`:
+            ^C\\d+: ^C\\d+
+            C{next(class_count)}: C{next(class_count)}
+        def `update_counts`:
+            def `_set_labels`:
+                {n_before} o: {n_before} o
+                "f {n_total} matching {pl(n_total, 'instance')} ": "f {n_total} passende {plde(n_total, 'Instanz|Instanzen')} "
+                {pl(n_before, 'is|are')} already covered above.: {plde(n_before, 'ist|sind')} bereits oben abgedeckt
+                All matching instances are already covered above: Alle passenden Instanzen sind bereits oben abgedeckt
+            def `_set_placeholders`:
+                (remaining instances): (verbleibende Instanzen)
+                (unused): (nicht verwendet)
+        def `send_report`:
+            def `_cond_part`:
+                if <b>{self.attribute.name}</b> contains <b>{patt}</b>: wenn <b>{self.attribute.name}</b> <b>{patt}</b> enthält
+                otherwise: sonst
+            def `_count_part`:
+                already covered above: Bereits oben abgedeckt
+                the single matching instance is {aca}: Die einzelne passende Instanz ist {aca}
+                both matching instances are {aca}: Beide passenden Instanzen sind {aca}
+                all {n_total} matching instances are {aca}: Alle {n_total} passenden Instanzen sind {aca}
+                {n_matched} {pl(n_matched, 'instance')}: {n_matched} {plde(n_matched, 'Instanz|Instanzen')}
+                {n_matched} matching {pl(n_matched, 'instance')}: {n_matched} passende {plde(n_matched, 'Instanz|Instanzen')}
+                " (+{n_already} that {pl(n_already, 'is|are')} {aca})": " (+{n_already}, die {plde(n_already, 'ist|sind')} {aca})"
+            Input: Eingabe
+            Source attribute: Quellattribut
+            Output: Ausgabe
+            Class name: Klassenname
+widgets/data/owcreateinstance.py:
+    class `TimeVariableEditor`:
+        yyyy-MM-dd: yyyy-MM-dd
+        hh:mm:ss: hh:mm:ss
+    class `OWCreateInstance`:
+        Create Instance: Instanz erstellen
+        Interactively create a data instance from sample dataset.: Interaktive Erstellung einer Dateninstanz aus dem Beispieldatensatz
+        Transform: Transformieren
+        create instance, simulator: create instance, simulator, Instanz erstellen, Simulator
+        class `Inputs`:
+            Data: Daten
+            Reference: Referenz
+        class `Outputs`:
+            Data: Daten
+        class `Information`:
+            'Variables with only missing values were ': 'Variablen mit nur fehlenden Werten wurden '
+            removed from the list.: aus der Liste entfernt
+        Median: Median
+        Mean: Mittelwert
+        Random: Zufällig
+        Input: Eingabe
+        Variable: Variable
+        Value: Wert
+        def `__init__`:
+            Filter...: Filter...
+            Append this instance to input data: Diese Instanz zu den Eingabedaten hinzufügen
+        def `_create_data_from_values`:
+            created: erstellt
+        def `_append_to_data`:
+            Source ID: Quellen-ID
+        def `send_report`:
+            Input: Eingabe
+            Output: Ausgabe
+            Values: Werte
+widgets/data/owcsvimport.py:
+    class `Options`:
+        def `__init__`:
+            .: .
+        def `from_dict`:
+            .: .
+    class `VarPathItem`:
+        def `data`:
+            ${{{vpath.name}}}/{vpath.relpath}: ${{{vpath.name}}}/{vpath.relpath}
+            ' (missing)': ' (fehlt)'
+    class `ImportItem`:
+        def `fromPath`:
+            ${{{path.name}}}/{path.relpath}: ${{{path.name}}}/{path.relpath}
+    Text - comma separated: Text – durch Komma getrennt
+    Text - tab separated: Text – durch Tab getrennt
+    Text - all files: Text – alle Dateien
+    class `FileDialog`:
+        def `filterStr`:
+            {f.name} ({', '.join(f.globs)}): {f.name} ({', '.join(f.globs)})
+    def `default_options_for_mime_type`:
+        iso8859-1: iso8859-1
+    class `OWCSVFileImport`:
+        CSV File Import: CSV-Datei importieren
+        Import a data table from a CSV formatted file.: Eine Datentabelle aus einer CSV-Datei importieren
+        Data: Daten
+        csv file import, file, load, read, open, csv: csv file import, file, load, read, open, csv, CSV-Import, Datei, laden, lesen, öffnen, CSV
+        class `Outputs`:
+            Data: Daten
+            Loaded data set.: Geladener Datensatz
+            Data Frame: Datenrahmen
+        class `Error`:
+            Unexpected error: Unerwarteter Fehler
+            Encoding error\n: Kodierungsfehler\n
+            'The file might be encoded in an unsupported encoding or it ': 'Die Datei könnte in einem nicht unterstützten Zeichensatz kodiert sein oder '
+            might be binary: könnte binär sein
+        def `__init__`:
+            File:: Datei:
+            recent-combo: Kürzlich
+            Recent files.: Kürzliche Dateien
+            Recent files…: Kürzliche Dateien…
+            …: …
+            Browse filesystem: Dateisystem durchsuchen
+            Import any file…: Beliebige Datei importieren…
+            Import relative to workflow file…: Relativ zur Workflow-Datei importieren…
+            Import a file within the workflow file directory: Datei im Workflow-Verzeichnis importieren
+            Info: Info
+            Load: Laden
+            Import Options…: Importoptionen…
+        def `_browse_dialog`:
+            Open Data File: Daten-Datei öffnen
+        def `_might_be_binary_mb`:
+            The '{basename}' may be a binary file.\n: Die Datei '{basename}' könnte binär sein.\n
+            Are you sure you want to continue?: Sind Sie sicher, dass Sie fortfahren möchten?
+        def `_path_must_be_relative_mb`:
+            Invalid path: Ungültiger Pfad
+            Selected path is not within '{prefix}': Ausgewählter Pfad liegt nicht innerhalb von '{prefix}'
+        def `browse`:
+            Import Options: Importoptionen
+        def `_activate_import_dialog_for_item`:
+            Import Options: Importoptionen
+        def `cancel`:
+            Cancelled: Abgebrochen
+            <div>Cancelled<br/><small>Press 'Reload' to try again</small></div>: <div>Abgebrochen<br/><small>Drücken Sie „Neu laden“, um es erneut zu versuchen</small></div>
+        def `__set_running_state`:
+            Running: Läuft
+            Restart: Neustart
+            '<div>Loading: <i>{}</i><br/>': <div>Lädt: <i>{}</i><br/>
+        def `__clear_running_state`:
+            Reload: Neu laden
+        def `__set_error_state`:
+            '<div><i>{basename}</i> was not loaded due to a text encoding ': '<div><i>{basename}</i> wurde aufgrund eines Textkodierungsfehlers nicht geladen '
+            'error. The file might be saved in an unknown or invalid ': 'Die Datei könnte in einem unbekannten oder ungültigen '
+            encoding, or it might be a binary file.</div>: Zeichensatz gespeichert sein oder binär sein.</div>'
+            <div><i>{basename}</i> was not loaded due to an error:: <div><i>{basename}</i> konnte aufgrund eines Fehlers nicht geladen werden:
+            "<p style='white-space: pre;'>{err}</p>": <p style='white-space: pre;'>{err}</p>
+        def `_update_status_messages`:
+            "{n_instances} {pl(n_instances, 'row')}, ": "{n_instances} {plde(n_instances, 'Zeile|Zeilen')}, "
+            "{n_features} {pl(n_features, 'feature')}, ": "{n_features} {plde(n_features, 'Merkmal|Merkmale')}, "
+            {n_meta} {pl(n_meta, 'meta')}: {n_meta} {plde(n_meta, 'Meta|Metadaten')}
+    def `_open`:
+        Expected a single file in the archive.: Es wurde eine einzelne Datei im Archiv erwartet
+    def `load_csv`:
+        .: .
+widgets/data/owdatainfo.py:
+    class `OWDataInfo`:
+        Data Info: Dateninfo
+        Display basic information about the data set: Grundlegende Informationen über den Datensatz anzeigen
+        Data: Daten
+        data info, information, inspect: data info, information, inspect, Dateninfo, Informationen, prüfen
+        class `Inputs`:
+            Data: Daten
+        def `__init__`:
+            Data table properties: Eigenschaften der Datentabelle
+            Additional attributes: Zusätzliche Attribute
+        def `data`:
+            Name: Name
+            Location: Ort
+            Size: Größe
+            Features: Merkmale
+            Targets: Zielvariablen
+            Metas: Metadaten
+            Missing data: Fehlende Daten
+            def `set_exact_length`:
+                Size: Größe
+        def `update_info`:
+            No data.: Keine Daten
+        def `send_report`:
+            Data table properties: Eigenschaften der Datentabelle
+            Additional attributes: Zusätzliche Attribute
+        def `_p_name`:
+            -: -
+        def `_p_location`:
+            SQL Table using connection:<br/>{connection_string}: SQL-Tabelle mit Verbindung:<br/>{connection_string}
+        def `_p_size`:
+            {n} {pl(n, 'row')}: {n} {plde(n, 'Zeile|Zeilen')}
+            ~{n} {pl(n, 'row')}: ~{n} {plde(n, 'Zeile|Zeilen')}
+            , {ncols} {pl(ncols, 'column')}: , {ncols} {plde(ncols, 'Spalte|Spalten')}
+            features: Merkmale
+            meta attributes: Metadaten
+            targets: Zielvariablen
+            ; sparse {', '.join(sparseness)}: ; spärlich {', '.join(sparseness)}
+        def `_p_targets`:
+            numeric target variable: numerische Zielvariable
+            'categorical outcome with ': kategoriales Ergebnis mit
+            {nclasses} {pl(nclasses, 'class|classes')}: {nclasses} {plde(nclasses, 'Klasse|Klassen')}
+            {disc_class} categorical {pl(disc_class, 'target')}: {disc_class} kategoriale {plde(disc_class, 'Ziel|Ziele')}
+            {cont_class} numeric {pl(cont_class, 'target')}: {cont_class} numerische {plde(cont_class, 'Ziel|Ziele')}
+            multi-target data,<br/>: Mehrziel-Daten,<br/>
+        def `_p_missing`:
+            (not checked for SQL data): (für SQL-Daten nicht geprüft)
+            feature: Merkmal
+            targets: Zielvariablen
+            meta variable: Metavariable
+            {n_miss} ({n_miss / np.prod(part.shape):.1%}) in {name}: {n_miss} ({n_miss / np.prod(part.shape):.1%}) in {name}
+            none: keine
+            ', ': ,
+        def `_pack_var_counts`:
+            categorical: kategorial
+            numeric: numerisch
+            text: Text
+            {count} {name}: {count} {name}
+widgets/data/owdatasampler.py:
+    class `OWDataSampler`:
+        Data Sampler: Daten-Sampler
+        'Randomly draw a subset of data points ': Zufällig eine Teilmenge von Datenpunkten ziehen
+        from the input dataset.: aus dem Eingabedatensatz
+        Transform: Transformieren
+        data sampler, random: data sampler, random, Daten-Sampler, zufällig
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data Sample: Datenprobe
+            Remaining Data: Verbleibende Daten
+        class `Information`:
+            Compatibility mode\n: Kompatibilitätsmodus\n
+            New versions of widget have swapped outputs for cross validation: Neue Versionen des Widgets haben die Ausgaben für Kreuzvalidierung vertauscht
+        class `Warning`:
+            Stratification failed.\n{}: Stratifikation fehlgeschlagen.\n{}
+            Sample is bigger than input.: Probe ist größer als die Eingabe
+        class `Error`:
+            Number of subsets exceeds data size.: Anzahl der Teilmengen überschreitet Datengröße
+            Sample can't be larger than data.: Probe darf nicht größer als die Daten sein
+            Data is too small to stratify.: Daten sind zu klein für Stratifikation
+            Dataset is empty.: Datensatz ist leer
+        def `__init__`:
+            Sampling Type: Stichprobentyp
+            Fixed proportion of data:: Fester Datenanteil:
+            %d %%: %d %%
+            Fixed sample size: Feste Stichprobengröße
+            'Instances: ': Instanzen:
+            Sample with replacement: Ziehen mit Zurücklegen
+            Cross validation: Kreuzvalidierung
+            Number of subsets:: Anzahl der Teilmengen:
+            Unused subset:: Unbenutzte Teilmenge:
+            Selected subset:: Ausgewählte Teilmenge:
+            Bootstrap: Bootstrap
+            Time:: Zeit:
+            ' sec': Sek
+            Percentage: Prozentsatz
+            Options: Optionen
+            Replicable (deterministic) sampling: Reproduzierbare (deterministische) Stichprobe
+            Stratify sample (when possible): Probe stratifizieren (wenn möglich)
+            Download data to local memory: Daten in den lokalen Speicher laden
+            Sample Data: Datenprobe
+        def `send_report`:
+            Random sample with {self.sampleSizePercentage} % of data: Zufällige Probe mit {self.sampleSizePercentage} % der Daten
+            Random data instance: Zufällige Dateninstanz
+            Random sample with {self.sampleSizeNumber} data instances: Zufällige Probe mit {self.sampleSizeNumber} Dateninstanzen
+            , with replacement: , mit Zurücklegen
+            '{self.number_of_folds}-fold cross-validation ': '{self.number_of_folds}-fache Kreuzvalidierung '
+            without subset #{self.selectedFold}: ohne Teilmenge #{self.selectedFold}
+            Bootstrap: Bootstrap
+            , stratified (if possible): , stratifiziert (wenn möglich)
+            , deterministic: , deterministisch
+            Sampling type: Stichprobentyp
+            Input: Eingabe
+            {len(self.data)} {pl(len(self.data), 'instance')}: {len(self.data)} {plde(len(self.data), 'Instanz|Instanzen')}
+            Sample: Probe
+            {self.sampled_instances} {pl(self.sampled_instances, 'instance')}: {self.sampled_instances} {plde(self.sampled_instances, 'Instanz|Instanzen')}
+            Remaining: Verbleibend
+            {self.remaining_instances} {pl(self.remaining_instances, 'instance')}: {self.remaining_instances} {plde(self.remaining_instances, 'Instanz|Instanzen')}
+widgets/data/owdatasets.py:
+    class `OWDataSets`:
+        Datasets: Datensätze
+        Load a dataset from an online repository: Einen Datensatz aus einem Online-Repository laden
+        datasets, online, data, sets: datasets, online, data, sets, Datensätze, online, Daten, Sets
+        English: Englisch
+        All Languages: Alle Sprachen
+        (General): (Allgemein)
+        (Show all): (Alle anzeigen)
+        Title: Titel
+        Size: Größe
+        Instances: Instanzen
+        Variables: Variablen
+        Target: Ziel
+        Tags: Tags
+        class `Error`:
+            Could not fetch dataset list: Konnte die Datensatzliste nicht abrufen
+        class `Warning`:
+            'Could not fetch datasets list, only local ': 'Konnte die Datensatzliste nicht abrufen, nur lokal '
+            cached datasets are shown: zwischengespeicherte Datensätze werden angezeigt
+        class `Outputs`:
+            Data: Daten
+        def `__init__`:
+            Search for data set ...: Nach Datensatz suchen ...
+            Typing four letters or more overrides domain and language filters: Vier oder mehr Buchstaben überschreiben Domain- und Sprachfilter
+            'Show data sets in ': 'Datensätze anzeigen in '
+            Domain:: Domain:
+            Press Return or double-click to send: Return drücken oder doppelklicken, um zu senden
+            Description: Beschreibung
+            Initializing: Initialisiere
+        def `set_model`:
+            '888 bytes ': 888 Bytes
+        def `commit`:
+            Fetching...: Abrufen...
+        def `__commit_complete`:
+            Error:: Fehler:
+    def `description_html`:
+        ' ({datainfo.year})': ' ({datainfo.year})'
+        , from {datainfo.source}: , von {datainfo.source}
+        <b>{escape(datainfo.title)}</b>{year}{source}: <b>{escape(datainfo.title)}</b>{year}{source}
+        <p>{datainfo.description}</p>: <p>{datainfo.description}</p>
+        <small><b>See Also</b>\n: <small><b>Siehe auch</b>\n
+        </small>: </small>
+        <small><b>References</b>\n: <small><b>Referenzen</b>\n
+        \n: \n
+widgets/data/owdiscretize.py:
+    \s*,\s*: \s*,\s*
+    year: Jahr
+    month: Monat
+    day: Tag
+    week: Woche
+    hour: Stunde
+    minute: Minute
+    second: Sekunde
+    invalid width: Ungültige Breite
+    too many intervals: Zu viele Intervalle
+    def `_fixed_width_discretization`:
+        .: .
+    def `_mdl_discretization`:
+        no discrete class: Keine diskrete Klasse
+    def `_custom_discretization`:
+        invalid cuts: Ungültige Schnittpunkte
+    Use default setting: Standard verwenden
+    default: Standard
+    Treat the variable as defined in 'default setting': Variable wie in „Standard“ behandeln
+    Keep numeric: Numerisch belassen
+    keep: Belassen
+    Keep the variable as is: Variable unverändert belassen
+    Entropy vs. MDL: Entropie vs. MDL
+    entropy: Entropie
+    Split values until MDL exceeds the entropy (Fayyad-Irani)\n: Werte teilen, bis MDL die Entropie übersteigt (Fayyad-Irani)\n
+    (requires discrete class variable): (erfordert diskrete Klassenvariable)
+    'Equal frequency, intervals: ': Gleichfrequenz, Intervalle:
+    equal freq, k={}: Gleichfrequenz, k={}
+    Create bins with same number of instances: Bins mit gleicher Anzahl an Instanzen erstellen
+    'Equal width, intervals: ': Gleiche Breite, Intervalle:
+    equal width, k={}: Gleiche Breite, k={}
+    Create bins of the same width: Bins gleicher Breite erstellen
+    Remove: Entfernen
+    remove: Entfernen
+    Remove variable: Variable entfernen
+    'Natural binning, desired bins: ': Natürliche Einteilung, gewünschte Bins:
+    binning, desired={}: Einteilung, gewünschte={}
+    'Create bins with nice thresholds; ': Bins mit sinnvollen Schwellenwerten erstellen;
+    try matching desired number of bins: Versuche gewünschte Anzahl an Bins zu erreichen
+    'Fixed width: ': Feste Breite:
+    fixed width {}: Feste Breite {}
+    Create bins with the given width (not for time variables): Bins mit gegebener Breite erstellen (nicht für Zeitvariablen)
+    'Time interval: ': Zeitintervall:
+    time interval, {} {}: Zeitintervall, {} {}
+    Create bins with the give width (for time variables): Bins mit gegebener Breite erstellen (für Zeitvariablen)
+    'Custom: ': Benutzerdefiniert:
+    'custom: {}': Benutzerdefiniert: {}
+    Use manually specified thresholds: Manuell angegebene Schwellenwerte verwenden
+    def `format_desc`:
+        {time_units[unit]}(s): {time_units[unit]}(e)
+        {pl(width, time_units[unit])}: {plde(width, time_units[unit])}
+    class `DefaultDiscModel`:
+        def `__init__`:
+            ★: ★
+        def `data`:
+            'Default setting: ': Standard:
+            Default setting for variables without specific setings: Standard für Variablen ohne spezielle Einstellungen
+    class `IncreasingNumbersListValidator`:
+        def `validate`:
+            ', ': ,
+    class `OWDiscretize`:
+        Discretize: Diskretisieren
+        Discretize numeric variables: Numerische Variablen diskretisieren
+        Transform: Transformieren
+        discretize, bin, categorical, nominal, ordinal: discretize, bin, categorical, nominal, ordinal, Diskretisieren, Binning, Kategorisch, Nominal, Ordinal
+        class `Inputs`:
+            Data: Daten
+            Input data table: Eingabetabelle
+        class `Outputs`:
+            Data: Daten
+            Table with categorical features: Tabelle mit kategorischen Merkmalen
+        def `_create_buttons`:
+            def `manual_cut_editline`:
+                e.g. 0.0, 0.5, 1.0: z.B. 0.0, 0.5, 1.0
+                Enter cut points as a comma-separate list of \n: Schnittpunkte als durch Komma getrennte Liste eingeben \n
+                strictly increasing numbers e.g. 0.0, 0.5, 1.0).</p>: streng steigende Zahlen, z.B. 0.0, 0.5, 1.0).</p>
+            {unit}(s): {unit}(e)
+            CC: CC
+            Copy the current cut points to manual mode: Aktuelle Schnittpunkte in den manuellen Modus kopieren
+        def `_discretize_var`:
+            ': <keep, time var>': : <belassen, Zeitvariable>
+            ': <keep, not time>': : <belassen, nicht Zeit>
+            ' <removed>': ' <entfernt>'
+            ': ': ': '
+            ', ': ', '
+        def `_copy_to_manual`:
+            ', ': ', '
+        def `send_report`:
+            ': ': ': '
+            ', ': ', '
+            Variables: Variablen
+widgets/data/oweditdomain.py:
+    class `DictItemsModel`:
+        def `__init__`:
+            Key: Schlüssel
+            Value: Wert
+    class `VariableEditor`:
+        def `__init__`:
+            Name:: Name:
+            Unlink variable from its source variable: Variable von ihrer Quellvariable trennen
+            'Make Orange forget that the variable is derived from ': Orange vergessen lassen, dass die Variable abgeleitet ist von
+            another.\n: einer anderen.\n
+            'Use this for instance when you want to consider variables ': Verwenden Sie dies z.B., wenn Sie Variablen
+            'with the same name but from different sources as the same ': mit demselben Namen, aber aus verschiedenen Quellen, als dieselbe
+            variable.: Variable betrachten möchten.
+            +: +
+            Add a new label.: Neues Label hinzufügen
+            \N{MINUS SIGN}: −
+            Remove selected label.: Ausgewähltes Label entfernen
+            Add: Hinzufügen
+            Remove: Entfernen
+            Labels:: Labels:
+    class `GroupItemsDialog`:
+        other: andere
+        def `__init__`:
+            Group selected values: Ausgewählte Werte gruppieren
+            Group values with less than: Werte gruppieren mit weniger als
+            Group all except: Alle gruppieren außer
+            occurrences: Vorkommen
+            most frequent values: Häufigste Werte
+            ' %': %
+            'New value name: ': Neuer Wertname:
+    class `CategoriesEditDelegate`:
+        def `initStyleOption`:
+            (dropped): (entfernt)
+            (added): (hinzugefügt)
+            (merged): (zusammengeführt)
+    class `DiscreteVariableEditor`:
+        def `__init__`:
+            Move up: Nach oben
+            \N{UPWARDS ARROW}: ↑
+            Move the selected item up.: Ausgewähltes Element nach oben verschieben
+            Move down: Nach unten
+            \N{DOWNWARDS ARROW}: ↓
+            Move the selected item down.: Ausgewähltes Element nach unten verschieben
+            Add: Hinzufügen
+            +: +
+            Append a new item.: Neues Element hinzufügen
+            Remove item: Element entfernen
+            \N{MINUS SIGN}: −
+            Delete the selected item.: Ausgewähltes Element löschen
+            Rename selected items: Ausgewählte Elemente umbenennen
+            =: =
+            Rename selected items.: Ausgewählte Elemente umbenennen
+            Merge: Zusammenführen
+            M: M
+            Merge infrequent items.: Unhäufige Elemente zusammenführen
+            Remove: Entfernen
+            Merge selected items: Ausgewählte Elemente zusammenführen
+            Merge infrequent: Unhäufige zusammenführen
+            Values:: Werte:
+        def `_merge_categories`:
+            Import Options: Importoptionen
+    class `TimeVariableEditor`:
+        def `__init__`:
+            Detect automatically: Automatisch erkennen
+            Format:: Format:
+    class `VariableEditDelegate`:
+        categorical: Kategorisch
+        numeric: Numerisch
+        string: Text
+        time: Zeit
+        def `initStyleOption`:
+            ' (reinterpreted as ': ' (neu interpretiert als '
+            {self.ReinterpretNames[type(tr)]}): {self.ReinterpretNames[type(tr)]})
+        def `helpEvent`:
+            Name `{name}` is duplicated: Name `{name}` ist doppelt vorhanden
+    class `ReinterpretVariableEditor`:
+        def `__init__`:
+            def `decorate`:
+                Categorical: Kategorisch
+                Numeric: Numerisch
+                Text: Text
+                Time: Zeit
+                (Restore original): (Original wiederherstellen)
+                Type:: Typ:
+    class `OWEditDomain`:
+        Edit Domain: Domäne bearbeiten
+        Rename variables, edit categories and variable annotations.: Variablen umbenennen, Kategorien und Variablenanmerkungen bearbeiten
+        edit domain, rename, drop, reorder, order: edit domain, rename, drop, reorder, order, Domäne bearbeiten, umbenennen, löschen, neu anordnen, anordnen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        class `Error`:
+            A variable name is duplicated.: Ein Variablenname ist doppelt vorhanden
+        class `Warning`:
+            Failed to restore transform {} for column {}: Transform {} für Spalte {} konnte nicht wiederhergestellt werden
+            Categories mapping for {} does not apply to current input: Kategoriezuordnung für {} gilt nicht für die aktuelle Eingabe
+        def `__init__`:
+            Variables: Variablen
+            Edit: Bearbeiten
+            'Output table name: ': Name der Ausgabetabelle:
+            Reset All: Alle zurücksetzen
+            Reset all variables to their input state.: Alle Variablen in den Eingabestatus zurücksetzen
+            Reset Selected: Ausgewählte zurücksetzen
+            Rest selected variable to its input state.: Ausgewählte Variable in den Eingabestatus zurücksetzen
+            Apply: Anwenden
+            Apply changes and commit data on output.: Änderungen anwenden und Daten auf der Ausgabe festschreiben
+        def `send_report`:
+            No changes: Keine Änderungen
+    def `report_transform`:
+        (unlinked from source): (Von Quelle gelöst)
+        Values: Werte
+        (added): (hinzugefügt)
+        Labels: Labels
+        <s>: <s>
+        ' : ': ' : '
+        </s>: </s>
+        (new): (neu)
+widgets/data/owfeatureconstructor.py:
+    class `FeatureEditor`:
+        def `__init__`:
+            Name...: Name...
+            Meta attribute: Meta-Attribut
+            Expression...: Ausdruck...
+            Select Feature: Merkmal auswählen
+            Select Function: Funktion auswählen
+        def `setEditorData`:
+            Select Feature: Merkmal auswählen
+    class `ContinuousFeatureEditor`:
+        A numeric expression\n\n: Ein numerischer Ausdruck\n\n
+    class `DateTimeFeatureEditor`:
+        'Result must be a string in ISO-8601 format ': Ergebnis muss ein String im ISO-8601-Format sein
+        (e.g. 2019-07-30T15:37:27 or a part thereof),\n: (z.B. 2019-07-30T15:37:27 oder ein Teil davon),\n
+        or a number of seconds since Jan 1, 1970.: oder eine Anzahl Sekunden seit dem 1. Jan. 1970.
+    class `DiscreteFeatureEditor`:
+        Result must be a string, if values are not explicitly given\n: Ergebnis muss ein String sein, falls Werte nicht explizit angegeben sind\n
+        or a zero-based integer indices into a list of values given below.: oder nullbasierte ganzzahlige Indizes in eine unten angegebene Werteliste
+        def `__init__`:
+            'If values are given, above expression must return zero-based ': Falls Werte angegeben sind, muss der obige Ausdruck nullbasierte
+            integer indices into that list.: ganzzahlige Indizes in dieser Liste zurückgeben
+            A, B ...: A, B ...
+            Values (optional): Werte (optional)
+    class `StringFeatureEditor`:
+        A string expression\n\n: Ein Textausdruck\n\n
+    class `OWFeatureConstructor`:
+        Formula: Formel
+        'Construct new features (data columns) from a set of ': Neue Merkmale (Daten-Spalten) aus einer Menge von
+        existing features in the input dataset.: bestehenden Merkmalen im Eingabedatensatz konstruieren
+        Transform: Transformieren
+        feature constructor, function, lambda, calculation: feature constructor, function, lambda, calculation, Merkmalskonstruktion, Funktion, Lambda, Berechnung
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        class `Error`:
+            Categorical feature {} needs more values.: Kategorisches Merkmal {} benötigt mehr Werte
+            'Invalid expressions: {}.': Ungültige Ausdrücke: {}.
+        class `Information`:
+            'A new variable that is named the same as an existing one will ': Eine neue Variable mit demselben Namen wie eine bestehende wird
+            replace it on the output.: diese in der Ausgabe ersetzen
+        def `__init__`:
+            Variable Definitions: Variablen-Definitionen
+            New: Neu
+            Create a new variable: Neue Variable erstellen
+            Numeric: Numerisch
+            X{}: X{}
+            Categorical: Kategorisch
+            D{}: D{}
+            Text: Text
+            S{}: S{}
+            Date/Time: Datum/Zeit
+            T{}: T{}
+            Duplicate Selected Variable: Ausgewählte Variable duplizieren
+            Remove: Entfernen
+            Remove selected variable: Ausgewählte Variable entfernen
+            Upgrade Expressions: Ausdrücke aktualisieren
+            Send: Senden
+        def `send_report`:
+            categorical: Kategorisch
+            ' with values ': mit Werten
+            ; ordered: ; geordnet
+            numeric: Numerisch
+            date/time: Datum/Zeit
+            text: Text
+            Constructed feature{s}: Konstruiertes Merkmal{s}
+        def `fix_expressions`:
+            Fix Expressions: Ausdrücke korrigieren
+            "This widget's behaviour has changed. Values of categorical ": Das Verhalten dieses Widgets hat sich geändert. Werte kategorischer
+            'variables are now inserted as their textual representations ': Variablen werden jetzt als Textdarstellung eingefügt
+            '(strings); previously they appeared as integer numbers, with an ': (Strings); zuvor erschienen sie als Ganzzahlen mit einem
+            attribute '.value' that contained the text.\n\n: Attribut '.value', das den Text enthielt.\n\n
+            'The widget currently runs in compatibility mode. After ': Das Widget läuft derzeit im Kompatibilitätsmodus. Nach
+            expressions are updated, manually check for their correctness.: Aktualisierung der Ausdrücke manuell auf Richtigkeit prüfen
+            Update: Aktualisieren
+            Cancel: Abbrechen
+widgets/data/owfeaturestatistics.py:
+    def `format_time_diff`:
+        ~{years} years: ~{years} Jahre
+        ~{months} months: ~{months} Monate
+        ~{weeks} weeks: ~{weeks} Wochen
+        ~{days} days: ~{days} Tage
+        ~{hours} hours: ~{hours} Stunden
+        ~{minutes} minutes: ~{minutes} Minuten
+        {seconds} seconds: {seconds} Sekunden
+    class `FeatureStatisticsTableModel`:
+        class `Columns`:
+            def `name`:
+                Name: Name
+                Distribution: Verteilung
+                Mean: Mittelwert
+                Mode: Modus
+                Median: Median
+                Dispersion: Streuung
+                Min.: Min.
+                Max.: Max.
+                Missing: Fehlend
+        def `get_statistics_table`:
+            Entropy: Entropie
+            Feature: Merkmal
+            Mode: Modus
+            {self.table.name} (Feature Statistics): {self.table.name} (Merkmalsstatistik)
+    class `OWFeatureStatistics`:
+        Feature Statistics: Merkmalsstatistik
+        Show basic statistics for data features.: Grundlegende Statistik der Merkmale anzeigen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Reduced Data: Reduzierte Daten
+            Statistics: Statistik
+        def `__init__`:
+            None: Keine
+            Color:: Farbe::
+widgets/data/owfile.py:
+    Determine type from the file extension: Bestimme den Typ anhand der Dateiendung
+    class `OWFile`:
+        File: Datei
+        'Read data from an input file or network ': 'Daten aus einer Eingabedatei oder dem Netzwerk lesen '
+        and send a data table to the output.: und eine Datentabelle an den Ausgang senden.
+        Data: Daten
+        file, load, read, open: file, load, read, open, Datei, laden, lesen, öffnen
+        class `Outputs`:
+            Data: Daten
+            Attribute-valued dataset read from the input file.: Datensatz mit Attributwerten aus der Eingabedatei gelesen
+        class `Information`:
+            No file selected.: Keine Datei ausgewählt.
+        class `Warning`:
+            The file is too large to load automatically.: Die Datei ist zu groß, um sie automatisch zu laden.
+            ' Press Reload to load.': ' Drücken Sie "Neu laden", um die Datei zu laden.'
+            Read warning:\n{}: Lese-Warnung:\n{}
+            Categorical variables with >100 values may decrease performance.: Kategoriale Variablen mit >100 Werten können die Leistung verringern.
+            'Some variables have been renamed ': 'Einige Variablen wurden umbenannt '
+            to avoid duplicates.\n{}: um Duplikate zu vermeiden.\n{}
+            Most widgets do not support multiple targets: Die meisten Widgets unterstützen keine mehreren Zielvariablen.
+        class `Error`:
+            File not found.: Datei nicht gefunden.
+            Missing reader.: Leser nicht gefunden.
+            Select file type.: "Dateityp auswählen"
+            Error listing available sheets.: Fehler beim Auflisten verfügbarer Tabellenblätter.
+            Read error:\n{}: Lese-Fehler:\n{}
+            Read error, possibly due to incorrect choice of file type:\n{}: "Lese Fehler, möglicherweise durch falsche Wahl des Dateityps:\n{}"
+        'Use CSV File Import widget for advanced options ': 'Verwenden Sie das CSV-Dateiimport-Widget für erweiterte Optionen '
+        for comma-separated files: für kommagetrennte Dateien
+        use-csv-file-import: csv-dateiimport verwenden
+        'This widget loads only tabular data. Use other widgets to load ': 'Dieses Widget lädt nur tabellarische Daten. Verwenden Sie andere Widgets, um '
+        other data types like models, distance matrices and networks.: andere Datentypen wie Modelle, Distanzmatrizen und Netzwerke zu laden.
+        def `__init__`:
+            Source: Quelle
+            File:: Datei:
+            ...: ...
+            Reload: Neu laden
+            Sheet: Tabellenblatt
+            URL:: URL:
+            File Type: Dateityp
+            Info: Info
+            No data loaded.: Keine Daten geladen.
+            Columns (Double click to edit): Spalten (Doppelklick zum Bearbeiten)
+            Reset: Zurücksetzen
+            Apply: Übernehmen
+            Browse documentation datasets: Dokumentationsdatensätze durchsuchen
+        def `browse_file`:
+            File: Datei
+            Cannot find the directory with documentation datasets: Verzeichnis mit Dokumentationsdatensätzen nicht gefunden
+        def `load_data`:
+            No data.: Keine Daten.
+        def `_get_reader`:
+            Can not find reader "{qname}": Leser "{qname}" nicht gefunden
+        def `_describe`:
+            Name: Name
+            Description: Beschreibung
+            <p>{len(table)} {pl(len(table), 'instance')}: <p>{len(table)} {plde(len(table), 'Instanz|Instanzen')}:
+            <br/>{nattrs} {pl(nattrs, 'feature')} {missing_in_attr}: <br/>{nattrs} {plde(nattrs, 'Merkmal|Merkmale')} {missing_in_attr}:
+            <br/>Regression; numerical class {missing_in_class}: <br/>Regression; numerische Klasse {missing_in_class}:
+            '<br/>Classification; categorical class ': <br/>Klassifikation; kategoriale Klasse
+            with {nvals} {pl(nvals, 'value')} {missing_in_class}: mit {nvals} {plde(nvals, 'Wert|Werte')} {missing_in_class}:
+            '<br/>Multi-target; ': <br/>Multi-Ziel; '
+            "{ntargets} target {pl(ntargets, 'variable')} ": '{ntargets} Zielvariable {plde(ntargets, "Variable|Variablen")} '
+            {missing_in_class}: {missing_in_class}
+            <br/>Data has no target variable.: <br/>Datensatz hat keine Zielvariable.
+            <br/>{nmetas} {pl(nmetas, 'meta attribute')}: <br/>{nmetas} {plde(nmetas, 'Metaattribut|Metaattribute')}:
+            "<p>First entry: {table[0, 'Timestamp']}<br/>": <p>Erster Eintrag: {table[0, 'Timestamp']}<br/>
+            "Last entry: {table[-1, 'Timestamp']}</p>": Letzter Eintrag: {table[-1, 'Timestamp']}</p>
+        def `apply_domain_edit`:
+            "Renamed: {', '.join(renamed)}": Umbenannt: {', '.join(renamed)}
+        def `send_report`:
+            def `get_ext_name`:
+                unknown: unbekannt
+            File: Datei
+            No file.: Keine Datei.
+            File name: Dateiname
+            Format: Format
+            Data: Daten
+            Resource: Ressource
+widgets/data/owgroupby.py:
+    Mean: Mittelwert
+    Median: Median
+    Q1: Q1
+    Q3: Q3
+    Min. value: Minimalwert
+    Max. value: Maximalwert
+    Mode: Modus
+    Standard deviation: Standardabweichung
+    Variance: Varianz
+    Sum: Summe
+    Concatenate: Verketten
+    Span: Spannweite
+    First value: Erster Wert
+    Last value: Letzter Wert
+    Random value: Zufallswert
+    Count defined: Anzahl definiert
+    Count: Anzahl
+    Proportion defined: Anteil definiert
+    def `_run`:
+        Aggregating: Aggregieren
+    Attributes: Attribute
+    Aggregations: Aggregationen
+    class `VarTableModel`:
+        def `data`:
+            ' and {len(aggs) - 3} more': ' und {len(aggs) - 3} weitere'
+    class `OWGroupBy`:
+        Group by: Gruppieren nach
+        Transform: Transformieren
+        aggregate, group by: aggregate, group by, aggregieren, gruppieren nach
+        class `Inputs`:
+            Data: Daten
+            Input data table: Eingabetabelle
+        class `Outputs`:
+            Data: Daten
+            Aggregated data: Aggregierte Daten
+        def `__init_control_area`:
+            Group by: Gruppieren nach
+        def `__init_main_area`:
+            Aggregations: Aggregationen
+widgets/data/owimpute.py:
+    class `AsDefault`:
+        Default (above): Standard (oben)
+    class `OWImpute`:
+        Impute: Imputieren
+        Impute missing values in the data table.: Fehlende Werte in der Datentabelle imputieren
+        impute, substitute, missing: impute, substitute, missing, imputieren, ersetzen, fehlend
+        Transform: Transformieren
+        class `Inputs`:
+            Data: Daten
+            Learner: Lernender
+        class `Outputs`:
+            Data: Daten
+        class `Error`:
+            Imputation failed for '{}': Imputation für '{}' fehlgeschlagen
+            Model based imputer does not work for sparse data: Modellbasierter Imputer funktioniert nicht für spärliche Daten
+        class `Warning`:
+            Default method can not handle '{}': Standardmethode kann '{}' nicht verarbeiten
+        def `__init__`:
+            Default Method: Standardmethode
+            Fixed values; numeric variables:: Feste Werte; numerische Variablen::
+            , time:: , Zeit::
+            Individual Attribute Settings: Einstellungen für einzelne Attribute
+            Restore All to Default: Alle auf Standard zurücksetzen
+        def `send_report`:
+            {} ({}): {} ({})
+            Default method: Standardmethode
+            Specific imputers: Spezielle Imputer
+            ', ': ', '
+            Method: Methode
+    def `__sample_data`:
+        c{i}: c{i}
+        t{i}: t{i}
+widgets/data/owmelt.py:
+    item: Element
+    value: Wert
+    row: Zeile
+    class `OWMelt`:
+        Melt: Schmelzen
+        Convert wide data to narrow data, a list of item-value pairs: Breite Daten in schmale Daten umwandeln, eine Liste von Element-Wert-Paaren
+        Transform: Transformieren
+        melt, shopping list, wide, narrow: melt, shopping list, wide, narrow, schmelzen, Einkaufsliste, breit, schmal
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        class `Information`:
+            No columns with unique values\n: Keine Spalten mit eindeutigen Werten\n
+            Only columns with unique valules are useful for row identifiers.: Nur Spalten mit eindeutigen Werten sind für Zeilenkennungen nützlich
+        def `__init__`:
+            Unique Row Identifier: Eindeutiger Zeilenkennzeichner
+            Row number: Zeilennummer
+            A column with identifier, like customer's id: Eine Spalte mit Kennzeichnung, z. B. Kunden-ID
+            Filter: Filter
+            Ignore non-numeric features: Nicht-numerische Merkmale ignorieren
+            Exclude zero values: Nullwerte ausschließen
+            Besides missing values, also omit items with zero values: Zusätzlich zu fehlenden Werten auch Elemente mit Nullwerten weglassen
+            Names for generated features: Namen für erzeugte Merkmale
+            Item:: Element::
+            Value:: Wert::
+        def `send_report`:
+            Settings: Einstellungen
+            Row identifier: Zeilenkennzeichner
+            Ignore non-numeric features: Nicht-numerische Merkmale ignorieren
+            Exclude zero values: Nullwerte ausschließen
+            Output: Ausgabe
+        def `_store_output_desc`:
+            Item column: Elementspalte
+            Value column: Wertspalte
+            Number of items: Anzahl der Elemente
+widgets/data/owmergedata.py:
+    Instance id: Instanz-ID
+    Row index: Zeilenindex
+    class `ConditionBox`:
+        def `add_row`:
+            and: und
+            ×: ×
+        def `add_plus_row`:
+            +: +
+    class `DomainModelWithTooltips`:
+        def `data`:
+            Match rows sequentially: Zeilen nacheinander abgleichen
+            'Re-match rows from tables obtained from the same ': Zeilen erneut abgleichen aus Tabellen, die aus derselben
+            source,\n: Quelle,\n
+            'e.g. data from the same file that was split within ': z. B. Daten aus derselben Datei, die innerhalb
+            the workflow.: des Workflows aufgeteilt wurde.
+    class `OWMergeData`:
+        Merge Data: Daten zusammenführen
+        Merge datasets based on the values of selected features.: Datensätze basierend auf den Werten ausgewählter Merkmale zusammenführen
+        Transform: Transformieren
+        merge data, join: merge data, join, Daten zusammenführen, verbinden
+        class `Inputs`:
+            Data: Daten
+            Extra Data: Zusätzliche Daten
+        class `Outputs`:
+            Data: Daten
+        Append columns from Extra data: Spalten aus zusätzlichen Daten anhängen
+        Find matching pairs of rows: Passende Zeilenpaare finden
+        Concatenate tables: Tabellen zusammenfügen
+        The first table may contain, for instance, city names,\n: Die erste Tabelle kann z. B. Städtenamen enthalten,\n
+        and the second would be a list of cities and their coordinates.\n: und die zweite eine Liste von Städten und deren Koordinaten.\n
+        Columns with coordinates would then be appended to the output.: Spalten mit Koordinaten werden dann an die Ausgabe angehängt.
+        'Input tables contain different features describing the same data ': Eingabetabellen enthalten unterschiedliche Merkmale, die dieselben Daten beschreiben
+        instances.\n: Instanzen.\n
+        Output contains matched instances. Rows without matches are removed.: Die Ausgabe enthält übereinstimmende Instanzen. Zeilen ohne Übereinstimmung werden entfernt.
+        'Output contains all instances. Data from merged instances is ': Die Ausgabe enthält alle Instanzen. Daten zusammengeführter Instanzen werden
+        merged into single rows.: in einzelne Zeilen zusammengeführt.
+        Confused about merging options?\nSee the tooltips!: Unsicher bezüglich der Zusammenführungsoptionen?\nSiehe die Tooltips!
+        class `Warning`:
+            'Some variables have been renamed ': Einige Variablen wurden umbenannt
+            to avoid duplicates.\n{}: um Duplikate zu vermeiden.\n{}
+            'Some (unused) combinations of values in Data appear in ': Einige (nicht genutzte) Kombinationen von Werten in Daten erscheinen in
+            multiple rows.: mehreren Zeilen.
+            'Some (unused) combinations of values in Extra Data appear in ': Einige (nicht genutzte) Kombinationen von Werten in zusätzlichen Daten erscheinen in
+        class `Error`:
+            Numeric and non-numeric columns ({} and {}) cannot be matched.: Numerische und nicht-numerische Spalten ({} und {}) können nicht abgeglichen werden.
+            Row index cannot be matched with {}.: Zeilenindex kann nicht mit {} abgeglichen werden.
+            Instance cannot be matched with {}.: Instanz kann nicht mit {} abgeglichen werden.
+            Some combinations of values in Data appear in multiple rows.: Einige Kombinationen von Werten in Daten erscheinen in mehreren Zeilen.
+            \nEvery matched combination may appear at most once.: \nJede abgeglichene Kombination darf höchstens einmal vorkommen.
+            \nEvery combination may appear at most once.: \nJede Kombination darf höchstens einmal vorkommen.
+            Some combinations of values in Extra Data appear in multiple rows.: Einige Kombinationen von Werten in zusätzlichen Daten erscheinen in mehreren Zeilen.
+        def `__init__`:
+            Merging: Zusammenführen
+            matches: Übereinstimmungen
+            Row matching: Zeilenabgleich
+        def `send_report`:
+            Merging: Zusammenführen
+            Match: Übereinstimmung
+            {self._get_col_name(left)} with {self._get_col_name(right)}: {self._get_col_name(left)} mit {self._get_col_name(right)}
+widgets/data/owneighbors.py:
+    Euclidean: Euklidisch
+    Manhattan: Manhattan
+    Mahalanobis: Mahalanobis
+    Cosine: Kosinus
+    Jaccard: Jaccard
+    Spearman: Spearman
+    Absolute Spearman: Absoluter Spearman
+    Pearson: Pearson
+    Absolute Pearson: Absoluter Pearson
+    class `OWNeighbors`:
+        Neighbors: Nachbarn
+        Compute nearest neighbors in data according to reference.: Berechne die nächsten Nachbarn in den Daten anhand der Referenz.
+        Unsupervised: Unüberwacht
+        class `Inputs`:
+            Data: Daten
+            Reference: Referenz
+        class `Outputs`:
+            Neighbors: Nachbarn
+        class `Info`:
+            Input data includes reference instance(s).\n: Eingabedaten enthalten Referenzinstanz(en).\n
+            Reference instances are excluded from the output.: Referenzinstanzen sind von der Ausgabe ausgeschlossen.
+        class `Warning`:
+            Every data instance is same as some reference: Jede Dateninstanz ist identisch mit einer Referenzinstanz
+        class `Error`:
+            Data and reference have different features: Daten und Referenz haben unterschiedliche Merkmale
+        def `__init__`:
+            'Distance metric: ': Distanzmetrik:
+            Limit number of neighbors to:: Begrenze die Anzahl der Nachbarn auf:
+        def `commit`:
+            ' (neighbors)': " (Nachbarn)"
+widgets/data/owoutliers.py:
+    def `run`:
+        Initializing...: Initialisiere...
+    class `SVMEditor`:
+        def `__init__`:
+            'An upper bound on the fraction of training errors and a ': Eine obere Grenze für den Anteil der Trainingsfehler und eine
+            lower bound of the fraction of support vectors: Untergrenze des Anteils der Stützvektoren
+            Nu:: Nu:
+            Kernel coefficient:: Kernelkoeffizient:
+        def `get_report_parameters`:
+            Detection method: Erkennungsmethode
+            One class SVM with non-linear kernel (RBF): One-Class SVM mit nichtlinearem Kernel (RBF)
+            Regularization (nu): Regularisierung (nu)
+            Kernel coefficient: Kernelkoeffizient
+    class `CovarianceEditor`:
+        def `__init__`:
+            Contamination:: Kontamination:
+            Support fraction:: Stützvektor-Anteil:
+        def `get_report_parameters`:
+            Detection method: Erkennungsmethode
+            Covariance estimator: Kovarianzschätzer
+            Contamination: Kontamination
+            Support fraction: Stützvektor-Anteil
+    class `LocalOutlierFactorEditor`:
+        Euclidean: Euklidisch
+        Manhattan: Manhattan
+        Cosine: Kosinus
+        Jaccard: Jaccard
+        Hamming: Hamming
+        Minkowski: Minkowski
+        def `__init__`:
+            Contamination:: Kontamination:
+            Neighbors:: Nachbarn:
+            Metric:: Metrik:
+        def `get_report_parameters`:
+            Detection method: Erkennungsmethode
+            Local Outlier Factor: Local Outlier Factor
+            Contamination: Kontamination
+            Number of neighbors: Anzahl der Nachbarn
+            Metric: Metrik
+    class `IsolationForestEditor`:
+        def `__init__`:
+            Contamination:: Kontamination:
+            Replicable training: Reproduzierbares Training
+        def `get_report_parameters`:
+            Detection method: Erkennungsmethode
+            Isolation Forest: Isolation Forest
+            Contamination: Kontamination
+            Replicable training: Reproduzierbares Training
+    class `OWOutliers`:
+        Outliers: Ausreißer
+        Detect outliers.: Erkenne Ausreißer.
+        Unsupervised: Unüberwacht
+        outliers, inlier: outliers, inlier, Ausreißer, Inlier
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Inliers: Inlier
+            Outliers: Ausreißer
+            Data: Daten
+        class `Warning`:
+            Too many features for covariance estimation.: Zu viele Merkmale für Kovarianzschätzung.
+        class `Error`:
+            Singular covariance matrix.: Singuläre Kovarianzmatrix.
+            Not enough memory: Nicht genügend Speicher.
+        def `init_gui`:
+            Method: Methode
+        def `_init_editors`:
+            Parameters: Parameter
+        def `send_report`:
+            Data: Daten
+            Input instances: Eingabeinstanzen
+            Inliers: Inlier
+            Outliers: Ausreißer
+            Detection: Erkennung
+widgets/data/owpaintdata.py:
+    class `OWPaintData`:
+        Brush: Pinsel
+        Create multiple instances: Mehrere Instanzen erstellen
+        Put: Platzieren
+        Put individual instances: Einzelne Instanzen platzieren
+        Select: Auswählen
+        Select and move instances: Instanzen auswählen und verschieben
+        Jitter: Zufällige Verschiebung
+        Jitter instances: Instanzen zufällig verschieben
+        Magnet: Magnet
+        Attract multiple instances: Mehrere Instanzen anziehen
+        Clear: Löschen
+        Clear the plot: Diagramm löschen
+        Paint Data: Daten malen
+        Create data by painting data points on a plane.: Erstellen von Daten durch Malen von Datenpunkten auf einer Ebene.
+        paint data, create, draw: paint data, create, draw, Daten malen, erstellen, zeichnen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        Painted data: Gemalte Daten
+        x: x
+        y: y
+        C1: C1
+        C2: C2
+        plot: Diagramm
+        class `Warning`:
+            Input data has no variables: Eingabedaten haben keine Variablen
+            Numeric target value can not be used.: Numerischer Zielwert kann nicht verwendet werden.
+            Sparse data is ignored.: Sparse-Daten werden ignoriert.
+            'Some variables have been renamed ': Einige Variablen wurden umbenannt
+            to avoid duplicates.\n{}: um Duplikate zu vermeiden.\n{}
+        class `Information`:
+            Paint Data uses data from the first two attributes.: Paint Data verwendet Daten der ersten beiden Attribute.
+        def `_init_ui`:
+            Names: Namen
+            'Variable X: ': Variable X:
+            'Variable Y: ': Variable Y:
+            hasAttr2: hasAttr2
+            Labels: Labels
+            +: +
+            Add new class label: Neue Klassenbezeichnung hinzufügen
+            MINUS SIGN: MINUS SIGN
+            Remove selected class label: Ausgewählte Klassenbezeichnung entfernen
+            Tools: Werkzeuge
+            Radius:: Radius:
+            Intensity:: Intensität:
+            Symbol:: Symbol:
+            Reset to Input Data: Auf Eingabedaten zurücksetzen
+        def `set_data`:
+            C1: C1
+        def `add_new_class_label`:
+            C: C
+        def `remove_selected_class_label`:
+            Delete class label: Klassenbezeichnung löschen
+        def `_add_command`:
+            Name: Name
+            Delete: Löschen
+            Clear All: Alles löschen
+            Move: Verschieben
+        def `_replot`:
+            +: +
+        def `commit`:
+            Class: Klasse
+            ', ': ', '
+        def `send_report`:
+            x: x
+            y: y
+            Axis x: Achse x
+            Axis y: Achse y
+            Number of points: Anzahl der Punkte
+            Painted data: Gemalte Daten
+widgets/data/owpivot.py:
+    class `Pivot`:
+        def `__init__`:
+            Total: Gesamt
+        def `__get_pivot_tab_domain`:
+            Total: Gesamt
+            Aggregate: Aggregat
+        Count: Anzahl
+        Count defined: Definierte Anzahl
+        Sum: Summe
+        Mean: Mittelwert
+        Min: Minimum
+        Max: Maximum
+        Mode: Modus
+        Median: Median
+        Var: Varianz
+        Majority: Mehrheit
+    class `PivotTableView`:
+        Total: Gesamt
+    class `OWPivot`:
+        Pivot Table: Pivot-Tabelle
+        Reshape data table based on column values.: Daten-Tabelle basierend auf Spaltenwerten umformen.
+        Transform: Transformieren
+        pivot table, pivot, group, aggregate: pivot table, pivot, group, aggregate, Pivot-Tabelle, Pivot, Gruppieren, Aggregieren
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Pivot Table: Pivot-Tabelle
+            Filtered Data: Gefilterte Daten
+            Grouped Data: Gruppierte Daten
+        class `Warning`:
+            Column feature should be selected.: Spaltenmerkmal muss ausgewählt werden.
+            Some aggregations ({}) cannot be computed.: Einige Aggregationen ({}) können nicht berechnet werden.
+            Some variables have been renamed in some tables: Einige Variablen wurden in manchen Tabellen umbenannt
+            to avoid duplicates.\n{}: um Duplikate zu vermeiden.\n{}
+            Selected variable has too many values.: Ausgewählte Variable hat zu viele Werte.
+            At least 1 primitive variable is required.: Mindestens 1 primitive Variable ist erforderlich.
+        def `_add_control_area_controls`:
+            Rows: Zeilen
+            Columns: Spalten
+            (Same as rows): (Wie Zeilen)
+            Values: Werte
+            (None): (Keine)
+        def `__add_aggregation_controls`:
+            Aggregations: Aggregationen
+        def `send_report`:
+            Row feature: Zeilenmerkmal
+            Column feature: Spaltenmerkmal
+            Value feature: Werte-Merkmal
+            Group by: Gruppieren nach
+widgets/data/owpreprocess.py:
+    class `DiscretizeEditor`:
+        None: Keine
+        Equal width discretization: Gleich breite Diskretisierung
+        Equal frequency discretization: Gleich häufige Diskretisierung
+        Remove numeric features: Numerische Merkmale entfernen
+        Entropy-MDL discretization: Entropie-MDL-Diskretisierung
+        def `__init__`:
+            Number of intervals (for equal width/frequency): Anzahl der Intervalle (für gleiche Breite/Häufigkeit)
+        def `__repr__`:
+            ', Number of intervals: {}': , Anzahl der Intervalle: {}
+    class `ContinuizeEditor`:
+        Most frequent is base: Häufigstes ist Basis
+        One feature per value: Ein Merkmal pro Wert
+        Remove non-binary features: Nicht-binäre Merkmale entfernen
+        Remove categorical features: Kategorische Merkmale entfernen
+        Treat as ordinal: Als ordinal behandeln
+        Divide by number of values: Durch Anzahl der Werte teilen
+    class `RemoveSparseEditor`:
+        missing values: Fehlende Werte
+        zeros: Nullen
+        def `__init__`:
+            Remove features with too many: Merkmale mit zu vielen entfernen
+            Threshold:: Schwelle::
+            Percentage: Prozent
+            Fixed: Fest
+        def `__repr__`:
+            'remove features with too many {self.options[self.filter0]}, threshold: ': 'Merkmale mit zu vielen {self.options[self.filter0]} entfernen, Schwelle: '
+            {self.fixedThresh} {pl(self.fixedThresh, 'instance')}: {self.fixedThresh} {plde(self.fixedThresh, 'Instanz|Instanzen')}
+            {self.percThresh} %: {self.percThresh} %
+    class `ImputeEditor`:
+        Don't impute.: Nicht imputieren
+        Replace with constant: Mit Konstante ersetzen
+        Average/Most frequent: Mittelwert/Am häufigsten
+        Model based imputer: Modellbasierter Imputer
+        Replace with random value: Mit Zufallswert ersetzen
+        Remove rows with missing values.: Zeilen mit fehlenden Werten entfernen
+    class `UnivariateFeatureSelect`:
+        def `__init__`:
+            Score: Wert
+            Number of features: Anzahl der Merkmale
+            Fixed:: Fest::
+            Proportion:: Anteil::
+            %: %
+    class `FeatureSelectEditor`:
+        Information Gain: Informationsgewinn
+        Gain ratio: Gewinnverhältnis
+        Gini index: Gini-Index
+        ReliefF: ReliefF
+        Fast Correlation Based Filter: Schnellkorrelationsbasierter Filter
+        ANOVA: ANOVA
+        Chi2: Chi2
+        RReliefF: RReliefF
+        Univariate Linear Regression: Univariable lineare Regression
+        def `__init__`:
+            Information Gain: Informationsgewinn
+            Gain Ratio: Gewinnverhältnis
+            Gini Index: Gini-Index
+            ReliefF: ReliefF
+            Fast Correlation Based Filter: Schnellkorrelationsbasierter Filter
+            ANOVA: ANOVA
+            Chi2: Chi2
+            RReliefF: RReliefF
+            Univariate Linear Regression: Univariable lineare Regression
+        def `__repr__`:
+            'Score: {}, Strategy (Fixed): {}': Wert: {}, Strategie (Fest): {}
+    class `RandomFeatureSelectEditor`:
+        def `__init__`:
+            Number of features: Anzahl der Merkmale
+            Fixed: Fest
+            Percentage: Prozent
+            %: %
+        def `__repr__`:
+            select {num} {pl(num,'feature')}: Wähle {num} {plde(num,'Merkmal|Merkmale')}
+            select {perc} % features: Wähle {perc} % Merkmale
+    class `Scale`:
+        Standardize to μ=0, σ²=1: Standardisieren auf μ=0, σ²=1
+        Center to μ=0: Zentrieren auf μ=0
+        Scale to σ²=1: Skalieren auf σ²=1
+        Normalize to interval [-1, 1]: Normalisieren auf Intervall [-1, 1]
+        Normalize to interval [0, 1]: Normalisieren auf Intervall [0, 1]
+    class `Randomize`:
+        def `__init__`:
+            Classes: Klassen
+            Features: Merkmale
+            Meta data: Metadaten
+            Randomize:: Zufällig::
+            Replicable shuffling:: Reproduzierbares Mischen::
+        def `__repr__`:
+            {}, {}: {}, {}
+            Replicable: Reproduzierbar
+            Not replicable: Nicht reproduzierbar
+    class `PCA`:
+        def `__init__`:
+            Components:: Komponenten::
+        def `__repr__`:
+            'Components: {}': Komponenten: {}
+    class `CUR`:
+        def `__init__`:
+            Rank:: Rang::
+            Relative error:: Relative Fehler::
+        def `__repr__`:
+            'Rank: {}, Relative error: {}': Rang: {}, Relativer Fehler: {}
+    def `icon_path`:
+        icons/: icons/
+    Discretize: Diskretisieren
+    Discretization: Diskretisierung
+    Discretize Continuous Variables: Kontinuierliche Variablen diskretisieren
+    Continuize: Kontinuieren
+    Continuization: Kontinuierung
+    Continuize Discrete Variables: Diskrete Variablen kontinuierlich machen
+    Impute: Imputieren
+    Impute Missing Values: Fehlende Werte imputieren
+    Feature Selection: Merkmalsauswahl
+    Select Relevant Features: Relevante Merkmale auswählen
+    Random Feature Selection: Zufällige Merkmalsauswahl
+    Select Random Features: Zufällige Merkmale auswählen
+    Normalize: Normalisieren
+    Scale: Skalieren
+    Normalize Features: Merkmale normalisieren
+    Randomize: Zufällig anordnen
+    Randomization: Zufällige Anordnung
+    Remove Sparse: Entferne spärliche Merkmale
+    Remove Sparse Features: Spärliche Merkmale entfernen
+    PCA: PCA
+    Principal Component Analysis: Hauptkomponentenanalyse
+    CUR: CUR
+    CUR Matrix Decomposition: CUR-Matrixzerlegung
+    class `OWPreprocess`:
+        Preprocess: Vorverarbeitung
+        Construct a data preprocessing pipeline.: Eine Datenvorverarbeitungspipeline erstellen.
+        Transform: Transformieren
+        preprocess, process: preprocess, process, vorverarbeiten, bearbeiten
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Preprocessor: Vorverarbeiter
+            Preprocessed Data: Vorverarbeitete Daten
+        def `__init__`:
+            Preprocessors: Vorverarbeiter
+            Drag items from the list on the left: Elemente aus der Liste links ziehen
+        def `send_report`:
+            Settings: Einstellungen
+widgets/data/owpurgedomain.py:
+    class `OWPurgeDomain`:
+        Purge Domain: Domäne bereinigen
+        'Remove redundant values and features from the dataset. ': Redundante Werte und Merkmale aus dem Datensatz entfernen.
+        Sort values.: Werte sortieren
+        Transform: Transformieren
+        remove, delete, unused: purge domain, remove, delete, unused, entfernen, löschen, ungenutzt
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        Sort categorical feature values: Kategorische Merkmalswerte sortieren
+        Remove unused feature values: Ungenutzte Merkmalswerte entfernen
+        Remove constant features: Konstante Merkmale entfernen
+        Sort categorical class values: Kategorische Klassenwerte sortieren
+        Remove unused class variable values: Ungenutzte Klassenvariablenwerte entfernen
+        Remove constant class variables: Konstante Klassenvariablen entfernen
+        Remove unused meta attribute values: Ungenutzte Meta-Attributwerte entfernen
+        Remove constant meta attributes: Konstante Meta-Attribute entfernen
+        Sorted features: Sortierte Merkmale
+        Reduced features: Reduzierte Merkmale
+        Removed features: Entfernte Merkmale
+        Sorted classes: Sortierte Klassen
+        Reduced classes: Reduzierte Klassen
+        Removed classes: Entfernte Klassen
+        Reduced metas: Reduzierte Metas
+        Removed metas: Entfernte Metas
+        def `__init__`:
+            -: -
+            Features: Merkmale
+            'Sorted: %(resortedAttrs)s, ': 'Sortiert: %(resortedAttrs)s, '
+            'reduced: %(reducedAttrs)s, removed: %(removedAttrs)s': Reduziert: %(reducedAttrs)s, Entfernt: %(removedAttrs)s
+            Classes: Klassen
+            'Sorted: %(resortedClasses)s,': Sortiert: %(resortedClasses)s,
+            'reduced: %(reducedClasses)s, removed: %(removedClasses)s': Reduziert: %(reducedClasses)s, Entfernt: %(removedClasses)s
+            Meta attributes: Meta-Attribute
+            'Reduced: %(reducedMetas)s, removed: %(removedMetas)s': Reduziert: %(reducedMetas)s, Entfernt: %(removedMetas)s
+        def `setData`:
+            -: -
+        def `send_report`:
+            def `list_opts`:
+                '; ': '; '
+                no changes: keine Änderungen
+            Settings: Einstellungen
+            Features: Merkmale
+            Classes: Klassen
+            Metas: Metas
+            Statistics: Statistiken
+widgets/data/owpythonscript.py:
+    class `OWPythonScript`:
+        Python Script: Python-Skript
+        Write a Python script and run it on input data or models.: Schreiben Sie ein Python-Skript und führen Sie es auf Eingabedaten oder Modellen aus.
+        Transform: Transformieren
+        program, function: python, script, Programm, Funktion
+        def `__init__`:
+            Editor: Editor
+            Preferences: Einstellungen
+            Vim mode: Vim-Modus
+            Only for the coolest.: Nur für die Coolsten
+            Library: Bibliothek
+            +: +
+            Add a new script to the library: Neues Skript zur Bibliothek hinzufügen
+            MINUS SIGN: MINUS-Zeichen
+            Remove script from library: Skript aus Bibliothek entfernen
+            Update: Aktualisieren
+            Save changes in the editor to library: Änderungen aus dem Editor in der Bibliothek speichern
+            More: Mehr
+            More actions: Weitere Aktionen
+            Import Script from File: Skript aus Datei importieren
+            Save Selected Script to File: Ausgewähltes Skript in Datei speichern
+            Undo Changes to Selected Script: Änderungen am ausgewählten Skript rückgängig machen
+            Run: Ausführen
+            Run script: Skript ausführen
+            &Save: &Speichern
+            Save script to file: Skript in Datei speichern
+            Console: Konsole
+        def `onAddScript`:
+            New script: Neues Skript
+        def `onAddScriptFromFile`:
+            Open Python Script: Python-Skript öffnen
+            Python files (*.py)\nAll files(*.*): Python-Dateien (*.py)\nAlle Dateien (*.*)
+        def `saveScript`:
+            Save Python Script: Python-Skript speichern
+            Python files (*.py)\nAll files(*.*): Python-Dateien (*.py)\nAlle Dateien (*.*)
+        def `commit`:
+            \nRunning script:\n: \nSkript wird ausgeführt:\n
+            "'{}' has to be an instance of '{}'.": "'{}' muss eine Instanz von '{}' sein."
+widgets/data/owrandomize.py:
+    class `OWRandomize`:
+        Randomize: Zufällig anordnen
+        Randomize features, class and/or metas in data table.: Merkmale, Klassen und/oder Metadaten in der Datentabelle zufällig anordnen.
+        Transform: Transformieren
+        randomize, random: randomize, random, zufällig anordnen, zufällig
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        def `__init__`:
+            Shuffled columns: Gemischte Spalten
+            Classes: Klassen
+            Features: Merkmale
+            Metas: Metadaten
+            Shuffled rows: Gemischte Zeilen
+            None: Keine
+            All: Alle
+            Replicable shuffling: Reproduzierbares Mischen
+        def `send_report`:
+            classes: Klassen
+            features: Merkmale
+            metas: Metadaten
+            none: keine
+            ' and ': ' und '
+            ', ': ', '
+            Settings: Einstellungen
+            Shuffled columns: Gemischte Spalten
+            Proportion of shuffled rows: Anteil gemischter Zeilen
+            Replicable: Reproduzierbar
+            yes: ja
+            no: nein
+widgets/data/owrank.py:
+    Information Gain: Informationsgewinn
+    Info. gain: Inf. Gewinn
+    Information Gain Ratio: Informationsgewinn-Verhältnis
+    Gain ratio: Gewinn-Verhältnis
+    Gini Decrease: Gini-Abnahme
+    Gini: Gini
+    ANOVA: ANOVA
+    χ²: χ²
+    ReliefF: ReliefF
+    FCBF: FCBF
+    Univariate Regression: Univariat. Regression
+    Univar. reg.: Univ. Reg.
+    RReliefF: RReliefF
+    class `OWRank`:
+        Rank: Rang
+        Rank and filter data features by their relevance.: Datenmerkmale nach Relevanz bewerten und filtern.
+        rank, filter: rank, filter, bewerten, filtern
+        class `Inputs`:
+            Data: Daten
+            Scorer: Bewertungsmethode
+        class `Outputs`:
+            Reduced Data: Reduzierte Daten
+            Scores: Werte
+            Features: Merkmale
+        class `Information`:
+            Data does not have a (single) target variable.: Daten enthalten keine (einzelne) Zielvariable.
+            Missing values will be imputed as needed.: Fehlende Werte werden bei Bedarf ergänzt.
+        class `Error`:
+            Cannot handle target variable type {}: Zielvariablentyp {} kann nicht verarbeitet werden.
+            'Scorer {} inadequate: {}': Bewertungsmethode {} ungeeignet: {}
+            Data does not have a single attribute.: Daten enthalten kein einzelnes Attribut.
+        class `Warning`:
+            Variables with duplicated names have been renamed.: Variablen mit doppelten Namen wurden umbenannt.
+        def `__init__`:
+            Scoring Methods: Bewertungsmethoden
+            Select Attributes: Attribute auswählen
+            None: Keine
+            All: Alle
+            Manual: Manuell
+            Best ranked:: Beste bewerteten::
+        def `handleNewSignals`:
+            Running: Läuft
+        def `send_report`:
+            Input: Eingabe
+            Ranks: Ränge
+            Output: Ausgabe
+        def `create_scores_table`:
+            Feature: Merkmal
+            ', ': ', '
+            Feature Scores: Merkmalwerte
+widgets/data/owsave.py:
+    class `OWSave`:
+        Save Data: Daten speichern
+        Save data to an output file.: Speichere Daten in einer Ausgabedatei.
+        Data: Daten
+        save data, export: save data, export, Daten speichern, exportieren
+        class `Inputs`:
+            Data: Daten
+        class `Error`:
+            Use Pickle format for sparse data.: Verwende Pickle-Format für spärliche Daten.
+        def `__init__`:
+            Add type annotations to header: Füge Typinformationen in den Kopfbereich ein
+            Some formats (Tab-delimited, Comma-separated) can include \n: Einige Formate (Tabulator-getrennt, Komma-getrennt) können \n enthalten
+            additional information about variables types in header rows.: zusätzliche Informationen über den Variablentyp in Kopfzeilen
+        def `get_filters`:
+            Compressed {w.DESCRIPTION} (*{w.EXTENSIONS[0]}.gz): Komprimiertes {w.DESCRIPTION} (*{w.EXTENSIONS[0]}.gz)
+        def `send_report`:
+            No: Nein
+            Yes: Ja
+            File name: Dateiname
+            not set: nicht gesetzt
+            Format: Format
+            Type annotations: Typinformationen
+widgets/data/owselectbydataindex.py:
+    class `OWSelectByDataIndex`:
+        Select by Data Index: Nach Datenindex auswählen
+        Match instances by index from data subset.: Instanzen anhand des Index aus der Teildatenmenge auswählen
+        Transform: Transformieren
+        class `Inputs`:
+            Data: Daten
+            Data Subset: Teildaten
+        class `Outputs`:
+            Matching Data: Übereinstimmende Daten
+            Unmatched Data: Nicht übereinstimmende Daten
+            Annotated Data: Annotierte Daten
+        class `Warning`:
+            Input tables do not share any instances.: Die Eingabetabellen teilen keine Instanzen
+        def `__init__`:
+            '
+Data rows keep their identity even when some or all original variables
+are replaced by variables computed from the original ones.
+
+This widget gets two data tables ("Data" and "Data Subset") that
+can be traced back to the same source. It selects all rows from Data
+that appear in Data Subset, based on row identity and not actual data.
+': '
+            Datenzeilen behalten ihre Identität, auch wenn einige oder alle ursprünglichen Variablen
+            durch Variablen ersetzt werden, die aus den ursprünglichen berechnet wurden.
+
+            Dieses Widget erhält zwei Datentabellen („Daten“ und „Datenuntermenge“), die
+            auf dieselbe Quelle zurückgeführt werden können. Es wählt alle Zeilen aus den Daten
+            aus, die in der Datenuntermenge erscheinen, basierend auf der Zeilenidentität und nicht auf den tatsächlichen Daten.'
+        def `send_report`:
+            def `data_info_text`:
+                No data.: Keine Daten
+                '{data.name}, ': '{data.name}, '
+                "{len(data)} {pl(len(data), 'instance')}, ": "{len(data)} {plde(len(data), 'Instanz|Instanzen')}, "
+                {nvars} {pl(nvars, 'variable')}: {nvars} {plde(nvars, 'Variable|Variablen')}
+            Data: Daten
+            Data Subset: Teildaten
+widgets/data/owselectcolumns.py:
+    class `OWSelectAttributes`:
+        Select Columns: Spalten auswählen
+        'Select columns from the data table and assign them to ': Wählen Sie Spalten aus der Datentabelle aus und weisen Sie sie zu
+        data features, classes or meta variables.: Datenfeatures, Klassen oder Metavariablen
+        Transform: Transformieren
+        select columns, filter, attributes, target, variable: select columns, filter, attributes, target, variable, Spalten auswählen, Filter, Attribute, Ziel, Variable
+        class `Inputs`:
+            Data: Daten
+            Features: Features
+        class `Outputs`:
+            Data: Daten
+            Features: Features
+        class `Warning`:
+            Features and data domain do not match: Features und Datendomäne stimmen nicht überein
+            Most widgets do not support multiple targets: Die meisten Widgets unterstützen keine mehreren Ziele
+        def `__init__`:
+            Ignored: Ignoriert
+            Features: Features
+            Use input features: Eingangsfeatures verwenden
+            Always use input features: Immer Eingangsfeatures verwenden
+            Target: Ziel
+            Metas: Metadaten
+            >: >
+            Reset: Zurücksetzen
+            Ignore new variables by default: Neue Variablen standardmäßig ignorieren
+            'When the widget receives data with additional columns ': Wenn das Widget Daten mit zusätzlichen Spalten erhält
+            'they are added to the available attributes column if ': werden diese der Spalte 'Verfügbare Attribute' hinzugefügt, falls
+            <i>Ignore new variables by default</i> is checked.: <i>Neue Variablen standardmäßig ignorieren</i> ist aktiviert.
+        def `update_var_counts`:
+            {name} ({nvars}/{nall}): {name} ({nvars}/{nall})
+            {name} ({nvars}): {name} ({plde(nvars, 'Variable|Variablen')})
+        def `update_interface_state`:
+            >: >
+            <: <
+        def `send_report`:
+            Input data: Eingabedaten
+            Output data: Ausgabedaten
+            No changes.: Keine Änderungen
+            {len(diff)} ({", ".join(x.name for x in diff)}): {len(diff)} ({', '.join(x.name for x in diff)})
+            Removed: Entfernt
+widgets/data/owselectrows.py:
+    class `OWSelectRows`:
+        Select Rows: Zeilen auswählen
+        Select rows from the data based on values of variables.: Zeilen basierend auf Variablenwerten auswählen
+        Transform: Transformieren
+        select rows, filter: select rows, filter, Zeilen auswählen, Filter
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Matching Data: Übereinstimmende Daten
+            Unmatched Data: Nicht übereinstimmende Daten
+        equals: gleich
+        equal: gleich
+        is not: ist nicht
+        are not: sind nicht
+        is below: ist kleiner als
+        are below: sind kleiner als
+        is at most: ist höchstens
+        are at most: sind höchstens
+        is greater than: ist größer als
+        are greater than: sind größer als
+        is at least: ist mindestens
+        are at least: sind mindestens
+        is between: liegt zwischen
+        are between: liegen zwischen
+        is outside: liegt außerhalb
+        are outside: liegen außerhalb
+        is defined: ist definiert
+        are defined: sind definiert
+        is: ist
+        is one of: ist einer von
+        is before: liegt vor
+        are before: liegen vor
+        is equal or before: ist gleich oder liegt vor
+        are equal or before: sind gleich oder liegen vor
+        is after: liegt nach
+        are after: liegen nach
+        is equal or after: ist gleich oder liegt nach
+        are equal or after: sind gleich oder liegen nach
+        contains: enthält
+        contain: enthalten
+        does not contain: enthält nicht
+        do not contain: enthalten nicht
+        begins with: beginnt mit
+        begin with: beginnen mit
+        does not begin with: beginnt nicht mit
+        do not begin with: beginnen nicht mit
+        ends with: endet mit
+        end with: enden mit
+        does not end with: endet nicht mit
+        do not end with: enden nicht mit
+        is not defined: ist nicht definiert
+        are not defined: sind nicht definiert
+        All variables: Alle Variablen
+        All numeric variables: Alle numerischen Variablen
+        All string variables: Alle String-Variablen
+        def `__init__`:
+            Conditions: Bedingungen
+            Add Condition: Bedingung hinzufügen
+            Add All Variables: Alle Variablen hinzufügen
+            Remove All: Alle entfernen
+            Remove unused values and constant features: Nicht genutzte Werte und konstante Features entfernen
+            Remove unused classes: Nicht genutzte Klassen entfernen
+        def `add_row`:
+            ×: ×
+            '* {font-size: 16pt; color: palette(button-text) }': * {font-size: 16pt; color: palette(button-text) }
+            '*:hover {color: palette(bright-text)}': *:hover {color: palette(bright-text)}
+        def `add_all`:
+            Remove existing filters: Bestehende Filter entfernen
+            'This will replace the existing filters with ': 'Dies ersetzt die bestehenden Filter durch '
+            filters for all variables.: Filter für alle Variablen
+        def `set_new_values`:
+            defined: definiert
+            ' one of': ' einer von'
+            ' and ': ' und '
+        def `_values_to_floats`:
+            Some values could not be parsed as floats: Einige Werte konnten nicht als Zahlen interpretiert werden
+            ' in the current locale: {values}': ' in der aktuellen Regionseinstellung: {values}'
+        def `send_report`:
+            No data.: Keine Daten
+            Data instances: Dateninstanzen
+            is one of: ist einer von
+            {', '.join(valnames[:-1])} or {valnames[-1]}: {', '.join(valnames[:-1])} oder {valnames[-1]}
+            {attr} is {valstr}: {attr} ist {valstr}
+            {attr} {name} {' and '.join(map(repr, values))}: {attr} {name} {' und '.join(map(repr, values))}
+            {attr} {name} {' and '.join(values)}: {attr} {name} {' und '.join(values)}
+            Instances: Instanzen
+            Condition: Bedingung
+            ' AND ': ' UND '
+            no conditions: Keine Bedingungen
+            Data: Daten
+            Matching data: Übereinstimmende Daten
+            Non-matching data: Nicht übereinstimmende Daten
+            Output: Ausgabe
+            {match_inst} {pl(match_inst, 'instance')}: {match_inst} {plde(match_inst, 'Instanz|Instanzen')}
+            None: Keine
+            {nonmatch_inst} {pl(nonmatch_inst, 'instance')}: {nonmatch_inst} {plde(nonmatch_inst, 'Instanz|Instanzen')}
+widgets/data/owsplit.py:
+    class `OWSplit`:
+        Split: "Aufteilen"
+        Split text or categorical variables into indicator variables: "Text- oder kategoriale Variablen in Indikatorvariablen aufteilen"
+        Transform: "Transformieren"
+        text to columns: "Text in Spalten"
+        word encoding: "Wortkodierung"
+        questionnaire: "Fragebogen"
+        survey: "Umfrage"
+        term: "Term"
+        word presence: "Wortvorkommen"
+        word counts: "Wortanzahl"
+        categorical encoding: "Kategoriale Kodierung"
+        indicator variables: "Indikatorvariablen"
+        class `Inputs`:
+            Data: "Daten"
+        class `Outputs`:
+            Data: "Daten"
+        class `Warning`:
+            Data contains only numeric variables.: "Daten enthalten nur numerische Variablen."
+        Categorical (No, Yes): "Kategorial (Nein, Ja)"
+        Numerical (0, 1): "Numerisch (0, 1)"
+        Counts: "Anzahlen"
+        ;: ";"
+        def `__init__`:
+            Variable: "Variable"
+            'Delimiter: ': "Trennzeichen: "
+            Output Values: "Ausgabewerte"
+        def `_get_new_columns`:
+            No: "Nein"
+            Yes: "Ja"
+widgets/data/owsql.py:
+    class `OWSql`:
+        SQL Table: SQL-Tabelle
+        Load dataset from SQL.: Datensatz aus SQL laden
+        Data: Daten
+        sql table, load: SQL-Tabelle, laden
+        class `Outputs`:
+            Data: Daten
+            Attribute-valued dataset read from the input file.: Datensatz mit Attributwerten aus der Eingabedatei gelesen
+        class `Information`:
+            Data description was generated from a sample.: Datenbeschreibung wurde aus einer Stichprobe erstellt
+        class `Warning`:
+            'Database is missing extensions: {}': Datenbank fehlt Erweiterungen: {}
+        class `Error`:
+            Please install a backend to use this widget.: Bitte installieren Sie ein Backend, um dieses Widget zu verwenden
+        def `_add_tables_controls`:
+            Tables: Tabellen
+            table: Tabelle
+            'Materialize to table ': 'In Tabelle materialisieren '
+            Save results of the query in a table: Speichern Sie die Ergebnisse der Abfrage in einer Tabelle
+            Execute: Ausführen
+            Auto-discover categorical variables: Kategorische Variablen automatisch erkennen
+            Download data to local memory: Daten in lokalen Speicher herunterladen
+        def `on_connection_success`:
+            ', ': ', '
+        def `refresh_tables`:
+            Select a table: Tabelle auswählen
+            Custom SQL: Benutzerdefiniertes SQL
+        def `select_table`:
+            Custom SQL: Benutzerdefiniertes SQL
+            Table: Tabelle
+            (None): (Keine)
+        def `get_table`:
+            (None): (Keine)
+            Custom SQL: Benutzerdefiniertes SQL
+            Query: Abfrage
+            Specify a table name to materialize the query: Geben Sie einen Tabellennamen an, um die Abfrage zu materialisieren
+            'Attribute discovery might take ': 'Die Attribut-Erkennung kann dauern: '
+            a long time on large tables.\n: Lange bei großen Tabellen.\n
+            Do you want to auto discover attributes?: Möchten Sie die Attribute automatisch erkennen?
+            Yes: Ja
+            No: Nein
+            Yes, on a sample: Ja, auf einer Stichprobe
+            'Data appears to be big. Do you really ': 'Die Daten scheinen groß zu sein. Möchten Sie wirklich '
+            want to download it to local memory?\n: diese in den lokalen Speicher herunterladen?\n
+            'Table length: {:,}. Limit {:,}': Tabellenlänge: {:,}. Limit {:,}
+            Yes, a sample: Ja, eine Stichprobe
+            Warning: Warnung
+            Data is too big to download.\n: Die Daten sind zu groß, um heruntergeladen zu werden.\n
+            Question: Frage
+            want to download it to local memory?: Möchten Sie sie in den lokalen Speicher herunterladen?
+widgets/data/owtable.py:
+    class `OWTable`:
+        Data Table: Datentabelle
+        View the dataset in a spreadsheet.: Datensatz in einer Tabellenkalkulation anzeigen.
+        data table, view: data table, view, Datentabelle, Ansicht
+        class `Inputs`:
+            Data: Daten
+            Data Subset: Datenauswahl
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Warning`:
+            Cannot restore sorting.\n: Sortierung kann nicht wiederhergestellt werden.\n
+            'Missing columns in input table: {}': Fehlende Spalten in der Eingabetabelle: {}
+            Input table cannot be sorted due to implementation constraints.: Eingabetabelle kann aufgrund von Implementierungsbeschränkungen nicht sortiert werden.
+        def `__init__`:
+            Info: Info
+            Variables: Variablen
+            Show variable labels (if present): Variablenbeschriftungen anzeigen (falls vorhanden)
+            Visualize numeric values: Numerische Werte visualisieren
+            Color by instance classes: Nach Klassen der Instanzen einfärben
+            Selection: Auswahl
+            Select full rows: Ganze Zeilen auswählen
+            Restore Original Order: Ursprüngliche Reihenfolge wiederherstellen
+            Show rows in the original order: Zeilen in der ursprünglichen Reihenfolge anzeigen
+        def `_update_input_summary`:
+            No data.: Keine Daten.
+widgets/data/owtransform.py:
+    class `TransformRunner`:
+        def `run`:
+            Transforming...: Transformiere...
+    class `OWTransform`:
+        Apply Domain: Domäne anwenden
+        Applies template domain on data table.: Wendet die Vorlagendomäne auf die Datentabelle an.
+        Transform: Transformieren
+        apply domain, transform: apply domain, Domäne anwenden, transformieren
+        class `Inputs`:
+            Data: Daten
+            Template Data: Vorlagendaten
+        class `Outputs`:
+            Transformed Data: Transformierte Daten
+        class `Error`:
+            An error occurred while transforming data.\n{}: Ein Fehler ist aufgetreten beim Transformieren der Daten.\n{}
+        def `__init__`:
+            '
+The widget takes Data, to which it re-applies transformations
+that were applied to Template Data.
+
+These include selecting a subset of variables as well as
+computing variables from other variables appearing in the data,
+like, for instance, discretization, feature construction, PCA etc.
+': 'Das Widget nimmt Daten, auf die es die Transformationen erneut anwendet, die auf Vorlagendaten angewendet wurden.
+
+Diese umfassen die Auswahl einer Teilmenge von Variablen sowie die Berechnung von Variablen aus anderen in den Daten erscheinenden Variablen, wie z. B. Diskretisierung, Merkmalskonstruktion, PCA usw.
+'
+        def `send_report`:
+            Data: Daten
+            Template data: Vorlagendaten
+            Transformed data: Transformierte Daten
+widgets/data/owtranspose.py:
+    class `OWTranspose`:
+        Transpose: Transponieren
+        Transpose data table.: Datentabelle transponieren.
+        Transform: Transformieren
+        transpose: transponieren
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        Feature: Variable
+        class `Warning`:
+            'Values are not unique.\nTo avoid multiple ': 'Werte sind nicht eindeutig.\nUm mehrere '
+            'features with the same name, values \nof ': 'Merkmale mit demselben Namen, Werte von '
+            "'{}' have been augmented with indices.": "'{}' wurden mit Indizes angereichert."
+            Categorical features have been encoded as numbers.: Kategorische Merkmale wurden als Zahlen codiert.
+        def `__init__`:
+            Feature names: Merkmalsnamen
+            Generic: Generisch
+            Type a prefix ...: Geben Sie ein Präfix ein ...
+            Custom feature name: Benutzerdefinierter Merkmalsname
+            From variable:: Von Variable:
+            Remove redundant instance: Überflüssige Instanz entfernen
+        def `send_report`:
+            from variable: Von Variable:
+            Feature names: Merkmalsnamen
+            Data: Daten
+widgets/data/owunique.py:
+    class `OWUnique`:
+        Unique: Einzigartig
+        Filter instances unique by specified key attribute(s).: Filtere Instanzen nach angegebenen Schlüsselattribut(en) eindeutig.
+        Transform: Transformieren
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Data: Daten
+        Last instance: Lätzte Instanz
+        First instance: Erste Instanz
+        Middle instance: Mittlere Instanz
+        Random instance: Zufällige Instanz
+        Discard non-unique instances: Überflüssige Instanzen verwerfen
+        def `__init__`:
+            Group by: Gruppieren nach
+            Instance to select in each group:: Instanz in jeder Gruppe auswählen:
+            Commit: Übernehmen
+widgets/data/utils/preprocess.py:
+    class `SequenceFlow`:
+        class `Frame`:
+            def `__init__`:
+                Remove: Entfernen
+widgets/data/utils/tablesummary.py:
+    def `format_summary`:
+        def `format_part`:
+            ' ({perc:.1f} % missing data)': ' ({perc:.1f} % fehlende Daten)'
+            sparse: dünn besetzt
+            tags: Tags
+            ' ({tag}, density {dens:.2f} %)': ' ({tag}, Dichte {dens:.2f} %)'
+        {ninst} {pl(ninst, 'instance')}: {ninst} {plde(ninst, 'Instanz|Instanzen')}
+        ~{ninst} {pl(ninst, 'instance')}: ~{ninst} {plde(ninst, 'Instanz|Instanzen')}
+        ' (no missing data)': ' (keine fehlenden Daten)'
+        {nattrs} {pl(nattrs, 'feature')}: {nattrs} {plde(nattrs, 'Merkmal|Merkmale')}
+        No target variable.: Keine Zielvariable
+        {nclasses} {pl(nclasses, 'outcome')}: {nclasses} {plde(nclasses, 'Ausgang|Ausgänge')}
+        Numeric outcome: Numerisches Ergebnis
+        Target with {nvalues} {pl(nvalues, 'value')}: Ziel mit {nvalues} {plde(nvalues, 'Wert|Werte')}
+        {nmetas} {pl(nmetas, 'meta attribute')}: {nmetas} {plde(nmetas, 'Metadate')}
+        No meta attributes.: Keine Metadaten
+widgets/evaluate/__init__.py:
+    Evaluate: Bewerten
+    Evaluate model performance: Modellleistung bewerten
+widgets/evaluate/owcalibrationplot.py:
+    Calibration curve: Kalibrierungskurve
+    Classification accuracy: Klassifikationsgenauigkeit
+    F1: F1
+    Sensitivity and specificity: Sensitivität und Spezifität
+    sens: Sens
+    spec: Spez
+    '<p><b>Sensitivity</b> (falling) is the proportion of correctly ': '<p><b>Sensitivität</b> (abnehmend) ist der Anteil korrekt '
+    detected positive instances (TP&nbsp;/&nbsp;P).</p>: detektierter positiver Instanzen (TP&nbsp;/&nbsp;P).</p>
+    '<p><b>Specificity</b> (rising) is the proportion of detected ': '<p><b>Spezifität</b> (zunehmend) ist der Anteil detektierter '
+    negative instances (TN&nbsp;/&nbsp;N).</p>: negativer Instanzen (TN&nbsp;/&nbsp;N).</p>
+    Precision and recall: Präzision und Trefferquote
+    prec: Präz
+    recall: Treff
+    '<p><b>Precision</b> (rising) is the fraction of retrieved instances ': '<p><b>Präzision</b> (zunehmend) ist der Anteil der abgerufenen Instanzen '
+    that are relevant, TP&nbsp;/&nbsp;(TP&nbsp;+&nbsp;FP).</p>: die relevant sind, TP&nbsp;/&nbsp;(TP&nbsp;+&nbsp;FP).</p>
+    '<p><b>Recall</b> (falling) is the proportion of discovered relevant ': '<p><b>Trefferquote</b> (abnehmend) ist der Anteil entdeckter relevanter '
+    instances, TP&nbsp;/&nbsp;P.</p>: Instanzen, TP&nbsp;/&nbsp;P.</p>
+    Pos and neg predictive value: Positiver und negativer Vorhersagewert
+    PPV: PPV
+    TPV: NPV
+    '<p><b>Positive predictive value</b> (rising) is the proportion of ': '<p><b>Positiver Vorhersagewert</b> (zunehmend) ist der Anteil der '
+    correct positives, TP&nbsp;/&nbsp;(TP&nbsp;+&nbsp;FP).</p>: korrekt positiven Instanzen, TP&nbsp;/&nbsp;(TP&nbsp;+&nbsp;FP).</p>
+    '<p><b>Negative predictive value</b> is the proportion of correct ': '<p><b>Negativer Vorhersagewert</b> ist der Anteil korrekt '
+    negatives, TN&nbsp;/&nbsp;(TN&nbsp;+&nbsp;FN).</p>: negativer Instanzen, TN&nbsp;/&nbsp;(TN&nbsp;+&nbsp;FN).</p>
+    True and false positive rate: Richtige und falsche Positivrate
+    TPR: TPR
+    FPR: FPR
+    '<p><b>True and false positive rate</b> are proportions of detected ': <p><b>Wahre und falsche Positivrate</b> sind Anteile erkannter und übersehener positiver Instanzen
+    and omitted positive instances</p>: </p>
+    class `OWCalibrationPlot`:
+        Calibration Plot: Kalibrierungsplot
+        Calibration plot based on evaluation of classifiers.: Kalibrierungsplot basierend auf der Auswertung von Klassifikatoren.
+        calibration plot: calibration plot, Kalibrierungsplot
+        class `Inputs`:
+            Evaluation Results: Auswertungsergebnisse
+        class `Outputs`:
+            Calibrated Model: Kalibriertes Modell
+        class `Error`:
+            'Calibration plot requires a categorical ': 'Kalibrierungsplot benötigt eine kategoriale '
+            target variable.: Zielvariable.
+            Empty result on input. Nothing to display.: Leeres Ergebnis. Nichts zum Anzeigen.
+            Remove test data instances with unknown classes.: Testdateninstanzen mit unbekannten Klassen entfernen.
+            All data instances belong to target class.: Alle Dateninstanzen gehören zur Zielklasse.
+            No data instances belong to target class.: Keine Dateninstanzen gehören zur Zielklasse.
+        class `Warning`:
+            Test folds where all data belongs to (non)-target are not shown.: Test-Folds, in denen alle Daten zur (Nicht-)Zielklasse gehören, werden nicht angezeigt.
+            Instance for which the model couldn't compute probabilities are: Instanzen, für die das Modell keine Wahrscheinlichkeiten berechnen konnte, werden
+            skipped.: übersprungen.
+            No valid data for model(s) {}: Keine gültigen Daten für Modell(e) {}
+        class `Information`:
+            "Can't output a model: {}": Kann Modell nicht ausgeben: {}
+        def `__init__`:
+            Settings: Einstellungen
+            Target:: Ziel:
+            Show rug: Rug anzeigen
+            Curves for individual folds: Kurven für einzelne Folds
+            Classifier: Klassifikator
+            Metrics: Metriken
+            Sigmoid calibration: Sigmoid-Kalibrierung
+            Isotonic calibration: Isotone Kalibrierung
+            Output model calibration: Kalibrierung des Ausgabemodells
+            Info: Info
+        def `_set_explanation`:
+            Predicted probability: Vorhergesagte Wahrscheinlichkeit
+            Threshold probability to classify as positive: Schwellenwahrscheinlichkeit für positive Klassifizierung
+        def `get_info_text`:
+            "<table>
+                            <tr>
+                                <th align='right'>Threshold: p=</th>
+                                <td colspan='4'>{self.threshold:.2f}<br/></td>
+                            </tr>": "<table>
+                            <tr>
+                                <th align='right'>Schwelle: p=</th>
+                                <td colspan='4'>{self.threshold:.2f}<br/></td>
+                            </tr>"
+            "<table>
+                            <tr>
+                                <th align='right'>Threshold:</th>
+                                <td colspan='4'>p = {self.threshold:.2f}<br/>
+                                </td>
+                                <tr/>
+                            </tr>": "<table>
+                            <tr>
+                                <th align='right'>Schwelle:</th>
+                                <td colspan='4'>p = {self.threshold:.2f}<br/>
+                                </td>
+                                <tr/>
+                            </tr>"
+        def `send_report`:
+            Target class: Zielklasse
+            Output model calibration: Kalibrierung des Ausgabemodells
+            Sigmoid calibration: Sigmoid-Kalibrierung
+            Isotonic calibration: Isotone Kalibrierung
+widgets/evaluate/owconfusionmatrix.py:
+    class `OWConfusionMatrix`:
+        Confusion Matrix: Konfusionsmatrix
+        'Display a confusion matrix constructed from ': 'Konstruierte Konfusionsmatrix anzeigen basierend auf '
+        the results of classifier evaluations.: den Ergebnissen der Klassifikator-Auswertungen.
+        confusion matrix: confusion matrix, Konfusionsmatrix
+        class `Inputs`:
+            Evaluation Results: Auswertungsergebnisse
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        Number of instances: Anzahl der Instanzen
+        Proportion of predicted: Anteil der Vorhersagen
+        Proportion of actual: Anteil der tatsächlichen Werte
+        Sum of probabilities: Summe der Wahrscheinlichkeiten
+        Number of correctly and incorrectly classified instances: Anzahl korrekt und inkorrekt klassifizierter Instanzen
+        'Number of instances, distributed across columns ': 'Anzahl der Instanzen, verteilt über die Spalten '
+        according to predicted probabilities: basierend auf den vorhergesagten Wahrscheinlichkeiten
+        'Clicking on cells or in headers outputs the corresponding ': 'Klicken auf Zellen oder Kopfzeilen zeigt die entsprechenden '
+        data instances: Dateninstanzen
+        class `Error`:
+            Confusion Matrix cannot show regression results.: Konfusionsmatrix kann keine Regressions-Ergebnisse anzeigen.
+            Evaluation Results input contains invalid values: Eingabe der Auswertungsergebnisse enthält ungültige Werte.
+            Empty result on input. Nothing to display.: Leeres Ergebnis. Nichts zum Anzeigen.
+        def `__init__`:
+            Learners: Lernende
+            Output: Ausgabe
+            Predictions: Vorhersagen
+            Probabilities: Wahrscheinlichkeiten
+            'Show: ': 'Anzeigen: '
+            Select Correct: Korrekt auswählen
+            Select Misclassified: Falsch klassifizierte auswählen
+            Clear Selection: Auswahl löschen
+        def `_init_table`:
+            Predicted: Vorhergesagt
+            Actual: Tatsächlich
+        def `set_results`:
+            Learner #{i + 1}: Lernender #{i + 1}
+        def `_prepare_data`:
+            p({value}): p({value})
+        def `_update`:
+            NA: n.a.
+            'actual: {}\npredicted: {}': tatsächlich: {}\nvorhergesagt: {}
+        def `send_report`:
+            Confusion matrix for {} (showing {}): Konfusionsmatrix für {} (zeige {})
+widgets/evaluate/owfeatureaspredictor.py:
+    class `OWFeatureAsPredictor`:
+        Feature as Predictor: "Merkmal als Prädiktor"
+        Use a column as probabilities or predictions: "Spalte als Wahrscheinlichkeiten oder Vorhersagen verwenden"
+        column predictor: column predictor, Spalten-Prädiktor
+        class `Inputs`:
+            Data: "Daten"
+        class `Outputs`:
+            Learner: "Lerner"
+            Model: "Modell"
+        class `Error`:
+            Data has no target variable.: "Daten haben keine Zielvariable."
+            No useful variables: "Keine nützlichen Variablen"
+        def `_update_controls`:
+            logistic: "Logistisch"
+            linear: "Linear"
+            Transform through {shape} function: "Transformation über {shape}-Funktion"
+            Use {shape} regression to fit the model's coefficients: "Verwende {shape}-Regression, um die Koeffizienten des Modells anzupassen"
+        def `send_report`:
+            Predict values from: "Werte vorhersagen aus"
+            Applied transformation: "Angewandte Transformation"
+            logistic: "Logistisch"
+            linear: "Linear"
+            Intercept: "Achsenabschnitt"
+            Coefficient: "Koeffizient"
+widgets/evaluate/owliftcurve.py:
+    class `ParameterSetter`:
+        Line: Linie
+        Default Line: Standardlinie
+        Solid line: Durchgezogene Linie
+        Dash line: Gestrichelte Linie
+    class `OWLiftCurve`:
+        Performance Curve: Leistungskurve
+        'Construct and display a performance curve ': 'Leistungskurve erstellen und anzeigen '
+        from the evaluation of classifiers.: basierend auf der Auswertung von Klassifikatoren.
+        performance curve, lift, cumulative gain, precision, recall, curve: performance curve, lift, cumulative gain, precision, recall, curve, Leistungskurve, Lift, kumulativer Gewinn, Präzision, Recall, Kurve
+        class `Inputs`:
+            Evaluation Results: Auswertungsergebnisse
+        class `Outputs`:
+            Calibrated Model: Kalibriertes Modell
+        class `Warning`:
+            Some curves are undefined; check models and data: Einige Kurven sind undefiniert; bitte Modelle und Daten prüfen
+        class `Error`:
+            No defined curves; check models and data: Keine definierten Kurven; bitte Modelle und Daten prüfen
+        class `Information`:
+            "Can't output a model: {}": Kann Modell nicht ausgeben: {}
+        P Rate: P-Rate
+        Recall: Recall
+        Lift: Lift
+        TP Rate: TP-Rate
+        Precision: Präzision
+        def `__init__`:
+            Curve: Kurve
+            'Target: ': 'Ziel: '
+            Lift Curve: Lift-Kurve
+            Cumulative Gains: Kumulative Gewinne
+            Precision Recall: Precision-Recall
+            Models: Modelle
+            Settings: Einstellungen
+            Show thresholds: Schwellenwerte anzeigen
+            Show points: Punkte anzeigen
+            Area under the curve: Fläche unter der Kurve
+        def `_plot_curve`:
+            def `tip`:
+                'Threshold: {round(data, 3)}': Schwelle: {round(data, 3)}
+        def `_set_tooltip`:
+            ' <span>Probability threshold(s):</span>': ' <span>Wahrscheinlichkeitsschwelle(n):</span>'
+        def `send_report`:
+            Target class: Zielklasse
+widgets/evaluate/owparameterfitter.py:
+    def `_search`:
+        Calculating...: Berechne...
+    class `ParameterSetter`:
+        Gridlines: Gitternetzlinien
+        Show: Anzeigen
+    class `FitterPlot`:
+        def `set_data`:
+            Train: Train
+            CV: CV
+        def `help_event`:
+            <td><b>Train:</b></td>: <td><b>Train:</b></td>
+            <td><b>CV:</b></td>: <td><b>CV:</b></td>
+    class `RangePreview`:
+        def `paintEvent`:
+            'Steps: ': 'Schritte: '
+    class `OWParameterFitter`:
+        Parameter Fitter: Parameteranpassung
+        Fit learner for various values of fitting parameter.: Passe Lernalgorithmus für verschiedene Werte des Parameters an.
+        class `Inputs`:
+            Data: Daten
+            Learner: Lerner
+        class `Error`:
+            At least {N_FOLD} instances are needed.: Mindestens {N_FOLD} Instanzen erforderlich.
+            "Invalid values for '{}': {}": Ungültige Werte für '{}': {}
+            Minimum must be less than maximum.: Minimum muss kleiner als Maximum sein.
+            Data has no target.: Daten haben keine Zielvariable.
+        class `Warning`:
+            {} has no parameters to fit.: {} hat keine Parameter zum Anpassen.
+        def `_add_controls`:
+            Settings: Einstellungen
+            Range:: Bereich:
+            From:: Von:
+            To:: Bis:
+            Manual:: Manuell:
+            e.g. 10, 20, ..., 50: z. B. 10, 20, ..., 50
+        def `_set_range_controls`:
+            Enter a list of values: Liste von Werten eingeben
+            {tip} between {param.min} and {param.max}.: {tip} zwischen {param.min} und {param.max}.
+            {tip} greater or equal to {param.min}.: {tip} größer oder gleich {param.min}.
+            {tip} smaller or equal to {param.max}.: {tip} kleiner oder gleich {param.max}.
+        def `send_report`:
+            Settings: Einstellungen
+            Parameter: Parameter
+            Range: Bereich
+            Plot: Diagramm
+widgets/evaluate/owpermutationplot.py:
+    def `permutation`:
+        Calculating...: Berechne...
+    class `ParameterSetter`:
+        Gridlines: Gitternetzlinien
+        Show: Anzeigen
+    class `PermutationPlot`:
+        def `__init__`:
+            Correlation between original Y and permuted Y (%): Korrelation zwischen originalem Y und permutiertem Y (%)
+        def `set_data`:
+            AUC: AUC
+            '#000': '#000'
+            '#333': '#333'
+            '#6fa255': '#6fa255'
+            '#3a78b6': '#3a78b6'
+            'x: {x:.3g}\ny: {y:.3g}': x: {x:.3g}\ny: {y:.3g}
+            Train: Train
+            CV: CV
+    class `OWPermutationPlot`:
+        Permutation Plot: Permutationsdiagramm
+        Permutation analysis plotting: Permutationsanalyse darstellen
+        class `Inputs`:
+            Data: Daten
+            Learner: Lerner
+        class `Error`:
+            At least {N_FOLD} instances are needed.: Mindestens {N_FOLD} Instanzen erforderlich.
+        def `_add_controls`:
+            Settings: Einstellungen
+            Permutations:: Permutationen:
+            Info: Info
+        def `__set_info`:
+            No data available.: Keine Daten verfügbar.
+            '
+<table width=100% align="center" style="font-size:11px">
+    <tr style="background:#fefefe">
+        <th style="background:transparent;padding: 2px 4px"></th>
+        <th style="background:transparent;padding: 2px 4px">Corr = 0</th>
+        <th style="background:transparent;padding: 2px 4px">Corr = 100</th>
+    </tr>
+    <tr style="background:#fefefe">
+        <th style="padding: 2px 4px" align=right>Train</th>
+        <td style="padding: 2px 4px" align=right>{intercept_tr:.4f}</td>
+        <td style="padding: 2px 4px" align=right>{y_tr:.4f}</td>
+    </tr>
+    <tr style="background:#fefefe">
+        <th style="padding: 2px 4px" align=right>CV</th>
+        <td style="padding: 2px 4px" align=right>{intercept_cv:.4f}</td>
+        <td style="padding: 2px 4px" align=right>{y_cv:.4f}</td>
+    </tr>
+</table>
+            ': '
+<table width=100% align="center" style="font-size:11px">
+    <tr style="background:#fefefe">
+        <th style="background:transparent;padding: 2px 4px"></th>
+        <th style="background:transparent;padding: 2px 4px">Corr = 0</th>
+        <th style="background:transparent;padding: 2px 4px">Corr = 100</th>
+    </tr>
+    <tr style="background:#fefefe">
+        <th style="padding: 2px 4px" align=right>Train</th>
+        <td style="padding: 2px 4px" align=right>{intercept_tr:.4f}</td>
+        <td style="padding: 2px 4px" align=right>{y_tr:.4f}</td>
+    </tr>
+    <tr style="background:#fefefe">
+        <th style="padding: 2px 4px" align=right>CV</th>
+        <td style="padding: 2px 4px" align=right>{intercept_cv:.4f}</td>
+        <td style="padding: 2px 4px" align=right>{y_cv:.4f}</td>
+    </tr>
+</table>
+            '
+        def `send_report`:
+            Settings: Einstellungen
+            Permutations: Permutationen
+            Info: Info
+            Plot: Diagramm
+widgets/evaluate/owpredictions.py:
+    (None): (Keine)
+    Difference: Differenz
+    Absolute difference: Absoluter Unterschied
+    Relative: Relativ
+    Absolute relative: Absolut relativ
+    Don't show columns with errors: Spalten mit Fehlern nicht anzeigen
+    Show difference between predicted and actual value: Differenz zwischen vorhergesagtem und tatsächlichem Wert anzeigen
+    Show absolute difference between predicted and actual value: Absoluten Unterschied zwischen vorhergesagtem und tatsächlichem Wert anzeigen
+    Show relative difference between predicted and actual value: Relativen Unterschied zwischen vorhergesagtem und tatsächlichem Wert anzeigen
+    Show absolute value of relative difference between predicted and actual value: Absoluten Wert des relativen Unterschieds zwischen vorhergesagtem und tatsächlichem Wert anzeigen
+    class `OWPredictions`:
+        Predictions: Vorhersagen
+        Display predictions of models for an input dataset.: Zeigt Vorhersagen von Modellen für einen Eingabedatensatz an.
+        predictions: predictions, Vorhersagen
+        class `Inputs`:
+            Data: Daten
+            Predictors: Prädiktoren
+        class `Outputs`:
+            Selected Predictions: Ausgewählte Vorhersagen
+            Predictions: Vorhersagen
+            Evaluation Results: Evaluationsergebnisse
+        class `Warning`:
+            Empty dataset: Leerer Datensatz
+            Some model(s) predict a different target (see more ...)\n{}: Einige Modelle sagen eine andere Zielvariable voraus (siehe mehr ...)\n{}
+            'Instances with missing targets ': 'Instanzen mit fehlenden Zielwerten '
+            are ignored while scoring.: werden beim Scoring ignoriert.
+        class `Error`:
+            Some predictor(s) failed (see more ...)\n{}: Einige Prädiktoren sind fehlgeschlagen (siehe mehr ...)\n{}
+            Some scorer(s) failed (see more ...)\n{}: Einige Scorer sind fehlgeschlagen (siehe mehr ...)\n{}
+        (None): (Keine)
+        Classes in data: Klassen im Datensatz
+        Classes known to the model: Vom Modell bekannte Klassen
+        Classes in data and model: Klassen im Datensatz und Modell
+        Don't show probabilities: Wahrscheinlichkeiten nicht anzeigen
+        Show probabilities for classes in the data: Wahrscheinlichkeiten für Klassen im Datensatz anzeigen
+        Show probabilities for classes known to the model,\n: Wahrscheinlichkeiten für Klassen anzeigen, die dem Modell bekannt sind,\n
+        including those that don't appear in this data: einschließlich der Klassen, die in diesen Daten nicht vorkommen
+        Show probabilities for classes in data that are also\n: Wahrscheinlichkeiten für Klassen anzeigen, die im Datensatz vorkommen und auch\n
+        known to the model: vom Modell bekannt sind
+        (Average over classes): (Durchschnitt über Klassen)
+        def `__init__`:
+            Show probabilities for: Wahrscheinlichkeiten anzeigen für
+            Show classification errors: Klassifikationsfehler anzeigen
+            Show 1 - probability assigned to the correct class: 1 - Wahrscheinlichkeit für die korrekte Klasse anzeigen
+            'Shown regression error: ': 'Angezeigter Regressionsfehler: '
+            See tooltips for individual options: Tooltips für einzelne Optionen beachten
+            Restore Original Order: Originalreihenfolge wiederherstellen
+            Show rows in the original order: Zeilen in der Originalreihenfolge anzeigen
+            Show perfomance scores: Leistungswerte anzeigen
+            Target class:: Zielklasse:
+        def `_update_scores`:
+            N/A: k.A.
+            NA: k.A.
+        def `_get_details`:
+            Data:<br>: Daten:<br>
+            "Model: {n_predictors} {pl(n_predictors, 'model')}": {n_predictors} {plde(n_predictors, 'Modell|Modelle')}
+            ' ({n_predictors - n_valid} failed)': ' ({n_predictors - n_valid} fehlgeschlagen)'
+            Model:<br>No model on input.: Modell:<br>Kein Modell als Eingabe.
+        def `_add_error_out_columns`:
+            {slot.predictor.name} (error): {slot.predictor.name} (Fehler)
+        def `send_report`:
+            '<br>Showing probabilities for ': '<br>Wahrscheinlichkeiten anzeigen für '
+            all classes known to the model.: alle vom Modell bekannten Klassen.
+            all classes that appear in the data.: alle Klassen, die im Datensatz vorkommen.
+            'all classes that appear in the data ': 'alle Klassen, die im Datensatz vorkommen '
+            and are known to the model.: und vom Modell bekannt sind.
+            Info: Info
+            Data & Predictions: Daten & Vorhersagen
+            Scores: Werte
+            Target class: Zielklasse
+    class `ClassificationItemDelegate`:
+        def `__init__`:
+            -: -
+            {probs} → {{value!s}}: {probs} → {{value!s}}
+            p({', '.join(tooltip_probabilities)}): p({', '.join(tooltip_probabilities)})
+    class `ClassificationErrorDelegate`:
+        def `displayText`:
+            ?: ?
+    class `RegressionErrorDelegate`:
+        def `displayText`:
+            ?: ?
+            -∞: -∞
+            ∞: ∞
+widgets/evaluate/owrocanalysis.py:
+    class `OWROCAnalysis`:
+        ROC Analysis: ROC-Analyse
+        'Display the Receiver Operating Characteristics curve ': 'Zeige die Receiver Operating Characteristics (ROC)-Kurve '
+        based on the evaluation of classifiers.: basierend auf der Auswertung von Klassifikatoren.
+        roc analysis, analyse: ROC-Analyse, Auswertung
+        class `Inputs`:
+            Evaluation Results: Evaluationsergebnisse
+        class `Outputs`:
+            Calibrated Model: Kalibriertes Modell
+        class `Information`:
+            "Can't output a model: {}": Kann kein Modell ausgeben: {}
+        def `__init__`:
+            Plot: Diagramm
+            Target: Zielklasse
+            Classifiers: Klassifikatoren
+            Curves: Kurven
+            Merge Predictions from Folds: Vorhersagen aus Folds zusammenführen
+            Mean TP Rate: Mittlere TP-Rate
+            Mean TP and FP at Threshold: Mittlere TP- und FP-Werte bei Schwellenwert
+            Show Individual Curves: Einzelne Kurven anzeigen
+            Show convex ROC curves: Konvexe ROC-Kurven anzeigen
+            Show ROC convex hull: Konvexe Hülle der ROC anzeigen
+            Analysis: Analyse
+            Default threshold (0.5) point: Standard-Schwellenwert (0,5) Punkt
+            Show performance line: Leistungsgerade anzeigen
+            FP Cost:: FP-Kosten:
+            FN Cost:: FN-Kosten:
+            ' %': ' %'
+            Prior probability:: Vorherige Wahrscheinlichkeit:
+            FP Rate (1-Specificity): FP-Rate (1-Spezifität)
+            TP Rate (Sensitivity): TP-Rate (Sensitivität)
+        def `_initialize`:
+            '#{}': '#{}'
+        def `_setup_plot`:
+            Some ROC curves are undefined: Einige ROC-Kurven sind undefiniert
+            All ROC curves are undefined: Alle ROC-Kurven sind undefiniert
+        def `_on_mouse_moved`:
+            Thresholds:\n: Schwellenwerte:\n
+        def `send_report`:
+            Target class: Zielklasse
+            Costs: Kosten
+            FP = {}, FN = {}: FP = {}, FN = {}
+            Target probability: Zielwahrscheinlichkeit
+widgets/evaluate/owtestandscore.py:
+    class `OWTestAndScore`:
+        Test and Score: Testen und Bewerten
+        Cross-validation accuracy estimation.: Schätzung der Genauigkeit mittels Kreuzvalidierung.
+        test and score, cross validation, cv: test and score, cross validation, Testen und Bewerten, Kreuzvalidierung, CV
+        class `Inputs`:
+            Data: Daten
+            Test Data: Testdaten
+            Learner: Lerner
+            Preprocessor: Vorverarbeiter
+        class `Outputs`:
+            Predictions: Vorhersagen
+            Evaluation Results: Evaluationsergebnisse
+        (None, show average over classes): (Keine, Durchschnitt über Klassen anzeigen)
+        class `Error`:
+            Test dataset is empty.: Testdatensatz ist leer.
+            Test data input requires a target variable.: Testdaten benötigen eine Zielvariable.
+            Number of folds exceeds the data size: Anzahl der Folds übersteigt die Datengröße.
+            'Test and train datasets ': 'Test- und Trainingsdatensätze '
+            have different target variables.: haben unterschiedliche Zielvariablen.
+            Not enough memory.: Nicht genügend Speicher.
+            Test data may be incompatible with train data.: Testdaten könnten inkompatibel zu Trainingsdaten sein.
+        class `Warning`:
+            Instances with unknown target values were removed from{}data.: Instanzen mit unbekannten Zielwerten wurden aus {}Daten entfernt.
+            Missing separate test data input.: Separate Testdaten fehlen.
+            Some scores could not be computed.: Einige Werte konnten nicht berechnet werden.
+            'Test data is present but unused. ': 'Testdaten sind vorhanden, aber ungenutzt. '
+            Select 'Test on test data' to use it.: Wählen Sie 'Test auf Testdaten', um sie zu verwenden.
+            "Can't run stratified {}-fold cross validation; ": 'Stratifizierte {}-Fold-Kreuzvalidierung kann nicht durchgeführt werden; '
+            the least common class has only {} instances.: die am seltensten vorkommende Klasse hat nur {} Instanzen.
+        class `Information`:
+            Train data has been sampled: Trainingsdaten wurden gesampelt.
+            Test data has been sampled: Testdaten wurden gesampelt.
+            Test data has been transformed to match the train data.: Testdaten wurden angepasst, um Trainingsdaten zu entsprechen.
+            Stratification is ignored for regression: Stratifizierung wird bei Regression ignoriert.
+            Stratification is ignored when there are: 'Stratifizierung wird ignoriert, wenn '
+            ' multiple target variables.': ' mehrere Zielvariablen vorhanden sind.'
+        def `__init__`:
+            Cross validation: Kreuzvalidierung
+            'Number of folds: ': 'Anzahl der Folds: '
+            Stratified: Stratifiziert
+            Cross validation by feature: Kreuzvalidierung nach Merkmal
+            Random sampling: Zufallssampling
+            'Repeat train/test: ': 'Train/Test wiederholen: '
+            'Training set size: ': 'Größe des Trainingssatzes: '
+            Leave one out: Leave-one-out
+            Test on train data: Test auf Trainingsdaten
+            Test on test data: Test auf Testdaten
+            Evaluation results for target: Evaluationsergebnisse für Zielklasse
+            Compare models by:: Modelle vergleichen nach:
+            'Negligible diff.: ': 'Vernachlässigbarer Unterschied: '
+            '<small>Table shows probabilities that the score for the model in ': '<small>Tabelle zeigt Wahrscheinlichkeiten, dass das Modell in '
+            'the row is higher than that of the model in the column. ': 'der Zeile höhere Werte als das Modell in der Spalte erzielt. '
+            'Small numbers show the probability that the difference is ': 'Kleine Zahlen zeigen die Wahrscheinlichkeit, dass der Unterschied '
+            negligible.</small>: vernachlässigbar ist.</small>
+        def `set_train_data`:
+            Train dataset is empty.: Trainingsdatensatz ist leer.
+            Train data input requires a target variable.: Trainingsdaten benötigen eine Zielvariable.
+            Target variable has no values.: Zielvariable hat keine Werte.
+            Target variable has only one value.: Zielvariable hat nur einen Wert.
+            Data has no features to learn from.: Daten enthalten keine Merkmale zum Lernen.
+        def `_which_missing_data`:
+            ' train ': ' Train '
+            ' test ': ' Test '
+        def `update_stats_model`:
+            {} (error): {} (Fehler)
+            {name} failed with error:\n: {name} schlug fehl mit Fehler:\n
+        def `send_report`:
+            'Stratified ': 'Stratifiziert '
+            Sampling type: Sampling-Typ
+            {}{}-fold Cross validation: {}{}-Fold-Kreuzvalidierung
+            Leave one out: Leave-one-out
+            '{}Shuffle split, {} random samples with {}% data ': '{}Shuffle-Split, {} Zufallsproben mit {}% der Daten '
+            No sampling, test on training data: Kein Sampling, Test auf Trainingsdaten
+            No sampling, test on testing data: Kein Sampling, Test auf Testdaten
+            Target class: Zielklasse
+            Settings: Einstellungen
+            Scores: Bewertungen
+        def `__submit`:
+            Running: Läuft
+widgets/evaluate/utils.py:
+    def `check_results_adequacy`:
+        Categorical target variable is required.: Kategorielle Zielvariable ist erforderlich.
+        Empty result on input. Nothing to display.: Leeres Ergebnis bei Eingabe. Nichts anzuzeigen.
+        Results contain invalid values.: Ergebnisse enthalten ungültige Werte.
+    def `check_can_calibrate`:
+        each training data sample produces a different model: Jede Trainingsstichprobe erzeugt ein anderes Modell.
+        'test results do not contain stored models - try testing ': 'Testergebnisse enthalten keine gespeicherten Modelle – versuchen Sie, '
+        on separate data or on training data: auf separaten Daten oder auf Trainingsdaten zu testen.
+        select a single model - the widget can output only one: Wählen Sie ein einzelnes Modell – das Widget kann nur eines ausgeben.
+        cannot calibrate non-binary models: Nicht-binäre Modelle können nicht kalibriert werden.
+        \n - {problem}: \n - {problem}
+    class `ScoreTable`:
+        def `update_header`:
+            Model: Modell
+            Train: Training
+            Train time [s]: Trainingszeit [s]
+            Test: Test
+            Test time [s]: Testzeit [s]
+widgets/evaluate/tests/base.py:
+    class `EvaluateTest`:
+        def `test_many_evaluation_results`:
+            Evaluation Results: Evaluierungsergebnisse
+widgets/model/__init__.py:
+    Model: Modell
+    Prediction: Vorhersage
+widgets/model/owadaboost.py:
+    class `OWAdaBoost`:
+        AdaBoost: AdaBoost
+        'An ensemble meta-algorithm that combines weak learners ': 'Ein Ensemble-Meta-Algorithmus, der schwache Lernende kombiniert '
+        "and adapts to the 'hardness' of each training sample. ": und sich an die 'Schwierigkeit' jeder Trainingsstichprobe anpasst.
+        adaboost, boost: adaboost, boost
+        class `Inputs`:
+            Learner: Lernender
+        Linear: Linear
+        Square: Quadratisch
+        Exponential: Exponential
+        class `Error`:
+            The base learner does not support weights.: Der Basislernende unterstützt keine Gewichte.
+        def `add_main_layout`:
+            Base estimator:: Basis-Schätzer:
+            Number of estimators:: Anzahl der Schätzer:
+            Learning rate:: Lernrate:
+            Loss (regression):: Fehler (Regression):
+            Reproducibility: Reproduzierbarkeit
+            Fixed seed for random generator:: Fester Seed für den Zufallsgenerator:
+        def `set_base_learner`:
+            INVALID: UNGÜLTIG
+        def `get_learner_parameters`:
+            Base estimator: Basis-Schätzer
+            Number of estimators: Anzahl der Schätzer
+            Loss (regression): Fehler (Regression)
+widgets/model/owcalibratedlearner.py:
+    class `OWCalibratedLearner`:
+        Calibrated Learner: Kalibrierter Lernender
+        'Wraps another learner with probability calibration and ': 'Umschließt einen anderen Lernenden mit Wahrscheinlichkeitskalibrierung und '
+        decision threshold optimization: Entscheidungsschwellenoptimierung
+        calibrated learner, calibration, threshold: calibrated learner, calibration, threshold, kalibrierter Lernender, Kalibrierung, Schwelle
+        Sigmoid calibration: Sigmoid-Kalibrierung
+        Isotonic calibration: Isotone Kalibrierung
+        No calibration: Keine Kalibrierung
+        Sigmoid: Sigmoid
+        Isotonic: Isoton
+        Optimize classification accuracy: Klassifikationsgenauigkeit optimieren
+        Optimize F1 score: F1-Wert optimieren
+        No threshold optimization: Keine Schwellenoptimierung
+        CA: CA
+        F1: F1
+        class `Inputs`:
+            Base Learner: Basis-Lernender
+        def `add_main_layout`:
+            Probability calibration: Wahrscheinlichkeitskalibrierung
+            Decision threshold optimization: Entscheidungsschwellenoptimierung
+        def `get_learner_parameters`:
+            Calibrate probabilities: Wahrscheinlichkeiten kalibrieren
+            Threshold optimization: Schwellenoptimierung
+widgets/model/owconstant.py:
+    class `OWConstant`:
+        Constant: Konstant
+        'Predict the most frequent class or mean value ': 'Die am häufigsten vorkommende Klasse oder den Mittelwert vorhersagen '
+        from the training set.: aus dem Trainingssatz.
+        constant, majority, mean: konstant, Mehrheit, Mittelwert
+widgets/model/owcurvefit.py:
+    class `ParametersWidget`:
+        def `_setup_gui`:
+            Name: Name
+            Initial value: Anfangswert
+            Lower bound: Untergrenze
+            Upper bound: Obergrenze
+        def `_add_row`:
+            p{row_id + 1}: p{row_id + 1}
+            ×: ×
+    class `OWCurveFit`:
+        Curve Fit: Kurvenanpassung
+        Fit a function to data.: Eine Funktion an die Daten anpassen.
+        curve fit, function: curve fit, function, Kurvenanpassung, Funktion
+        class `Outputs`:
+            Coefficients: Koeffizienten
+        class `Warning`:
+            Duplicated parameter name.: Doppelter Parametername.
+            "Unused parameter '{}' in ": "Unbenutzter Parameter '{}' in "
+            "'Parameters' declaration.": "'Parameters'-Deklaration."
+            Provide data on the input.: Geben Sie Daten am Eingang an.
+        class `Error`:
+            Invalid expression.: Ungültiger Ausdruck.
+            Missing a fitting parameter.\n: Fehlender Anpassungsparameter.\n
+            Use 'Feature Constructor' widget instead.: Verwenden Sie stattdessen das 'Feature Constructor'-Widget.
+            Unknown parameter '{}'.\n: Unbekannter Parameter '{}'.\n
+            Declare the parameter in 'Parameters' box: Deklarieren Sie den Parameter im 'Parameters'-Feld.
+            'Some parameters and features have the same ': 'Einige Parameter und Features haben denselben '
+            name '{}'.: Namen '{}'.
+        Select Feature: Feature auswählen
+        Select Parameter: Parameter auswählen
+        Select Function: Funktion auswählen
+        def `add_main_layout`:
+            Parameters: Parameter
+            Expression: Ausdruck
+            Expression...: Ausdruck...
+        def `get_learner_parameters`:
+            Expression: Ausdruck
+        def `check_data`:
+            Data has no continuous features.: Daten enthalten keine kontinuierlichen Features.
+widgets/model/owgradientboosting.py:
+    class `LearnerItemModel`:
+        Extreme Gradient Boosting (xgboost): Extreme Gradient Boosting (xgboost)
+        Extreme Gradient Boosting Random Forest (xgboost): Extreme Gradient Boosting Random Forest (xgboost)
+        Gradient Boosting (catboost): Gradient Boosting (catboost)
+        def `_add_data`:
+            {lib} is not installed: {lib} ist nicht installiert
+    class `BaseEditor`:
+        def `_add_main_layout`:
+            Basic Properties: Grundlegende Eigenschaften
+            Number of trees:: Anzahl der Bäume:
+            'Learning rate: ': 'Lernrate: '
+            Replicable training: Reproduzierbares Training
+            Growth Control: Wachstumskontrolle
+            'Limit depth of individual trees: ': 'Begrenze die Tiefe einzelner Bäume: '
+            Subsampling: Teilstichprobe
+        def `get_learner_parameters`:
+            Method: Methode
+            Number of trees: Anzahl der Bäume
+            Learning rate: Lernrate
+            Replicable training: Reproduzierbares Training
+            Yes: Ja
+            No: Nein
+            Maximum tree depth: Maximale Baumtiefe
+    class `RegEditor`:
+        def `_add_main_layout`:
+            Regularization:: Regularisierung:
+        def `_set_lambda_label`:
+            'Lambda: {}': Lambda: {}
+        def `get_learner_parameters`:
+            Regularization strength: Regularisierungsstärke
+    class `GBLearnerEditor`:
+        def `_add_main_layout`:
+            'Fraction of training instances: ': 'Anteil der Trainingsinstanzen: '
+            'Do not split subsets smaller than: ': 'Teilmengen kleiner als nicht aufteilen: '
+        def `get_learner_parameters`:
+            Fraction of training instances: Anteil der Trainingsinstanzen
+            Stop splitting nodes with maximum instances: Teilen von Knoten mit maximalen Instanzen stoppen
+    class `CatGBLearnerEditor`:
+        def `_add_main_layout`:
+            'Fraction of features for each tree: ': 'Anteil der Features für jeden Baum: '
+        def `get_learner_parameters`:
+            Fraction of features for each tree: Anteil der Features für jeden Baum
+    class `XGBBaseEditor`:
+        def `_add_main_layout`:
+            'Fraction of training instances: ': 'Anteil der Trainingsinstanzen: '
+            'Fraction of features for each tree: ': 'Anteil der Features für jeden Baum: '
+            'Fraction of features for each level: ': 'Anteil der Features für jede Ebene: '
+            'Fraction of features for each split: ': 'Anteil der Features für jeden Split: '
+        def `get_learner_parameters`:
+            Fraction of training instances: Anteil der Trainingsinstanzen
+            Fraction of features for each tree: Anteil der Features für jeden Baum
+            Fraction of features for each level: Anteil der Features für jede Ebene
+            Fraction of features for each split: Anteil der Features für jeden Split
+    class `OWGradientBoosting`:
+        Gradient Boosting: Gradient Boosting
+        Predict using gradient boosting on decision trees.: Vorhersage mit Gradient Boosting auf Entscheidungsbäumen.
+        gradient boosting, catboost, gradient, boost, tree, forest, xgb, gb, extreme: tree, gradient boosting, catboost, gradient, boost, Baum, Wald, xgb, gb, extrem
+        def `add_main_layout`:
+            Method: Methode
+widgets/model/owknn.py:
+    class `OWKNNLearner`:
+        kNN: kNN
+        Predict according to the nearest training instances.: Vorhersage basierend auf den nächsten Trainingsinstanzen.
+        knn, k nearest, knearest, neighbor, neighbour: k nearest, knearest, neighbor, neighbour, knn, k-nächste, knearest, Nachbar, Nachbarin
+        Uniform: Uniform
+        By Distances: Nach Distanz
+        Euclidean: Euklidisch
+        Manhattan: Manhattan
+        Chebyshev: Tschebyschew
+        Mahalanobis: Mahalanobis
+        def `add_main_layout`:
+            Neighbors: Nachbarn
+            Number of neighbors:: Anzahl der Nachbarn:
+            Metric:: Metrik:
+            Weight:: Gewichtung:
+        def `get_learner_parameters`:
+            Number of neighbours: Anzahl der Nachbarn
+            Metric: Metrik
+            Weight: Gewichtung
+widgets/model/owlinearregression.py:
+    class `OWLinearRegression`:
+        Linear Regression: Lineare Regression
+        'A linear regression algorithm with optional L1 (LASSO), ': 'Ein lineares Regressionsverfahren mit optionaler L1- (LASSO), '
+        L2 (ridge) or L1L2 (elastic net) regularization.: L2- (Ridge) oder L1L2- (Elastic Net) Regularisierung.
+        linear regression, ridge, lasso, elastic net: lineare Regression, Ridge, Lasso, Elastic Net
+        class `Outputs`:
+            Coefficients: Koeffizienten
+        No regularization: Keine Regularisierung
+        Ridge regression (L2): Ridge-Regression (L2)
+        Lasso regression (L1): Lasso-Regression (L1)
+        Elastic net regression: Elastic-Net-Regression
+        def `add_main_layout`:
+            Parameters: Parameter
+            Fit intercept (unchecking it fixes it to zero): Achsenabschnitt anpassen (ohne Haken = fixiert auf Null)
+            Regularization: Regularisierung
+            Regularization strength:: Regularisierungsstärke:
+            Elastic net mixing:: Elastic-Net-Mischung:
+            L1: L1
+            L2: L2
+        def `_set_alpha_label`:
+            'Alpha: {}': Alpha: {}
+        def `update_model`:
+            coefficients: Koeffizienten
+        def `get_learner_parameters`:
+            No Regularization: Keine Regularisierung
+            Ridge Regression (L2) with α={}: Ridge-Regression (L2) mit α={}
+            Lasso Regression (L1) with α={}: Lasso-Regression (L1) mit α={}
+            Elastic Net Regression with α={}: Elastic-Net-Regression mit α={}
+            ' and L1:L2 ratio of {}:{}': ' und L1:L2-Verhältnis von {}:{}'
+            Regularization: Regularisierung
+            Fit intercept: Achsenabschnitt anpassen
+            No: Nein
+            Yes: Ja
+widgets/model/owloadmodel.py:
+    class `OWLoadModel`:
+        Load Model: Modell laden
+        Load a model from an input file.: Lädt ein Modell aus einer Eingabedatei.
+        load model, file, open, model: load model, file, open, model, Modell laden, Datei, öffnen, Modell
+        class `Outputs`:
+            Model: Modell
+        class `Error`:
+            An error occured while reading '{}': Fehler beim Lesen von '{}'
+        def `__init__`:
+            File: Datei
+            ...: ...
+            Reload: Neu laden
+        def `browse_file`:
+            Open Model File: Modelldatei öffnen
+widgets/model/owlogisticregression.py:
+    class `OWLogisticRegression`:
+        Logistic Regression: Logistische Regression
+        'The logistic regression classification algorithm with ': 'Der Klassifikationsalgorithmus der logistischen Regression mit '
+        LASSO (L1) or ridge (L2) regularization.: LASSO (L1) oder Ridge (L2) Regularisierung.
+        logistic regression: logistische Regression
+        class `Outputs`:
+            Coefficients: Koeffizienten
+        Lasso (L1): Lasso (L1)
+        Ridge (L2): Ridge (L2)
+        None: Keine
+        class `Warning`:
+            Weighting by class may decrease performance.: Gewichtung nach Klassen kann die Leistung verringern.
+        def `add_main_layout`:
+            'Regularization type: ': 'Regularisierungstyp: '
+            Strength:: 'Stärke: '
+            Weak: Schwach
+            Strong: Stark
+            Balance class distribution: Klassenverteilung ausgleichen
+            Weigh classes inversely proportional to their frequencies.: Klassen invers proportional zu ihren Häufigkeiten gewichten.
+        def `set_c`:
+            C={}: C={}
+            C={:.3f}: C={:.3f}
+            N/A: k.A.
+        def `get_learner_parameters`:
+            Regularization: Regularisierung
+            '{}, C={}, class weights: {}': {}, C={}, Klassengewichte: {}
+    def `create_coef_table`:
+        name: "Name"
+        intercept: "Achsenabschnitt"
+        coefficients: "Koeffizienten"
+widgets/model/ownaivebayes.py:
+    class `OWNaiveBayes`:
+        Naive Bayes: Naiver Bayes
+        'A fast and simple probabilistic classifier based on ': 'Ein schneller und einfacher probabilistischer Klassifikator basierend auf '
+        Bayes' theorem with the assumption of feature independence.: dem Bayesschen Theorem unter der Annahme der Merkmalsunabhängigkeit.
+        naive bayes: naiver Bayes
+widgets/model/owneuralnetwork.py:
+    class `OWNNLearner`:
+        Neural Network: Neuronales Netzwerk
+        'A multi-layer perceptron (MLP) algorithm with ': 'Ein Multi-Layer-Perzeptron (MLP)-Algorithmus mit '
+        backpropagation.: Backpropagation.
+        neural network, mlp: neuronales Netzwerk, MLP
+        Identity: Identity
+        Logistic: Logistisch
+        ReLu: ReLU
+        L-BFGS-B: L-BFGS-B
+        SGD: SGD
+        Adam: Adam
+        class `Warning`:
+            'ANN without hidden layers is equivalent to logistic ': 'Ein ANN ohne versteckte Schichten entspricht einer logistischen '
+            'regression with worse fitting.\nWe recommend using ': 'Regression mit schlechterer Anpassung.\nWir empfehlen die Verwendung von '
+            logistic regression.: logistischer Regression.
+        def `add_main_layout`:
+            Neurons in hidden layers:: Neuronen in versteckten Schichten:
+            'A list of integers defining neurons. Length of list ': 'Eine Liste von Ganzzahlen, die die Neuronen definieren. Die Länge der Liste '
+            defines the number of layers. E.g. 4, 2, 2, 3.: bestimmt die Anzahl der Schichten. Z.B. 4, 2, 2, 3.
+            e.g. 10,: z.B. 10,
+            Activation:: Aktivierung:
+            Solver:: Solver:
+            Maximal number of iterations:: Maximale Anzahl Iterationen:
+            Max iterations:: Max. Iterationen:
+            Replicable training: Reproduzierbares Training
+        def `set_alpha`:
+            Regularization, α={}:: Regularisierung, α={}:
+        def `setup_layout`:
+            Cancel: Abbrechen
+        def `get_learner_parameters`:
+            Hidden layers: Versteckte Schichten
+            Activation: Aktivierung
+            Solver: Solver
+            Alpha: Alpha
+            Max iterations: Max. Iterationen
+            Replicable training: Reproduzierbares Training
+widgets/model/owpls.py:
+    class `OWPLS`:
+        PLS: PLS
+        Partial Least Squares Regression widget for multivariate data analysis: Partial-Least-Squares-Regression-Widget für multivariate Datenanalyse
+        partial least squares: Partial Least Squares
+        class `Outputs`:
+            Coefficients and Loadings: Koeffizienten und Ladungen
+            Data with Scores: Daten mit Scores
+            Components: Komponenten
+        class `Warning`:
+            'Sparse input data: default preprocessing is to scale it.': Spärliche Eingabedaten: Standardvorverarbeitung skaliert sie.
+        def `add_main_layout`:
+            Optimization Parameters: Optimierungsparameter
+            'Components: ': 'Komponenten: '
+            'Iteration limit: ': 'Iterationslimit: '
+            Scale features and target: Merkmale und Ziel skalieren
+        def `_create_output_coeffs_loadings`:
+            coef ({v.name}): Koeff ({v.name})
+            coef * X_sd ({v.name}): Koeff * X_sd ({v.name})
+            w*c {i + 1}: w*c {i + 1}
+            Variable name: Variablenname
+            Variable role: Variablenrolle
+            Feature: Merkmal
+            Target: Ziel
+            intercept: Achsenabschnitt
+            Coefficients and Loadings: Koeffizienten und Ladungen
+        def `set_data`:
+            Data has no target variable.\n: Daten haben keine Zielvariable.\n
+            Select one with the Select Columns widget.: Wählen Sie eine mit dem 'Spalten auswählen'-Widget.
+widgets/model/owrandomforest.py:
+    class `OWRandomForest`:
+        Random Forest: Random Forest
+        Predict using an ensemble of decision trees.: Vorhersage mithilfe eines Ensembles von Entscheidungsbäumen.
+        random forest: Random Forest, wald
+        class `Error`:
+            Insufficient number of attributes ({}): Unzureichende Anzahl von Attributen ({}).
+        class `Warning`:
+            Weighting by class may decrease performance.: Gewichtung nach Klasse kann die Leistung verringern.
+        def `add_main_layout`:
+            Basic Properties: Grundlegende Eigenschaften
+            'Number of trees: ': 'Anzahl der Bäume: '
+            'Number of attributes considered at each split: ': 'Anzahl der bei jedem Split betrachteten Attribute: '
+            Replicable training: Reproduzierbares Training
+            Balance class distribution: Klassendistribution ausgleichen
+            Weigh classes inversely proportional to their frequencies.: Gewichte Klassen umgekehrt proportional zu ihrer Häufigkeit.
+            Growth Control: Wachstumskontrolle
+            'Limit depth of individual trees: ': 'Maximale Tiefe einzelner Bäume: '
+            'Do not split subsets smaller than: ': 'Teile keine Teilmengen, die kleiner als … sind: '
+        def `get_learner_parameters`:
+            Number of trees: Anzahl der Bäume
+            Maximal number of considered features: Maximale Anzahl betrachteter Merkmale
+            unlimited: unbegrenzt
+            Replicable training: Reproduzierbares Training
+            No: Nein
+            Yes: Ja
+            Maximal tree depth: Maximale Baumtiefe
+            Stop splitting nodes with maximum instances: Stoppe Splitting von Knoten mit maximalen Instanzen
+            Class weights: Klassen-Gewichte
+widgets/model/owrules.py:
+    class `CustomRuleClassifier`:
+        def `__init__`:
+            Rule ordering: Regelreihenfolge
+            Covering algorithm: Covering-Algorithmus
+        def `predict`:
+            ordered: geordnet
+            exclusive: exklusiv
+            unordered: ungeordnet
+            weighted: gewichtet
+    class `CustomRuleLearner`:
+        def `__init__`:
+            Rule ordering: Regelreihenfolge
+            Covering algorithm: Covering-Algorithmus
+            exclusive: exklusiv
+            weighted: gewichtet
+            Gamma: Gamma
+            Beam width: Beam-Breite
+            Restrict to equality: "Auf Gleichheit beschränken"
+            Evaluation measure: Bewertungsmaß
+            entropy: Entropie
+            laplace: Laplace
+            wracc: WRAcc
+            Minimum rule coverage: Minimale Regelabdeckung
+            Maximum rule length: Maximale Regellänge
+            Default alpha: Standard-α
+            Parent alpha: Eltern-α
+        def `fit_storage`:
+            ordered: geordnet
+            weighted: gewichtet
+            unordered: ungeordnet
+    class `OWRuleLearner`:
+        CN2 Rule Induction: CN2-Regelinduktion
+        Induce rules from data using CN2 algorithm.: Leite Regeln aus Daten mit dem CN2-Algorithmus ab.
+        cn2 rule induction: cn2 rule induction, cn2-Regelinduktion
+        ordered: geordnet
+        unordered: ungeordnet
+        exclusive: exklusiv
+        weighted: gewichtet
+        entropy: Entropie
+        laplace: Laplace
+        wracc: WRAcc
+        def `add_main_layout`:
+            Rule ordering: Regelreihenfolge
+            Ordered: Geordnet
+            Unordered: Ungeordnet
+            Covering algorithm: Covering-Algorithmus
+            Exclusive: Exklusiv
+            Weighted: Gewichtet
+            γ:: γ:
+            Rule search: Regelsuche
+            Evaluation measure:: Bewertungsmaß:
+            Entropy: Entropie
+            Laplace accuracy: Laplace-Genauigkeit
+            WRAcc: WRAcc
+            Beam width:: Beam-Breite:
+            Rule filtering: Regelfilterung
+            Minimum rule coverage:: Minimale Regelabdeckung:
+            Maximum rule length:: Maximale Regellänge:
+            Statistical significance (default α):: Statistische Signifikanz (Standard-α):
+            Relative significance (parent α):: Relative Signifikanz (Eltern-α):
+            Restrict operator for categorical values to equality: "Operator für kategoriale Werte auf Gleichheit beschränken"
+        def `get_learner_parameters`:
+            Rule ordering: Regelreihenfolge
+            Covering algorithm: Covering-Algorithmus
+            Gamma: Gamma
+            Evaluation measure: Bewertungsmaß
+            Restrict to equality: "Auf Gleichheit beschränken"
+            Beam width: Beam-Breite
+            Minimum rule coverage: Minimale Regelabdeckung
+            Maximum rule length: Maximale Regellänge
+            Default alpha: Standard-α
+            Parent alpha: Eltern-α
+widgets/model/owsavemodel.py:
+    class `OWSaveModel`:
+        Save Model: Modell speichern
+        Save a trained model to an output file.: Speichere ein trainiertes Modell in eine Ausgabedatei.
+        save model, save: save model, save, Modell speichern, speichern
+        class `Inputs`:
+            Model: Modell
+        Pickled model (*.pkcls): Pickled-Modell (*.pkcls)
+widgets/model/owscoringsheet.py:
+    class `ScoringSheetRunner`:
+        def `run`:
+            Learning...: Lernen...
+    class `OWScoringSheet`:
+        Scoring Sheet: Scoring-Tabelle
+        A fast and explainable classifier.: Ein schneller und erklärbarer Klassifikator.
+        scoring sheet: Scoring-Tabelle
+        class `Information`:
+            If the number of input features used is too low for the number of decision \n: Wenn die Anzahl der verwendeten Eingabemerkmale für die Anzahl der Entscheidungsparameter zu gering ist, \n
+            parameters, the number of decision parameters will be adjusted to fit the model.: wird die Anzahl der Entscheidungsparameter angepasst, um zum Modell zu passen.
+        def `add_main_layout`:
+            Preprocessing: Vorverarbeitung
+            Number of Attributes After Feature Selection:: Anzahl der Merkmale nach der Merkmalsauswahl:
+            Model Parameters: Modellparameter
+            Maximum Number of Decision Parameters:: Maximale Anzahl der Entscheidungsparameter:
+            Maximum Points per Decision Parameter:: Maximale Punkte pro Entscheidungsparameter:
+            Custom number of input features: Benutzerdefinierte Anzahl von Eingabemerkmalen
+            Number of Input Features Used:: Anzahl der verwendeten Eingabemerkmale:
+widgets/model/owsgd.py:
+    class `OWSGD`:
+        Stochastic Gradient Descent: Stochastischer Gradientenabstieg
+        'Minimize an objective function using a stochastic ': 'Minimiere eine Zielfunktion mithilfe einer stochastischen '
+        approximation of gradient descent.: Approximation des Gradientenabstiegs.
+        stochastic gradient descent, sgd: stochastic gradient descent, stochastischer Gradient, SGD
+        class `Outputs`:
+            Coefficients: Koeffizienten
+        Squared Loss: Quadratischer Verlust
+        Huber: Huber
+        ε insensitive: ε-insensitiv
+        Squared ε insensitive: Quadratisch ε-insensitiv
+        Hinge: Hinge
+        Logistic regression: Logistische Regression
+        Modified Huber: Modifizierter Huber
+        Squared Hinge: Quadratischer Hinge
+        Perceptron: Perzeptron
+        None: Keine
+        Lasso (L1): Lasso (L1)
+        Ridge (L2): Ridge (L2)
+        Elastic Net: Elastic Net
+        Constant: Konstant
+        Optimal: Optimal
+        Inverse scaling: Inverse Skalierung
+        def `_add_algorithm_to_layout`:
+            Loss functions: Verlustfunktionen
+            'Classification: ': 'Klassifikation: '
+            'Regression: ': 'Regression: '
+        def `_add_regularization_to_layout`:
+            Regularization: Regularisierung
+            'Mixing: ': 'Mixing: '
+            'Strength (α): ': 'Stärke (α): '
+        def `_add_learning_params_to_layout`:
+            Optimization: Optimierung
+            'Learning rate: ': 'Lernrate: '
+            'Initial learning rate (η<sub>0</sub>): ': 'Anfangslernrate (η<sub>0</sub>): '
+            'Inverse scaling exponent (t): ': 'Exponent für inverse Skalierung (t): '
+            'Number of iterations: ': 'Anzahl der Iterationen: '
+            'Tolerance (stopping criterion): ': 'Toleranz (Abbruchkriterium): '
+            Shuffle data after each iteration: Daten nach jeder Iteration mischen
+            'Fixed seed for random shuffling: ': 'Fester Seed für zufälliges Mischen: '
+        def `get_learner_parameters`:
+            Classification loss function: "Verlustfunktion für Klassifikation"
+            Epsilon (ε) for classification: "Epsilon (ε) für Klassifikation"
+            Regression loss function: "Verlustfunktion für Regression"
+            Epsilon (ε) for regression: "Epsilon (ε) für Regression"
+            Regularization: "Regularisierung"
+            Regularization strength (α): "Regularisierungsstärke (α)"
+            Elastic Net mixing parameter (L1 ratio): "Elastic Net Mixing-Parameter (L1-Anteil)"
+            Learning rate: "Lernrate"
+            Initial learning rate (η<sub>0</sub>): "Anfängliche Lernrate (η<sub>0</sub>)"
+            Inverse scaling exponent (t): "Inverser Skalierungsexponent (t)"
+            Shuffle data after each iteration: "Daten nach jeder Iteration mischen"
+            Random seed for shuffling: "Zufallssamen zum Mischen"
+        def `update_model`:
+            coefficients: "Koeffizienten"
+widgets/model/owstack.py:
+    class `OWStackedLearner`:
+        Stacking: Stacking
+        Stack multiple models.: Mehrere Modelle stapeln.
+        Stack: Stapel
+        class `Inputs`:
+            Learners: Lerner
+            Aggregate: Aggregieren
+        def `get_learner_parameters`:
+            Base learners: Basis-Lerner
+            Aggregator: Aggregator
+            default: Standard
+widgets/model/owsvm.py:
+    class `OWSVM`:
+        SVM: SVM
+        'Support Vector Machines map inputs to higher-dimensional ': Support-Vektor-Maschinen bilden Eingaben in höherdimensionale
+        feature spaces.: Merkmalsräume ab.
+        svm, support vector machines: svm, Support-Vektor-Maschinen
+        class `Outputs`:
+            Support Vectors: Stützvektoren
+            Support vectors: Stützvektoren
+        class `Warning`:
+            Input data is sparse, default preprocessing is to scale it.: Eingabedaten sind dünn besetzt, Standardvorverarbeitung skaliert sie.
+        auto: Auto
+        Linear: Linear
+        x⋅y: x⋅y
+        Polynomial: Polynomial
+        (g x⋅y + c)<sup>d</sup>: (g x⋅y + c)<sup>d</sup>
+        RBF: RBF
+        exp(-g|x-y|²): exp(-g|x-y|²)
+        Sigmoid: Sigmoid
+        tanh(g x⋅y + c): tanh(g x⋅y + c)
+        def `_add_type_box`:
+            SVM Type: SVM-Typ
+            SVM: SVM
+            Cost (C):: Kosten (C)::
+            Regression loss epsilon (ε):: Regressionsverlust ε::
+            ν-SVM: ν-SVM
+            Regression cost (C):: Regressionskosten (C)::
+            Complexity bound (ν):: Komplexitätsgrenze (ν)::
+        def `_add_kernel_box`:
+            Kernel: Kernel
+            'Kernel: %(kernel_eq)s': Kernel: %(kernel_eq)s
+            ' g: ': ' g: '
+            ' c: ': ' c: '
+            ' d: ': ' d: '
+        def `_add_optimization_box`:
+            Optimization Parameters: Optimierungsparameter
+            'Numerical tolerance: ': 'Numerische Toleranz: '
+            'Iteration limit: ': 'Iterationslimit: '
+        def `get_learner_parameters`:
+            SVM type: SVM-Typ
+            SVM, C={}, ε={}: SVM, C={}, ε={}
+            ν-SVM, ν={}, C={}: ν-SVM, ν={}, C={}
+            Numerical tolerance: Numerische Toleranz
+            Iteration limt: Iterationslimit
+            unlimited: unbegrenzt
+        def `_report_kernel_parameters`:
+            Kernel: Kernel
+            Linear: Linear
+            Polynomial, ({g:.4} x⋅y + {c:.4})<sup>{d}</sup>: Polynomial, ({g:.4} x⋅y + {c:.4})<sup>{d}</sup>
+            RBF, exp(-{:.4}|x-y|²): RBF, exp(-{:.4}|x-y|²)
+            Sigmoid, tanh({g:.4} x⋅y + {c:.4}): Sigmoid, tanh({g:.4} x⋅y + {c:.4})
+widgets/model/owtree.py:
+    class `OWTreeLearner`:
+        Tree: Baum
+        A tree algorithm with forward pruning.: Ein Baum-Algorithmus mit Vorwärtsbeschneidung.
+        tree, classification tree: tree, classification tree, Baum, Klassifikationsbaum
+        'Min. number of instances in leaves: ': Minimale Anzahl an Instanzen in Blättern:
+        'Do not split subsets smaller than: ': Teile keine Teilmengen kleiner als:
+        'Limit the maximal tree depth to: ': Maximiere die Baumtiefe auf:
+        'Stop when majority reaches [%]: ': Stoppe, wenn die Mehrheit [%] erreicht:
+        def `add_main_layout`:
+            Parameters: Parameter
+            Induce binary tree: Binären Baum erzeugen
+        def `get_learner_parameters`:
+            Pruning: Beschneidung
+            ', ': ,
+            'at least {self.min_leaf} ': Mindestens {self.min_leaf}
+            {pl(self.min_leaf, "instance")} in leaves: {plde(self.min_leaf, "Instanz|Instanzen")} in Blättern
+            'at least {self.min_internal} ': Mindestens {self.min_internal}
+            {pl(self.min_internal, "instance")} in internal nodes: {plde(self.min_internal, "Instanz|Instanzen")} in internen Knoten
+            maximum depth {self.max_depth}: Maximale Tiefe {self.max_depth}
+            None: Keine
+            Splitting: Aufteilung
+            'Stop splitting when majority reaches %d%% ': Aufteilung stoppen, wenn die Mehrheit %d%% erreicht
+            (classification only): (nur Klassifikation)
+            Binary trees: Binärbäume
+            No: Nein
+            Yes: Ja
+widgets/obsolete/owtable.py:
+    class `OWDataTable`:
+        Orange Obsolete: Orange Veraltet
+        Data Table: Datentabelle
+        View the dataset in a spreadsheet.: Datensatz in einer Tabellenansicht anzeigen.
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Warning`:
+            Multiple Data inputs are deprecated.\n: Mehrere Dateneingänge sind veraltet.\n
+            This functionality will be removed soon.\n: Diese Funktionalität wird bald entfernt.\n
+            Use multiple Tables instead.: Verwenden Sie stattdessen mehrere Tabellen.
+        def `__init__`:
+            Info: Info
+            Variables: Variablen
+            Show variable labels (if present): Variablenbeschriftungen anzeigen (falls vorhanden)
+            Visualize numeric values: Numerische Werte visualisieren
+            Color by instance classes: Nach Klassen der Instanzen einfärben
+            Selection: Auswahl
+            Select full rows: Ganze Zeilen auswählen
+            Restore Original Order: Ursprüngliche Reihenfolge wiederherstellen
+            Show rows in the original order: Zeilen in ursprünglicher Reihenfolge anzeigen
+        def `set_dataset`:
+            Data: Daten
+        def `insert_dataset`:
+            Data: Daten
+        def `_set_input_summary`:
+            No data.: Keine Daten.
+widgets/report/report.py:
+    def `describe_domain`:
+        def `clip_attrs`:
+            ' (total: {nitems} {desc})': ' (gesamt: {nitems} {desc})'
+        Features: Merkmale
+        features: Merkmale
+        Meta attributes: Metadatenattribute
+        meta attributes: Metadatenattribute
+        Target: Ziel
+        target variables: Zielvariablen
+    def `describe_data`:
+        Data instances: Dateninstanzen
+    def `describe_domain_brief`:
+        Features: Merkmale
+        None: Keine
+        Meta attributes: Metadatenattribute
+        Target: Ziel
+        Class '{}': Klasse '{}'
+        Numeric variable '{}': Numerische Variable '{}'
+        Targets: Ziele
+    def `describe_data_brief`:
+        Data instances: Dateninstanzen
+widgets/unsupervised/__init__.py:
+    Unsupervised: Unüberwacht
+    Unsupervised learning.: Unüberwachtes Lernen
+    '#CAE1EF': false
+widgets/unsupervised/owcorrespondence.py:
+    class `OWCorrespondenceAnalysis`:
+        Correspondence Analysis: Korrespondenzanalyse
+        Correspondence analysis for categorical multivariate data.: Korrespondenzanalyse für kategoriale multivariate Daten.
+        correspondence analysis: correspondence analysis, Korrespondenzanalyse
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Coordinates: Koordinaten
+        class `Error`:
+            Empty dataset: Leerer Datensatz
+            No categorical data: Keine kategorialen Daten
+        def `__init__`:
+            Variables: Variablen
+            Axes: Achsen
+            X:: X:
+            Y:: Y:
+            Contribution to Inertia: Beitrag zur Trägheit
+            \n: \n
+        def `commit`:
+            Component {i + 1}: Komponente {i + 1}
+            Variable: Variable
+            Value: Wert
+        def `_setup_plot`:
+            Component {} ({:.1f}%): Komponente {} ({:.1f}%)
+        def `_update_info`:
+            'Axis 1: {:.2f}\n': Achse 1: {:.2f}\n
+            'Axis 2: {:.2f}': Achse 2: {:.2f}
+        def `send_report`:
+            Data instances: Dateninstanzen
+            Selected variable: Ausgewählte Variable
+            Selected variables: Ausgewählte Variablen
+            {} and {}: {} und {}
+widgets/unsupervised/owdbscan.py:
+    class `OWDBSCAN`:
+        DBSCAN: DBSCAN
+        Density-based spatial clustering.: Dichtebasierte räumliche Clusteranalyse.
+        class `Inputs`:
+            Data: Daten
+        class `Error`:
+            'Not enough unique data instances. ': 'Nicht genügend eindeutige Dateninstanzen. '
+            At least two are required.: Mindestens zwei werden benötigt.
+            The data does not contain any features.: Die Daten enthalten keine Merkmale.
+        Euclidean: Euklidisch
+        Manhattan: Manhattan
+        Cosine: Kosinus
+        def `__init__`:
+            Parameters: Parameter
+            Core point neighbors: Nachbarn des Kernpunkts
+            Neighborhood distance: Nachbarschaftsdistanz
+            Distance Metric: Distanzmetrik
+            Normalize features: Merkmale normalisieren
+            Data items sorted by score: Datenobjekte nach Bewertung sortiert
+            Distance to the k-th nearest neighbour: Distanz zum k-ten nächsten Nachbarn
+        def `send_data`:
+            Cluster: Cluster
+            C%d: C%d
+            DBSCAN Core: DBSCAN-Kern
+widgets/unsupervised/owdistancefile.py:
+    class `OWDistanceFile`:
+        Distance File: Distanzdatei
+        Read distances from a file.: Lese Distanzen aus einer Datei.
+        distance file, load, read, open: distance file, load, read, open, Distanzdatei, laden, lesen, öffnen
+        class `Outputs`:
+            Distances: Distanzen
+        class `Error`:
+            Data was not loaded:{}: Daten wurden nicht geladen:{}
+            'Matrix is not square. ': Matrix ist nicht quadratisch.
+            Reformat the file and use the File widget to read it.: Formatiere die Datei neu und verwende das Datei-Widget, um sie zu lesen.
+        def `__init__`:
+            Distance File: Distanzdatei
+            ...: ...
+            Reload: Neu laden
+            Options: Optionen
+            Treat triangular matrices as symmetric: Dreiecksmatrizen als symmetrisch behandeln
+            'If matrix is triangular, this will copy the data to the ': 'Wenn die Matrix dreieckig ist, werden die Daten in die '
+            other triangle: andere Dreieckshälfte kopiert
+            Browse documentation datasets: Dokumentationsdatensätze durchsuchen
+        def `browse_file`:
+            File: Datei
+            Cannot find the directory with documentation datasets: Verzeichnis mit Dokumentationsdatensätzen konnte nicht gefunden werden
+            Open Distance File: Distanzdatei öffnen
+            Excel File (*.xlsx);;Distance File (*.dst): Excel-Datei (*.xlsx);;Distanzdatei (*.dst)
+        def `open_file`:
+            (none): (keine)
+        def `send_report`:
+            No data was loaded.: Keine Daten wurden geladen.
+            File name: Dateiname
+widgets/unsupervised/owdistancemap.py:
+    class `OWDistanceMap`:
+        Distance Map: Distanzkarte
+        Visualize a distance matrix.: Distanzmatrix visualisieren.
+        distance map: map, Distanzkarte
+        class `Inputs`:
+            Distances: Distanzen
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+            Features: Merkmale
+        class `Error`:
+            Empty distance matrix: Leere Distanzmatrix
+            Distance matrix is not symmetric.: Distanzmatrix ist nicht symmetrisch.
+        def `__init__`:
+            Element Sorting: Elementsortierung
+            None: Keine
+            Clustering: Clustering
+            Clustering with ordered leaves: Clustering mit geordneten Blättern
+            Colors: Farben
+            Annotations: Anmerkungen
+            Enumeration: Aufzählung
+        def `set_distances`:
+            'Cluster ordering was disabled due to the input ': 'Clusterreihenfolge wurde deaktiviert aufgrund der Eingabe '
+            matrix being to big: Matrix ist zu groß
+            'Clustering was disabled due to the input ': 'Clustering wurde deaktiviert aufgrund der Eingabe '
+        def `set_items`:
+            None: Keine
+            Enumeration: Aufzählung
+            Attribute names: Attributnamen
+            Name: Name
+        def `_update_labels`:
+            Attribute names: Attributnamen
+        def `send_report`:
+            Sorting: Sortierung
+            Annotations: Anmerkungen
+widgets/unsupervised/owdistancematrix.py:
+    class `OWDistanceMatrix`:
+        Distance Matrix: Distanzmatrix
+        View distance matrix.: Distanzmatrix anzeigen.
+        distance matrix: distance matrix, Distanzmatrix
+        class `Inputs`:
+            Distances: Distanzen
+        class `Outputs`:
+            Distances: Distanzen
+            Selected Data: Ausgewählte Daten
+            Table: Tabelle
+        class `Error`:
+            Distance matrix is empty.: Distanzmatrix ist leer.
+        def `__init__`:
+            'Labels: ': 'Beschriftungen: '
+            None: Keine
+            Enumeration: Aufzählung
+        def `set_distances`:
+            None: Keine
+            Enumerate: Aufzählen
+            Labels: Beschriftungen
+            Attribute names: Attributnamen
+            Name: Name
+        def `_choose_label`:
+            Enumerate: Aufzählen
+        def `_update_labels`:
+            Attribute names: Attributnamen
+            Labels: Beschriftungen
+    zoo: zoo
+widgets/unsupervised/owdistances.py:
+    Euclidean (normalized): Euklidisch (normalisiert)
+    Square root of summed difference between normalized values: Wurzel der Summe der Differenzen zwischen normalisierten Werten
+    Euclidean: Euklidisch
+    Square root of summed difference between values: Wurzel der Summe der Differenzen zwischen Werten
+    Manhattan (normalized): Manhattan (normalisiert)
+    Sum of absolute differences between normalized values: Summe der absoluten Differenzen zwischen normalisierten Werten
+    Manhattan: Manhattan
+    Sum of absolute differences between values: Summe der absoluten Differenzen zwischen Werten
+    Mahalanobis: Mahalanobis
+    Mahalanobis distance: Mahalanobis-Distanz
+    Hamming: Hamming
+    Hamming distance: Hamming-Distanz
+    Cosine: Kosinus
+    Cosine distance: Kosinus-Distanz
+    Pearson: Pearson
+    Pearson correlation; distance = 1 - ρ/2: Pearson-Korrelation; Distanz = 1 - ρ/2
+    Pearson (absolute): Pearson (absolut)
+    Absolute value of Pearson correlation; distance = 1 - |ρ|: Absoluter Wert der Pearson-Korrelation; Distanz = 1 - |ρ|
+    Spearman: Spearman
+    Spearman correlation; distance = 1 - ρ/2: Spearman-Korrelation; Distanz = 1 - ρ/2
+    Spearman (absolute): Spearman (absolut)
+    Jaccard: Jaccard
+    Jaccard distance: Jaccard-Distanz
+    class `DistanceRunner`:
+        def `run`:
+            Calculating...: Berechne...
+    class `OWDistances`:
+        Distances: Distanzen
+        Compute a matrix of pairwise distances.: Matrix paarweiser Distanzen berechnen.
+        distances: distances, Distanzen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Distances: Distanzen
+        class `Error`:
+            No numeric features: Keine numerischen Merkmale
+            No binary features: Keine binären Merkmale
+            {} requires dense data.: {} erfordert dichte Daten.
+            Not enough memory: Nicht genügend Speicher
+            Problem in calculation:\n{}: Problem bei der Berechnung:\n{}
+            Mahalanobis handles up to 1000 {}.: Mahalanobis verarbeitet bis zu 1000 {}.
+            Data is too large (> {MAX_ITEMS} items).: "Die Daten sind zu groß (> {MAX_ITEMS} Elemente)."
+        class `Warning`:
+            Ignoring categorical features: Kategoriale Merkmale werden ignoriert
+            Ignoring non-binary features: Nicht-binäre Merkmale werden ignoriert
+            Some metrics don't support sparse data\n: Einige Metriken unterstützen keine spärlichen Daten\n
+            'and were disabled: {}': und wurden deaktiviert: {}
+            Missing values were imputed: Fehlende Werte wurden ersetzt
+            Data has no features: Daten haben keine Merkmale
+        def `__init__`:
+            Rows: Zeilen
+            Columns: Spalten
+            Compare: Vergleichen
+            Distance Metric: Distanzmetrik
+        def `compute_distances`:
+            def `_check_tractability`:
+                rows: Zeilen
+                columns: Spalten
+        def `send_report`:
+            Distances Between: Distanzen zwischen
+            Rows: Zeilen
+            Columns: Spalten
+            Metric: Metrik
+widgets/unsupervised/owdistancetransformation.py:
+    class `OWDistanceTransformation`:
+        Distance Transformation: Distanztransformation
+        Transform distances according to selected criteria.: Distanzen gemäß ausgewählten Kriterien transformieren.
+        distance transformation: distance transformation, Distanztransformation
+        class `Inputs`:
+            Distances: Distanzen
+        class `Outputs`:
+            Distances: Distanzen
+        No normalization: Keine Normalisierung
+        To interval [0, 1]: Auf Intervall [0, 1] skalieren
+        To interval [-1, 1]: Auf Intervall [-1, 1] skalieren
+        'Sigmoid function: 1/(1+exp(-X))': Sigmoidfunktion: 1/(1+exp(-X))
+        No inversion: Keine Inversion
+        -X: -X
+        1 - X: 1 - X
+        max(X) - X: max(X) - X
+        1/X: 1/X
+        def `__init__`:
+            Normalization: Normalisierung
+            Inversion: Inversion
+        def `send_report`:
+            inversion ({}): Inversion ({})
+            normalization ({}): Normalisierung ({})
+            Model parameters: Modellparameter
+            Transformation: Transformation
+            None: Keine
+widgets/unsupervised/owhierarchicalclustering.py:
+    Single: Single
+    Average: Mittel
+    Weighted: Gewichtet
+    Complete: Komplett
+    Ward: Ward
+    class `OWHierarchicalClustering`:
+        Hierarchical Clustering: Hierarchisches Clustering
+        'Display a dendrogram of a hierarchical clustering ': 'Dendrogramm eines hierarchischen Clusterings anzeigen '
+        constructed from the input distance matrix.: aus der Eingabedistanzmatrix erstellt.
+        hierarchical clustering: hierarchical clustering, Hierarchisches Clustering
+        class `Inputs`:
+            Distances: Distanzen
+            Data Subset: Datenausschnitt
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        Enumeration: Aufzählung
+        Name: Name
+        class `Error`:
+            Distance matrix is empty.: Distanzmatrix ist leer.
+            Some distances are infinite: Einige Distanzen sind unendlich
+            Distance matrix is not symmetric.: Distanzmatrix ist nicht symmetrisch.
+        class `Warning`:
+            'Unused data subset: distances do not refer to data instances': Unbenutzter Datenausschnitt: Distanzen beziehen sich nicht auf Dateninstanzen
+            Some data from the subset does not appear in distance matrix: Einige Daten aus dem Ausschnitt erscheinen nicht in der Distanzmatrix
+            Subset data refers to a different table: Daten des Ausschnitts beziehen sich auf eine andere Tabelle
+            Pruned cluster doesn't show colors and indicate subset: Beschnittener Cluster zeigt keine Farben und keinen Ausschnitt an
+            'Variables with too many values may ': 'Variablen mit zu vielen Werten können '
+            degrade the performance of downstream widgets.: die Leistung nachfolgender Widgets verschlechtern.
+        def `__init__`:
+            Linkage: Verknüpfung
+            None: Keine
+            Annotations: Anmerkungen
+            Show labels only for subset: Beschriftungen nur für Ausschnitt anzeigen
+            Color by:: Färben nach:
+            Pruning: Beschnitt
+            Max depth:: Maximale Tiefe:
+            Selection: Auswahl
+            Manual: Manuell
+            Height ratio:: Höhenverhältnis:
+            ' %': ' %'
+            Top N:: Top N:
+            Zoom: Zoom
+            Zoom in: Hineinzoomen
+            Zoom out: Herauszoomen
+            Reset zoom: Zoom zurücksetzen
+        def `_set_items`:
+            Name: Name
+        def `_update_labels`:
+            Enumeration: Aufzählung
+            Name: Name
+            ', ': ', '
+        def `commit`:
+            Cluster: Cluster
+            C{i + 1}: C{i + 1}
+            Other: Andere
+            cluster: Cluster
+        def `send_report`:
+            manual: Manuell
+            at {:.1f} of height: bei {:.1f} der Höhe
+            top {self.top_n} {pl(self.top_n, 'cluster')}: oberste {self.top_n} {plde(self.top_n, 'Cluster')}
+            Linkage: Verknüpfung
+            Annotation: Anmerkung
+            Pruning: Beschnitt
+            {} levels: {} Ebenen
+            Selection: Auswahl
+widgets/unsupervised/owkmeans.py:
+    class `ClusterTableModel`:
+        def `data`:
+            NA: k.A.
+    class `OWKMeans`:
+        k-Means: k-Means
+        'k-Means clustering algorithm with silhouette-based ': 'k-Means-Clustering-Algorithmus mit Silhouette-basierter '
+        quality estimation.: Qualitätsabschätzung.
+        k-means, kmeans, clustering: k-means, kmeans, clustering, k-means, kmeans, Clustering
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Annotated Data: Annotierte Daten
+            Centroids: Zentroiden
+        class `Error`:
+            'Clustering failed\nError: {}': Clustering fehlgeschlagen\nFehler: {}
+            Too few ({}) unique data instances for {} clusters: Zu wenige ({}) eindeutige Dateninstanzen für {} Cluster
+            Data is missing features.: Daten haben keine Merkmale.
+        class `Warning`:
+            Silhouette scores are not computed for >{} samples: Silhouette-Werte werden für >{} Proben nicht berechnet
+            Too few ({}) unique data instances for {} clusters: Zu wenige ({}) eindeutige Dateninstanzen für {} Cluster
+            Sparse data cannot be normalized: Spärliche Daten können nicht normalisiert werden
+        Initialize with KMeans++: Mit KMeans++ initialisieren
+        Random initialization: Zufällige Initialisierung
+        def `__init__`:
+            Number of Clusters: Anzahl der Cluster
+            Fixed:: Fest::
+            From: Von
+            to: bis
+            Preprocessing: Vorverarbeitung
+            Normalize columns: Spalten normalisieren
+            Initialization: Initialisierung
+            'Re-runs: ': 'Wiederholungen: '
+            'Maximum iterations: ': 'Maximale Iterationen: '
+            Silhouette Scores: Silhouette-Werte
+        def `send_data`:
+            Cluster: Cluster
+            C%d: C%d
+            Silhouette: Silhouette
+            centroids: Zentroiden
+            {self.data.name} centroids: Zentroiden von {self.data.name}
+        def `send_report`:
+            Number of clusters: Anzahl der Cluster
+            Optimization: Optimierung
+            {}, {} re-runs limited to {} steps: {}, {} Wiederholungen auf {} Schritte begrenzt
+            Data: Daten
+            Silhouette scores for different numbers of clusters: Silhouette-Werte für unterschiedliche Clusterzahlen
+widgets/unsupervised/owlouvainclustering.py:
+    Euclidean: Euklidisch
+    Manhattan: Manhattan
+    Cosine: Kosinus
+    class `OWLouvainClustering`:
+        Louvain Clustering: Louvain-Clustering
+        Detects communities in a network of nearest neighbors.: Erkennt Communities in einem Netzwerk der nächsten Nachbarn.
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Network: Netzwerk
+        class `Information`:
+            Press commit to recompute clusters and send new data: Drücken Sie „Commit“, um Cluster neu zu berechnen und neue Daten zu senden.
+        class `Error`:
+            No features in data: Daten enthalten keine Merkmale
+        def `__init__`:
+            Info: Info
+            No data on input.: Keine Eingabedaten.
+            Preprocessing: Vorverarbeitung
+            Normalize data: Daten normalisieren
+            Apply PCA preprocessing: PCA-Vorverarbeitung anwenden
+            'PCA Components: ': 'PCA-Komponenten: '
+            Graph parameters: Graph-Parameter
+            Distance metric: Distanzmetrik
+            k neighbors: k Nachbarn
+            Resolution: Auflösung
+            'The resolution parameter affects the number of clusters to find. ': 'Der Auflösungsparameter beeinflusst die Anzahl der zu findenden Cluster. '
+            'Smaller values tend to produce more clusters and larger values ': 'Kleinere Werte erzeugen tendenziell mehr Cluster und größere Werte '
+            retrieve less clusters.: weniger Cluster.'
+        def `commit`:
+            Running...: Wird ausgeführt...
+        def `__set_results`:
+            {num_clusters} {pl(num_clusters, 'cluster')} found.: {num_clusters} {plde(num_clusters, 'Cluster')} gefunden.
+        def `_send_data`:
+            Cluster: Cluster
+            C%d: C%d
+        def `set_data`:
+            Clustering not yet run.: Clustering noch nicht durchgeführt.
+        def `clear`:
+            No data on input.: Keine Eingabedaten.
+        def `send_report`:
+            , {self.pca_components} {pl(self.pca_components, 'component')}: , {self.pca_components} {plde(self.pca_components, 'Komponente')}
+            Normalize data: Daten normalisieren
+            PCA preprocessing: PCA-Vorverarbeitung
+            Metric: Metrik
+            k neighbors: k Nachbarn
+            Resolution: Auflösung
+    def `run_on_data`:
+        Computing PCA...: PCA wird berechnet...
+        Building graph...: Graph wird aufgebaut...
+        Detecting communities...: Communities werden erkannt...
+    def `run_on_graph`:
+        Detecting communities...: Communities werden erkannt...
+widgets/unsupervised/owmanifoldlearning.py:
+    class `TSNEParametersEditor`:
+        Euclidean: Euklidisch
+        Manhattan: Manhattan
+        Chebyshev: Tschebyschew
+        Jaccard: Jaccard
+        PCA: PCA
+        Random: Zufällig
+        def `__init__`:
+            Metric:: Metrik::
+            Perplexity:: Perplexität::
+            Early exaggeration:: Frühe Übertreibung::
+            Learning rate:: Lernrate::
+            Max iterations:: Maximale Iterationen::
+            Initialization:: Initialisierung::
+        def `get_report_parameters`:
+            Metric: Metrik
+            Perplexity: Perplexität
+            Early exaggeration: Frühe Übertreibung
+            Learning rate: Lernrate
+            Max iterations: Maximale Iterationen
+            Initialization: Initialisierung
+    class `MDSParametersEditor`:
+        PCA (Torgerson): PCA (Torgerson)
+        Random: Zufällig
+        def `__init__`:
+            Max iterations:: Maximale Iterationen::
+            Initialization:: Initialisierung::
+        def `get_report_parameters`:
+            Max iterations: Maximale Iterationen
+            Initialization: Initialisierung
+    class `IsomapParametersEditor`:
+        def `__init__`:
+            Neighbors:: Nachbarn::
+        def `get_report_parameters`:
+            Neighbors: Nachbarn
+    class `LocallyLinearEmbeddingParametersEditor`:
+        Standard: Standard
+        Modified: Modifiziert
+        Hessian eigenmap: Hessian-Eigenabbildung
+        Local: Lokal
+        def `__init__`:
+            Method:: Methode::
+            Neighbors:: Nachbarn::
+            Max iterations:: Maximale Iterationen::
+        def `get_report_parameters`:
+            Method: Methode
+            Neighbors: Nachbarn
+            Max iterations: Maximale Iterationen
+    class `SpectralEmbeddingParametersEditor`:
+        Nearest neighbors: Nächste Nachbarn
+        RBF kernel: RBF-Kern
+        def `__init__`:
+            Affinity:: Affinität::
+        def `get_report_parameters`:
+            Affinity: Affinität
+    class `OWManifoldLearning`:
+        Manifold Learning: Mannigfaltigkeitslernen
+        Nonlinear dimensionality reduction.: Nichtlineare Dimensionsreduktion.
+        manifold learning: manifold learning, Mannigfaltigkeitslernen
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Transformed Data: Transformierte Daten
+            Transformed data: Transformierte Daten
+        class `Error`:
+            'For chosen method and components, ': 'Für die gewählte Methode und Komponenten, '
+            neighbors must be greater than {}: Nachbarn müssen größer als {} sein
+            Sparse data is not supported.: Spärliche Daten werden nicht unterstützt.
+            Out of memory: Nicht genügend Speicher
+        class `Warning`:
+            Disconnected graph, embedding may not work: Graph ist nicht vollständig verbunden, Einbettung möglicherweise nicht möglich
+        def `__init__`:
+            Method: Methode
+            Output: Ausgabe
+            Components:: Komponenten::
+        def `commit`:
+            def `_handle_disconnected_graph_warning`:
+                Graph is not fully connected: Graph ist nicht vollständig verbunden
+        def `send_report`:
+            Method: Methode
+            Number of components: Anzahl der Komponenten
+            Method parameters: Methodenparameter
+            Data: Daten
+widgets/unsupervised/owmds.py:
+    def `run_mds`:
+        Running...: Wird ausgeführt...
+    class `OWMDS`:
+        MDS: MDS
+        'Two-dimensional data projection by multidimensional ': 'Zweidimensionale Datenprojektion durch multidimensionale '
+        scaling constructed from a distance matrix.: Skalierung, erstellt aus einer Distanzmatrix.
+        mds, multidimensional scaling, multi dimensional scaling: mds, multidimensional scaling, multi dimensional scaling, mds, multidimensionale Skalierung, multi-dimensionale Skalierung
+        class `Inputs`:
+            Distances: Distanzen
+        Every iteration: Jede Iteration
+        Every 5 steps: Alle 5 Schritte
+        Every 10 steps: Alle 10 Schritte
+        Every 25 steps: Alle 25 Schritte
+        Every 50 steps: Alle 50 Schritte
+        None: Keine
+        class `Error`:
+            Input data needs at least 2 rows: Eingabedaten benötigen mindestens 2 Zeilen
+            Distance matrix is not symmetric: Distanzmatrix ist nicht symmetrisch
+            Input matrix must be at least 2x2: Eingabematrix muss mindestens 2x2 sein
+            Data has no attributes: Daten haben keine Attribute
+            Data and distances dimensions do not match.: Daten- und Distanzdimensionen stimmen nicht überein.
+            Out of memory: Nicht genügend Speicher
+            Error during optimization\n{}: Fehler während der Optimierung\n{}
+        def `__init__`:
+            Stress: Stress
+        def `_add_controls`:
+            Show similar pairs:: Ähnliche Paare anzeigen::
+        def `_add_controls_optimization`:
+            Optimize: Optimieren
+            PCA: PCA
+            Randomize: Zufällig initialisieren
+            Jitter: Jitter
+            Start: Start
+            Refresh:: Aktualisieren::
+            'Kruskal Stress: -': Kruskal-Stress: -
+        def `_toggle_run`:
+            Resume: Fortsetzen
+        def `_run`:
+            Stop: Stop
+            PCA: PCA
+        def `on_done`:
+            Start: Start
+        def `update_stress`:
+            'Kruskal Stress: {stress_val}': Kruskal-Stress: {stress_val}
+        def `on_exception`:
+            Start: Start
+        def `do_initialization`:
+            Start: Start
+        def `get_size_data`:
+            Stress: Stress
+widgets/unsupervised/owpca.py:
+    component variance: Komponentenvarianz
+    cumulative variance: Kumulative Varianz
+    class `OWPCA`:
+        PCA: PCA
+        Principal component analysis with a scree-diagram.: Hauptkomponentenanalyse mit Scree-Diagramm.
+        pca, principal component analysis, linear transformation: pca, principal component analysis, linear transformation, pca, Hauptkomponentenanalyse, lineare Transformation
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Transformed Data: Transformierte Daten
+            Transformed data: Transformierte Daten
+            Data: Daten
+            Components: Komponenten
+            PCA: PCA
+        class `Warning`:
+            'All components of the PCA are trivial (explain 0 variance). ': 'Alle Komponenten der PCA sind trivial (erklären 0 Varianz). '
+            Input data is constant (or near constant).: Eingabedaten sind konstant (oder fast konstant).
+        class `Error`:
+            At least 1 feature is required: Mindestens 1 Merkmal erforderlich
+            At least 1 data instance is required: Mindestens 1 Dateninstanz erforderlich
+        def `__init__`:
+            Components Selection: Komponentenauswahl
+            All: Alle
+            %: %
+            Components:: Komponenten::
+            Explained variance:: Erklärte Varianz::
+            Options: Optionen
+            Normalize variables: Variablen normalisieren
+            Show only first: Nur die ersten anzeigen
+            Principal Components: Hauptkomponenten
+            Proportion of variance: Varianzanteil
+        def `set_data`:
+            Data has been sampled: Daten wurden stichprobenartig ausgewählt
+        def `commit`:
+            components: Komponenten
+            PC{i + 1}: PC{i + 1}
+        def `send_report`:
+            Normalize data: Daten normalisieren
+            Selected components: Ausgewählte Komponenten
+            Explained variance: Erklärte Varianz
+widgets/unsupervised/owsavedistances.py:
+    class `OWSaveDistances`:
+        Save Distance Matrix: Distanzmatrix speichern
+        Save distance matrix to an output file.: Distanzmatrix in einer Ausgabedatei speichern.
+        save distance matrix, distance matrix, save: save distance matrix, distance matrix, save, Distanzmatrix speichern, Distanzmatrix, speichern
+        Excel File (*.xlsx): Excel-Datei (*.xlsx)
+        Distance File (*.dst): Distanzdatei (*.dst)
+        class `Warning`:
+            Associated data was not saved.: Zugehörige Daten wurden nicht gespeichert.
+            Data associated with {} was not saved.: Daten, die mit {} verknüpft sind, wurden nicht gespeichert.
+        class `Inputs`:
+            Distances: Distanzen
+        def `do_save`:
+            columns: Spalten
+            rows: Zeilen
+        def `send_report`:
+            Input: Eingabe
+            none: Keine
+            File name: Dateiname
+            not set: Nicht festgelegt
+        def `_description`:
+            ' and ': ' und '
+            row: Zeile
+            column: Spalte
+            ; {labels} labels: ; {labels} Beschriftungen
+            {len(dist)}-dimensional matrix{labels}: {len(dist)}-dimensionale Matrix{labels}
+widgets/unsupervised/owsom.py:
+    class `OWSOM`:
+        Self-Organizing Map: Selbstorganisierende Karte
+        Computation of self-organizing map.: Berechnung der selbstorganisierenden Karte.
+        self-organizing map, som: self-organizing map, selbstorganisierende Karte, som
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Information`:
+            'The parameter settings have been changed. Press "Start" to ': 'Die Parametereinstellungen wurden geändert. Drücken Sie "Start", um '
+            rerun with the new settings.: mit den neuen Einstellungen erneut auszuführen.
+        class `Warning`:
+            SOM ignores categorical variables.: SOM ignoriert kategoriale Variablen.
+            Some data instances have undefined value of '{}'.: Einige Dateninstanzen haben undefinierten Wert von '{}'.
+            "'{}' has no defined values.": "'{}' hat keine definierten Werte."
+            Data contains a single numeric column.: Daten enthalten nur eine numerische Spalte.
+        class `Error`:
+            Data contains no numeric columns.: Daten enthalten keine numerischen Spalten.
+            SOM needs at least two data rows without missing values.: SOM benötigt mindestens zwei Datenzeilen ohne fehlende Werte.
+        def `__init__`:
+            SOM: SOM
+            Hexagonal grid: Hexagonales Gitter
+            Square grid: Quadratisches Gitter
+            Set dimensions automatically: Dimensionen automatisch festlegen
+            Initialize with PCA: Mit PCA initialisieren
+            Random initialization: Zufällige Initialisierung
+            Replicable random: Reproduzierbares Zufall
+            Restart: Neustart
+            Color: Farbe
+            (Same color): (Gleiche Farbe)
+            Show pie charts: Kreisdiagramme anzeigen
+            Size by number of instances: Größe nach Anzahl der Instanzen
+        def `set_data`:
+            def `set_warnings`:
+                {missing} data {pl(missing, "instance")} with undefined value(s) {pl(missing, "is|are")} not shown.: {missing} Daten {plde(missing, "Instanz|Instanzen")} mit undefiniertem {plde(missing, "Wert werde|Werte werden")} nicht angezeigt.
+        def `enable_controls`:
+            Start: Start
+            Stop: Stop
+        def `_draw_same_color`:
+            {n} instances: {n} Instanzen
+        def `_tooltip`:
+            (N/A): (k.A.)
+        def `update_output`:
+            Unselected: Nicht ausgewählt
+            No: Nein
+            Yes: Ja
+        def `_bin_names`:
+            < {labels[0]}: < {labels[0]}
+            {x} - {y}: {x} - {y}
+            ≥ {labels[-1]}: ≥ {labels[-1]}
+        def `send_report`:
+            Self-organizing map colored by '{self.attr_color.name}': Selbstorganisierende Karte gefärbt nach '{self.attr_color.name}'
+widgets/unsupervised/owtsne.py:
+    PCA: PCA
+    Spectral: Spektral
+    Euclidean: Euklidisch
+    Manhattan: Manhattan
+    Cosine: Kosinus
+    class `TSNERunner`:
+        def `compute_tsne_preprocessing`:
+            Preprocessing data...: Daten werden vorverarbeitet...
+        def `compute_normalization`:
+            Normalizing data...: Daten werden normalisiert...
+        def `compute_pca`:
+            Computing PCA...: PCA wird berechnet...
+        def `compute_initialization`:
+            Preparing initialization...: Initialisierung wird vorbereitet...
+        def `compute_affinities`:
+            Finding nearest neighbors...: Nächste Nachbarn werden gesucht...
+        def `compute_tsne`:
+            Running optimization...: Optimierung läuft...
+    class `OWtSNE`:
+        Two-dimensional data projection with t-SNE.: Zweidimensionale Datenprojektion mit t-SNE.
+        t-sne, tsne: t-sne, tsne
+        class `Inputs`:
+            Distances: Distanzen
+        class `Information`:
+            'The parameter settings have been changed. Press ': 'Die Parametereinstellungen wurden geändert. Drücken Sie '
+            \"Start\" to rerun with the new settings.: \"Start\", um mit den neuen Einstellungen erneut auszuführen.
+        class `Warning`:
+            The input data contains a large number of features, which may slow: Die Eingabedaten enthalten viele Merkmale, was die Berechnung verlangsamen kann
+            ' down t-SNE computation. Consider enabling PCA preprocessing.': . Erwägen Sie, die PCA-Vorverarbeitung zu aktivieren.
+        class `Error`:
+            Input data needs at least 2 rows: Eingabedaten benötigen mindestens 2 Zeilen
+            Input data needs at least 2 attributes: Eingabedaten benötigen mindestens 2 Attribute
+            Input data is constant: Eingabedaten sind konstant
+            No projection due to no valid data: Keine Projektion aufgrund fehlender gültiger Daten
+            Distance matrix is not symmetric: Distanzmatrix ist nicht symmetrisch
+            Input matrix must be at least 2x2: Eingabematrix muss mindestens 2x2 sein
+            Data and distance dimensions do not match: Daten- und Distanzdimensionen stimmen nicht überein
+        def `_add_controls_start_box`:
+            Preprocessing: Vorverarbeitung
+            Normalize data: Daten normalisieren
+            Apply PCA preprocessing: PCA-Vorverarbeitung anwenden
+            PCA Components:: PCA-Komponenten::
+            Parameters: Parameter
+            Initialization:: Initialisierung::
+            Distance metric:: Distanzmetrik::
+            Perplexity:: Perplexität::
+            Preserve global structure: Globale Struktur bewahren
+            Exaggeration:: Übertreibung::
+            Start: Start
+        def `_stop_running_task`:
+            Start: Start
+        def `_toggle_run`:
+            Resume: Fortsetzen
+        def `enable_controls`:
+            Precomputed distances provided. Preprocessing is unnecessary!: Vorgefertigte Distanzen vorhanden. Vorverarbeitung ist nicht erforderlich!
+            Spectral: Spektral
+            'Only spectral intialization is supported with precomputed ': 'Nur spektrale Initialisierung wird bei vorgefertigten '
+            distance matrices.: Distanzmatrizen unterstützt.
+            Precomputed distances provided.: Vorgefertigte Distanzen vorhanden.
+            Data normalization is not supported on sparse matrices.: Daten-Normalisierung wird bei spärlichen Matrizen nicht unterstützt.
+        def `run`:
+            Stop: Stop
+        def `on_done`:
+            Start: Start
+        def `cancel`:
+            Start: Start
+widgets/utils/__init__.py:
+    def `instance_tooltip`:
+        def `show_part`:
+            ... and {n_vars - max_shown + 1} others: ... und {n_vars - max_shown + 1} weitere
+        Class: Klasse
+        Classes: Klassen
+        Meta: Meta
+        Metas: Metas
+        Feature: Merkmal
+        Features: Merkmale
+widgets/utils/annotated_data.py:
+    Data: Daten
+    Selected: Ausgewählt
+    def `domain_with_annotation_column`:
+        No: Nein
+        Yes: Ja
+    def `create_annotated_table`:
+        No: Nein
+        Yes: Ja
+    def `group_values`:
+        G{}: G{}
+        Unselected: Nicht ausgewählt
+widgets/utils/colorgradientselection.py:
+    class `ColorGradientSelection`:
+        def `__init__`:
+            Low gradient threshold: Niedriger Gradienten-Schwellenwert
+            'Applying a low threshold will squeeze the ': 'Ein niedriger Schwellenwert komprimiert den '
+            gradient from the lower end: Gradient am unteren Ende
+            Range:: Bereich::
+        def `__update_center_visibility`:
+            Center at:: Zentrum bei::
+widgets/utils/colorpalettes.py:
+    class `DiscretePalette`:
+        def `from_colors`:
+            Custom: Benutzerdefiniert
+    class `ContinuousPalette`:
+        def `from_colors`:
+            Custom: Benutzerdefiniert
+    Default: Standard
+    Dark: Dunkel
+    Blue-Green-Yellow: Blau-Grün-Gelb
+    Blue-Magenta-Yellow: Blau-Magenta-Gelb
+    Dim gray: Dunkelgrau
+    Inferno: Inferno
+    Viridis: Viridis
+    Coolwarm: Coolwarm
+    Green-Red: Grün-Rot
+    Diverging protanopic: Divergierend protanopisch
+    Color-blind friendly: Farbenblind-freundlich
+    Diverging tritanopic: Divergierend tritanopisch
+    Linear protanopic: Linear protanopisch
+    Linear tritanopic: Linear tritanopisch
+    Isoluminant: Isoluminant
+    Other: Andere
+    Rainbow: Regenbogen
+widgets/utils/domaineditor.py:
+    class `VarTableModel`:
+        feature: Merkmal
+        target: Ziel
+        meta: Meta
+        skip: Überspringen
+        categorical: Kategorisch
+        numeric: Numerisch
+        text: Text
+        datetime: Datum/Uhrzeit
+        def `headerData`:
+            Name: Name
+            Type: Typ
+            Role: Rolle
+            Values: Werte
+    class `VarTypeDelegate`:
+        def `setEditorData`:
+            numeric: Numerisch
+            datetime: Datum/Uhrzeit
+    class `DomainEditor`:
+        def `_is_missing`:
+            nan: k.A.
+widgets/utils/encodings.py:
+    class `SelectEncodingsWidget`:
+        def `__init__`:
+            Select all: Alle auswählen
+    def `main`:
+        Select encodings visible in text encoding menus: Wählen Sie die in den Textkodierungsmenüs sichtbaren Kodierungen aus
+widgets/utils/filedialogs.py:
+    def `dialog_formats`:
+        All readable files ({});;: Alle lesbaren Dateien ({});;
+widgets/utils/graphicsview.py:
+    class `GraphicsWidgetView`:
+        def `__init__`:
+            Zoom in: Vergrößern
+            Zoom out: Verkleinern
+            Actual Size: Tatsächliche Größe
+            Zoom to fit: Auf Fenstergröße anpassen
+widgets/utils/itemmodels.py:
+    class `VariableListModel`:
+        def `data`:
+            None: k.A.
+        def `variable_labels_tooltip`:
+            <br/>Variable Labels:<br/>: <br/>Variablenbeschriftungen:<br/>
+        def `discrete_variable_tooltip`:
+            '<b>%s</b><br/>Categorical with %i values: ': '<b>%s</b><br/>Kategorisch mit %i Werten: '
+        def `time_variable_toltip`:
+            <b>%s</b><br/>Time: <b>%s</b><br/>Zeit
+        def `continuous_variable_toltip`:
+            <b>%s</b><br/>Numeric: <b>%s</b><br/>Numerisch
+        def `string_variable_tooltip`:
+            <b>%s</b><br/>Text: <b>%s</b><br/>Text
+widgets/utils/listfilter.py:
+    def `variables_filter`:
+        Filter the list of available variables.: Liste der verfügbaren Variablen filtern.
+        Filter: Filter
+widgets/utils/multi_target.py:
+    Multiple targets are not supported.: Mehrere Zielvariablen werden nicht unterstützt.
+widgets/utils/owbasesql.py:
+    class `OWBaseSql`:
+        class `Outputs`:
+            Data: Daten
+        class `Error`:
+            {}: {}
+        def `_setup_gui`:
+            Server: Server
+            {}:{}: {}:{}
+            Database[/Schema]: Datenbank[/Schema]
+            Database or optionally Database/Schema: Datenbank oder optional Datenbank/Schema
+            {}/{}: {}/{}
+            Username: Benutzername
+            Password: Passwort
+            Connect: Verbinden
+        def `_credential_manager`:
+            'SQL Table: {}:{}': SQL-Tabelle: {}:{}
+        def `on_connection_success`:
+            Host: Host
+            Port: Port
+            Database: Datenbank
+            User name: Benutzername
+        def `on_connection_error`:
+            \n: \n
+        def `send_report`:
+            No database connection.: Keine Datenbankverbindung.
+            Database: Datenbank
+            Data: Daten
+widgets/utils/owlearnerwidget.py:
+    class `OWBaseLearner`:
+        class `Error`:
+            Fitting failed.\n{}: Anpassung fehlgeschlagen.\n{}
+            Sparse data is not supported.: Sparse Daten werden nicht unterstützt.
+            Out of memory.: Nicht genügend Speicher.
+        class `Warning`:
+            Press Apply to submit changes.: Drücken Sie "Übernehmen", um Änderungen zu speichern.
+        class `Information`:
+            Ignoring default preprocessing.\n: Standardvorverarbeitung wird ignoriert.\n
+            'Default preprocessing, such as scaling, one-hot encoding and ': 'Standardvorverarbeitung, wie Skalierung, One-Hot-Encoding und '
+            'treatment of missing data, has been replaced with user-specified ': 'Umgang mit fehlenden Daten, wurde durch benutzerspezifizierte '
+            'preprocessors. Problems may occur if these are inadequate ': 'Preprozessoren ersetzt. Probleme können auftreten, wenn diese unzureichend '
+            for the given data.: für die gegebenen Daten sind.
+        class `Inputs`:
+            Data: Daten
+            Preprocessor: Vorverarbeitung
+        class `Outputs`:
+            Learner: Lernalgorithmus
+            Model: Modell
+            Classifier: Klassifikator
+            Predictor: Prädiktor
+        def `set_data`:
+            Data contains multiple target variables.\n: Daten enthalten mehrere Zielvariablen.\n
+            Select a single one with the Select Columns widget.: Wählen Sie eine einzelne mit dem Widget "Spalten auswählen".
+            Data has no target variable.\n: Daten enthalten keine Zielvariable.\n
+            Select one with the Select Columns widget.: Wählen Sie eine mit dem Widget "Spalten auswählen".
+        def `check_data`:
+            Dataset is empty.: Datensatz ist leer.
+            Data contains a single target value.: Daten enthalten einen einzelnen Zielwert.
+            Data has no features to learn from.: Daten enthalten keine Merkmale zum Lernen.
+        def `send_report`:
+            Name: Name
+            Model parameters: Modellparameter
+            Data: Daten
+        def `setup_layout`:
+            Classification: Klassifikation
+            Regression: Regression
+        def `add_learner_name_widget`:
+            Name: Name
+            The name will identify this model in other widgets: Der Name identifiziert dieses Modell in anderen Widgets
+widgets/utils/state_summary.py:
+    def `format_variables_string`:
+        —: —
+        categorical: Kategorisch
+        numeric: Numerisch
+        time: Zeit
+        string: Text
+        {i} {j}: {i} {j}
+        {counts[0]} {attrs[0]}: {counts[0]} {attrs[0]}
+    def `format_summary_details`:
+        untitled: Unbenannt
+        '{len(data):n} {pl(len(data), "instance")}, ': '{len(data):n} {plde(len(data), "Instanz|Instanzen")}, '
+        {n_features} {pl(n_features, "variable")}: {n_features} {plde(n_features, "Variable|Variablen")}
+        'Features: {features}{features_missing}': Merkmale: {features}{features_missing}
+        'Target: {targets}': Ziel: {targets}
+        'Metas: {metas}': Metadaten: {metas}
+        '{name}: ': '{name}: '
+        'Table with ': 'Tabelle mit '
+        {basic}\n{features}\n{targets}: {basic}\n{features}\n{targets}
+        \n{metas}: \n{metas}
+        '<b><u>{escape(name)}</u></b>: {basic}': <b><u>{escape(name)}</u></b>: {basic}
+        Table with {basic}: Tabelle mit {basic}
+    def `missing_values`:
+        ' ({value*100:.1f}% missing values)': ' ({value*100:.1f}% fehlende Werte)'
+        ' (no missing values)': ' (keine fehlenden Werte)'
+    def `format_multiple_summaries`:
+        input: Eingabe
+        No data on {type_io}.: Keine Daten für {type_io}.
+    def `summarize_matrix`:
+        {w}×{h} distance matrix: {w}×{h}-Distanzmatrix
+    def `summarize_results`:
+        "{nmethods} {pl(nmethods, 'method')} ": "{nmethods} {plde(nmethods, 'Methode|Methoden')} "
+        on {ninstances} test {pl(ninstances, 'instance')}: an {ninstances} Test-{plde(ninstances, 'Instanz|Instanzen')}
+    def `summarize_attributes`:
+        empty list: leere Liste
+        ' and {n - 2} others': ' und {n - 2} andere'
+    def `summarize_preprocessor`:
+        {_name_of(preprocessor)} (empty): {_name_of(preprocessor)} (leer)
+widgets/utils/textimport.py:
+    class `ColumnType`:
+        Skip: Überspringen
+        Auto: Automatisch
+        Numeric: Numerisch
+        Categorical: Kategorisch
+        Text: Text
+        Time: Zeit
+    class `CSVOptionsWidget`:
+        Tab: Tabulator
+        Comma: Komma
+        Semicolon: Semikolon
+        Space: Leerzeichen
+        def `__init__`:
+            ,: ,
+            '|': '|'
+            \": \"
+            Select file text encoding: Textkodierung der Datei auswählen
+            Select cell delimiter character.: Trennzeichen für Zellen auswählen.
+            Other: Andere
+            .: .
+            "'": "'"
+            Encoding: Kodierung
+            Cell delimiter: Zelltrennzeichen
+            Quote character: Anführungszeichen
+        def `encoding`:
+            latin-1: latin-1
+        def `__show_encodings_widget`:
+            Customize Encodings List: Kodierungsliste anpassen
+        def `__set_visible_codecs`:
+            Customize Encodings List...: Kodierungsliste anpassen...
+    class `CSVImportWidget`:
+        def `__init__`:
+            X: X
+            Thousands group separator: Tausendertrennzeichen
+            None: Keine
+            No separator: Kein Trennzeichen
+            Space: Leerzeichen
+            Decimal separator: Dezimaltrennzeichen
+            Grouping:: Gruppierung:
+            Decimal:: Dezimal:
+            Number separators:: Zahlen-Trennzeichen:
+            Auto: Automatisch
+            'The type will be determined automatically based ': 'Der Typ wird automatisch bestimmt basierend auf '
+            on column contents.: dem Spalteninhalt.
+            Numeric: Numerisch
+            Categorical: Kategorisch
+            Text: Text
+            Datetime: Datum/Zeit
+            Ignore: Ignorieren
+            The column will not be loaded: Die Spalte wird nicht geladen
+            Column type: Spaltentyp
+        def `__run_row_menu`:
+            Skip: Überspringen
+            Header: Kopfzeile
+    def `format_exception_csv`:
+        'CSV parsing error: ': 'CSV-Fehler beim Einlesen: '
+widgets/utils/userinput.py:
+    def `_get_points`:
+        invalid value ({msg[msg.rindex(':') + 1:]}): Ungültiger Wert ({msg[msg.rindex(':') + 1:]})
+    def `_numbers_from_no_dots`:
+        value must be between {minimum} and {maximum}: Wert muss zwischen {minimum} und {maximum} liegen
+        value must be at least {minimum}: Wert muss mindestens {minimum} betragen
+        value must be at most {maximum}: Wert darf höchstens {maximum} betragen
+    def `_numbers_from_dots`:
+        multiple '...'.: Mehrfaches '...'.
+        values before '...' must be smaller than values after.: Werte vor '...' müssen kleiner als Werte danach sein
+        at least two values are required before or after '...'.: Mindestens zwei Werte vor oder nach '...' sind erforderlich
+        points must be in uniform order.: Punkte müssen in einheitlicher Reihenfolge sein
+        points must be in increasing order.: Punkte müssen in aufsteigender Reihenfolge sein
+        minimum value is missing.: Minimalwert fehlt
+        maximum value is missing.: Maximalwert fehlt
+        minimum value is below the minimum {minimum}.: Minimalwert liegt unter dem Minimum {minimum}
+        maximum value is above the maximum {maximum}.: Maximalwert liegt über dem Maximum {maximum}
+        the sequence before '...' does not end with the sequence after it.: Die Sequenz vor '...' endet nicht mit der Sequenz danach
+widgets/utils/plot/owplotgui.py:
+    class `VariablesDelegate`:
+        def `paint`:
+            ' Add ': Hinzufügen
+            ' Remove ': Entfernen
+    class `OWPlotGUI`:
+        def `__init__`:
+            (Same color): Gleiche Farbe
+            (Same shape): Gleiche Form
+            (Same size): Gleiche Größe
+            (No labels): Keine Beschriftungen
+        Zoom: Zoomen
+        Reset zoom: Zoom zurücksetzen
+        Pan: Verschieben
+        Select: Auswählen
+        Add to selection: Zur Auswahl hinzufügen
+        Remove from selection: Aus Auswahl entfernen
+        Toggle selection: Auswahl umschalten
+        Replace selection: Auswahl ersetzen
+        Send selection: Auswahl senden
+        Clear selection: Auswahl löschen
+        ShufflePoints: Punkte mischen
+        Animate plot: Diagramm animieren
+        Animate points: Punkte animieren
+        Antialias plot: Diagramm Kantenglättung
+        Antialias points: Punkte Kantenglättung
+        Antialias lines: Linien Kantenglättung
+        Disable effects for large datasets: Effekte bei großen Datensätzen deaktivieren
+        def `antialiasing_check_box`:
+            Use antialiasing: Kantenglättung verwenden
+        def `jitter_size_slider`:
+            'Jittering: ': Jitter:
+        def `jitter_numeric_check_box`:
+            Jitter numeric values: Numerische Werte jittert anzeigen
+        def `show_legend_check_box`:
+            Show legend: Legende anzeigen
+        def `tooltip_shows_all_check_box`:
+            Show all data on mouse hover: Alle Daten beim Überfahren mit der Maus anzeigen
+        def `class_density_check_box`:
+            Show color regions: Farbregionen anzeigen
+        def `regression_line_check_box`:
+            Show regression line: Regressionslinie anzeigen
+        def `label_only_selected_check_box`:
+            Label only selection and subset: Nur Auswahl und Teilmengen beschriften
+        def `filled_symbols_check_box`:
+            Show filled symbols: Gefüllte Symbole anzeigen
+        def `grid_lines_check_box`:
+            Show gridlines: Gitternetzlinien anzeigen
+        def `animations_check_box`:
+            Use animations: Animationen verwenden
+        def `point_size_slider`:
+            'Symbol size: ': Symbolgröße:
+        def `alpha_value_slider`:
+            'Opacity: ': Deckkraft:
+        def `color_value_combo`:
+            'Color: ': Farbe:
+        def `shape_value_combo`:
+            'Shape: ': Form:
+        def `size_value_combo`:
+            'Size: ': Größe:
+        def `label_value_combo`:
+            'Label: ': Beschriftung:
+        def `point_properties_box`:
+            Attributes: Attribute
+        def `zoom_select_toolbar`:
+            Zoom / Select: Zoomen / Auswählen
+        def `theme_combo_box`:
+            Theme: Thema
+            Default: Standard
+            Light: Hell
+            Dark: Dunkel
+        def `box_zoom_select`:
+            Zoom/Select: Zoomen/Auswählen
+widgets/utils/save/owsavebase.py:
+    class `OWSaveBase`:
+        class `Information`:
+            Empty input; nothing was saved.: Leere Eingabe; nichts wurde gespeichert.
+        class `Warning`:
+            Auto save disabled.\n: Automatisches Speichern deaktiviert.\n
+            'Due to security reasons auto save is only restored for paths ': 'Aus Sicherheitsgründen wird das automatische Speichern nur für Pfade wiederhergestellt '
+            'that are in the same directory as the workflow file or in a ': 'die im gleichen Verzeichnis wie die Arbeitsflussdatei oder in einem '
+            subtree of that directory.: Unterverzeichnis dieses Verzeichnisses liegen.
+        class `Error`:
+            File name is not set.: Dateiname ist nicht festgelegt.
+            File format is unsupported.\n{}: Dateiformat wird nicht unterstützt.\n{}
+        def `__init__`:
+            Autosave when receiving new data: Automatisches Speichern bei neuen Daten
+            Save as {self.stored_name}: Speichern als {self.stored_name}
+            Save: Speichern
+            Save as ...: Speichern als ...
+        def `save_file_as`:
+            Save as {self.stored_name}: Speichern als {self.stored_name}
+        def `get_save_filename`:
+            Save File: Datei speichern
+widgets/visualize/__init__.py:
+    Visualize: Visualisieren
+    Data visualization: Datenvisualisierung
+widgets/visualize/owbarplot.py:
+    class `ParameterSetter`:
+        Gridlines: Gitternetzlinien
+        Show: Anzeigen
+        Bottom axis: Untere Achse
+        Group axis: Gruppenachse
+        Vertical ticks: Vertikale Teilstriche
+    class `OWBarPlot`:
+        Bar Plot: Balkendiagramm
+        Visualizes comparisons among categorical variables.: Stellt Vergleiche zwischen kategorialen Variablen dar.
+        bar plot, chart: bar plot, chart, Balkendiagramm, Diagramm
+        class `Inputs`:
+            Data: Daten
+            Data Subset: Daten-Teilmenge
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Error`:
+            Plotting requires a numeric feature.: Für die Darstellung wird ein numerisches Merkmal benötigt.
+        class `Information`:
+            Data has too many instances. Only first {}: Die Daten enthalten zu viele Instanzen. Nur die ersten {}
+            ' are shown.': ' werden angezeigt.'
+        Enumeration: Aufzählung
+        def `_add_controls`:
+            Values:: Werte:
+            None: Keine
+            Group by:: Gruppieren nach:
+            Annotations:: Beschriftungen:
+            (Same color): Gleiche Farbe
+            Color:: Farbe:
+widgets/visualize/owboxplot.py:
+    class `OWBoxPlot`:
+        Box Plot: Boxplot
+        Visualize the distribution of feature values in a box plot.: Verteilung der Merkmalswerte in einem Boxplot visualisieren.
+        box plot, whisker: Boxplot, Whisker
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Warning`:
+            Data contains no categorical or numeric variables: Die Daten enthalten keine kategorialen oder numerischen Variablen
+        def `__init__`:
+            Variable: Variable
+            Order by relevance to subgroups: Nach Relevanz für Untergruppen sortieren
+            Order by 𝜒² or ANOVA over the subgroups: Nach 𝜒² oder ANOVA über die Untergruppen sortieren
+            None: Keine
+            Subgroups: Untergruppen
+            Order by relevance to variable: Nach Relevanz für die Variable sortieren
+            Order by 𝜒² or ANOVA over the variable values: Nach 𝜒² oder ANOVA über die Variablenwerte sortieren
+            Display: Anzeigen
+            Annotate: Beschriften
+            No comparison: Kein Vergleich
+            Compare medians: Mediane vergleichen
+            Compare means: Mittelwerte vergleichen
+            Stretch bars: Balken strecken
+            Show box labels: Boxbeschriftungen anzeigen
+            Sort by subgroup frequencies: Nach Untergruppenhäufigkeiten sortieren
+        def `compute_box_data`:
+            missing '{self.group_var.name}': fehlend {self.group_var.name}
+        def `_compute_tests_cont`:
+            'At least one group has just one instance, ': 'Mindestens eine Gruppe hat nur eine Instanz, '
+            cannot compute significance: Signifikanz kann nicht berechnet werden
+            "Student's t: {t:.3f} (p={p:.3f}, N={n})": Student-t: {t:.3f} (p={p:.3f}, N={n})
+            'ANOVA: {F:.3f} (p={p:.3f}, N={n})': ANOVA: {F:.3f} (p={p:.3f}, N={n})
+        def `_compute_tests_disc`:
+            'χ²: {chi:.2f} (p={p:.3f}, dof={dof})': χ²: {chi:.2f} (p={p:.3f}, df={dof})
+        def `mean_label`:
+            ' \u00b1 ': ' \u00b1 '
+            %.*f: %.*f
+            ': ': ': '
+        def `draw_axis`:
+            ?: ?
+        def `strudel`:
+            missing '{attr.name}': fehlend {attr.name}
+            '{value}: {100 * freq / total:.2f}%': {value}: {100 * freq / total:.2f}%
+            '{value}: ({int(freq)})': {value}: ({int(freq)})
+        def `send_report`:
+            "Box plot for attribute '{self.attribute.name}' ": "Boxplot für Merkmal '{self.attribute.name}' "
+            grouped by '{self.group_var.name}': gruppiert nach {self.group_var.name}
+widgets/visualize/owdistributions.py:
+    class `ElidedAxisNoUnits`:
+        def `labelString`:
+            ;: ;
+            '{k}: {v}': {k}: {v}
+    class `OWDistributions`:
+        Distributions: Verteilungen
+        Display value distributions of a data feature in a graph.: Wertverteilungen eines Merkmals grafisch darstellen.
+        distributions, histogram: distributions, histogram, Verteilungen, Histogramm
+        class `Inputs`:
+            Data: Daten
+            Set the input dataset: Eingabedatensatz festlegen
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+            Histogram Data: Histogrammdaten
+        class `Error`:
+            Variable '{}' does not have any defined values: Variable '{}' hat keine definierten Werte
+            No data instances with '{}' and '{}' defined: Keine Dateninstanzen mit definierten '{}' und '{}' vorhanden
+        class `Warning`:
+            Data instances with missing values are ignored: Dateninstanzen mit fehlenden Werten werden ignoriert
+        None: Keine
+        Normal: Normal
+        μ: μ
+        σ: σ
+        Beta: Beta
+        α: α
+        β: β
+        Gamma: Gamma
+        Rayleigh: Rayleigh
+        Pareto: Pareto
+        Exponential: Exponential
+        λ: λ
+        Kernel density: Kerneldichte
+        def `__init__`:
+            Variable: Variable
+            Sort categories by frequency: Kategorien nach Häufigkeit sortieren
+            Distribution: Verteilung
+            Fitted distribution: Angepasste Verteilung
+            Bin width: Kastenbreite
+            Smoothing: Glättung
+            Hide bars: Balken ausblenden
+            Columns: Spalten
+            Split by: Aufteilen nach
+            (None): (Keine)
+            Stack columns: Spalten stapeln
+            Show probabilities: Wahrscheinlichkeiten anzeigen
+            Show cumulative distribution: Kumulative Verteilung anzeigen
+        def `_on_show_probabilities_changed`:
+            Fitted probability: Angepasste Wahrscheinlichkeit
+            Chosen distribution is used to compute Bayesian probabilities: Ausgewählte Verteilung wird zur Berechnung bayesscher Wahrscheinlichkeiten verwendet
+            Fitted distribution: Angepasste Verteilung
+        def `_set_axis_names`:
+            Probability of '{self.cvar.name}' at given '{self.var.name}': Wahrscheinlichkeit von '{self.cvar.name}' für gegebenes '{self.var.name}'
+            Frequency: Häufigkeit
+        def `_disc_plot`:
+            <p style='white-space:pre;'>: <p style="white-space:pre;">
+            '<b>{escape(desc)}</b>: {int(freq)} ': '<b>{escape(desc)}</b>: {int(freq)} '
+            '({100 * freq / len(self.valid_data):.2f} %) ': ({100 * freq / len(self.valid_data):.2f} %)
+        def `_cont_plot`:
+            <p style='white-space:pre;'>: <p style="white-space:pre;">
+            '<b>{escape(desc)}</b>: ': '<b>{escape(desc)}</b>: '
+            {freq} ({100 * freq / total:.2f} %)</p>: {freq} ({100 * freq / total:.2f} %)</p>
+        def `_fit_approximation`:
+            def `join_pars`:
+                ', ': ', '
+                {sname}={strv(val)}: {sname}={strv(val)}
+            def `str_params`:
+                -: -
+                ' ({par})': ' ({par})'
+        def `_split_tooltip`:
+            'white-space:pre; text-align: right;': white-space:pre; text-align: right;
+            "style='{cs} padding-left: 1em'": style='{cs} padding-left: 1em'
+            "<table style='border-collapse: collapse'>": <table style='border-collapse: collapse'>
+            <tr><th {s}>{escape(valname)}:</th>: <tr><th {s}>{escape(valname)}:</th>
+            <td {snp}><b>{int(tot_group)}</b></td>: <td {snp}><b>{int(tot_group)}</b></td>
+            <td/>: <td/>
+            <td {s}><b>{100 * tot_group / total:.2f} %</b></td></tr>: <td {s}><b>{100 * tot_group / total:.2f} %</b></td></tr>
+            <tr><td/><td/><td {s}>(in group)</td><td {s}>(overall)</td>: <tr><td/><td/><td {s}>(in Gruppe)</td><td {s}>(gesamt)</td>
+            </tr>: </tr>
+            <tr>: <tr>
+            <th {s}>{value}:</th>: <th {s}>{value}:</th>
+            <td {snp}><b>{int(freq)}</b></td>: <td {snp}><b>{int(freq)}</b></td>
+            <td {s}>{100 * freq / div_group:.2f} %</td>: <td {s}>{100 * freq / div_group:.2f} %</td>
+            <td {s}>{100 * freq / total:.2f} %</td>: <td {s}>{100 * freq / total:.2f} %</td>
+            </table>: </table>
+        def `_display_legend`:
+            ' ({desc})': ' ({desc})'
+        def `str_int`:
+            {var.name} < {sx1}: {var.name} < {sx1}
+            {var.name} = {sx0}: {var.name} = {sx0}
+            {var.name} ≥ {sx0}: {var.name} ≥ {sx0}
+            {sx0} ≤ {var.name} < {sx1}: {sx0} ≤ {var.name} < {sx1}
+        def `show_selection`:
+            <p style='white-space:pre;'>: <p style="white-space:pre;">
+            '<b>{escape(valname)}</b>: ': '<b>{escape(valname)}</b>: '
+            {inside} ({100 * inside / total:.2f} %): {inside} ({100 * inside / total:.2f} %)
+        def `apply`:
+            Bin: Kasten
+        def `_get_histogram_table`:
+            Bin: Kasten
+            Count: Anzahl
+        def `send_report`:
+            Cummulative distribution of '{self.var.name}': Kumulative Verteilung von '{self.var.name}'
+            Distribution of '{self.var.name}': Verteilung von '{self.var.name}'
+            " with columns split by '{self.cvar.name}'": " mit Spalten aufgeteilt nach '{self.cvar.name}'"
+widgets/visualize/owfreeviz.py:
+    def `run_freeviz`:
+        Calculating...: Berechne...
+    class `InitType`:
+        def `items`:
+            Circular: Zirkulär
+            Random: Zufällig
+    class `OWFreeViz`:
+        FreeViz: FreeViz
+        Displays FreeViz projection: Zeigt FreeViz-Projektion
+        freeviz, viz: freeviz, viz
+        class `Error`:
+            Data must have a target variable.: Daten müssen eine Zielvariable enthalten.
+            Data must have a single target variable.: Daten müssen genau eine Zielvariable enthalten.
+            Target variable must have at least two unique values.: Zielvariable muss mindestens zwei verschiedene Werte haben.
+            Number of features exceeds the number of instances.: Anzahl der Merkmale überschreitet die Anzahl der Instanzen.
+            Data is too large.: Daten sind zu groß.
+            All data columns are constant.: Alle Datenspalten sind konstant.
+            At least two features are required.: Mindestens zwei Merkmale sind erforderlich.
+        class `Warning`:
+            Categorical features with more than: Kategoriale Merkmale mit mehr als
+            ' two values are not shown.': ' zwei Werten werden nicht angezeigt.'
+        def `_add_controls`:
+            Hide radius:: Radius ausblenden:
+        def `__add_controls_start_box`:
+            Optimize: Optimieren
+            Initialization:: Initialisierung:
+            Gravity: Gravitation
+            Start: Start
+        def `_toggle_run`:
+            Resume: Fortsetzen
+        def `_run`:
+            Stop: Stopp
+        def `on_done`:
+            Start: Start
+        def `on_exception`:
+            Start: Start
+        def `enable_controls`:
+            Start: Start
+widgets/visualize/owheatmap.py:
+    def `split_domain`:
+        N/A: Nicht verfügbar
+    None: Keine
+    No clustering: Keine Clusterbildung
+    Clustering: Clusterbildung
+    Apply hierarchical clustering: Hierarchische Clusterbildung anwenden
+    Clustering (opt. ordering): Clusterbildung (optimale Reihenfolge)
+    'Apply hierarchical clustering with optimal leaf ': 'Hierarchische Clusterbildung mit optimalem Blatt anwenden '
+    ordering.: Reihenfolge.
+    Top: Oben
+    Bottom: Unten
+    Top and Bottom: Oben und Unten
+    class `OWHeatMap`:
+        Heat Map: Heatmap
+        Plot a data matrix heatmap.: Eine Datenmatrix-Heatmap darstellen.
+        heat map: Heatmap
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Information`:
+            Data has been sampled: Daten wurden gesampelt
+            Categorical features are ignored.: Kategoriale Merkmale werden ignoriert.
+            Showing this data may require a lot of memory: Die Anzeige dieser Daten kann viel Speicher erfordern
+        class `Error`:
+            No numeric features: Keine numerischen Merkmale
+            Not enough features for column clustering: Nicht genügend Merkmale für Spalten-Clusterbildung
+            Not enough instances for clustering: Nicht genügend Instanzen für Clusterbildung
+            Not enough instances for k-means merging: Nicht genügend Instanzen für K-Means-Zusammenführung
+            Not enough memory to show this data: Nicht genügend Speicher zur Anzeige dieser Daten
+        class `Warning`:
+            Empty clusters were removed: Leere Cluster wurden entfernt
+        'For data with a meaningful mid-point, ': 'Für Daten mit sinnvoller Mitte, '
+        choose one of diverging palettes.: wählen Sie eine der divergierenden Paletten.
+        def `__init__`:
+            Color: Farbe
+            Merge: Zusammenführen
+            Merge by k-means: Nach K-Means zusammenführen
+            Clusters:: Cluster:
+            Clustering: Clusterbildung
+            Rows:: Zeilen:
+            Columns:: Spalten:
+            Split By: Aufteilen nach
+            (None): (Keine)
+            Split the heatmap vertically by a categorical column: Heatmap vertikal nach einer kategorialen Spalte aufteilen
+            Split the heatmap horizontally by column annotation: Heatmap horizontal nach Spaltenannotation aufteilen
+            Annotation && Legends: Annotationen & Legenden
+            Show legend: Legende anzeigen
+            Stripes with averages: Streifen mit Mittelwerten
+            Row Annotations: Zeilenannotations
+            Text: Text
+            Column annotations: Spaltenannotations
+            Position: Position
+            Keep aspect ratio: Seitenverhältnis beibehalten
+            Resize: Größe ändern
+            Increase Font: Schrift vergrößern
+            ctrl+>: Strg+>
+            Decrease Font: Schrift verkleinern
+            ctrl+<: Strg+<
+        def `_make_parts`:
+            N/A: Nicht verfügbar
+        def `__update_clustering_enable_state`:
+            'Row cluster ordering was disabled due to the ': 'Reihen-Clusterreihenfolge wurde deaktiviert aufgrund des '
+            estimated runtime cost: geschätzten Laufzeitaufwands
+            'Row clustering was was disabled due to the ': 'Reihen-Clusterbildung wurde deaktiviert aufgrund des '
+            'Column cluster ordering was disabled due to ': 'Spalten-Clusterreihenfolge wurde deaktiviert aufgrund des '
+            'Column clustering was disabled due to the ': 'Spalten-Clusterbildung wurde deaktiviert aufgrund des '
+        def `update_annotations`:
+            ' ({} more)': ' ({} weitere)'
+        def `send_report`:
+            Columns:: Spalten:
+            Clustering: Clusterbildung
+            No sorting: Keine Sortierung
+            Rows:: Zeilen:
+            Split:: Aufteilung:
+            Row annotation: Zeilenannotation
+    def `join_elided`:
+        ...: ...
+    def `colorize`:
+        N/A: Nicht verfügbar
+    def `aggregate`:
+        ' ({} more)': ' ({} weitere)'
+    def `agg_join_str`:
+        ' ({} more)': ' ({} weitere)'
+widgets/visualize/owlinearprojection.py:
+    class `OWLinProjGraph`:
+        def `update_anchors`:
+            ...: ...
+    class `OWLinearProjection`:
+        Linear Projection: Lineare Projektion
+        'A multi-axis projection of data onto ': 'Eine Mehrachsenprojektion der Daten auf '
+        a two-dimensional plane.: eine zweidimensionale Ebene.
+        linear projection: lineare Projektion
+        Circular Placement: Kreisplatzierung
+        Linear Discriminant Analysis: Lineare Diskriminanzanalyse
+        Principal Component Analysis: Hauptkomponentenanalyse
+        class `Error`:
+            Plotting requires numeric features: Für die Darstellung werden numerische Merkmale benötigt
+        class `Information`:
+            LDA placement is disabled due to unsuitable target.\n{}: LDA-Platzierung deaktiviert aufgrund ungeeignetem Ziel.\n{}
+        def `_add_controls`:
+            Features: Merkmale
+            Hide radius:: Radius ausblenden:
+        def `_add_controls_variables`:
+            Suggest Features: Merkmale vorschlagen
+        def `_check_options`:
+            Current data has no target variable: Aktuelle Daten haben keine Zielvariable
+            {class_var.name} is not categorical: {class_var.name} ist nicht kategorial
+            Data has no defined values for {class_var.name}: Daten haben keine definierten Werte für {class_var.name}
+            ' and ': ' und '
+            "Data contains just {['one', 'two'][nclasses - 1]} distinct ": Daten enthalten nur {['ein', 'zwei'][nclasses - 1]} verschiedene
+            "{pl(nclasses, 'value')} ({vals}) for '{class_var.name}'; ": "{plde(nclasses, 'Wert')} ({vals}) für '{class_var.name}'; "
+            at least three are required.: mindestens drei werden benötigt.
+        def `init_vizrank`:
+            There is no data.: Keine Daten vorhanden.
+            Color variable has to be selected: Farbvariable muss ausgewählt werden
+            'Suggest Features does not work for Linear ': 'Merkmale vorschlagen funktioniert nicht für Lineare '
+            'Discriminant Analysis Projection when ': 'Diskriminanzanalyse-Projektion, wenn '
+            continuous color variable is selected.: kontinuierliche Farbvariable ausgewählt ist.
+            Not enough available continuous variables: Nicht genügend verfügbare kontinuierliche Variablen
+            Not enough valid data instances: Nicht genügend gültige Dateninstanzen
+        def `_get_send_report_caption`:
+            Projection: Projektion
+            Color: Farbe
+            Label: Beschriftung
+            Shape: Form
+            Size: Größe
+            Jittering: Jitter
+widgets/visualize/owlineplot.py:
+    class `ParameterSetter`:
+        Mean: Mittelwert
+        Lines: Linien
+        Lines (missing value): Linien (fehlender Wert)
+        Selected lines: Ausgewählte Linien
+        Selected lines (missing value): Ausgewählte Linien (fehlender Wert)
+        Range: Bereich
+        Selected range: Ausgewählter Bereich
+        def `update_setters`:
+            Dash line: Strichlinie
+    class `OWLinePlot`:
+        Line Plot: Liniendiagramm
+        Visualization of data profiles (e.g., time series).: Visualisierung von Datenprofilen (z.B. Zeitreihen).
+        line plot: line plot, Liniendiagramm
+        class `Inputs`:
+            Data: Daten
+            Data Subset: Daten-Teilmenge
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Error`:
+            Need at least one numeric feature.: Es wird mindestens ein numerisches Merkmal benötigt.
+        class `Warning`:
+            No display option is selected.: Keine Anzeigeoption ausgewählt.
+        class `Information`:
+            Data has too many features. Only first {}: Die Daten enthalten zu viele Merkmale. Nur die ersten {}
+            ' are shown.': ' werden angezeigt.'
+        def `_add_controls`:
+            Display: Anzeigen
+            Lines: Linien
+            Plot lines: Linien darstellen
+            Range: Bereich
+            Plot range between 10th and 90th percentile: Bereich zwischen 10. und 90. Perzentil darstellen
+            Mean: Mittelwert
+            Plot mean curve: Mittelwertkurve darstellen
+            Error bars: Fehlerbalken
+            Show standard deviation: Standardabweichung anzeigen
+            None: Keine
+            Group by: Gruppieren nach
+        def `send_report`:
+            Group by: Gruppieren nach
+widgets/visualize/owmosaic.py:
+    class `MosaicVizRank`:
+        def `__init__`:
+            'Score Mosaics with ': 'Mosaike bewerten mit '
+            a single variable: einer einzelnen Variable
+            two variables: zwei Variablen
+            three variables: drei Variablen
+            four variables: vier Variablen
+            at most two variables: höchstens zwei Variablen
+            at most three variables: höchstens drei Variablen
+            at most four variables: höchstens vier Variablen
+        def `on_attrs_changed`:
+            Restart with new settings: Mit neuen Einstellungen neu starten
+    class `OWMosaicDisplay`:
+        Mosaic Display: Mosaik-Darstellung
+        Display data in a mosaic plot.: Daten in einem Mosaikdiagramm darstellen.
+        mosaic display: mosaic display, Mosaik-Darstellung
+        class `Inputs`:
+            Data: Daten
+            Data Subset: Daten-Teilmenge
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Warning`:
+            Data subset is incompatible with Data: Daten-Teilmenge ist inkompatibel mit den Daten
+            No valid data: Keine gültigen Daten
+            Selection of numeric features on SQL is not supported: Auswahl numerischer Merkmale auf SQL wird nicht unterstützt
+        def `__init__`:
+            (None): (Keine)
+            Find Informative Mosaics: Informative Mosaike finden
+            Interior Coloring: Innenfärbung
+            (Pearson residuals): (Pearson-Residuen)
+            Compare with total: Mit Gesamt vergleichen
+        def `init_vizrank`:
+            Not enough data: Nicht genügend Daten
+        def `update_graph`:
+            def `get_counts`:
+                -: -
+            def `draw_data`:
+                -: -
+            def `add_rect`:
+                'Expected instances: %.1f<br>': Erwartete Instanzen: %.1f<br>
+                'Actual instances: %d<br>': Tatsächliche Instanzen: %d<br>
+                'Standardized (Pearson) residual: %.1f': Standardisiertes (Pearson) Residuum: %.1f
+                -: -
+                '<b>%s</b>: %d / %.1f%% (Expected %.1f / %.1f%%)': <b>%s</b>: %d / %.1f%% (Erwartet %.1f / %.1f%%)
+                '{}<hr>Instances: {}<br><br>{}': {}<hr>Instanzen: {}<br><br>{}
+            def `create_legend`:
+                Residuals:: Residuen:
+            Feature {} has no values: Merkmal {} hat keine Werte
+widgets/visualize/ownomogram.py:
+    class `SortBy`:
+        def `items`:
+            Original order: Ursprüngliche Reihenfolge
+            Alphabetically: Alphabetisch
+            Absolute importance: Absolute Wichtigkeit
+            Positive influence: Positiver Einfluss
+            Negative influence: Negativer Einfluss
+    class `ProbabilitiesDotItem`:
+        def `get_tooltip_text`:
+            'Total: {} <br/>Probability: {:.0%}': Gesamt: {} <br/>Wahrscheinlichkeit: {:.0%}
+    class `DiscreteMovableDotItem`:
+        def `get_tooltip_text`:
+            'Points: {}': Punkte: {}
+    class `ContinuousItemMixin`:
+        def `get_tooltip_text`:
+            'Points: {}': Punkte: {}
+            'Value: {}': Wert: {}
+    class `ProbabilitiesRulerItem`:
+        def `__init__`:
+            Total: Gesamt
+    class `OWNomogram`:
+        Nomogram: Nomogramm
+        ' Nomograms for Visualization of Naive Bayesian': ' Nomogramme zur Visualisierung von Naive-Bayes-'
+        ' and Logistic Regression Classifiers.': ' und Logistic-Regression-Klassifikatoren.'
+        nomogram: Nomogramm
+        class `Inputs`:
+            Classifier: Klassifikator
+            Data: Daten
+        class `Outputs`:
+            Features: Merkmale
+        class `Error`:
+            'Nomogram accepts only Naive Bayes and ': Nomogramme akzeptieren nur Naive-Bayes-
+            Logistic Regression classifiers.: und Logistic-Regression-Klassifikatoren.
+        def `__init__`:
+            'Target class: ': 'Zielklasse: '
+            Normalize probabilities: Wahrscheinlichkeiten normalisieren
+            For multiclass data 1 vs. all probabilities do not: 'Bei Mehrklassen-Daten summieren 1-gegen-alle-Wahrscheinlichkeiten nicht '
+            ' sum to 1 and therefore could be normalized.': ' zu 1 und könnten daher normalisiert werden.'
+            'Scale: ': 'Skalierung: '
+            Point scale: Punkt-Skala
+            Log odds ratios: Log-Odds-Verhältnisse
+            Displayed features: Angezeigte Merkmale
+            'Order: ': 'Reihenfolge: '
+            All features: Alle Merkmale
+            Best ranked:: Beste Rangliste:
+            'Show: ': 'Anzeigen: '
+            Numeric features:: Numerische Merkmale:
+            1D projection: 1D-Projektion
+            2D curve: 2D-Kurve
+        def `update_scene`:
+            Points: Punkte
+            Probabilities (%): Wahrscheinlichkeiten (%)
+widgets/visualize/owpythagorastree.py:
+    class `OWPythagorasTree`:
+        Pythagorean Tree: Pythagoras-Baum
+        Pythagorean Tree visualization for tree like-structures.: Visualisierung von Pythagoras-Bäumen für baumartige Strukturen.
+        pythagorean tree, fractal: Pythagoras-Baum, Fraktal
+        class `Inputs`:
+            Tree: Baum
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        def `__init__`:
+            Normal: Normal
+            Square root: Quadratwurzel
+            Logarithmic: Logarithmisch
+            Tree Info: Bauminformationen
+            Display Settings: Anzeigeeinstellungen
+            Depth: Tiefe
+            Target class: Zielklasse
+            Size: Größe
+            Log scale factor: Log-Skalenfaktor
+            Plot Properties: Diagrammeigenschaften
+            Enable tooltips: Tooltips aktivieren
+            Show legend: Legende anzeigen
+            Redraw: Neu zeichnen
+        def `_update_info_box`:
+            'Nodes: {}\nDepth: {}': Knoten: {}\nTiefe: {}
+        def `_update_log_scale_slider`:
+            Logarithmic: Logarithmisch
+        def `_clear_info_box`:
+            No tree on input: Kein Baum in den Eingabedaten
+        def `_update_target_class_combo`:
+            Target class: Zielklasse
+            None: Keine
+            Node color: Knotenfarbe
+widgets/visualize/owpythagoreanforest.py:
+    class `OWPythagoreanForest`:
+        Pythagorean Forest: Pythagoras-Wald
+        Pythagorean forest for visualising random forests.: Pythagoras-Wald zur Visualisierung von Random Forests.
+        pythagorean forest, fractal: Pythagoras-Wald, Fraktal
+        class `Inputs`:
+            Random Forest: Random Forest
+            Random forest: Random Forest
+        class `Outputs`:
+            Tree: Baum
+        Normal: Normal
+        Square root: Quadratwurzel
+        Logarithmic: Logarithmisch
+        def `__init__`:
+            Forest: Wald
+            Display: Anzeige
+            Depth: Tiefe
+            Target class: Zielklasse
+            Size: Größe
+            Zoom: Zoom
+        def `_update_info_box`:
+            'Trees: {}': Bäume: {}
+        def `_update_target_class_combo`:
+            Target class: Zielklasse
+            None: Keine
+            Node color: Knotenfarbe
+        def `_clear_info_box`:
+            No forest on input.: Kein Wald in den Eingabedaten
+widgets/visualize/owradviz.py:
+    class `RadvizVizRank`:
+        def `__init__`:
+            'Maximum number of variables: ': 'Maximale Anzahl der Variablen: '
+    class `OWRadviz`:
+        Radviz: Radviz
+        Display Radviz projection: Radviz-Projektion anzeigen
+        radviz, viz: radviz, viz
+        class `Warning`:
+            Categorical variables with more than two values are not shown.: Kategoriale Variablen mit mehr als zwei Werten werden nicht angezeigt.
+            Maximum number of selected variables reached.: Maximale Anzahl ausgewählter Variablen erreicht.
+        def `_add_controls`:
+            Features: Merkmale
+            Suggest features: Merkmale vorschlagen
+        def `init_vizrank`:
+            No data: Keine Daten
+            Not enough variables: Nicht genügend Variablen
+            Color is not set.: Farbe ist nicht gesetzt.
+            No rows with defined color variable: Keine Zeilen mit definierter Farbvariable
+            Not enough rows without missing data: Nicht genügend Zeilen ohne fehlende Daten
+            Constant data: Konstante Daten
+widgets/visualize/owruleviewer.py:
+    class `OWRuleViewer`:
+        CN2 Rule Viewer: CN2-Regelanzeige
+        Review rules induced from data.: Regeln überprüfen, die aus Daten abgeleitet wurden.
+        cn2 rule viewer: cn2 rule viewer, CN2-Regelanzeige
+        class `Inputs`:
+            Data: Daten
+            Classifier: Klassifikator
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        def `__init__`:
+            IF conditions: WENN-Bedingungen
+            THEN class: DANN-Klasse
+            Distribution: Verteilung
+            Probabilities [%]: Wahrscheinlichkeiten [%]
+            Quality: Qualität
+            Length: Länge
+            Compact view: Kompakte Ansicht
+            Restore original order: Ursprüngliche Reihenfolge wiederherstellen
+        def `send_report`:
+            Induced rules: Abgeleitete Regeln
+    class `CustomRuleViewerTableModel`:
+        def `data`:
+            def `_display_role`:
+                ' AND ': ' UND '
+                ' AND\n': ' UND\n'
+                TRUE: WAHR
+            def `_tooltip_role`:
+                ' AND ': ' UND '
+                ' AND\n': ' UND\n'
+widgets/visualize/owscatterplot.py:
+    class `OWScatterPlotGraph`:
+        def `_regression_line`:
+            r = {rvalue:.2f}: r = {rvalue:.2f}
+        def `_update_curve`:
+            '#505050': '#505050'
+        def `update_error_bars`:
+            '#505050': '#505050'
+    class `OWScatterPlot`:
+        Scatter Plot: Streudiagramm
+        'Interactive scatter plot visualization with ': 'Interaktive Streudiagramm-Visualisierung mit '
+        intelligent data visualization enhancements.: intelligenten Datenvisualisierungsverbesserungen.
+        scatter plot: scatter plot, Streudiagramm
+        class `Inputs`:
+            Features: Merkmale
+        class `Outputs`:
+            Features: Merkmale
+        class `Warning`:
+            "Plot cannot be displayed because '{}' or '{}' ": 'Diagramm kann nicht angezeigt werden, da "{}" oder "{}" '
+            is missing for all data points.: für alle Datenpunkte fehlt.
+        class `Information`:
+            Large SQL table; showing a sample.: Große SQL-Tabelle; Zeige eine Stichprobe.
+            Points with missing '{}' or '{}' are not displayed: Punkte mit fehlendem "{}" oder "{}" werden nicht angezeigt
+        def `_add_controls`:
+            Treat variables as independent: Variablen als unabhängig behandeln
+            If checked, fit line to group (minimize distance from points);\n: Wenn aktiviert, Linie an Gruppe anpassen (Abstand zu Punkten minimieren);\n
+            otherwise fit y as a function of x (minimize vertical distances): ansonsten y als Funktion von x anpassen (vertikale Abstände minimieren)
+            Show confidence ellipse: Konfidenzellipse anzeigen
+            Hotelling's T² confidence ellipse (α=95%): Hotellings T²-Konfidenzellipse (α=95%)
+        def `_add_controls_axis`:
+            Axes: Achsen
+            Axis x:: Achse x:
+            Axis y:: Achse y:
+            Find Informative Projections: Informative Projektionen finden
+        def `_add_controls_sampling`:
+            Sample: Stichprobe
+            Sampling: Stichproben
+        def `init_vizrank`:
+            No data on input: Keine Daten in den Eingaben
+            Data is sparse: Daten sind spärlich
+            Not enough features for ranking: Nicht genügend Merkmale für die Rangfolge
+            Color variable is not selected: Farbvariable nicht ausgewählt
+            Color variable has no values: Farbvariable hat keine Werte
+        def `set_subset_data`:
+            Data subset does not support large Sql tables: Daten-Teilmenge unterstützt keine großen SQL-Tabellen
+        def `get_widget_name_extension`:
+            {} vs {}: {} vs {}
+        def `_get_send_report_caption`:
+            Color: Farbe
+            Label: Beschriftung
+            Shape: Form
+            Size: Größe
+            Jittering: Jitter
+widgets/visualize/owscatterplotgraph.py:
+    class `AxisItem`:
+        def `tickStrings`:
+            %Y: %Y
+            %Y %b: %Y %b
+            %Y %b %d: %Y %b %d
+            %Hh: %Hh
+            %d %Hh: %d %Hh
+            %H:%M: %H:%M
+            %H:%M:%S: %H:%M:%S
+            %S.%f: %S.%f
+    class `ScatterBaseParameterSetter`:
+        Categorical legend: Kategorische Legende
+        Numerical legend: Numerische Legende
+    class `OWScatterPlotBase`:
+        def `_create_drag_tooltip`:
+            '{}: Append to group': {}: Zur Gruppe hinzufügen
+            Cmd: Cmd
+            Ctrl: Strg
+            'Shift: Add group': Shift: Gruppe hinzufügen
+            'Alt: Remove': Alt: Entfernen
+widgets/visualize/owscoringsheetviewer.py:
+    class `ScoringSheetTable`:
+        def `__init__`:
+            Attribute Name: Attributname
+            Points: Punkte
+            Selected: Ausgewählt
+    class `RiskSlider`:
+        def `setup_labels`:
+            <b>Total:</b>: <b>Gesamt:</b>
+            <b>Probabilities (%):</b>: <b>Wahrscheinlichkeiten (%):</b>
+        def `handle_hover_event`:
+            <b>Points:</b> {int(points)}<br>: <b>Punkte:</b> {int(points)}<br>
+            <b>Probability:</b> {probability:.1f}%: <b>Wahrscheinlichkeit:</b> {probability:.1f}%
+    class `OWScoringSheetViewer`:
+        Scoring Sheet Viewer: Scoring Sheet-Anzeige
+        Visualize the scoring sheet model.: Scoring Sheet-Modell visualisieren.
+        scoring sheet viewer: Scoring Sheet-Anzeige
+        class `Inputs`:
+            Classifier: Klassifikator
+            Data: Daten
+        class `Outputs`:
+            Features: Merkmale
+        class `Error`:
+            Scoring Sheet Viewer only accepts a Scoring Sheet model.: Scoring Sheet-Anzeige akzeptiert nur ein Scoring Sheet-Modell.
+        class `Information`:
+            The input data contains multiple instances. Only the first instance will be used.: Die Eingabedaten enthalten mehrere Instanzen. Nur die erste Instanz wird verwendet.
+        def `_setup_gui`:
+            Target class:: Zielklasse:
+widgets/visualize/owsieve.py:
+    class `OWSieveDiagram`:
+        Sieve Diagram: Siebdiagramm
+        'Visualize the observed and expected frequencies ': 'Beobachtete und erwartete Häufigkeiten visualisieren '
+        for a combination of values.: für eine Kombination von Werten.
+        icons/SieveDiagram.svg: icons/SieveDiagram.svg
+        sieve diagram: sieve diagram, Siebdiagramm
+        class `Inputs`:
+            Data: Daten
+            Features: Merkmale
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Warning`:
+            Data does not meet the Cochran's rule\n{}: "Daten erfüllen nicht die Cochran-Regel\n{}"
+        def `__init__`:
+            \u2717: \u2717
+            Score Combinations: Kombinationen bewerten
+        def `init_vizrank`:
+            No data: Keine Daten
+            Not enough data: Nicht genügend Daten
+            Data is sparse: Daten sind spärlich
+        def `resolve_shown_attributes`:
+            Features from the input signal are not present in the data: Merkmale aus dem Eingabesignal sind in den Daten nicht vorhanden
+        def `update_graph`:
+            def `make_tooltip`:
+                def `_oper`:
+                    ' in ': ' in '
+                '<b>combination of values: </b><br/>
+                   &nbsp;&nbsp;&nbsp;expected {exp} ({p_exp:.0f} %)<br/>
+                   &nbsp;&nbsp;&nbsp;observed {obs} ({p_obs:.0f} %)': <b>Kombination von Werten: </b><br/>&nbsp;&nbsp;&nbsp;erwartet {exp} ({p_exp:.0f} %)<br/>&nbsp;&nbsp;&nbsp;beobachtet {obs} ({p_obs:.0f} %)
+            Features {} and {} have no values: Merkmale {} und {} haben keine Werte
+            Feature {} has no values: Merkmal {} hat keine Werte
+            χ²={:.2f}, p={:.3f}: χ²={:.2f}, p={:.3f}
+            'N = ': 'N = '
+        def `_check_cochran`:
+            no cells in contingency table: "Keine Zellen in der Kontingenztabelle"
+            some expected frequencies are below 1: "Einige erwartete Häufigkeiten liegen unter 1"
+            more than 20% of expected frequencies are below 5: "Mehr als 20 % der erwarteten Häufigkeiten liegen unter 5"
+        def `get_widget_name_extension`:
+            {} vs {}: {} vs {}
+widgets/visualize/owsilhouetteplot.py:
+    class `NoGroupVariable`:
+        Input does not have any suitable labels: Eingabe hat keine geeigneten Labels
+    class `OWSilhouettePlot`:
+        Silhouette Plot: Silhouette-Diagramm
+        'Visually assess cluster quality and ': 'Clusterqualität visuell bewerten und '
+        the degree of cluster membership.: den Grad der Clusterzugehörigkeit bestimmen.
+        silhouette plot: Silhouette-Diagramm
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        Euclidean: Euklidisch
+        Manhattan: Manhattan
+        Cosine: Kosinus
+        class `Error`:
+            Need at least two non-empty clusters: Mindestens zwei nicht-leere Cluster erforderlich
+            All clusters are singletons: Alle Cluster sind Einzelinstanzen
+            Not enough memory: Nicht genügend Speicher
+            "Distances could not be computed: '{}'": Abstände konnten nicht berechnet werden: "{}"
+            Distance matrix is not symmetric.: Abstandsmatrix ist nicht symmetrisch.
+        class `Warning`:
+            {} instance{s} omitted (missing cluster assignment): {} Instanz{plde(s,"")} ausgelassen (fehlende Clusterzuordnung)
+            {} instance{s} omitted (undefined distances): {} Instanz{plde(s,"")} ausgelassen (undefinierte Abstände)
+            Ignoring categorical features: Kategoriale Merkmale werden ignoriert
+        def `__init__`:
+            Distance: Abstand
+            Grouping: Gruppierung
+            (None): (Keine)
+            Show in groups: In Gruppen anzeigen
+            Bars: Balken
+            Bar width:: Balkenbreite:
+            Annotations:: Annotationen:
+            (increase the width to show): (Breite erhöhen, um anzuzeigen)
+        def `_set_distances`:
+            Distance matrix is not symmetric.: Abstandsmatrix ist nicht symmetrisch.
+            Input matrix does not have associated data: Eingabematrix hat keine zugehörigen Daten
+        def `commit`:
+            Silhouette ({}): Silhouette ({})
+        def `send_report`:
+            'Silhouette plot ': 'Silhouette-Diagramm '
+            '({self.Distances[self.distance_idx][0]} distance), ': '({self.Distances[self.distance_idx][0]} Abstand), '
+            clustered by '{self.cluster_var.name}': geclustert nach '{self.cluster_var.name}'
+            , annotated with '{self.annotation_var.name}': , annotiert mit '{self.annotation_var.name}'
+widgets/visualize/owtreeviewer.py:
+    class `OWTreeGraph`:
+        Tree Viewer: Baum-Viewer
+        tree viewer: tree viewer, Baum-Viewer
+        class `Inputs`:
+            Tree: Baum
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        Default: Standard
+        Number of instances: Anzahl der Instanzen
+        Mean value: Mittelwert
+        Variance: Varianz
+        def `__init__`:
+            'Target class: ': 'Zielklasse: '
+            None: "Keine"
+            Variable that identifies the instances in nodes.: "Variable, die die Instanzen in den Knoten identifiziert"
+            Node labels:: "Knotenbeschriftungen:"
+            Show details in non-leaves: "Details in Nicht-Blättern anzeigen"
+        def `_ctree_clean`:
+            No tree.: Kein Baum.
+        def `_ctree_setup`:
+            'Target class: ': 'Zielklasse: '
+            None: Keine
+            'Color by: ': 'Färben nach: '
+            {nodes} {pl(nodes, "node")}, {leaves} {pl(leaves, "leaf|leaves")}: {nodes} {plde(nodes,"Knoten")}, {leaves} {plde(leaves,"Blatt|Blätter")}
+        def `node_tooltip`:
+            <p><b>Selection</b></p><p>{rule}</p>: <p><b>Auswahl</b></p><p>{rule}</p>
+            {nbp}<b>Distribution of</b> '{name}'</p><p>: {nbp}<b>Verteilung von</b> '{name}'</p><p>
+            ({self.tree_adapter.num_samples(node.node_inst)} instances)</p>: ({self.tree_adapter.num_samples(node.node_inst)} Instanzen)</p>
+            '{nbp}<b>Next split: </b>{split}</p>': {nbp}<b>Nächste Aufteilung: </b>{split}</p>
+        def `send_report`:
+            Tree size: Baumgröße
+            Edge widths: Kantenbreiten
+            Fixed: Fest
+            Relative to root: Relativ zur Wurzel
+            Relative to parent: Relativ zum Elternknoten
+            Target class: Zielklasse
+            Color by: Färben nach
+        def `update_node_info`:
+            , …: false
+        def `node_content_reg`:
+            {insts} instances: {insts} Instanzen
+widgets/visualize/owtreeviewer2d.py:
+    class `OWTreeViewer2D`:
+        def `__init__`:
+            Tree: Baum
+            No tree.: Kein Baum.
+            Display: Anzeige
+            'Zoom: ': 'Zoom: '
+            'Width: ': 'Breite: '
+            'Depth: ': 'Tiefe: '
+            Unlimited: Unbegrenzt
+            {x} levels: {x} Ebenen
+            'Edge width: ': 'Kantenbreite: '
+            Fixed: Fest
+            Relative to root: Relativ zur Wurzel
+            Relative to parent: Relativ zum Elternknoten
+        def `send_report`:
+            Tree: Baum
+        def `node_tooltip`:
+            tree node: Baumknoten
+widgets/visualize/owvenndiagram.py:
+    Instance identity: Instanzidentität
+    Instance equality: Instanzgleichheit
+    class `OWVennDiagram`:
+        Venn Diagram: Venn-Diagramm
+        'A graphical visualization of the overlap of data instances ': 'Grafische Darstellung der Überlappung von Dateninstanzen '
+        from a collection of input datasets.: aus einer Sammlung von Eingabedatensätzen.
+        venn diagram: Venn-Diagramm
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Error`:
+            Data sets do not contain the same instances.: Datensätze enthalten nicht die gleichen Instanzen.
+            Venn diagram accepts at most five datasets.: Venn-Diagramm akzeptiert höchstens fünf Datensätze.
+        class `Warning`:
+            'Some variables have been renamed ': 'Einige Variablen wurden umbenannt '
+            to avoid duplicates.\n{}: um Duplikate zu vermeiden.\n{}
+        def `__init__`:
+            Columns (features): Spalten (Merkmale)
+            Rows (instances), matched by: Zeilen (Instanzen), abgeglichen nach
+            'Instances are identical if originally coming from the ': 'Instanzen sind identisch, wenn sie ursprünglich aus derselben '
+            same row of the same table.\n: Zeile derselben Tabelle stammen.\n
+            'Instances can be check for equality only if described by ': Instanzen können nur auf Gleichheit geprüft werden, wenn sie durch dieselben Variablen beschrieben sind.
+            the same variables.: die gleichen Variablen.
+            Output duplicates: Duplikate ausgeben
+        def `_createDiagram`:
+            '{} <i>(all: {})</i>': {} <i>(alle: {})</i>
+            </br>({len(area_items) - 32} items not shown): </br>({len(area_items) - 32} Elemente nicht angezeigt)
+widgets/visualize/owviolinplot.py:
+    class `ParameterSetter`:
+        Bottom axis: Untere Achse
+        Vertical tick text: Vertikaler Tick-Text
+    class `OWViolinPlot`:
+        Violin Plot: Violinen-Diagramm
+        Visualize the distribution of feature: Verteilung des Merkmals visualisieren
+        ' values in a violin plot.': Werte in einem Violinen-Diagramm.
+        violin plot, kernel, density: Violinen-Diagramm, Kernel, Dichte
+        class `Inputs`:
+            Data: Daten
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Error`:
+            Plotting requires a numeric feature.: Für das Diagramm wird ein numerisches Merkmal benötigt.
+            Plotting requires at least two instances.: Für das Diagramm werden mindestens zwei Instanzen benötigt.
+        Normal: Normal
+        Epanechnikov: Epanechnikov
+        Linear: Linear
+        Area: Fläche
+        Count: Anzahl
+        Width: Breite
+        def `_add_controls`:
+            None: Keine
+            Variable: Variable
+            Order by relevance to subgroups: Nach Relevanz für Untergruppen sortieren
+            Order by 𝜒² or ANOVA over the subgroups: Nach 𝜒² oder ANOVA über die Untergruppen sortieren
+            Subgroups: Untergruppen
+            Order by relevance to variable: Nach Relevanz für Variable sortieren
+            Order by 𝜒² or ANOVA over the variable values: Nach 𝜒² oder ANOVA über die Variablenwerte sortieren
+            Display: Anzeige
+            Box plot: Box-Diagramm
+            Density dots: Dichtepunkte
+            Density lines: Dichtelinien
+            Order subgroups: Untergruppen sortieren
+            Show grid: Gitter anzeigen
+            Horizontal: Horizontal
+            Vertical: Vertikal
+            'Orientation: ': 'Orientierung: '
+            Density Estimation: Dichteschätzung
+            Kernel:: Kernel:
+            Scale:: Skala:
+widgets/visualize/pythagorastreeviewer.py:
+    class `DiscreteTreeNode`:
+        def `tooltip`:
+            {}/{} samples ({:2.3f}%): {}/{} Stichproben ({:2.3f}%)
+            'Split by ': 'Aufgeteilt nach '
+    class `ContinuousTreeNode`:
+        None: Keine
+        Mean: Mittelwert
+        Standard deviation: Standardabweichung
+        def `tooltip`:
+            '<p>Mean: {:2.3f}': <p>Mittelwert: {:2.3f}
+            '<br>Standard deviation: {:2.3f}': <br>Standardabweichung: {:2.3f}
+            <br>{} samples: <br>{} Stichproben
+            'Split by ': 'Aufgeteilt nach '
+widgets/visualize/utils/__init__.py:
+    class `VizRankDialog`:
+        class `Information`:
+            There is nothing to rank.: Es gibt nichts zu bewerten.
+        def `__init__`:
+            Start: Start
+        def `initialize`:
+            Start: Start
+        def `on_done`:
+            Finished: Fertig
+        def `toggle`:
+            Pause: Pause
+            Continue: Fortsetzen
+    def `run_vizrank`:
+        Getting combinations...: Kombinationen werden berechnet...
+        Getting scores...: Punktzahlen werden berechnet...
+    class `CanvasText`:
+        def `elide`:
+            ...: ...
+widgets/visualize/utils/component.py:
+    class `AnchorParameterSetter`:
+        Anchor: Anker
+widgets/visualize/utils/customizableplot.py:
+    class `Updater`:
+        Font family: Schriftart
+        Font size: Schriftgröße
+        Italic: Kursiv
+        Width: Breite
+        Opacity: Deckkraft
+        Style: Stil
+        Antialias: Kantenglättung
+        Solid line: Durchgezogene Linie
+        Dash line: Gestrichelte Linie
+        Dot line: Gepunktete Linie
+        Dash dot line: Strich-Punkt-Linie
+        Dash dot dot line: Strich-Punkt-Punkt-Linie
+    class `CommonParameterSetter`:
+        Fonts: Schriften
+        Annotations: Anmerkungen
+        Figure: Diagramm
+        Font family: Schriftart
+        Axis title: Achsentitel
+        Axis ticks: Achsen-Ticks
+        Legend: Legende
+        Label: Beschriftung
+        Line label: Linienbeschriftung
+        Title: Titel
+        Lines: Linien
+widgets/visualize/utils/error_bars_dialog.py:
+    class `ErrorBarsDialog`:
+        def `__init__`:
+            (None): (Keine)
+            Difference from plotted value: Differenz zum geplotteten Wert
+            Absolute position on the plot: Absolute Position im Diagramm
+            Upper:: Oberer Wert:
+            Lower:: Unterer Wert:
+widgets/visualize/utils/vizrank.py:
+    class `VizRankDialog`:
+        Score Plots: Diagramme bewerten
+        Start: Start
+        Pause: Pause
+        Continue: Fortsetzen
+        Finished: Fertig
+        def `__init__`:
+            Filter ...: Filter ...
+            Start: Start
+        def `set_run_state`:
+            {self.captionTitle} (paused at {self._progress}%): {self.captionTitle} (pausiert bei {self._progress}%)
+    class `VizRankDialogAttrs`:
+        def `row_for_state`:
+            ', ': ', '
+    class `VizRankDialogNAttrs`:
+        def `__init__`:
+            'Number of variables: ': 'Anzahl der Variablen: '
+        def `on_n_attrs_changed`:
+            Restart with {new_attrs} variables: Neu starten mit {new_attrs} Variablen
+widgets/visualize/utils/widget.py:
+    class `OWProjectionWidgetBase`:
+        class `Information`:
+            Points with undefined '{}' are shown in smaller size: Punkte mit undefiniertem \'{}\' werden kleiner dargestellt
+            Points with undefined '{}' are shown as crossed circles: Punkte mit undefiniertem \'{}\' werden als durchkreuzte Kreise dargestellt
+        def `get_column`:
+            Other: Andere
+        def `_point_tooltip`:
+            def `show_part`:
+                ... and {over} {pl(over, 'other')}: ... und {over} {plde(over, "Andere")}
+            {pl(len(dom.class_vars), 'Class|Classes')}: {plde(len(dom.class_vars), "Klasse|Klassen")}
+            {pl(len(dom.metas), 'Meta')}: {plde(len(dom.metas), "Meta")}
+            {pl(len(dom.attributes), 'Feature')}: {plde(len(dom.attributes), "Merkmal|Merkmale")}
+        def `get_tooltip`:
+            {len(point_ids)} instances<hr/>{text}<hr/>...: {len(point_ids)} Instanzen<hr/>{text}<hr/>...
+    class `OWDataProjectionWidget`:
+        class `Inputs`:
+            Data: Daten
+            Data Subset: Daten-Subset
+        class `Outputs`:
+            Selected Data: Ausgewählte Daten
+        class `Warning`:
+            Too many labels to show (zoom in or label only selected): Zu viele Beschriftungen zum Anzeigen (hineinzoomen oder nur Auswahl beschriften)
+            'Subset data contains some instances that do not appear in ': Das Daten-Subset enthält Instanzen, die nicht in den
+            input data: Eingabedaten erscheinen
+            No subset data instances appear in input data: Keine Instanzen des Daten-Subsets erscheinen in den Eingabedaten
+            Increase opacity if subset is difficult to see: Deckkraft erhöhen, wenn das Subset schwer sichtbar ist
+        def `_get_selected_data`:
+            Group: Gruppe
+        def `_get_send_report_caption`:
+            Color: Farbe
+            Label: Beschriftung
+            Shape: Form
+            Size: Größe
+            Jittering: Jitter
+    class `OWAnchorProjectionWidget`:
+        class `Outputs`:
+            Components: Komponenten
+        class `Error`:
+            Sparse data is not supported: Spärliche Daten werden nicht unterstützt
+            No projection due to no valid data: Keine Projektion aufgrund fehlender gültiger Daten
+            At least two data instances are required: Mindestens zwei Dateninstanzen sind erforderlich
+            An error occurred while projecting data.\n{}: Fehler bei der Projektion der Daten aufgetreten.\n{}
+        def `send_components`:
+            components: Komponenten

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -7390,8 +7390,8 @@ arr = np.array([
 out_data = Table.from_numpy(domain, arr)
 ': false
     def `read_file_content`:
-        utf-8: true
-        strict: true
+        utf-8: false
+        strict: false
     Light: false
     '#000': false
     '#f00': false
@@ -11921,7 +11921,7 @@ widgets/unsupervised/owmds.py:
     __main__: false
     iris: false
 widgets/unsupervised/owpca.py:
-    component variance: varianca kompomente
+    component variance: varianca komponente
     cumulative variance: skupna varianca
     class `OWPCA`:
         PCA: PCA

--- a/i18n/trubar-config.yaml
+++ b/i18n/trubar-config.yaml
@@ -6,6 +6,10 @@ languages:
     name: Slovenščina
     international-name: Slovenian
     auto-import: from orangecanvas.localization.si import plsi, plsi_sz, z_besedo  # pylint: disable=wrong-import-order
+  de:
+    name: Deutsch
+    international-name: German
+    auto-import: from orangecanvas.localization.de import plde  # pylint: disable=wrong-import-order
 auto-import: |2
   from orangecanvas.localization import Translator  # pylint: disable=wrong-import-order
   _tr = Translator("Orange", "biolab.si", "Orange")


### PR DESCRIPTION
Add German translation, one German-translation-related fix, and a fixed type in Slovenian translation.

Possible problems (among others):

- Bad translations, e.g. bad wording, a different word used in translation.
- Incorrect translations of code in f-strings, e.g. translated variable names, incorrect calls of plde.
- "Strings" that must not be translated. These were marked as "must not be translated" in the Slovenian translation, which is used as template, but I could have missed some. E.g. in open(..., error="strict"), I did't mark "strict" as non-translatable, and in the German translation it was translated to "strikt".

The first problem causes embarrasment, the latter two cause runtime errors.