### PR TITLE
Colors: Use css styled icon

### DIFF
--- a/Orange/widgets/data/icons/Colors.svg
+++ b/Orange/widgets/data/icons/Colors.svg
@@ -3,21 +3,32 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="47.8px" height="59.96px" viewBox="0 0 47.8 59.96" enable-background="new 0 0 47.8 59.96" xml:space="preserve">
-<path fill="#A7A9AC" stroke="#000000" stroke-width="1.9052" stroke-miterlimit="10" d="M29,32.46c-6.01-4.87,4.26-13.32-4.71-18.21
+<defs>
+<style type="text/css" id="current-color-scheme">
+* { color: #333; }
+.ColorScheme-Text { color: #333; }
+.ColorScheme-Text-Disabled { color: #666; }
+.ColorScheme-Background { color: #fff; }
+</style>
+<path id="palette-outline" stroke-width="1.5" stroke-miterlimit="10" d="M29,32.46c-6.01-4.87,4.26-13.32-4.71-18.21
 	c-8.97-4.89-23.78,5-23.44,20.74c0.34,15.74,15.3,16.98,19.83,17.39c4.53,0.41,14.34-2.54,15.75-7.56
 	c1.82-6.47,1.68-10.08-1.93-12.11C32.52,31.59,32.2,35.05,29,32.46z"/>
-<ellipse fill="#FBB040" stroke="#000000" stroke-miterlimit="10" cx="22" cy="44.19" rx="4.31" ry="4.27"/>
-<ellipse fill="#8DC63F" stroke="#000000" stroke-miterlimit="10" cx="11.03" cy="39.31" rx="4.31" ry="4.27"/>
-<ellipse fill="#C49A6C" stroke="#000000" stroke-miterlimit="10" cx="10.15" cy="28.19" rx="4.31" ry="4.27"/>
-<ellipse fill="#FFF200" stroke="#000000" stroke-miterlimit="10" cx="19.27" cy="20.84" rx="4.31" ry="4.27"/>
-<rect x="-6.01" y="0" fill="none" width="59.82" height="59.82"/>
+</defs>
+	<use class="ColorScheme-Background" fill="currentColor" stroke="none" xlink:href="#palette-outline"/>
+	<use class="ColorScheme-Text-Disabled" fill="currentColor" stroke="none" opacity="0.4" xlink:href="#palette-outline"/>
+	<use class="ColorScheme-Text-Disabled" fill="none" stroke="currentColor" xlink:href="#palette-outline"/>
+<g style="ColorScheme-Text" stroke="currentColor">
+	<ellipse fill="#FBB040" stroke-miterlimit="10" cx="22" cy="44.19" rx="4.31" ry="4.27"/>
+	<ellipse fill="#8DC63F" stroke-miterlimit="10" cx="11.03" cy="39.31" rx="4.31" ry="4.27"/>
+	<ellipse fill="#C49A6C" stroke-miterlimit="10" cx="10.15" cy="28.19" rx="4.31" ry="4.27"/>
+	<ellipse fill="#FFF200" stroke-miterlimit="10" cx="19.27" cy="20.84" rx="4.31" ry="4.27"/>
+</g>
 <g>
-	
-		<rect x="37.01" y="14.82" transform="matrix(0.8987 0.4385 -0.4385 0.8987 14.1796 -14.7986)" fill="#333333" width="4.24" height="16.95"/>
-	<path fill="#333333" d="M32.23,32.59c-0.06,0-0.12,0-0.18,0c-1.57,0-3.07,0.87-3.81,2.38c-0.46,0.94-0.64,1.98-1.15,2.91
+	<rect class="ColorScheme-Text-Disabled" fill="currentColor" x="37.01" y="14.82" transform="matrix(0.8987 0.4385 -0.4385 0.8987 14.1796 -14.7986)" width="4.24" height="16.95"/>
+	<path class="ColorScheme-Text-Disabled" fill="currentColor" d="M32.23,32.59c-0.06,0-0.12,0-0.18,0c-1.57,0-3.07,0.87-3.81,2.38c-0.46,0.94-0.64,1.98-1.15,2.91
 		c-0.4,0.72-0.92,1.36-1.6,1.83c-0.96,0.67-2.17,1.08-3.32,1.32c-0.24,0.05-0.46,0.06-0.71,0.06c2.95,1.2,5.32,1.66,7.22,1.66
 		c5.71,0,7.16-4.07,7.16-4.07c0.61-1.25,0.54-2.65-0.06-3.8l0.02,0.01l0.74-1.52l-3.81-1.86L32.23,32.59z"/>
-	<path fill="#FFFFFF" d="M45.19,15.71l-3.81-1.86c-0.14-0.07-0.29-0.1-0.44-0.1c-0.11,0-0.22,0.02-0.32,0.05
+	<path class="ColorScheme-Background" fill="currentColor" d="M45.19,15.71l-3.81-1.86c-0.14-0.07-0.29-0.1-0.44-0.1c-0.11,0-0.22,0.02-0.32,0.05
 		c-0.25,0.09-0.46,0.27-0.57,0.51l-7.44,15.24c-0.12,0.24-0.13,0.51-0.05,0.76c0.03,0.08,0.08,0.14,0.12,0.21
 		c-0.34,0.03-0.66,0.22-0.82,0.55l-0.26,0.54c-1.83,0.15-3.44,1.24-4.25,2.92c-0.24,0.49-0.41,0.99-0.57,1.47
 		c-0.17,0.51-0.33,0.98-0.56,1.4c-0.35,0.64-0.78,1.14-1.29,1.49c-0.73,0.5-1.75,0.91-2.95,1.16c-0.15,0.03-0.29,0.04-0.52,0.04


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Use css styling for better dark mode visuals.

Before 
<img width="58" height="72" alt="Screenshot 2026-03-25 at 11 01 28" src="https://github.com/user-attachments/assets/33b1d841-eed4-43fa-b5fe-a63a7c991edc" />
After
<img width="59" height="75" alt="Screenshot 2026-03-25 at 11 01 14" src="https://github.com/user-attachments/assets/811bfa15-01d3-4d06-b260-6e9503a8da72" />

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
