### PR TITLE
util.countnans: Don't treat single-row sparse matrices as 1-d

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -344,7 +344,12 @@ def stats(X, weights=None, compute_variance=False):
 
     if X.size and is_numeric:
         if is_sparse:
-            nans = countnans(X, axis=0)
+            if X.shape[0] == 1:
+                # Since `countnans` assumes vector shape to be (1, n) and `x`
+                # shape is (n, 1), we pass the transpose
+                nans = countnans(X.T, axis=1)
+            else:
+                nans = countnans(X, axis=0)
             X = X.tocsc()
         else:
             nans = np.isnan(X).sum(axis=0)

--- a/Orange/widgets/data/tests/test_owtable.py
+++ b/Orange/widgets/data/tests/test_owtable.py
@@ -40,6 +40,12 @@ class TestOWTable(WidgetTest, WidgetOutputsTestMixin):
         output = self.get_output(self.widget.Outputs.annotated_data)
         self.assertIsNone(output)
 
+    def test_data_single_sparse(self):
+        data = self.data[:1].to_sparse()
+        self.send_signal(self.widget.Inputs.data, data)
+        self.assertIs(self.widget.input.table, data)
+        self.assertIs(self.widget.view.model().source, data)
+
     def test_data_model(self):
         self.send_signal(self.widget.Inputs.data, self.data)
         self.assertEqual(self.widget.view.model().rowCount(), len(self.data))


### PR DESCRIPTION
##### Issue

Fixes #7164.

##### Description of changes

`countnans` treats a sparse matrix of shape (1, n) as a vector. Using @pavlin-policar 's trick, we transpose it. (Besides being the inventor of the trick, he also caused this trick to be needed.)

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
