### PR TITLE
[FIX] Manifold Learning: Fix reseting of selected number of components

### DIFF
--- a/Orange/widgets/unsupervised/owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/owmanifoldlearning.py
@@ -43,7 +43,7 @@ class ManifoldParametersEditor(QWidget, gui.OWComponent):
         width = QFontMetrics(self.font()).horizontalAdvance("0" * 10)
         control = gui.spin(
             self, self, name, minv, maxv,
-            alignment=Qt.AlignRight, callbackOnReturn=True,
+            alignment=Qt.AlignRight,
             addToLayout=False, controlWidth=width,
             callback=lambda f=self.__spin_parameter_update,
                             p=name: self.__parameter_changed(f, p))
@@ -225,6 +225,9 @@ class OWManifoldLearning(OWWidget):
 
     class Warning(OWWidget.Warning):
         graph_not_connected = Msg("Disconnected graph, embedding may not work")
+        less_components = Msg(
+            "Creating {} components\n"
+            "The number of components is limited by the number of variables.")
 
     @classmethod
     def migrate_settings(cls, settings, version):
@@ -269,13 +272,17 @@ class OWManifoldLearning(OWWidget):
         self.params_widget.show()
 
         output_box = gui.vBox(self.controlArea, "Output")
-        self.n_components_spin = gui.spin(
+        gui.spin(
             output_box, self, "n_components", 1, 10, label="Components:",
             controlWidth=QFontMetrics(self.font()).horizontalAdvance("0" * 10),
-            alignment=Qt.AlignRight, callbackOnReturn=True,
+            alignment=Qt.AlignRight,
             callback=self.settings_changed)
-        gui.rubber(self.n_components_spin.box)
         self.apply_button = gui.auto_apply(self.buttonsArea, self)
+
+    @property
+    def act_components(self):
+        return min(self.n_components,
+                   len(self.data.domain.attributes) if self.data else 0)
 
     def manifold_method_changed(self):
         self.params_widget.hide()
@@ -289,8 +296,6 @@ class OWManifoldLearning(OWWidget):
     @Inputs.data
     def set_data(self, data):
         self.data = data
-        self.n_components_spin.setMaximum(len(self.data.domain.attributes)
-                                          if self.data else 10)
         self.commit.now()
 
     @gui.deferred
@@ -325,8 +330,8 @@ class OWManifoldLearning(OWWidget):
                 if e.args[0] == "for method='hessian', n_neighbors " \
                                 "must be greater than [n_components" \
                                 " * (n_components + 3) / 2]":
-                    n = self.n_components * (self.n_components + 3) / 2
-                    self.Error.n_neighbors_too_small("{}".format(n))
+                    n = self.act_components * (self.act_components + 3) // 2
+                    self.Error.n_neighbors_too_small(n)
                 else:
                     self.Error.manifold_error(e.args[0])
             except MemoryError:
@@ -338,6 +343,8 @@ class OWManifoldLearning(OWWidget):
 
         output = self._create_output_table(embedding)
         self.Outputs.transformed_data.send(output)
+        if output and self.n_components != self.act_components:
+            self.Warning.less_components(self.act_components)
 
     def _create_output_table(self, embedding: np.ndarray) -> Optional[Table]:
         if embedding is None:
@@ -346,7 +353,7 @@ class OWManifoldLearning(OWWidget):
         data = self.data
         metas = list(data.domain.metas)
         names = [v.name for v in data.domain.variables + data.domain.metas]
-        proposed = ["C{}".format(i) for i in range(self.n_components)]
+        proposed = ["C{}".format(i) for i in range(self.act_components)]
         unique = get_unique_names(names, proposed)
         domain = Domain(data.domain.attributes, data.domain.class_vars,
                         metas + [ContinuousVariable(name) for name in unique])
@@ -356,14 +363,14 @@ class OWManifoldLearning(OWWidget):
         return table
 
     def get_method_parameters(self):
-        parameters = dict(n_components=self.n_components)
+        parameters = dict(n_components=self.act_components)
         parameters.update(self.params_widget.get_parameters())
         return parameters
 
     def send_report(self):
         method = self.MANIFOLD_METHODS[self.manifold_method_index]
         self.report_items((("Method", method.name),))
-        parameters = {"Number of components": self.n_components}
+        parameters = {"Number of components": self.act_components}
         parameters.update(self.params_widget.get_report_parameters())
         self.report_items("Method parameters", parameters)
         if self.data:

--- a/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
+++ b/Orange/widgets/unsupervised/tests/test_owmanifoldlearning.py
@@ -81,13 +81,52 @@ class TestOWManifoldLearning(WidgetTest):
     def test_n_components(self):
         """Check the output for various numbers of components"""
         self.send_signal(self.widget.Inputs.data, self.iris)
-        for i in range(self.widget.n_components_spin.minimum(),
-                       self.widget.n_components_spin.maximum()):
+        for i in range(1, 5):
             self.assertEqual(self.widget.data, self.iris)
-            self.widget.n_components_spin.setValue(i)
-            self.widget.n_components_spin.onEnter()
+            self.widget.controls.n_components.setValue(i)
             self.click_apply()
             self._compare_tables(self.get_output(self.widget.Outputs.transformed_data), i)
+
+    def test_too_few_attributes(self):
+        widget = self.widget
+        widget.auto_apply = True
+        spin = widget.controls.n_components
+        widget.n_components = 3
+
+        self.send_signal(self.iris)
+        self.assertFalse(widget.Warning.less_components.is_shown())
+        self.assertEqual(self.get_output().metas.shape[1], 3)
+        self.assertEqual(widget.act_components, 3)
+
+        self.send_signal(self.iris[:, :2])
+        self.assertTrue(widget.Warning.less_components.is_shown())
+        self.assertEqual(self.get_output().metas.shape[1], 2)
+        self.assertEqual(widget.act_components, 2)
+
+        self.send_signal(None)
+        self.assertFalse(widget.Warning.less_components.is_shown())
+        self.assertIsNone(self.get_output())
+
+        self.send_signal(self.iris[:, :2])
+        self.assertTrue(widget.Warning.less_components.is_shown())
+        self.assertEqual(self.get_output().metas.shape[1], 2)
+        self.assertEqual(widget.act_components, 2)
+
+        self.send_signal(self.iris)
+        self.assertFalse(widget.Warning.less_components.is_shown())
+        self.assertEqual(self.get_output().metas.shape[1], 3)
+        self.assertEqual(widget.act_components, 3)
+
+        spin.setValue(6)
+        assert widget.n_components == 6
+        self.assertTrue(widget.Warning.less_components.is_shown())
+        self.assertEqual(self.get_output().metas.shape[1], 4)
+        self.assertEqual(widget.act_components, 4)
+
+        spin.setValue(4)
+        self.assertFalse(widget.Warning.less_components.is_shown())
+        self.assertEqual(self.get_output().metas.shape[1], 4)
+        self.assertEqual(widget.act_components, 4)
 
     def test_manifold_methods(self):
         """Check output for various manifold methods"""

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -11882,6 +11882,8 @@ widgets/unsupervised/owmanifoldlearning.py:
             Out of memory: Premalo pomnilnika
         class `Warning`:
             Disconnected graph, embedding may not work: Graf je nepovezan, vložitev morda ne bo delovala.
+            Creating {} components\n: Računam {} komponent.\n
+            The number of components is limited by the number of variables.: Število komponent je omejeno s številom spremenljivk.
         def `migrate_settings`:
             tsne_editor: false
             init_index: false
@@ -11900,7 +11902,6 @@ widgets/unsupervised/owmanifoldlearning.py:
             "for method='hessian', n_neighbors ": false
             must be greater than [n_components: false
             ' * (n_components + 3) / 2]': false
-            {}: false
         def `_create_output_table`:
             C{}: false
         def `send_report`:


### PR DESCRIPTION
##### Issue

Fixes #7163 and a few deprecation warnings.

##### Description of changes

The original sin was that the limit on the number of components was enforced by setting the maximal value of the spin, thus changing the user's setting. I think a better approach is to let users set whatever they want and show a warning if the actual number of components (which is limited by the data) is lower.

Further considerations:
- what is the reasonable limit? I currently set it to 99, which is way too large.
- Should individual methods further restrain it? t-SNE with 10 components takes ages.
 
##### Includes
- [X] Code changes
- [X] Tests
