### PR TITLE
Discretize and Continuize: Unify design

### DIFF
--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -195,25 +195,16 @@ class ListViewSearch(listview.ListViewSearch):
         """
         A delegate that shows items (variables) with specific settings in bold
         """
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._default_hints = False
-
         def initStyleOption(self, option, index):
             super().initStyleOption(option, index)
             hint = index.data(ContDomainModel.HintRole)
             option.font.setBold(hint is not None and hint[1])
 
-        def set_default_hints(self, show):
-            self._default_hints = show
-
         def displayText(self, value, _):
             if value is None:
                 return None
-            name, hint, nondefault = value
-            if self._default_hints or nondefault:
-                name += f": {hint}"
-            return name
+            name, hint, _ = value
+            return f"{name}: {hint}"
 
     def __init__(self, *args, **kwargs):
         self.default_view = None
@@ -263,17 +254,6 @@ class ListViewSearch(listview.ListViewSearch):
         # Then the real list view
         margins.setTop(def_height + 2 + src_height)
         self.setViewportMargins(margins)
-
-    def event(self, ev):
-        if ev.type() == ev.ToolTip:
-            self.itemDelegate().set_default_hints(True)
-            self.viewport().update()
-            return True
-        return super().event(ev)
-
-    def leaveEvent(self, _):
-        self.itemDelegate().set_default_hints(False)
-        self.viewport().update()
 
 
 class OWContinuize(widget.OWWidget):

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -45,8 +45,8 @@ DiscreteOptions: Dict[int, MethodDesc] = {
     method.id_: method
     for method in (
         MethodDesc(
-            Continuize.Default, "Use preset", "preset",
-            "Treat the variable as defined in preset"),
+            Continuize.Default, "Use general preset", "preset",
+            "Treat the variable as defined in general preset"),
         MethodDesc(
             Continuize.Leave, "Keep categorical", "keep as is",
             "Keep the variable discrete"),
@@ -86,8 +86,8 @@ ContinuousOptions: Dict[int, MethodDesc] = {
     method.id_: method
     for method in (
         MethodDesc(
-            Normalize.Default, "Use preset", "preset",
-            "Treat the variable as defined in 'default setting'"),
+            Normalize.Default, "Use general preset", "preset",
+            "Treat the variable as defined in general preset"),
         MethodDesc(
             Normalize.Leave, "Keep as it is", "no change",
             "Keep the variable as it is"),
@@ -166,7 +166,7 @@ class DefaultContModel(QAbstractListModel):
 
     def data(self, _, role=Qt.DisplayRole):
         if role == Qt.DisplayRole:
-            return f"Preset: {self.method}"
+            return f"General preset: {self.method}"
         elif role == Qt.DecorationRole:
             return self.icon
         elif role == Qt.ToolTipRole:
@@ -700,7 +700,7 @@ class OWContinuize(widget.OWWidget):
             elif len(self.disc_view.model()) > 0:
                 self.report_items(
                     "Categorical variables",
-                    [("Preset" if name == DefaultKey else name,
+                    [("General preset" if name == DefaultKey else name,
                       DiscreteOptions[id_].label.lower())
                      for name, id_ in self.disc_var_hints.items()])
             if single_cont:
@@ -708,11 +708,11 @@ class OWContinuize(widget.OWWidget):
             elif len(self.cont_view.model()) > 0:
                 self.report_items(
                     "Numeric variables",
-                    [("Preset" if name == DefaultKey else name,
+                    [("General preset" if name == DefaultKey else name,
                       ContinuousOptions[id_].label.lower())
                      for name, id_ in self.cont_var_hints.items()])
             self.report_paragraph("Unlisted",
-                "Any unlisted attributes default to preset option, and "
+                "Any unlisted attributes default to general preset, and "
                 "unlisted meta attributes and target variables are kept "
                 "as they are")
 

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -158,8 +158,8 @@ Options: Dict[Methods, MethodDesc] = {
     method.id_: method
     for method in (
         MethodDesc(Methods.Default,
-                   "Use default setting", "default",
-                   "Treat the variable as defined in 'default setting'",
+                   "Use general preset", "as preset",
+                   "Treat the variable as defined in general preset",
                    None,
                    ()),
         MethodDesc(Methods.Keep,
@@ -355,7 +355,7 @@ class DiscDomainModel(DomainModel):
 
 class DefaultDiscModel(QAbstractListModel):
     """
-    A model used for showing "Default settings" above the list view with var
+    A model used for showing "General preset" above the list view with var
     """
     icon = None
 
@@ -376,7 +376,7 @@ class DefaultDiscModel(QAbstractListModel):
 
     def data(self, _, role=Qt.DisplayRole):
         if role == Qt.DisplayRole:
-            return "Default setting: " + format_desc(self.hint)
+            return "General preset: " + format_desc(self.hint)
         elif role == Qt.DecorationRole:
             return DefaultDiscModel.icon
         elif role == Qt.ToolTipRole:
@@ -667,9 +667,13 @@ class OWDiscretize(widget.OWWidget):
                                      (self.copy_to_custom, None),
                                      stretch=False)
         button(Methods.Default)
-        maxheight = max(w.sizeHint().height() for w in children)
-        for w in children:
-            w.itemAt(0).widget().setFixedHeight(maxheight)
+        # Increase the height of smaller items to make the spacing look more
+        # uniform. Setting the same height for all make it look too large.
+        heights = [w.sizeHint().height() for w in children]
+        maxheight = max(heights)
+        midheight = (min(heights) + maxheight) // 2
+        for widg, h in zip(children, heights):
+            widg.itemAt(0).widget().setFixedHeight(max(h, midheight))
         button_box.layout().addStretch(1)
 
     def _update_default_model(self):

--- a/Orange/widgets/data/owdiscretize.py
+++ b/Orange/widgets/data/owdiscretize.py
@@ -158,7 +158,7 @@ Options: Dict[Methods, MethodDesc] = {
     method.id_: method
     for method in (
         MethodDesc(Methods.Default,
-                   "Use general preset", "as preset",
+                   "Use general preset", "preset",
                    "Treat the variable as defined in general preset",
                    None,
                    ()),
@@ -349,7 +349,9 @@ class DiscDomainModel(DomainModel):
             except TypeError:
                 pass  # don't have user role (yet)
             else:
-                value += f" ({format_desc(hint)}){points}"
+                value += ": " + format_desc(hint)
+                if points:
+                    value += " " + points
         return value
 
 
@@ -638,6 +640,7 @@ class OWDiscretize(widget.OWWidget):
         self.button_group = QButtonGroup(self)
         self.button_group.idClicked.connect(self.update_hints)
 
+        button(Methods.Default)
         button(Methods.Keep)
         button(Methods.Remove)
 
@@ -666,7 +669,6 @@ class OWDiscretize(widget.OWWidget):
                                      manual_cut_editline(),
                                      (self.copy_to_custom, None),
                                      stretch=False)
-        button(Methods.Default)
         # Increase the height of smaller items to make the spacing look more
         # uniform. Setting the same height for all make it look too large.
         heights = [w.sizeHint().height() for w in children]
@@ -839,7 +841,7 @@ class OWDiscretize(widget.OWWidget):
         thresholds = dvar.compute_value.points
         if len(thresholds) == 0:
             return " <removed>", None
-        return ": " + ", ".join(map(var.repr_val, thresholds)), dvar
+        return "(" + ", ".join(map(var.repr_val, thresholds))+ ")", dvar
 
     def _copy_to_manual(self):
         """

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -841,15 +841,10 @@ class TestListViewDelegate(unittest.TestCase):
     def test_displaytext(self):
         delegate = ListViewSearch.Delegate()
         self.assertEqual(delegate.displayText(("a", "foo", False), Mock()),
-                         "a")
+                         "a: foo")
         self.assertEqual(delegate.displayText(("a", "foo", True), Mock()),
                          "a: foo")
-        delegate.set_default_hints(True)
-        self.assertEqual(delegate.displayText(("a", "foo", False), Mock()),
-                         "a: foo")
-        delegate.set_default_hints(False)
-        self.assertEqual(delegate.displayText(("a", "foo", False), Mock()),
-                         "a")
+        self.assertIsNone(delegate.displayText(None, Mock()))
 
     @patch.object(SeparatedListDelegate, "initStyleOption")
     def test_bold(self, _):

--- a/Orange/widgets/data/tests/test_owcontinuize.py
+++ b/Orange/widgets/data/tests/test_owcontinuize.py
@@ -832,7 +832,7 @@ class TestModelsAndViews(GuiTest):
         spy = QSignalSpy(model.dataChanged)
         model.setMethod("mega encoding")
         self.assertEqual(spy[0][0].row(), 0)
-        self.assertEqual(ind.data(), "Preset: mega encoding")
+        self.assertEqual(ind.data(), "General preset: mega encoding")
         self.assertIsNotNone(ind.data(Qt.DecorationRole))
         self.assertIsNotNone(ind.data(Qt.ToolTipRole))
 

--- a/Orange/widgets/data/tests/test_owdiscretize.py
+++ b/Orange/widgets/data/tests/test_owdiscretize.py
@@ -567,7 +567,7 @@ class TestDiscModel(GuiTest, DataMixin):
                 VarHint(Methods.EqualFreq, (3, )), "1, 2", ("1", "2")),
             Qt.UserRole
         )
-        self.assertTrue(index.data(Qt.DisplayRole).startswith("x "))
+        self.assertTrue(index.data(Qt.DisplayRole).startswith("x: "))
         self.assertIn("2", index.data(Qt.ToolTipRole))
 
 

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -4645,7 +4645,6 @@ widgets/data/owcontinuize.py:
     Treat as normalized ordinal: Obravnavaj kot normalizirano ordinalno
     as norm. ordinal: kot norm. ordinalna
     Same as above, but scaled to [0, 1]: Enako kot zgoraj, vendar skalirano na [0, 1]
-    Treat the variable as defined in general preset: Spremeni, kot določajo splošne nastavitve
     Keep as it is: Ohrani tako, kot je
     no change: brez sprememb
     Keep the variable as it is: Ohrani spremenljivko tako, kot je
@@ -4679,7 +4678,7 @@ widgets/data/owcontinuize.py:
     class `ListViewSearch`:
         class `Delegate`:
             def `displayText`:
-                ': {hint}': false
+                '{name}: {hint}': false
     class `OWContinuize`:
         Continuize: Kontinuizacija
         'Transform categorical attributes into numeric and, ': 'Kategorične atribute pretvori v številčne in '
@@ -5451,7 +5450,7 @@ widgets/data/owdiscretize.py:
     def `_custom_discretization`:
         invalid cuts: nepravilne meje
     Use general preset: Uporabi splošno nastavitvo
-    as preset: splošno
+    preset: splošno
     Treat the variable as defined in general preset: Spremeni, kot je določeno v splošni nastavitvi
     Keep numeric: Ohrani številsko
     keep: ohrani
@@ -5499,7 +5498,8 @@ widgets/data/owdiscretize.py:
             {",&nbsp;&nbsp;".join(values)}</p>: false
             <br/>: false
             - {value}<br/>: false
-            ' ({format_desc(hint)}){points}': false
+            ': ': false
+            ' ': false
     class `DefaultDiscModel`:
         def `__init__`:
             ★: true
@@ -5557,8 +5557,9 @@ widgets/data/owdiscretize.py:
             ': <keep, not time>': : <ohrani, ni časovna>
             ' <{dvar}>': false
             ' <removed>': ' <odstranjena>'
-            ': ': true
+            (: false
             ', ': true
+            ): false
         def `_copy_to_manual`:
             ', ': true
         def `send_report`:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -4618,9 +4618,9 @@ widgets/data/owconcatenate.py:
     iris: false
     zoo: false
 widgets/data/owcontinuize.py:
-    Use preset: Uporabi privzeto
-    preset: privzeto
-    Treat the variable as defined in preset: Obravnavaj spremenljivko, kot je privzeto določena
+    Use general preset: Uporabi splošne nastavitve
+    preset: splošno
+    Treat the variable as defined in general preset: Spremeni, kot določajo splošne nastavitve
     Keep categorical: Ohrani kategorično
     keep as is: ohrani, kot je
     Keep the variable discrete: Ohrani spremenljivko diskretno
@@ -4645,7 +4645,7 @@ widgets/data/owcontinuize.py:
     Treat as normalized ordinal: Obravnavaj kot normalizirano ordinalno
     as norm. ordinal: kot norm. ordinalna
     Same as above, but scaled to [0, 1]: Enako kot zgoraj, vendar skalirano na [0, 1]
-    Treat the variable as defined in 'default setting': Obravnavaj spremenljivko, kot je prenastavljena.
+    Treat the variable as defined in general preset: Spremeni, kot določajo splošne nastavitve
     Keep as it is: Ohrani tako, kot je
     no change: brez sprememb
     Keep the variable as it is: Ohrani spremenljivko tako, kot je
@@ -4674,7 +4674,7 @@ widgets/data/owcontinuize.py:
         def `__init__`:
             ★: false
         def `data`:
-            'Preset: {self.method}': Privzeto: {self.method}
+            'General preset: {self.method}': Splošna nastavitev: {self.method}
             Default for variables without specific settings: Privzeto za spremenljivke brez posebnih nastavitev
     class `ListViewSearch`:
         class `Delegate`:
@@ -4720,9 +4720,9 @@ widgets/data/owcontinuize.py:
         def `send_report`:
             Categorical variables: Kategorične spremenljivke
             Numeric variables: Numerične spremenljivke
-            Preset: Privzeto
+            General preset: Splošna nastavitev
             Unlisted: Nerazvrščeno
-            'Any unlisted attributes default to preset option, and ': 'Za atribute, ki niso izpisani, je uporabljena privzeta nastavitev, '
+            'Any unlisted attributes default to general preset, and ': 'Za atribute, ki niso izpisani, je uporabljena privzeta nastavitev, '
             'unlisted meta attributes and target variables are kept ': 'neizpisani meta atributi pa ostajajo '
             as they are: nespremenjeni.
         def `migrate_settings`:
@@ -5450,9 +5450,9 @@ widgets/data/owdiscretize.py:
         no discrete class: razred ni kategoričen
     def `_custom_discretization`:
         invalid cuts: nepravilne meje
-    Use default setting: Uporabi privzeto nastavitev
-    default: privzeto
-    Treat the variable as defined in 'default setting': Obravnavaj spremenljivko po določeni privzeti metodi
+    Use general preset: Uporabi splošno nastavitvo
+    as preset: splošno
+    Treat the variable as defined in general preset: Spremeni, kot je določeno v splošni nastavitvi
     Keep numeric: Ohrani številsko
     keep: ohrani
     Keep the variable as is: Pusti spremenljivko tako, kot je
@@ -5504,7 +5504,7 @@ widgets/data/owdiscretize.py:
         def `__init__`:
             ★: true
         def `data`:
-            'Default setting: ': 'Privzeta nastavitev: '
+            'General preset: ': 'Splošna nastavitev: '
             Default setting for variables without specific setings: Privzeta metoda za spremenljivke brez specifičnih nastavitev
     class `IncreasingNumbersListValidator`:
         def `validate`:


### PR DESCRIPTION
##### Issue

Resolves #6984.

##### Description of changes

I adopted a term "General preset" and consistently use it in both widges.

The Discretize widget had very large spacing between radio buttons; the height was made uniform by adjusting all heights to the largest height. Now the height of smaller items is adjusted to the mean  between minimal and maximal. This looks better, imho.

##### Includes
- [X] Code changes
