### PR TITLE
Hierarchical clustering: Elide annotations, replace newlines with spaces

### DIFF
--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -652,7 +652,8 @@ class OWHierarchicalClustering(widget.OWWidget):
                 labels = [str(attr[i]) for i in indices]
             elif isinstance(self.annotation, Orange.data.Variable):
                 col_data = self.items.get_column(self.annotation)
-                labels = [self.annotation.str_val(val) for val in col_data]
+                labels = [self.annotation.str_val(val).replace("\n", " ")
+                          for val in col_data]
                 labels = [labels[idx] for idx in indices]
             else:
                 labels = []

--- a/Orange/widgets/unsupervised/owhierarchicalclustering.py
+++ b/Orange/widgets/unsupervised/owhierarchicalclustering.py
@@ -442,7 +442,7 @@ class OWHierarchicalClustering(widget.OWWidget):
         self.dendrogram.selectionChanged.connect(self._invalidate_output)
         self.dendrogram.selectionEdited.connect(self._selection_edited)
 
-        self.labels = TextListView()
+        self.labels = TextListView(elideMode=Qt.ElideRight)
         self.label_model = SelectedLabelsModel()
         self.labels.setModel(self.label_model)
         self.labels.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)

--- a/Orange/widgets/utils/graphicstextlist.py
+++ b/Orange/widgets/utils/graphicstextlist.py
@@ -305,6 +305,11 @@ class TextListBase(QGraphicsWidget):
             fm = QFontMetrics(font)
             fontheight = fm.height()
 
+        advance = cell_height + spacing
+        self.__remove_items((self.__strip, ), self.scene())
+        self.__strip = self.__color_strip(round(advance))
+        offset = int(round(advance * 1.3)) if self.__strip else 0
+
         if self.__autoScale and self.__effectiveFont != font \
                 and self.data(0, Qt.FontRole) is None:
             self.__effectiveFont = font
@@ -312,17 +317,20 @@ class TextListBase(QGraphicsWidget):
 
         if self.__elideMode != Qt.ElideNone:
             if self.__orientation == Qt.Vertical:
-                textwidth = math.ceil(crect.width())
+                textwidth = math.ceil(crect.width()) - offset
             else:
                 textwidth = math.ceil(crect.height())
             for row, item in enumerate(self.__textitems):
                 text = self.data(row)
-                textelide = fm.elidedText(
-                    text, self.__elideMode, textwidth, Qt.TextSingleLine
-                )
-                item.setText(textelide)
+                if text:
+                    fmr = QFontMetrics(self.data(row, Qt.FontRole) or font)
+                    textelide = fmr.elidedText(
+                        text, self.__elideMode, textwidth, Qt.TextSingleLine
+                    )
+                    item.setText(textelide)
+                else:
+                    item.setText(text)
 
-        advance = cell_height + spacing
         if align_vertical == Qt.AlignTop:
             align_dy = 0.
         elif align_vertical == Qt.AlignVCenter:
@@ -346,9 +354,6 @@ class TextListBase(QGraphicsWidget):
                     crect.top() + i * advance + align_dy
                 )
 
-        self.__remove_items((self.__strip, ), self.scene())
-        self.__strip = self.__color_strip(round(advance))
-        offset = int(round(advance * 1.3)) if self.__strip else 0
         if self.__orientation == Qt.Vertical:
             self.__group.setRotation(0)
             self.__group.setPos(offset, 0)

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -11676,6 +11676,8 @@ widgets/unsupervised/owhierarchicalclustering.py:
             label_model: false
             Enumeration: Številčenje
             Name: Ime
+            \n: false
+            ' ': false
             ', ': true
         def `commit`:
             items: false


### PR DESCRIPTION
##### Issue

Fixes #7251.

##### Description of changes

- Replace \n with spaces
- Enable eliding
- Fix eliding, which didn't account for color strip showing the selection and for different font weights

##### Includes
- [X] Code changes
