### PR TITLE
KMeans: Scale silhouette bars

### DIFF
--- a/Orange/widgets/unsupervised/owkmeans.py
+++ b/Orange/widgets/unsupervised/owkmeans.py
@@ -34,6 +34,7 @@ class ClusterTableModel(QAbstractTableModel):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.scores = []
+        self.max_score = 1
         self.start_k = 0
 
     def rowCount(self, index=QModelIndex()):
@@ -51,12 +52,15 @@ class ClusterTableModel(QAbstractTableModel):
     def set_scores(self, scores, start_k):
         self.modelAboutToBeReset.emit()
         self.scores = scores
+        self.max_score = max(
+            (s for s in scores if not isinstance(s, str)), default=1)
         self.start_k = start_k
         self.modelReset.emit()
 
     def clear_scores(self):
         self.modelAboutToBeReset.emit()
         self.scores = []
+        self.max_score = 1
         self.start_k = 0
         self.modelReset.emit()
 
@@ -70,7 +74,7 @@ class ClusterTableModel(QAbstractTableModel):
         elif role == Qt.ToolTipRole and not valid:
             return score
         elif role == gui.BarRatioRole and valid:
-            return score
+            return score / self.max_score if self.max_score > 0 else 0
         return None
 
     def headerData(self, row, _orientation, role=Qt.DisplayRole):

--- a/Orange/widgets/unsupervised/tests/test_owkmeans.py
+++ b/Orange/widgets/unsupervised/tests/test_owkmeans.py
@@ -20,21 +20,21 @@ from Orange.widgets.unsupervised.owkmeans import OWKMeans, ClusterTableModel
 class TestClusterTableModel(unittest.TestCase):
     def test_model(self):
         model = ClusterTableModel()
-        model.set_scores(["bad", 0.250, "another bad"], 3)
+        model.set_scores(["bad", 0.125, "another bad", 0.5], 3)
 
         self.assertEqual(model.start_k, 3)
-        self.assertEqual(model.rowCount(), 3)
+        self.assertEqual(model.rowCount(), 4)
         ind0, ind1 = model.index(0, 0), model.index(1, 0)
         self.assertEqual(model.flags(ind0), Qt.NoItemFlags)
         self.assertEqual(model.flags(ind1),
                          Qt.ItemIsEnabled | Qt.ItemIsSelectable)
         data = model.data
         self.assertEqual(data(ind0), "NA")
-        self.assertEqual(data(ind1), "0.250")
+        self.assertEqual(data(ind1), "0.125")
         self.assertEqual(data(ind0, Qt.ToolTipRole), "bad")
         self.assertIsNone(data(ind1, Qt.ToolTipRole))
         self.assertIsNone(data(ind0, gui.BarRatioRole))
-        self.assertAlmostEqual(data(ind1, gui.BarRatioRole), 0.250)
+        self.assertAlmostEqual(data(ind1, gui.BarRatioRole), 0.25)
 
         self.assertAlmostEqual(data(ind1, Qt.TextAlignmentRole),
                                Qt.AlignVCenter | Qt.AlignLeft)


### PR DESCRIPTION
##### Issue

Fixes #7217.

##### Description of changes

I noticed that even the Silhouette widget scales the bars.

In its current form, KMeans' silhouette bars are almost always of the same length, even for reasonably good clustering. Thus I just scale them, always. No checkboxes.

##### Includes
- [X] Code changes
- [X] Tests
