### PR TITLE
[FIX] Freeviz: Fix disappearing label at angles close to a multiple of 90

### DIFF
--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -124,7 +124,7 @@ class AnchorItem(pg.GraphicsWidget):
 
         self._label.setPos(label_pos)
         self._label.setAnchor(pg.Point(*anchor))
-        self._label.setRotation(-angle if left_quad else 180 - angle)
+        self._label.setAngle(angle if left_quad else 180 + angle)
 
         self._arrow.setPos(self._spine.line().p2())
         self._arrow.setRotation(180 - angle)


### PR DESCRIPTION
##### Issue

Fixes #7240. Labels in Freeviz disappear if their angle is too close to vertical or horizontal, depending on the length of the label.

##### Description of changes

Using `setAngle` instead of `setRotation` solves the problem. I don't know why (and don't care much :).

##### Includes
- [X] Code changes