### PR TITLE
[FIX] Save dialogs: Avoid weird behavior with extensions on macOS

### DIFF
--- a/Orange/widgets/data/owsave.py
+++ b/Orange/widgets/data/owsave.py
@@ -128,14 +128,13 @@ class OWSave(OWSaveBase):
 
     def initial_start_dir(self):
         if self.filename and os.path.exists(os.path.split(self.filename)[0]):
-            return self.filename
+            return os.path.splitext(self.filename)[0]
         else:
             data_name = getattr(self.data, 'name', '')
             if data_name:
                 if self.writer is None:
                     self.filter = self.default_filter()
                 assert self.writer is not None
-                data_name += self.writer.EXTENSIONS[0]
             return os.path.join(self.last_dir or _userhome, data_name)
 
     def valid_filters(self):

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -13642,6 +13642,8 @@ widgets/utils/plot/owplotgui_obsolete.py:
             Dark: false
 widgets/utils/save/owsavebase.py:
     ~{os.sep}: false
+    darwin: false
+    win32: false
     class `OWSaveBase`:
         class `Information`:
             Empty input; nothing was saved.: Ni podatkov.
@@ -13678,8 +13680,6 @@ widgets/utils/save/owsavebase.py:
             stored_path: false
             filename: false
             stored_name: false
-        darwin: false
-        win32: false
         def `get_save_filename`:
             Save File: Shrani datoteko
             ;;: false


### PR DESCRIPTION
##### Issue

Fixes #7156.

1. On macOS, the native file dialog added a (correct) extension and then complained that, e.g. extension .tab is invalid and that the required extension is .tab. This may be due to changed behavior in Qt6 or macOS Sequoia.

2. Furthermore, macOS native dialog already asks whether to override the file (the flag `DontConfirmOverwrite` is ignored), hence the user was asked twice.

##### Description of changes

1. This seems to be fixed by

   a. keeping the `*` in filters and
   b. by not giving the extension to the initial file name.

   Point a won't affect Window because we already had * there. Point 2 can; we need to try and patch if necessary.
  
2. I removed the confirmation dialog for macOS, but kept it for Windows.

##### Includes
- [X] Code changes
