### PR TITLE
Distribution bar hide legend

### DIFF
--- a/Orange/widgets/visualize/owbarplot.py
+++ b/Orange/widgets/visualize/owbarplot.py
@@ -188,13 +188,18 @@ class BarPlotGraph(PlotWidget):
     def update_legend(self):
         self.legend.clear()
         self.legend.hide()
-        for color, text in self.master.get_legend_data():
+        if not self.master.show_legend:
+            return
+        legend_data = self.master.get_legend_data()
+        if not legend_data:
+            return
+        for color, text in legend_data:
             dot = pg.ScatterPlotItem(
                 pen=pg.mkPen(color=color),
                 brush=pg.mkBrush(color=color)
             )
             self.legend.addItem(dot, escape(text))
-            self.legend.show()
+        self.legend.show()
         Updater.update_legend_font(self.legend.items,
                                    **self.parameter_setter.legend_settings)
 
@@ -386,6 +391,7 @@ class OWBarPlot(OWWidget):
     group_var = ContextSetting(None)
     annot_var = ContextSetting(None)
     color_var = ContextSetting(None)
+    show_legend = Setting(True)
     auto_commit = Setting(True)
     selection = Setting(None, schema_only=True)
     visual_settings = Setting({}, schema_only=True)
@@ -476,6 +482,10 @@ class OWBarPlot(OWWidget):
             callback=self.__parameter_changed,
         )
 
+        gui.checkBox(
+            box, self, "show_legend", "Show legend",
+            callback=self.__show_legend_changed
+        )
         plot_gui = OWPlotGUI(self)
         plot_gui.box_zoom_select(self.buttonsArea)
 
@@ -483,6 +493,9 @@ class OWBarPlot(OWWidget):
 
     def __parameter_changed(self):
         self.graph.reset_graph()
+
+    def __show_legend_changed(self):
+        self.graph.update_legend()
 
     def __group_var_changed(self):
         self.clear_cache()

--- a/Orange/widgets/visualize/owbarplot.py
+++ b/Orange/widgets/visualize/owbarplot.py
@@ -706,6 +706,7 @@ class OWBarPlot(OWWidget):
 
     def set_visual_settings(self, key: KeyType, value: ValueType):
         self.graph.parameter_setter.set_parameter(key, value)
+        # pylint: disable=unsupported-assignment-operation
         self.visual_settings[key] = value
 
     def sizeHint(self):  # pylint: disable=no-self-use

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -285,6 +285,7 @@ class OWDistributions(OWWidget):
     show_probs = settings.Setting(False)
     stacked_columns = settings.Setting(False)
     cumulative_distr = settings.Setting(False)
+    show_legend = settings.Setting(True)
     sort_by_freq = settings.Setting(False)
     kde_smoothing = settings.Setting(10)
 
@@ -371,6 +372,10 @@ class OWDistributions(OWWidget):
         gui.checkBox(
             box, self, "cumulative_distr", "Show cumulative distribution",
             callback=self._on_show_cumulative)
+        gui.checkBox(
+            box, self, "show_legend", "Show legend",
+            callback=self.show_hide_legend
+        )
 
         gui.auto_apply(self.buttonsArea, self, commit=self.apply)
 
@@ -872,12 +877,22 @@ class OWDistributions(OWWidget):
                    for value, freq in zip(gvalues, freqs)) + \
                "</table>"
 
+    def show_hide_legend(self):
+        if self.is_valid:
+            self._display_legend()
+
     def _display_legend(self):
-        assert self.is_valid  # called only from replot, so assumes data is OK
+        # called only from replot and show_hide_legend, so it assumes data is OK
+        assert self.is_valid
+        self._legend.clear()
+        if not self.show_legend or \
+                self.cvar is None and (
+                    not self.curve_descriptions
+                    or not self.curve_descriptions[0]
+                ):
+            self._legend.hide()
+            return
         if self.cvar is None:
-            if not self.curve_descriptions or not self.curve_descriptions[0]:
-                self._legend.hide()
-                return
             self._legend.addItem(
                 pg.PlotCurveItem(pen=pg.mkPen(width=5, color=0.0)),
                 self.curve_descriptions[0])

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -216,6 +216,7 @@ class ParameterSetter(CommonParameterSetter):
 
     @property
     def legend_items(self):
+        # pylint: disable=protected-access
         return self.master.parent_widget._legend.items
 
 
@@ -977,6 +978,8 @@ class OWDistributions(OWWidget):
     # Bins
 
     def recompute_binnings(self):
+        self.binnings = []
+        max_bins = 0
         if self.is_valid and self.var.is_continuous:
             # binning is computed on valid var data, ignoring any cvar nans
             column = self.data.get_column(self.var)
@@ -994,9 +997,6 @@ class OWDistributions(OWWidget):
                             for binning in self.binnings)
                 self.bin_width_label.setFixedWidth(width)
                 max_bins = len(self.binnings) - 1
-        else:
-            self.binnings = []
-            max_bins = 0
 
         self.controls.number_of_bins.setMaximum(max_bins)
         self.number_of_bins = min(
@@ -1142,6 +1142,9 @@ class OWDistributions(OWWidget):
         if right_idx < len(self.bar_items) - 1:
             right_pad = _padding(right_idx)
         else:
+            # if (left_idx, right_idx) span across all, we would have returned
+            # above, so left_idx > 0 here,
+            # pylint: disable=possibly-used-before-assignment
             right_pad = left_pad
         if left_idx == 0:
             left_pad = right_pad
@@ -1173,6 +1176,7 @@ class OWDistributions(OWWidget):
             self.selected_bars.add(self.ordered_values[self.last_click_idx])
 
         def on_key_left():
+            # first and last are defined, pylint: possibly-used-before-assignment
             if e.modifiers() & Qt.ShiftModifier:
                 if self.key_operation == Qt.Key_Right and first != last:
                     self.selected_bars.remove(self.ordered_values[last])

--- a/Orange/widgets/visualize/tests/test_owbarplot.py
+++ b/Orange/widgets/visualize/tests/test_owbarplot.py
@@ -395,6 +395,31 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertTrue(all([pen.style() == Qt.SolidLine for i, pen
                              in enumerate(pens) if i not in indices]))
 
+    @staticmethod
+    def _set_check(checkbox, value):
+        state = Qt.Checked if value else Qt.Unchecked
+        checkbox.setCheckState(state)
+        checkbox.toggled[bool].emit(value)
+
+    def test_show_hide_legend(self):
+        widget = self.widget
+        legend = widget.graph.legend
+
+        self._set_check(widget.controls.show_legend, False)
+        self._set_check(widget.controls.show_legend, True)
+
+        self.send_signal(widget.Inputs.data, self.heart)
+        simulate.combobox_activate_index(widget.controls.color_var, 2)
+        self.assertTrue(legend.isVisible())
+        self._set_check(widget.controls.show_legend, False)
+        self.assertFalse(legend.isVisible())
+        self._set_check(widget.controls.show_legend, True)
+        self.assertTrue(legend.isVisible())
+
+        self.send_signal(widget.Inputs.data, None)
+        self._set_check(widget.controls.show_legend, False)
+        self._set_check(widget.controls.show_legend, True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/visualize/tests/test_owbarplot.py
+++ b/Orange/widgets/visualize/tests/test_owbarplot.py
@@ -315,7 +315,7 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         font.setItalic(True)
         font.setFamily("Helvetica")
 
-        self.send_signal(self.widget.Inputs.data, self.data)
+        self.send_signal(self.widget.Inputs.data, self.data[50:])
         key, value = ("Fonts", "Font family", "Font family"), "Helvetica"
         self.widget.set_visual_settings(key, value)
 
@@ -373,6 +373,18 @@ class TestOWBarPlot(WidgetTest, WidgetOutputsTestMixin):
         self.assertFalse(graph.group_axis.style["rotateTicks"])
         self.widget.set_visual_settings(key, value)
         self.assertTrue(graph.group_axis.style["rotateTicks"])
+
+        key = "Figure", "Legend", "Hide empty categories in the legend"
+        value = True
+        self.assertEqual(
+            [i[1].text for i in graph.parameter_setter.legend_items],
+            ["Iris-setosa", "Iris-versicolor", "Iris-virginica"]
+        )
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(
+            [i[1].text for i in graph.parameter_setter.legend_items],
+            ["Iris-versicolor", "Iris-virginica"]
+        )
 
     def assertFontEqual(self, font1, font2):
         self.assertEqual(font1.family(), font2.family())

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -720,6 +720,23 @@ class TestOWDistributions(WidgetTest):
             self.get_output(widget.Outputs.selected_data).X,
             np.arange(200, 300)[:, np.newaxis])
 
+    def test_hide_legend(self):
+        widget = self.widget
+        legend = widget._legend
+
+        self._set_check(widget.controls.show_legend, False)
+        self._set_check(widget.controls.show_legend, True)
+
+        self.send_signal(widget.Inputs.data, self.iris)
+        self.assertTrue(legend.isVisible())
+        self._set_check(widget.controls.show_legend, False)
+        self.assertFalse(legend.isVisible())
+        self._set_check(widget.controls.show_legend, True)
+        self.assertTrue(legend.isVisible())
+
+        self.send_signal(widget.Inputs.data, None)
+        self._set_check(widget.controls.show_legend, False)
+        self._set_check(widget.controls.show_legend, True)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 from AnyQt.QtCore import QItemSelection, Qt, QEvent
-from AnyQt.QtGui import QKeyEvent
+from AnyQt.QtGui import QKeyEvent, QFont
 from AnyQt.QtWidgets import QCheckBox
 
 from orangewidget.utils.combobox import qcombobox_emit_activated
@@ -737,6 +737,59 @@ class TestOWDistributions(WidgetTest):
         self.send_signal(widget.Inputs.data, None)
         self._set_check(widget.controls.show_legend, False)
         self._set_check(widget.controls.show_legend, True)
+
+    @WidgetTest.skipNonEnglish
+    def test_visual_settings(self):
+        graph = self.widget.plotview
+        font = QFont()
+        font.setItalic(True)
+        font.setFamily("Helvetica")
+
+        self.send_signal(self.widget.Inputs.data, self.iris[50:])
+        key, value = ("Fonts", "Font family", "Font family"), "Helvetica"
+        self.widget.set_visual_settings(key, value)
+
+        key, value = ("Fonts", "Axis title", "Font size"), 16
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis title", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(16)
+        for item in graph.parameter_setter.axis_items:
+            self.assertFontEqual(item.label.font(), font)
+
+        key, value = ("Fonts", "Axis ticks", "Font size"), 15
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis ticks", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(15)
+        for item in graph.parameter_setter.axis_items:
+            self.assertFontEqual(item.style["tickFont"], font)
+
+        key, value = ("Fonts", "Legend", "Font size"), 14
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Legend", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(14)
+        legend_item = list(graph.parameter_setter.legend_items)[0]
+        self.assertFontEqual(legend_item[1].item.font(), font)
+
+        key = "Figure", "Legend", "Hide empty categories in the legend"
+        value = True
+        self.assertEqual(
+            [i[1].text for i in graph.parameter_setter.legend_items],
+            ["Iris-setosa", "Iris-versicolor", "Iris-virginica"]
+        )
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(
+            [i[1].text for i in graph.parameter_setter.legend_items],
+            ["Iris-versicolor", "Iris-virginica"]
+        )
+
+    def assertFontEqual(self, font1, font2):
+        self.assertEqual(font1.family(), font2.family())
+        self.assertEqual(font1.pointSize(), font2.pointSize())
+        self.assertEqual(font1.italic(), font2.italic())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -13844,6 +13844,7 @@ widgets/visualize/owbarplot.py:
         Bottom axis: Spodnja os
         Group axis: Os skupin
         Vertical ticks: Navpične oznake
+        Hide empty categories in the legend: Skrij prazne kategorije v legendi
         def `update_setters`:
             def `update_bottom_axis`:
                 bottom: false

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -13893,6 +13893,8 @@ widgets/visualize/owbarplot.py:
             (Same color): (Enaka barva)
             color_var: false
             Color:: Barva:
+            show_legend: false
+            Show legend: Pokaži legendo
             auto_commit: false
         def `grouped_indices`:
             mergesort: false

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -13999,6 +13999,10 @@ widgets/visualize/owdistributions.py:
         def `paint`:
             pxMode: false
             antialias: false
+    class `ParameterSetter`:
+        Hide empty categories in the legend: V legendo ne vključi praznih kategorij
+        def `axis_items`:
+            item: false
     class `AshCurve`:
         def `pdf`:
             same: false

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -14064,6 +14064,8 @@ widgets/visualize/owdistributions.py:
             Show probabilities: Pokaži verjetnosti
             cumulative_distr: false
             Show cumulative distribution: Pokaži kumulativno porazdelitev
+            show_legend: false
+            Show legend: Pokaži legendo
         def `_setup_plots`:
             def `add_new_plot`:
                 right: false


### PR DESCRIPTION
##### Issue

Fixes #5491. Partially, for now.

##### Description of changes

So far, this PR adds a checkbox for hiding the legend in Distributions and in Bar Plot.

It also allows the user to hide empty categories in the legend, but just for Bar Plot. A similar change would probably be needed in general, but I need some @VesnaT assistance.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
