### PR TITLE
ScatterplotGraph: Group points within dense cells

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -78,6 +78,7 @@ MAX_N_PAIRS = 10000
 class OWMDSGraph(OWScatterPlotBase):
     #: Percentage of all pairs displayed (ranges from 0 to 20)
     connected_pairs = Setting(5)
+    aggregate_dense_regions = Setting(True)
 
     def __init__(self, scatter_widget, parent):
         super().__init__(scatter_widget, parent)

--- a/Orange/widgets/unsupervised/owtsne.py
+++ b/Orange/widgets/unsupervised/owtsne.py
@@ -13,7 +13,7 @@ from Orange.preprocess import preprocess
 from Orange.projection import PCA
 from Orange.projection import manifold
 from Orange.widgets import gui
-from Orange.widgets.settings import SettingProvider, ContextSetting
+from Orange.widgets.settings import SettingProvider, Setting, ContextSetting
 from Orange.widgets.utils.concurrent import TaskState, ConcurrentWidgetMixin
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
@@ -343,6 +343,8 @@ class TSNERunner:
 
 
 class OWtSNEGraph(OWScatterPlotBase):
+    aggregate_dense_regions = Setting(True)
+
     def update_coordinates(self):
         super().update_coordinates()
         if self.scatterplot_item is not None:

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -494,6 +494,7 @@ class OWPlotGUI:
     ZoomReset = 16
 
     ToolTipShowsAll = 17
+    AggregatePoints = 53
     ClassDensity = 18
     RegressionLine = 19
     LabelOnlySelected = 20
@@ -633,6 +634,20 @@ class OWPlotGUI:
                             cb_name=self._plot.update_density,
                             stateWhenDisabled=False)
 
+    def aggregate_points_check_box(self, widget):
+        cb = self._master.cb_aggregate_points = \
+            self._check_box(
+                widget=widget,
+                value="aggregate_dense_regions",
+                label="Aggregate points in dense regions",
+                cb_name=self._plot.set_aggregation,
+                stateWhenDisabled=False,
+            )
+        cb.setToolTip(
+            "Dense regions with many points are aggregated into "
+            "circles or pie charts,\n"
+            "unless data is jittered or labels, selection or subset is shown")
+
     def regression_line_check_box(self, widget):
         self._master.cb_reg_line = \
             self._check_box(widget=widget, value="show_reg_line",
@@ -758,7 +773,11 @@ class OWPlotGUI:
         """
         Create a box with controls for common plot settings
         """
-        return self.create_box([
+        return self.create_box(
+            ([self.AggregatePoints]
+             if type(self._plot).__dict__.get("aggregate_dense_regions", False) is not False else
+             [])
+            + [
             self.ClassDensity,
             self.ShowLegend], widget, box, False)
 
@@ -769,6 +788,7 @@ class OWPlotGUI:
         ShowLegend: show_legend_check_box,
         ShowGridLines: grid_lines_check_box,
         ToolTipShowsAll: tooltip_shows_all_check_box,
+        AggregatePoints: aggregate_points_check_box,
         ClassDensity: class_density_check_box,
         RegressionLine: regression_line_check_box,
         LabelOnlySelected: label_only_selected_check_box,

--- a/Orange/widgets/utils/plot/owplotgui.py
+++ b/Orange/widgets/utils/plot/owplotgui.py
@@ -646,7 +646,7 @@ class OWPlotGUI:
         cb.setToolTip(
             "Dense regions with many points are aggregated into "
             "circles or pie charts,\n"
-            "unless data is jittered or labels, selection or subset is shown")
+            "unless data is jittered or labels, selection or subset is shown.")
 
     def regression_line_check_box(self, widget):
         self._master.cb_reg_line = \

--- a/Orange/widgets/visualize/owfreeviz.py
+++ b/Orange/widgets/visualize/owfreeviz.py
@@ -57,6 +57,7 @@ def run_freeviz(data: Table, projector: FreeViz, state: TaskState):
 
 class OWFreeVizGraph(OWGraphWithAnchors):
     hide_radius = settings.Setting(0)
+    aggregate_dense_regions = settings.Setting(True)
 
     @property
     def scaled_radius(self):

--- a/Orange/widgets/visualize/owlinearprojection.py
+++ b/Orange/widgets/visualize/owlinearprojection.py
@@ -98,6 +98,7 @@ class LinearProjectionVizRank(VizRankDialogNAttrs):
 
 class OWLinProjGraph(OWGraphWithAnchors):
     hide_radius = Setting(0)
+    aggregate_dense_regions = Setting(True)
 
     @property
     def always_show_axes(self):

--- a/Orange/widgets/visualize/owradviz.py
+++ b/Orange/widgets/visualize/owradviz.py
@@ -82,6 +82,8 @@ class RadvizVizRank(VizRankDialogNAttrs):
 
 
 class OWRadvizGraph(OWGraphWithAnchors):
+    aggregate_dense_regions = Setting(True)
+
     def __init__(self, scatter_widget, parent):
         super().__init__(scatter_widget, parent)
         self.anchors_scatter_item = None

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -164,6 +164,7 @@ class OWScatterPlotGraph(OWScatterPlotBase):
 
     def update_coordinates(self):
         super().update_coordinates()
+        self.set_aggregation()
         self.update_axes()
         self.update_error_bars()
         # Don't update_regression line here: update_coordinates is always
@@ -346,6 +347,20 @@ class OWScatterPlotGraph(OWScatterPlotBase):
     def update_jittering(self):
         super().update_jittering()
         self.update_error_bars()
+
+    def allow_aggregation(self):
+        # Reimplement to allow aggregation when jittering is non-zero but
+        # disabled for continuous variables
+        return (
+            (self.selection is None or len(self.selection) == 0)
+            and not self.subset_is_shown
+            and (self.labels is None or len(self.labels) == 0)
+            and (self.jitter_size == 0
+                 or (self.master.attr_x.is_continuous
+                     and self.master.attr_y.is_continuous
+                     and not self.jitter_continuous)
+                 )
+        )
 
     def update_error_bars(self):
         for item in self.error_bars_items:

--- a/Orange/widgets/visualize/owscatterplot.py
+++ b/Orange/widgets/visualize/owscatterplot.py
@@ -146,6 +146,7 @@ class OWScatterPlotGraph(OWScatterPlotBase):
     orthonormal_regression = Setting(False)
     show_ellipse = Setting(False)
     jitter_continuous = Setting(False)
+    aggregate_dense_regions = Setting(True)
 
     def __init__(self, scatter_widget, parent):
         super().__init__(scatter_widget, parent)
@@ -347,12 +348,14 @@ class OWScatterPlotGraph(OWScatterPlotBase):
     def update_jittering(self):
         super().update_jittering()
         self.update_error_bars()
+        self.set_aggregation()
 
     def allow_aggregation(self):
-        # Reimplement to allow aggregation when jittering is non-zero but
-        # disabled for continuous variables
+        # Reimplemented to allow aggregation when jittering is zero, or when
+        # both axes are continuous and continuous jittering is disabled
         return (
-            (self.selection is None or len(self.selection) == 0)
+            self.aggregate_dense_regions
+            and (self.selection is None or len(self.selection) == 0)
             and not self.subset_is_shown
             and (self.labels is None or len(self.labels) == 0)
             and (self.jitter_size == 0

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -628,6 +628,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
     show_legend = Setting(True)
     class_density = Setting(False)
     jitter_size = Setting(0)
+    aggregate_dense_regions = False  # Override in subclasses
 
     resolution = 256
 

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -158,6 +158,10 @@ class ScatterPlotItem(pg.ScatterPlotItem):
         self._update_spots_in_paint = False
         self._z_mapping = None
         self._inv_mapping = None
+        self._aggregation_size = None
+        self._aggregation_threshold = None
+        self._agg_size_default = 50
+        self._agg_threshold_default = 10
 
     def setZ(self, z):
         """
@@ -200,49 +204,27 @@ class ScatterPlotItem(pg.ScatterPlotItem):
         self._update_spots_in_paint = True
         self.update()
 
+    def setAggregationOptions(self, size, threshold):
+        self._agg_size_default = size
+        self._agg_threshold_default = threshold
+
+    def setAggregation(self, enabled):
+        if enabled != (self._aggregation_size is None):
+            return
+        if enabled:
+            self._aggregation_size = self._agg_size_default
+            self._aggregation_threshold = self._agg_threshold_default
+        else:
+            self._aggregation_size = None
+            self._aggregation_threshold = None
+        self.update()
+
     # pylint: disable=arguments-differ
     def paint(self, painter, option, widget=None):
         # super().paint will reset painter.transform, so we must compute
         # all transformations in advance
-        viewmask = self._maskAt(self.viewRect())
-        data = self.data[viewmask]
-        if len(data) == 0:
-            super().paint(painter, option, widget)
-            return
-        x, y = data["x"], data["y"]
-        xmi, xma = np.min(x), np.max(x)
-        ymi, yma = np.min(y), np.max(y)
+        agg_pts, agg_colors = self._get_aggregated_points(painter)
 
-        tr = fn.transformCoordinates(
-            painter.transform(),
-            np.array([[xmi, ymi], [xma, yma]]).T).T
-        width = tr[1, 0] - tr[0, 0] or 1
-        height = tr[0, 1] - tr[1, 1] or 1
-
-        NX = int(width / 50) or 1
-        NY = int(height / 50) or 1
-        cellx = (xma - xmi) / NX or 1
-        celly = (yma - ymi) / NY or 1
-        xg = np.clip((x - xmi) // cellx, 0, NX - 1)
-        yg = np.clip((y - ymi) // celly, 0, NY - 1)
-        idx = (xg + NX * yg).astype(int)
-        counts = np.bincount(idx, minlength=NX * NY)
-
-        agg_pts = []
-        agg_colors = []
-        brushes = data["brush"]
-        for i, count in enumerate(counts):
-            if count < 10:
-                continue
-            mask = idx == i
-            agg_pts.append([np.mean(x[mask]), np.mean(y[mask])])
-            agg_colors.append(Counter(brush.color().getRgb() for brush in brushes[mask]))
-        if agg_pts:
-            agg_pts = fn.transformCoordinates(painter.transform(), np.array(agg_pts).T).T
-
-        visible = np.ones(len(self.data), dtype=bool)
-        visible[viewmask] = counts[idx] < 10
-        self.data["visible"] = visible
         try:
             if self._z_mapping is not None:
                 assert len(self._z_mapping) == len(self.data)
@@ -253,14 +235,70 @@ class ScatterPlotItem(pg.ScatterPlotItem):
             painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
             super().paint(painter, option, widget)
         finally:
-            self.data["visible"] = True
             if self._inv_mapping is not None:
                 self.data = self.data[self._inv_mapping]
 
-        if len(agg_pts) == 0:
+        self._paint_aggregated_points(painter, agg_pts, agg_colors)
+
+    def _get_aggregated_points(self, painter):
+        if self._aggregation_size is None:
+            return None, None
+
+        viewmask = self._maskAt(self.viewRect())
+        data = self.data[viewmask]
+        if len(data) == 0:
+            return None, None
+
+        x, y = data["x"], data["y"]
+        xmi, xma = np.min(x), np.max(x)
+        ymi, yma = np.min(y), np.max(y)
+
+        tr = fn.transformCoordinates(
+            painter.transform(),
+            np.array([[xmi, ymi], [xma, yma]]).T).T
+        width = tr[1, 0] - tr[0, 0] or 1
+        height = tr[0, 1] - tr[1, 1] or 1
+
+        NX = int(width / self._aggregation_size) or 1
+        NY = int(height / self._aggregation_size) or 1
+        cellx = (xma - xmi) / NX or 1
+        celly = (yma - ymi) / NY or 1
+        xg = np.clip((x - xmi) // cellx, 0, NX - 1)
+        yg = np.clip((y - ymi) // celly, 0, NY - 1)
+        idx = (xg + NX * yg).astype(int)
+        counts = np.bincount(idx, minlength=NX * NY)
+
+        if np.max(counts) < self._aggregation_threshold:
+            return None, None
+
+        visible = np.ones(len(self.data), dtype=bool)
+        visible[viewmask] = counts[idx] < self._aggregation_threshold
+        self.data["visible"] = visible
+
+        agg_pts = []
+        agg_colors = []
+        brushes = data["brush"]
+        for i, count in enumerate(counts):
+            if count < self._aggregation_threshold:
+                continue
+            mask = idx == i
+            agg_pts.append([np.mean(x[mask]), np.mean(y[mask])])
+            agg_colors.append(
+                Counter(
+                    brush.color().getRgb() for brush in brushes[mask]
+                )
+            )
+        agg_pts = fn.transformCoordinates(painter.transform(), np.array(agg_pts).T).T
+
+        return agg_pts, agg_colors
+
+    def _paint_aggregated_points(self, painter, agg_pts, agg_colors):
+        if agg_pts is None:
             return
 
-        countf = 8 / np.max(counts)
+        self.data["visible"] = True
+
+        countf = 8 / max(sum(c.values()) for c in agg_colors)
         text_opt = QTextOption()
         text_opt.setAlignment(Qt.AlignCenter)
         for (pt, spot_colors) in zip(agg_pts, agg_colors):
@@ -294,7 +332,6 @@ class ScatterPlotItem(pg.ScatterPlotItem):
             painter.setBrush(fn.mkBrush(QColor(0, 0, 0)))
             painter.setPen(fn.mkPen(QColor(0, 0, 0)))
             painter.drawText(QRectF(-15, -15, 30, 30), str(total), text_opt)
-
 
 def _define_symbols():
     """
@@ -662,6 +699,19 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
 
         self.parameter_setter = ScatterBaseParameterSetter(self)
 
+    def allow_aggregation(self):
+        return (
+            (self.selection is None or len(self.selection) == 0)
+            and not self.subset_is_shown
+            and (self.labels is None or len(self.labels) == 0)
+            and self.jitter_size == 0
+        )
+
+    def set_aggregation(self):
+        if self.scatterplot_item is not None:
+            self.scatterplot_item.setAggregation(
+                self.aggregate_dense_regions and self.allow_aggregation())
+
     def _create_legend(self, anchor):
         legend = LegendItem()
         legend.setParentItem(self.plot_widget.getViewBox())
@@ -734,6 +784,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         self.scatterplot_item.setCoordinates(x, y)
         self.scatterplot_item_sel.setCoordinates(x, y)
         self.update_labels()
+        self.set_aggregation()
 
     # TODO: Rename to remove_plot_items
     def clear(self):
@@ -1358,6 +1409,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         self._signal_too_many_labels(
             bool(mask is not None and mask.sum() > self.MAX_VISIBLE_LABELS))
         if self._too_many_labels or mask is None or not np.any(mask):
+            self.set_aggregation()
             return
 
         foreground = self.plot_widget.palette().color(QPalette.Text)
@@ -1370,6 +1422,8 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             self.plot_widget.addItem(ti)
             self.labels.append(ti)
             ti.setFont(self.parameter_setter.label_font)
+
+        self.set_aggregation()
 
     def _signal_too_many_labels(self, too_many):
         if self._too_many_labels != too_many:
@@ -1626,6 +1680,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             if self.label_only_selected:
                 self.update_labels()
             self.master.selection_changed()
+            self.set_aggregation()
 
     def select(self, points):
         # noinspection PyArgumentList
@@ -1670,6 +1725,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         if self.label_only_selected:
             self.update_labels()
         self.master.selection_changed()
+        self.set_aggregation()
 
     def _compress_indices(self):
         indices = sorted(set(self.selection) | {0})

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -163,6 +163,11 @@ class ScatterPlotItem(pg.ScatterPlotItem):
         self._agg_size_default = 50
         self._agg_threshold_default = 10
 
+        self._nonaggregated = True
+        self._agg_indices = None
+        self._agg_coords = None
+        self._agg_r2s = None
+
     def setZ(self, z):
         """
         Set z values for all points.
@@ -223,9 +228,14 @@ class ScatterPlotItem(pg.ScatterPlotItem):
     def paint(self, painter, option, widget=None):
         # super().paint will reset painter.transform, so we must compute
         # all transformations in advance
-        agg_pts, agg_colors = self._get_aggregated_points(painter)
+        self._nonaggregated = True
+        self._agg_indices = None
+        self._agg_coords = None
+        self._agg_r2s = None
+        agg_colors = self._get_aggregated_points(painter)
 
         try:
+            self.data["visible"] = self._nonaggregated
             if self._z_mapping is not None:
                 assert len(self._z_mapping) == len(self.data)
                 self.data = self.data[self._z_mapping]
@@ -235,19 +245,20 @@ class ScatterPlotItem(pg.ScatterPlotItem):
             painter.setRenderHint(QPainter.SmoothPixmapTransform, True)
             super().paint(painter, option, widget)
         finally:
+            self.data["visible"] = True
             if self._inv_mapping is not None:
                 self.data = self.data[self._inv_mapping]
 
-        self._paint_aggregated_points(painter, agg_pts, agg_colors)
+        self._paint_aggregated_points(painter, agg_colors)
 
     def _get_aggregated_points(self, painter):
         if self._aggregation_size is None:
-            return None, None
+            return None
 
         viewmask = self._maskAt(self.viewRect())
         data = self.data[viewmask]
         if len(data) == 0:
-            return None, None
+            return None
 
         x, y = data["x"], data["y"]
         xmi, xma = np.min(x), np.max(x)
@@ -269,13 +280,13 @@ class ScatterPlotItem(pg.ScatterPlotItem):
         counts = np.bincount(idx, minlength=NX * NY)
 
         if np.max(counts) < self._aggregation_threshold:
-            return None, None
+            return None
 
-        visible = np.ones(len(self.data), dtype=bool)
-        visible[viewmask] = counts[idx] < self._aggregation_threshold
-        self.data["visible"] = visible
+        self._nonaggregated = np.ones(len(self.data), dtype=bool)
+        self._nonaggregated[viewmask] = counts[idx] < self._aggregation_threshold
 
         agg_pts = []
+        self._agg_indices = []
         agg_colors = []
         brushes = data["brush"]
         for i, count in enumerate(counts):
@@ -283,29 +294,29 @@ class ScatterPlotItem(pg.ScatterPlotItem):
                 continue
             mask = idx == i
             agg_pts.append([np.mean(x[mask]), np.mean(y[mask])])
+            self._agg_indices.append(np.flatnonzero(mask))
             agg_colors.append(
                 Counter(
                     brush.color().getRgb() for brush in brushes[mask]
                 )
             )
-        agg_pts = fn.transformCoordinates(painter.transform(), np.array(agg_pts).T).T
+        self._agg_coords = fn.transformCoordinates(painter.transform(), np.array(agg_pts).T).T
+        return agg_colors
 
-        return agg_pts, agg_colors
-
-    def _paint_aggregated_points(self, painter, agg_pts, agg_colors):
-        if agg_pts is None:
+    def _paint_aggregated_points(self, painter, agg_colors):
+        if self._agg_coords is None:
             return
-
-        self.data["visible"] = True
 
         countf = 8 / max(sum(c.values()) for c in agg_colors)
         text_opt = QTextOption()
         text_opt.setAlignment(Qt.AlignCenter)
-        for (pt, spot_colors) in zip(agg_pts, agg_colors):
+        rs = []
+        for (pt, spot_colors) in zip(self._agg_coords, agg_colors):
             painter.resetTransform()
             painter.translate(*pt)
             total = sum(spot_colors.values())
             r = int(6 + countf * total)
+            rs.append(r + 12)
             if len(spot_colors) == 1:
                 color = QColor(*next(iter(spot_colors)))
                 painter.setBrush(fn.mkBrush(color))
@@ -332,6 +343,33 @@ class ScatterPlotItem(pg.ScatterPlotItem):
             painter.setBrush(fn.mkBrush(QColor(0, 0, 0)))
             painter.setPen(fn.mkPen(QColor(0, 0, 0)))
             painter.drawText(QRectF(-15, -15, 30, 30), str(total), text_opt)
+        self._agg_r2s = np.array(rs) ** 2
+
+    def aggregatedPointsAt(self, pos):
+        """
+        Returns indices of aggregated points for the given **scene** coordinate.
+
+        Note that unlike pointsAt, this function's argument is scene coordinate
+        and not data coordinate. This is because the aggregation is done in scene
+        coordinates.
+        """
+        if self._agg_indices is None:
+            indices = []
+        else:
+            x, y = pos.x(), pos.y()
+            aggs = np.flatnonzero(
+                np.sum((self._agg_coords - np.array([x, y])) ** 2, axis=1)
+                < self._agg_r2s)
+            indices = list(itertools.chain(*(self._agg_indices[i] for i in aggs)))
+        return self.points()[indices][::-1]
+
+    def pointsAt(self, pos):
+        # Override to ignore aggregated points.
+        try:
+            self.data["visible"] = self._nonaggregated
+            return super().pointsAt(pos)
+        finally:
+            self.data["visible"] = True
 
 def _define_symbols():
     """
@@ -628,7 +666,11 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
     show_legend = Setting(True)
     class_density = Setting(False)
     jitter_size = Setting(0)
-    aggregate_dense_regions = False  # Override in subclasses
+
+    # Subclasses that want to "opt in" aggregation of dense regions should
+    # override this with `aggregate_dense_regions = Setting(True)`
+    # (or `Setting(False)` if they want to have it disabled by default).
+    aggregate_dense_regions = False
 
     resolution = 256
 
@@ -1749,11 +1791,13 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         """
         if self.scatterplot_item is None:
             return False
-        act_pos = self.scatterplot_item.mapFromScene(event.scenePos())
-        point_data = [p.data() for p in self.scatterplot_item.pointsAt(act_pos)]
-        text = self.master.get_tooltip(point_data)
-        if text:
-            QToolTip.showText(event.screenPos(), text, widget=self.plot_widget)
-            return True
+        pos = event.scenePos()
+        act_pos = self.scatterplot_item.mapFromScene(pos)
+        if len(points := self.scatterplot_item.aggregatedPointsAt(pos)) != 0:
+            text = self.master.get_aggregated_tooltip([p.data() for p in points])
+        elif len(points := self.scatterplot_item.pointsAt(act_pos)) != 0:
+            text = self.master.get_tooltip([p.data() for p in points])
         else:
             return False
+        QToolTip.showText(event.screenPos(), text, widget=self.plot_widget)
+        return True

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -1481,6 +1481,42 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         self.assertEqual(list(error_bar_item.opts["left"][:3].round(1)),
                          [0.1] * 3)
 
+    def test_allow_aggregation(self):
+        widget = self.widget
+        graph = self.widget.graph
+
+        self.send_signal(widget.Inputs.data, self.data)
+
+        self.assertTrue(graph.allow_aggregation())
+
+        self._select_data()
+        self.assertFalse(graph.allow_aggregation())
+
+        graph.unselect_all()
+        self.assertTrue(graph.allow_aggregation())
+
+        self.send_signal(widget.Inputs.data_subset, self.data[:5])
+        self.assertFalse(graph.allow_aggregation())
+
+        self.send_signal(widget.Inputs.data_subset, None)
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.jitter_size = 1
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.jitter_continuous = True
+        self.assertFalse(graph.allow_aggregation())
+
+        graph.jitter_size = 0
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.jitter_size = 1
+        graph.jitter_continuous = False
+        self.send_signal(widget.Inputs.data, Table("titanic"))
+        self.assertFalse(graph.allow_aggregation())
+
+        graph.jitter_size = 0
+        self.assertTrue(graph.allow_aggregation())
 
 if __name__ == "__main__":
     import unittest

--- a/Orange/widgets/visualize/tests/test_owscatterplot.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplot.py
@@ -664,6 +664,8 @@ class TestOWScatterPlot(WidgetTest, ProjectionWidgetTestMixin,
         data = Table("heart_disease")
         self.send_signal(self.widget.Inputs.data, data)
         widget = self.widget
+        widget.graph.aggregate_dense_regions = False
+
         graph = widget.graph
         scatterplot_item = graph.scatterplot_item
 

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, Mock
 import numpy as np
 
 from AnyQt.QtCore import QRectF, Qt
-from AnyQt.QtGui import QColor
+from AnyQt.QtGui import QColor, QTransform
 from AnyQt.QtTest import QSignalSpy
 
 from pyqtgraph import mkPen, mkBrush
@@ -1319,6 +1319,51 @@ class TestOWScatterPlotBase(WidgetTest):
         self.assertEqual(graph.scatterplot_item.data["symbol"][2],
                          graph.CurveSymbols[0])
 
+    def test_set_aggregations(self):
+        graph = self.graph
+        graph.aggregate_dense_regions = True
+
+
+        with patch.object(graph, "allow_aggregation") as aa:
+            assert self.graph.scatterplot_item is None
+            aa.return_value = True
+            # Must not crash
+            graph.set_aggregation()
+
+            graph.reset_graph()
+            aa.return_value = True
+            graph.set_aggregation()
+            self.assertIsNotNone(self.graph.scatterplot_item._aggregation_size)
+
+            aa.return_value = False
+            graph.set_aggregation()
+            self.assertIsNone(self.graph.scatterplot_item._aggregation_size)
+
+    def test_allow_aggregation(self):
+        graph = self.graph
+
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.selection = [1, 2, 3]
+        self.assertFalse(graph.allow_aggregation())
+        graph.selection = []
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.subset_is_shown = True
+        self.assertFalse(graph.allow_aggregation())
+        graph.subset_is_shown = False
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.labels = ["Foo"]
+        self.assertFalse(graph.allow_aggregation())
+        graph.labels = []
+        self.assertTrue(graph.allow_aggregation())
+
+        graph.jitter_size = 1
+        self.assertFalse(graph.allow_aggregation())
+        graph.jitter_size = 0
+        self.assertTrue(graph.allow_aggregation())
+
     def test_show_grid(self):
         graph = self.graph
         show_grid = self.graph.plot_widget.showGrid = Mock()
@@ -1648,6 +1693,82 @@ class TestScatterPlotItem(GuiTest):
             x, y = scp.getData()
             np.testing.assert_equal(x, np.arange(10, 15))
             np.testing.assert_equal(y, np.arange(20, 25))
+
+    def test_set_aggregation(self):
+        orig_x = np.arange(10, 15)
+        orig_y = np.arange(20, 25)
+        scp = ScatterPlotItem(x=orig_x[:], y=orig_y[:])
+        scp.update = Mock()
+
+        self.assertIsNone(scp._aggregation_size)
+        scp.setAggregation(False)
+        scp.update.assert_not_called()
+
+        scp.setAggregation(True)
+        self.assertIsNotNone(scp._aggregation_size)
+        scp.update.assert_called_once()
+        scp.update.reset_mock()
+
+        scp.setAggregation(True)
+        self.assertIsNotNone(scp._aggregation_size)
+        scp.update.assert_not_called()
+
+        scp.setAggregation(False)
+        scp.update.assert_called_once()
+
+    def test_get_aggregate_points(self):
+        x, y = np.array([[1, 3], [1, 3], [1.5, 3.2],
+                         [24, 100],
+                         [200, 1],
+                         [24.5, 100], [200, 20]]).T
+        n = len(x)
+        scp = ScatterPlotItem(x=x, y=y)
+        scp.setBrush([mkBrush(QColor(0, 0, 0))] +
+                     [mkBrush(QColor(10 * i, 10 * i, 10 * i)) for i in range(n - 1)])
+
+        scp._agg_size_default = 10
+        scp._agg_threshold_default = 3
+        scp._maskAt = Mock(return_value=np.arange(n - 1))
+        painter = Mock()
+        painter.transform = lambda: QTransform(1, 0, 0, 0, -1, 0, 0, 0, 1)
+
+        self.assertEqual(scp._get_aggregated_points(painter), (None, None))
+        np.testing.assert_equal(scp.data["visible"], np.ones(n))
+
+        scp.setAggregation(True)
+        pts, colors = scp._get_aggregated_points(painter)
+        np.testing.assert_almost_equal(pts, [[ 1.16666667, -3.06666667]])
+        self.assertEqual(colors, [{(0, 0, 0, 255): 2, (10, 10, 10, 255): 1}])
+        np.testing.assert_equal(scp.data["visible"], [0, 0, 0, 1, 1, 1, 1])
+
+        scp._aggregation_threshold = 2
+        pts, colors = scp._get_aggregated_points(painter)
+        np.testing.assert_almost_equal(pts, [[1.16666667, -3.06666667],
+                                             [24.25, -100]])
+        self.assertEqual(colors, [
+            {(0, 0, 0, 255): 2, (10, 10, 10, 255): 1},
+            {(20, 20, 20, 255): 1, (40, 40, 40, 255): 1}
+        ])
+        np.testing.assert_equal(scp.data["visible"], [0, 0, 0, 0, 1, 0, 1])
+        scp.data["visible"] = np.ones(n)
+
+        scp._aggregation_threshold = 4
+        self.assertEqual(scp._get_aggregated_points(painter), (None, None))
+        np.testing.assert_equal(scp.data["visible"], np.ones(n))
+
+    def test_paint_aggregated_points(self):
+        scp = ScatterPlotItem()
+        painter = Mock()
+
+        pts = [[1, 2], [3, 4]]
+        colors = [
+            {(0, 0, 0, 255): 2, (10, 10, 10, 255): 1},
+            {(20, 20, 20, 255): 3}
+        ]
+
+        # Well ... don't crash, OK?
+        scp._paint_aggregated_points(painter, pts, colors)
+        scp._paint_aggregated_points(painter, None, None)
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/tests/test_owscatterplotbase.py
+++ b/Orange/widgets/visualize/tests/test_owscatterplotbase.py
@@ -4,10 +4,9 @@ from itertools import count
 from unittest.mock import patch, Mock
 import numpy as np
 
-from AnyQt.QtCore import QRectF, Qt
+from AnyQt.QtCore import QRectF, QPointF, Qt
 from AnyQt.QtGui import QColor, QTransform
 from AnyQt.QtTest import QSignalSpy
-
 from pyqtgraph import mkPen, mkBrush
 
 from orangewidget.tests.base import GuiTest
@@ -1364,6 +1363,42 @@ class TestOWScatterPlotBase(WidgetTest):
         graph.jitter_size = 0
         self.assertTrue(graph.allow_aggregation())
 
+    @patch("AnyQt.QtWidgets.QToolTip.showText")
+    def test_help_event(self, _):
+        master = self.master
+        graph = self.graph
+        event = Mock()
+
+        graph.scatterplot_item = None
+        self.assertFalse(graph.help_event(event))
+
+        scp = graph.scatterplot_item = Mock()
+        scp.mapFromScene = Mock()
+        scp.aggregatedPointsAt = Mock(return_value=[])
+        master.get_aggregated_tooltip = Mock()
+        scp.pointsAt = Mock(return_value=[])
+        master.get_tooltip = Mock()
+
+        self.assertFalse(graph.help_event(event))
+
+        mv = [Mock(), Mock()]
+        scp.pointsAt = Mock(return_value=mv)
+        self.assertTrue(graph.help_event(event))
+        master.get_aggregated_tooltip.assert_not_called()
+        master.get_tooltip.assert_called_with([mv[0].data.return_value,
+                                               mv[1].data.return_value])
+        master.get_aggregated_tooltip.reset_mock()
+        scp.pointsAt.reset_mock()
+        master.get_tooltip.reset_mock()
+
+        scp.aggregatedPointsAt = Mock(return_value=mv)
+        self.assertTrue(graph.help_event(event))
+        master.get_tooltip.assert_not_called()
+        scp.pointsAt.assert_not_called()
+        master.get_aggregated_tooltip.assert_called_with([mv[0].data.return_value,
+                                                          mv[1].data.return_value])
+
+
     def test_show_grid(self):
         graph = self.graph
         show_grid = self.graph.plot_widget.showGrid = Mock()
@@ -1732,43 +1767,86 @@ class TestScatterPlotItem(GuiTest):
         painter = Mock()
         painter.transform = lambda: QTransform(1, 0, 0, 0, -1, 0, 0, 0, 1)
 
-        self.assertEqual(scp._get_aggregated_points(painter), (None, None))
+        self.assertIsNone(scp._get_aggregated_points(painter))
         np.testing.assert_equal(scp.data["visible"], np.ones(n))
 
         scp.setAggregation(True)
-        pts, colors = scp._get_aggregated_points(painter)
+        scp._nonaggregated = True
+        colors = scp._get_aggregated_points(painter)
+        pts = scp._agg_coords
         np.testing.assert_almost_equal(pts, [[ 1.16666667, -3.06666667]])
         self.assertEqual(colors, [{(0, 0, 0, 255): 2, (10, 10, 10, 255): 1}])
-        np.testing.assert_equal(scp.data["visible"], [0, 0, 0, 1, 1, 1, 1])
+        np.testing.assert_equal(scp._nonaggregated, [0, 0, 0, 1, 1, 1, 1])
 
         scp._aggregation_threshold = 2
-        pts, colors = scp._get_aggregated_points(painter)
+        scp._nonaggregated = True
+        colors = scp._get_aggregated_points(painter)
+        pts = scp._agg_coords
         np.testing.assert_almost_equal(pts, [[1.16666667, -3.06666667],
                                              [24.25, -100]])
         self.assertEqual(colors, [
             {(0, 0, 0, 255): 2, (10, 10, 10, 255): 1},
             {(20, 20, 20, 255): 1, (40, 40, 40, 255): 1}
         ])
-        np.testing.assert_equal(scp.data["visible"], [0, 0, 0, 0, 1, 0, 1])
+        np.testing.assert_equal(scp._nonaggregated, [0, 0, 0, 0, 1, 0, 1])
         scp.data["visible"] = np.ones(n)
 
         scp._aggregation_threshold = 4
-        self.assertEqual(scp._get_aggregated_points(painter), (None, None))
-        np.testing.assert_equal(scp.data["visible"], np.ones(n))
+        scp._nonaggregated = True
+        self.assertIsNone(scp._get_aggregated_points(painter))
+        np.testing.assert_equal(scp._nonaggregated, np.ones(n))
 
     def test_paint_aggregated_points(self):
         scp = ScatterPlotItem()
         painter = Mock()
 
-        pts = [[1, 2], [3, 4]]
+        scp._agg_coordspts = [[1, 2], [3, 4]]
         colors = [
             {(0, 0, 0, 255): 2, (10, 10, 10, 255): 1},
             {(20, 20, 20, 255): 3}
         ]
 
         # Well ... don't crash, OK?
-        scp._paint_aggregated_points(painter, pts, colors)
-        scp._paint_aggregated_points(painter, None, None)
+        scp._paint_aggregated_points(painter, colors)
+        scp._paint_aggregated_points(painter, None)
+
+    def test_pointsAt(self):
+        x, y = np.array([[1, 3], [1, 3], [1.5, 3.2],
+                         [24, 100],
+                         [200, 1],
+                         [24.5, 100], [200, 20]]).T
+        n = len(x)
+        scp = ScatterPlotItem(x=x, y=y)
+        scp.setBrush([mkBrush(QColor(0, 0, 0))] +
+                     [mkBrush(QColor(10 * i, 10 * i, 10 * i)) for i in range(n - 1)])
+        scp.setPointData(np.arange(n))
+        scp._agg_size_default = 10
+        scp._maskAt = Mock(return_value=np.arange(n - 1))
+        painter = Mock()
+        painter.transform = lambda: QTransform(1, 0, 0, 0, -1, 0, 0, 0, 1)
+        scp.setAggregation(True)
+        scp._aggregation_threshold = 2
+
+        scp._nonaggregated = True
+        agg_colors = scp._get_aggregated_points(painter)
+        scp._paint_aggregated_points(painter, agg_colors)
+
+        self.assertEqual(
+            {p.data() for p in scp.aggregatedPointsAt(QPointF(1.2, 1.3))}, {0, 1, 2})
+        self.assertEqual(
+            len(scp.aggregatedPointsAt(QPointF(200, 1))), 0)
+
+        def test_mask(*_, **__):
+            np.testing.assert_equal(
+                scp.data["visible"],
+                [False, False, False, False, True, False, True])
+
+        with patch(
+                "pyqtgraph.graphicsItems.ScatterPlotItem.ScatterPlotItem.pointsAt",
+                new=test_mask):
+            scp.pointsAt(QPointF(1.2, 1.3))
+        np.testing.assert_equal(scp.data["visible"], True)
+
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/visualize/utils/widget.py
+++ b/Orange/widgets/visualize/utils/widget.py
@@ -341,6 +341,20 @@ class OWProjectionWidgetBase(OWWidget, openclass=True):
             text = f"{len(point_ids)} instances<hr/>{text}<hr/>..."
         return text
 
+    def get_aggregated_tooltip(self, point_ids):
+        """
+        Return tooltip for aggregate points (e.g. piecharts).
+
+        Default implementation falls back to get_tooltip
+
+        Args:
+            point_ids (list): indices into 'data'
+
+        Returns:
+            tooltip (str)
+        """
+        return self.get_tooltip(point_ids)
+
     def keyPressEvent(self, event):
         """Update the tip about using the modifier keys when selecting"""
         super().keyPressEvent(event)

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -196,9 +196,9 @@ util.py:
         def `funcv`:
             unsafe: false
 version.py:
-    3.40.0: false
-    3.40.0.dev0+e7d811b: null
-    e7d811bac580723c707decd32c550a75874dc9c8: null
+    3.41.0: false
+    3.41.0.dev0+58e68e8: false
+    58e68e8bc9a6b560967ca49f37f89a3dd0d213b8: false
     .dev: false
 canvas/__main__.py:
     ORANGE_STATISTICS_API_URL: false
@@ -13640,6 +13640,12 @@ widgets/utils/plot/owplotgui.py:
         def `class_density_check_box`:
             class_density: false
             Show color regions: Pokaži barvna področja
+        def `aggregate_points_check_box`:
+            aggregate_dense_regions: false
+            Aggregate points in dense regions: Združi točke v gostih regijah
+            'Dense regions with many points are aggregated into ': "Goste regije z veliko točkami so združene v "
+            circles or pie charts,\n: kroge ali tortne diagrame,\n
+            unless data is jittered or labels, selection or subset is shown: razen če so točke tresene ali pa so prikazane oznake, izbori ali podmnožice.
         def `regression_line_check_box`:
             show_reg_line: false
             Show regression line: Pokaži regresijsko premico
@@ -13684,6 +13690,8 @@ widgets/utils/plot/owplotgui.py:
             labels_changed: false
         def `point_properties_box`:
             Attributes: Izgled
+        def `plot_properties_box`:
+            aggregate_dense_regions: false
         def `zoom_select_toolbar`:
             Zoom / Select: Povečava / Izbor
         def `theme_combo_box`:
@@ -15125,6 +15133,13 @@ widgets/visualize/owscatterplotgraph.py:
             size: false
             symbol: false
             data: false
+        def `_get_aggregated_points`:
+            x: false
+            y: false
+            visible: false
+            brush: false
+        def `_paint_aggregated_points`:
+            visible: false
     def `_define_symbols`:
         ?: false
         +: false

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -13643,9 +13643,9 @@ widgets/utils/plot/owplotgui.py:
         def `aggregate_points_check_box`:
             aggregate_dense_regions: false
             Aggregate points in dense regions: Združi točke v gostih regijah
-            'Dense regions with many points are aggregated into ': "Goste regije z veliko točkami so združene v "
+            'Dense regions with many points are aggregated into ': 'Goste regije z veliko točkami so združene v '
             circles or pie charts,\n: kroge ali tortne diagrame,\n
-            unless data is jittered or labels, selection or subset is shown: razen če so točke tresene ali pa so prikazane oznake, izbori ali podmnožice.
+            unless data is jittered or labels, selection or subset is shown.: razen če so točke tresene ali pa so prikazane oznake, izbori ali podmnožice.
         def `regression_line_check_box`:
             show_reg_line: false
             Show regression line: Pokaži regresijsko premico
@@ -14753,9 +14753,6 @@ widgets/visualize/ownomogram.py:
             Numeric features:: Številske spremenljivke:
             1D projection: 1D projekcija
             2D curve: 2D krivulja
-            class `GraphicsView`:
-                def `__init__`:
-                    'QGraphicsView {background: white}': false
         def `_class_combo_changed`:
             ignore: false
         def `update_scene`:
@@ -15133,12 +15130,13 @@ widgets/visualize/owscatterplotgraph.py:
             size: false
             symbol: false
             data: false
+        def `paint`:
+            visible: false
         def `_get_aggregated_points`:
             x: false
             y: false
-            visible: false
             brush: false
-        def `_paint_aggregated_points`:
+        def `pointsAt`:
             visible: false
     def `_define_symbols`:
         ?: false


### PR DESCRIPTION
##### Issue

Fixes #7064.

##### Description of changes

@ajdapretnar might get her new year's gift. :)

This doesn't check for actual overlapping of points. It divides the plotted area into 50-pixel grid and plots cells with > 10 points as bigger circles or pie charts (in case there are multiple colors).

The change is mostly constrained to the `paint` method and I'd prefer to keep it this way. The scatter plot graph is too complex to be poked. :)

Aggregation is opt-in and is disabled if:

- widget shows subset or selection,
- jittering is enabled,
- labels are shown.

https://github.com/user-attachments/assets/eab8ef44-c5a7-4388-90a2-61507e4e46c3

https://github.com/user-attachments/assets/aaeca847-561f-4309-91ca-86b0be59b284

##### Includes
- [X] Code changes
- [ ] Tests?! There's not much that can be tested, everything is in paint :|
- [ ] Documentation
