### PR TITLE
[FIX] requirements-core.txt: Raise minimum pandas version to 2.0.*

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -12,7 +12,7 @@ numpy>=1.21.0
 openpyxl>=3.1.3
 openTSNE>=0.6.2,!=0.7.0  # 0.7.0 segfaults
 packaging
-pandas>=1.4.0,!=1.5.0,!=2.0.0
+pandas>=2.0.1
 python-louvain>=0.13
 pyyaml
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ deps =
     oldest: numpy==1.23.2
     oldest: openpyxl==3.1.3
     oldest: openTSNE==1.0.0
-    oldest: pandas==1.5.1
+    oldest: pandas==2.0.1
     oldest: python-louvain==0.13
     # oldest: pyyaml
     # oldest: requests


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Orange.widgets.data.tests.test_oweditdomain.TestReinterpretTransforms.test_reinterpret_string is failing on oldest test since https://github.com/biolab/orange3/pull/7182 or rather would have failed if the tests were actually run.

It fails because guess_datetime_format("2010") does not infer %Y format prior to 2.0

##### Description of changes

Raise pandas requirement to 2.0.1

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
