### PR TITLE
Jaccard Distance: Fix distance over columns

### DIFF
--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -548,15 +548,11 @@ class JaccardModel(FittedDistanceModel):
             callback(100 * (i / steps) ** (1 + symmetric))
             x1_ind = set(x1.indices[i1:i2])
             for j, j1, j2 in jlines[:i if symmetric else m]:
-                x2_ind = x2.indices[j1:j2]
-                union = len(x1_ind.union(x2_ind))
-                if union:
-                    jacc = 1 - len(x1_ind.intersection(x2_ind)) / union
-                else:
-                    jacc = 0
-                matrix[i, j] = jacc
-                if symmetric:
-                    matrix[j, i] = jacc
+                x2_ind = set(x2.indices[j1:j2])
+                union = len(x1_ind | x2_ind)
+                matrix[i, j] = union and 1 - len(x1_ind & x2_ind) / union
+        if symmetric:
+            matrix += matrix.T
         return matrix
 
 

--- a/Orange/distance/distance.py
+++ b/Orange/distance/distance.py
@@ -539,8 +539,13 @@ class JaccardModel(FittedDistanceModel):
         jlines = np.hstack((np.arange(len(x2.indptr) - 1)[:, None],
                             x2.indptr[:-1, None],
                             x2.indptr[1:, None]))
+        steps = len(x1.indptr) - 1
         for i, i1, i2 in zip(count(), x1.indptr, x1.indptr[1:]):
-            callback(i1 * 100 / n)
+            # For asymmetric case, we've done i / steps of work.
+            # For symmetric case, the total time is proportional to steps ** 2
+            # and the time used so far is proportional to i ** 2.
+            # Thence the exponent is 1 + symmetric.
+            callback(100 * (i / steps) ** (1 + symmetric))
             x1_ind = set(x1.indices[i1:i2])
             for j, j1, j2 in jlines[:i if symmetric else m]:
                 x2_ind = x2.indices[j1:j2]

--- a/Orange/distance/tests/test_distance.py
+++ b/Orange/distance/tests/test_distance.py
@@ -904,27 +904,32 @@ class JaccardDistanceTest(unittest.TestCase, CommonFittedTests):
              [1, 1, 1],
              [1, 0, 1],
              [1, 0, 0]])
+        self.sparse_data = Table.from_numpy(self.domain, csr_matrix(self.data.X))
 
     def test_jaccard_rows(self):
         assert_almost_equal = np.testing.assert_almost_equal
 
-        model = distance.Jaccard().fit(self.data)
-        assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
-        assert_almost_equal(
-            model(self.data),
-            1 - np.array([[1, 2/3, 1/3, 0],
-                          [2/3, 1, 2/3, 1/3],
-                          [1/3, 2/3, 1, 1/2],
-                          [0, 1/3, 1/2, 1]]))
+        for data, name in [(self.data, "dense"), (self.sparse_data, "sparse")]:
+            with self.subTest(name):
+                model = distance.Jaccard().fit(data)
+                if name == "dense":
+                    assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
+                assert_almost_equal(
+                    model(data),
+                    1 - np.array([[1, 2/3, 1/3, 0],
+                                  [2/3, 1, 2/3, 1/3],
+                                  [1/3, 2/3, 1, 1/2],
+                                  [0, 1/3, 1/2, 1]]))
 
-        model = distance.Jaccard(similarity=True).fit(self.data)
-        assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
-        assert_almost_equal(
-            model(self.data),
-            np.array([[1, 2/3, 1/3, 0],
-                      [2/3, 1, 2/3, 1/3],
-                      [1/3, 2/3, 1, 1/2],
-                      [0, 1/3, 1/2, 1]]))
+                model = distance.Jaccard(similarity=True).fit(data)
+                if name == "dense":
+                    assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
+                assert_almost_equal(
+                    model(data),
+                    np.array([[1, 2/3, 1/3, 0],
+                              [2/3, 1, 2/3, 1/3],
+                              [1/3, 2/3, 1, 1/2],
+                              [0, 1/3, 1/2, 1]]))
 
         X = self.data.X
         with self.data.unlocked():
@@ -941,22 +946,26 @@ class JaccardDistanceTest(unittest.TestCase, CommonFittedTests):
 
     def test_jaccard_cols(self):
         assert_almost_equal = np.testing.assert_almost_equal
-        model = distance.Jaccard(axis=0).fit(self.data)
-        assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
-        assert_almost_equal(
-            model(self.data),
-            1 - np.array([[1, 1/4, 1/2],
-                          [1/4, 1, 2/3],
-                          [1/2, 2/3, 1]]))
+        for data, name in [(self.data, "dense"), (self.sparse_data, "sparse")]:
+            with self.subTest(name):
+                model = distance.Jaccard(axis=0).fit(data)
+                if name == "dense":
+                    assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
+                assert_almost_equal(
+                    model(data),
+                    1 - np.array([[1, 1/4, 1/2],
+                                  [1/4, 1, 2/3],
+                                  [1/2, 2/3, 1]]))
 
-        assert_almost_equal = np.testing.assert_almost_equal
-        model = distance.Jaccard(axis=0, similarity=True).fit(self.data)
-        assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
-        assert_almost_equal(
-            model(self.data),
-            np.array([[1, 1/4, 1/2],
-                      [1/4, 1, 2/3],
-                      [1/2, 2/3, 1]]))
+                assert_almost_equal = np.testing.assert_almost_equal
+                model = distance.Jaccard(axis=0, similarity=True).fit(data)
+                if name == "dense":
+                    assert_almost_equal(model.ps, [0.75, 0.5, 0.75])
+                assert_almost_equal(
+                    model(data),
+                    np.array([[1, 1/4, 1/2],
+                              [1/4, 1, 2/3],
+                              [1/2, 2/3, 1]]))
 
         with self.data.unlocked():
             self.data.X = np.array([[0, 1, 1],


### PR DESCRIPTION
##### Issue

Fixes #7237.

Jaccard distance over sparse data ignored the `axis` and always computed distances between rows. This resulted in a matrix of wrong dimensions and (hopefully) crash in downstream widgets or, alternatively, nonsensical matrix. The bug described in #7237 can also be reproduced with, for instance, Distance Matrix.

The problem does not appear for dense data, which was treated correctly.

##### Description of changes

Fixes computation over columns and speeds up computation over rows -- both for sparse data only.

**Note**:  coverage test must be mistaken -- the line is covered with tests. Puting `1 / 0` there makes it fail.

##### Includes
- [X] Code changes
- [X] Tests
