### PR TITLE
[FIX] itemmodels: Limit VariableModel's tooltip length

### DIFF
--- a/Orange/widgets/utils/itemmodels.py
+++ b/Orange/widgets/utils/itemmodels.py
@@ -426,7 +426,10 @@ class VariableListModel(PyListModel):
     def discrete_variable_tooltip(self, var):
         text = "<b>%s</b><br/>Categorical with %i values: " %\
                (safe_text(var.name), len(var.values))
-        text += ", ".join("%r" % safe_text(v) for v in var.values)
+        values, nmore = var.values[:10], len(var.values) - 10
+        text += ", ".join("%r" % safe_text(v) for v in values)
+        if nmore > 0:
+            text += " (%i more)" % nmore
         text += self.variable_labels_tooltip(var)
         return text
 

--- a/i18n/si/msgs.jaml
+++ b/i18n/si/msgs.jaml
@@ -13018,6 +13018,7 @@ widgets/utils/itemmodels.py:
         def `discrete_variable_tooltip`:
             '<b>%s</b><br/>Categorical with %i values: ': '<b>%s</b><br/>Kategorična, %i vrednost(i): '
             ', ': false
+            ' (%i more)': ' (in še %i)'
             %r: false
         def `time_variable_toltip`:
             <b>%s</b><br/>Time: <b>%s</b><br/>Časovna


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Closes #2, Resolves #3, etc. -->
<!-- Or a short description, if the issue does not exist. -->

Fixes #7315

##### Description of changes

Limit VariableModel's tooltip length for categoricals

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
