### PR TITLE
Logistic regression: Remove deprecated argument multi_class

### DIFF
--- a/Orange/classification/logistic_regression.py
+++ b/Orange/classification/logistic_regression.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import sklearn.linear_model as skl_linear_model
 
@@ -7,7 +5,6 @@ from Orange.classification import SklLearner, SklModel
 from Orange.preprocess import Normalize
 from Orange.preprocess.score import LearnerScorer
 from Orange.data import Variable, DiscreteVariable
-from Orange.util import OrangeDeprecationWarning
 
 
 __all__ = ["LogisticRegressionLearner"]
@@ -42,22 +39,12 @@ class LogisticRegressionLearner(SklLearner, _FeatureScorerMixin):
     def __init__(self, penalty="l2", dual=False, tol=0.0001, C=1.0,
                  fit_intercept=True, intercept_scaling=1, class_weight=None,
                  random_state=None, solver="auto", max_iter=100,
-                 multi_class="deprecated", verbose=0, n_jobs=1, preprocessors=None):
-        if multi_class != "deprecated":
-            warnings.warn("The multi_class parameter was "
-                          "deprecated in scikit-learn 1.5. Using it with "
-                          "scikit-learn 1.7 will lead to a crash.",
-                          OrangeDeprecationWarning,
-                          stacklevel=2)
+                 verbose=0, n_jobs=1, preprocessors=None):
         super().__init__(preprocessors=preprocessors)
         self.params = vars()
 
     def _initialize_wrapped(self):
         params = self.params.copy()
-
-        multi_class = params.pop("multi_class")
-        if multi_class != "deprecated":
-            params["multi_class"] = multi_class
 
         # The default scikit-learn solver `lbfgs` (v0.22) does not support the
         # l1 penalty.

--- a/Orange/tests/test_logistic_regression.py
+++ b/Orange/tests/test_logistic_regression.py
@@ -156,11 +156,3 @@ class TestLogisticRegressionLearner(unittest.TestCase):
 
     def test_supports_weights(self):
         self.assertTrue(LogisticRegressionLearner().supports_weights)
-
-    def test_multi_class_deprecation(self):
-        with self.assertWarns(OrangeDeprecationWarning):
-            LogisticRegressionLearner(penalty="l1", multi_class="multinomial")
-        now = datetime.now()
-        if (now.year, now.month) >= (2026, 1):
-            raise Exception("If Orange depends on scikit-learn >= 1.7, remove this test "
-                            "and any mention of multi_class in LogisticRegressionLearner.")


### PR DESCRIPTION
##### Issue

Parameter `multi_class` was deprecated in scikit 1.5 and is removed in the current nightly build. Class `LogisticRegressionLearner` allowed it, but Orange itself didn't use it.

##### Description of changes

Remove the argument and related tests.

##### Includes
- [X] Code changes
- [X] Tests
