### PR TITLE
Scipy: fix some future tests

### DIFF
--- a/Orange/statistics/util.py
+++ b/Orange/statistics/util.py
@@ -10,7 +10,7 @@ from typing import Iterable
 import bottleneck as bn
 import numpy as np
 import pandas
-import scipy.stats.stats
+import scipy.stats
 from scipy import sparse as sp
 
 from sklearn.utils.sparsefuncs import mean_variance_axis


### PR DESCRIPTION
##### Issue
```
[71](https://github.com/biolab/orange3/actions/runs/34688489002/job/103539549615?pr=7320#step:8:172)
  File "/home/runner/work/orange3/orange3/.tox/beta/lib/python3.14/site-packages/Orange/statistics/util.py", line 13, in <module>
    import scipy.stats.stats
ModuleNotFoundError: No module named 'scipy.stats.stats'
```