### PR TITLE
[FIX] Distributions: Fix mislabelled gamma parameter

### DIFF
--- a/Orange/widgets/visualize/owdistributions.py
+++ b/Orange/widgets/visualize/owdistributions.py
@@ -365,7 +365,7 @@ class OWDistributions(OWWidget):
         ("Normal", norm, ("loc", "scale"), ("μ", "σ")),
         ("Beta", beta, ("a", "b", "loc", "scale"),
          ("α", "β", "-loc", "-scale")),
-        ("Gamma", gamma, ("a", "loc", "scale"), ("α", "β", "-loc", "-scale")),
+        ("Gamma", gamma, ("a", "loc", "scale"), ("α", "-loc", "θ")),
         ("Rayleigh", rayleigh, ("loc", "scale"), ("-loc", "σ")),
         ("Pareto", pareto, ("b", "loc", "scale"), ("α", "-loc", "-scale")),
         ("Exponential", expon, ("loc", "scale"), ("-loc", "λ")),

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -14138,6 +14138,7 @@ widgets/visualize/owdistributions.py:
         -loc: false
         -scale: false
         Gamma: Gama
+        θ: false
         Rayleigh: true
         Pareto: true
         Exponential: Eksponentna


### PR DESCRIPTION
##### Issue

Fixes #7310.

1. As reported by @GottM in #7310, the scale/beta and location were mixed up in the label.
2. The scale is usually denoted as theta, while beta is rate (1/theta).

##### Description of changes

Swap the labels, replace beta with theta.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
