### PR TITLE
Feature Statistics: Disable stretching of distribution column, set minimal width

### DIFF
--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -632,7 +632,7 @@ class FeatureStatisticsTableModel(AbstractSortTableModel):
 
 class FeatureStatisticsTableView(QTableView):
     HISTOGRAM_ASPECT_RATIO = (7, 3)
-    MINIMUM_HISTOGRAM_HEIGHT = 50
+    MINIMUM_HISTOGRAM_HEIGHT = 30
     MAXIMUM_HISTOGRAM_HEIGHT = 80
 
     def __init__(self, model, parent=None, **kwargs):
@@ -659,14 +659,8 @@ class FeatureStatisticsTableView(QTableView):
         # appears to work properly when the widget is actually shown. When the
         # widget is not shown, size `sizeHint` is called on every row.
         hheader.setResizeContentsPrecision(5)
-        # Set a nice default size so that headers have some space around titles
-        hheader.setMinimumSectionSize(100)
-        # Set individual column behaviour in `set_data` since the logical
-        # indices must be valid in the model, which requires data.
-        hheader.setSectionResizeMode(QHeaderView.Interactive)
+        self._resize_columns()
 
-        columns = model.Columns
-        hheader.setSectionResizeMode(columns.ICON.index, QHeaderView.ResizeToContents)
 
         vheader = self.verticalHeader()
         vheader.setVisible(False)
@@ -680,6 +674,15 @@ class FeatureStatisticsTableView(QTableView):
             FeatureStatisticsTableModel.Columns.DISTRIBUTION,
             DistributionDelegate(parent=self),
         )
+
+    def _resize_columns(self):
+        hheader = self.horizontalHeader()
+        hheader.setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        for i in range(1, hheader.count()):
+            hheader.setSectionResizeMode(i, QHeaderView.ResizeToContents)
+            width = max(100, hheader.sectionSize(i))
+            hheader.setSectionResizeMode(i, QHeaderView.Interactive)
+            hheader.resizeSection(i, width)
 
     def bind_histogram_aspect_ratio(self, logical_index, _, new_size):
         """Force the horizontal and vertical header to maintain the defined

--- a/Orange/widgets/data/owfeaturestatistics.py
+++ b/Orange/widgets/data/owfeaturestatistics.py
@@ -660,14 +660,13 @@ class FeatureStatisticsTableView(QTableView):
         # widget is not shown, size `sizeHint` is called on every row.
         hheader.setResizeContentsPrecision(5)
         # Set a nice default size so that headers have some space around titles
-        hheader.setDefaultSectionSize(100)
+        hheader.setMinimumSectionSize(100)
         # Set individual column behaviour in `set_data` since the logical
         # indices must be valid in the model, which requires data.
         hheader.setSectionResizeMode(QHeaderView.Interactive)
 
         columns = model.Columns
         hheader.setSectionResizeMode(columns.ICON.index, QHeaderView.ResizeToContents)
-        hheader.setSectionResizeMode(columns.DISTRIBUTION.index, QHeaderView.Stretch)
 
         vheader = self.verticalHeader()
         vheader.setVisible(False)

--- a/Orange/widgets/data/tests/test_owfeaturestatistics.py
+++ b/Orange/widgets/data/tests/test_owfeaturestatistics.py
@@ -288,15 +288,6 @@ class TestVariousDataSets(WidgetTest):
             except Exception as e:
                 raise AssertionError(f"Failed on `{data.name}`") from e
 
-    def test_header_resize_aspect_ratio(self):
-        self.widget.show()  # must be visible for header resize to work
-        size = self.widget.size()
-        self.widget.resize(size.width() + 2000, size.height())
-        self.assertEqual(
-            self.widget.table_view.verticalHeader().defaultSectionSize(),
-            self.widget.table_view.MAXIMUM_HISTOGRAM_HEIGHT
-        )
-
 
 def select_rows(rows: List[int], widget: OWFeatureStatistics):
     """Since the widget sorts the rows, selecting rows isn't trivial."""


### PR DESCRIPTION
##### Issue

Fixes #6983. I think. @ajdapretnar ?

##### Description of changes

Column distributions was set to stretch, i.e. occupy all extra width. Other columns had a default size (100).

After this, columns have a minimum size of 100, and the distribution column gets no special treatment. Sizes are reasonable. Downside is that they can't be manually reduced below 100.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
