### PR TITLE
Feature Constructor: Form plural using localization.pl

### DIFF
--- a/Orange/widgets/data/owfeatureconstructor.py
+++ b/Orange/widgets/data/owfeatureconstructor.py
@@ -32,6 +32,7 @@ from AnyQt.QtWidgets import (
 from AnyQt.QtGui import QKeySequence
 from AnyQt.QtCore import Qt, pyqtSignal as Signal, pyqtProperty as Property
 
+from orangecanvas.localization import pl
 from orangewidget.utils.combobox import ComboBoxSearch
 
 import Orange
@@ -44,7 +45,6 @@ from Orange.widgets.utils import (
     itemmodels, vartype, ftry, unique_everseen as unique
 )
 from Orange.widgets.utils.sql import check_sql_input
-from Orange.widgets import report
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.widgets.utils.concurrent import ConcurrentWidgetMixin, TaskState
@@ -822,8 +822,7 @@ class OWFeatureConstructor(OWWidget, ConcurrentWidgetMixin):
             else:
                 desc = "text"
             items[feature.name] = f"{feature.expression} ({desc})"
-        self.report_items(
-            report.plural("Constructed feature{s}", len(items)), items)
+        self.report_items(f"Constructed {pl(len(items), 'feature')}", items)
 
     def fix_expressions(self):
         dlg = QMessageBox(

--- a/Orange/widgets/data/tests/test_owfeatureconstructor.py
+++ b/Orange/widgets/data/tests/test_owfeatureconstructor.py
@@ -1,7 +1,6 @@
 # pylint: disable=unsubscriptable-object
 import unittest
 import ast
-import sys
 import math
 import pickle
 import copy

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -6012,7 +6012,7 @@ Categorical features are passed as strings
             date/time: datum/čas
             text: besedilna
             {feature.expression} ({desc}): false
-            Constructed feature{s}: Sestavljene spremenljivke
+            Constructed {pl(len(items), 'feature')}: {plsi(len(items), "Sestavljena spremenljivka|Sestavljeni spremenljivki|Sestavljene spremenljivke")}
         def `fix_expressions`:
             Fix Expressions: Popravi izraze
             "This widget's behaviour has changed. Values of categorical ": true


### PR DESCRIPTION
##### Issue

Plural forms created with `report.plural` cannot be translated.

##### Description of changes

In Feature constructor, replace `report.plural` by `localization.pl`.

##### Includes
- [X] Code changes