### PR TITLE
OWCSVFileImport: Auto-resolve paths within workflow directory

### DIFF
--- a/Orange/widgets/data/owcsvimport.py
+++ b/Orange/widgets/data/owcsvimport.py
@@ -68,6 +68,7 @@ from Orange.widgets.utils import (
 from Orange.widgets.utils.combobox import ItemStyledComboBox
 from Orange.widgets.utils.pathutils import (
     PathItem, VarPath, AbsPath, samepath, prettyfypath, isprefixed,
+    infer_prefix,
 )
 from Orange.widgets.utils.overlay import OverlayWidget
 from Orange.widgets.utils.settings import (
@@ -1282,9 +1283,17 @@ class OWCSVFileImport(OWUrlDropBase):
     def _saveState(self):
         session_items = []
         model = self.import_items_model
+        env = list(self._replacements().items())
         for item in map(model.item, range(model.rowCount())):
             if isinstance(item, ImportItem) and item.data(ImportItem.IsSessionItemRole):
                 vp = item.data(VarPathItem.VarPathRole)
+                # If the file lives inside a known prefix (e.g. the workflow's
+                # basedir), persist it as a VarPath so that moving the
+                # workflow together with its data resolves automatically.
+                if isinstance(vp, AbsPath) and env:
+                    inferred = infer_prefix(vp.path, env)
+                    if inferred is not None:
+                        vp = inferred
                 session_items.append((vp.as_dict(), item.options().as_dict()))
         self._session_items_v2 = session_items
 

--- a/Orange/widgets/data/tests/test_owcsvimport.py
+++ b/Orange/widgets/data/tests/test_owcsvimport.py
@@ -374,6 +374,44 @@ class TestOWCSVFileImport(WidgetTest):
             self.assertEqual(item[0], cur.varPath())
             self.assertEqual(item[1].as_dict(), cur.options().as_dict())
 
+    def test_save_state_infers_basedir_relative(self):
+        # A file chosen via the regular (non-prefixed) browse action should be
+        # persisted as a VarPath when it lives inside the workflow's basedir,
+        # so that moving the workflow together with its data resolves
+        # automatically (see GH-5155).
+        path = self.data_regions_path
+        basedir = os.path.dirname(path)
+        widget = self.widget
+        widget.workflowEnv = lambda: {"basedir": basedir}
+        widget.workflowEnvChanged("basedir", basedir, "")
+        with self._browse_setup(widget, path):
+            widget.browse()
+        cur = widget.current_item()
+        self.assertIsInstance(cur.varPath(), PathItem.AbsPath)
+
+        widget._saveState()
+        self.assertEqual(len(widget._session_items_v2), 1)
+        stored, _ = widget._session_items_v2[0]
+        self.assertEqual(
+            stored,
+            PathItem.VarPath("basedir", "data-regions.tab").as_dict(),
+        )
+
+    def test_save_state_keeps_abspath_outside_basedir(self):
+        # Files that live outside the workflow's basedir remain absolute.
+        path = self.data_regions_path
+        basedir = tempfile.mkdtemp()
+        widget = self.widget
+        widget.workflowEnv = lambda: {"basedir": basedir}
+        widget.workflowEnvChanged("basedir", basedir, "")
+        with self._browse_setup(widget, path):
+            widget.browse()
+
+        widget._saveState()
+        self.assertEqual(len(widget._session_items_v2), 1)
+        stored, _ = widget._session_items_v2[0]
+        self.assertEqual(stored, PathItem.AbsPath(path).as_dict())
+
     def test_activate_import_dialog(self):
         path = self.data_regions_path
         item = ImportItem.fromPath(path)


### PR DESCRIPTION
##### Issue
Fixes #5155

##### Description of changes
The CSV Import widget persists the selected file either as an `AbsPath` (default when the user picks a file through the main "…" button / "Import any file…" action) or as a `VarPath("basedir", relpath)` (only when the user explicitly picks "Import relative to workflow file…"). The relative-import menu entry is only available once the workflow has been saved, so new users rarely encounter it — which means moving a saved workflow alongside its data usually breaks the link, contrary to how the File widget behaves.

This change teaches `_saveState` to upgrade an `AbsPath` to a `VarPath("basedir", relpath)` when the selected file lives inside the workflow's `basedir`, using the existing `infer_prefix` helper in `Orange/widgets/utils/pathutils.py`. Files outside `basedir` continue to be stored as `AbsPath`. No settings schema bump is required — `VarPath` is already a valid v3 shape.

Effect:
- Files within the workflow directory resolve automatically after the workflow+data are moved together (matches the File widget's implicit behavior).
- The confusing two-entry browse menu behaves consistently: either entry now ends up with a workflow-relative path when applicable.
- Absolute paths pointing outside the workflow directory are untouched.

##### Includes
- [x] Code changes
- [x] Tests
- [ ] Documentation