### PR TITLE
io: Fix for chardet>=7

### DIFF
--- a/Orange/data/io_util.py
+++ b/Orange/data/io_util.py
@@ -12,14 +12,22 @@ try:
 except ImportError:  # pandas < 2.2.0
     from pandas.core.tools.datetimes import guess_datetime_format
 
-from chardet.universaldetector import UniversalDetector
-
 from Orange.data import (
     is_discrete_values, MISSING_VALUES, Variable,
     DiscreteVariable, StringVariable, ContinuousVariable, TimeVariable, Table,
 )
 from Orange.misc.collections import natural_sorted
 from Orange.util import ftry, frompyfunc
+
+# pylint: disable=wrong-import-order
+import chardet
+if chardet.__version__ < "7":  # pragma: no cover
+    # pylint: disable=wrong-import-position
+    from chardet.universaldetector import UniversalDetector
+else:  # pragma: no cover
+    # pylint: disable=wrong-import-position
+    from chardet.detector import UniversalDetector
+
 
 __all__ = [
     "Compression",
@@ -46,6 +54,7 @@ class Compression:
 
 def open_compressed(filename, *args, _open=open, **kwargs):
     """Return seamlessly decompressed open file handle for `filename`"""
+    # pylint: disable=import-outside-toplevel
     if isinstance(filename, str):
         if filename.endswith(Compression.GZIP):
             from gzip import open as _open

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -1233,6 +1233,7 @@ data/io_base.py:
         def `qualified_name`:
             .: false
 data/io_util.py:
+    7: false
     Compression: false
     open_compressed: false
     detect_encoding: false


### PR DESCRIPTION
##### Issue

Alternative to #7250.

"Nightly wheels" tests fail with

```
  File "/home/runner/work/orange3/orange3/.tox/beta/lib/python3.14/site-packages/Orange/data/io_util.py", line 15, in <module>
    from chardet.universaldetector import UniversalDetector
ModuleNotFoundError: No module named 'chardet.universaldetector'
```

because `UniveralDetector was moved to `chardet.detector` in chardet 7.

##### Description of changes

Check the version before importing, and import from the appropriate place.