### PR TITLE
Update readthedocs runner: fix failing readthedocs.org checks

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-24.04
    tools:
-      python: "3.10"
+      python: "3.12"
 
 submodules:
    include: all


### PR DESCRIPTION
##### Issue
PyPi does not have Qt6 binaries for Ubuntu 20.04. Thus install crashed.

##### Description of changes
Changed the runner to ubuntu 24.04.