### PR TITLE
Implement MAPE and SMAPE

### DIFF
--- a/Orange/evaluation/scoring.py
+++ b/Orange/evaluation/scoring.py
@@ -23,7 +23,8 @@ from Orange.util import OrangeDeprecationWarning
 
 
 __all__ = ["CA", "Precision", "Recall", "F1", "PrecisionRecallFSupport", "AUC",
-           "MSE", "RMSE", "MAE", "MAPE", "R2", "LogLoss", "MatthewsCorrCoefficient"]
+           "MSE", "RMSE", "MAE", "MAPE", "SMAPE", "R2", "LogLoss",
+           "MatthewsCorrCoefficient"]
 
 
 class ScoreMetaType(WrapperMeta):
@@ -423,14 +424,30 @@ class MAE(RegressionScore):
 
 
 class MAPE(RegressionScore):
-    __wraps__ = skl_metrics.mean_absolute_percentage_error
     name = "MAPE"
     long_name = "Mean absolute percentage error"
     priority = 45
 
-    def compute_score(self, results):
-        res = super().compute_score(results)
-        return res * 100
+    @staticmethod
+    def __wraps__(actual, predicted):
+        if np.any(actual == 0):
+            return np.inf
+        return np.sum(np.abs((actual - predicted) / actual)) / len(actual) * 100
+
+
+class SMAPE(RegressionScore):
+    name = "sMAPE"
+    long_name = "Symmetric mean absolute percentage error"
+    priority = 45
+
+    @staticmethod
+    def __wraps__(actual, predicted):
+        diff = np.abs(actual - predicted)
+        summ = np.abs(actual) + np.abs(predicted)
+        # To avoid 0 / 0, set divisor to 1; error will be 0, as it should be
+        summ[summ == 0] = 1.0
+        error = diff / summ
+        return 2 * np.sum(error) / len(actual) * 100
 
 
 # pylint: disable=invalid-name

--- a/Orange/evaluation/tests/test_scoring.py
+++ b/Orange/evaluation/tests/test_scoring.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from Orange.evaluation import MAPE
+from Orange.evaluation.scoring import SMAPE
+
+
+class TestScoring(unittest.TestCase):
+    def test_mape(self):
+        f = MAPE.__wraps__
+        exp = np.array([100, -200, 300, 60])
+        pred = np.array([110, -180, 340, 60])
+        self.assertEqual(f(exp, pred), (10 / 100 + 20 / 200 + 40 / 300) / 4 * 100)
+
+        exp = np.array([0, 200, 300])
+        self.assertEqual(f(exp, pred), np.inf)
+
+    def test_smape(self):
+        f = SMAPE.__wraps__
+        exp = np.array([100, -200, 300, 60, 80])
+        pred = np.array([110, -180, -340, 60, 50])
+        self.assertEqual(
+            f(exp, pred),
+            2 * (10 / 210 + 20 / 380 + 640 / 640 + 0 / 120 + 30 / 130) / 5 * 100)
+
+        exp = np.array([0, -200, 300, 60, 80])
+        self.assertEqual(
+            f(exp, pred),
+            2 * (110 / 110 + 20 / 380 + 640 / 640 + 0 / 120 + 30 / 130) / 5 * 100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -2186,6 +2186,7 @@ evaluation/scoring.py:
     RMSE: false
     MAE: false
     MAPE: false
+    SMAPE: false
     R2: false
     LogLoss: false
     MatthewsCorrCoefficient: false
@@ -2254,6 +2255,9 @@ evaluation/scoring.py:
     class `MAPE`:
         MAPE: true
         Mean absolute percentage error: Povprečna absolutna odstotna napaka
+    class `SMAPE`:
+        sMAPE: true
+        Symmetric mean absolute percentage error: Simetrična povprečna absolutna odstotna napaka
     class `R2`:
         R2: true
         # Je to OK?


### PR DESCRIPTION
##### Issue

Fixes #7041.

If a function cannot compute a value (e.g. because of division by zero), it is an awesome idea to return an arbitrary value instead. At least this is a common practice in SciPy. For instance, when MAPE is infinite, it returns 1/epsilon instead, which is a meaningless large number.

##### Description of changes

I may not entirely subscribe to the above approach, though, so this PR contains a reimplementation of MAPE that returns inf in such case.

It also implements [SMAPE](https://en.wikipedia.org/wiki/Symmetric_mean_absolute_percentage_error), as suggested in #7041.

**To discuss:** I guess we should hide MAPE by default in predictions.

A workflow and data for which MAPE now returns inf: 

[test-mape.zip](https://github.com/user-attachments/files/23690742/test-mape.zip)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
