### PR TITLE
Add View Options (title and axis titles) to Distributions widget

### DIFF
--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -5,8 +5,8 @@ from typing import Optional, Sequence
 
 import numpy as np
 
-from AnyQt.QtWidgets import QGridLayout, QLabel, QLineEdit, QSizePolicy, QWidget
-from AnyQt.QtCore import Qt
+from AnyQt.QtWidgets import QFrame ,QGridLayout, QLabel, QLineEdit, QSizePolicy, QWidget,QScrollArea
+from AnyQt.QtCore import Qt , QTimer
 
 from Orange.data import StringVariable, DiscreteVariable, Domain
 from Orange.data.table import Table
@@ -227,6 +227,8 @@ class OWCreateClass(widget.OWWidget):
 
     want_main_area = False
     buttons_area_orientation = Qt.Vertical
+    #: Max pixel height of the rules area before it scrolls instead of
+    MAX_RULES_AREA_HEIGHT = 360
 
     settingsHandler = DomainContextHandler()
     attribute = ContextSetting(None)
@@ -301,9 +303,15 @@ class OWCreateClass(widget.OWWidget):
         rules_box.addWidget(QLabel("Count"), 0, 3, 1, 2)
         self.update_rules()
 
-        widg = QWidget(patternbox)
+        self._rules_widget = widg = QWidget()
         widg.setLayout(rules_box)
-        patternbox.layout().addWidget(widg)
+
+        self._rules_scroll = scroll = QScrollArea()
+        scroll.setWidget(widg)
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        patternbox.layout().addWidget(scroll)
 
         box = gui.hBox(patternbox)
         gui.rubber(box)
@@ -330,6 +338,8 @@ class OWCreateClass(widget.OWWidget):
 
         # TODO: Resizing upon changing the number of rules does not work
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
+
+
 
     @property
     def active_rules(self):
@@ -427,9 +437,33 @@ class OWCreateClass(widget.OWWidget):
             _remove_line()
         _fix_tab_order()
 
+        QTimer.singleShot(0, self._refit_rules_area)
+
+    def _refit_rules_area(self):
+        """Size the rules scroll area to its contents, but never taller than
+        MAX_RULES_AREA_HEIGHT (beyond that it scrolls, so the Apply button
+        stays on screen), then re-fit the window to its new contents."""
+        content_height = self._rules_widget.sizeHint().height()
+        needs_scroll = content_height > self.MAX_RULES_AREA_HEIGHT
+        self._rules_scroll.setVerticalScrollBarPolicy(
+            Qt.ScrollBarAlwaysOn if needs_scroll else Qt.ScrollBarAlwaysOff)
+        self._rules_scroll.setFixedHeight(
+            min(content_height, self.MAX_RULES_AREA_HEIGHT))
+        self.adjustSize()
+
+        if getattr(self, "_scroll_to_bottom_pending", False):
+            self._scroll_to_bottom_pending = False
+            QTimer.singleShot(0, self._scroll_rules_to_bottom)
+
+    def _scroll_rules_to_bottom(self):
+        """Scroll the rules area down so a newly added row is visible."""
+        bar = self._rules_scroll.verticalScrollBar()
+        bar.setValue(bar.maximum())
+
     def add_row(self):
         """Append a new row at the end."""
         self.active_rules.append(["", ""])
+        self._scroll_to_bottom_pending = True
         self.adjust_n_rule_rows()
         self.update_counts()
 

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -229,6 +229,7 @@ class OWCreateClass(widget.OWWidget):
     want_main_area = False
     buttons_area_orientation = Qt.Vertical
     #: Max pixel height of the rules area before it scrolls instead of
+    #: growing the widget further
     MAX_RULES_AREA_HEIGHT = 360
 
     settingsHandler = DomainContextHandler()
@@ -340,10 +341,7 @@ class OWCreateClass(widget.OWWidget):
 
         gui.button(self.buttonsArea, self, "Apply", callback=self.apply)
 
-        # TODO: Resizing upon changing the number of rules does not work
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Maximum)
-
-
 
     @property
     def active_rules(self):
@@ -444,13 +442,7 @@ class OWCreateClass(widget.OWWidget):
         QTimer.singleShot(0, self._refit_rules_area)
 
     def _refit_rules_area(self):
-        """Size the rules scroll area to its contents, but never taller than
-        MAX_RULES_AREA_HEIGHT (beyond that it scrolls, so the Apply button
-        stays on screen), then re-fit the window to its new contents."""
         content_height = self._rules_widget.sizeHint().height()
-        needs_scroll = content_height > self.MAX_RULES_AREA_HEIGHT
-        self._rules_scroll.setVerticalScrollBarPolicy(
-            Qt.ScrollBarAlwaysOn if needs_scroll else Qt.ScrollBarAlwaysOff)
         self._rules_scroll.setFixedHeight(
             min(content_height, self.MAX_RULES_AREA_HEIGHT))
         self.adjustSize()

--- a/Orange/widgets/data/owcreateclass.py
+++ b/Orange/widgets/data/owcreateclass.py
@@ -5,8 +5,9 @@ from typing import Optional, Sequence
 
 import numpy as np
 
-from AnyQt.QtWidgets import QFrame ,QGridLayout, QLabel, QLineEdit, QSizePolicy, QWidget,QScrollArea
-from AnyQt.QtCore import Qt , QTimer
+from AnyQt.QtWidgets import QFrame, QGridLayout, QLabel, QLineEdit, \
+    QSizePolicy, QWidget, QScrollArea
+from AnyQt.QtCore import Qt, QTimer
 
 from Orange.data import StringVariable, DiscreteVariable, Domain
 from Orange.data.table import Table
@@ -271,6 +272,9 @@ class OWCreateClass(widget.OWWidget):
         self.remove_buttons = []
         #: list of list of QLabel: pairs of labels with counts
         self.counts = []
+        #: bool: set by add_row, tells _refit_rules_area to scroll down
+        #    once the new row's height has been applied
+        self._scroll_to_bottom_pending = False
 
         gui.lineEdit(
             self.controlArea, self, "class_name",
@@ -451,7 +455,7 @@ class OWCreateClass(widget.OWWidget):
             min(content_height, self.MAX_RULES_AREA_HEIGHT))
         self.adjustSize()
 
-        if getattr(self, "_scroll_to_bottom_pending", False):
+        if self._scroll_to_bottom_pending:
             self._scroll_to_bottom_pending = False
             QTimer.singleShot(0, self._scroll_rules_to_bottom)
 

--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -190,9 +190,15 @@ class ParameterSetter(CommonParameterSetter):
         self.initial_settings = {
             self.LABELS_BOX: {
                 self.FONT_FAMILY_LABEL: self.FONT_FAMILY_SETTING,
+                self.TITLE_LABEL: self.FONT_SETTING,
                 self.AXIS_TITLE_LABEL: self.FONT_SETTING,
                 self.AXIS_TICKS_LABEL: self.FONT_SETTING,
                 self.LEGEND_LABEL: self.FONT_SETTING,
+            },
+            self.ANNOT_BOX: {
+                self.TITLE_LABEL: {self.TITLE_LABEL: ("", "")},
+                self.X_AXIS_LABEL: {self.TITLE_LABEL: ("", "")},
+                self.Y_AXIS_LABEL: {self.TITLE_LABEL: ("", "")},
             },
             self.PLOT_BOX: {
                 self.LEGEND_LABEL: {
@@ -208,6 +214,14 @@ class ParameterSetter(CommonParameterSetter):
         self._setters[self.PLOT_BOX] = {
             self.LEGEND_LABEL: update_show_empty,
         }
+
+    @property
+    def title_item(self):
+        return self.master.parent_widget.ploti.titleLabel
+
+    @property
+    def getAxis(self):
+        return self.master.parent_widget.ploti.getAxis
 
     @property
     def axis_items(self):
@@ -648,16 +662,26 @@ class OWDistributions(OWWidget):
     def _set_axis_names(self):
         assert self.is_valid  # called only from replot, so assumes data is OK
         bottomaxis = self.ploti.getAxis("bottom")
-        bottomaxis.setLabel(self.var and self.var.name)
+        bottomaxis.setLabel(
+            self._custom_axis_title(ParameterSetter.X_AXIS_LABEL)
+            or (self.var and self.var.name))
         bottomaxis.setShowUnit(not (self.var and self.var.is_time))
 
         leftaxis = self.ploti.getAxis("left")
-        if self.show_probs and self.cvar:
+        custom_label = self._custom_axis_title(ParameterSetter.Y_AXIS_LABEL)
+        if custom_label:
+            leftaxis.setLabel(custom_label)
+        elif self.show_probs and self.cvar:
             leftaxis.setLabel(
                 f"Probability of '{self.cvar.name}' at given '{self.var.name}'")
         else:
             leftaxis.setLabel("Frequency")
         leftaxis.resizeEvent()
+
+    def _custom_axis_title(self, axis_label):
+        return self.visual_settings.get(
+            (ParameterSetter.ANNOT_BOX, axis_label, ParameterSetter.TITLE_LABEL),
+            "")
 
     def _update_controls_state(self):
         assert self.is_valid  # called only from replot, so assumes data is OK
@@ -1391,6 +1415,11 @@ class OWDistributions(OWWidget):
     def set_visual_settings(self, key: KeyType, value: ValueType):
         self.visual_settings[key] = value
         self.plotview.parameter_setter.set_parameter(key, value)
+        if self.is_valid and key[:2] in (
+                (ParameterSetter.ANNOT_BOX, ParameterSetter.X_AXIS_LABEL),
+                (ParameterSetter.ANNOT_BOX, ParameterSetter.Y_AXIS_LABEL)):
+            # an empty custom title falls back to the auto-generated label
+            self._set_axis_names()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/Orange/widgets/visualize/tests/test_owdistributions.py
+++ b/Orange/widgets/visualize/tests/test_owdistributions.py
@@ -749,6 +749,13 @@ class TestOWDistributions(WidgetTest):
         key, value = ("Fonts", "Font family", "Font family"), "Helvetica"
         self.widget.set_visual_settings(key, value)
 
+        key, value = ("Fonts", "Title", "Font size"), 20
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Title", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        font.setPointSize(20)
+        self.assertFontEqual(graph.parameter_setter.title_item.item.font(), font)
+
         key, value = ("Fonts", "Axis title", "Font size"), 16
         self.widget.set_visual_settings(key, value)
         key, value = ("Fonts", "Axis title", "Italic"), True
@@ -784,6 +791,104 @@ class TestOWDistributions(WidgetTest):
             [i[1].text for i in graph.parameter_setter.legend_items],
             ["Iris-versicolor", "Iris-virginica"]
         )
+
+        self.assertFalse(graph.parameter_setter.title_item.isVisible())
+        key, value = ("Annotations", "Title", "Title"), "iris distributions"
+        self.widget.set_visual_settings(key, value)
+        self.assertTrue(graph.parameter_setter.title_item.isVisible())
+        self.assertEqual(graph.parameter_setter.title_item.item.toPlainText(), "iris distributions")
+
+        key, value = ("Annotations", "x-axis title", "Title"), "x-axis custom label"
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(self.widget.ploti.getAxis("bottom").labelText, "x-axis custom label")
+
+        key, value = ("Annotations", "y-axis title", "Title"), "y-axis custom label"
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(self.widget.ploti.getAxis("left").labelText, "y-axis custom label")
+    
+    def test_custom_titles_variable_change(self):
+        """Custom titles persist when plotted variable is changed"""
+        self.send_signal(self.widget.Inputs.data, self.iris)
+        graph = self.widget.plotview
+
+        key, value = ("Annotations", "Title", "Title"), "iris distributions"
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Annotations", "x-axis title", "Title"), "x-axis custom label"
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Annotations", "y-axis title", "Title"), "y-axis custom label"
+        self.widget.set_visual_settings(key, value)
+
+        self._set_var(1)
+
+        self.assertEqual(graph.parameter_setter.title_item.item.toPlainText(), "iris distributions")
+        self.assertEqual(self.widget.ploti.getAxis("bottom").labelText, "x-axis custom label")
+        self.assertEqual(self.widget.ploti.getAxis("left").labelText, "y-axis custom label")
+
+        key, value = ("Annotations", "x-axis title", "Title"), ""
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(self.widget.ploti.getAxis("bottom").labelText, "sepal length")
+
+        key, value = ("Annotations", "y-axis title", "Title"), ""
+        self.widget.set_visual_settings(key, value)
+        self.assertEqual(self.widget.ploti.getAxis("left").labelText, "Frequency")
+
+    def test_saved_workflow(self):
+        """Visual settings are saved and restored"""
+        font = QFont()
+        font.setItalic(True)
+        font.setFamily("Helvetica")
+
+        key, value = ("Fonts", "Title", "Font size"), 20
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Title", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis title", "Font size"), 16
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis title", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis ticks", "Font size"), 15
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Axis ticks", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Legend", "Font size"), 14
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Fonts", "Legend", "Italic"), True
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Figure", "Legend", "Hide empty categories in the legend"), True
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Annotations", "Title", "Title"), "iris distributions"
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Annotations", "x-axis title", "Title"), "x-axis custom label"
+        self.widget.set_visual_settings(key, value)
+        key, value = ("Annotations", "y-axis title", "Title"), "y-axis custom label"
+        self.widget.set_visual_settings(key, value)
+
+        settings = self.widget.settingsHandler.pack_data(self.widget)
+        w = self.create_widget(OWDistributions, stored_settings=settings)
+        
+        self.send_signal(w.Inputs.data, self.iris[50:], widget=w)
+        key, value = ("Fonts", "Font family", "Font family"), "Helvetica"
+        w.set_visual_settings(key, value)
+
+        font.setPointSize(20)
+        self.assertFontEqual(w.plotview.parameter_setter.title_item.item.font(), font)
+        font.setPointSize(16)
+        for item in w.plotview.parameter_setter.axis_items:
+            self.assertFontEqual(item.label.font(), font)
+        font.setPointSize(15)
+        for item in w.plotview.parameter_setter.axis_items:
+            self.assertFontEqual(item.style["tickFont"], font)
+        font.setPointSize(14)
+        legend_item = list(w.plotview.parameter_setter.legend_items)[0]
+        self.assertFontEqual(legend_item[1].item.font(), font)
+        self.assertEqual(
+            [i[1].text for i in w.plotview.parameter_setter.legend_items],
+            ["Iris-versicolor", "Iris-virginica"]
+        )
+        self.assertTrue(w.plotview.parameter_setter.title_item.isVisible())
+        self.assertEqual(w.plotview.parameter_setter.title_item.item.toPlainText(), "iris distributions")
+        self.assertEqual(w.ploti.getAxis("bottom").labelText, "x-axis custom label")
+        self.assertEqual(w.ploti.getAxis("left").labelText, "y-axis custom label")
 
     def assertFontEqual(self, font1, font2):
         self.assertEqual(font1.family(), font2.family())


### PR DESCRIPTION
Implements #7298.

Adds custom plot title and custom x/y axis title support to the Distributions widget View Options dialog, consistent with Line Plot, Bar Plot and Violin Plot. Empty fields fall back to the existing automatic behaviour (variable name / "Frequency"), and the new settings are saved with the workflow like any other visual setting.

Also includes a small fix for Create Class: the widget did not resize when rule rows were added or removed, and the rule list had no height cap.

This was done as a student project; happy to adjust based on review feedback.