### PR TITLE
Rename Feature Statistics -> Column Statistics in docs

### DIFF
--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -113,11 +113,14 @@
     "keywords": []
    },
    {
-    "text": "Feature Statistics",
+    "text": "Column Statistics",
     "doc": "visual-programming/source/widgets/data/featurestatistics.md",
     "icon": "../Orange/widgets/data/icons/FeatureStatistics.svg",
     "background": "#FFD39F",
-    "keywords": []
+    "keywords": [
+     "feature",
+     "variable"
+    ]
    },
    {
     "text": "Save Data",


### PR DESCRIPTION
##### Issue
After #7085 was merge docs tests started crashing: documentation was gone, because names did not match.