### PR TITLE
Update quantile calculation method in owboxplot.py

### DIFF
--- a/Orange/widgets/visualize/owboxplot.py
+++ b/Orange/widgets/visualize/owboxplot.py
@@ -62,7 +62,7 @@ class BoxData:
         self.var = np.nanvar(col)
         self.dev = np.sqrt(self.var)
         self.q25, self.median, self.q75 = \
-            np.nanquantile(col, [0.25, 0.5, 0.75], interpolation="midpoint")
+            np.nanquantile(col, [0.25, 0.5, 0.75], method="midpoint")
         self.data_range = ContDataRange(self.q25, self.q75, group_val)
         if self.q25 == self.median:
             self.q25 = None


### PR DESCRIPTION
The parameter name has been changed in NumPy 1.22
```
methodstr, optional

    This parameter specifies the method to use for estimating the quantile. There are many different methods, some unique to NumPy. See the notes for explanation. The options sorted by their R type as summarized in the H&F paper [1] are:

        ‘inverted_cdf’

        ‘averaged_inverted_cdf’

        ‘closest_observation’

        ‘interpolated_inverted_cdf’

        ‘hazen’

        ‘weibull’

        ‘linear’ (default)

        ‘median_unbiased’

        ‘normal_unbiased’

    The first three methods are discontinuous. NumPy further defines the following discontinuous variations of the default ‘linear’ (7.) option:

        ‘lower’

        ‘higher’,

        ‘midpoint’

        ‘nearest’

    Changed in version 1.22.0: This argument was previously called “interpolation” and only offered the “linear” default and last four options.
```
https://numpy.org/doc/stable/reference/generated/numpy.nanquantile.html

##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->


##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
