### PR TITLE
Fix FutureWarning in table_to_frame for pandas 2.x

### DIFF
--- a/Orange/data/pandas_compat.py
+++ b/Orange/data/pandas_compat.py
@@ -471,7 +471,7 @@ def table_to_frame(tab, include_metas=False):
     def _column_to_series(col, vals):
         result = ()
         if col.is_discrete:
-            codes = pd.Series(vals).fillna(-1).astype(int)
+            codes = (pd.Series(vals).fillna(-1).infer_objects(copy=False).astype(int))
             result = (col.name, pd.Categorical.from_codes(
                 codes=codes, categories=col.values, ordered=True
             ))


### PR DESCRIPTION
This PR fixes a pandas FutureWarning triggered in table_to_frame when
handling discrete variables by following pandas' recommended
infer_objects(copy=False) usage.

Closes #7063.

