### PR TITLE
io: fix for chardet >= 7

### DIFF
--- a/Orange/data/io_util.py
+++ b/Orange/data/io_util.py
@@ -12,7 +12,7 @@ try:
 except ImportError:  # pandas < 2.2.0
     from pandas.core.tools.datetimes import guess_datetime_format
 
-from chardet.universaldetector import UniversalDetector
+from chardet import UniversalDetector
 
 from Orange.data import (
     is_discrete_values, MISSING_VALUES, Variable,


### PR DESCRIPTION
##### Issue

Alternative to #7252.

"Nightly wheels" tests fail with

```
  File "/home/runner/work/orange3/orange3/.tox/beta/lib/python3.14/site-packages/Orange/data/io_util.py", line 15, in <module>
    from chardet.universaldetector import UniversalDetector
ModuleNotFoundError: No module named 'chardet.universaldetector'
```

because `UniveralDetector was moved to `chardet.detector` in chardet 7.

##### Description of changes

Import from the appropriate place that is mentioned in the docs. :)