### PR TITLE
Violin Plot: display time as time, not as a number

### DIFF
--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -273,6 +273,9 @@ class AxisItem(AxisItem):
         self._use_time = enable
         self.enableAutoSIPrefix(not enable)
 
+    def is_time(self):
+        return self._use_time
+
     def tickValues(self, minVal, maxVal, size):
         """Find appropriate tick locations."""
         if not self._use_time:

--- a/Orange/widgets/visualize/owviolinplot.py
+++ b/Orange/widgets/visualize/owviolinplot.py
@@ -29,7 +29,8 @@ from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.visualize.owboxplot import SortProxyModel
 from Orange.widgets.visualize.utils.customizableplot import \
     CommonParameterSetter, Updater
-from Orange.widgets.visualize.utils.plotutils import AxisItem, PlotWidget
+from Orange.widgets.visualize.utils.plotutils import PlotWidget
+from Orange.widgets.visualize.owscatterplotgraph import AxisItem
 from Orange.widgets.widget import OWWidget, Input, Output, Msg
 
 # scaling types
@@ -555,14 +556,19 @@ class ViolinPlot(PlotWidget):
     def _set_axes(self):
         if self.__value_var is None:
             return
-        value_title = self.__value_var.name
-        group_title = self.__group_var.name if self.__group_var else ""
         vertical = self.__orientation == Qt.Vertical
-        self.getAxis("left" if vertical else "bottom").setLabel(value_title)
-        self.getAxis("bottom" if vertical else "left").setLabel(group_title)
 
-        if self.__group_var is None:
-            self.getAxis("bottom" if vertical else "left").setTicks([])
+        value_axis = self.getAxis("left" if vertical else "bottom")
+        value_axis.setLabel(self.__value_var.name)
+        value_axis.use_time(self.__value_var.is_time)
+
+        group_axis = self.getAxis("bottom" if vertical else "left")
+        group_axis.use_time(False)
+        if self.__group_var:
+            group_axis.setLabel(self.__group_var.name)
+        else:
+            group_axis.setLabel("")
+            group_axis.setTicks([])
 
     def _plot_data(self):
         # save selection ranges

--- a/Orange/widgets/visualize/tests/test_owviolinplot.py
+++ b/Orange/widgets/visualize/tests/test_owviolinplot.py
@@ -9,7 +9,7 @@ from AnyQt.QtGui import QFont
 
 from pyqtgraph import ViewBox
 
-from Orange.data import Table
+from Orange.data import Table, Domain, ContinuousVariable, TimeVariable
 from Orange.widgets.tests.base import datasets, simulate, \
     WidgetOutputsTestMixin, WidgetTest
 from Orange.widgets.visualize.owviolinplot import OWViolinPlot, \
@@ -381,6 +381,37 @@ class TestOWViolinPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertEqual(font1.family(), font2.family())
         self.assertEqual(font1.pointSize(), font2.pointSize())
         self.assertEqual(font1.italic(), font2.italic())
+
+    def test_use_time(self):
+        widget = self.widget
+        widget.orientation_index = 1  # Vertical
+        left_axis = widget.graph.plotItem.getAxis("left")
+        bottom_axis = widget.graph.plotItem.getAxis("bottom")
+        x, y = TimeVariable("x"), ContinuousVariable("y")
+        domain = Domain([x, y], [])
+        data = Table.from_list(domain, [
+            ["2020-01-01", 1],
+            ["2020-01-02", 2],
+            ["2020-01-03", 3],
+            ["2020-01-04", 4],
+            ["2020-01-05", 5]])
+        self.send_signal(widget.Inputs.data, data)
+        self.__select_value(widget._value_var_view, "y")
+        self.assertFalse(left_axis.is_time())
+        self.assertFalse(bottom_axis.is_time())
+
+        self.__select_value(widget._value_var_view, "x")
+        self.assertTrue(left_axis.is_time())
+        self.assertFalse(bottom_axis.is_time())
+
+        widget.controls.orientation_index.buttons[0].click()
+        assert widget.orientation_index == 0  # Horizontal
+        self.assertFalse(left_axis.is_time())
+        self.assertTrue(bottom_axis.is_time())
+
+        self.__select_value(widget._value_var_view, "y")
+        self.assertFalse(left_axis.is_time())
+        self.assertFalse(bottom_axis.is_time())
 
     @staticmethod
     def __select_value(list_, value):


### PR DESCRIPTION
##### Issue

Fixes #7048

##### Description of changes

Use `AxisItem` from the scatter plot util, and call `use_time` as necessary.

##### Includes
- [X] Code changes
- [X] Tests
