### PR TITLE
Transpose: Rename output column

### DIFF
--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -82,7 +82,7 @@ class OWTranspose(OWWidget, ConcurrentWidgetMixin):
 
         # self.apply is changed later, pylint: disable=unnecessary-lambda
         box = gui.radioButtons(
-            self.controlArea, self, "feature_type", box="Feature names",
+            self.controlArea, self, "feature_type", box="Output column names",
             callback=self.commit.deferred)
 
         button = gui.appendRadioButton(box, "Generic")
@@ -92,7 +92,7 @@ class OWTranspose(OWWidget, ConcurrentWidgetMixin):
             placeholderText="Type a prefix ...", toolTip="Custom feature name")
         edit.editingFinished.connect(self._apply_editing)
 
-        self.meta_button = gui.appendRadioButton(box, "From variable:")
+        self.meta_button = gui.appendRadioButton(box, "From column:")
         self.feature_model = DomainModel(
             valid_types=(ContinuousVariable, StringVariable),
             alphabetical=False)
@@ -106,7 +106,8 @@ class OWTranspose(OWWidget, ConcurrentWidgetMixin):
             "remove_redundant_inst", "Remove redundant instance",
             callback=self.commit.deferred)
 
-        box = gui.vBox(self.controlArea, "Name for column with column names")
+        box = gui.vBox(self.controlArea,
+                       "Name for column with original column names")
         gui.lineEdit(
             box, self, "output_column_name",
             placeholderText="Column name",

--- a/Orange/widgets/data/owtranspose.py
+++ b/Orange/widgets/data/owtranspose.py
@@ -61,7 +61,7 @@ class OWTranspose(OWWidget, ConcurrentWidgetMixin):
     feature_name = ContextSetting("")
     feature_names_column = ContextSetting(None)
     remove_redundant_inst = ContextSetting(False)
-    output_column_name = Setting("")
+    output_column_name = Setting("", schema_only=True)
     auto_apply = Setting(True)
 
     settings_version = 2

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -8403,16 +8403,16 @@ widgets/data/owtranspose.py:
             {}: false
         def `__init__`:
             feature_type: false
-            Feature names: Imena spremenljivk
+            Output column names: Imena izhodnih stolpcev
             Generic: Generična imena
             feature_name: false
             Type a prefix ...: Določi predpono ...
             Custom feature name: Določi predpono imen spremenljivk
-            From variable:: Po vrednosti spremenljivke:
+            From column:: Po stolpcu:
             feature_names_column: false
             remove_redundant_inst: false
             Remove redundant instance: Odstrani odvečni primer
-            Name for column with column names: Ime stolpca z imeni stolpcev
+            Name for column with original column names: Ime stolpca z imeni izvornih stolpcev
             output_column_name: false
             Column name: Ime stolpca
         def `commit`:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -8412,11 +8412,19 @@ widgets/data/owtranspose.py:
             feature_names_column: false
             remove_redundant_inst: false
             Remove redundant instance: Odstrani odvečni primer
+            Name for column with column names: Ime stolpca z imeni stolpcev
+            output_column_name: false
+            Column name: Ime stolpca
+        def `commit`:
+            Column name: Ime stolpca
         def `send_report`:
             from variable: po spremenljivki
             "  '{}'": false
             Feature names: Imena spremenljivk
             Data: Podatki
+        def `migrate_settings`:
+            output_column_name: false
+            Feature name: Ime spremenljivke
     __main__: false
     iris: false
 widgets/data/owunique.py:


### PR DESCRIPTION
##### Issue

Resolves #7086.

##### Description of changes

Default name is now "Column name", but user can change it.

To maintain compatibility with older workflows, settings migration sets the column name to "Feature name" -- as if the user manually changed it!

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
