### PR TITLE
Change behavior of set class_var by RowInstance.

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -150,9 +150,9 @@ class RowInstance(Instance):
                     self._x[key] = value
             else:
                 if self.sparse_y is not None:
-                    self.table._Y[self.row_index, key - len(self._x)] = value
+                    self._y[key - len(self._x)] = value
                 else:
-                    self.table._Y[self.row_index] = value
+                    self.table.Y[self.row_index, key - len(self._x)] = value
                     if self.table._Y.ndim == 1:  # if _y is not a view
                         self._y[0] = value
         else:


### PR DESCRIPTION
Now one can change single cell on class_var table, but must to be remembered that indexes are relative to length of attributes (table.X). So to change index zero it must be exactly `len(table.X[row_index])`.

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes #7291


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
