### PR TITLE
Restrict /rebase to org members

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && github.event.comment.author_association == 'MEMBER'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
##### Issue

Fix a potential vulnerability in rebase workflow.

##### Description of changes

Restrict rebase to org members.
