### PR TITLE
RowInstance: Fix setting class when there are multiple classes

### DIFF
--- a/Orange/data/table.py
+++ b/Orange/data/table.py
@@ -149,12 +149,11 @@ class RowInstance(Instance):
                 if self.sparse_x is not None:
                     self._x[key] = value
             else:
-                if self.sparse_y is not None:
+                if self.table._Y.ndim == 2:
                     self.table._Y[self.row_index, key - len(self._x)] = value
                 else:
                     self.table._Y[self.row_index] = value
-                    if self.table._Y.ndim == 1:  # if _y is not a view
-                        self._y[0] = value
+                    self._y[0] = value  # _y is not a view
         else:
             self.table.metas[self.row_index, -1 - key] = value
             if self.sparse_metas is not None:

--- a/Orange/data/tests/test_table.py
+++ b/Orange/data/tests/test_table.py
@@ -797,6 +797,24 @@ class TestTableGetColumnView(TableColumnViewTests):
         self.assertEqual(data.get_column("y").dtype, float)
 
 
+class TestRowInstance(unittest.TestCase):
+    def test_multiclass_set(self):
+        foo = ContinuousVariable("Foo")
+        cont = ContinuousVariable("Cont Var")
+        disc = DiscreteVariable("Disc Var", values=("0", "1"))
+        domain = Domain([foo], [cont, disc], [])
+
+        X = np.array([[1], [2]])
+        Y = np.array([
+            [float("nan"), float("nan")],
+            [float("nan"), float("nan")]
+        ], dtype=float)
+        data = Table(domain, X, Y, None)
+        row = data[1]
+        with data.unlocked():
+            row[1] = 4
+        np.testing.assert_equal(row._y, [4, np.nan])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
##### Issue

Fixes #7291.

##### Description of changes

Do not ignore the class index.

**Note**: Failed tests are unrelated. (See #7294, which fixes the problem, though not for oldest supported scikit.)

##### Includes
- [X] Code changes
- [X] Tests