### PR TITLE
test_owparameterfitter: smaller test data, faster learners

### DIFF
--- a/Orange/widgets/evaluate/tests/test_owparameterfitter.py
+++ b/Orange/widgets/evaluate/tests/test_owparameterfitter.py
@@ -33,11 +33,11 @@ class TestOWParameterFitter(WidgetTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._heart = Table("heart_disease")
-        cls._housing = Table("housing")
+        cls._heart = Table("heart_disease")[::10]
+        cls._housing = Table("housing")[::10]
         cls._naive_bayes = NaiveBayesLearner()
         cls._pls = PLSRegressionLearner()
-        cls._rf = RandomForestLearner()
+        cls._rf = RandomForestLearner(n_estimators=3)
         cls._dummy = DummyLearner()
 
     def setUp(self):
@@ -359,10 +359,10 @@ class TestOWParameterFitter(WidgetTest):
         self.assertEqual(controls.parameter_index.currentText(),
                          "Number of trees")
         self.assertEqual(controls.minimum.value(), 1)
-        self.assertEqual(controls.maximum.value(), 10)
+        self.assertEqual(controls.maximum.value(), 3)
         self.assertEqual(self.widget.parameter_index, 0)
         self.assertEqual(self.widget.minimum, 1)
-        self.assertEqual(self.widget.maximum, 10)
+        self.assertEqual(self.widget.maximum, 3)
 
     def test_visual_settings(self):
         graph = self.widget.graph


### PR DESCRIPTION
##### Issue

Quite often tests on Windows fail with.

```
======================================================================
FAIL: test_tooltip (Orange.widgets.evaluate.tests.test_owparameterfitter.TestOWParameterFitter.test_tooltip)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\unittest\mock.py", line 1378, in patched
    return func(*newargs, **newkeywargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\a\orange3\orange3\.tox\orange-released\Lib\site-packages\Orange\widgets\evaluate\tests\test_owparameterfitter.py", line 149, in test_tooltip
    self.wait_until_finished()
  File "D:\a\orange3\orange3\.tox\orange-released\Lib\site-packages\orangewidget\tests\base.py", line 529, in wait_until_finished
    self.assertTrue(
AssertionError: False is not true : Did not finish in the specified 5000ms timeout
```

##### Solution

This made tests a bit faster on my linux machine. Hoping it will also work better on Github Actions.