### PR TITLE
Pin chardet<7

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,7 +1,7 @@
 baycomp>=1.0.2
 bottleneck>=1.3.4
 # Encoding detection
-chardet>=3.0.2
+chardet>=3.0.2,<7
 httpx>=0.21.0,<1
 # Multiprocessing abstraction
 joblib>=1.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ deps =
     oldest: pyqtgraph>=0.13.1
     oldest: qtconsole==4.7.2
     # core requirements
+    chardet<7
     oldest: baycomp==1.0.2
     oldest: bottleneck==1.3.7
     oldest: catboost==1.2.2


### PR DESCRIPTION
##### Issue

**Note: #7250, if it works, is preferred over this PR.**

"Nightly wheels" tests fail with

```
  File "/home/runner/work/orange3/orange3/.tox/beta/lib/python3.14/site-packages/Orange/data/io_util.py", line 15, in <module>
    from chardet.universaldetector import UniversalDetector
ModuleNotFoundError: No module named 'chardet.universaldetector'
```

because `UniveralDetector was moved to `chardet.detector` in chardet 7.

##### Description of changes

Pin chardet to <7. Alternative fixes would be
- to try to import from the new location if the current import fails.
- to pin chardet to >=7.