### PR TITLE
[FIX] Create Class: Remove context settings in favour of schema-only non-context

### DIFF
--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -14,7 +14,7 @@ from Orange.data.table import Table
 from Orange.statistics.util import bincount
 from Orange.preprocess.transformation import Transformation, Lookup
 from Orange.widgets import gui, widget
-from Orange.widgets.settings import DomainContextHandler, ContextSetting
+from Orange.widgets.settings import DomainContextHandler, ContextSetting, Setting
 from Orange.widgets.utils.itemmodels import DomainModel
 from Orange.widgets.utils.localization import pl
 from Orange.widgets.utils.widgetpreview import WidgetPreview
@@ -233,12 +233,14 @@ class OWCreateClass(widget.OWWidget):
     MAX_RULES_AREA_HEIGHT = 360
 
     settingsHandler = DomainContextHandler()
-    attribute = ContextSetting(None)
-    class_name = ContextSetting("class")
-    rules = ContextSetting({})
-    match_beginning = ContextSetting(False)
-    case_sensitive = ContextSetting(False)
-    regular_expressions = ContextSetting(False)
+    attribute = ContextSetting(None, schema_only=True)
+    class_name = Setting("class", schema_only=True)
+    rules = Setting({}, schema_only=True)
+    match_beginning = Setting(False, schema_only=True)
+    case_sensitive = Setting(False, schema_only=True)
+    regular_expressions = Setting(False, schema_only=True)
+
+    settings_version = 2
 
     TRANSFORMERS = {StringVariable: ValueFromStringSubstring,
                     DiscreteVariable: ValueFromDiscreteSubstring}
@@ -363,7 +365,6 @@ class OWCreateClass(widget.OWWidget):
     def set_data(self, data):
         """Input data signal handler."""
         self.closeContext()
-        self.rules = {}
         self.data = data
         model = self.controls.attribute.model()
         model.set_domain(data.domain if data is not None else None)
@@ -722,6 +723,18 @@ class OWCreateClass(widget.OWWidget):
         if output:
             self.report_items("Output", [("Class name", self.class_name)])
             self.report_raw(f"<ol>{output}</ol>")
+
+    @classmethod
+    def migrate_settings(cls, settings, version):
+        if version < 2:
+            contexts = settings.pop("context_settings", [])
+            if contexts:
+                print(contexts[0].values)
+                print(settings)
+                settings.update(
+                    {name: contexts[0].values[name][0]
+                     for name in ("class_name", "rules", "match_beginning",
+                                  "case_sensitive")})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -279,15 +279,15 @@ class OWCreateClass(widget.OWWidget):
         #    once the new row's height has been applied
         self._scroll_to_bottom_pending = False
 
-        gui.lineEdit(
+        le = gui.lineEdit(
             self.controlArea, self, "class_name",
             orientation=Qt.Horizontal, box="New Class Name")
+        le.setStyleSheet("QLineEdit { padding-left: 4px; }")
 
-        variable_select_box = gui.vBox(self.controlArea, "Match by Substring")
+        variable_select_box = gui.vBox(self.controlArea, box="Source column and patterns")
 
         combo = gui.comboBox(
-            variable_select_box, self, "attribute", label="From column:",
-            orientation=Qt.Horizontal, searchable=True,
+            variable_select_box, self, "attribute", searchable=True,
             callback=self.update_rules,
             model=DomainModel(valid_types=(StringVariable, DiscreteVariable)))
         # Don't use setSizePolicy keyword argument here: it applies to box,
@@ -344,6 +344,7 @@ class OWCreateClass(widget.OWWidget):
         gui.button(self.buttonsArea, self, "Apply", callback=self.apply)
 
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
+        self.update_dynamic_height(initial=True)
 
     @property
     def active_rules(self):
@@ -360,6 +361,12 @@ class OWCreateClass(widget.OWWidget):
         for editr, textr in zip(self.line_edits, self.active_rules):
             for edit, text in zip(editr, textr):
                 edit.setText(text)
+
+    def update_dynamic_height(self, initial=False):
+        self.updateGeometry()
+        current_width = 350 if initial else self.width()
+        target_height = self.layout().sizeHint().height()
+        self.resize(current_width, target_height)
 
     @Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -736,12 +736,13 @@ class OWCreateClass(widget.OWWidget):
         if version < 2:
             contexts = settings.pop("context_settings", [])
             if contexts:
-                print(contexts[0].values)
-                print(settings)
+                context = contexts[0]
                 settings.update(
-                    {name: contexts[0].values[name][0]
+                    {name: context.values.pop(name)[0]
                      for name in ("class_name", "rules", "match_beginning",
-                                  "case_sensitive")})
+                                  "case_sensitive", "regular_expressions")})
+                context.values["__version__"] = 2
+                settings["context_settings"] = [context]  # selected attribute
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 
 import numpy as np
 
-from AnyQt.QtWidgets import QFrame, QGridLayout, QLabel, QLineEdit, \
+from AnyQt.QtWidgets import QLayout, QFrame, QGridLayout, QLabel, QLineEdit, \
     QSizePolicy, QWidget, QScrollArea
 from AnyQt.QtCore import Qt, QTimer
 
@@ -295,11 +295,12 @@ class OWCreateClass(widget.OWWidget):
         combo.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Preferred)
 
         patternbox = gui.vBox(variable_select_box)
+        patternbox.layout().setSpacing(0)
         #: QWidget: the box that contains the remove buttons, line edits and
         #    count labels. The lines are added and removed dynamically.
         self.rules_box = rules_box = QGridLayout()
         rules_box.setSpacing(4)
-        rules_box.setContentsMargins(4, 4, 4, 4)
+        rules_box.setContentsMargins(4, 4, 4, 0)
         self.rules_box.setColumnMinimumWidth(1, 70)
         self.rules_box.setColumnMinimumWidth(0, 10)
         self.rules_box.setColumnStretch(0, 1)
@@ -344,7 +345,7 @@ class OWCreateClass(widget.OWWidget):
         gui.button(self.buttonsArea, self, "Apply", callback=self.apply)
 
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
-        self.update_dynamic_height(initial=True)
+        self.layout().setSizeConstraint(QLayout.SetFixedSize)
 
     @property
     def active_rules(self):
@@ -361,12 +362,6 @@ class OWCreateClass(widget.OWWidget):
         for editr, textr in zip(self.line_edits, self.active_rules):
             for edit, text in zip(editr, textr):
                 edit.setText(text)
-
-    def update_dynamic_height(self, initial=False):
-        self.updateGeometry()
-        current_width = 350 if initial else self.width()
-        target_height = self.layout().sizeHint().height()
-        self.resize(current_width, target_height)
 
     @Inputs.data
     def set_data(self, data):

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -678,16 +678,23 @@ class TestOWCreateClass(WidgetTest):
                 'class_name': ('class', -2),
                 'match_beginning': (True, -2),
                 'regular_expressions': (False, -2),
-                'rules': ({'type': [['', 'am'], ['', 'er'], ['', '']]}, -2),
+                'rules': ({'type': [['cam', 'am'], ['cer', 'er'], ['', '']],
+                           'eggs': [['de', 'e1'], ['', '']]},
+                          -2),
                 '__version__': 1},
             attributes = {'hair': 1, 'feathers': 1, 'eggs': 1, 'type': 1},
             metas = {'name': 3})]}
         w = self.create_widget(OWCreateClass, stored_settings=settings)
+        self.send_signal(w.Inputs.data, self.zoo, widget=w)
+        self.assertEqual(w.active_rules, [['cam', 'am'], ['cer', 'er'], ['', '']])
+        self.assertEqual(w.class_name, "class")
         self.assertTrue(w.case_sensitive)
         self.assertTrue(w.match_beginning)
         self.assertFalse(w.regular_expressions)
-        self.assertEqual(w.class_name, "class")
-        self.assertEqual(w.rules["type"], [['', 'am'], ['', 'er'], ['', '']])
+
+        w.attribute = self.zoo.domain["eggs"]
+        self.assertEqual(w.active_rules, [['de', 'e1'], ['', '']])
+
 
 
 if __name__ == "__main__":

--- a/Orange/widgets/data/tests/test_owcreateclass.py
+++ b/Orange/widgets/data/tests/test_owcreateclass.py
@@ -673,11 +673,11 @@ class TestOWCreateClass(WidgetTest):
     def test_migrate_settings_1_2(self):
         settings = {"__version__": 1, "context_settings": [Context(
             values= {
-                'attribute': ('type', 101),
+                'attribute': ('eggs', 101),  # not a default selection
                 'case_sensitive': (True, -2),
-                'class_name': ('class', -2),
+                'class_name': ('myclass', -2),
                 'match_beginning': (True, -2),
-                'regular_expressions': (False, -2),
+                'regular_expressions': (True, -2),
                 'rules': ({'type': [['cam', 'am'], ['cer', 'er'], ['', '']],
                            'eggs': [['de', 'e1'], ['', '']]},
                           -2),
@@ -686,14 +686,15 @@ class TestOWCreateClass(WidgetTest):
             metas = {'name': 3})]}
         w = self.create_widget(OWCreateClass, stored_settings=settings)
         self.send_signal(w.Inputs.data, self.zoo, widget=w)
-        self.assertEqual(w.active_rules, [['cam', 'am'], ['cer', 'er'], ['', '']])
-        self.assertEqual(w.class_name, "class")
+        self.assertEqual(w.attribute, self.zoo.domain["eggs"])
+        self.assertEqual(w.active_rules, [['de', 'e1'], ['', '']])
+        self.assertEqual(w.class_name, "myclass")
         self.assertTrue(w.case_sensitive)
         self.assertTrue(w.match_beginning)
-        self.assertFalse(w.regular_expressions)
+        self.assertTrue(w.regular_expressions)
 
-        w.attribute = self.zoo.domain["eggs"]
-        self.assertEqual(w.active_rules, [['de', 'e1'], ['', '']])
+        w.attribute = self.zoo.domain["type"]
+        self.assertEqual(w.active_rules, [['cam', 'am'], ['cer', 'er'], ['', '']])
 
 
 

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -4881,9 +4881,9 @@ widgets/data/owcreateclass.py:
         def `__init__`:
             class_name: false
             New Class Name: Ime novega razreda
-            Match by Substring: Vzorci in razredi
+            'QLineEdit { padding-left: 4px; }': false
+            Source column and patterns: Izvorni stolpec in vzorci
             attribute: false
-            From column:: Iz stolpca:
             Name: Ime
             Substring: Vzorec
             Count: Primerov

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -4940,6 +4940,8 @@ widgets/data/owcreateclass.py:
             rules: false
             match_beginning: false
             case_sensitive: false
+            regular_expressions: false
+            __version__: false
     __main__: false
     zoo: false
 widgets/data/owcreateinstance.py:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -4934,6 +4934,12 @@ widgets/data/owcreateclass.py:
             Output: Izhod
             Class name: Ime razreda
             <ol>{output}</ol>: false
+        def `migrate_settings`:
+            context_settings: false
+            class_name: false
+            rules: false
+            match_beginning: false
+            case_sensitive: false
     __main__: false
     zoo: false
 widgets/data/owcreateinstance.py:


### PR DESCRIPTION
##### Issue

Fixes #5499, assuming that weird behaviour is caused by context settings. (Which it almost certainly is.)

##### Description of changes

As per title, I replaced context settings with schema-only (non-context) settings. The only remaining context setting is the variable.

It gets even better. Rules were already an "internal context setting" with the variable as a context. That is, if the user sets the rules for one variable, switches to another, sets some rules, and switches back (s)he will get the rules for the former variable.

After removing context settings, this works as hinting. Load zoo, set some rules for type. Load Iris (rules disappear), set different rules. Go back to zoo and you get the rules back. This hinting is based on variable name.

If this is merged and documentation is updated, close #6961, too.

##### Includes
- [X] Code changes
- [X] Tests
