### PR TITLE
Scatterplotgraph: Implement manual repositioning of points

### DIFF
--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -520,6 +520,9 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
             self.update_stress()
             self.graph.update_sizes()
 
+    def finish_dragging(self):
+        self.commit.deferred()
+
     def _on_connected_changed(self):
         self.graph.set_effective_matrix(self.effective_matrix)
         self.graph.update_pairs()

--- a/Orange/widgets/unsupervised/owmds.py
+++ b/Orange/widgets/unsupervised/owmds.py
@@ -1,6 +1,8 @@
 # pylint: disable=too-many-ancestors
 import time
 from types import SimpleNamespace as namespace
+from typing import Optional
+import hashlib
 
 import numpy as np
 import scipy.spatial.distance
@@ -178,6 +180,8 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
     GRAPH_CLASS = OWMDSGraph
     graph = SettingProvider(OWMDSGraph)
     embedding_variables_names = ("mds-x", "mds-y")
+    positions_hint: Optional[tuple[list[list[float]], str]] = \
+        Setting(None, schema_only=True)
 
     class Error(OWDataProjectionWidget.Error):
         not_enough_rows = Msg("Input data needs at least 2 rows")
@@ -201,6 +205,8 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
 
         self.embedding = None  # type: Optional[np.ndarray]
         self.effective_matrix = None  # type: Optional[DistMatrix]
+        self._effective_matrix_hash_ref: Optional[DistMatrix] = None
+        self._effective_matrix_hash: Optional[str] = None
         self.stress = None
 
         self.size_model = self.gui.points_models[2]
@@ -389,14 +395,9 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
         first_result = self.embedding is None
         new_embedding = result.embedding
         need_update = new_embedding is not self.embedding
-        self.embedding = new_embedding
+        self.set_embedding(new_embedding, update=not first_result and need_update)
         if first_result:
             self.setup_plot()
-        else:
-            if need_update:
-                self.graph.update_coordinates()
-                self.graph.update_density()
-                self.update_stress()
 
     def on_done(self, result: Result):
         assert isinstance(result.embedding, np.ndarray)
@@ -470,15 +471,54 @@ class OWMDS(OWDataProjectionWidget, ConcurrentWidgetMixin):
         else:
             self.update_stress()
 
+    def __array_hash(self):
+        X = self.effective_matrix
+        if X is None:
+            return ""
+        if self._effective_matrix_hash_ref is X:
+            return self._effective_matrix_hash
+        h = hashlib.sha256()
+        digest = h.hexdigest()
+        self._effective_matrix_hash_ref = X
+        self._effective_matrix_hash = digest
+        return digest
+
     def handleNewSignals(self):
         self._initialize()
         self.input_changed.emit(self.data)
         if self._invalidated:
-            self.__invalidate_embedding()
             self.enable_controls()
-            if self.effective_matrix is not None:
-                self._run()
+            if (self.positions_hint is not None
+                    and self.effective_matrix is not None
+                    and len(self.positions_hint[0]) == len(self.effective_matrix)
+                    and self.positions_hint[1] == self.__array_hash()):
+                self.embedding = np.array(self.positions_hint[0])
+                self.positions_hint = None
+                self.graph.update_coordinates()
+                self.graph.update_density()
+                self.update_stress()
+            else:
+                self.__invalidate_embedding()
+                if self.effective_matrix is not None:
+                    self._run()
         super().handleNewSignals()
+
+    def set_embedding(self, embedding, update=True):
+        self.set_coordinates(..., embedding, update)
+
+    def set_coordinates(self, idx, coordinates, update=True):
+        if coordinates is not None \
+                and self.effective_matrix is not None \
+                and self.embedding is not None:
+            self.embedding[idx] = coordinates
+            self.positions_hint = (self.embedding.tolist(), self.__array_hash())
+        else:
+            self.positions_hint = None
+        if update:
+            self.graph.update_coordinates()
+            self.graph.update_density()
+            self.update_stress()
+            self.graph.update_sizes()
 
     def _on_connected_changed(self):
         self.graph.set_effective_matrix(self.effective_matrix)

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1785,6 +1785,26 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         else:
             return np.flatnonzero(self.selection)
 
+    def get_dragged_points(self, pos):
+        if not hasattr(self.master, "set_coordinates") \
+                or self.scatterplot_item is None:
+            return None
+
+        pts = self.scatterplot_item.pointsAt(pos)
+        if pts is None or len(pts) == 0:
+            return None
+        idx = np.array([p.data() for p in pts], dtype=int)
+
+        if self.selection is not None and np.all(self.selection[idx]):
+            idx = np.flatnonzero(self.selection)
+
+        x, y = self.scatterplot_item.getData()
+        return idx, x[idx], y[idx]
+
+    def move_dragged_points(self, points, dist):
+        idx, x, y = points
+        self.master.set_coordinates(idx, np.vstack((x + dist.x(), y + dist.y())).T)
+
     def help_event(self, event):
         """
         Create a `QToolTip` for the point hovered by the mouse

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1817,7 +1817,7 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
             return None
         idx = np.array([p.data() for p in pts], dtype=int)
 
-        if self.selection is not None and np.all(self.selection[idx]):
+        if self.selection is not None and np.any(self.selection[idx]):
             idx = np.flatnonzero(self.selection)
 
         x, y = self.scatterplot_item.getData()

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1827,6 +1827,10 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         idx, x, y = points
         self.master.set_coordinates(idx, np.vstack((x + dist.x(), y + dist.y())).T)
 
+    def finish_dragging(self):
+        if hasattr(self.master, "finish_dragging"):
+            self.master.finish_dragging()
+
     def help_event(self, event):
         """
         Create a `QToolTip` for the point hovered by the mouse

--- a/Orange/widgets/visualize/owscatterplotgraph.py
+++ b/Orange/widgets/visualize/owscatterplotgraph.py
@@ -1785,10 +1785,32 @@ class OWScatterPlotBase(gui.OWComponent, QObject):
         else:
             return np.flatnonzero(self.selection)
 
+    def __adjust_pos(self, pos):
+        # This code is "inspired" by the code in pyqtgraph's ScatterPlotItem._maskAt
+        x = pos.x()
+        y = pos.y()
+        w = h = 3
+        if self.scatterplot_item.opts['pxMode']:
+            px, py = self.scatterplot_item.pixelVectors()
+            try:
+                px = 0 if px is None else px.length()
+            except OverflowError:
+                px = 0
+            try:
+                py = 0 if py is None else py.length()
+            except OverflowError:
+                py = 0
+            w *= px
+            h *= py
+        return QRectF(x - w, y - w, 2 * w, 2 * h)
+
     def get_dragged_points(self, pos):
         if not hasattr(self.master, "set_coordinates") \
                 or self.scatterplot_item is None:
             return None
+
+        # Expand the position to a rectangle of 3 pixels in each direction
+        pos = self.__adjust_pos(pos)
 
         pts = self.scatterplot_item.pointsAt(pos)
         if pts is None or len(pts) == 0:

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -259,7 +259,9 @@ class InteractiveViewBox(pg.ViewBox):
 
         def drag():
             if ev.isFinish():
-                self.dragged_points = None
+                if self.dragged_points:
+                    self.graph.finish_dragging()
+                    self.dragged_points = None
                 self.graph.unsuspend_jittering()
             else:
                 ev.accept()

--- a/Orange/widgets/visualize/utils/plotutils.py
+++ b/Orange/widgets/visualize/utils/plotutils.py
@@ -175,6 +175,7 @@ class InteractiveViewBox(pg.ViewBox):
         self.init_history()
         pg.ViewBox.__init__(self, enableMenu=enable_menu)
         self.graph = graph
+        self.dragged_points = None
         self.setMouseMode(self.PanMode)
         self.grabGesture(Qt.PinchGesture)
 
@@ -256,7 +257,27 @@ class InteractiveViewBox(pg.ViewBox):
             self.axHistoryPointer += 1
             self.axHistory = self.axHistory[:self.axHistoryPointer] + [ax]
 
-        if self.graph.state == SELECT and axis is None:
+        def drag():
+            if ev.isFinish():
+                self.dragged_points = None
+                self.graph.unsuspend_jittering()
+            else:
+                ev.accept()
+                p0 = self.mapToView(ev.buttonDownPos())
+                p1 = self.mapToView(ev.pos())
+                dist = p1 - p0
+                self.graph.move_dragged_points(self.dragged_points, dist)
+
+        if ev.isStart() and ev.button() & (Qt.LeftButton | Qt.MiddleButton) \
+                and hasattr(self.graph, "get_dragged_points"):
+            view_pos = self.mapSceneToView(ev.pos())
+            self.dragged_points = self.graph.get_dragged_points(view_pos)
+            if self.dragged_points is not None:
+                self.graph.suspend_jittering()
+
+        if self.dragged_points:
+            drag()
+        elif self.graph.state == SELECT and axis is None:
             select()
         elif self.graph.state == ZOOMING or self.graph.state == PANNING:
             # Inherited mouseDragEvent doesn't work for large zooms because it

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -15183,6 +15183,8 @@ widgets/visualize/owscatterplotgraph.py:
             impute_shapes: false
         def `_update_color_legend`:
             o: false
+        def `__adjust_pos`:
+            pxMode: false
         def `get_dragged_points`:
             set_coordinates: false
         def `finish_dragging`:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -15185,6 +15185,8 @@ widgets/visualize/owscatterplotgraph.py:
             o: false
         def `get_dragged_points`:
             set_coordinates: false
+        def `finish_dragging`:
+            finish_dragging: false
 widgets/visualize/owscoringsheetviewer.py:
     class `ScoringSheetTable`:
         def `__init__`:

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -15183,6 +15183,8 @@ widgets/visualize/owscatterplotgraph.py:
             impute_shapes: false
         def `_update_color_legend`:
             o: false
+        def `get_dragged_points`:
+            set_coordinates: false
 widgets/visualize/owscoringsheetviewer.py:
     class `ScoringSheetTable`:
         def `__init__`:
@@ -15929,6 +15931,7 @@ widgets/visualize/utils/plotutils.py:
             def `select`:
                 unsuspend_jittering: false
                 suspend_jittering: false
+            get_dragged_points: false
             mouseMode: false
     class `PaletteItemSample`:
         def `__init__`:


### PR DESCRIPTION
##### Description of changes

- Implement moving of points (a single point or selection) by dragging them.

    The functionality is enabled if the widget (not graph!) implements a method `set_coordinates`.
- Implement this in MDS.
- Also, implement saving of coordinate hints in MDS.

I don't know how to write reasonable tests for this. Test on https://github.com/biolab/orange3-network/pull/293.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
