### PR TITLE
ElasticNetCVLearner: Fix parameter alphas

### DIFF
--- a/Orange/regression/linear.py
+++ b/Orange/regression/linear.py
@@ -79,7 +79,7 @@ class ElasticNetCVLearner(LinearRegressionLearner):
     supports_weights = True
 
     # Arguments are needed for signatures, pylint: disable=unused-argument
-    def __init__(self, l1_ratio=0.5, eps=0.001, n_alphas=100, alphas=None,
+    def __init__(self, l1_ratio=0.5, eps=0.001, n_alphas=100, alphas=100,
                  fit_intercept=True, precompute='auto', max_iter=1000,
                  tol=0.0001, cv=5, copy_X=True, verbose=0, n_jobs=1,
                  positive=False, preprocessors=None):

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ deps =
     oldest: python-louvain==0.13
     # oldest: pyyaml
     # oldest: requests
-    oldest: scikit-learn==1.5.1
+    oldest: scikit-learn==1.7
     oldest: scipy==1.10
     # oldest: serverfiles
     oldest: xgboost==2.1.0


### PR DESCRIPTION
##### Issue

`ElasticNetCVLearner` requires `int` or an array, and no longer accepts `None`.

##### Description of changes

Set it to the default value, `100`. This duplicates the value of `n_alpha`, which we need to keep for compatibility

We have a problem with scikit versions and should probably require 1.7. We currently require 1.5

- 1.5 (from 2024) does not accept an `int` argument for `alpha`; it requires a list or `None` (default, effectively sets it to 100).
- 1.7 (2025) deprecates allows `int` and deprecates `None`; it defaults to `100`.
- 1.9 (2026) no longer accepts `None`.

There is no common argument type for 1.5 and 1.9. If we omit the argument to use the default, we have a problem with signature.

The easiest solution is to require Scikit 1.7

##### Includes
- [X] Code changes
