### PR TITLE
[FIX] Linux Wayland fixes

### DIFF
--- a/Orange/widgets/data/utils/preprocess.py
+++ b/Orange/widgets/data/utils/preprocess.py
@@ -16,7 +16,7 @@ from AnyQt.QtCore import (
 )
 
 from AnyQt.QtGui import (
-    QCursor, QIcon, QPainter, QPixmap, QStandardItemModel,
+    QIcon, QPainter, QPixmap, QStandardItemModel,
     QDrag, QKeySequence
 )
 
@@ -291,7 +291,7 @@ class Controller(QObject):
         if event.mimeData().hasFormat(self.MimeType) and \
                 self.model() is not None:
             event.accept()
-            self._setDropIndicatorAt(event.pos())
+            self._setDropIndicatorAt(event.position())
             return True
         else:
             return False
@@ -646,8 +646,7 @@ class SequenceFlow(QWidget):
     def dropEvent(self, event):
         """Reimplemented."""
         layout = self.__flowlayout
-        index = self.__insertIndexAt(self.mapFromGlobal(QCursor.pos()))
-
+        index = self.__insertIndexAt(event.position())
         if event.mimeData().hasFormat("application/x-internal-move") and \
                 event.source() is self:
             # Complete the internal move
@@ -677,8 +676,7 @@ class SequenceFlow(QWidget):
 
     def dragMoveEvent(self, event):
         """Reimplemented."""
-        pos = self.mapFromGlobal(QCursor.pos())
-        self.__setDropIndicatorAt(pos)
+        self.__setDropIndicatorAt(event.position())
 
     def dragLeaveEvent(self, event):
         """Reimplemented."""

--- a/Orange/widgets/evaluate/owrocanalysis.py
+++ b/Orange/widgets/evaluate/owrocanalysis.py
@@ -695,8 +695,8 @@ class OWROCAnalysis(widget.OWWidget):
                         mask = np.equal(cache_clf, clf_idx)
                         curr_thresh = np.compress(mask, cache_thresh).tolist()
                         curr_clf = np.compress(mask, cache_clf).tolist()
-                    else:
-                        QToolTip.showText(QCursor.pos(), "")
+                    else: # pragma: no cover
+                        QToolTip.showText(QCursor.pos(), "", self.plotview)
                         self._tooltip_cache = None
 
                     if curr_thresh:
@@ -721,7 +721,7 @@ class OWROCAnalysis(widget.OWWidget):
             clf_names = self.classifier_names
             msg = "Thresholds:\n" + "\n".join(["({:s}) {:.3f}".format(clf_names[i], thresh)
                                                for i, thresh in zip(valid_clf, valid_thresh)])
-            QToolTip.showText(QCursor.pos(), msg)
+            QToolTip.showText(QCursor.pos(), msg, self.plotview)
             self._tooltip_cache = (pt, valid_thresh, valid_clf, ave_mode)
 
     def _on_target_changed(self):

--- a/Orange/widgets/evaluate/tests/test_owrocanalysis.py
+++ b/Orange/widgets/evaluate/tests/test_owrocanalysis.py
@@ -234,7 +234,7 @@ class TestOWROCAnalysis(EvaluateTest):
             pos = item.mapToScene(0, 0.1)
             pos = view.mapFromScene(pos)
             mouseMove(view.viewport(), pos)
-            (_, text), _ = show_text.call_args
+            (_, text, *_), _ = show_text.call_args
             self.assertIn("(#1) 0.900", text)
             self.assertNotIn("#2", text)
 
@@ -242,13 +242,13 @@ class TestOWROCAnalysis(EvaluateTest):
             pos = item.mapToScene(0.0, 0.0)
             pos = view.mapFromScene(pos)
             mouseMove(view.viewport(), pos)
-            (_, text), _ = show_text.call_args
+            (_, text, *_), _ = show_text.call_args
             self.assertIn("(#1) 1.000\n(#2) 1.000", text)
 
             pos = item.mapToScene(0.1, 0.3)
             pos = view.mapFromScene(pos)
             mouseMove(view.viewport(), pos)
-            (_, text), _ = show_text.call_args
+            (_, text, *_), _ = show_text.call_args
             self.assertIn("(#1) 0.600\n(#2) 0.590", text)
             show_text.reset_mock()
 
@@ -256,7 +256,7 @@ class TestOWROCAnalysis(EvaluateTest):
             self.widget.roc_averaging = OWROCAnalysis.Threshold
             self.widget._replot()
             mouseMove(view.viewport(), pos)
-            (_, text), _ = show_text.call_args
+            (_, text, *_), _ = show_text.call_args
             self.assertIn("(#1) 0.600\n(#2) 0.590", text)
             show_text.reset_mock()
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

* Cannot reorder preprocessors in Prepprocess widget via drag drop on Wayland. 
* Tool tips are misplaced in ROC Analysis widget on Wayland.

##### Description of changes

* preprocess: Fix drop index selection on Wayland
* owrocanalysis: Fix tooltip positioning on Wayland


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
