### PR TITLE
[FIX] HeaderView: Do nothing in initStyleOptionForIndex if model is None

### DIFF
--- a/Orange/widgets/utils/headerview.py
+++ b/Orange/widgets/utils/headerview.py
@@ -70,6 +70,9 @@ class HeaderView(QHeaderView):
         is used (isSectionSelected will scan the entire model column/row
         when the whole column/row is selected).
         """
+        model = self.model()
+        if model is None:
+            return
         hover = self.logicalIndexAt(self.mapFromGlobal(QCursor.pos()))
         pressed = self.__pressed
 
@@ -100,7 +103,6 @@ class HeaderView(QHeaderView):
             )
 
         style = self.style()
-        model = self.model()
         orientation = self.orientation()
         textAlignment = model.headerData(logicalIndex, self.orientation(),
                                          Qt.TextAlignmentRole)


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fix error in initStyleOptionForIndex:
```
Traceback (most recent call last):
  File "/Users/aleserjavec/devel/orange3/Orange/widgets/data/owtable.py", line 83, in sectionSizeFromContents
    super().initStyleOptionForIndex(opt, logicalIndex)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/Users/aleserjavec/devel/orange3/Orange/widgets/utils/headerview.py", line 105, in initStyleOptionForIndex
    textAlignment = model.headerData(logicalIndex, self.orientation(),
                    ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'headerData'
```

This happens during test tear down with Qt 6.8.2
 
##### Description of changes

Do nothing in initStyleOptionForIndex if model is None

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
